### PR TITLE
Render title sequence as VP9 video

### DIFF
--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -69,7 +69,7 @@
     </ClCompile>
     <Link>
       <LargeAddressAware Condition="'$(Platform)'=='Win32'">true</LargeAddressAware>
-      <AdditionalDependencies>wininet.lib;imm32.lib;version.lib;winmm.lib;crypt32.lib;wldap32.lib;shlwapi.lib;setupapi.lib;bcrypt.lib;winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>wininet.lib;imm32.lib;version.lib;winmm.lib;crypt32.lib;wldap32.lib;shlwapi.lib;setupapi.lib;bcrypt.lib;winhttp.lib;vpx.lib;yuv.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Platform)'=='Win32' or '$(Platform)'=='x64'">fribidi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/OPT:NOLBR /ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>

--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -36,7 +36,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>
-      <DisableSpecificWarnings>4068;4091;4100;4121;4132;4200;4201;4204;4206;4221;4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4068;4091;4100;4121;4132;4200;4201;4204;4206;4221;4244;4505;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <!-- Warnings:
              C4068: unknown pragma
              C4091: 'keyword': ignored on left of 'type' when no variable is declared
@@ -49,6 +49,7 @@
              C4206: nonstandard extension used: translation unit is empty
              C4221: nonstandard extension used: 'identifier': cannot be initialized using address of automatic variable 'identifier'
              C4244: 'conversion_type': conversion from 'type1' to 'type2', possible loss of data
+             C4505: 'function' : unreferenced local function has been removed
       -->
       <TreatSpecificWarningsAsErrors>4263;4265;4548;4549;4555</TreatSpecificWarningsAsErrors>
       <!-- Warnings, that have to be enabled manually:

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -37,12 +37,12 @@
   <!-- 3rd party libraries / dependencies -->
   <PropertyGroup>
     <DependenciesCheckFile>$(RootDir).dependencies</DependenciesCheckFile>
-    <LibsUrl Condition="'$(Platform)'=='Win32'">https://github.com/OpenRCT2/Dependencies/releases/download/v34/openrct2-libs-v34-x86-windows-static.zip</LibsUrl>
-    <LibsSha1 Condition="'$(Platform)'=='Win32'">5173c04611c94da44af0db9e099edca2d6a7b829</LibsSha1>
-    <LibsUrl Condition="'$(Platform)'=='x64'">https://github.com/OpenRCT2/Dependencies/releases/download/v34/openrct2-libs-v34-x64-windows-static.zip</LibsUrl>
-    <LibsSha1 Condition="'$(Platform)'=='x64'">930df83ef49d91b1ef886f5dbf0a9cb61d704a50</LibsSha1>
-    <LibsUrl Condition="'$(Platform)'=='ARM64'">https://github.com/OpenRCT2/Dependencies/releases/download/v34/openrct2-libs-v34-arm64-windows-static.zip</LibsUrl>
-    <LibsSha1 Condition="'$(Platform)'=='ARM64'">bd338aa3da9a357fb996dcaa6cea02c4f906718c</LibsSha1>
+    <LibsUrl Condition="'$(Platform)'=='Win32'">https://github.com/janisozaur/Dependencies/releases/download/v999-libyuv-libvpx-v2/openrct2-libs-v999-libyuv-libvpx-v2-x86-windows-static.zip</LibsUrl>
+    <LibsSha1 Condition="'$(Platform)'=='Win32'">68f3dc82b7c5a019a654e74daf1128c564538f44</LibsSha1>
+    <LibsUrl Condition="'$(Platform)'=='x64'">https://github.com/janisozaur/Dependencies/releases/download/v999-libyuv-libvpx-v2/openrct2-libs-v999-libyuv-libvpx-v2-x64-windows-static.zip</LibsUrl>
+    <LibsSha1 Condition="'$(Platform)'=='x64'">aa64cc5362c55e94218aa8edabf59b81bcbe5558</LibsSha1>
+    <LibsUrl Condition="'$(Platform)'=='ARM64'">https://github.com/janisozaur/Dependencies/releases/download/v999-libyuv-libvpx-v2/openrct2-libs-v999-libyuv-libvpx-v2-arm64-windows-static.zip</LibsUrl>
+    <LibsSha1 Condition="'$(Platform)'=='ARM64'">7573444ab7b44492c7134c9362b4c570617fb7fa</LibsSha1>
     <TitleSequencesUrl>https://github.com/OpenRCT2/title-sequences/releases/download/v0.4.0/title-sequences.zip</TitleSequencesUrl>
     <TitleSequencesSha1>4ab0065e5a4d9f9c77d94718bbdfcfcd5a389da0</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.3.11/objects.zip</ObjectsUrl>

