### PR TITLE
Extra difficulty option for scenarios

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3696,6 +3696,10 @@ STR_6590    :Show the window buttons (e.g. to close the window) on the left of t
 STR_6591    :Staff member is currently fixing a ride and can’t be fired.
 STR_6592    :Staff member is currently inspecting a ride and can’t be fired.
 
+STR_6593    :Stricter park requirements
+STR_6594    :Adds anti-cheesing requirements for guest generation, park value, etc.
+
+
 #############
 # Scenarios #
 ################

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Fix: [#20111] All coaster types can access the new diagonal slope pieces.
 - Fix: [#20155] Fairground organ style 2 shows up as regular music, rather than for the merry-go-round.
 - Fix: [#20260] Ride locks up when inspecting/fixing staff member is fired.
+- Fix: [#20262] Title screen music missing when “random” title music is selected and RCT1 is no longer linked.
 
 0.4.5 (2023-05-08)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -36,7 +36,7 @@ static constexpr const int32_t WW_GUESTS = 380;
 static constexpr const int32_t WH_GUESTS = 149;
 
 static constexpr const int32_t WW_PARK = 400;
-static constexpr const int32_t WH_PARK = 200;
+static constexpr const int32_t WH_PARK = 217;
 
 #pragma region Widgets
 
@@ -116,7 +116,8 @@ enum {
     WIDX_FORBID_LANDSCAPE_CHANGES,
     WIDX_FORBID_HIGH_CONSTRUCTION,
     WIDX_HARD_PARK_RATING,
-    WIDX_HARD_GUEST_GENERATION
+    WIDX_HARD_GUEST_GENERATION,
+    WIDX_STRICT_DIFFICULTY 
 };
 
 static Widget window_editor_scenario_options_financial_widgets[] = {
@@ -168,6 +169,8 @@ static Widget window_editor_scenario_options_park_widgets[] = {
     MakeWidget        ({  8, 150}, {WW_PARK - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_FORBID_HIGH_CONSTRUCTION, STR_FORBID_HIGH_CONSTRUCTION_TIP  ),
     MakeWidget        ({  8, 167}, {WW_PARK - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_HARD_PARK_RATING,         STR_HARD_PARK_RATING_TIP          ),
     MakeWidget        ({  8, 184}, {WW_PARK - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_HARD_GUEST_GENERATION,    STR_HARD_GUEST_GENERATION_TIP     ),
+    MakeWidget        ({  8, 201}, {WW_PARK - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_STRICT_DIFFICULTY,    STR_STRICT_DIFFICULTY_TIP     ),
+ 
     WIDGETS_END,
 };
 
@@ -969,12 +972,20 @@ private:
                 Invalidate();
                 break;
             }
+            case WIDX_STRICT_DIFFICULTY:
+            {
+                auto scenarioSetSetting = ScenarioSetSettingAction(
+                    ScenarioSetSetting::GuestStrictDifficulty, gParkFlags & PARK_FLAGS_STRICT_DIFFICULTY ? 0 : 1);
+                GameActions::Execute(&scenarioSetSetting);
+                Invalidate();
+                break;
+            }
         }
     }
 
     void ParkResize()
     {
-        WindowSetResize(*this, 400, 200, 400, 200);
+        WindowSetResize(*this, 400, 217, 400, 217);
     }
 
     void ParkMouseDown(WidgetIndex widgetIndex)
@@ -1169,6 +1180,7 @@ private:
         SetWidgetPressed(WIDX_FORBID_HIGH_CONSTRUCTION, gParkFlags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION);
         SetWidgetPressed(WIDX_HARD_PARK_RATING, gParkFlags & PARK_FLAGS_DIFFICULT_PARK_RATING);
         SetWidgetPressed(WIDX_HARD_GUEST_GENERATION, gParkFlags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION);
+        SetWidgetPressed(WIDX_STRICT_DIFFICULTY, gParkFlags & PARK_FLAGS_STRICT_DIFFICULTY);
 
         widgets[WIDX_CLOSE].type = (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) ? WindowWidgetType::Empty
                                                                                  : WindowWidgetType::CloseBox;

--- a/src/openrct2/actions/ScenarioSetSettingAction.cpp
+++ b/src/openrct2/actions/ScenarioSetSettingAction.cpp
@@ -258,6 +258,18 @@ GameActions::Result ScenarioSetSettingAction::Execute() const
             }
             break;
         }
+        case ScenarioSetSetting::GuestStrictDifficulty:
+        {
+            if (_value != 0)
+            {
+                gParkFlags |= PARK_FLAGS_STRICT_DIFFICULTY;
+            }
+            else
+            {
+                gParkFlags &= ~PARK_FLAGS_STRICT_DIFFICULTY;
+            }
+            break;
+        }
         default:
             LOG_ERROR("Invalid setting: %u", _setting);
             return GameActions::Result(GameActions::Status::InvalidParameters, STR_NONE, STR_NONE);

--- a/src/openrct2/actions/ScenarioSetSettingAction.h
+++ b/src/openrct2/actions/ScenarioSetSettingAction.h
@@ -36,6 +36,7 @@ enum class ScenarioSetSetting : uint8_t
     GuestGenerationHigherDifficultyLevel,
     AllowEarlyCompletion,
     UseRCT1Interest,
+    GuestStrictDifficulty,
     Count
 };
 

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -269,34 +269,44 @@ namespace OpenRCT2::Audio
         }
     }
 
-    static ObjectEntryDescriptor GetTitleMusicDescriptor()
+    static bool IsRCT1TitleMusicAvailable()
     {
-        static constexpr std::array selectableAudioIds{
-            AudioObjectIdentifiers::OpenRCT2Title,
-            AudioObjectIdentifiers::RCT1Title,
-            AudioObjectIdentifiers::RCT2Title,
+        auto env = GetContext()->GetPlatformEnvironment();
+        auto rct1path = env->GetDirectoryPath(DIRBASE::RCT1);
+        return !rct1path.empty();
+    }
+
+    static std::map<TitleMusicKind, std::string_view> GetAvailableMusicMap()
+    {
+        auto musicMap = std::map<TitleMusicKind, std::string_view>{
+            { TitleMusicKind::OpenRCT2, AudioObjectIdentifiers::OpenRCT2Title },
+            { TitleMusicKind::RCT2, AudioObjectIdentifiers::RCT2Title },
         };
-        int32_t IdIndex{};
-        switch (gConfigSound.TitleMusic)
+
+        if (IsRCT1TitleMusicAvailable())
         {
-            default:
-            case TitleMusicKind::OpenRCT2:
-                IdIndex = 0;
-                break;
-            case TitleMusicKind::RCT1:
-                IdIndex = 1;
-                break;
-            case TitleMusicKind::RCT2:
-                IdIndex = 2;
-                break;
-            case TitleMusicKind::Random:
-                IdIndex = UtilRand() % std::size(selectableAudioIds);
-                break;
-            case TitleMusicKind::None:
-                return {};
+            musicMap.emplace(TitleMusicKind::RCT1, AudioObjectIdentifiers::RCT1Title);
         }
 
-        return ObjectEntryDescriptor(ObjectType::Audio, selectableAudioIds[IdIndex]);
+        return musicMap;
+    }
+
+    static ObjectEntryDescriptor GetTitleMusicDescriptor(TitleMusicKind musicKind)
+    {
+        auto musicMap = GetAvailableMusicMap();
+        auto it = musicMap.find(musicKind);
+        if (musicKind == TitleMusicKind::Random)
+        {
+            it = std::next(musicMap.begin(), UtilRand() % musicMap.size());
+        }
+
+        if (it != musicMap.end())
+        {
+            return ObjectEntryDescriptor(ObjectType::Audio, it->second);
+        }
+
+        // No music descriptor for the current setting, intentional for TitleMusicKind::None
+        return {};
     }
 
     void PlayTitleMusic()
@@ -313,7 +323,7 @@ namespace OpenRCT2::Audio
         }
 
         // Load title sequence audio object
-        auto descriptor = GetTitleMusicDescriptor();
+        auto descriptor = GetTitleMusicDescriptor(gConfigSound.TitleMusic);
         auto& objManager = GetContext()->GetObjectManager();
         auto* audioObject = static_cast<AudioObject*>(objManager.LoadObject(descriptor));
         if (audioObject != nullptr)

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -832,6 +832,12 @@ void Peep::UpdateFalling()
         {
             // Remove peep if it has gone to the void
             Remove();
+
+            // Strict Difficulty scenario option treats voided guests like casualties.
+            if (gParkFlags & PARK_FLAGS_STRICT_DIFFICULTY)
+            {
+                gParkRatingCasualtyPenalty = std::min(gParkRatingCasualtyPenalty + 25, 1000);
+            }
             return;
         }
         MoveTo({ x, y, z - 2 });

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -41,6 +41,7 @@
 #include "../windows/Intent.h"
 #include "../world/Entrance.h"
 #include "../world/Footpath.h"
+#include "../world/Park.h"
 #include "../world/Scenery.h"
 #include "../world/Surface.h"
 #include "PatrolArea.h"
@@ -913,7 +914,11 @@ void Staff::EntertainerUpdateNearbyPeeps() const
         }
         else if (guest->State == PeepState::Queuing)
         {
-            guest->TimeInQueue = std::max(0, guest->TimeInQueue - 200);
+            // Strict Difficulty will make guests eventually leave queue lines if they stay
+            // in them long enough, even with entertainers, so TimeInQueue shouldn't be
+            // decreased in this case.
+            if (!(gParkFlags & PARK_FLAGS_STRICT_DIFFICULTY))
+                guest->TimeInQueue = std::max(0, guest->TimeInQueue - 200);
             guest->HappinessTarget = std::min(guest->HappinessTarget + 3, PEEP_MAX_HAPPINESS);
         }
     }

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -649,6 +649,10 @@ static int32_t ConsoleCommandGet(InteractiveConsole& console, const arguments_t&
         {
             console.WriteFormatLine("difficult_guest_generation %d", (gParkFlags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION) != 0);
         }
+        else if (argv[0] == "strict_difficulty")
+        {
+            console.WriteFormatLine("strict_difficulty %d", (gParkFlags & PARK_FLAGS_STRICT_DIFFICULTY) != 0);
+        }
         else if (argv[0] == "park_open")
         {
             console.WriteFormatLine("park_open %d", (gParkFlags & PARK_FLAGS_PARK_OPEN) != 0);
@@ -970,6 +974,17 @@ static int32_t ConsoleCommandSet(InteractiveConsole& console, const arguments_t&
                     console.WriteLineError("set difficult_guest_generation command failed, likely due to permissions.");
                 else
                     console.Execute("get difficult_guest_generation");
+            });
+            GameActions::Execute(&scenarioSetSetting);
+        }
+        else if (argv[0] == "strict_difficulty" && InvalidArguments(&invalidArgs, int_valid[0]))
+        {
+            auto scenarioSetSetting = ScenarioSetSettingAction(ScenarioSetSetting::GuestStrictDifficulty, int_val[0]);
+            scenarioSetSetting.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
+                if (res->Error != GameActions::Status::Ok)
+                    console.WriteLineError("set strict_difficulty command failed, likely due to permissions.");
+                else
+                    console.Execute("get strict_difficulty");
             });
             GameActions::Execute(&scenarioSetSetting);
         }
