### PR TITLE
Fix #20018: Shops not calculating up-keep cost

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -38,6 +38,7 @@
 - Fix: [#19987] [Plugin] ‘SetCheatAction’ has wrong ID in plugin API.
 - Fix: [#19991] Crash using cut-away view.
 - Fix: [#20016] The group box for small scenery details in the Tile Inspector window has unused empty space.
+- Fix: [#20018] Shops not calculating up-keep cost.
 
 0.4.4 (2023-03-28)
 ------------------------------------------------------------------------

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "15"
+#define NETWORK_STREAM_VERSION "16"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -188,12 +188,6 @@ static bool RideRatingIsUpdatingRide(RideId id)
 
 static bool ShouldSkipRatingCalculation(const Ride& ride)
 {
-    // Skip anything that isn't a real ride.
-    if (ride.GetClassification() != RideClassification::Ride)
-    {
-        return true;
-    }
-
     // Skip rides that are closed.
     if (ride.status == RideStatus::Closed)
     {


### PR DESCRIPTION
Turns out I can't exclude shops after all, the upkeep calculation is tied with ride ratings for shops currently, this should be separated eventually but this is a quick fix and won't affect the ride rating calculation time too much.

Closes #20018