--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -267,4 +267,4 @@ if(MACOS_BUNDLE)
     )
 endif ()
 
-target_link_libraries(${PROJECT_NAME} vpx)
+target_link_libraries(${PROJECT_NAME} vpx yuv)

--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -266,3 +266,5 @@ if(MACOS_BUNDLE)
         "  BUNDLE DESTINATION ${CMAKE_BINARY_DIR}
     )
 endif ()
+
+target_link_libraries(${PROJECT_NAME} vpx)

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -760,7 +760,6 @@ private:
 
         // Initialise the surface, palette and draw buffer
         DrawingEngineInit();
-        OnResize(width, height);
 
         UpdateFullscreenResolutions();
 

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -340,7 +340,7 @@ public:
                     if (e.window.event == SDL_WINDOWEVENT_RESIZED)
                     {
                         LOG_VERBOSE("New Window size: %ux%u\n", e.window.data1, e.window.data2);
-                        OnResize(e.window.data1, e.window.data2);
+                        //OnResize(e.window.data1, e.window.data2);
                     }
 
                     switch (e.window.event)

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -279,6 +279,11 @@ public:
         SDL_SetWindowGrab(_window, value ? SDL_TRUE : SDL_FALSE);
     }
 
+    void SetWindowTitle(std::string value) override
+    {
+        SDL_SetWindowTitle(_window, value.c_str());
+    }
+
     void SetKeysPressed(uint32_t keysym, uint8_t scancode) override
     {
         _lastKeyPressed = keysym;
@@ -340,7 +345,7 @@ public:
                     if (e.window.event == SDL_WINDOWEVENT_RESIZED)
                     {
                         LOG_VERBOSE("New Window size: %ux%u\n", e.window.data1, e.window.data2);
-                        //OnResize(e.window.data1, e.window.data2);
+                        // OnResize(e.window.data1, e.window.data2);
                     }
 
                     switch (e.window.event)

--- a/src/openrct2-ui/drawing/engines/SoftwareDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/SoftwareDrawingEngine.cpp
@@ -460,6 +460,7 @@ private:
             exit(1);
         }
 
+        if (gShouldRender)
         {
             std::unique_lock lock(SurfaceMutex);
             if (SDL_BlitSurface(_surface, nullptr, _RGBASurface, nullptr))

--- a/src/openrct2-ui/drawing/engines/SoftwareDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/SoftwareDrawingEngine.cpp
@@ -390,7 +390,8 @@ public:
         using namespace std::string_literals;
         char* titleSeqName = getenv("TITLE_SEQUENCE_NAME");
         std::string titleSequenceNameStr;
-        if (titleSeqName != nullptr) {
+        if (titleSeqName != nullptr)
+        {
             titleSequenceNameStr = titleSeqName;
         }
         std::string filename = "out"s + titleSequenceNameStr + ".webm";

--- a/src/openrct2-ui/drawing/engines/SoftwareDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/SoftwareDrawingEngine.cpp
@@ -206,6 +206,9 @@ static int encode_frame(vpx_codec_ctx_t* codec, vpx_image_t* img, int frame_inde
                 die_codec(codec, "Failed to write compressed frame");
             }
             printf(keyframe ? "K" : ".");
+            if (frame_index % 100 == 0) {
+                printf("%d", frame_index);
+            }
             fflush(stdout);
         }
     }
@@ -251,7 +254,7 @@ public:
             die_codec(&codec, "Failed to destroy codec.");
         }
         vpx_video_writer_close(writer);
-        fclose(file);
+        //fclose(file);
     }
 
     void Initialise() override
@@ -272,7 +275,7 @@ public:
         _RGBASurface = SDL_CreateRGBSurfaceWithFormat(0, width, height, 32, SDL_PIXELFORMAT_ARGB8888);
         SDL_SetSurfaceBlendMode(_RGBASurface, SDL_BLENDMODE_NONE);
         _palette = SDL_AllocPalette(256);
