### PR TITLE
PoC: condense simple paint calls into one

### DIFF
--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -270,6 +270,43 @@ struct FootpathPaintInfo
     colour_t SupportColour = 255;
 };
 
+using RotatedImageIndex = std::array<ImageIndex, NumOrthogonalDirections>;
+
+class RotatedTrackPiece
+{
+protected:
+    RotatedImageIndex Regular;
+
+public:
+    RotatedTrackPiece(const RotatedImageIndex& _regular)
+    {
+        Regular = _regular;
+    }
+
+    constexpr RotatedImageIndex Get()
+    {
+        return Regular;
+    }
+};
+
+class RotatedChainedPiece : RotatedTrackPiece
+{
+protected:
+    RotatedImageIndex WithChain;
+
+public:
+    RotatedChainedPiece(const RotatedImageIndex& _regular, const RotatedImageIndex& _withChain)
+        : RotatedTrackPiece(_regular)
+    {
+        WithChain = _withChain;
+    }
+
+    constexpr RotatedImageIndex Get(bool hasChain) const
+    {
+        return hasChain ? WithChain : Regular;
+    }
+};
+
 struct RecordedPaintSession
 {
     PaintSessionCore Session;
@@ -325,6 +362,14 @@ PaintStruct* PaintAddImageAsChildRotated(
 PaintStruct* PaintAddImageAsParentRotated(
     PaintSession& session, const uint8_t direction, const ImageId imageId, const CoordsXYZ& offset,
     const BoundBoxXYZ& boundBox);
+inline PaintStruct* PaintAddImageAsParentRotated(
+    PaintSession& session, const uint8_t direction, const RotatedImageIndex imageIds, const CoordsXYZ& offset,
+    const BoundBoxXYZ& boundBox)
+{
+    // 0 = SCHEME_TRACK
+    return PaintAddImageAsParentRotated(
+        session, direction, session.TrackColours[0].WithIndex(imageIds[direction]), offset, boundBox);
+}
 
 inline PaintStruct* PaintAddImageAsParentRotated(
     PaintSession& session, const uint8_t direction, const ImageId imageId, const CoordsXYZ& offset,

--- a/src/openrct2/ride/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/ride/coaster/MineTrainCoaster.cpp
@@ -35,68 +35,14 @@ static void MineTrainRCTrackFlat(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    if (trackElement.HasChain())
-    {
-        switch (direction)
-        {
-            case 0:
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20054), { 0, 0, height },
-                    { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(
-                    session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
-                    session.TrackColours[SCHEME_SUPPORTS]);
-                break;
-            case 1:
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20055), { 0, 0, height },
-                    { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(
-                    session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
-                    session.TrackColours[SCHEME_SUPPORTS]);
-                break;
-            case 2:
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20056), { 0, 0, height },
-                    { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(
-                    session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
-                    session.TrackColours[SCHEME_SUPPORTS]);
-                break;
-            case 3:
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20057), { 0, 0, height },
-                    { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(
-                    session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
-                    session.TrackColours[SCHEME_SUPPORTS]);
-                break;
-        }
-    }
-    else
-    {
-        switch (direction)
-        {
-            case 0:
-            case 2:
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20052), { 0, 0, height },
-                    { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(
-                    session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
-                    session.TrackColours[SCHEME_SUPPORTS]);
-                break;
-            case 1:
-            case 3:
-                PaintAddImageAsParentRotated(
-                    session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20053), { 0, 0, height },
-                    { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(
-                    session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
-                    session.TrackColours[SCHEME_SUPPORTS]);
-                break;
-        }
-    }
+    const auto imageIds = RotatedChainedPiece({ 20052, 20053, 20052, 20053 }, { 20054, 20055, 20056, 20057 });
+
+    PaintAddImageAsParentRotated(
+        session, direction, imageIds.Get(trackElement.HasChain()), { 0, 0, height }, { { 0, 6, height }, { 32, 20, 1 } });
+
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_SUPPORTS]);
+
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);


### PR DESCRIPTION
This builds on an idea I got from @duncanspumpkin . Together with the rotated support calls, this can massively reduce the amount of lines needed for simple functions.

To avoid wasting time in case changes are requested, I have only modified one drawing call. I will do the rest once the infrastructure is approved.