### PR TITLE
Revert #20286 and change game actions to be always queued

### DIFF
--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -264,7 +264,7 @@ void GameState::UpdateLogic(LogicTimings* timings)
     };
 
     gInUpdateCode = true;
-    
+
     gScreenAge++;
     if (gScreenAge == 0)
         gScreenAge--;

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -109,8 +109,6 @@ void GameState::Tick()
 {
     PROFILED_FUNCTION();
 
-    gInUpdateCode = true;
-
     // Normal game play will update only once every GAME_UPDATE_TIME_MS
     uint32_t numUpdates = 1;
 
@@ -250,7 +248,6 @@ void GameState::Tick()
     }
 
     gDoSingleUpdate = false;
-    gInUpdateCode = false;
 }
 
 void GameState::UpdateLogic(LogicTimings* timings)
@@ -266,6 +263,8 @@ void GameState::UpdateLogic(LogicTimings* timings)
         }
     };
 
+    gInUpdateCode = true;
+    
     gScreenAge++;
     if (gScreenAge == 0)
         gScreenAge--;
@@ -290,6 +289,7 @@ void GameState::UpdateLogic(LogicTimings* timings)
         // Don't run past the server, this condition can happen during map changes.
         if (NetworkGetServerTick() == gCurrentTicks)
         {
+            gInUpdateCode = false;
             return;
         }
 
@@ -397,6 +397,8 @@ void GameState::UpdateLogic(LogicTimings* timings)
     {
         timings->CurrentIdx = (timings->CurrentIdx + 1) % LOGIC_UPDATE_MEASUREMENTS_COUNT;
     }
+
+    gInUpdateCode = false;
 }
 
 void GameState::CreateStateSnapshot()

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -334,10 +334,11 @@ namespace GameActions
                         return result;
                     }
                 }
-                else if (NetworkGetMode() == NETWORK_MODE_SERVER)
+                else if (NetworkGetMode() == NETWORK_MODE_SERVER || !gInUpdateCode)
                 {
                     // If player is the server it would execute right away as where clients execute the commands
                     // at the beginning of the frame, so we have to put them into the queue.
+                    // This is also the case when its executed from the UI update.
                     if (!(actionFlags & GameActions::Flags::ClientOnly) && !(flags & GAME_COMMAND_FLAG_NETWORKED))
                     {
                         LOG_VERBOSE("[%s] GameAction::Execute %s (Queue)", GetRealm(), action->GetName());

--- a/src/openrct2/entity/EntityBase.h
+++ b/src/openrct2/entity/EntityBase.h
@@ -35,14 +35,6 @@ struct EntitySpriteData
     ScreenRect SpriteRect;
 };
 
-namespace EntityRenderFlags
-{
-    // Disables tweening for this tick, this is helpful when entities are teleported
-    // and should not be tweened.
-    constexpr uint32_t kInvalidateTweening = (1U << 0);
-
-} // namespace EntityRenderFlags
-
 struct EntityBase
 {
     EntityType Type;
@@ -50,8 +42,6 @@ struct EntityBase
     int32_t x;
     int32_t y;
     int32_t z;
-    // Rendering specific flags, this should not be stored in the save file.
-    uint32_t RenderFlags;
     EntitySpriteData SpriteData;
     // Used as direction or rotation depending on the entity.
     uint8_t Orientation;

--- a/src/openrct2/entity/EntityRegistry.cpp
+++ b/src/openrct2/entity/EntityRegistry.cpp
@@ -273,7 +273,6 @@ static void EntityReset(EntityBase* entity)
 
     entity->Id = entityIndex;
     entity->Type = EntityType::Null;
-    entity->RenderFlags = 0;
 }
 
 static constexpr uint16_t MAX_MISC_SPRITES = 300;
@@ -472,13 +471,6 @@ void EntityBase::MoveTo(const CoordsXYZ& newLocation)
     {
         EntitySetCoordinates(loc, this);
         Invalidate(); // Invalidate new position.
-    }
-
-    if (!gInUpdateCode)
-    {
-        // Make sure we don't tween when the position was modified outside of the
-        // update loop.
-        RenderFlags |= EntityRenderFlags::kInvalidateTweening;
     }
 }
 

--- a/src/openrct2/entity/EntityTweener.cpp
+++ b/src/openrct2/entity/EntityTweener.cpp
@@ -18,8 +18,6 @@
 
 void EntityTweener::AddEntity(EntityBase* entity)
 {
-    entity->RenderFlags &= ~EntityRenderFlags::kInvalidateTweening;
-
     Entities.push_back(entity);
     PrePos.emplace_back(entity->GetLocation());
 }
@@ -92,9 +90,6 @@ void EntityTweener::Tween(float alpha)
         if (ent == nullptr)
             continue;
 
-        if (ent->RenderFlags & EntityRenderFlags::kInvalidateTweening)
-            continue;
-
         auto& posA = PrePos[i];
         auto& posB = PostPos[i];
 
@@ -116,9 +111,6 @@ void EntityTweener::Restore()
     {
         auto* ent = Entities[i];
         if (ent == nullptr)
-            continue;
-
-        if (ent->RenderFlags & EntityRenderFlags::kInvalidateTweening)
             continue;
 
         EntitySetCoordinates(PostPos[i], ent);


### PR DESCRIPTION
~~This ensures that even when not in network play it stays deterministic and well defined where the game state can update.~~ 
Decided to go a slightly different route to preserve the replays, I will clean this up afterwards for now it keeps the tests happy and enqueues the game actions only when issues from UI or like before when its network play, I would need to fix two replays if its always queued as it would stop executing it directly so there is a minor difference when it captures the state.

Should also Close #20294, while I was not able to reproduce this the author says it started happening with that specific commit which I revert in here.