### PR TITLE
Guests will only jump in mazes when facing a hedge

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#15660] Ability to show window buttons on the left.
 - Feature: [OpenMusic#41] Official Title Theme by Allister Brimble.
 - Improved: [#20243] Add new colour preset to Side Friction Roller Coaster (using the new colours).
+- Improved: [#20264] Guests will only jump in mazes when facing a hedge.
 - Change: [#20110] Fix a few RCT1 build height parity discrepancies.
 - Fix: [#6152] Camera and UI are no longer locked at 40 Hz, providing a smoother experience.
 - Fix: [#19823] Parkobj: disallow overriding objects of different object types.

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -4882,17 +4882,6 @@ void Guest::UpdateRideMazePathfinding()
         return;
     }
 
-    if (IsActionInterruptable())
-    {
-        if (Energy > 80 && !(PeepFlags & PEEP_FLAGS_SLOW_WALK) && !ClimateIsRaining() && (ScenarioRand() & 0xFFFF) <= 2427)
-        {
-            Action = PeepActionType::Jump;
-            ActionFrame = 0;
-            ActionSpriteImageOffset = 0;
-            UpdateCurrentActionSpriteType();
-        }
-    }
-
     auto targetLoc = GetDestination().ToTileStart();
 
     auto stationBaseZ = ride->GetStation().GetBaseZ();
@@ -4970,6 +4959,18 @@ void Guest::UpdateRideMazePathfinding()
         case maze_type::hedge:
             SetDestination(targetLoc);
             Var37 = _MazeGetNewDirectionFromEdge[Var37 / 4][chosenEdge];
+            if (chosenEdge != MazeLastEdge)
+            {
+                // Guest is facing a hedge before turning, occasionally jump to look over
+                if (IsActionInterruptable() && Energy > 80 && !(PeepFlags & PEEP_FLAGS_SLOW_WALK) && !ClimateIsRaining()
+                    && (ScenarioRand() & 0xFFFF) <= 2427)
+                {
+                    Action = PeepActionType::Jump;
+                    ActionFrame = 0;
+                    ActionSpriteImageOffset = 0;
+                    UpdateCurrentActionSpriteType();
+                }
+            }
             MazeLastEdge = chosenEdge;
             break;
         case maze_type::entrance_or_exit:


### PR DESCRIPTION
Before this change, guests would randomly jump within a maze. The idea of jumping in a maze is to look over a hedge. This change ensures guests only jump when they are facing one.

Please note that I did not change the random modifier which is used to determine whether a guest will jump. This means guests will jump less than before. However, currently, they jump **a lot** and I personally think it's better this way. See the demo below. Let me know if y'all think otherwise.

**Before:**
![Before](https://github.com/OpenRCT2/OpenRCT2/assets/30838294/85de1973-d593-40d5-8dd1-5c90d27b2d8d)

**After:**
![After](https://github.com/OpenRCT2/OpenRCT2/assets/30838294/4a136a0b-41b8-4744-a59a-419988606bb1)
