### PR TITLE
Rework Object Identifier callers

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4138,17 +4138,6 @@ STR_SCNR    :Fort Anachronism
 STR_PARK    :Fort Anachronism
 STR_DTLS    :
 
-###########
-# Scenery #
-###########
-
-## Start OpenRCT2 Official
-
-[TTPIRF05]
-STR_NAME    :Roof
-
-## End OpenRCT2 Official
-
 ###############################################################################
 ## RCT2 Scenarios
 ###############################################################################

--- a/src/openrct2/localisation/LanguagePack.cpp
+++ b/src/openrct2/localisation/LanguagePack.cpp
@@ -205,7 +205,6 @@ public:
     }
 
 private:
-
     ScenarioOverride* GetScenarioOverride(const std::string& scenarioIdentifier)
     {
         for (auto& so : _scenarioOverrides)

--- a/src/openrct2/localisation/LanguagePack.cpp
+++ b/src/openrct2/localisation/LanguagePack.cpp
@@ -323,14 +323,13 @@ private:
 
     void ParseGroupObject(IStringReader* reader)
     {
-        auto sb = StringBuilder();
+        // THIS IS NO LONGER USED SO WE ARE JUST SKIPPING OVER
         codepoint_t codepoint;
 
         // Should have already deduced that the next codepoint is a [
         reader->Skip();
 
         // Read string up to ] or line end
-        bool closedCorrectly = false;
         while (reader->TryPeek(&codepoint))
         {
             if (IsNewLine(codepoint))
@@ -339,10 +338,8 @@ private:
             reader->Skip();
             if (codepoint == ']')
             {
-                closedCorrectly = true;
                 break;
             }
-            sb.Append(codepoint);
         }
     }
 

--- a/src/openrct2/localisation/LanguagePack.cpp
+++ b/src/openrct2/localisation/LanguagePack.cpp
@@ -182,27 +182,6 @@ public:
         return nullptr;
     }
 
-    StringId GetObjectOverrideStringId(std::string_view legacyIdentifier, uint8_t index) override
-    {
-        Guard::Assert(index < ObjectOverrideMaxStringCount);
-
-        int32_t ooIndex = 0;
-        for (const ObjectOverride& objectOverride : _objectOverrides)
-        {
-            if (std::string_view(objectOverride.name, 8) == legacyIdentifier)
-            {
-                if (objectOverride.strings[index].empty())
-                {
-                    return STR_NONE;
-                }
-                return ObjectOverrideBase + (ooIndex * ObjectOverrideMaxStringCount) + index;
-            }
-            ooIndex++;
-        }
-
-        return STR_NONE;
-    }
-
     StringId GetScenarioOverrideStringId(const utf8* scenarioFilename, uint8_t index) override
     {
         Guard::ArgumentNotNull(scenarioFilename);
@@ -226,17 +205,6 @@ public:
     }
 
 private:
-    ObjectOverride* GetObjectOverride(const std::string& objectIdentifier)
-    {
-        for (auto& oo : _objectOverrides)
-        {
-            if (strncmp(oo.name, objectIdentifier.c_str(), 8) == 0)
-            {
-                return &oo;
-            }
-        }
-        return nullptr;
-    }
 
     ScenarioOverride* GetScenarioOverride(const std::string& scenarioIdentifier)
     {
@@ -375,31 +343,6 @@ private:
                 break;
             }
             sb.Append(codepoint);
-        }
-
-        if (closedCorrectly)
-        {
-            while (sb.GetLength() < 8)
-            {
-                sb.Append(' ');
-            }
-            if (sb.GetLength() == 8)
-            {
-                _currentGroup = sb.GetStdString();
-                _currentObjectOverride = GetObjectOverride(_currentGroup);
-                _currentScenarioOverride = nullptr;
-                if (_currentObjectOverride == nullptr)
-                {
-                    if (_objectOverrides.size() == MAX_OBJECT_OVERRIDES)
-                    {
-                        LOG_WARNING("Maximum number of localised object strings exceeded.");
-                    }
-
-                    _objectOverrides.emplace_back();
-                    _currentObjectOverride = &_objectOverrides[_objectOverrides.size() - 1];
-                    std::copy_n(_currentGroup.c_str(), 8, _currentObjectOverride->name);
-                }
-            }
         }
     }
 

