### PR TITLE
Fix #20027: Looping coaster with the reverse train option makes the wrong sound

### DIFF
--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "15"
+#define NETWORK_STREAM_VERSION "16"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/ride/CarEntry.h
+++ b/src/openrct2/ride/CarEntry.h
@@ -68,7 +68,7 @@ enum : uint32_t
     CAR_ENTRY_FLAG_SWINGING = 1 << 17,
     CAR_ENTRY_FLAG_SPINNING = 1 << 18,
     CAR_ENTRY_FLAG_POWERED = 1 << 19,
-    CAR_ENTRY_FLAG_RIDERS_SCREAM = 1 << 20,
+    CAR_ENTRY_FLAG_RIDERS_SCREAM = 1 << 20,   // Only valid for front/default car of train
     CAR_ENTRY_FLAG_SUSPENDED_SWING = 1 << 21, // Suspended swinging coaster, or bobsleigh if SLIDE_SWING is also enabled.
     CAR_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION = 1 << 22,
     CAR_ENTRY_FLAG_VEHICLE_ANIMATION = 1 << 23, // Set on animated vehicles like the Multi-dimension coaster trains,
@@ -193,7 +193,7 @@ struct CarEntry
     uint8_t no_seating_rows;
     uint8_t spinning_inertia;
     uint8_t spinning_friction;
-    OpenRCT2::Audio::SoundId friction_sound_id;
+    OpenRCT2::Audio::SoundId friction_sound_id; // Only valid for front/default car of train
     uint8_t ReversedCarIndex; // When the car is reversed (using a turntable or reverser), it will be changed to this car.
     uint8_t sound_range;
     uint8_t double_sound_frequency; // (Doubles the velocity when working out the sound frequency {used on go karts})

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -5410,7 +5410,9 @@ void Vehicle::UpdateSound()
     if (rideEntry == nullptr)
         return;
 
-    const auto& carEntry = rideEntry->Cars[0];
+    // Always use the head car's sound data (Some of the other vehicle subtypes have improperly set data)
+    auto soundCarIndex = (rideEntry->FrontCar == 0xff) ? rideEntry->DefaultCar : rideEntry->FrontCar;
+    const auto& carEntry = rideEntry->Cars[soundCarIndex];
 
     int32_t ecx = abs(velocity) - 1.0_mph;
     if (ecx >= 0)

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -5410,7 +5410,7 @@ void Vehicle::UpdateSound()
     if (rideEntry == nullptr)
         return;
 
-    const auto& carEntry = rideEntry->Cars[vehicle_type];
+    const auto& carEntry = rideEntry->Cars[0];
 
     int32_t ecx = abs(velocity) - 1.0_mph;
     if (ecx >= 0)


### PR DESCRIPTION
Fix #20027

Previously, the lead car referenced Cars[vehicle_type] to get the friction sound. With the newly added reversed trains option, the lead car is not always type 0, so it can get the friction_sound_id of the other entries. This caused issues for the Looping Coaster, which does not initialize the friction_sound_id for the other entries, so it defaults to SoundId::LiftClassic (For the record, this bug could also be observed if you used the Ride Vehicle Editor to change the type of the lead car).

This is fixed by simply always referencing the front car type when retrieving the friction sound. This shouldn't impact anything else as far as I know (If it does, I'll come up with a more robust solution).