### PR TITLE
Fix #20361: Crash when using random map generation

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Fix: [#20155] Fairground organ style 2 shows up as regular music, rather than for the merry-go-round.
 - Fix: [#20260] Ride locks up when inspecting/fixing staff member is fired.
 - Fix: [#20262] Title screen music missing when “random” title music is selected and RCT1 is no longer linked.
+- Fix: [#20361] Crash when using random map generation.
 
 0.4.5 (2023-05-08)
 ------------------------------------------------------------------------

--- a/src/openrct2/world/MapGen.cpp
+++ b/src/openrct2/world/MapGen.cpp
@@ -370,7 +370,7 @@ static void MapGenPlaceTrees()
                         neighbourPos.y = std::clamp(neighbourPos.y, COORDS_XY_STEP, COORDS_XY_STEP * (gMapSize.y - 1));
 
                         const auto neighboutSurface = MapGetSurfaceElementAt(neighbourPos);
-                        if (neighboutSurface->GetWaterHeight() > 0)
+                        if (neighboutSurface != nullptr && neighboutSurface->GetWaterHeight() > 0)
                         {
                             float distance = std::sqrt(offsetX * offsetX + offsetY * offsetY);
                             oasisScore += 0.5f / (maxOasisDistance * distance);


### PR DESCRIPTION
Closes #20361, Closes #20390