### PR TITLE
Add support for invalidation on OpenGL renderer

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.22 (in development)
 ------------------------------------------------------------------------
+- Improved: [#20073] The OpenGL drawing engine now supports screen invalidation which avoids the redrawing of unchanged regions.
 - Improved: [#21767] RCT Classic for macOS can now be used as the source game.
 - Improved: [#23590] Title bars are now drawn bigger when “Enlarged UI” is enabled.
 - Improved: [#23626] Add small, medium and large flat and sloped turns, S-bends and diagonal track to the Go-Karts.

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -968,6 +968,12 @@ private:
             }
 
             w = it->get();
+
+            if (w->flags & WF_DEAD)
+            {
+                continue;
+            }
+
             if (right <= w->windowPos.x || bottom <= w->windowPos.y)
             {
                 continue;

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -639,9 +639,6 @@ public:
             mainWindow->savedViewPos.x -= viewport->ViewWidth() / 2;
             mainWindow->savedViewPos.y -= viewport->ViewHeight() / 2;
 
-            // Make sure the viewport has correct coordinates set.
-            ViewportUpdatePosition(mainWindow);
-
             mainWindow->Invalidate();
         }
     }

--- a/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
@@ -177,9 +177,7 @@ public:
         SDL_QueryTexture(_screenTexture, &format, nullptr, nullptr, nullptr);
         _screenTextureFormat = SDL_AllocFormat(format);
 
-        ConfigureBits(width, height, width);
-
-        _drawingContext->Clear(_bitsDPI, PaletteIndex::pi10);
+        X8DrawingEngine::Resize(width, height);
     }
 
     void SetPalette(const GamePalette& palette) override
@@ -205,6 +203,8 @@ public:
 
     void EndDraw() override
     {
+        X8DrawingEngine::EndDraw();
+
         Display();
         if (gShowDirtyVisuals)
         {

--- a/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
@@ -201,6 +201,11 @@ public:
         }
     }
 
+    void BeginDraw() override
+    {
+        X8DrawingEngine::BeginDraw();
+    }
+
     void EndDraw() override
     {
         X8DrawingEngine::EndDraw();

--- a/src/openrct2-ui/drawing/engines/SoftwareDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/SoftwareDrawingEngine.cpp
@@ -96,6 +96,8 @@ public:
 
     void EndDraw() override
     {
+        X8DrawingEngine::EndDraw();
+
         Display();
     }
 

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLAPI.h
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLAPI.h
@@ -38,6 +38,7 @@
     #define glTexImage3D __static__glTexImage3D
     #define glGetIntegerv __static__glGetIntegerv
     #define glGetTexImage __static__glGetTexImage
+    #define glTexSubImage2D __static__glTexSubImage2D
 
 #endif
 
@@ -74,6 +75,7 @@
     #undef glTexImage3D
     #undef glGetIntegerv
     #undef glGetTexImage
+    #undef glTexSubImage2D
 
 // 1.1 function signatures
 using PFNGLBEGINPROC = void(APIENTRYP)(GLenum mode);
@@ -106,6 +108,9 @@ using PFNGLTEXIMAGE3DPROC = void(APIENTRYP)(
     GLenum type, const GLvoid* data);
 using PFNGLGETINTERGERVPROC = void(APIENTRYP)(GLenum pname, GLint* data);
 using PFNGLGETTEXIMAGEPROC = void(APIENTRYP)(GLenum target, GLint level, GLenum format, GLenum type, GLvoid* img);
+using PFNGLTEXSUBIMAGE2D = void(APIENTRYP)(
+    GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type,
+    const GLvoid* pixels);
 
     #define OPENGL_PROC(TYPE, PROC) extern TYPE PROC;
     #include "OpenGLAPIProc.h"

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLAPIProc.h
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLAPIProc.h
@@ -102,3 +102,4 @@ extern "C" void glDrawArraysInstanced(GLenum mode, GLint first, GLsizei count, G
 extern "C" void glVertexAttribDivisor(GLuint index, GLuint divisor);
 #endif
 OPENGL_PROC(PFNGLBLENDFUNCSEPARATEPROC, glBlendFuncSeparate)
+OPENGL_PROC(PFNGLTEXSUBIMAGE2D, glTexSubImage2D)

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -128,6 +128,11 @@ public:
 
     void FlushCommandBuffers();
 
+    bool IsActive() const
+    {
+        return _inDraw;
+    }
+
 private:
     void FlushLines();
     void FlushRectangles();
@@ -448,6 +453,11 @@ public:
 
     IDrawingContext* GetDrawingContext() override
     {
+        if (!_drawingContext->IsActive())
+        {
+            Guard::Fail("Drawing context is not active.");
+            return nullptr;
+        }
         return _drawingContext.get();
     }
 

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -275,8 +275,8 @@ public:
 
     void ConfigureDirtyGrid()
     {
-        const auto blockWidth = 1u << 7;
-        const auto blockHeight = 1u << 5;
+        const auto blockWidth = 1u << 8;
+        const auto blockHeight = 1u << 8;
 
         _invalidationGrid.reset(_width, _height, blockWidth, blockHeight);
     }

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -343,6 +343,11 @@ public:
 
     void PaintWindows() override
     {
+        WindowResetVisibilities();
+
+        // Redraw dirty regions before updating the viewports, otherwise
+        // when viewports get panned, they copy dirty pixels
+        DrawAllDirtyBlocks();
         WindowUpdateAllViewports();
         DrawAllDirtyBlocks();
     }
@@ -435,7 +440,7 @@ public:
 
     DrawingEngineFlags GetFlags() override
     {
-        return DrawingEngineFlag::dirtyOptimisations;
+        return {};
     }
 
     void InvalidateImage(uint32_t image) override

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -344,12 +344,18 @@ public:
     void PaintWindows() override
     {
         WindowResetVisibilities();
-
-        // Redraw dirty regions before updating the viewports, otherwise
-        // when viewports get panned, they copy dirty pixels
-        DrawAllDirtyBlocks();
         WindowUpdateAllViewports();
-        DrawAllDirtyBlocks();
+
+        if (ClimateIsRaining() || ClimateIsSnowing() || ClimateIsSnowingHeavily())
+        {
+            // OpenGL doesn't support restoring pixels, always redraw.
+            // TODO: Render the weather to a texture and use that instead.
+            WindowDrawAll(_bitsDPI, 0, 0, static_cast<int32_t>(_width), static_cast<int32_t>(_height));
+        }
+        else
+        {
+            DrawAllDirtyBlocks();
+        }
     }
 
     void DrawAllDirtyBlocks()

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -255,8 +255,11 @@ public:
         ConfigureBits(width, height, width);
         ConfigureCanvas();
         ConfigureDirtyGrid();
+
         _drawingContext->Resize(width, height);
+        _drawingContext->StartNewDraw();
         _drawingContext->Clear(_bitsDPI, PaletteIndex::pi10);
+        _drawingContext->FlushCommandBuffers();
     }
 
     void ConfigureDirtyGrid()

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -361,16 +361,20 @@ public:
     void PaintWindows() override
     {
         WindowResetVisibilities();
-        WindowUpdateAllViewports();
 
         if (ClimateIsRaining() || ClimateIsSnowing() || ClimateIsSnowingHeavily())
         {
+            WindowUpdateAllViewports();
             // OpenGL doesn't support restoring pixels, always redraw.
             // TODO: Render the weather to a texture and use that instead.
             WindowDrawAll(_bitsDPI, 0, 0, static_cast<int32_t>(_width), static_cast<int32_t>(_height));
         }
         else
         {
+            // Redraw dirty regions before updating the viewports, otherwise
+            // when viewports get panned, they copy dirty pixels
+            DrawAllDirtyBlocks();
+            WindowUpdateAllViewports();
             DrawAllDirtyBlocks();
         }
     }

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.cpp
@@ -150,4 +150,27 @@ GLuint OpenGLFramebuffer::CreateDepthTexture(int32_t width, int32_t height)
     return depth;
 }
 
+  void OpenGLFramebuffer::SetPixels(const DrawPixelInfo& dpi)
+{
+    assert(dpi.width == _width && dpi.height == _height);
+
+    auto pixels = std::make_unique<uint8_t[]>(_width * _height);
+    // Flip pixels vertically on copy
+    uint8_t* dst = pixels.get() + ((_height - 1) * _width);
+    uint8_t* src = dpi.bits;
+    for (int32_t y = 0; y < _height; y++)
+    {
+        std::copy_n(src, _width, dst);
+        src += dpi.width + dpi.pitch;
+        dst -= _width;
+    }
+
+    glBindTexture(GL_TEXTURE_2D, _texture);
+    CheckGLError();
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+    CheckGLError();
+    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, _width, _height, GL_RED_INTEGER, GL_UNSIGNED_BYTE, pixels.get());
+    CheckGLError();
+}
+
 #endif /* DISABLE_OPENGL */

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.cpp
@@ -150,7 +150,7 @@ GLuint OpenGLFramebuffer::CreateDepthTexture(int32_t width, int32_t height)
     return depth;
 }
 
