### PR TITLE
Fix #20285: Workaround to disable tweening when updated from UI

### DIFF
--- a/src/openrct2/entity/EntityBase.h
+++ b/src/openrct2/entity/EntityBase.h
@@ -35,6 +35,14 @@ struct EntitySpriteData
     ScreenRect SpriteRect;
 };
 
+namespace EntityRenderFlags
+{
+    // Disables tweening for this tick, this is helpful when entities are teleported
+    // and should not be tweened.
+    constexpr uint32_t kInvalidateTweening = (1U << 0);
+
+} // namespace EntityRenderFlags
+
 struct EntityBase
 {
     EntityType Type;
@@ -42,6 +50,8 @@ struct EntityBase
     int32_t x;
     int32_t y;
     int32_t z;
+    // Rendering specific flags, this should not be stored in the save file.
+    uint32_t RenderFlags;
     EntitySpriteData SpriteData;
     // Used as direction or rotation depending on the entity.
     uint8_t Orientation;

--- a/src/openrct2/entity/EntityRegistry.cpp
+++ b/src/openrct2/entity/EntityRegistry.cpp
@@ -473,6 +473,13 @@ void EntityBase::MoveTo(const CoordsXYZ& newLocation)
         EntitySetCoordinates(loc, this);
         Invalidate(); // Invalidate new position.
     }
+
+    if (!gInUpdateCode)
+    {
+        // Make sure we don't tween when the position was modified outside of the
+        // update loop.
+        RenderFlags |= EntityRenderFlags::kInvalidateTweening;
+    }
 }
 
 void EntitySetCoordinates(const CoordsXYZ& entityPos, EntityBase* entity)

--- a/src/openrct2/entity/EntityRegistry.cpp
+++ b/src/openrct2/entity/EntityRegistry.cpp
@@ -273,6 +273,7 @@ static void EntityReset(EntityBase* entity)
 
     entity->Id = entityIndex;
     entity->Type = EntityType::Null;
+    entity->RenderFlags = 0;
 }
 
 static constexpr uint16_t MAX_MISC_SPRITES = 300;

--- a/src/openrct2/entity/EntityTweener.cpp
+++ b/src/openrct2/entity/EntityTweener.cpp
@@ -19,7 +19,7 @@
 void EntityTweener::AddEntity(EntityBase* entity)
 {
     entity->RenderFlags &= ~EntityRenderFlags::kInvalidateTweening;
-    
+
     Entities.push_back(entity);
     PrePos.emplace_back(entity->GetLocation());
 }

--- a/src/openrct2/entity/EntityTweener.h
+++ b/src/openrct2/entity/EntityTweener.h
@@ -21,6 +21,7 @@ class EntityTweener
 
 private:
     void PopulateEntities();
+    void AddEntity(EntityBase* entity);
 
 public:
     static EntityTweener& Get();


### PR DESCRIPTION
This is not the most practical approach but the alternative is to re-work the entire loop to strictly separate things further which is not a task I can just do in a day or two. This PR just checks if the position was updated outside of the Tick and tells the tweener via a flag on the entity to ignore it until the next Tick.

Closes #20285