### PR TITLE
en-GB: Fix misspelling

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3692,7 +3692,7 @@ STR_6584    :Select to run trains backwards
 STR_6585    :Can’t make changes…
 
 STR_6586    :OpenRCT2
-STR_6587    :The OpenRCT2 Title Theme is a work of Allister Brimble,{NEWLINE}licenced CC BY-SA 4.0.
+STR_6587    :The OpenRCT2 Title Theme is a work of Allister Brimble,{NEWLINE}licensed CC BY-SA 4.0.
 STR_6588    :Thanks to Herman Riddering for allowing us to record the 35er Voigt.
 
 #############


### PR DESCRIPTION
Unlike the noun (`licence` vs `license`), the verb `to license` is always spelt with an ‘s’, including in British English.