-        file = fopen("/tmp/frameyuv", "wb");
+        //file = fopen("/tmp/frameyuv", "wb");
 
         if (_surface == nullptr || _palette == nullptr || _RGBASurface == nullptr)
         {
@@ -293,7 +296,8 @@ public:
         info.time_base.denominator = 60;
         if (info.frame_width <= 0 || info.frame_height <= 0 || (info.frame_width % 2) != 0 || (info.frame_height % 2) != 0)
         {
-            LOG_FATAL("Invalid frame size: %dx%d", info.frame_width, info.frame_height);
+            LOG_FATAL(
+                "Invalid frame size: %dx%d (need to be larger than zero and even-sized)", info.frame_width, info.frame_height);
         }
 
         if (!vpx_img_alloc(&raw, VPX_IMG_FMT_I444, info.frame_width, info.frame_height, 1))

--- a/src/openrct2-ui/drawing/engines/SoftwareDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/SoftwareDrawingEngine.cpp
@@ -387,7 +387,15 @@ public:
         cfg.g_threads = 8;
         cfg.g_profile = 0;
 
-        writer = vpx_video_writer_open("/tmp/out.webm", kContainerIVF, &info);
+        using namespace std::string_literals;
+        char* titleSeqName = getenv("TITLE_SEQUENCE_NAME");
+        std::string titleSequenceNameStr;
+        if (titleSeqName != nullptr) {
+            titleSequenceNameStr = titleSeqName;
+        }
+        std::string filename = "out"s + titleSequenceNameStr + ".webm";
+        printf("Rendering to file %s\n", filename.c_str());
+        writer = vpx_video_writer_open(filename.c_str(), kContainerIVF, &info);
         if (!writer)
         {
             LOG_FATAL("Failed to open %s for writing.", "/tmp/out.webm");

--- a/src/openrct2-ui/drawing/engines/SoftwareDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/SoftwareDrawingEngine.cpp
@@ -251,7 +251,7 @@ static void EncodeThreadFunc(EncodeThreadData& etd)
             LOG_FATAL("SDL_BlitScaled %s", SDL_GetError());
             exit(1);
         }
-        libyuv::ARGBToI444(
+        libyuv::ARGBToI420(
             static_cast<uint8_t*>((*etd.ScaledSurface)->pixels), (*etd.ScaledSurface)->pitch, etd.raw->planes[0],
             etd.raw->stride[0], etd.raw->planes[1], etd.raw->stride[1], etd.raw->planes[2], etd.raw->stride[1],
             (*etd.ScaledSurface)->w, (*etd.ScaledSurface)->h);
@@ -369,7 +369,7 @@ public:
                 "Invalid frame size: %dx%d (need to be larger than zero and even-sized)", info.frame_width, info.frame_height);
         }
 
-        if (!vpx_img_alloc(&raw, VPX_IMG_FMT_I444, info.frame_width, info.frame_height, 1))
+        if (!vpx_img_alloc(&raw, VPX_IMG_FMT_I420, info.frame_width, info.frame_height, 1))
         {
             LOG_FATAL("Failed to allocate image.");
         }
@@ -385,7 +385,7 @@ public:
         cfg.g_timebase.num = info.time_base.numerator;
         cfg.g_timebase.den = info.time_base.denominator;
         cfg.g_threads = 8;
-        cfg.g_profile = 1;
+        cfg.g_profile = 0;
 
         writer = vpx_video_writer_open("/tmp/out.webm", kContainerIVF, &info);
         if (!writer)

--- a/src/openrct2-ui/drawing/engines/SoftwareDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/SoftwareDrawingEngine.cpp
@@ -8,7 +8,6 @@
  *****************************************************************************/
 
 #include "DrawingEngineFactory.hpp"
-#include "vpx/vpx_encoder.h"
 
 #include <SDL.h>
 #include <algorithm>
@@ -19,6 +18,8 @@
 #include <openrct2/drawing/IDrawingEngine.h>
 #include <openrct2/drawing/X8DrawingEngine.h>
 #include <openrct2/ui/UiContext.h>
+#include <vpx/vp8cx.h>
+#include <vpx/vpx_encoder.h>
 
 using namespace OpenRCT2;
 using namespace OpenRCT2::Drawing;
