### PR TITLE
Disallow firing staff who are currently fixing or inspecting rides

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3693,8 +3693,8 @@ STR_6587    :The OpenRCT2 Title Theme is a work of Allister Brimble,{NEWLINE}lic
 STR_6588    :Thanks to Herman Riddering for allowing us to record the 35er Voigt.
 STR_6589    :Show window buttons on the left
 STR_6590    :Show the window buttons (e.g. to close the window) on the left of the title bar instead of on the right.
-STR_6591    :Staff is currently fixing a ride and can't be fired.
-STR_6592    :Staff is currently inspecting a ride and can't be fired.
+STR_6591    :Staff member is currently fixing a ride and can’t be fired.
+STR_6592    :Staff member is currently inspecting a ride and can’t be fired.
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3693,6 +3693,8 @@ STR_6587    :The OpenRCT2 Title Theme is a work of Allister Brimble,{NEWLINE}lic
 STR_6588    :Thanks to Herman Riddering for allowing us to record the 35er Voigt.
 STR_6589    :Show window buttons on the left
 STR_6590    :Show the window buttons (e.g. to close the window) on the left of the title bar instead of on the right.
+STR_6591    :Staff is currently fixing a ride and can't be fired.
+STR_6592    :Staff is currently inspecting a ride and can't be fired.
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Fix: [#19823] Parkobj: disallow overriding objects of different object types.
 - Fix: [#20111] All coaster types can access the new diagonal slope pieces.
 - Fix: [#20155] Fairground organ style 2 shows up as regular music, rather than for the merry-go-round.
+- Fix: [#20260] Ride locks up when inspecting/fixing staff member is fired.
 
 0.4.5 (2023-05-08)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1055,6 +1055,8 @@ private:
             {
                 SetWidgetDisabled(WIDX_PICKUP, true);
             }
+
+            SetWidgetDisabled(WIDX_FIRE, staff->State == PeepState::Fixing || staff->State == PeepState::Inspecting);
         }
     }
 

--- a/src/openrct2/actions/StaffFireAction.cpp
+++ b/src/openrct2/actions/StaffFireAction.cpp
@@ -49,6 +49,15 @@ GameActions::Result StaffFireAction::Query() const
         return GameActions::Result(GameActions::Status::InvalidParameters, STR_NONE, STR_NONE);
     }
 
+    if (staff->State == PeepState::Fixing)
+    {
+        return GameActions::Result(GameActions::Status::Disallowed, STR_CANT_FIRE_STAFF_FIXING, STR_NONE);
+    }
+    else if (staff->State == PeepState::Inspecting)
+    {
+        return GameActions::Result(GameActions::Status::Disallowed, STR_CANT_FIRE_STAFF_INSPECTING, STR_NONE);
+    }
+
     return GameActions::Result();
 }
 

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3997,6 +3997,9 @@ enum : uint16_t
     STR_WINDOW_BUTTONS_ON_THE_LEFT = 6589,
     STR_WINDOW_BUTTONS_ON_THE_LEFT_TIP = 6590,
 
+    STR_CANT_FIRE_STAFF_FIXING = 6591,
+    STR_CANT_FIRE_STAFF_INSPECTING = 6592,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "3"
+#define NETWORK_STREAM_VERSION "4"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 


### PR DESCRIPTION
This may lock up the ride when staff is fired at the right time, since staff manipulates the state of the ride status there is no work-around without enabling exploits that people can use to immediately fix rides by sending mechanics in and then immediately fire them. I think this solution is the right way to solve the problem without adding any complex extra logic on top of.

Here is a park where I isolated the problem:
[0_Everything_Park_Unfixable_ride.zip](https://github.com/OpenRCT2/OpenRCT2/files/11523181/0_Everything_Park_Unfixable_ride.zip)

With this PR when you try to fire mechanics that are either inspecting or fixing the ride you'll get an error as shown below:
![openrct2_2023-05-20_23-39-509be846cea41947e06](https://github.com/OpenRCT2/OpenRCT2/assets/5415177/f6a910c9-9dac-4380-ad3c-fd50ea735c08)

Also in order to reproduce this you have to fire the mechanic at the right time, ActionFrame has to be 0x28 in order for this bug to trigger, that's where it sets the new mechanic status on the ride and would set it to completed in another sub state.