### PR TITLE
Fix #20121: Guard against nullptr on viewport scroll

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1646,7 +1646,12 @@ bool InputTestPlaceObjectModifier(PLACE_OBJECT_MODIFIER modifier)
 void InputScrollViewport(const ScreenCoordsXY& scrollScreenCoords)
 {
     WindowBase* mainWindow = WindowGetMain();
+    if (mainWindow == nullptr)
+        return;
+
     Viewport* viewport = mainWindow->viewport;
+    if (viewport == nullptr)
+        return;
 
     const int32_t speed = gConfigGeneral.EdgeScrollingSpeed;
 


### PR DESCRIPTION
Not exactly sure how to trigger this crash, crash dump analysis however shows that WindowGetMain() returned null for some reason. This will prevent the crash at least.

Closes #20121