### PR TITLE
Add code to draw Cyrillic characters Ѕѕ, Іі, Її, and Јј

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,7 +3,7 @@
 - Feature: [#15660] Ability to show window buttons on the left.
 - Feature: [OpenMusic#41] Official Title Theme by Allister Brimble.
 - Improved: [#20119, #20243] Add new colour presets to several roller coasters (using the new colours).
-- Improved: Add Cyrillic characters Ѕѕ, Іі, Її, and Јј to the sprite font. 
+- Improved: [#20393] Add Cyrillic characters Ѕѕ, Іі, Її, and Јј to the sprite font. 
 - Change: [#20110] Fix a few RCT1 build height parity discrepancies.
 - Fix: [#6152] Camera and UI are no longer locked at 40 Hz, providing a smoother experience.
 - Fix: [#19823] Parkobj: disallow overriding objects of different object types.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#15660] Ability to show window buttons on the left.
 - Feature: [OpenMusic#41] Official Title Theme by Allister Brimble.
 - Improved: [#20119, #20243] Add new colour presets to several roller coasters (using the new colours).
+- Improved: Add Cyrillic characters Ѕѕ, Іі, Її, and Јј to the sprite font. 
 - Change: [#20110] Fix a few RCT1 build height parity discrepancies.
 - Fix: [#6152] Camera and UI are no longer locked at 40 Hz, providing a smoother experience.
 - Fix: [#19823] Parkobj: disallow overriding objects of different object types.

--- a/src/openrct2/drawing/Font.cpp
+++ b/src/openrct2/drawing/Font.cpp
@@ -117,6 +117,10 @@ static const std::unordered_map<char32_t, int32_t> codepointOffsetMap = {
 
     // Cyrillic alphabet
     { UnicodeChar::cyrillic_io_uc, 203 - CS_SPRITE_FONT_OFFSET }, // Looks just like Ë
+    { UnicodeChar::cyrillic_dze_uc, 'S' - CS_SPRITE_FONT_OFFSET },
+    { UnicodeChar::cyrillic_dotted_i_uc, 'I' - CS_SPRITE_FONT_OFFSET },
+    { UnicodeChar::cyrillic_yi_uc, 207 - CS_SPRITE_FONT_OFFSET }, // Looks just like Ï
+    { UnicodeChar::cyrillic_je_uc, 'J' - CS_SPRITE_FONT_OFFSET },
     { UnicodeChar::cyrillic_a_uc, 'A' - CS_SPRITE_FONT_OFFSET },
     { UnicodeChar::cyrillic_be_uc, SPR_G2_CYRILLIC_BE_UPPER - SPR_CHAR_START },
     { UnicodeChar::cyrillic_ve_uc, 'B' - CS_SPRITE_FONT_OFFSET },
@@ -183,6 +187,10 @@ static const std::unordered_map<char32_t, int32_t> codepointOffsetMap = {
     { UnicodeChar::cyrillic_yu, SPR_G2_CYRILLIC_YU_LOWER - SPR_CHAR_START },
     { UnicodeChar::cyrillic_ya, SPR_G2_CYRILLIC_YA_LOWER - SPR_CHAR_START },
     { UnicodeChar::cyrillic_io, 235 - CS_SPRITE_FONT_OFFSET }, // Looks just like ë
+    { UnicodeChar::cyrillic_dze, 's' - CS_SPRITE_FONT_OFFSET },
+    { UnicodeChar::cyrillic_dotted_i, 'i' - CS_SPRITE_FONT_OFFSET },
+    { UnicodeChar::cyrillic_yi, 239 - CS_SPRITE_FONT_OFFSET }, // Looks just like ï
+    { UnicodeChar::cyrillic_je, 'j' - CS_SPRITE_FONT_OFFSET },
 
     // Punctuation
     { UnicodeChar::left_brace, SPR_G2_LEFT_BRACE - SPR_CHAR_START },

--- a/src/openrct2/localisation/FormatCodes.h
+++ b/src/openrct2/localisation/FormatCodes.h
@@ -213,6 +213,10 @@ namespace UnicodeChar
 
     // Cyrillic alphabet
     constexpr char32_t cyrillic_io_uc = 0x401;
+    constexpr char32_t cyrillic_dze_uc = 0x0405;
+    constexpr char32_t cyrillic_dotted_i_uc = 0x0406;
+    constexpr char32_t cyrillic_yi_uc = 0x0407;
+    constexpr char32_t cyrillic_je_uc = 0x0408;
     constexpr char32_t cyrillic_a_uc = 0x410;
     constexpr char32_t cyrillic_be_uc = 0x411;
     constexpr char32_t cyrillic_ve_uc = 0x412;
@@ -280,6 +284,10 @@ namespace UnicodeChar
     constexpr char32_t cyrillic_ya = 0x44F;
 
     constexpr char32_t cyrillic_io = 0x451;
+    constexpr char32_t cyrillic_dze = 0x0455;
+    constexpr char32_t cyrillic_dotted_i = 0x0456;
+    constexpr char32_t cyrillic_yi = 0x0457;
+    constexpr char32_t cyrillic_je = 0x0458;
 
     // Punctuation
     constexpr char32_t left_brace = 0x7B;


### PR DESCRIPTION
This adds code to properly draw Іі and Її (needed for Ukrainian). For good measure, I have also added support for Ѕѕ and Јј (used in Macedonian, and also looking exactly like some Latin letters that we already support).