### PR TITLE
Fix #20081: Mine Train Diagonal Piece Drawing Incorrectly

### DIFF
--- a/src/openrct2/ride/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/ride/coaster/MineTrainCoaster.cpp
@@ -5556,7 +5556,7 @@ static void MineTrainRCTrackDiagFlatTo25DegUp(
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
         case 2:
-            if (direction == 0)
+            if (direction == 2)
             {
                 ImageIndex imageIndex = trackElement.HasChain() ? 20392 : 20364;
                 PaintAddImageAsParent(


### PR DESCRIPTION
Fix #20081

A minor mistake in the recent refactor caused the Mine Train Coaster's DiagFlatTo25Up piece to draw incorrectly.