### PR TITLE
Fix input cursor blinking too fast

### DIFF
--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -130,7 +130,7 @@ public:
         ContextStopTextInput();
     }
 
-    void OnPeriodicUpdate() override
+    void OnUpdate() override
     {
         if (HasParentWindow())
         {


### PR DESCRIPTION
Not the right function to handle this, OnPeriodicUpdate is actually misleading and is called every frame currently which I will fix in another PR.