### PR TITLE
Fix #19823. Disallow overriding with wrong object type

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.6 (in development)
 ------------------------------------------------------------------------
 - Change: [#20110] Fix a few RCT1 build height parity discrepancies.
+- Fix: [#19823] Parkobj, disallow overriding objects of different object types.
 
 0.4.5 (2023-05-08)
 ------------------------------------------------------------------------

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "1"
+#define NETWORK_STREAM_VERSION "2"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -531,10 +531,20 @@ namespace ObjectFactory
                 RCTObjectEntry entry = {};
                 entry.flags = std::stoul(originalId.substr(0, 8), nullptr, 16);
                 entry.checksum = std::stoul(originalId.substr(18, 8), nullptr, 16);
-                entry.SetType(objectType);
                 auto minLength = std::min<size_t>(8, originalName.length());
                 std::memcpy(entry.name, originalName.c_str(), minLength);
-                descriptor = ObjectEntryDescriptor(entry);
+
+                // Some bad objects try to override different types
+                if (entry.GetType() != objectType)
+                {
+                    LOG_ERROR(
+                        "Object \"%s\" has invalid originalId set \"%s\". Ignoring override.", id.c_str(), originalId.c_str());
+                    descriptor = ObjectEntryDescriptor(objectType, id);
+                }
+                else
+                {
+                    descriptor = ObjectEntryDescriptor(entry);
+                }
             }
             else
             {


### PR DESCRIPTION
Some community objects have been made incorrectly and override small scenery objects with large scenery objects. This prevents that overload from being allowed.