### PR TITLE
Fix #20310: Create map animations in title

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Fix: [#20155] Fairground organ style 2 shows up as regular music, rather than for the merry-go-round.
 - Fix: [#20260] Ride locks up when inspecting/fixing staff member is fired.
 - Fix: [#20262] Title screen music missing when “random” title music is selected and RCT1 is no longer linked.
+- Fix: [#20310] Map animations are not created on the title screen.
 - Fix: [#20342] Large Half Loop (left) now only appears once in the special elements dropdown.
 - Fix: [#20361] Crash when using random map generation.
 - Fix: [#20364] Adding too much money with cheats causes an overflow.

--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -305,6 +305,7 @@ namespace OpenRCT2::Title
                     objectManager.LoadObjects(result.RequiredObjects);
 
                     parkImporter->Import();
+                    MapAnimationAutoCreate();
                 }
                 PrepareParkForPlayback();
                 success = true;


### PR DESCRIPTION
The startup sequence runs `MapAnimationAutoCreate()` many times, but never after the actual map has been loaded. This means that signs in the title sequence have glitchy text (see #20310)

For some reason when loading a savegame it uses a different function to load the map which ultimately calls `LoadParkFromStream()` which calls `MapAnimationAutoCreate()` in the appropriate spot. This is not done when loading the title sequence which has its own `LoadParkFromFile()` which doesn't end up calling `MapAnimationAutoCreate()`

This PR adds a call to `MapAnimationAutoCreate()` in the title sequence's `LoadParkFromFile()`.

`MapAnimationAutoCreate()` seems to be run in places where it doesn't do anything. Perhaps someone should go through and get rid of most of these calls.