### PR TITLE
Fix #19816: Improve "Unknown custom action" tooltip error

### DIFF
--- a/src/openrct2/actions/CustomAction.cpp
+++ b/src/openrct2/actions/CustomAction.cpp
@@ -13,9 +13,10 @@
 #    include "../Context.h"
 #    include "../scripting/ScriptEngine.h"
 
-CustomAction::CustomAction(const std::string& id, const std::string& json)
+CustomAction::CustomAction(const std::string& id, const std::string& json, const std::string& pluginName)
     : _id(id)
     , _json(json)
+    , _pluginName(pluginName)
 {
 }
 
@@ -27,6 +28,11 @@ std::string CustomAction::GetId() const
 std::string CustomAction::GetJson() const
 {
     return _json;
+}
+
+std::string CustomAction::GetPluginName() const
+{
+    return _pluginName;
 }
 
 uint16_t CustomAction::GetActionFlags() const

--- a/src/openrct2/actions/CustomAction.h
+++ b/src/openrct2/actions/CustomAction.h
@@ -18,13 +18,15 @@ class CustomAction final : public GameActionBase<GameCommand::Custom>
 private:
     std::string _id;
     std::string _json;
+    std::string _pluginName;
 
 public:
     CustomAction() = default;
-    CustomAction(const std::string& id, const std::string& json);
+    CustomAction(const std::string& id, const std::string& json, const std::string& pluginName);
 
     std::string GetId() const;
     std::string GetJson() const;
+    std::string GetPluginName() const;
 
     uint16_t GetActionFlags() const override;
 

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -1090,7 +1090,7 @@ GameActions::Result ScriptEngine::QueryOrExecuteCustomGameAction(const CustomAct
 
     auto action = GameActions::Result();
     action.Error = GameActions::Status::Unknown;
-    action.ErrorTitle = "Unknown custom action";
+    action.ErrorTitle = " [Unknown custom action] \n" + customAction.GetPluginName() + ": " + actionz;
     return action;
 }
 
@@ -1466,7 +1466,7 @@ void ScriptEngine::RunGameActionHooks(const GameAction& action, GameActions::Res
     }
 }
 
-std::unique_ptr<GameAction> ScriptEngine::CreateGameAction(const std::string& actionid, const DukValue& args)
+std::unique_ptr<GameAction> ScriptEngine::CreateGameAction(const std::string& actionid, const DukValue& args, const std::string& pluginName)
 {
     auto action = CreateGameActionFromActionId(actionid);
     if (action != nullptr)
@@ -1494,7 +1494,7 @@ std::unique_ptr<GameAction> ScriptEngine::CreateGameAction(const std::string& ac
     auto jsonz = duk_json_encode(ctx, -1);
     auto json = std::string(jsonz);
     duk_pop(ctx);
-    auto customAction = std::make_unique<CustomAction>(actionid, json);
+    auto customAction = std::make_unique<CustomAction>(actionid, json, pluginName);
 
     if (customAction->GetPlayer() == -1 && NetworkGetMode() != NETWORK_MODE_NONE)
     {

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -1087,7 +1087,7 @@ GameActions::Result ScriptEngine::QueryOrExecuteCustomGameAction(const CustomAct
         }
         return DukToGameActionResult(dukResult);
     }
- 
+
     auto action = GameActions::Result();
     action.Error = GameActions::Status::Unknown;
     action.ErrorTitle = "Unknown custom action";

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -1466,7 +1466,8 @@ void ScriptEngine::RunGameActionHooks(const GameAction& action, GameActions::Res
     }
 }
 
-std::unique_ptr<GameAction> ScriptEngine::CreateGameAction(const std::string& actionid, const DukValue& args, const std::string& pluginName)
+std::unique_ptr<GameAction> ScriptEngine::CreateGameAction(
+    const std::string& actionid, const DukValue& args, const std::string& pluginName)
 {
     auto action = CreateGameActionFromActionId(actionid);
     if (action != nullptr)

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -1087,10 +1087,11 @@ GameActions::Result ScriptEngine::QueryOrExecuteCustomGameAction(const CustomAct
         }
         return DukToGameActionResult(dukResult);
     }
-
+ 
     auto action = GameActions::Result();
     action.Error = GameActions::Status::Unknown;
-    action.ErrorTitle = " [Unknown custom action] \n" + customAction.GetPluginName() + ": " + actionz;
+    action.ErrorTitle = "Unknown custom action";
+    action.ErrorMessage = customAction.GetPluginName() + ": " + actionz;
     return action;
 }
 

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -257,7 +257,7 @@ namespace OpenRCT2::Scripting
         bool RegisterCustomAction(
             const std::shared_ptr<Plugin>& plugin, std::string_view action, const DukValue& query, const DukValue& execute);
         void RunGameActionHooks(const GameAction& action, GameActions::Result& result, bool isExecute);
-        [[nodiscard]] std::unique_ptr<GameAction> CreateGameAction(const std::string& actionid, const DukValue& args);
+        [[nodiscard]] std::unique_ptr<GameAction> CreateGameAction(const std::string& actionid, const DukValue& args, const std::string& pluginName);
         [[nodiscard]] DukValue GameActionResultToDuk(const GameAction& action, const GameActions::Result& result);
 
         void SaveSharedStorage();

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -257,7 +257,8 @@ namespace OpenRCT2::Scripting
         bool RegisterCustomAction(
             const std::shared_ptr<Plugin>& plugin, std::string_view action, const DukValue& query, const DukValue& execute);
         void RunGameActionHooks(const GameAction& action, GameActions::Result& result, bool isExecute);
-        [[nodiscard]] std::unique_ptr<GameAction> CreateGameAction(const std::string& actionid, const DukValue& args, const std::string& pluginName);
+        [[nodiscard]] std::unique_ptr<GameAction> CreateGameAction(
+            const std::string& actionid, const DukValue& args, const std::string& pluginName);
         [[nodiscard]] DukValue GameActionResultToDuk(const GameAction& action, const GameActions::Result& result);
 
         void SaveSharedStorage();

--- a/src/openrct2/scripting/bindings/game/ScContext.hpp
+++ b/src/openrct2/scripting/bindings/game/ScContext.hpp
@@ -348,10 +348,10 @@ namespace OpenRCT2::Scripting
             auto ctx = scriptEngine.GetContext();
             try
             {
-                auto action = scriptEngine.CreateGameAction(actionid, args);
+                auto plugin = scriptEngine.GetExecInfo().GetCurrentPlugin();
+                auto action = scriptEngine.CreateGameAction(actionid, args, plugin->GetMetadata().Name);
                 if (action != nullptr)
                 {
-                    auto plugin = scriptEngine.GetExecInfo().GetCurrentPlugin();
                     if (isExecute)
                     {
                         action->SetCallback(


### PR DESCRIPTION
Fixes #19816 by updating the "Unknown custom action" error messages to include the plugin name and action ID, making it easier to identify the offending plugin/action.

### Before
![Before)](https://github.com/OpenRCT2/OpenRCT2/assets/5142096/366d8099-afdc-4b7a-b609-bc8786994d2c)

### After

![After](https://github.com/OpenRCT2/OpenRCT2/assets/5142096/fc7a1ef7-1470-4757-bc4c-1d10c1629dd9)