--- a/src/openrct2/localisation/LanguagePack.h
+++ b/src/openrct2/localisation/LanguagePack.h
@@ -26,7 +26,6 @@ struct ILanguagePack
     virtual void RemoveString(StringId stringId) abstract;
     virtual void SetString(StringId stringId, const std::string& str) abstract;
     virtual const utf8* GetString(StringId stringId) const abstract;
-    virtual StringId GetObjectOverrideStringId(std::string_view legacyIdentifier, uint8_t index) abstract;
     virtual StringId GetScenarioOverrideStringId(const utf8* scenarioFilename, uint8_t index) abstract;
 };
 

--- a/src/openrct2/localisation/LocalisationService.cpp
+++ b/src/openrct2/localisation/LocalisationService.cpp
@@ -153,15 +153,6 @@ std::tuple<StringId, StringId, StringId> LocalisationService::GetLocalisedScenar
     return std::make_tuple(result0, result1, result2);
 }
 
-StringId LocalisationService::GetObjectOverrideStringId(std::string_view legacyIdentifier, uint8_t index) const
-{
-    if (_loadedLanguages.empty())
-    {
-        return STR_NONE;
-    }
-    return _loadedLanguages[0]->GetObjectOverrideStringId(legacyIdentifier, index);
-}
-
 StringId LocalisationService::AllocateObjectString(const std::string& target)
 {
     if (_availableObjectStringIds.empty())

--- a/src/openrct2/localisation/LocalisationService.h
+++ b/src/openrct2/localisation/LocalisationService.h
@@ -59,7 +59,6 @@ namespace OpenRCT2::Localisation
 
         const char* GetString(StringId id) const;
         std::tuple<StringId, StringId, StringId> GetLocalisedScenarioStrings(const std::string& scenarioFilename) const;
-        StringId GetObjectOverrideStringId(std::string_view legacyIdentifier, uint8_t index) const;
         std::string GetLanguagePath(uint32_t languageId) const;
 
         void OpenLanguage(int32_t id);

--- a/src/openrct2/object/BannerObject.cpp
+++ b/src/openrct2/object/BannerObject.cpp
@@ -41,10 +41,9 @@ void BannerObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* st
 
     // Add banners to 'Signs and items for footpaths' group, rather than lumping them in the Miscellaneous tab.
     // Since this is already done the other way round for original items, avoid adding those to prevent duplicates.
-    auto identifier = GetLegacyIdentifier();
 
     auto& objectRepository = context->GetObjectRepository();
-    auto item = objectRepository.FindObjectLegacy(identifier);
+    auto item = objectRepository.FindObject(GetDescriptor());
     if (item != nullptr)
     {
         auto sourceGame = item->GetFirstSourceGame();

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -115,28 +115,9 @@ void Object::PopulateTablesFromJson(IReadObjectContext* context, json_t& root)
     _usesFallbackImages = _imageTable.ReadJson(context, root);
 }
 
-std::string Object::GetOverrideString(uint8_t index) const
-{
-    auto legacyIdentifier = GetLegacyIdentifier();
-    const auto& localisationService = OpenRCT2::GetContext()->GetLocalisationService();
-    auto stringId = localisationService.GetObjectOverrideStringId(legacyIdentifier, index);
-
-    const utf8* result = nullptr;
-    if (stringId != STR_NONE)
-    {
-        result = LanguageGetString(stringId);
-    }
-    return String::ToStd(result);
-}
-
 std::string Object::GetString(ObjectStringID index) const
 {
-    auto sz = GetOverrideString(static_cast<uint8_t>(index));
-    if (sz.empty())
-    {
-        sz = GetStringTable().GetString(index);
-    }
-    return sz;
+    return GetStringTable().GetString(index);
 }
 
 std::string Object::GetString(int32_t language, ObjectStringID index) const

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -220,7 +220,6 @@ protected:
      */
     void PopulateTablesFromJson(IReadObjectContext* context, json_t& root);
 
-    std::string GetOverrideString(uint8_t index) const;
     std::string GetString(ObjectStringID index) const;
     std::string GetString(int32_t language, ObjectStringID index) const;
 

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -265,7 +265,7 @@ public:
         return _usesFallbackImages;
     }
 
