### PR TITLE
Make Reverser Turntable and Transfer pieces compatible with all vehic…

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.6 (in development)
 ------------------------------------------------------------------------
 - Feature: [OpenMusic#41] Official Title Theme by Allister Brimble.
+- Feature: [#20149] Make Reverser Turntable and Transfer pieces compatible with all vehicle types.
 - Improved: [#20200] Allow audio files to play to up to 44100hz sample rate (from 22050hz).
 - Change: [#20110] Fix a few RCT1 build height parity discrepancies.
 - Fix: [#19823] Parkobj, disallow overriding objects of different object types.

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7636,8 +7636,7 @@ Loc6DAEB9:
     {
         if (track_progress == 80)
         {
-            vehicle_type ^= 1;
-            carEntry = Entry();
+            Flags ^= VehicleFlags::CarIsReversed;
         }
         if (_vehicleVelocityF64E08 >= 0x40000)
         {
@@ -7713,8 +7712,7 @@ Loc6DAEB9:
         {
             if (track_progress == 32)
             {
-                vehicle_type = carEntry->ReversedCarIndex;
-                carEntry = Entry();
+                Flags ^= VehicleFlags::CarIsReversed;
             }
         }
         else


### PR DESCRIPTION
More follow up for reversed trains.

This change makes all ride vehicles compatible with the log flume turntable and heartline transfer pieces, by integrating it with the new vehicle reversal system. 

This makes the special vehicle subtypes on these rides obsolete. Eliminating those could help save some sprite data. I currently haven't touched these, but will look into replacing them in save file import / inventions list - not sure if that should be done in this PR or saved for one more follow up.

This also makes the ReversedCarIndex obsolete, as well as the logFlumeReverserVehicleType_get() plugin API function. Not sure how best to handle these, if they should be marked obsolete or just removed.

![](https://user-images.githubusercontent.com/8711258/236703804-add280ec-9bd2-447e-bd4b-5e3706df2323.gif)
