### PR TITLE
Fix #19878: Pre-built rides respect scenery research

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#6152] Camera and UI are no longer locked at 40 Hz, providing a smoother experience.
 - Fix: [#9534] Screams no longer cut-off on steep diagonal drops
 - Fix: [#19823] Parkobj: disallow overriding objects of different object types.
+- Fix: [#19878] Unresearched scenery can be placed via prebuilt rides.
 - Fix: [#20083] Cannot use terrain surfaces with ID > 32 and terrain edges with ID > 16.
 - Fix: [#20089] Potential crash when a window is closed from another window.
 - Fix: [#20103] [Plugin] Crash when custom plugin actions fail due to immutable state.

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -537,11 +537,15 @@ bool ResearchIsInvented(ObjectType objectType, ObjectEntryIndex index)
         case ObjectType::SceneryGroup:
             return SceneryGroupIsInvented(index);
         case ObjectType::SmallScenery:
+            return SceneryIsInvented({ SCENERY_TYPE_SMALL, index });
         case ObjectType::LargeScenery:
+            return SceneryIsInvented({ SCENERY_TYPE_LARGE, index });
         case ObjectType::Walls:
+            return SceneryIsInvented({ SCENERY_TYPE_WALL, index });
         case ObjectType::Banners:
+            return SceneryIsInvented({ SCENERY_TYPE_BANNER, index });
         case ObjectType::PathAdditions:
-            return SceneryIsInvented({ static_cast<uint8_t>(objectType), index });
+            return SceneryIsInvented({ SCENERY_TYPE_PATH_ITEM, index });
         default:
             return true;
     }

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -757,12 +757,17 @@ static std::optional<TrackSceneryEntry> TrackDesignPlaceSceneryElementGetEntry(c
     else
     {
         auto obj = objectMgr.GetLoadedObject(scenery.scenery_object);
+        bool objectUnavailable = obj == nullptr;
         if (obj != nullptr)
         {
             result.Type = obj->GetObjectType();
             result.Index = objectMgr.GetLoadedObjectEntryIndex(obj);
+            if (!gCheatsIgnoreResearchStatus)
+            {
+                objectUnavailable = !ResearchIsInvented(result.Type, result.Index);
+            }
         }
-        else
+        if (objectUnavailable)
         {
             _trackDesignPlaceStateSceneryUnavailable = true;
             return {};


### PR DESCRIPTION
Fix for #19878

Pre built tracks now respect whether or not scenery has been researched. This matches the behaviour with vehicle types.

There is also a fix for `ResearchIsInvented`, which was incorrectly converting `ObjectType` enums to `SceneryType` enums.