### PR TITLE
Fix openrct2.d.ts duplicate slopes25Banked67

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1707,7 +1707,6 @@ declare global {
         readonly slopes25Banked45?: SpriteGroup;
         readonly slopes12Banked45?: SpriteGroup;
         readonly slopes25Banked67?: SpriteGroup;
-        readonly slopes25Banked67?: SpriteGroup;
         readonly slopes25InlineTwists?: SpriteGroup;
         readonly slopes42Banked22?: SpriteGroup;
         readonly slopes42Banked45?: SpriteGroup;


### PR DESCRIPTION
Fixes error

```
lib/openrct2.d.ts(1709,18): error TS2300: Duplicate identifier 'slopes25Banked67'.
lib/openrct2.d.ts(1710,18): error TS2300: Duplicate identifier 'slopes25Banked67'.
Error: Process completed with exit code 2.
```