### PR TITLE
Fix #20223: Reduce amount of audio samples to 256 to avoid high latency

### DIFF
--- a/src/openrct2-ui/audio/AudioMixer.cpp
+++ b/src/openrct2-ui/audio/AudioMixer.cpp
@@ -30,7 +30,7 @@ void AudioMixer::Init(const char* device)
     want.freq = 44100;
     want.format = AUDIO_S16SYS;
     want.channels = 2;
-    want.samples = 4096;
+    want.samples = 256;
     want.callback = [](void* arg, uint8_t* dst, int32_t length) -> void {
         auto* mixer = static_cast<AudioMixer*>(arg);
         mixer->GetNextAudioChunk(dst, static_cast<size_t>(length));


### PR DESCRIPTION
The reason that we have those cracking sounds is because the sampler can't keep up when we demand that many, 256 is more than enough.

Closes #20223