### PR TITLE
Revert audio changes

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,7 +2,6 @@
 ------------------------------------------------------------------------
 - Feature: [#15660] Ability to show window buttons on the left.
 - Feature: [OpenMusic#41] Official Title Theme by Allister Brimble.
-- Improved: [#20200] Allow audio files to play to up to 44100 Hz sample rate (from 22050 Hz).
 - Improved: [#20243] Add new colour preset to Side Friction Roller Coaster (using the new colours).
 - Change: [#20110] Fix a few RCT1 build height parity discrepancies.
 - Fix: [#6152] Camera and UI are no longer locked at 40 Hz, providing a smoother experience.

--- a/src/openrct2-ui/audio/AudioMixer.cpp
+++ b/src/openrct2-ui/audio/AudioMixer.cpp
@@ -27,10 +27,10 @@ void AudioMixer::Init(const char* device)
     Close();
 
     SDL_AudioSpec want = {};
-    want.freq = 44100;
+    want.freq = 22050;
     want.format = AUDIO_S16SYS;
     want.channels = 2;
-    want.samples = 256;
+    want.samples = 2048;
     want.callback = [](void* arg, uint8_t* dst, int32_t length) -> void {
         auto* mixer = static_cast<AudioMixer*>(arg);
         mixer->GetNextAudioChunk(dst, static_cast<size_t>(length));


### PR DESCRIPTION
This reverts the changes from #20200 due to issues with cracking sound.