-  void OpenGLFramebuffer::SetPixels(const DrawPixelInfo& dpi)
+void OpenGLFramebuffer::SetPixels(const DrawPixelInfo& dpi)
 {
     assert(dpi.width == _width && dpi.height == _height);
 

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.h
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.h
@@ -59,6 +59,7 @@ namespace OpenRCT2::Ui
         void SwapColourBuffer(OpenGLFramebuffer& other);
         GLuint SwapDepthTexture(GLuint depth);
         void Copy(OpenGLFramebuffer& src, GLenum filter);
+        void SetPixels(const DrawPixelInfo& dpi);
 
         static GLuint CreateDepthTexture(int32_t width, int32_t height);
     };

--- a/src/openrct2-ui/drawing/engines/opengl/SwapFramebuffer.h
+++ b/src/openrct2-ui/drawing/engines/opengl/SwapFramebuffer.h
@@ -39,6 +39,10 @@ namespace OpenRCT2::Ui
         {
             return _opaqueFramebuffer;
         }
+        OpenGLFramebuffer& GetFinalFramebuffer()
+        {
+            return _opaqueFramebuffer;
+        }
         GLuint GetBackDepthTexture() const
         {
             return _backDepth;

--- a/src/openrct2-ui/scripting/CustomImages.cpp
+++ b/src/openrct2-ui/scripting/CustomImages.cpp
@@ -452,8 +452,12 @@ namespace OpenRCT2::Scripting
             dpi.bits = new uint8_t[bufferSize];
             std::memset(dpi.bits, 0, bufferSize);
 
+            drawingEngine->BeginDraw();
+
             // Draw the original image if we are creating a new one
             GfxDrawSprite(dpi, ImageId(id), { 0, 0 });
+
+            drawingEngine->EndDraw();
         }
         else
         {

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -112,7 +112,7 @@ namespace OpenRCT2::Editor
         gameState.scenarioCategory = ScenarioCategory::other;
         ViewportInitAll();
         WindowBase* mainWindow = OpenEditorWindows();
-        mainWindow->SetLocation(TileCoordsXYZ{ 75, 75, 14 }.ToCoordsXYZ());
+        mainWindow->SetViewportLocation(TileCoordsXYZ{ 75, 75, 14 }.ToCoordsXYZ());
         LoadPalette();
         gScreenAge = 0;
         gameState.scenarioName = LanguageGetString(STR_MY_NEW_SCENARIO);
@@ -183,7 +183,7 @@ namespace OpenRCT2::Editor
         getGameState().editorStep = EditorStep::ObjectSelection;
         ViewportInitAll();
         WindowBase* mainWindow = OpenEditorWindows();
-        mainWindow->SetLocation(TileCoordsXYZ{ 75, 75, 14 }.ToCoordsXYZ());
+        mainWindow->SetViewportLocation(TileCoordsXYZ{ 75, 75, 14 }.ToCoordsXYZ());
         LoadPalette();
 
         GameLoadScripts();
@@ -211,7 +211,7 @@ namespace OpenRCT2::Editor
         getGameState().editorStep = EditorStep::ObjectSelection;
         ViewportInitAll();
         WindowBase* mainWindow = OpenEditorWindows();
-        mainWindow->SetLocation(TileCoordsXYZ{ 75, 75, 14 }.ToCoordsXYZ());
+        mainWindow->SetViewportLocation(TileCoordsXYZ{ 75, 75, 14 }.ToCoordsXYZ());
         LoadPalette();
 
         GameLoadScripts();

--- a/src/openrct2/drawing/InvalidationGrid.cpp
+++ b/src/openrct2/drawing/InvalidationGrid.cpp
@@ -1,0 +1,74 @@
+#include "InvalidationGrid.h"
+
+#include <algorithm>
+#include <cstring>
+
+namespace OpenRCT2::Drawing
+{
+    uint32_t InvalidationGrid::getRowCount() const noexcept
+    {
+        return _rowCount;
+    }
+
+    uint32_t InvalidationGrid::getColumnCount() const noexcept
+    {
+        return _columnCount;
+    }
+
+    uint32_t InvalidationGrid::getBlockWidth() const noexcept
+    {
+        return _blockWidth;
+    }
+
+    uint32_t InvalidationGrid::getBlockHeight() const noexcept
+    {
+        return _blockHeight;
+    }
+
+    void InvalidationGrid::reset(int32_t width, int32_t height, uint32_t blockWidth, uint32_t blockHeight) noexcept
+    {
+        _blockWidth = blockWidth;
+        _blockHeight = blockHeight;
+        _columnCount = (width / blockWidth) + 1;
+        _rowCount = (height / blockHeight) + 1;
+        _screenWidth = width;
+        _screenHeight = height;
+    }
+
+    void InvalidationGrid::invalidate(int32_t left, int32_t top, int32_t right, int32_t bottom) noexcept
+    {
+        left = std::max(left, 0);
+        top = std::max(top, 0);
+        right = std::min(right, static_cast<int32_t>(_screenWidth));
+        bottom = std::min(bottom, static_cast<int32_t>(_screenHeight));
+
+        if (left >= right)
+        {
+            return;
+        }
+        if (top >= bottom)
+        {
+            return;
+        }
+
+        left /= _blockWidth;
+        right /= _blockWidth;
+
+        top /= _blockHeight;
+        bottom /= _blockHeight;
+
+        // TODO: Remove this once _blocks is no longer interop wrapper.
+        auto& blocks = _blocks;
+
+        const auto columnSize = right - left + 1;
+
+        for (int16_t y = top; y <= bottom; y++)
+        {
+            const auto yOffset = y * _columnCount;
+
+            // Mark row by column size as invalidated.
+            std::memset(blocks + yOffset + left, 0xFF, columnSize);
+        }
+    }
+
+} // namespace OpenRCT2::Drawing

--- a/src/openrct2/drawing/InvalidationGrid.cpp
+++ b/src/openrct2/drawing/InvalidationGrid.cpp
@@ -33,6 +33,11 @@ namespace OpenRCT2::Drawing
         _rowCount = (height / blockHeight) + 1;
         _screenWidth = width;
         _screenHeight = height;
+
+        _blocks.resize(_columnCount * _rowCount);
+        _blocks.shrink_to_fit();
+
+        std::fill(_blocks.begin(), _blocks.end(), 0);
     }
 
     void InvalidationGrid::invalidate(int32_t left, int32_t top, int32_t right, int32_t bottom) noexcept