@@ -47,11 +48,143 @@ typedef struct VpxInterface
 
 #define VP9_FOURCC 0x30395056
 
-extern "C" vpx_codec_iface_t* vpx_codec_vp9_cx();
-
 static const VpxInterface vpx_encoders[] = {
     { "vp9", VP9_FOURCC, &vpx_codec_vp9_cx },
 };
+
+struct VpxVideoWriterStruct
+{
+    VpxVideoInfo info;
+    FILE* file;
+    int frame_count;
+};
+
+typedef struct VpxVideoWriterStruct VpxVideoWriter;
+
+typedef enum
+{
+    kContainerIVF
+} VpxContainer;
+
+static void mem_put_le16(void* dst, uint16_t data)
+{
+    memcpy(dst, &data, 2);
+}
+static void mem_put_le32(void* dst, uint32_t data)
+{
+    memcpy(dst, &data, 4);
+}
+static void ivf_write_file_header_with_video_info(
+    FILE* outfile, unsigned int fourcc, int frame_cnt, int frame_width, int frame_height, vpx_rational_t timebase)
+{
+    char header[32];
+
+    header[0] = 'D';
+    header[1] = 'K';
+    header[2] = 'I';
+    header[3] = 'F';
+    mem_put_le16(header + 4, 0);             // version
+    mem_put_le16(header + 6, 32);            // header size
+    mem_put_le32(header + 8, fourcc);        // fourcc
+    mem_put_le16(header + 12, frame_width);  // width
+    mem_put_le16(header + 14, frame_height); // height
+    mem_put_le32(header + 16, timebase.den); // rate
+    mem_put_le32(header + 20, timebase.num); // scale
+    mem_put_le32(header + 24, frame_cnt);    // length
+    mem_put_le32(header + 28, 0);            // unused
+
+    fwrite(header, 1, 32, outfile);
+}
+
+static void ivf_write_file_header(FILE* outfile, const struct vpx_codec_enc_cfg* cfg, unsigned int fourcc, int frame_cnt)
+{
+    ivf_write_file_header_with_video_info(outfile, fourcc, frame_cnt, cfg->g_w, cfg->g_h, cfg->g_timebase);
+}
+/*
+static void ivf_write_frame_header(FILE* outfile, int64_t pts, size_t frame_size)
+{
+    char header[12];
+
+    mem_put_le32(header, static_cast<int>(frame_size));
+    mem_put_le32(header + 4, static_cast<int>(pts & 0xFFFFFFFF));
+    mem_put_le32(header + 8, static_cast<int>(pts >> 32));
+    fwrite(header, 1, 12, outfile);
+}
+*/
+
+static void write_header(FILE* file, const VpxVideoInfo* info, int frame_count)
+{
+    struct vpx_codec_enc_cfg cfg;
+    cfg.g_w = info->frame_width;
+    cfg.g_h = info->frame_height;
+    cfg.g_timebase.num = info->time_base.numerator;
+    cfg.g_timebase.den = info->time_base.denominator;
+
+    ivf_write_file_header(file, &cfg, info->codec_fourcc, frame_count);
+}
+
+static VpxVideoWriter* vpx_video_writer_open(const char* filename, VpxContainer container, const VpxVideoInfo* info)
+{
+    if (container == kContainerIVF)
+    {
+        VpxVideoWriter* writer = NULL;
+        FILE* const file = fopen(filename, "wb");
+        if (!file)
+        {
+            fprintf(stderr, "%s can't be written to.\n", filename);
+            return NULL;
+        }
+        writer = static_cast<VpxVideoWriter*>(malloc(sizeof(*writer)));
+        if (!writer)
+        {
+            fprintf(stderr, "Can't allocate VpxVideoWriter.\n");
+            return NULL;
+        }
+        writer->frame_count = 0;
+        writer->info = *info;
+        writer->file = file;
+
+        write_header(writer->file, info, 0);
+
+        return writer;
+    }
+    fprintf(stderr, "VpxVideoWriter supports only IVF.\n");
+    return NULL;
+}
+
+static void vpx_video_writer_close(VpxVideoWriter* writer)
+{
+    if (writer)
+    {
+        // Rewriting frame header with real frame count
+        rewind(writer->file);
+        write_header(writer->file, &writer->info, writer->frame_count);
+
+        fclose(writer->file);
+        free(writer);
+    }
+}
+/*
+static int vpx_video_writer_write_frame(VpxVideoWriter* writer, const uint8_t* buffer, size_t size, int64_t pts)
+{
+    ivf_write_frame_header(writer->file, pts, size);
+    if (fwrite(buffer, 1, size, writer->file) != size)
+        return 0;
+
+    ++writer->frame_count;
+
+    return 1;
+}
+*/
+static void die_codec(vpx_codec_ctx_t* ctx, const char* s)
+{
+    const char* detail = vpx_codec_error_detail(ctx);
+
+    LOG_ERROR("%s: %s\n", s, vpx_codec_error(ctx));
+    if (detail)
+        LOG_ERROR("    %s\n", detail);
+    exit(EXIT_FAILURE);
+}
 
 class SoftwareDrawingEngine final : public X8DrawingEngine
 {
@@ -64,6 +197,8 @@ private:
     VpxVideoInfo info{};
     const VpxInterface* encoder = NULL;
     vpx_image_t raw{};
+    VpxVideoWriter* writer = NULL;
+    vpx_codec_ctx_t codec{};
 
 public:
     explicit SoftwareDrawingEngine(const std::shared_ptr<IUiContext>& uiContext)
@@ -121,10 +256,42 @@ public:
             LOG_FATAL("Invalid frame size: %dx%d", info.frame_width, info.frame_height);
         }
 
