### PR TITLE
Fix #20417: Plugin windows missing the left title bar border

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Fix: [#20262] Title screen music missing when “random” title music is selected and RCT1 is no longer linked.
 - Fix: [#20361] Crash when using random map generation.
 - Fix: [#20413] Crash when attempting to navigate an empty console history.
+- Fix: [#20417] Plugin/custom windows are missing the left border in the title bar.
 
 0.4.5 (2023-05-08)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -48,10 +48,8 @@ namespace OpenRCT2::Ui::Windows
     };
 
     static Widget CustomDefaultWidgets[] = {
-        { WindowWidgetType::Frame, 0, 0, 0, 0, 0, 0xFFFFFFFF, STR_NONE },                  // panel / background
-        { WindowWidgetType::Caption, 0, 0, 0, 1, 14, STR_STRING, STR_WINDOW_TITLE_TIP },   // title bar
-        { WindowWidgetType::CloseBox, 0, 0, 0, 2, 13, STR_CLOSE_X, STR_CLOSE_WINDOW_TIP }, // close x button
-        { WindowWidgetType::Resize, 1, 0, 0, 14, 0, 0xFFFFFFFF, STR_NONE },                // content panel
+        WINDOW_SHIM(STR_STRING, 50, 50),
+        MakeWidget({ 0, 14 }, { 50, 36 }, WindowWidgetType::Resize, WindowColour::Secondary), // content panel
     };
 
     struct CustomWidgetDesc


### PR DESCRIPTION
As I suspected, the bug was caused by initialising everything to 0. The window was also one of the few (or even the only one) that did not use the shim or MakeWidget, which drastically simply this kind of thing. Initialising the window to 50×50 also means that it should no longer try and divide by zero, making any future refactors much easier.

![Forest Frontiers 2023-06-18 22-39-24](https://github.com/OpenRCT2/OpenRCT2/assets/1478678/0fa69375-19d1-4418-af0d-a2d6f26241e4)
![Forest Frontiers 2023-06-18 22-41-11](https://github.com/OpenRCT2/OpenRCT2/assets/1478678/164ed914-7391-4b1e-a191-c10640cf1c73)
