### PR TITLE
Fix #20134: Don't update grass length outside of the actual map

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -44,6 +44,7 @@
 - Fix: [#20033] Asset packs cannot reference game data.
 - Fix: [#20104] [Plugin] Some network APIs use player index and group index.
 - Fix: [#20099] Some scrollbar is glitched or have incorrect size when open window for the first time
+- Fix: [#20134] Grass length being updated for tiles in the void, causing unneccesary drawing operations.
 
 0.4.4 (2023-03-28)
 ------------------------------------------------------------------------

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "19"
+#define NETWORK_STREAM_VERSION "20"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1348,7 +1348,6 @@ void MapUpdateTiles()
         }
 
         gGrassSceneryTileLoopPosition++;
-        gGrassSceneryTileLoopPosition &= 0xFFFF;
     }
 }
 

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1335,6 +1335,9 @@ void MapUpdateTiles()
             for (int32_t blockX = 0; blockX < gMapSize.x; blockX += 256)
             {
                 auto mapPos = TileCoordsXY{ blockX + x, blockY + y }.ToCoordsXY();
+                if (MapIsEdge(mapPos))
+                    continue;
+
                 auto* surfaceElement = MapGetSurfaceElementAt(mapPos);
                 if (surfaceElement != nullptr)
                 {


### PR DESCRIPTION
Closes #20134