-        if (!vpx_img_alloc(&raw, VPX_IMG_FMT_I420, info.frame_width, info.frame_height, 1))
+        if (!vpx_img_alloc(&raw, VPX_IMG_FMT_I444, info.frame_width, info.frame_height, 1))
         {
             LOG_FATAL("Failed to allocate image.");
         }
+        LOG_INFO("Using %s\n", vpx_codec_iface_name(encoder->codec_interface()));
+        vpx_codec_enc_cfg_t cfg{};
+        vpx_codec_err_t res = vpx_codec_enc_config_default(encoder->codec_interface(), &cfg, 0);
+        if (res)
+        {
+            die_codec(&codec, "Failed to get default codec config.");
+        }
+        cfg.g_w = info.frame_width;
+        cfg.g_h = info.frame_height;
+        cfg.g_timebase.num = info.time_base.numerator;
+        cfg.g_timebase.den = info.time_base.denominator;
+        cfg.g_threads = 8;
+
+        writer = vpx_video_writer_open("/tmp/out.webm", kContainerIVF, &info);
+        if (!writer)
+        {
+            LOG_FATAL("Failed to open %s for writing.", "/tmp/out.webm");
+        }
+        if (vpx_codec_enc_init(&codec, encoder->codec_interface(), &cfg, 0))
+        {
+            LOG_FATAL("Failed to initialize encoder");
+        }
+        if (vpx_codec_control_(&codec, VP9E_SET_LOSSLESS, 1))
+        {
+            die_codec(&codec, "Failed to use lossless mode");
+        }
+        vpx_img_free(&raw);
+        if (vpx_codec_destroy(&codec))
+        {
+            die_codec(&codec, "Failed to destroy codec.");
+        }
+        vpx_video_writer_close(writer);
 
         ConfigureBits(width, height, _surface->pitch);
     }

--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -268,6 +268,8 @@ namespace OpenRCT2::Title
             if (_position >= static_cast<int32_t>(_sequence->Commands.size()))
             {
                 _position = 0;
+                printf(" Reached the end of script, closing ");
+                ContextQuit();
             }
             _waitCounter = 0;
         }

--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -34,6 +34,7 @@
 #include <openrct2/title/TitleSequence.h>
 #include <openrct2/title/TitleSequenceManager.h>
 #include <openrct2/title/TitleSequencePlayer.h>
+#include <openrct2/title/TitleSequenceRender.h>
 #include <openrct2/ui/UiContext.h>
 #include <openrct2/ui/WindowManager.h>
 #include <openrct2/windows/Intent.h>
@@ -270,6 +271,7 @@ namespace OpenRCT2::Title
                 _position = 0;
                 printf(" Reached the end of script, closing ");
                 ContextQuit();
