### PR TITLE
Add forgotten changelog entry

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Improved: [#20200] Allow audio files to play to up to 44100hz sample rate (from 22050hz).
 - Change: [#20110] Fix a few RCT1 build height parity discrepancies.
 - Fix: [#19823] Parkobj, disallow overriding objects of different object types.
+- Fix: [#20155] Fairground organ style 2 shows up as regular song, rather than for the merry-go-round.
 
 0.4.5 (2023-05-08)
 ------------------------------------------------------------------------


### PR DESCRIPTION
Seems this disappeared with a rebase while working on the main theme.