### PR TITLE
Fix compatibility with GCC 13.1

### DIFF
--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -74,10 +74,9 @@ public:
             throw std::runtime_error("Unable to open " + path);
         }
         auto length = fs.tellg();
-        char* buffer = new char[length];
-        fs.read(buffer, length);
-        auto result = std::string(buffer, buffer + length);
-        delete[] buffer;
+        std::unique_ptr<char[]> buffer = std::make_unique<char[]>(length);
+        fs.read(buffer.get(), length);
+        auto result = std::string(buffer.get(), buffer.get() + length);
         return result;
     }
 

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -73,7 +73,12 @@ public:
         {
             throw std::runtime_error("Unable to open " + path);
         }
-        return std::string((std::istreambuf_iterator<char>(fs)), std::istreambuf_iterator<char>());
+        auto length = fs.tellg();
+        char* buffer = new char[length];
+        fs.read(buffer, length);
+        auto result = std::string(buffer, buffer + length);
+        delete[] buffer;
+        return result;
     }
 
     /**

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -73,7 +73,9 @@ public:
         {
             throw std::runtime_error("Unable to open " + path);
         }
-        auto length = fs.end - fs.beg;
+        fs.seekg(0, fs.end);
+        auto length = fs.tellg();
+        fs.seekg(0, fs.beg);
         std::unique_ptr<char[]> buffer = std::make_unique<char[]>(length);
         fs.read(buffer.get(), length);
         auto result = std::string(buffer.get(), buffer.get() + length);

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -73,7 +73,7 @@ public:
         {
             throw std::runtime_error("Unable to open " + path);
         }
-        auto length = fs.tellg();
+        auto length = fs.end - fs.beg;
         std::unique_ptr<char[]> buffer = std::make_unique<char[]>(length);
         fs.read(buffer.get(), length);
         auto result = std::string(buffer.get(), buffer.get() + length);


### PR DESCRIPTION
I've done a test with the recently released GCC 13.1 and it complained about potential null dereference in one of the internal functions from streambuf_iterator. Possibly a bug with GCC itself, but don't have the time to report it upstream currently, so let's have this workaround for a rarely used function.