@@ -1971,6 +1986,8 @@ static constexpr const utf8* console_variable_table[] = {
     "cheat_disable_clearance_checks",
     "cheat_disable_support_limits",
     "current_rotation",
+    "strict_difficulty",
+ 
 };
 
 static constexpr const utf8* console_window_table[] = {

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -4000,6 +4000,8 @@ enum : uint16_t
     STR_CANT_FIRE_STAFF_FIXING = 6591,
     STR_CANT_FIRE_STAFF_INSPECTING = 6592,
 
+    STR_STRICT_DIFFICULTY = 6593,
+    STR_STRICT_DIFFICULTY_TIP = 6594,
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -894,6 +894,46 @@ int32_t Ride::GetTotalTime() const
     return totalTime;
 }
 
+int32_t Ride::GetSimilarRidesCount() const
+{
+    // Iterate through rides and return the number of rides that have similar stats
+    uint32_t otherSimilarRidesOfSameType = 0;
+
+    for (auto& r : GetRideManager())
+    {
+        uint16_t similar_count = 0;
+
+        if (std::abs(r.max_speed - max_speed) / 29127 < 10)
+            similar_count++;
+        if (std::abs(r.turn_count_default - turn_count_default) < 3)
+            similar_count++;
+        if (std::abs(r.turn_count_banked - turn_count_banked) < 3)
+            similar_count++;
+        if (std::abs(r.turn_count_sloped - turn_count_sloped) < 2)
+            similar_count++;
+        if (std::abs(r.drops - drops) < 3)
+            similar_count++;
+        if (std::abs(r.highest_drop_height - highest_drop_height) < 2)
+            similar_count++;
+        if (std::abs(r.inversions - inversions) < 2)
+            similar_count++;
+        if (std::abs(r.GetTotalLength() - GetTotalLength()) < std::min(r.GetTotalLength(), GetTotalLength()) / 3)
+            similar_count++;
+        if (std::abs(r.max_lateral_g - max_lateral_g) < FIXED_2DP(0, 20))
+            similar_count++;
+        if (std::abs(r.intensity - intensity) < FIXED_2DP(0, 50))
+            similar_count++;
+        if (std::abs(r.excitement - excitement) < FIXED_2DP(0, 50))
+            similar_count++;
+
+        if ((GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_FLAT_RIDE) && similar_count >= 10) || similar_count >= 8)
+        {
+            otherSimilarRidesOfSameType += 1;
+        }
+    }
+    return otherSimilarRidesOfSameType;
+}
+
 bool Ride::CanHaveMultipleCircuits() const
 {
     if (!(GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_ALLOW_MULTIPLE_CIRCUITS)))

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -396,6 +396,7 @@ public:
 
     int32_t GetTotalLength() const;
     int32_t GetTotalTime() const;
