### PR TITLE
Fix #20250: Entity tweening corrupting entity positions changing parks

### DIFF
--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -22,6 +22,7 @@
 #include "actions/GameAction.h"
 #include "config/Config.h"
 #include "entity/EntityRegistry.h"
+#include "entity/EntityTweener.h"
 #include "entity/PatrolArea.h"
 #include "entity/Staff.h"
 #include "interface/Screenshot.h"
@@ -94,6 +95,8 @@ void GameState::InitAll(const TileCoordsXY& mapSize)
     auto& scriptEngine = GetContext()->GetScriptEngine();
     scriptEngine.ClearParkStorage();
 #endif
+
+    EntityTweener::Get().Reset();
 }
 
 /**


### PR DESCRIPTION
This happens now because I moved the UI update out of ticks so there is a chance the entity tweener still holds the positions from a previous tick. This PR ensures that when a park is loaded the entity tweener is reset.

Closes #20250