### PR TITLE
Refactor/wooden supports 2

### DIFF
--- a/src/openrct2/paint/Supports.cpp
+++ b/src/openrct2/paint/Supports.cpp
@@ -824,6 +824,28 @@ bool WoodenBSupportsPaintSetup(
     return hasSupports;
 }
 
+bool WoodenBSupportsPaintSetup(
+    PaintSession& session, WoodenSupportType supportType, WoodenSupportSubType subType, int32_t height, ImageId imageTemplate,
+    WoodenSupportTransitionType transitionType, Direction direction)
+{
+    int32_t oldSupportType = (EnumValue(supportType) * 6) + EnumValue(subType);
+    int32_t special = 0;
+    if (transitionType != WoodenSupportTransitionType::None)
+    {
+        special = (EnumValue(transitionType) * NumOrthogonalDirections) + direction + 1;
+    }
+
+    return WoodenBSupportsPaintSetup(session, oldSupportType, special, height, imageTemplate);
+}
+
+bool WoodenBSupportsPaintSetupRotated(
+    PaintSession& session, WoodenSupportType supportType, WoodenSupportSubType subType, Direction direction, int32_t height,
+    ImageId imageTemplate, WoodenSupportTransitionType transitionType)
+{
+    subType = rotatedWoodenSupportSubTypes[EnumValue(subType)][direction];
+    return WoodenBSupportsPaintSetup(session, supportType, subType, height, imageTemplate, transitionType, direction);
+}
+
 /**
  * Metal pole supports
  * @param supportType (edi)

--- a/src/openrct2/paint/Supports.h
+++ b/src/openrct2/paint/Supports.h
@@ -54,6 +54,12 @@ bool WoodenASupportsPaintSetupRotated(
     ImageId imageTemplate, WoodenSupportTransitionType transitionType = WoodenSupportTransitionType::None);
 bool WoodenBSupportsPaintSetup(
     PaintSession& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate);
+bool WoodenBSupportsPaintSetup(
+    PaintSession& session, WoodenSupportType supportType, WoodenSupportSubType subType, int32_t height, ImageId imageTemplate,
+    WoodenSupportTransitionType transitionType = WoodenSupportTransitionType::None, Direction direction = 0);
+bool WoodenBSupportsPaintSetupRotated(
+    PaintSession& session, WoodenSupportType supportType, WoodenSupportSubType subType, Direction direction, int32_t height,
+    ImageId imageTemplate, WoodenSupportTransitionType transitionType = WoodenSupportTransitionType::None);
 bool MetalASupportsPaintSetup(
     PaintSession& session, uint8_t supportType, uint8_t segment, int32_t special, int32_t height, ImageId imageTemplate);
 bool MetalBSupportsPaintSetup(

--- a/src/openrct2/ride/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/ride/coaster/MineTrainCoaster.cpp
@@ -2435,29 +2435,10 @@ static void MineTrainRCTrackLeftQuarterTurn3(
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 1:
-            switch (direction)
-            {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-            }
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 2:
@@ -2602,29 +2583,10 @@ static void MineTrainRCTrackLeftQuarterTurn3Bank(
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 1:
-            switch (direction)
-            {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-            }
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 2:
@@ -2769,29 +2731,10 @@ static void MineTrainRCTrackLeftQuarterTurn325DegUp(
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
         case 1:
-            switch (direction)
-            {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-            }
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
         case 2:
@@ -2901,29 +2844,10 @@ static void MineTrainRCTrackRightQuarterTurn325DegUp(
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
         case 1:
-            switch (direction)
-            {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-            }
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
         case 2:
@@ -3058,29 +2982,10 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpSmall(
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 1:
-            switch (direction)
-            {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-            }
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 2:
@@ -3222,29 +3127,9 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpSmall(
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 5:
-            switch (direction)
-            {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-            }
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 6:
@@ -3386,29 +3271,10 @@ static void MineTrainRCTrackRightHalfBankedHelixUpSmall(
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 1:
-            switch (direction)
-            {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-            }
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 2:
@@ -3550,29 +3416,10 @@ static void MineTrainRCTrackRightHalfBankedHelixUpSmall(
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 5:
-            switch (direction)
-            {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-            }
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 6:
@@ -4908,29 +4755,10 @@ static void MineTrainRCTrackLeftEighthToDiag(
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 3:
-            switch (direction)
-            {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-            }
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
@@ -5093,29 +4921,10 @@ static void MineTrainRCTrackRightEighthToDiag(
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 3:
-            switch (direction)
-            {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-            }
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
@@ -5296,29 +5105,10 @@ static void MineTrainRCTrackLeftEighthBankToDiag(
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 3:
-            switch (direction)
-            {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-            }
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
@@ -5481,29 +5271,10 @@ static void MineTrainRCTrackRightEighthBankToDiag(
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 3:
-            switch (direction)
-            {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-            }
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
@@ -5563,178 +5334,58 @@ static void MineTrainRCTrackDiagFlat(
     switch (trackSequence)
     {
         case 0:
-            if (trackElement.HasChain())
+            if (direction == 3)
             {
-                switch (direction)
-                {
-                    case 3:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20389), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20389 : 20361;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 3:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20361), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
-            }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 1:
-            if (trackElement.HasChain())
+            if (direction == 0)
             {
-                switch (direction)
-                {
-                    case 0:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20386), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20386 : 20358;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 0:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20358), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
-            }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 2:
-            if (trackElement.HasChain())
+            if (direction == 2)
             {
-                switch (direction)
-                {
-                    case 0:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20388), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20388 : 20360;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 0:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20360), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
-            }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 3:
-            if (trackElement.HasChain())
+            if (direction == 1)
             {
-                switch (direction)
-                {
-                    case 1:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20387), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20387 : 20359;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 1:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20359), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
-            }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
@@ -5876,178 +5527,58 @@ static void MineTrainRCTrackDiagFlatTo25DegUp(
     switch (trackSequence)
     {
         case 0:
-            if (trackElement.HasChain())
+            if (direction == 3)
             {
-                switch (direction)
-                {
-                    case 3:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20393), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20393 : 20365;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 3:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20365), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
-            }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
         case 1:
-            if (trackElement.HasChain())
+            if (direction == 0)
             {
-                switch (direction)
-                {
-                    case 0:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20390), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20390 : 20362;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 0:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20362), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
-            }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
         case 2:
-            if (trackElement.HasChain())
+            if (direction == 0)
             {
-                switch (direction)
-                {
-                    case 0:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20392), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20392 : 20364;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 0:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20364), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
-            }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
         case 3:
-            if (trackElement.HasChain())
+            if (direction == 1)
             {
-                switch (direction)
-                {
-                    case 1:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20391), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20391 : 20363;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 1:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20363), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
-            }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
@@ -6569,178 +6100,58 @@ static void MineTrainRCTrackDiag25DegDownToFlat(
     switch (trackSequence)
     {
         case 0:
-            if (trackElement.HasChain())
+            if (direction == 3)
             {
-                switch (direction)
-                {
-                    case 3:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20391), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20391 : 20363;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 3:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20363), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
-            }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
         case 1:
-            if (trackElement.HasChain())
+            if (direction == 0)
             {
-                switch (direction)
-                {
-                    case 0:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20392), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20392 : 20364;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 0:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20364), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
-            }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
         case 2:
-            if (trackElement.HasChain())
+            if (direction == 2)
             {
-                switch (direction)
-                {
-                    case 0:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20390), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20390 : 20362;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 0:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20362), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenASupportsPaintSetup(
-                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
-            }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
         case 3:
-            if (trackElement.HasChain())
+            if (direction == 1)
             {
-                switch (direction)
-                {
-                    case 1:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20393), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20393 : 20365;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 1:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20365), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
-            }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
@@ -6755,89 +6166,57 @@ static void MineTrainRCTrackDiagFlatToLeftBank(
     switch (trackSequence)
     {
         case 0:
-            switch (direction)
+            if (direction == 3)
             {
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20409), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20409), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 1:
-            switch (direction)
+            if (direction == 0)
             {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20406), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20410), { -16, -16, height },
-                        { { -16, -16, height + 27 }, { 32, 32, 0 } });
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20406), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20410), { -16, -16, height },
+                    { { -16, -16, height + 27 }, { 32, 32, 0 } });
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 2:
-            switch (direction)
+            if (direction == 2)
             {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20408), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20408), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 3:
-            switch (direction)
+            if (direction == 1)
             {
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20407), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20407), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
@@ -6852,89 +6231,57 @@ static void MineTrainRCTrackDiagFlatToRightBank(
     switch (trackSequence)
     {
         case 0:
-            switch (direction)
+            if (direction == 3)
             {
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20414), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20414), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 1:
-            switch (direction)
+            if (direction == 0)
             {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20411), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20411), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 2:
-            switch (direction)
+            if (direction == 2)
             {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20413), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20415), { -16, -16, height },
-                        { { -16, -16, height + 27 }, { 32, 32, 0 } });
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20413), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20415), { -16, -16, height },
+                    { { -16, -16, height + 27 }, { 32, 32, 0 } });
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 3:
-            switch (direction)
+            if (direction == 1)
             {
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20412), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20412), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
@@ -6949,89 +6296,57 @@ static void MineTrainRCTrackDiagLeftBankToFlat(
     switch (trackSequence)
     {
         case 0:
-            switch (direction)
+            if (direction == 3)
             {
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20412), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20412), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 1:
-            switch (direction)
+            if (direction == 0)
             {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20413), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20415), { -16, -16, height },
-                        { { -16, -16, height + 27 }, { 32, 32, 0 } });
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20413), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20415), { -16, -16, height },
+                    { { -16, -16, height + 27 }, { 32, 32, 0 } });
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 2:
-            switch (direction)
+            if (direction == 2)
             {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20411), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20411), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 3:
-            switch (direction)
+            if (direction == 1)
             {
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20414), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20414), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
@@ -7046,89 +6361,57 @@ static void MineTrainRCTrackDiagRightBankToFlat(
     switch (trackSequence)
     {
         case 0:
-            switch (direction)
+            if (direction == 3)
             {
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20407), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20407), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 1:
-            switch (direction)
+            if (direction == 0)
             {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20408), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20408), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 2:
-            switch (direction)
+            if (direction == 2)
             {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20406), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20410), { -16, -16, height },
-                        { { -16, -16, height + 27 }, { 32, 32, 0 } });
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20406), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20410), { -16, -16, height },
+                    { { -16, -16, height + 27 }, { 32, 32, 0 } });
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 3:
-            switch (direction)
+            if (direction == 1)
             {
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20409), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20409), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
@@ -7143,89 +6426,57 @@ static void MineTrainRCTrackDiagLeftBankTo25DegUp(
     switch (trackSequence)
     {
         case 0:
-            switch (direction)
+            if (direction == 3)
             {
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20429), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20429), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
         case 1:
-            switch (direction)
+            if (direction == 0)
             {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20426), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20430), { -16, -16, height },
-                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20426), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20430), { -16, -16, height },
+                    { { -16, -16, height + 35 }, { 32, 32, 0 } });
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
         case 2:
-            switch (direction)
+            if (direction == 2)
             {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20428), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20428), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
         case 3:
-            switch (direction)
+            if (direction == 1)
             {
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20427), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20427), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
@@ -7240,89 +6491,57 @@ static void MineTrainRCTrackDiagRightBankTo25DegUp(
     switch (trackSequence)
     {
         case 0:
-            switch (direction)
+            if (direction == 3)
             {
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20434), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20434), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
         case 1:
-            switch (direction)
+            if (direction == 0)
             {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20431), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20431), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
         case 2:
-            switch (direction)
+            if (direction == 2)
             {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20433), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20435), { -16, -16, height },
-                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20433), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20435), { -16, -16, height },
+                    { { -16, -16, height + 35 }, { 32, 32, 0 } });
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
         case 3:
-            switch (direction)
+            if (direction == 1)
             {
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20432), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20432), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
@@ -7589,89 +6808,57 @@ static void MineTrainRCTrackDiag25DegDownToLeftBank(
     switch (trackSequence)
     {
         case 0:
-            switch (direction)
+            if (direction == 3)
             {
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20432), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20432), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
         case 1:
-            switch (direction)
+            if (direction == 0)
             {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20433), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20435), { -16, -16, height },
-                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20433), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20435), { -16, -16, height },
+                    { { -16, -16, height + 35 }, { 32, 32, 0 } });
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
         case 2:
-            switch (direction)
+            if (direction == 2)
             {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20431), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20431), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
         case 3:
-            switch (direction)
+            if (direction == 1)
             {
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20434), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20434), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
@@ -7686,89 +6873,57 @@ static void MineTrainRCTrackDiag25DegDownToRightBank(
     switch (trackSequence)
     {
         case 0:
-            switch (direction)
+            if (direction == 3)
             {
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20427), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20427), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
         case 1:
-            switch (direction)
+            if (direction == 0)
             {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20428), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20428), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
         case 2:
-            switch (direction)
+            if (direction == 2)
             {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20426), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20430), { -16, -16, height },
-                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20426), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20430), { -16, -16, height },
+                    { { -16, -16, height + 35 }, { 32, 32, 0 } });
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
         case 3:
-            switch (direction)
+            if (direction == 1)
             {
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20429), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20429), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
@@ -7783,89 +6938,57 @@ static void MineTrainRCTrackDiagLeftBank(
     switch (trackSequence)
     {
         case 0:
-            switch (direction)
+            if (direction == 3)
             {
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20405), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 3 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20405), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 3 } });
             }
+
             PaintUtilSetSegmentSupportHeight(
                 session, PaintUtilRotateSegments(SEGMENT_BC | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D4, direction), 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 1:
-            switch (direction)
+            if (direction == 0)
             {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20402), { -16, -16, height },
-                        { { -16, -16, height + 27 }, { 32, 32, 0 } });
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20402), { -16, -16, height },
+                    { { -16, -16, height + 27 }, { 32, 32, 0 } });
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(
                 session, PaintUtilRotateSegments(SEGMENT_B4 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC, direction), 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 2:
-            switch (direction)
+            if (direction == 2)
             {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20404), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 3 } });
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20404), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 3 } });
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(
                 session, PaintUtilRotateSegments(SEGMENT_C0 | SEGMENT_C4 | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 3:
-            switch (direction)
+            if (direction == 1)
             {
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20403), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 3 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20403), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 3 } });
             }
+
             PaintUtilSetSegmentSupportHeight(
                 session, PaintUtilRotateSegments(SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_D0, direction), 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
@@ -7881,89 +7004,57 @@ static void MineTrainRCTrackDiagRightBank(
     switch (trackSequence)
     {
         case 0:
-            switch (direction)
+            if (direction == 3)
             {
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20403), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 3 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20403), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 3 } });
             }
+
             PaintUtilSetSegmentSupportHeight(
                 session, PaintUtilRotateSegments(SEGMENT_BC | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D4, direction), 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 1:
-            switch (direction)
+            if (direction == 0)
             {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20404), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 3 } });
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20404), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 3 } });
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(
                 session, PaintUtilRotateSegments(SEGMENT_B4 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC, direction), 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 2:
-            switch (direction)
+            if (direction == 2)
             {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20402), { -16, -16, height },
-                        { { -16, -16, height + 27 }, { 32, 32, 0 } });
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20402), { -16, -16, height },
+                    { { -16, -16, height + 27 }, { 32, 32, 0 } });
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(
                 session, PaintUtilRotateSegments(SEGMENT_C0 | SEGMENT_C4 | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 3:
-            switch (direction)
+            if (direction == 1)
             {
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20405), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 3 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20405), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 3 } });
             }
+
             PaintUtilSetSegmentSupportHeight(
                 session, PaintUtilRotateSegments(SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_D0, direction), 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/ride/coaster/MineTrainCoaster.cpp
@@ -5478,8 +5478,8 @@ static void MineTrainRCTrackDiag60DegUp(
         case 1:
             if (direction == 0)
             {
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20382), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20382), { -16, -16, height },
                     { { -16, -16, height }, { 32, 32, 1 } });
             }
 
@@ -5606,8 +5606,8 @@ static void MineTrainRCTrackDiag25DegUpTo60DegUp(
         case 1:
             if (direction == 0)
             {
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20374), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20374), { -16, -16, height },
                     { { -16, -16, height }, { 32, 32, 1 } });
             }
 
@@ -5621,8 +5621,8 @@ static void MineTrainRCTrackDiag25DegUpTo60DegUp(
         case 2:
             if (direction == 2)
             {
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20376), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20376), { -16, -16, height },
                     { { -16, -16, height }, { 32, 32, 1 } });
             }
 
@@ -5684,8 +5684,8 @@ static void MineTrainRCTrackDiag60DegUpTo25DegUp(
         case 2:
             if (direction == 2)
             {
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20380), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20380), { -16, -16, height },
                     { { -16, -16, height }, { 32, 32, 1 } });
             }
 
@@ -5863,8 +5863,8 @@ static void MineTrainRCTrackDiag60DegDown(
         case 1:
             if (direction == 0)
             {
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20384), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20384), { -16, -16, height },
                     { { -16, -16, height }, { 32, 32, 1 } });
             }
 
@@ -5878,8 +5878,8 @@ static void MineTrainRCTrackDiag60DegDown(
         case 2:
             if (direction == 2)
             {
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20382), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20382), { -16, -16, height },
                     { { -16, -16, height }, { 32, 32, 1 } });
             }
 
@@ -5989,8 +5989,8 @@ static void MineTrainRCTrackDiag25DegDownTo60DegDown(
         case 1:
             if (direction == 0)
             {
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20380), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20380), { -16, -16, height },
                     { { -16, -16, height }, { 32, 32, 1 } });
             }
 
@@ -6179,11 +6179,11 @@ static void MineTrainRCTrackDiagFlatToLeftBank(
         case 1:
             if (direction == 0)
             {
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20406), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20406), { -16, -16, height },
                     { { -16, -16, height }, { 32, 32, 1 } });
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20410), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20410), { -16, -16, height },
                     { { -16, -16, height + 27 }, { 32, 32, 0 } });
             }
 
@@ -6197,8 +6197,8 @@ static void MineTrainRCTrackDiagFlatToLeftBank(
         case 2:
             if (direction == 2)
             {
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20408), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20408), { -16, -16, height },
                     { { -16, -16, height }, { 32, 32, 1 } });
             }
 
@@ -6244,8 +6244,8 @@ static void MineTrainRCTrackDiagFlatToRightBank(
         case 1:
             if (direction == 0)
             {
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20411), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20411), { -16, -16, height },
                     { { -16, -16, height }, { 32, 32, 1 } });
             }
 
@@ -6259,11 +6259,11 @@ static void MineTrainRCTrackDiagFlatToRightBank(
         case 2:
             if (direction == 2)
             {
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20413), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20413), { -16, -16, height },
                     { { -16, -16, height }, { 32, 32, 1 } });
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20415), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20415), { -16, -16, height },
                     { { -16, -16, height + 27 }, { 32, 32, 0 } });
             }
 
@@ -6309,11 +6309,11 @@ static void MineTrainRCTrackDiagLeftBankToFlat(
         case 1:
             if (direction == 0)
             {
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20413), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20413), { -16, -16, height },
                     { { -16, -16, height }, { 32, 32, 1 } });
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20415), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20415), { -16, -16, height },
                     { { -16, -16, height + 27 }, { 32, 32, 0 } });
             }
 
@@ -6327,8 +6327,8 @@ static void MineTrainRCTrackDiagLeftBankToFlat(
         case 2:
             if (direction == 2)
             {
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20411), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20411), { -16, -16, height },
                     { { -16, -16, height }, { 32, 32, 1 } });
             }
 
@@ -6635,8 +6635,8 @@ static void MineTrainRCTrackDiag25DegUpToRightBank(
         case 1:
             if (direction == 0)
             {
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20421), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20421), { -16, -16, height },
                     { { -16, -16, height }, { 32, 32, 1 } });
             }
 
@@ -6699,11 +6699,11 @@ static void MineTrainRCTrackDiagLeftBankTo25DegDown(
         case 1:
             if (direction == 0)
             {
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20423), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20423), { -16, -16, height },
                     { { -16, -16, height }, { 32, 32, 1 } });
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20425), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20425), { -16, -16, height },
                     { { -16, -16, height + 35 }, { 32, 32, 0 } });
             }
 
@@ -6715,8 +6715,8 @@ static void MineTrainRCTrackDiagLeftBankTo25DegDown(
         case 2:
             if (direction == 2)
             {
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20421), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20421), { -16, -16, height },
                     { { -16, -16, height }, { 32, 32, 1 } });
             }
 
@@ -6886,8 +6886,8 @@ static void MineTrainRCTrackDiag25DegDownToRightBank(
         case 1:
             if (direction == 0)
             {
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20428), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20428), { -16, -16, height },
                     { { -16, -16, height }, { 32, 32, 1 } });
             }
 
@@ -7034,8 +7034,8 @@ static void MineTrainRCTrackDiagRightBank(
         case 2:
             if (direction == 2)
             {
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20402), { -16, -16, height },
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20402), { -16, -16, height },
                     { { -16, -16, height + 27 }, { 32, 32, 0 } });
             }
 

--- a/src/openrct2/ride/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/ride/coaster/MineTrainCoaster.cpp
@@ -5749,146 +5749,58 @@ static void MineTrainRCTrackDiag25DegUp(
     switch (trackSequence)
     {
         case 0:
-            if (trackElement.HasChain())
+            if (direction == 3)
             {
-                switch (direction)
-                {
-                    case 3:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20401), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20401 : 20373;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 3:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20373), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
-            }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
         case 1:
-            if (trackElement.HasChain())
+            if (direction == 0)
             {
-                switch (direction)
-                {
-                    case 0:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20398), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20398 : 20370;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 0:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20370), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
-            }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
         case 2:
-            if (trackElement.HasChain())
+            if (direction == 2)
             {
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20400), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20400 : 20372;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20372), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
-            }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
         case 3:
-            if (trackElement.HasChain())
+            if (direction == 1)
             {
-                switch (direction)
-                {
-                    case 1:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20399), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20399 : 20371;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 1:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20371), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
-            }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
@@ -5903,70 +5815,53 @@ static void MineTrainRCTrackDiag60DegUp(
     switch (trackSequence)
     {
         case 0:
-            switch (direction)
+            if (direction == 3)
             {
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20385), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20385), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
             break;
         case 1:
-            switch (direction)
+            if (direction == 0)
             {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20382), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20382), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
             break;
         case 2:
-            switch (direction)
+            if (direction == 2)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20384), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20384), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
             break;
         case 3:
-            switch (direction)
+            if (direction == 1)
             {
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20383), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20383), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
             break;
@@ -6167,70 +6062,54 @@ static void MineTrainRCTrackDiag25DegUpTo60DegUp(
     switch (trackSequence)
     {
         case 0:
-            switch (direction)
+            if (direction == 3)
             {
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20377), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20377), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
         case 1:
-            switch (direction)
+            if (direction == 0)
             {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20374), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20374), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
         case 2:
-            switch (direction)
+            if (direction == 2)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20376), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20376), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
         case 3:
-            switch (direction)
+            if (direction == 1)
             {
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20375), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20375), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
@@ -6257,58 +6136,43 @@ static void MineTrainRCTrackDiag60DegUpTo25DegUp(
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
         case 1:
-            switch (direction)
+            if (direction == 0)
             {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20378), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20378), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
         case 2:
-            switch (direction)
+            if (direction == 2)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20380), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20380), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
         case 3:
-            switch (direction)
+            if (direction == 1)
             {
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20379), { -16, -16, height },
-                        { { 0, 0, height }, { 16, 16, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20379), { -16, -16, height },
+                    { { 0, 0, height }, { 16, 16, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
@@ -6323,146 +6187,58 @@ static void MineTrainRCTrackDiag25DegUpToFlat(
     switch (trackSequence)
     {
         case 0:
-            if (trackElement.HasChain())
+            if (direction == 3)
             {
-                switch (direction)
-                {
-                    case 3:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20397), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20397 : 20369;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 3:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20369), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
-            }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
         case 1:
-            if (trackElement.HasChain())
+            if (direction == 0)
             {
-                switch (direction)
-                {
-                    case 0:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20394), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20394 : 20366;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 0:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20366), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
-            }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
         case 2:
-            if (trackElement.HasChain())
+            if (direction == 2)
             {
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20396), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20396 : 20368;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20368), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
-            }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
         case 3:
-            if (trackElement.HasChain())
+            if (direction == 1)
             {
-                switch (direction)
-                {
-                    case 1:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20395), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20395 : 20367;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 1:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20367), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
-            }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
@@ -6477,146 +6253,58 @@ static void MineTrainRCTrackDiag25DegDown(
     switch (trackSequence)
     {
         case 0:
-            if (trackElement.HasChain())
+            if (direction == 3)
             {
-                switch (direction)
-                {
-                    case 3:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20399), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20399 : 20371;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 3:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20371), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
-            }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
         case 1:
-            if (trackElement.HasChain())
+            if (direction == 0)
             {
-                switch (direction)
-                {
-                    case 0:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20400), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20400 : 20372;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 0:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20372), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
-            }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
         case 2:
-            if (trackElement.HasChain())
+            if (direction == 2)
             {
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20398), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20398 : 20370;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20370), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
-            }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
         case 3:
-            if (trackElement.HasChain())
+            if (direction == 1)
             {
-                switch (direction)
-                {
-                    case 1:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20401), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20401 : 20373;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 1:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20373), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
-            }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
@@ -6631,70 +6319,54 @@ static void MineTrainRCTrackDiag60DegDown(
     switch (trackSequence)
     {
         case 0:
-            switch (direction)
+            if (direction == 3)
             {
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20383), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20383), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
             break;
         case 1:
-            switch (direction)
+            if (direction == 0)
             {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20384), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20384), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
             break;
         case 2:
-            switch (direction)
+            if (direction == 2)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20382), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20382), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
             break;
         case 3:
-            switch (direction)
+            if (direction == 1)
             {
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20385), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20385), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
             break;
@@ -6709,143 +6381,55 @@ static void MineTrainRCTrackDiagFlatTo25DegDown(
     switch (trackSequence)
     {
         case 0:
-            if (trackElement.HasChain())
+            if (direction == 3)
             {
-                switch (direction)
-                {
-                    case 3:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20395), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20395 : 20367;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 3:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20367), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
-            }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             break;
         case 1:
-            if (trackElement.HasChain())
+            if (direction == 0)
             {
-                switch (direction)
-                {
-                    case 0:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20396), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20396 : 20368;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 0:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20368), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
-            }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             break;
         case 2:
-            if (trackElement.HasChain())
+            if (direction == 2)
             {
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20394), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20394 : 20366;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20366), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
-            }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             break;
         case 3:
-            if (trackElement.HasChain())
+            if (direction == 1)
             {
-                switch (direction)
-                {
-                    case 1:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20397), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
+                ImageIndex imageIndex = trackElement.HasChain() ? 20397 : 20369;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIndex), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
-            else
-            {
-                switch (direction)
-                {
-                    case 1:
-                        PaintAddImageAsParentRotated(
-                            session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20369), { -16, -16, height },
-                            { { -16, -16, height }, { 32, 32, 1 } });
-                        break;
-                }
-            }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             break;
     }
@@ -6861,70 +6445,54 @@ static void MineTrainRCTrackDiag25DegDownTo60DegDown(
     switch (trackSequence)
     {
         case 0:
-            switch (direction)
+            if (direction == 3)
             {
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20379), { -16, -16, height },
-                        { { 0, 0, height }, { 16, 16, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20379), { -16, -16, height },
+                    { { 0, 0, height }, { 16, 16, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
         case 1:
-            switch (direction)
+            if (direction == 0)
             {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20380), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20380), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
         case 2:
-            switch (direction)
+            if (direction == 2)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20378), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20378), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
         case 3:
-            switch (direction)
+            if (direction == 1)
             {
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20381), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20381), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
@@ -6939,70 +6507,54 @@ static void MineTrainRCTrackDiag60DegDownTo25DegDown(
     switch (trackSequence)
     {
         case 0:
-            switch (direction)
+            if (direction == 3)
             {
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20375), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20375), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
         case 1:
-            switch (direction)
+            if (direction == 0)
             {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20376), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20376), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
         case 2:
-            switch (direction)
+            if (direction == 2)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20374), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20374), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
         case 3:
-            switch (direction)
+            if (direction == 1)
             {
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20377), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20377), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
@@ -7785,73 +7337,57 @@ static void MineTrainRCTrackDiag25DegUpToLeftBank(
     switch (trackSequence)
     {
         case 0:
-            switch (direction)
+            if (direction == 3)
             {
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20419), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20419), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
         case 1:
-            switch (direction)
+            if (direction == 0)
             {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20416), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20420), { -16, -16, height },
-                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20416), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20420), { -16, -16, height },
+                    { { -16, -16, height + 35 }, { 32, 32, 0 } });
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
         case 2:
-            switch (direction)
+            if (direction == 2)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20418), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20418), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
         case 3:
-            switch (direction)
+            if (direction == 1)
             {
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20417), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20417), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
@@ -7878,61 +7414,46 @@ static void MineTrainRCTrackDiag25DegUpToRightBank(
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
         case 1:
-            switch (direction)
+            if (direction == 0)
             {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20421), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20421), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
         case 2:
-            switch (direction)
+            if (direction == 2)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20423), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20425), { -16, -16, height },
-                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20423), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20425), { -16, -16, height },
+                    { { -16, -16, height + 35 }, { 32, 32, 0 } });
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
         case 3:
-            switch (direction)
+            if (direction == 1)
             {
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20422), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20422), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
@@ -7957,57 +7478,42 @@ static void MineTrainRCTrackDiagLeftBankTo25DegDown(
             }
             break;
         case 1:
-            switch (direction)
+            if (direction == 0)
             {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20423), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20425), { -16, -16, height },
-                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20423), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20425), { -16, -16, height },
+                    { { -16, -16, height + 35 }, { 32, 32, 0 } });
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             break;
         case 2:
-            switch (direction)
+            if (direction == 2)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20421), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20421), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             break;
         case 3:
-            switch (direction)
+            if (direction == 1)
             {
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20424), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20424), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             break;
     }
 
@@ -8023,67 +7529,51 @@ static void MineTrainRCTrackDiagRightBankTo25DegDown(
     switch (trackSequence)
     {
         case 0:
-            switch (direction)
+            if (direction == 3)
             {
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20417), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20417), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             break;
         case 1:
-            switch (direction)
+            if (direction == 0)
             {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20418), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20418), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             break;
         case 2:
-            switch (direction)
+            if (direction == 2)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(session, 10, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(session, 11, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20416), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20420), { -16, -16, height },
-                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 8, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(session, 9, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20416), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
+                PaintAddImageAsParent(
+                    session, session.TrackColours[SCHEME_TRACK].WithIndex(20420), { -16, -16, height },
+                    { { -16, -16, height + 35 }, { 32, 32, 0 } });
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             break;
         case 3:
-            switch (direction)
+            if (direction == 1)
             {
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20419), { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 1 } });
-                    break;
+                PaintAddImageAsParentRotated(
+                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20419), { -16, -16, height },
+                    { { -16, -16, height }, { 32, 32, 1 } });
             }
+
             break;
     }
 


### PR DESCRIPTION
This PR:
- Introduces the new overloads for the Wooden B support call
- Uses the enum from the previous PR in MiniatureRailway.cpp
- Consolidates support calls in MineTrainCoaster.cpp, reducing the file by more than 1400 lines