### PR TITLE
Fix: small scenery details group box is unnecessarily big

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -36,6 +36,7 @@
 - Fix: [#19955] Mine Train Roller Coaster has incorrect supports on the sloped left small turn (original bug).
 - Fix: [#19987] [Plugin] ‘SetCheatAction’ has wrong ID in plugin API.
 - Fix: [#19991] Crash using cut-away view.
+- Fix: [#20016] The group box for small scenery details in the Tile Inspector window has unused empty space.
 
 0.4.4 (2023-03-28)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -327,7 +327,7 @@ static Widget TrackWidgets[] = {
 };
 
 constexpr int32_t NumSceneryProperties = 4; // The checkbox groups both count for 2 rows
-constexpr int32_t NumSceneryDetails = 4;
+constexpr int32_t NumSceneryDetails = 3;
 constexpr int32_t SceneryPropertiesHeight = 16 + NumSceneryProperties * 21;
 constexpr int32_t SceneryDetailsHeight = 20 + NumSceneryDetails * 11;
 static Widget SceneryWidgets[] = {


### PR DESCRIPTION
Small mistake from d46f981f03758c90dd40d1c45a33afe84247f001 that I only noticed just now.