@@ -58,7 +63,7 @@ namespace OpenRCT2::Drawing
         bottom /= _blockHeight;
 
         // TODO: Remove this once _blocks is no longer interop wrapper.
-        auto& blocks = _blocks;
+        auto* blocks = _blocks.data();
 
         const auto columnSize = right - left + 1;
 

--- a/src/openrct2/drawing/InvalidationGrid.h
+++ b/src/openrct2/drawing/InvalidationGrid.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <limits>
 #include <vector>
 
 namespace OpenRCT2::Drawing
@@ -16,6 +17,12 @@ namespace OpenRCT2::Drawing
         std::vector<uint8_t> _blocks;
         uint32_t _screenWidth{};
         uint32_t _screenHeight{};
+
+        uint32_t _lowestRow{ std::numeric_limits<uint32_t>::max() };
+        uint32_t _highestRow{ 0 };
+
+        uint32_t _lowestColumn{ std::numeric_limits<uint32_t>::max() };
+        uint32_t _highestColumn{};
 
     public:
         uint32_t getRowCount() const noexcept;
@@ -33,53 +40,87 @@ namespace OpenRCT2::Drawing
         template<typename F>
         void traverseDirtyCells(F&& func)
         {
-            const auto columnCount = _columnCount;
-            const auto rowCount = _rowCount;
-            const auto blockWidth = _blockWidth;
-            const auto blockHeight = _blockHeight;
+            const uint32_t columnCount = _columnCount;
+            const uint32_t rowCount = _rowCount;
+            const uint32_t blockWidth = _blockWidth;
+            const uint32_t blockHeight = _blockHeight;
             auto& blocks = _blocks;
 
-            for (uint32_t column = 0; column < columnCount; column++)
+            const uint32_t startRow = rowCount ? std::clamp(_lowestRow, 0u, rowCount - 1) : 0;
+            const uint32_t endRow = rowCount ? std::clamp(_highestRow, 0u, rowCount - 1) : 0;
+            const uint32_t startCol = columnCount ? std::clamp(_lowestColumn, 0u, columnCount - 1) : 0;
+            const uint32_t endCol = columnCount ? std::clamp(_highestColumn, 0u, columnCount - 1) : 0;
+
+            for (uint32_t currentRow = startRow; currentRow <= endRow; ++currentRow)
             {
-                for (uint32_t row = 0; row < rowCount; row++)
+                for (uint32_t currentCol = startCol; currentCol <= endCol;)
                 {
-                    const auto rowStartOffset = row * columnCount;
-                    if (blocks[rowStartOffset + column] != 0)
+                    const uint32_t blockIndex = currentRow * columnCount + currentCol;
+
+                    if (blocks[blockIndex] == 0)
                     {
-                        uint32_t rowEndOffset = rowStartOffset;
-                        uint32_t numRowsDirty = 0;
+                        ++currentCol;
+                        continue;
+                    }
 
-                        // Count amount of dirty rows at current column.
-                        while (true)
+                    // Horizontal merge.
+                    uint32_t horizontalSpan = 1;
+                    while (currentCol + horizontalSpan < columnCount
+                           && blocks[currentRow * columnCount + currentCol + horizontalSpan] != 0)
+                    {
+                        ++horizontalSpan;
+                    }
+
+                    // Vertical merge.
+                    uint32_t mergedWidth = horizontalSpan;
+                    uint32_t verticalSpan = 0;
+                    for (uint32_t rowOffset = 1; currentRow + rowOffset <= endRow; ++rowOffset)
+                    {
+                        uint32_t validWidth = 0;
+                        while (validWidth < mergedWidth
+                               && blocks[(currentRow + rowOffset) * columnCount + currentCol + validWidth] != 0)
                         {
-                            if (row + numRowsDirty + 1 >= rowCount || blocks[rowEndOffset + column + columnCount] == 0)
-                            {
-                                break;
-                            }
-
-                            numRowsDirty++;
-                            rowEndOffset += columnCount;
+                            ++validWidth;
                         }
+                        if (validWidth == 0)
+                            break;
+                        mergedWidth = validWidth;
+                        ++verticalSpan;
+                    }
 
-                        // Clear rows at the current column.
-                        for (auto rowOffset = rowStartOffset; rowOffset <= rowEndOffset; rowOffset += columnCount)
+                    const uint32_t totalRows = verticalSpan + 1;
+
+                    // Clear blocks
+                    for (uint32_t y = currentRow; y < currentRow + totalRows; ++y)
+                    {
+                        for (uint32_t x = currentCol; x < currentCol + mergedWidth; ++x)
                         {
-                            blocks[rowOffset + column] = 0;
-                        }
-
-                        // Convert to pixel coordinates.
-                        const auto left = column * blockWidth;
-                        const auto top = row * blockHeight;
-                        const auto right = (column + 1) * blockWidth;
-                        const auto bottom = (row + numRowsDirty + 1) * blockHeight;
-
-                        if (left < _screenWidth && top < _screenHeight)
-                        {
-                            func(left, top, std::min(right, _screenWidth), std::min(bottom, _screenHeight));
+                            blocks[y * columnCount + x] = 0;
                         }
                     }
+
+                    const uint32_t coordLeft = currentCol * blockWidth;
+                    const uint32_t coordTop = currentRow * blockHeight;
+                    const uint32_t coordRight = (currentCol + mergedWidth) * blockWidth;
+                    const uint32_t coordBottom = (currentRow + totalRows) * blockHeight;
+
+                    const uint32_t clampedRight = std::min(coordRight, _screenWidth);
+                    const uint32_t clampedBottom = std::min(coordBottom, _screenHeight);
+
+                    if (coordLeft < _screenWidth && coordTop < _screenHeight)
+                    {
+                        func(coordLeft, coordTop, clampedRight, clampedBottom);
+                    }
+
+                    // Skip processed columns
+                    currentCol += mergedWidth;
                 }
             }
+
+            _lowestRow = std::numeric_limits<uint32_t>::max();
+            _highestRow = 0;
+            _lowestColumn = std::numeric_limits<uint32_t>::max();
+            _highestColumn = 0;
         }
     };
 

