### PR TITLE
Fix periodic window update function being called every frame

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -104,8 +104,6 @@ static void InputUpdateTooltip(WindowBase* w, WidgetIndex widgetIndex, const Scr
  */
 void GameHandleInput()
 {
-    WindowVisitEach([](WindowBase* w) { WindowEventPeriodicUpdateCall(w); });
-
     InvalidateAllWindowsAfterInput();
 
     MouseState state;

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -129,13 +129,10 @@ void WindowUpdateAllViewports()
  */
 void WindowUpdateAll()
 {
-    // WindowUpdateAllViewports();
-
-    // 1000 tick update
-    gWindowUpdateTicks += gCurrentDeltaTime;
-    if (gWindowUpdateTicks >= 1000)
+    // Periodic update happens every second so 40 ticks.
+    if (gCurrentRealTimeTicks >= gWindowUpdateTicks)
     {
-        gWindowUpdateTicks = 0;
+        gWindowUpdateTicks = gCurrentRealTimeTicks + 40;
 
         WindowVisitEach([](WindowBase* w) { WindowEventPeriodicUpdateCall(w); });
     }

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -132,7 +132,7 @@ void WindowUpdateAll()
     // Periodic update happens every second so 40 ticks.
     if (gCurrentRealTimeTicks >= gWindowUpdateTicks)
     {
-        gWindowUpdateTicks = gCurrentRealTimeTicks + 40;
+        gWindowUpdateTicks = gCurrentRealTimeTicks + GAME_UPDATE_FPS;
 
         WindowVisitEach([](WindowBase* w) { WindowEventPeriodicUpdateCall(w); });
     }


### PR DESCRIPTION
Instead of being called every second this was called every frame. Only the scenery window seems to use it and it doesn't quite make any difference also so we can probably remove it in the upcoming legacy code cleanups.