### PR TITLE
Fix #20111: All coaster types can access the new diagonal slope pieces

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Improved: [#20200] Allow audio files to play to up to 44100hz sample rate (from 22050hz).
 - Change: [#20110] Fix a few RCT1 build height parity discrepancies.
 - Fix: [#19823] Parkobj, disallow overriding objects of different object types.
+- Fix: [#20111] All coaster types can access the new diagonal slope pieces.
 - Fix: [#20155] Fairground organ style 2 shows up as regular song, rather than for the merry-go-round.
 
 0.4.5 (2023-05-08)

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -390,6 +390,18 @@ public:
                     | (1uLL << WIDX_LEVEL) | (1uLL << WIDX_SLOPE_UP) | (1uLL << WIDX_SLOPE_UP_STEEP);
             }
         }
+        // If ride type does not have access to diagonal sloped turns, disallow simultaneous use of banked and sloped diagonals
+        if (!IsTrackEnabled(TRACK_SLOPE_CURVE_LARGE) && TrackPieceDirectionIsDiagonal(_currentTrackPieceDirection))
+        {
+            if (_currentTrackSlopeEnd != TRACK_SLOPE_NONE)
+            {
+                disabledWidgets |= (1uLL << WIDX_BANK_LEFT) | (1uLL << WIDX_BANK_RIGHT);
+            }
+            else if (_currentTrackBankEnd != TRACK_BANK_NONE)
+            {
+                disabledWidgets |= (1uLL << WIDX_SLOPE_DOWN) | (1uLL << WIDX_SLOPE_UP);
+            }
+        }
         if (currentRide->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_UP_INCLINE_REQUIRES_LIFT)
             && !gCheatsEnableAllDrawableTrackPieces)
         {


### PR DESCRIPTION
Fix #20111

~This might warrant a changelog entry, as you've always been able to select banked sloped diagonals, there just wasn't an actual track piece previously.~