### PR TITLE
Small symbol cleanup

### DIFF
--- a/src/openrct2/localisation/Localisation.h
+++ b/src/openrct2/localisation/Localisation.h
@@ -20,7 +20,6 @@
 
 std::string FormatStringID(StringId format, const void* args);
 void FormatStringToUpper(char* dest, size_t size, StringId format, const void* args);
-void generate_string_file();
 
 /**
  * Formats sizeBytes into buf as a human readable text, e.x.: "1024 MB"

--- a/src/openrct2/localisation/Localisation.h
+++ b/src/openrct2/localisation/Localisation.h
@@ -39,8 +39,6 @@ size_t GetStringSize(const utf8* text);
 money64 StringToMoney(const char* string_to_monetise);
 void MoneyToString(money64 amount, char* buffer_to_put_value_to, size_t buffer_len, bool forceDecimals);
 
-bool IsUserStringID(StringId stringId);
-
 #define MAX_USER_STRINGS 1024
 #define USER_STRING_MAX_LENGTH 32
 

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -690,22 +690,6 @@ std::unique_ptr<Object> ObjectRepositoryLoadObject(const RCTObjectEntry* objectE
     return object;
 }
 
-void ScenarioTranslate(ScenarioIndexEntry* scenarioEntry)
-{
-    StringId localisedStringIds[3];
-    if (LanguageGetLocalisedScenarioStrings(scenarioEntry->Name, localisedStringIds))
-    {
-        if (localisedStringIds[0] != STR_NONE)
-        {
-            String::Set(scenarioEntry->Name, sizeof(scenarioEntry->Name), LanguageGetString(localisedStringIds[0]));
-        }
-        if (localisedStringIds[2] != STR_NONE)
-        {
-            String::Set(scenarioEntry->Details, sizeof(scenarioEntry->Details), LanguageGetString(localisedStringIds[2]));
-        }
-    }
-}
-
 size_t ObjectRepositoryGetItemsCount()
 {
     auto& objectRepository = GetContext()->GetObjectRepository();

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -870,6 +870,7 @@ uint8_t GetStationStyleFromIdentifier(u8string_view identifier);
 std::optional<uint8_t> GetStyleFromMusicIdentifier(std::string_view identifier);
 void RCT12AddDefaultObjects(ObjectList& objectList);
 void AppendRequiredObjects(ObjectList& objectList, ObjectType objectType, const RCT12::EntryList& entryList);
+bool IsUserStringID(StringId stringId);
 
 static constexpr money32 RCT12_COMPANY_VALUE_ON_FAILED_OBJECTIVE = 0x80000001;
 

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -804,3 +804,19 @@ bool ScenarioRepositoryTryRecordHighscore(const utf8* scenarioFileName, money64 
     IScenarioRepository* repo = GetScenarioRepository();
     return repo->TryRecordHighscore(LocalisationService_GetCurrentLanguage(), scenarioFileName, companyValue, name);
 }
+
+void ScenarioTranslate(ScenarioIndexEntry* scenarioEntry)
+{
+    StringId localisedStringIds[3];
+    if (LanguageGetLocalisedScenarioStrings(scenarioEntry->Name, localisedStringIds))
+    {
+        if (localisedStringIds[0] != STR_NONE)
+        {
+            String::Set(scenarioEntry->Name, sizeof(scenarioEntry->Name), LanguageGetString(localisedStringIds[0]));
+        }
+        if (localisedStringIds[2] != STR_NONE)
+        {
+            String::Set(scenarioEntry->Details, sizeof(scenarioEntry->Details), LanguageGetString(localisedStringIds[2]));
+        }
+    }
+}


### PR DESCRIPTION
This moves two symbols to a more logical place, and removes one that was never defined or used, just declared.