### PR TITLE
Add functionality to shift the entire map

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -42,6 +42,7 @@
 0.4.10 (2024-04-02)
 ------------------------------------------------------------------------
 - Feature: [#18171] Add port of the RCT1 Stand-Up Roller Coaster.
+- Feature: [#20263] Ability to increase the size of the map in the (0, 0) direction.
 - Feature: [#21590] [Plugin] Plugins can now read and write banner properties of tile elements.
 - Feature: [#21636] Add shortcut key for sorting tile elements.
 - Feature: [objects#294] Add scenery versions of wooden truss supports.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.12 (in development)
 ------------------------------------------------------------------------
 - Feature: [#622] Add option to align the top toolbar buttons horizontally centred (off by default).
+- Feature: [#20263] Ability to increase the size of the map in the (0, 0) direction.
 - Feature: [#21714] [Plugin] Costume assignment is now tailored to each staff type.
 - Feature: [#21893] On launch, the game now indicates what system is being initialised.
 - Feature: [#21913] [Plugin] Allow precise and safe control of peep animations.
@@ -42,7 +43,6 @@
 0.4.10 (2024-04-02)
 ------------------------------------------------------------------------
 - Feature: [#18171] Add port of the RCT1 Stand-Up Roller Coaster.
-- Feature: [#20263] Ability to increase the size of the map in the (0, 0) direction.
 - Feature: [#21590] [Plugin] Plugins can now read and write banner properties of tile elements.
 - Feature: [#21636] Add shortcut key for sorting tile elements.
 - Feature: [objects#294] Add scenery versions of wooden truss supports.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -939,6 +939,8 @@ declare global {
     interface MapChangeSizeArgs extends GameActionArgs {
         targetSizeX: number;
         targetSizeY: number;
+        shiftX: number;
+        shiftY: number;
     }
 
     interface MazePlaceTrackArgs extends GameActionArgs {

--- a/src/openrct2/actions/MapChangeSizeAction.cpp
+++ b/src/openrct2/actions/MapChangeSizeAction.cpp
@@ -18,7 +18,13 @@
 #include "../world/Park.h"
 
 MapChangeSizeAction::MapChangeSizeAction(const TileCoordsXY& targetSize)
+    : MapChangeSizeAction(targetSize, TileCoordsXY())
+{
+}
+
+MapChangeSizeAction::MapChangeSizeAction(const TileCoordsXY& targetSize, const TileCoordsXY& shift)
     : _targetSize(targetSize)
+    , _shift(shift)
 {
 }
 
@@ -31,6 +37,7 @@ void MapChangeSizeAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);
     stream << DS_TAG(_targetSize);
+    stream << DS_TAG(_shift);
 }
 
 GameActions::Result MapChangeSizeAction::Query() const
@@ -63,6 +70,9 @@ GameActions::Result MapChangeSizeAction::Execute() const
         MapExtendBoundarySurfaceY();
     }
 
+    // Shift the map (allows increasing the map at the 0,0 position
+    ShiftMap(_shift);
+
     // Shrink map
     if (_targetSize.x < gameState.MapSize.x || _targetSize.y < gameState.MapSize.y)
     {
@@ -84,4 +94,6 @@ void MapChangeSizeAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit("targetSizeX", _targetSize.x);
     visitor.Visit("targetSizeY", _targetSize.y);
+    visitor.Visit("shiftX", _shift.x);
+    visitor.Visit("shiftY", _shift.y);
 }

--- a/src/openrct2/actions/MapChangeSizeAction.h
+++ b/src/openrct2/actions/MapChangeSizeAction.h
@@ -17,6 +17,7 @@ class MapChangeSizeAction final : public GameActionBase<GameCommand::ChangeMapSi
 public:
     MapChangeSizeAction() = default;
     MapChangeSizeAction(const TileCoordsXY& targetSize);
+    MapChangeSizeAction(const TileCoordsXY& targetSize, const TileCoordsXY& shift);
 
     void AcceptParameters(GameActionParameterVisitor& visitor) override;
     uint16_t GetActionFlags() const override;
@@ -27,4 +28,5 @@ public:
 
 private:
     TileCoordsXY _targetSize;
+    TileCoordsXY _shift;
 };

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2298,7 +2298,7 @@ void ShiftMap(const TileCoordsXY& amount)
     for (auto& spawn : gameState.PeepSpawns)
         spawn += amountToMove;
 
-    for (auto& entrance : gameState.ParkEntrances)
+    for (auto& entrance : gameState.Park.Entrances)
         entrance += amountToMove;
 
     // Entities

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2308,10 +2308,10 @@ void ShiftMap(const TileCoordsXY& amount)
     MapRemoveOutOfRangeElements();
 
     for (auto& spawn : gameState.PeepSpawns)
-        spawn += amountToMove;
+        shiftIfNotNull(spawn, amountToMove);
 
     for (auto& entrance : gameState.Park.Entrances)
-        entrance += amountToMove;
+        shiftIfNotNull(entrance, amountToMove);
 
     // Entities
     auto& entityTweener = EntityTweener::Get();
@@ -2327,7 +2327,7 @@ void ShiftMap(const TileCoordsXY& amount)
             entityTweener.RemoveEntity(entity);
 
             auto location = entity->GetLocation();
-            location += amountToMove;
+            shiftIfNotNull(location, amountToMove);
             entity->MoveTo(location);
 
             switch (entityType)
@@ -2338,12 +2338,12 @@ void ShiftMap(const TileCoordsXY& amount)
                     auto peep = entity->As<Peep>();
                     if (peep != nullptr)
                     {
-                        peep->NextLoc += amountToMove;
+                        shiftIfNotNull(peep->NextLoc, amountToMove);
                         peep->DestinationX += amountToMove.x;
                         peep->DestinationY += amountToMove.y;
-                        peep->PathfindGoal += amount;
+                        shiftIfNotNull(peep->PathfindGoal, amount);
                         for (auto& h : peep->PathfindHistory)
-                            h += amount;
+                            shiftIfNotNull(h, amount);
                     }
                     break;
                 }
@@ -2352,8 +2352,8 @@ void ShiftMap(const TileCoordsXY& amount)
                     auto vehicle = entity->As<Vehicle>();
                     if (vehicle != nullptr)
                     {
-                        vehicle->TrackLocation += amountToMove;
-                        vehicle->BoatLocation += amountToMove;
+                        shiftIfNotNull(vehicle->TrackLocation, amountToMove);
+                        shiftIfNotNull(vehicle->BoatLocation, amountToMove);
                     }
                     break;
                 }
@@ -2389,7 +2389,7 @@ void ShiftMap(const TileCoordsXY& amount)
                     {
                         auto positions = patrol->ToVector();
                         for (auto& p : positions)
-                            p += amount;
+                            shiftIfNotNull(p, amount);
                         patrol->Clear();
                         patrol->Union(positions);
                     }
@@ -2426,7 +2426,7 @@ void ShiftMap(const TileCoordsXY& amount)
         auto* banner = GetBanner(id);
         if (banner != nullptr)
         {
-            banner->position += amount;
+            shiftIfNotNull(banner->position, amount);
             count++;
         }
         id = BannerIndex::FromUnderlying(id.ToUnderlying() + 1);

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2243,17 +2243,18 @@ void ShiftMap(const TileCoordsXY& amount)
         return;
 
     auto amountToMove = amount.ToCoordsXY();
+    auto& gameState = GetGameState();
 
     // Tile elements
     auto newElements = std::vector<TileElement>();
-    for (int32_t y = 0; y < MAXIMUM_MAP_SIZE_TECHNICAL; y++)
+    for (int32_t y = 0; y < kMaximumMapSizeTechnical; y++)
     {
-        for (int32_t x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
+        for (int32_t x = 0; x < kMaximumMapSizeTechnical; x++)
         {
             auto srcX = x - amount.x;
             auto srcY = y - amount.y;
-            if (x > 0 && y > 0 && x < gMapSize.x - 1 && y < gMapSize.y - 1 && srcX > 0 && srcY > 0 && srcX < gMapSize.x - 1
-                && srcY < gMapSize.y - 1)
+            if (x > 0 && y > 0 && x < gameState.MapSize.x - 1 && y < gameState.MapSize.y - 1 && srcX > 0 && srcY > 0
+                && srcX < gameState.MapSize.x - 1 && srcY < gameState.MapSize.y - 1)
             {
                 auto srcTile = _tileIndex.GetFirstElementAt(TileCoordsXY(srcX, srcY));
                 do
@@ -2261,19 +2262,19 @@ void ShiftMap(const TileCoordsXY& amount)
                     newElements.push_back(*srcTile);
                 } while (!(srcTile++)->IsLastForTile());
             }
-            else if (x == 0 || y == 0 || x == gMapSize.x - 1 || y == gMapSize.y - 1)
+            else if (x == 0 || y == 0 || x == gameState.MapSize.x - 1 || y == gameState.MapSize.y - 1)
             {
                 auto surface = GetDefaultSurfaceElement();
-                surface.SetBaseZ(MINIMUM_LAND_HEIGHT_BIG);
-                surface.SetClearanceZ(MINIMUM_LAND_HEIGHT_BIG);
+                surface.SetBaseZ(kMinimumLandZ);
+                surface.SetClearanceZ(kMinimumLandZ);
                 surface.AsSurface()->SetSlope(0);
                 surface.AsSurface()->SetWaterHeight(0);
                 newElements.push_back(surface);
             }
             else
             {
-                auto copyX = std::clamp(srcX, 1, gMapSize.x - 2);
-                auto copyY = std::clamp(srcY, 1, gMapSize.y - 2);
+                auto copyX = std::clamp(srcX, 1, gameState.MapSize.x - 2);
+                auto copyY = std::clamp(srcY, 1, gameState.MapSize.y - 2);
                 auto srcTile = MapGetSurfaceElementAt(TileCoordsXY(copyX, copyY));
                 if (srcTile != nullptr)
                 {
@@ -2293,10 +2294,10 @@ void ShiftMap(const TileCoordsXY& amount)
     SetTileElements(std::move(newElements));
     MapRemoveOutOfRangeElements();
 
-    for (auto& spawn : gPeepSpawns)
+    for (auto& spawn : gameState.PeepSpawns)
         spawn += amountToMove;
 
-    for (auto& entrance : gParkEntrances)
+    for (auto& entrance : gameState.ParkEntrances)
         entrance += amountToMove;
 
     // Entities

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2251,8 +2251,8 @@ void ShiftMap(const TileCoordsXY& amount)
         {
             auto srcX = x - amount.x;
             auto srcY = y - amount.y;
-            if (x >= 0 && y >= 0 && x < gMapSize.x && y < gMapSize.y && srcX >= 0 && srcY >= 0 && srcX < gMapSize.x
-                && srcY < gMapSize.y)
+            if (x > 0 && y > 0 && x < gMapSize.x - 1 && y < gMapSize.y - 1 && srcX > 0 && srcY > 0 && srcX < gMapSize.x - 1
+                && srcY < gMapSize.y - 1)
             {
                 auto srcTile = _tileIndex.GetFirstElementAt(TileCoordsXY(srcX, srcY));
                 do
@@ -2271,7 +2271,21 @@ void ShiftMap(const TileCoordsXY& amount)
             }
             else
             {
-                newElements.push_back(GetDefaultSurfaceElement());
+                auto copyX = std::clamp(srcX, 1, gMapSize.x - 2);
+                auto copyY = std::clamp(srcY, 1, gMapSize.y - 2);
+                auto srcTile = MapGetSurfaceElementAt(TileCoordsXY(copyX, copyY));
+                if (srcTile != nullptr)
+                {
+                    auto tileEl = *srcTile;
+                    tileEl.SetOwner(OWNERSHIP_UNOWNED);
+                    tileEl.SetParkFences(0);
+                    tileEl.SetLastForTile(true);
+                    newElements.push_back(*reinterpret_cast<TileElement*>(&tileEl));
+                }
+                else
+                {
+                    newElements.push_back(GetDefaultSurfaceElement());
+                }
             }
         }
     }
@@ -2324,6 +2338,8 @@ void ShiftMap(const TileCoordsXY& amount)
                     duck->target_y += amountToMove.y;
                     break;
                 }
+                default:
+                    break;
             }
             if (entityType == EntityType::Staff)
             {

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2239,7 +2239,7 @@ MapRange ClampRangeWithinMap(const MapRange& range)
 
 void ShiftMap(const TileCoordsXY& amount)
 {
-    if (amount.x == 0 || amount.y == 0)
+    if (amount.x == 0 && amount.y == 0)
         return;
 
     auto amountToMove = amount.ToCoordsXY();

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2397,6 +2397,7 @@ void ShiftMap(const TileCoordsXY& amount)
             }
         }
     }
+    UpdateConsolidatedPatrolAreas();
 
     // Rides
     for (auto& ride : GetRideManager())

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -576,7 +576,7 @@ int16_t TileElementHeight(const CoordsXYZ& loc, uint8_t slope)
     int8_t quad = 0, quad_extra = 0; // which quadrant the element is in?
                                      // quad_extra is for extra height tiles
 
-    uint8_t xl, yl; // coordinates across this tile
+    uint8_t xl, yl;                  // coordinates across this tile
 
     uint8_t TILE_SIZE = 32;
 
@@ -2300,6 +2300,7 @@ void ShiftMap(const TileCoordsXY& amount)
         entrance += amountToMove;
 
     // Entities
+    auto& entityTweener = EntityTweener::Get();
     for (auto i = 0; i < EnumValue(EntityType::Count); i++)
     {
         auto entityType = static_cast<EntityType>(i);
@@ -2309,7 +2310,7 @@ void ShiftMap(const TileCoordsXY& amount)
             auto entity = GetEntity(entityId);
 
             // Do not tween the entity
-            EntityTweener::Get().RemoveEntity(entity);
+            entityTweener.RemoveEntity(entity);
 
             auto location = entity->GetLocation();
             location += amountToMove;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -576,7 +576,7 @@ int16_t TileElementHeight(const CoordsXYZ& loc, uint8_t slope)
     int8_t quad = 0, quad_extra = 0; // which quadrant the element is in?
                                      // quad_extra is for extra height tiles
 
-    uint8_t xl, yl;                  // coordinates across this tile
+    uint8_t xl, yl; // coordinates across this tile
 
     uint8_t TILE_SIZE = 32;
 

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2238,6 +2238,18 @@ MapRange ClampRangeWithinMap(const MapRange& range)
     return validRange;
 }
 
+static inline void shiftIfNotNull(TileCoordsXY& coords, const TileCoordsXY& amount)
+{
+    if (!coords.IsNull())
+        coords += amount;
+}
+
+static inline void shiftIfNotNull(CoordsXY& coords, const CoordsXY& amount)
+{
+    if (!coords.IsNull())
+        coords += amount;
+}
+
 void ShiftMap(const TileCoordsXY& amount)
 {
     if (amount.x == 0 && amount.y == 0)
@@ -2392,17 +2404,17 @@ void ShiftMap(const TileCoordsXY& amount)
         auto& stations = ride.GetStations();
         for (auto& station : stations)
         {
-            station.Start += amountToMove;
-            station.Entrance += amount;
-            station.Exit += amount;
+            shiftIfNotNull(station.Start, amountToMove);
+            shiftIfNotNull(station.Entrance, amount);
+            shiftIfNotNull(station.Exit, amount);
         }
 
-        ride.overall_view += amountToMove;
-        ride.boat_hire_return_position += amount;
-        ride.CurTestTrackLocation += amount;
-        ride.ChairliftBullwheelLocation[0] += amount;
-        ride.ChairliftBullwheelLocation[1] += amount;
-        ride.CableLiftLoc += amountToMove;
+        shiftIfNotNull(ride.overall_view, amountToMove);
+        shiftIfNotNull(ride.boat_hire_return_position, amount);
+        shiftIfNotNull(ride.CurTestTrackLocation, amount);
+        shiftIfNotNull(ride.ChairliftBullwheelLocation[0], amount);
+        shiftIfNotNull(ride.ChairliftBullwheelLocation[1], amount);
+        shiftIfNotNull(ride.CableLiftLoc, amountToMove);
     }
 
     // Banners

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -23,6 +23,7 @@
 #include "../core/Guard.hpp"
 #include "../entity/Duck.h"
 #include "../entity/EntityTweener.h"
+#include "../entity/Fountain.h"
 #include "../entity/PatrolArea.h"
 #include "../entity/Staff.h"
 #include "../interface/Cursors.h"
@@ -2354,6 +2355,15 @@ void ShiftMap(const TileCoordsXY& amount)
                     }
                     break;
                 }
+                case EntityType::JumpingFountain:
+                {
+                    auto fountain = entity->As<JumpingFountain>();
+                    if (fountain != nullptr)
+                    {
+                        fountain->TargetX += amountToMove.x;
+                        fountain->TargetY += amountToMove.y;
+                    }
+                }
                 default:
                     break;
             }
@@ -2409,4 +2419,6 @@ void ShiftMap(const TileCoordsXY& amount)
         }
         id = BannerIndex::FromUnderlying(id.ToUnderlying() + 1);
     }
+
+    ShiftAllMapAnimations(amountToMove);
 }

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -22,6 +22,7 @@
 #include "../audio/audio.h"
 #include "../core/Guard.hpp"
 #include "../entity/Duck.h"
+#include "../entity/EntityTweener.h"
 #include "../entity/PatrolArea.h"
 #include "../entity/Staff.h"
 #include "../interface/Cursors.h"
@@ -2306,6 +2307,10 @@ void ShiftMap(const TileCoordsXY& amount)
         for (const auto& entityId : list)
         {
             auto entity = GetEntity(entityId);
+
+            // Do not tween the entity
+            EntityTweener::Get().RemoveEntity(entity);
+
             auto location = entity->GetLocation();
             location += amountToMove;
             entity->MoveTo(location);
@@ -2316,26 +2321,35 @@ void ShiftMap(const TileCoordsXY& amount)
                 case EntityType::Staff:
                 {
                     auto peep = entity->As<Peep>();
-                    peep->NextLoc += amountToMove;
-                    peep->DestinationX += amountToMove.x;
-                    peep->DestinationY += amountToMove.y;
-                    peep->PathfindGoal += amount;
-                    for (auto& h : peep->PathfindHistory)
-                        h += amount;
+                    if (peep != nullptr)
+                    {
+                        peep->NextLoc += amountToMove;
+                        peep->DestinationX += amountToMove.x;
+                        peep->DestinationY += amountToMove.y;
+                        peep->PathfindGoal += amount;
+                        for (auto& h : peep->PathfindHistory)
+                            h += amount;
+                    }
                     break;
                 }
                 case EntityType::Vehicle:
                 {
                     auto vehicle = entity->As<Vehicle>();
-                    vehicle->TrackLocation += amountToMove;
-                    vehicle->BoatLocation += amountToMove;
+                    if (vehicle != nullptr)
+                    {
+                        vehicle->TrackLocation += amountToMove;
+                        vehicle->BoatLocation += amountToMove;
+                    }
                     break;
                 }
                 case EntityType::Duck:
                 {
                     auto duck = entity->As<Duck>();
-                    duck->target_x += amountToMove.x;
-                    duck->target_y += amountToMove.y;
+                    if (duck != nullptr)
+                    {
+                        duck->target_x += amountToMove.x;
+                        duck->target_y += amountToMove.y;
+                    }
                     break;
                 }
                 default:
@@ -2344,14 +2358,17 @@ void ShiftMap(const TileCoordsXY& amount)
             if (entityType == EntityType::Staff)
             {
                 auto staff = entity->As<Staff>();
-                auto patrol = staff->PatrolInfo;
-                if (patrol != nullptr)
+                if (staff != nullptr)
                 {
-                    auto positions = patrol->ToVector();
-                    for (auto& p : positions)
-                        p += amount;
-                    patrol->Clear();
-                    patrol->Union(positions);
+                    auto patrol = staff->PatrolInfo;
+                    if (patrol != nullptr)
+                    {
+                        auto positions = patrol->ToVector();
+                        for (auto& p : positions)
+                            p += amount;
+                        patrol->Clear();
+                        patrol->Union(positions);
+                    }
                 }
             }
         }

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2406,5 +2406,6 @@ void ShiftMap(const TileCoordsXY& amount)
             banner->position += amount;
             count++;
         }
+        id = BannerIndex::FromUnderlying(id.ToUnderlying() + 1);
     }
 }

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -246,3 +246,4 @@ void FixLandOwnershipTiles(std::initializer_list<TileCoordsXY> tiles);
 void FixLandOwnershipTilesWithOwnership(
     std::initializer_list<TileCoordsXY> tiles, uint8_t ownership, bool doNotDowngrade = false);
 MapRange ClampRangeWithinMap(const MapRange& range);
+void ShiftMap(const TileCoordsXY& amount);

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -709,3 +709,14 @@ void MapAnimationAutoCreateAtTileElement(TileCoordsXY coords, TileElement* el)
             break;
     }
 }
+
+void ShiftAllMapAnimations(CoordsXY amount)
+{
+    if (amount.x == 0 && amount.y == 0)
+        return;
+
+    for (auto& a : _mapAnimations)
+    {
+        a.location += amount;
+    }
+}

--- a/src/openrct2/world/MapAnimation.h
+++ b/src/openrct2/world/MapAnimation.h
@@ -46,3 +46,4 @@ void MapAnimationInvalidateAll();
 const std::vector<MapAnimation>& GetMapAnimations();
 void MapAnimationAutoCreate();
 void MapAnimationAutoCreateAtTileElement(TileCoordsXY coords, TileElement* el);
+void ShiftAllMapAnimations(CoordsXY amount);


### PR DESCRIPTION
Allows increasing the map size at 0, 0 direction.
New parameters are added to the change map size game action so that the map is shifted after increasing the map size.

Needs testing to make sure all stored coordinates across tiles, entities, maps, banners, everything are shifted correctly.

Zip contains a saved game for testing and a plugin to trigger the action with shift 8, 8
[shiftmap.zip](https://github.com/OpenRCT2/OpenRCT2/files/11524752/shiftmap.zip)