+                gShouldRender = false;
             }
             _waitCounter = 0;
         }

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -1057,7 +1057,7 @@ namespace OpenRCT2
             WindowClose(*WindowFindByClass(WindowClass::TitleMenu));
             WindowClose(*WindowFindByClass(WindowClass::TitleExit));
             TitleSetHideVersionInfo(true);
-            gConfigGeneral.ShowFPS = false;
+            gConfigGeneral.ShowFPS = true;
             Platform::AdvanceTicks();
             PROFILED_FUNCTION();
 

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -69,6 +69,7 @@
 #include "scripting/ScriptEngine.h"
 #include "title/TitleScreen.h"
 #include "title/TitleSequenceManager.h"
+#include "title/TitleSequenceRender.h"
 #include "ui/UiContext.h"
 #include "ui/WindowManager.h"
 #include "util/Util.h"
@@ -1075,7 +1076,7 @@ namespace OpenRCT2
                 tweener.Reset();
             }
 
-            constexpr float deltaTime = 1.0f / 60;
+            constexpr float deltaTime = 1.0f / FPS;
 
             UpdateTimeAccumulators(deltaTime);
 

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -1051,9 +1051,10 @@ namespace OpenRCT2
 
         void RunFrame()
         {
+            Platform::AdvanceTicks();
             PROFILED_FUNCTION();
 
-            const auto deltaTime = _timer.GetElapsedTimeAndRestart().count();
+            //const auto deltaTime = _timer.GetElapsedTimeAndRestart().count();
 
             // Make sure we catch the state change and reset it.
             bool useVariableFrame = ShouldRunVariableFrame();
@@ -1067,6 +1068,8 @@ namespace OpenRCT2
                 tweener.Restore();
                 tweener.Reset();
             }
+
+            constexpr float deltaTime = 1.0f / 60;
 
             UpdateTimeAccumulators(deltaTime);
 

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -1051,10 +1051,16 @@ namespace OpenRCT2
 
         void RunFrame()
         {
+            WindowClose(*WindowFindByClass(WindowClass::TitleLogo));
+            WindowClose(*WindowFindByClass(WindowClass::TitleOptions));
+            WindowClose(*WindowFindByClass(WindowClass::TitleMenu));
+            WindowClose(*WindowFindByClass(WindowClass::TitleExit));
+            TitleSetHideVersionInfo(true);
+            gConfigGeneral.ShowFPS = false;
             Platform::AdvanceTicks();
             PROFILED_FUNCTION();
 
-            //const auto deltaTime = _timer.GetElapsedTimeAndRestart().count();
+            // const auto deltaTime = _timer.GetElapsedTimeAndRestart().count();
 
             // Make sure we catch the state change and reset it.
             bool useVariableFrame = ShouldRunVariableFrame();

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -1495,6 +1495,11 @@ void ContextSetCursorTrap(bool value)
     GetContext()->GetUiContext()->SetCursorTrap(value);
 }
 
+void ContextSetWindowTitle(std::string value)
+{
+    GetContext()->GetUiContext()->SetWindowTitle(value);
+}
+
 WindowBase* ContextOpenWindow(WindowClass wc)
 {
     auto windowManager = GetContext()->GetUiContext()->GetWindowManager();

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -1072,11 +1072,11 @@ namespace OpenRCT2
 
             if (useVariableFrame)
             {
-                RunVariableFrame(deltaTime);
+                RunVariableFrame();
             }
             else
             {
-                RunFixedFrame(deltaTime);
+                RunFixedFrame();
             }
         }
 
@@ -1095,7 +1095,7 @@ namespace OpenRCT2
             }
         }
 
-        void RunFixedFrame(float deltaTime)
+        void RunFixedFrame()
         {
             PROFILED_FUNCTION();
 
@@ -1124,7 +1124,7 @@ namespace OpenRCT2
             }
         }
 