-    // Legacy data structures
+    // DONOT USE THIS CAN LEAD TO OBJECT COLLISIONS
     std::string_view GetLegacyIdentifier() const
     {
         return _descriptor.GetName();

--- a/src/openrct2/object/PathAdditionObject.cpp
+++ b/src/openrct2/object/PathAdditionObject.cpp
@@ -45,10 +45,9 @@ void PathAdditionObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStre
 
     // Add path additions to 'Signs and items for footpaths' group, rather than lumping them in the Miscellaneous tab.
     // Since this is already done the other way round for original items, avoid adding those to prevent duplicates.
-    auto identifier = GetLegacyIdentifier();
 
     auto& objectRepository = context->GetObjectRepository();
-    auto item = objectRepository.FindObjectLegacy(identifier);
+    auto item = objectRepository.FindObject(GetDescriptor());
     if (item != nullptr)
     {
         auto sourceGame = item->GetFirstSourceGame();

--- a/test/tests/LanguagePackTest.cpp
+++ b/test/tests/LanguagePackTest.cpp
@@ -47,7 +47,6 @@ TEST_F(LanguagePackTest, language_pack_simple)
     ASSERT_STREQ(lang->GetString(2), "Spiral Roller Coaster");
     ASSERT_EQ(lang->GetScenarioOverrideStringId("Arid Heights", 0), 0x7000);
     ASSERT_STREQ(lang->GetString(0x7000), "Arid Heights scenario string");
-    ASSERT_STREQ(lang->GetString(0x6000), "my test ride");
     // Test some negatives too
     ASSERT_EQ(lang->GetString(1000), nullptr);
     ASSERT_EQ(lang->GetScenarioOverrideStringId("No such park", 0), STR_NONE);
@@ -63,7 +62,6 @@ TEST_F(LanguagePackTest, language_pack_multibyte)
     ASSERT_EQ(lang->GetScenarioOverrideStringId("Forest Frontiers", 2), 0x7002);
     ASSERT_STREQ(lang->GetString(0x7000), "Forest Frontiers");
     ASSERT_STREQ(lang->GetString(0x7002), u8"在隱藏於森林深處的清空範圍中, 建造一個很受歡迎的樂園");
-    ASSERT_STREQ(lang->GetString(0x6000), u8"神鷹暢遊");
 }
 
 const utf8* LanguagePackTest::LanguageEnGB = "# STR_XXXX part is read and XXXX becomes the string id number.\n"

--- a/test/tests/LanguagePackTest.cpp
+++ b/test/tests/LanguagePackTest.cpp
@@ -47,12 +47,10 @@ TEST_F(LanguagePackTest, language_pack_simple)
     ASSERT_STREQ(lang->GetString(2), "Spiral Roller Coaster");
     ASSERT_EQ(lang->GetScenarioOverrideStringId("Arid Heights", 0), 0x7000);
     ASSERT_STREQ(lang->GetString(0x7000), "Arid Heights scenario string");
-    ASSERT_EQ(lang->GetObjectOverrideStringId("CONDORRD", 0), 0x6000);
     ASSERT_STREQ(lang->GetString(0x6000), "my test ride");
     // Test some negatives too
     ASSERT_EQ(lang->GetString(1000), nullptr);
     ASSERT_EQ(lang->GetScenarioOverrideStringId("No such park", 0), STR_NONE);
-    ASSERT_EQ(lang->GetObjectOverrideStringId("        ", 0), STR_NONE);
 }
 
 TEST_F(LanguagePackTest, language_pack_multibyte)
@@ -65,7 +63,6 @@ TEST_F(LanguagePackTest, language_pack_multibyte)
     ASSERT_EQ(lang->GetScenarioOverrideStringId("Forest Frontiers", 2), 0x7002);
     ASSERT_STREQ(lang->GetString(0x7000), "Forest Frontiers");
     ASSERT_STREQ(lang->GetString(0x7002), u8"在隱藏於森林深處的清空範圍中, 建造一個很受歡迎的樂園");
-    ASSERT_EQ(lang->GetObjectOverrideStringId("CONDORRD", 0), 0x6000);
     ASSERT_STREQ(lang->GetString(0x6000), u8"神鷹暢遊");
 }
 


### PR DESCRIPTION
`FindObjectLegacy` is a broken function that can cause incorrect objects to be returned. I've replaced 2 callers with FindObject. (FindObject is also broken but at least we pass that the correct fields to fix it {follow on pr hopefully}). GetObjectOverrideStringId is how we originally overrode the language strings for official objects. It is no longer used.