### PR TITLE
Make conditional addition of stdc++fs more robust.

### DIFF
--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -37,13 +37,6 @@ endif ()
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
 SET_CHECK_CXX_FLAGS(${PROJECT_NAME})
 
-# GCC / Clang likes us to pass the -lstdc++fs flag to link C++17 filesystem implementation.
-if (NOT MINGW AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD" AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-        target_link_libraries(${PROJECT_NAME} stdc++fs)
-    endif()
-endif()
-
 if (NOT DISABLE_NETWORK OR NOT DISABLE_HTTP)
     if (WIN32)
         target_link_libraries(${PROJECT_NAME} bcrypt)


### PR DESCRIPTION
Please see [my comment](https://github.com/OpenRCT2/OpenRCT2/pull/10522#issuecomment-1605839657). Clang on Linux does not necessarily mean libstdc++ is in use or even installed, so I made the check more robust.