-        void RunVariableFrame(float deltaTime)
+        void RunVariableFrame()
         {
             PROFILED_FUNCTION();
 

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -209,6 +209,7 @@ int32_t ContextGetWidth();
 int32_t ContextGetHeight();
 bool ContextHasFocus();
 void ContextSetCursorTrap(bool value);
+void ContextSetWindowTitle(std::string value);
 WindowBase* ContextOpenWindow(WindowClass wc);
 WindowBase* ContextOpenDetailWindow(uint8_t type, int32_t id);
 WindowBase* ContextOpenWindowView(uint8_t view);

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -26,6 +26,8 @@
 #include "../title/TitleScreen.h"
 #include "../ui/UiContext.h"
 
+#include <string>
+
 using namespace OpenRCT2;
 using namespace OpenRCT2::Drawing;
 using namespace OpenRCT2::Paint;
@@ -102,20 +104,9 @@ void Painter::PaintReplayNotice(DrawPixelInfo& dpi, const char* text)
 
 void Painter::PaintFPS(DrawPixelInfo& dpi)
 {
-    ScreenCoordsXY screenCoords(_uiContext->GetWidth() / 2, 2);
-
     MeasureFPS();
-
-    char buffer[64]{};
-    FormatStringToBuffer(buffer, sizeof(buffer), "{OUTLINE}{WHITE}{INT32}", _currentFPS);
-
-    // Draw Text
-    int32_t stringWidth = GfxGetStringWidth(buffer, FontStyle::Medium);
-    screenCoords.x = screenCoords.x - (stringWidth / 2);
-    GfxDrawString(dpi, screenCoords, buffer);
-
-    // Make area dirty so the text doesn't get drawn over the last
-    GfxSetDirtyBlocks({ { screenCoords - ScreenCoordsXY{ 16, 4 } }, { dpi.lastStringPos.x + 16, 16 } });
+    using namespace std::string_literals;
+    ContextSetWindowTitle("OpenRCT2 FPS: "s + std::to_string(_currentFPS));
 }
 
 void Painter::MeasureFPS()

--- a/src/openrct2/platform/Platform.Posix.cpp
+++ b/src/openrct2/platform/Platform.Posix.cpp
@@ -387,17 +387,6 @@ namespace Platform
     void InitTicks()
     {
     }
-
-    uint32_t GetTicks()
-    {
-        struct timespec ts;
-        if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
-        {
-            LOG_FATAL("clock_gettime failed");
-            exit(-1);
-        }
-        return static_cast<uint32_t>(ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
-    }
 } // namespace Platform
 
 #endif

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -901,17 +901,6 @@ namespace Platform
         return false;
     }
 
