### PR TITLE
Fix #20413: Crash attempting to navigate an empty console history

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,6 +13,7 @@
 - Fix: [#20260] Ride locks up when inspecting/fixing staff member is fired.
 - Fix: [#20262] Title screen music missing when “random” title music is selected and RCT1 is no longer linked.
 - Fix: [#20361] Crash when using random map generation.
+- Fix: [#20413] Crash when attempting to navigate an empty console history.
 
 0.4.5 (2023-05-08)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -82,7 +82,7 @@ void InGameConsole::Input(ConsoleInput input)
             _consoleTextInputSession->SelectionStart = _consoleCurrentLine.size();
             break;
         case ConsoleInput::HistoryNext:
-            if (_consoleHistoryIndex < _consoleHistory.size() - 1)
+            if (_consoleHistoryIndex + 1 < _consoleHistory.size())
             {
                 _consoleHistoryIndex++;
                 _consoleCurrentLine = _consoleHistory[_consoleHistoryIndex];


### PR DESCRIPTION
Closes #20413