--- a/src/openrct2/drawing/InvalidationGrid.h
+++ b/src/openrct2/drawing/InvalidationGrid.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <vector>
 
 namespace OpenRCT2::Drawing
 {
@@ -12,7 +13,7 @@ namespace OpenRCT2::Drawing
         uint32_t _columnCount{};
         uint32_t _rowCount{};
 
-        uint8_t _blocks[7500]{};
+        std::vector<uint8_t> _blocks;
         uint32_t _screenWidth{};
         uint32_t _screenHeight{};
 

--- a/src/openrct2/drawing/InvalidationGrid.h
+++ b/src/openrct2/drawing/InvalidationGrid.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+namespace OpenRCT2::Drawing
+{
+    class InvalidationGrid
+    {
+        uint16_t _blockWidth{};
+        uint16_t _blockHeight{};
+        uint32_t _columnCount{};
+        uint32_t _rowCount{};
+
+        uint8_t _blocks[7500]{};
+        uint32_t _screenWidth{};
+        uint32_t _screenHeight{};
+
+    public:
+        uint32_t getRowCount() const noexcept;
+
+        uint32_t getColumnCount() const noexcept;
+
+        uint32_t getBlockWidth() const noexcept;
+
+        uint32_t getBlockHeight() const noexcept;
+
+        void reset(int32_t width, int32_t height, uint32_t blockWidth, uint32_t blockHeight) noexcept;
+
+        void invalidate(int32_t left, int32_t top, int32_t right, int32_t bottom) noexcept;
+
+        template<typename F>
+        void traverseDirtyCells(F&& func)
+        {
+            const auto columnCount = _columnCount;
+            const auto rowCount = _rowCount;
+            const auto blockWidth = _blockWidth;
+            const auto blockHeight = _blockHeight;
+            auto& blocks = _blocks;
+
+            for (uint32_t column = 0; column < columnCount; column++)
+            {
+                for (uint32_t row = 0; row < rowCount; row++)
+                {
+                    const auto rowStartOffset = row * columnCount;
+                    if (blocks[rowStartOffset + column] != 0)
+                    {
+                        uint32_t rowEndOffset = rowStartOffset;
+                        uint32_t numRowsDirty = 0;
+
+                        // Count amount of dirty rows at current column.
+                        while (true)
+                        {
+                            if (row + numRowsDirty + 1 >= rowCount || blocks[rowEndOffset + column + columnCount] == 0)
+                            {
+                                break;
+                            }
+
+                            numRowsDirty++;
+                            rowEndOffset += columnCount;
+                        }
+
+                        // Clear rows at the current column.
+                        for (auto rowOffset = rowStartOffset; rowOffset <= rowEndOffset; rowOffset += columnCount)
+                        {
+                            blocks[rowOffset + column] = 0;
+                        }
+
+                        // Convert to pixel coordinates.
+                        const auto left = column * blockWidth;
+                        const auto top = row * blockHeight;
+                        const auto right = (column + 1) * blockWidth;
+                        const auto bottom = (row + numRowsDirty + 1) * blockHeight;
+
+                        if (left < _screenWidth && top < _screenHeight)
+                        {
+                            func(left, top, std::min(right, _screenWidth), std::min(bottom, _screenHeight));
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+} // namespace OpenRCT2::Drawing

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -319,8 +319,7 @@ void X8DrawingEngine::ConfigureBits(uint32_t width, uint32_t height, uint32_t pi
     }
 }
 
-void X8DrawingEngine::OnDrawDirtyBlock(
-    [[maybe_unused]] uint32_t x, [[maybe_unused]] uint32_t y, [[maybe_unused]] uint32_t columns, [[maybe_unused]] uint32_t rows)
+void X8DrawingEngine::OnDrawDirtyBlock(int32_t, int32_t, int32_t, int32_t)
 {
 }
 
@@ -334,16 +333,16 @@ void X8DrawingEngine::ConfigureDirtyGrid()
 
 void X8DrawingEngine::DrawAllDirtyBlocks()
 {
-    _invalidationGrid.traverseDirtyCells(
-        [this](int32_t left, int32_t top, int32_t right, int32_t bottom) {
-            DrawDirtyBlocks(left, top, right, bottom);
-        });
+    _invalidationGrid.traverseDirtyCells([this](int32_t left, int32_t top, int32_t right, int32_t bottom) {
+        // Draw region
+        DrawDirtyBlocks(left, top, right, bottom);
+    });
 }
 
 void X8DrawingEngine::DrawDirtyBlocks(int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
     // Draw region
-    //OnDrawDirtyBlock(x, y, columns, rows);
+    OnDrawDirtyBlock(left, top, right, bottom);
     WindowDrawAll(_bitsDPI, left, top, right, bottom);
 }
 

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -129,7 +129,6 @@ X8DrawingEngine::X8DrawingEngine([[maybe_unused]] const std::shared_ptr<Ui::IUiC
 X8DrawingEngine::~X8DrawingEngine()
 {
     delete _drawingContext;
-    delete[] _dirtyGrid.Blocks;
     delete[] _bits;
 }
 

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -20,6 +20,7 @@
 #include "Drawing.h"
 #include "IDrawingContext.h"
 #include "IDrawingEngine.h"
+#include "InvalidationGrid.h"
 #include "LightFX.h"
 #include "Weather.h"
 
@@ -153,34 +154,7 @@ void X8DrawingEngine::SetVSync([[maybe_unused]] bool vsync)
 
 void X8DrawingEngine::Invalidate(int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
-    left = std::max(left, 0);
-    top = std::max(top, 0);
-    right = std::min(right, static_cast<int32_t>(_width));
-    bottom = std::min(bottom, static_cast<int32_t>(_height));
-
-    if (left >= right)
-        return;
-    if (top >= bottom)
-        return;
-
-    right--;
-    bottom--;
-
-    left >>= _dirtyGrid.BlockShiftX;
-    right >>= _dirtyGrid.BlockShiftX;
-    top >>= _dirtyGrid.BlockShiftY;
-    bottom >>= _dirtyGrid.BlockShiftY;
-
-    uint32_t dirtyBlockColumns = _dirtyGrid.BlockColumns;
-    uint8_t* screenDirtyBlocks = _dirtyGrid.Blocks;
-    for (int16_t y = top; y <= bottom; y++)
-    {
-        uint32_t yOffset = y * dirtyBlockColumns;
-        for (int16_t x = left; x <= right; x++)
-        {
-            screenDirtyBlocks[yOffset + x] = 0xFF;
-        }
-    }
+    _invalidationGrid.invalidate(left, top, right, bottom);
 }
 
 void X8DrawingEngine::BeginDraw()
@@ -352,103 +326,24 @@ void X8DrawingEngine::OnDrawDirtyBlock(
 
 void X8DrawingEngine::ConfigureDirtyGrid()
 {
-    _dirtyGrid.BlockShiftX = 7;
-    _dirtyGrid.BlockShiftY = 5; // Keep column at 32 (1 << 5)
-    _dirtyGrid.BlockWidth = 1 << _dirtyGrid.BlockShiftX;
-    _dirtyGrid.BlockHeight = 1 << _dirtyGrid.BlockShiftY;
-    _dirtyGrid.BlockColumns = (_width >> _dirtyGrid.BlockShiftX) + 1;
-    _dirtyGrid.BlockRows = (_height >> _dirtyGrid.BlockShiftY) + 1;
+    const auto blockWidth = 1u << 7;
+    const auto blockHeight = 1u << 5;
 
-    delete[] _dirtyGrid.Blocks;
-    _dirtyGrid.Blocks = new uint8_t[_dirtyGrid.BlockColumns * _dirtyGrid.BlockRows];
+    _invalidationGrid.reset(_width, _height, blockWidth, blockHeight);
 }
 
 void X8DrawingEngine::DrawAllDirtyBlocks()
 {
-    // TODO: For optimal performance it is currently limited to a single column.
-    // The optimal approach would be to extract all dirty regions as rectangles not including
-    // parts that are not marked dirty and have the grid more fine grained.
-    // A situation like following:
-    //
-    //   0 1 2 3 4 5 6 7 8 9
-    //   1 - - - - - - - - -
-    //   2 - x x x x - - - -
-    //   3 - x x - - - - - -
-    //   4 - - - - - - - - -
-    //   5 - - - - - - - - -
-    //   6 - - - - - - - - -
-    //   7 - - - - - - - - -
-    //   8 - - - - - - - - -
-    //   9 - - - - - - - - -
-    //
-    // Would currently redraw {2,2} to {3,5} where {3,4} and {3,5} are not dirty. Choosing to do this
-    // per column eliminates this issue but limits it to rendering just a single column at a time.
-
-    for (uint32_t x = 0; x < _dirtyGrid.BlockColumns; x++)
-    {
-        for (uint32_t y = 0; y < _dirtyGrid.BlockRows; y++)
-        {
-            uint32_t yOffset = y * _dirtyGrid.BlockColumns;
-            if (_dirtyGrid.Blocks[yOffset + x] == 0)
-            {
-                continue;
-            }
-
-            // See comment above as to why this is 1.
-            const uint32_t columns = 1;
-
-            // Check rows
-            auto rows = GetNumDirtyRows(x, y, columns);
-            DrawDirtyBlocks(x, y, columns, rows);
-        }
-    }
+    _invalidationGrid.traverseDirtyCells(
+        [this](int32_t left, int32_t top, int32_t right, int32_t bottom) {
+            DrawDirtyBlocks(left, top, right, bottom);
+        });
 }
 
-uint32_t X8DrawingEngine::GetNumDirtyRows(const uint32_t x, const uint32_t y, const uint32_t columns)
+void X8DrawingEngine::DrawDirtyBlocks(int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
-    uint32_t yy = y;
-
-    for (yy = y; yy < _dirtyGrid.BlockRows; yy++)
-    {
-        uint32_t yyOffset = yy * _dirtyGrid.BlockColumns;
-        for (uint32_t xx = x; xx < x + columns; xx++)
-        {
-            if (_dirtyGrid.Blocks[yyOffset + xx] == 0)
-            {
-                return yy - y;
-            }
-        }
-    }
-    return yy - y;
-}
-
-void X8DrawingEngine::DrawDirtyBlocks(uint32_t x, uint32_t y, uint32_t columns, uint32_t rows)
-{
-    uint32_t dirtyBlockColumns = _dirtyGrid.BlockColumns;
-    uint8_t* screenDirtyBlocks = _dirtyGrid.Blocks;
-
-    // Unset dirty blocks
-    for (uint32_t top = y; top < y + rows; top++)
-    {
-        uint32_t topOffset = top * dirtyBlockColumns;
-        for (uint32_t left = x; left < x + columns; left++)
-        {
-            screenDirtyBlocks[topOffset + left] = 0;
-        }
-    }
-
-    // Determine region in pixels
-    uint32_t left = std::max<uint32_t>(0, x * _dirtyGrid.BlockWidth);
-    uint32_t top = std::max<uint32_t>(0, y * _dirtyGrid.BlockHeight);
-    uint32_t right = std::min(_width, left + (columns * _dirtyGrid.BlockWidth));
-    uint32_t bottom = std::min(_height, top + (rows * _dirtyGrid.BlockHeight));
-    if (right <= left || bottom <= top)
-    {
-        return;
-    }
-
     // Draw region
-    OnDrawDirtyBlock(x, y, columns, rows);
+    //OnDrawDirtyBlock(x, y, columns, rows);
     WindowDrawAll(_bitsDPI, left, top, right, bottom);
 }
 

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -337,7 +337,7 @@ void X8DrawingEngine::OnDrawDirtyBlock(int32_t, int32_t, int32_t, int32_t)
 void X8DrawingEngine::ConfigureDirtyGrid()
 {
     const auto blockWidth = 1u << 7;
-    const auto blockHeight = 1u << 5;
+    const auto blockHeight = 1u << 7;
 
     _invalidationGrid.reset(_width, _height, blockWidth, blockHeight);
 }

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -132,10 +132,13 @@ namespace OpenRCT2
         {
         private:
             X8DrawingEngine* _engine = nullptr;
+            bool _isDrawing = false;
 
         public:
             explicit X8DrawingContext(X8DrawingEngine* engine);
 
+            void BeginDraw();
+            void EndDraw();
             void Clear(DrawPixelInfo& dpi, uint8_t paletteIndex) override;
             void FillRect(DrawPixelInfo& dpi, uint32_t colour, int32_t x, int32_t y, int32_t w, int32_t h) override;
             void FilterRect(
@@ -150,6 +153,11 @@ namespace OpenRCT2
             void DrawTTFBitmap(
                 DrawPixelInfo& dpi, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y,
                 uint8_t hintingThreshold) override;
+
+            bool IsActive() const noexcept
+            {
+                return _isDrawing;
+            }
         };
     } // namespace Drawing
 } // namespace OpenRCT2

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -26,17 +26,6 @@ namespace OpenRCT2
     {
         class X8DrawingContext;
 
-        struct DirtyGrid
-        {
-            uint32_t BlockShiftX;
-            uint32_t BlockShiftY;
-            uint32_t BlockWidth;
-            uint32_t BlockHeight;
-            uint32_t BlockColumns;
-            uint32_t BlockRows;
-            uint8_t* Blocks;
-        };
-
         class X8WeatherDrawer final : public IWeatherDrawer
         {
         private:
@@ -73,8 +62,6 @@ namespace OpenRCT2
             uint32_t _pitch = 0;
             size_t _bitsSize = 0;
             uint8_t* _bits = nullptr;
-
-            DirtyGrid _dirtyGrid = {};
 
             DrawPixelInfo _bitsDPI = {};
 

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -11,6 +11,7 @@
 
 #include "IDrawingContext.h"
 #include "IDrawingEngine.h"
+#include "InvalidationGrid.h"
 
 #include <memory>
 
@@ -81,6 +82,7 @@ namespace OpenRCT2
 
             X8WeatherDrawer _weatherDrawer;
             X8DrawingContext* _drawingContext;
+            InvalidationGrid _invalidationGrid;
 
         public:
             explicit X8DrawingEngine(const std::shared_ptr<Ui::IUiContext>& uiContext);
@@ -120,8 +122,7 @@ namespace OpenRCT2
         private:
             void ConfigureDirtyGrid();
             void DrawAllDirtyBlocks();
-            uint32_t GetNumDirtyRows(const uint32_t x, const uint32_t y, const uint32_t columns);
-            void DrawDirtyBlocks(uint32_t x, uint32_t y, uint32_t columns, uint32_t rows);
+            void DrawDirtyBlocks(int32_t left, int32_t top, int32_t right, int32_t bottom);
         };
 #ifdef __WARN_SUGGEST_FINAL_TYPES__
     #pragma GCC diagnostic pop

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -117,7 +117,7 @@ namespace OpenRCT2
 
         protected:
             void ConfigureBits(uint32_t width, uint32_t height, uint32_t pitch);
-            virtual void OnDrawDirtyBlock(uint32_t x, uint32_t y, uint32_t columns, uint32_t rows);
+            virtual void OnDrawDirtyBlock(int32_t left, int32_t top, int32_t right, int32_t bottom);
 
         private:
             void ConfigureDirtyGrid();

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -89,8 +89,16 @@ namespace OpenRCT2
             void SetPalette(const GamePalette& palette) override;
             void SetVSync(bool vsync) override;
             void Invalidate(int32_t left, int32_t top, int32_t right, int32_t bottom) override;
+#ifdef __WARN_SUGGEST_FINAL_METHODS__
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wsuggest-final-methods"
+    #pragma GCC diagnostic ignored "-Wsuggest-final-types"
+#endif
             void BeginDraw() override;
             void EndDraw() override;
+#ifdef __WARN_SUGGEST_FINAL_METHODS__
+    #pragma GCC diagnostic pop
+#endif
             void PaintWindows() override;
             void PaintWeather() override;
             void CopyRect(int32_t x, int32_t y, int32_t width, int32_t height, int32_t dx, int32_t dy) override;

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -916,7 +916,7 @@ static void ConsoleCommandSet(InteractiveConsole& console, const arguments_t& ar
             {
                 auto location = TileCoordsXYZ(int_val[0], int_val[1], 0).ToCoordsXYZ().ToTileCentre();
                 location.z = TileElementHeight(location);
-                w->SetLocation(location);
+                w->SetViewportLocation(location);
                 console.Execute("get location");
             }
         }

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -917,7 +917,6 @@ static void ConsoleCommandSet(InteractiveConsole& console, const arguments_t& ar
                 auto location = TileCoordsXYZ(int_val[0], int_val[1], 0).ToCoordsXYZ().ToTileCentre();
                 location.z = TileElementHeight(location);
                 w->SetLocation(location);
-                ViewportUpdatePosition(w);
                 console.Execute("get location");
             }
         }

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -316,8 +316,13 @@ static void RenderViewport(IDrawingEngine* drawingEngine, const Viewport& viewpo
         tempDrawingEngine = std::make_unique<X8DrawingEngine>(GetContext()->GetUiContext());
         drawingEngine = tempDrawingEngine.get();
     }
+
+    tempDrawingEngine->BeginDraw();
+
     dpi.DrawingEngine = drawingEngine;
     ViewportRender(dpi, &viewport);
+
+    tempDrawingEngine->EndDraw();
 }
 
 void ScreenshotGiant()

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -718,7 +718,7 @@ namespace OpenRCT2
 
             if (gLegacyScene != LegacyScene::titleSequence)
             {
-                int32_t height = (TileElementHeight({ sprite->x, sprite->y })) - 16;
+                int32_t height = TileElementHeight({ sprite->x, sprite->y }) - 16;
                 int32_t underground = sprite->z < height;
                 ViewportSetUndergroundFlag(underground, window, window->viewport);
             }

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -345,7 +345,15 @@ namespace OpenRCT2
                 || drawRect.GetTop() >= window->windowPos.y + window->height)
             {
                 auto itWindowPos = WindowGetIterator(window);
-                auto itNextWindow = itWindowPos != g_window_list.end() ? std::next(itWindowPos) : g_window_list.end();
+                // Get next valid window after.
+                auto itNextWindow = [&]() {
+                    auto itNext = std::next(itWindowPos);
+                    while (itNext != g_window_list.end() && (itNext->get()->flags & WF_DEAD))
+                    {
+                        ++itNext;
+                    }
+                    return itNext;
+                }();
                 ViewportRedrawAfterShift(
                     dpi, itNextWindow == g_window_list.end() ? nullptr : itNextWindow->get(), originalWindow, shift, drawRect);
                 return;
@@ -441,7 +449,7 @@ namespace OpenRCT2
         for (; it != g_window_list.end(); it++)
         {
             auto w = it->get();
-            if (!(w->flags & WF_TRANSPARENT))
+            if (!(w->flags & WF_TRANSPARENT) || (w->flags & WF_DEAD))
                 continue;
             if (w->viewport == viewport)
                 continue;
@@ -710,7 +718,7 @@ namespace OpenRCT2
 
             if (gLegacyScene != LegacyScene::titleSequence)
             {
-                int32_t height = (TileElementHeight({ sprite->x, sprite->y }))-16;
+                int32_t height = (TileElementHeight({ sprite->x, sprite->y })) - 16;
                 int32_t underground = sprite->z < height;
                 ViewportSetUndergroundFlag(underground, window, window->viewport);
             }

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -615,6 +615,10 @@ namespace OpenRCT2
      */
     void ViewportUpdatePosition(WindowBase* window)
     {
+        // Guard against any code attempting to call this at the wrong time.
+        Guard::Assert(
+            GetContext()->GetDrawingEngine()->GetDrawingContext() != nullptr, "We must be in a valid drawing context.");
+
         window->OnResize();
 
         Viewport* viewport = window->viewport;

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -526,6 +526,10 @@ namespace OpenRCT2
                 WindowDrawAll(dpi, left, top, right, bottom);
                 return;
             }
+            else
+            {
+                GfxInvalidateScreen();
+            }
         }
 
         Viewport view_copy = *viewport;
@@ -572,6 +576,10 @@ namespace OpenRCT2
         {
             DrawPixelInfo& dpi = DrawingEngineGetDpi();
             ViewportShiftPixels(dpi, w, viewport, x_diff, y_diff);
+        }
+        else
+        {
+            GfxInvalidateScreen();
         }
 
         *viewport = view_copy;

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -326,6 +326,9 @@ static constexpr float kWindowScrollLocations[][2] = {
                     auto it = WindowGetIterator(&w);
                     for (; it != g_window_list.end(); it++)
                     {
+                        if ((*it)->flags & WF_DEAD)
+                            continue;
+
                         auto w2 = (*it).get();
                         auto x1 = w2->windowPos.x - 10;
                         auto y1 = w2->windowPos.y - 10;
@@ -498,11 +501,13 @@ static constexpr float kWindowScrollLocations[][2] = {
         {
             // Check if this window overlaps w
             auto topwindow = it->get();
+            if (topwindow->flags & WF_TRANSPARENT)
+                continue;
+            if (topwindow->flags & WF_DEAD)
+                continue;
             if (topwindow->windowPos.x >= right || topwindow->windowPos.y >= bottom)
                 continue;
             if (topwindow->windowPos.x + topwindow->width <= left || topwindow->windowPos.y + topwindow->height <= top)
-                continue;
-            if (topwindow->flags & WF_TRANSPARENT)
                 continue;
 
             // A window overlaps w, split up the draw into two regions where the window starts to overlap

--- a/src/openrct2/interface/WindowBase.cpp
+++ b/src/openrct2/interface/WindowBase.cpp
@@ -8,7 +8,7 @@
 
 namespace OpenRCT2
 {
-    void WindowBase::SetLocation(const CoordsXYZ& coords)
+    void WindowBase::SetViewportLocation(const CoordsXYZ& coords)
     {
         WindowScrollToLocation(*this, coords);
         flags &= ~WF_SCROLLING_TO_LOCATION;

--- a/src/openrct2/interface/WindowBase.cpp
+++ b/src/openrct2/interface/WindowBase.cpp
@@ -12,6 +12,12 @@ namespace OpenRCT2
     {
         WindowScrollToLocation(*this, coords);
         flags &= ~WF_SCROLLING_TO_LOCATION;
+
+        // Immediately update the viewport position since we are not scrolling.
+        if (viewport != nullptr)
+        {
+            viewport->viewPos = savedViewPos;
+        }
     }
 
     void WindowBase::Invalidate()

--- a/src/openrct2/interface/WindowBase.cpp
+++ b/src/openrct2/interface/WindowBase.cpp
@@ -18,6 +18,8 @@ namespace OpenRCT2
         {
             viewport->viewPos = savedViewPos;
         }
+
+        Invalidate();
     }
 
     void WindowBase::Invalidate()

--- a/src/openrct2/interface/WindowBase.h
+++ b/src/openrct2/interface/WindowBase.h
@@ -109,7 +109,7 @@ namespace OpenRCT2
         VisibilityCache visibility{};
         EntityId viewport_smart_follow_sprite{ EntityId::GetNull() }; // Handles setting viewport target sprite etc
 
-        void SetLocation(const CoordsXYZ& coords);
+        void SetViewportLocation(const CoordsXYZ& coords);
         void Invalidate();
         void RemoveViewport();
         void SetWidgets(const std::span<const Widget> newWidgets);

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -249,6 +249,7 @@
     <ClInclude Include="drawing\Image.h" />
     <ClInclude Include="drawing\ImageId.hpp" />
     <ClInclude Include="drawing\ImageImporter.h" />
+    <ClInclude Include="drawing\InvalidationGrid.h" />
     <ClInclude Include="drawing\LightFX.h" />
     <ClInclude Include="drawing\NewDrawing.h" />
     <ClInclude Include="drawing\ScrollingText.h" />
@@ -805,6 +806,7 @@
     <ClCompile Include="drawing\Font.cpp" />
     <ClCompile Include="drawing\Image.cpp" />
     <ClCompile Include="drawing\ImageImporter.cpp" />
+    <ClCompile Include="drawing\InvalidationGrid.cpp" />
     <ClCompile Include="drawing\LightFX.cpp" />
     <ClCompile Include="drawing\Line.cpp" />
     <ClCompile Include="drawing\NewDrawing.cpp" />

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -103,43 +103,6 @@ static void PaintSessionAddPSToQuadrant(PaintSession& session, PaintStruct* ps)
     session.QuadrantFrontIndex = std::max(session.QuadrantFrontIndex, paintQuadrantIndex);
 }
 
-static constexpr bool ImageWithinDPI(const ScreenCoordsXY& imagePos, const G1Element& g1, const DrawPixelInfo& dpi)
-{
-    int32_t left = imagePos.x + g1.x_offset;
-    int32_t bottom = imagePos.y + g1.y_offset;
-
-    int32_t right = left + g1.width;
-    int32_t top = bottom + g1.height;
-
-    // mber: It is possible to use only the bottom else block here if you change <= and >= to simply < and >.
-    // However, since this is used to cull paint structs, I'd prefer to keep the condition strict and calculate
-    // the culling differently for minifying and magnifying.
-    auto zoom = dpi.zoom_level;
-    if (zoom > ZoomLevel{ 0 })
-    {
-        if (right <= dpi.WorldX())
-            return false;
-        if (top <= dpi.WorldY())
-            return false;
-        if (left >= dpi.WorldX() + dpi.WorldWidth())
-            return false;
-        if (bottom >= dpi.WorldY() + dpi.WorldHeight())
-            return false;
-    }
-    else
-    {
-        if (zoom.ApplyInversedTo(right) <= dpi.x)
-            return false;
-        if (zoom.ApplyInversedTo(top) <= dpi.y)
-            return false;
-        if (zoom.ApplyInversedTo(left) >= dpi.x + dpi.width)
-            return false;
-        if (zoom.ApplyInversedTo(bottom) >= dpi.y + dpi.height)
-            return false;
-    }
-    return true;
-}
-
 static constexpr CoordsXYZ RotateBoundBoxSize(const CoordsXYZ& bbSize, const uint8_t rotation)
 {
     auto output = bbSize;
@@ -183,12 +146,6 @@ static PaintStruct* CreateNormalPaintStruct(
     swappedRotCoord += session.SpritePosition;
 
     const auto imagePos = Translate3DTo2DWithZ(session.CurrentRotation, swappedRotCoord);
-
-    if (!ImageWithinDPI(imagePos, *g1, session.DPI))
-    {
-        return nullptr;
-    }
-
     const auto rotBoundBoxOffset = CoordsXYZ{ boundBox.offset.Rotate(swappedRotation), boundBox.offset.z };
     const auto rotBoundBoxSize = RotateBoundBoxSize(boundBox.length, session.CurrentRotation);
 
@@ -231,12 +188,6 @@ static PaintStruct* CreateNormalPaintStructHeight(
     swappedRotCoord += session.SpritePosition;
 
     const auto imagePos = Translate3DTo2DWithZ(session.CurrentRotation, swappedRotCoord);
-
-    if (!ImageWithinDPI(imagePos, *g1, session.DPI))
-    {
-        return nullptr;
-    }
-
     const auto rotBoundBoxOffset = CoordsXYZ{ boundBox.offset.Rotate(swappedRotation), boundBox.offset.z + height };
     const auto rotBoundBoxSize = RotateBoundBoxSize(boundBox.length, session.CurrentRotation);
 

--- a/src/openrct2/park/ParkPreview.cpp
+++ b/src/openrct2/park/ParkPreview.cpp
@@ -222,6 +222,8 @@ namespace OpenRCT2
         if (!drawingEngine)
             return std::nullopt;
 
+        drawingEngine->BeginDraw();
+
         DrawPixelInfo dpi{
             .bits = static_cast<uint8_t*>(image.pixels),
             .x = 0,
@@ -234,6 +236,8 @@ namespace OpenRCT2
         };
 
         ViewportRender(dpi, &saveVp);
+
+        drawingEngine->EndDraw();
 
         return image;
     }

--- a/src/openrct2/scenes/title/Command/SetLocation.cpp
+++ b/src/openrct2/scenes/title/Command/SetLocation.cpp
@@ -31,7 +31,7 @@ namespace OpenRCT2::Title
             w->SetLocation({ loc, z });
             gLegacyScene = oldLegacyScene;
 
-            ViewportUpdatePosition(w);
+            //ViewportUpdatePosition(w);
         }
 
         return 0;

--- a/src/openrct2/scenes/title/Command/SetLocation.cpp
+++ b/src/openrct2/scenes/title/Command/SetLocation.cpp
@@ -28,7 +28,7 @@ namespace OpenRCT2::Title
             // Prevent scroll adjustment due to window placement when in-game
             auto oldLegacyScene = gLegacyScene;
             gLegacyScene = LegacyScene::titleSequence;
-            w->SetLocation({ loc, z });
+            w->SetViewportLocation({ loc, z });
             gLegacyScene = oldLegacyScene;
         }
 

--- a/src/openrct2/scenes/title/Command/SetLocation.cpp
+++ b/src/openrct2/scenes/title/Command/SetLocation.cpp
@@ -30,8 +30,6 @@ namespace OpenRCT2::Title
             gLegacyScene = LegacyScene::titleSequence;
             w->SetLocation({ loc, z });
             gLegacyScene = oldLegacyScene;
-
-            //ViewportUpdatePosition(w);
         }
 
         return 0;


### PR DESCRIPTION
There are some minor quirks remaining, the rain is currently not drawing correctly and sometimes when panning a few stray pixels will appear from the toolbar somehow. Other than that its mostly fine for testing, this dramatically increases the performance on large parks where nothing is really going on.
Here is an example:
develop:
![openrct2_2023-07-04_20-33-35c660add360c7647d9](https://github.com/OpenRCT2/OpenRCT2/assets/5415177/f07d4f4d-5e26-45ef-a0d2-8414c0d8e828)
PR:
![openrct2_2023-07-04_20-33-52dc4401a9d2488f7b4](https://github.com/OpenRCT2/OpenRCT2/assets/5415177/f0270d39-9e8c-4ac0-aa20-f7673d27ccf2)

I'll have it in draft until I fix the remaining things, there might be other broken things so this is a good opportunity to start testing early.