### PR TITLE
fix restraints with 8 angles

### DIFF
--- a/src/openrct2/ride/VehiclePaint.cpp
+++ b/src/openrct2/ride/VehiclePaint.cpp
@@ -1036,10 +1036,8 @@ static void VehicleSpritePaintRestraints(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     int32_t boundingBoxNum = YawTo16(imageDirection);
-    auto restraintFrame = ((vehicle->restraints_position - 64) / 64) * 4;
-    auto spriteNum = (carEntry->SpriteByYaw(imageDirection, SpriteGroupType::RestraintAnimation) + restraintFrame)
-            * carEntry->base_num_frames
-        + carEntry->GroupImageId(SpriteGroupType::RestraintAnimation);
+    auto restraintFrame = ((vehicle->restraints_position - 64) / 64);
+    auto spriteNum = carEntry->SpriteOffset(SpriteGroupType::RestraintAnimation, imageDirection, restraintFrame);
     vehicle_sprite_paint(session, vehicle, spriteNum, VehicleBoundboxes[carEntry->draw_order][boundingBoxNum], z, carEntry);
 }
 


### PR DESCRIPTION
Custom vehicles with a RestraintAnimation SpritePrecision of Sprites8 (or any precision other than Sprites4) will render incorrectly. I don't remember why I did it the way it was, but the `* 4` multiplier more-or-less hardcodes a Sprites4 requirement. The new method aligns the restraint paint with the rest of the paint code.

No changelog because as far as I am aware I am the only person to attempt diagonal restraint animations.

Test object: 
[spacek.ride.coaster.skywarp.zip](https://github.com/OpenRCT2/OpenRCT2/files/11469193/spacek.ride.coaster.skywarp.zip)
