### PR TITLE
Exclude the 'All' tab when searching for scenery group

### DIFF
--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -1108,6 +1108,11 @@ private:
         for (size_t i = 0; i < _tabEntries.size(); i++)
         {
             const auto& tabInfo = _tabEntries[i];
+            if (tabInfo.IsAll())
+            {
+                // The scenery will be always added here so exclude this one.
+                continue;
+            }
             if (tabInfo.Contains(scenery))
             {
                 return i;


### PR DESCRIPTION
The Misc tab never showed up because it considered the All tab as a specific scenery group.

Closes #20409