-    uint32_t GetTicks()
-    {
-        LARGE_INTEGER pfc;
-        QueryPerformanceCounter(&pfc);
-
-        LARGE_INTEGER runningDelta;
-        runningDelta.QuadPart = pfc.QuadPart - _entryTimestamp.QuadPart;
-
-        return static_cast<uint32_t>(runningDelta.QuadPart / _frequency);
-    }
-
     void Sleep(uint32_t ms)
     {
         ::Sleep(ms);

--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -12,6 +12,7 @@
 #include "../common.h"
 #include "../config/Config.h"
 
+#include <cmath>
 #include <ctime>
 #include <string>
 
@@ -78,6 +79,8 @@ namespace Platform
     bool IsRCT2Path(std::string_view path);
     bool IsRCTClassicPath(std::string_view path);
     bool OriginalGameDataExists(std::string_view path);
+
+    void AdvanceTicks();
 
     std::string GetUsername();
 

--- a/src/openrct2/platform/Shared.cpp
+++ b/src/openrct2/platform/Shared.cpp
@@ -35,6 +35,8 @@ static constexpr std::array _prohibitedCharacters = { '/' };
 
 namespace Platform
 {
+    static double _ticks = 0;
+
     void CoreInit()
     {
         static bool initialised = false;
@@ -50,6 +52,17 @@ namespace Platform
             BitCountInit();
             MaskInit();
         }
+    }
+
+    uint32_t GetTicks()
+    {
+        return round(_ticks);
+    }
+
+    void AdvanceTicks()
+    {
+        // ms to advance ticks by. 16.67 => 1000/16.67 = 60fps
+        _ticks += 16.67;
     }
 
     CurrencyType GetCurrencyValue(const char* currCode)

--- a/src/openrct2/title/TitleSequence.cpp
+++ b/src/openrct2/title/TitleSequence.cpp
@@ -25,6 +25,7 @@
 #include "../scenario/ScenarioRepository.h"
 #include "../scenario/ScenarioSources.h"
 #include "../util/Util.h"
+#include "TitleSequenceRender.h"
 
 #include <algorithm>
 #include <array>
@@ -389,7 +390,7 @@ namespace OpenRCT2::Title
                 {
                     uint16_t milliseconds = atoi(parts[1].data()) & 0xFFFF;
                     command = WaitCommand{ milliseconds };
-                    NumFramesToRender += std::ceil(static_cast<double>(milliseconds) / (1000.f / 60.f));
+                    NumFramesToRender += std::ceil(static_cast<double>(milliseconds) / (1000.f / FPS));
                 }
                 else if (_stricmp(token, "RESTART") == 0)
                 {

--- a/src/openrct2/title/TitleSequence.cpp
+++ b/src/openrct2/title/TitleSequence.cpp
@@ -332,6 +332,7 @@ namespace OpenRCT2::Title
     {
         std::vector<TitleCommand> commands;
         auto fs = OpenRCT2::MemoryStream(script.data(), script.size());
+        uint32_t NumFramesToRender{};
         do
         {
             std::vector<std::array<char, 128>> parts;
@@ -388,6 +389,7 @@ namespace OpenRCT2::Title
                 {
                     uint16_t milliseconds = atoi(parts[1].data()) & 0xFFFF;
                     command = WaitCommand{ milliseconds };
+                    NumFramesToRender += std::ceil(static_cast<double>(milliseconds) / (1000.f / 60.f));
                 }
                 else if (_stricmp(token, "RESTART") == 0)
                 {
@@ -410,6 +412,7 @@ namespace OpenRCT2::Title
                 commands.push_back(std::move(*command));
             }
         } while (fs.GetPosition() < fs.GetLength());
+        LOG_INFO("Need to render around %u frames", NumFramesToRender);
         return commands;
     }
 

--- a/src/openrct2/title/TitleSequenceRender.h
+++ b/src/openrct2/title/TitleSequenceRender.h
@@ -1,0 +1,15 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2023 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+constexpr uint8_t FPS = 60;
+extern bool gShouldRender;

--- a/src/openrct2/ui/DummyUiContext.cpp
+++ b/src/openrct2/ui/DummyUiContext.cpp
@@ -147,6 +147,9 @@ namespace OpenRCT2::Ui
         void SetCursorTrap(bool /*value*/) override
         {
         }
+        void SetWindowTitle(std::string /*value*/) override
+        {
+        }
         const uint8_t* GetKeysState() override
         {
             return nullptr;

--- a/src/openrct2/ui/UiContext.h
+++ b/src/openrct2/ui/UiContext.h
@@ -142,6 +142,7 @@ namespace OpenRCT2
             virtual ScreenCoordsXY GetCursorPosition() abstract;
             virtual void SetCursorPosition(const ScreenCoordsXY& cursorPosition) abstract;
             virtual void SetCursorTrap(bool value) abstract;
+            virtual void SetWindowTitle(std::string value) abstract;
             virtual const uint8_t* GetKeysState() abstract;
             virtual const uint8_t* GetKeysPressed() abstract;
             virtual void SetKeysPressed(uint32_t keysym, uint8_t scancode) abstract;


### PR DESCRIPTION
This is #5900 all over again, but updated to current code base and no longer rendering screenshots, but VP9 lossless video instead in stable 60 FPS.

This will take into consideration the scale set in config.ini and resolution, even if it cannot be displayed. VP9 encoding is offloaded to separate thread. It is possible to add filename part through `TITLE_SEQUENCE_NAME` environment variable, so you can render multiple sequences at the same time.

config.ini must be manually set to software renderer, uncap FPS, windowed mode.

I rendered three of the available title sequences: `*OPENRCT2`, `*RCT2` and `*RCT1AALL` in 4k60 and uploaded them to youtube: https://www.youtube.com/watch?v=oE3j7eem384&list=PLY6HqQMBfGNKG2ZpLtR_faTMfno0Lnl2-

I rendered it on rk3588 device and got ~2 FPS rendering speed, on amd64 machine it was oscillating around 6 FPS, while also consuming significantly more power.

I deliberated whether to use I444, I422 or I420 format, but ended up using the last one, as it is the only to have hardware acceleration and rendering at 2x scale meant I would still get the same result as with I444.

This only renders video, sound has to muxed in externally.