### PR TITLE
Fix #20433. Dropdown default selections not working

### DIFF
--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -381,6 +381,10 @@ public:
 
     void OnDropdown(WidgetIndex widgetIndex, int32_t dropdownIndex) override
     {
+        if (dropdownIndex == -1)
+        {
+            return;
+        }
         switch (widgetIndex)
         {
             case WIDX_PAGE_DROPDOWN_BUTTON:

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -169,6 +169,10 @@ public:
 
     void OnDropdown(WidgetIndex widgetIndex, int32_t selectedIndex) override
     {
+        if (selectedIndex == -1)
+        {
+            return;
+        }
         auto serverIndex = selected_list_item;
         if (serverIndex >= 0 && serverIndex < static_cast<int32_t>(_serverList.GetCount()))
         {

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -238,6 +238,10 @@ public:
 
     void OnDropdown(WidgetIndex widgetIndex, int32_t dropdownIndex) override
     {
+        if (dropdownIndex == -1)
+        {
+            return;
+        }
         if (widgetIndex == WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER)
         {
             auto action = StaffSetColourAction(GetSelectedStaffType(), ColourDropDownIndexToColour(dropdownIndex));

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -219,6 +219,10 @@ public:
 
     void OnDropdown(WidgetIndex widgetIndex, int32_t selectedIndex) override
     {
+        if (selectedIndex == -1)
+        {
+            return;
+        }
         if (widgetIndex == WIDX_GAME_TOOLS)
         {
             switch (selectedIndex)

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -2653,6 +2653,10 @@ public:
 
     void OnDropdown(WidgetIndex widgetIndex, int32_t selectedIndex) override
     {
+        if (selectedIndex == -1)
+        {
+            return;
+        }
         switch (widgetIndex)
         {
             case WIDX_FILE_MENU:

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -1450,10 +1450,7 @@ void WindowEventDropdownCall(WindowBase* w, WidgetIndex widgetIndex, int32_t dro
 {
     if (w->event_handlers == nullptr)
     {
-        if (dropdownIndex != -1)
-        {
-            w->OnDropdown(widgetIndex, dropdownIndex);
-        }
+        w->OnDropdown(widgetIndex, dropdownIndex);
     }
     else if (w->event_handlers->dropdown != nullptr)
     {


### PR DESCRIPTION
This fixes it for rides but it is also an issue effecting a few different dropdowns.

Not sure if this warrants a changelog there is more than just the ride window that had default behaviour when clicking the dropdown that was missing.