### PR TITLE
Update all backtrace commits in body

### DIFF
--- a/.github/workflows/backtrace-commit-fix.yml
+++ b/.github/workflows/backtrace-commit-fix.yml
@@ -17,7 +17,7 @@ jobs:
           BODY: ${{ github.event.issue.body }}
         id: fix
         run: |
-          changed_body=$(echo "$BODY" | sed '/<strong>commit<\/strong>/,/<\/li>/ s/<code>\([0-9a-f]\{7,\}\)<\/code>/\1/')
+          changed_body=$(echo "$BODY" | sed '/<strong>commit<\/strong>/,/<\/ul>/ s/<code>\([0-9a-f]\{7,\}\)<\/code>/\1/g')
           if [[ "$changed_body" == "$BODY" ]]; then
             echo "Unable to match the Backtrace report format."
             exit 1


### PR DESCRIPTION
Since backtrace reports can now have multiple commits in the same report, the script that makes these commits into links had to be updated. Instead of looking for the first </li>, it searches until </ul> and replaces all occurrences of <code>hash</code> within these bounds.

I've tested this change with an [actual report](https://github.com/OpenRCT2/OpenRCT2/issues/20163) to see:

![image](https://user-images.githubusercontent.com/9705046/236933520-ff71e5b5-9ad2-4427-905e-cd25409b9cd2.png)
