### PR TITLE
Fix #19800. Crash when more than 62 stations on a ride

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -27,6 +27,7 @@
 - Fix: [#19733] Favorite ride of X guests integer overflow
 - Fix: [#19756] Crash with title sequences containing no commands.
 - Fix: [#19767] No message when path is not connected to ride exit and is therefore unreachable for mechanics.
+- Fix: [#19800] Crash when displaying station stats with more than 62 stations.
 - Fix: [#19801] The in-game load/save window cannot be resized anymore.
 - Fix: [#19854] Looping Coaster trains clipping through steep quarter turns down.
 - Fix: [#19858] Issue drawing simulate flag icon on alternate colour palettes.

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -5775,7 +5775,7 @@ static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo& dpi)
                     // TODO: STR_RIDE_TIME only takes up to 4 stations modify to take more
                     // also if modified may need to be split into multiple format strings
                     // as formatter cannot take more than 256 bytes
-                    for (int32_t i = 0; i < ride->num_stations && i < 4; i++)
+                    for (int32_t i = 0; i < std::min<int32_t>(ride->num_stations, 4); i++)
                     {
                         StationIndex stationIndex = StationIndex::FromUnderlying(numTimes);
                         auto time = ride->GetStation(stationIndex).SegmentTime;
@@ -5814,7 +5814,7 @@ static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo& dpi)
                 ft = Formatter();
                 int32_t numLengths = 0;
                 // TODO: see above STR_RIDE_LENGTH is also only able to display max 4
-                for (int32_t i = 0; i < ride->num_stations && i < 4; i++)
+                for (int32_t i = 0; i < std::min<int32_t>(ride->num_stations, 4); i++)
                 {
                     StationIndex stationIndex = StationIndex::FromUnderlying(i);
                     auto length = ride->GetStation(stationIndex).SegmentLength;

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -5772,7 +5772,10 @@ static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo& dpi)
                     // Ride time
                     ft = Formatter();
                     int32_t numTimes = 0;
-                    for (int32_t i = 0; i < ride->num_stations; i++)
+                    // TODO: STR_RIDE_TIME only takes up to 4 stations modify to take more
+                    // also if modified may need to be split into multiple format strings
+                    // as formatter cannot take more than 256 bytes
+                    for (int32_t i = 0; i < ride->num_stations && i < 4; i++)
                     {
                         StationIndex stationIndex = StationIndex::FromUnderlying(numTimes);
                         auto time = ride->GetStation(stationIndex).SegmentTime;
@@ -5810,7 +5813,8 @@ static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo& dpi)
                 // Ride length
                 ft = Formatter();
                 int32_t numLengths = 0;
-                for (int32_t i = 0; i < ride->num_stations; i++)
+                // TODO: see above STR_RIDE_LENGTH is also only able to display max 4
+                for (int32_t i = 0; i < ride->num_stations && i < 4; i++)
                 {
                     StationIndex stationIndex = StationIndex::FromUnderlying(i);
                     auto length = ride->GetStation(stationIndex).SegmentLength;


### PR DESCRIPTION
This is a bit of a temporary fix. The crash happens due to exhausting the space in the formatter but the format string only ever handled 4 stations so it was still not going to work for 5 <=> 62 stations. So for the time being capped the output at 4 stations.