+    int32_t GetSimilarRidesCount() const;
 
     const StationObject* GetStationObject() const;
     const MusicObject* GetMusicObject() const;

--- a/src/openrct2/scripting/bindings/world/ScPark.cpp
+++ b/src/openrct2/scripting/bindings/world/ScPark.cpp
@@ -42,6 +42,7 @@ namespace OpenRCT2::Scripting
         { "freeParkEntry", PARK_FLAGS_PARK_FREE_ENTRY },
         { "difficultParkRating", PARK_FLAGS_DIFFICULT_PARK_RATING },
         { "unlockAllPrices", PARK_FLAGS_UNLOCK_ALL_PRICES },
+        { "strictDifficulty", PARK_FLAGS_STRICT_DIFFICULTY },
     });
 
     ScPark::ScPark(duk_context* ctx)

--- a/src/openrct2/world/Park.h
+++ b/src/openrct2/world/Park.h
@@ -40,9 +40,10 @@ enum : uint32_t
     PARK_FLAGS_NO_MONEY_SCENARIO = (1 << 17),                 // Deprecated, originally used in scenario editor
     PARK_FLAGS_SPRITES_INITIALISED = (1 << 18),  // After a scenario is loaded this prevents edits in the scenario editor
     PARK_FLAGS_SIX_FLAGS_DEPRECATED = (1 << 19), // Not used anymore
-
+    PARK_FLAGS_STRICT_DIFFICULTY = (1 << 20),
     PARK_FLAGS_RCT1_INTEREST = (1u << 30),     // OpenRCT2 only
     PARK_FLAGS_UNLOCK_ALL_PRICES = (1u << 31), // OpenRCT2 only
+
 };
 
 struct Guest;


### PR DESCRIPTION
This adds a new scenario option under the "Option - Park" dialog, called "Extra difficulty." The idea here is to add some extra checks to discourage some common scenario cheesing techniques. This includes:

1.) Voiding guests now counts as casualties.
2.) Guests will eventually leave queue lines with TVs.
3.) Guests need to ride more rides to stay in the park over time, instead of just 1.
4.) Excessive g-forces or intensity lowers ride value.
5.) Guests will leave the park if they've spent more than 3 times the average guest start cash.
6.) Umbrellas have just an increased max price in rain, not $20.
7.) Advertising guest generation affected by park rating.
8.) Rides with similar stats (length, max speed, etc.) to an existing ride of the same type get value and soft guest cap penalties.

In general, these changes should not affect normal play that much, just optimized play by discouraging coaster spam, death mazes, guest storage, park value bombs, etc. This is still a draft PR, as I have to continue to play test.