### PR TITLE
Fix #20312: Affected windows now update properly

### DIFF
--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -665,6 +665,7 @@ private:
             y = std::max<int32_t>(y, widget->bottom);
         }
         height = y + 6;
+        ResizeFrameWithPage();
     }
 
     void OnResize() override

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -741,6 +741,7 @@ public:
             }
         }
 
+        ResizeFrameWithPage();
         widgets[WIDX_SCENERY_LIST].right = windowWidth - 26;
         widgets[WIDX_SCENERY_LIST].bottom = height - 14;
 

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -268,6 +268,7 @@ public:
         }
         SetWidgetPressed(WIDX_STAFF_LIST_QUICK_FIRE, _quickFireMode);
 
+        ResizeFrameWithPage();
         widgets[WIDX_STAFF_LIST_LIST].right = width - 4;
         widgets[WIDX_STAFF_LIST_LIST].bottom = height - 15;
         widgets[WIDX_STAFF_LIST_QUICK_FIRE].left = width - 77;

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -379,6 +379,7 @@ public:
             _colour_index_2 = -1;
         }
 
+        ResizeFrameWithPage();
         widgets[WIDX_THEMES_LIST].right = width - 4;
         widgets[WIDX_THEMES_LIST].bottom = height - 0x0F;
 


### PR DESCRIPTION
This PR fixes #20312 which is a regression in #20176 

Due to the dynamic position of the close button, certain widgets needed to be sized depending on the position of the close button. Code that didn't respect this setting was removed from some windows (e.g. the Options window) but appropriate code wasn't put in its place. This PR fixes that by calling `ResizeFrameWithPage()` in these places.