### PR TITLE
Fix #20364: Money cheat no longer overflows

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -221,6 +221,7 @@ The following people are not part of the development team, but have been contrib
 * John Mulcahy (jayjay300)
 * Chase Percy (Chase-Percy)
 * Wenzhao Qiu (qwzhaox)
+* Michael Bernardi (mrmbernardi)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -18,6 +18,7 @@
 - Fix: [#20413] Crash when attempting to navigate an empty console history.
 - Fix: [#20417] Plugin/custom windows are missing the left border in the title bar.
 - Fix: [#20429] Error window tooltip not closing after 8 seconds.
+- Fix: [#20364] Adding too much money with cheats causes an overflow.
 
 0.4.5 (2023-05-08)
 ------------------------------------------------------------------------

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -85,7 +85,7 @@ void CheatsReset()
     gCheatsMakeAllDestructible = false;
 }
 
-void CheatsSet(CheatType cheatType, int32_t param1 /* = 0*/, int32_t param2 /* = 0*/)
+void CheatsSet(CheatType cheatType, int64_t param1 /* = 0*/, int64_t param2 /* = 0*/)
 {
     auto cheatSetAction = CheatSetAction(cheatType, param1, param2);
     GameActions::Execute(&cheatSetAction);

--- a/src/openrct2/Cheats.h
+++ b/src/openrct2/Cheats.h
@@ -123,5 +123,5 @@ constexpr auto CHEATS_GIVE_GUESTS_MONEY = 1000.00_GBP;
 
 void CheatsReset();
 const char* CheatsGetName(CheatType cheatType);
-void CheatsSet(CheatType cheatType, int32_t param1 = 0, int32_t param2 = 0);
+void CheatsSet(CheatType cheatType, int64_t param1 = 0, int64_t param2 = 0);
 void CheatsSerialise(class DataSerialiser& ds);

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -39,9 +39,9 @@
 #include "ParkSetLoanAction.h"
 #include "ParkSetParameterAction.h"
 
-using ParametersRange = std::pair<std::pair<int32_t, int32_t>, std::pair<int32_t, int32_t>>;
+using ParametersRange = std::pair<std::pair<int64_t, int64_t>, std::pair<int64_t, int64_t>>;
 
-CheatSetAction::CheatSetAction(CheatType cheatType, int32_t param1, int32_t param2)
+CheatSetAction::CheatSetAction(CheatType cheatType, int64_t param1, int64_t param2)
     : _cheatType(static_cast<int32_t>(cheatType))
     , _param1(param1)
     , _param2(param2)
@@ -320,7 +320,7 @@ ParametersRange CheatSetAction::GetParameterRange(CheatType cheatType) const
         case CheatType::AddMoney:
             [[fallthrough]];
         case CheatType::SetMoney:
-            return { { std::numeric_limits<int32_t>::min(), std::numeric_limits<int32_t>::max() }, { 0, 0 } };
+            return { { std::numeric_limits<money64>::min(), std::numeric_limits<money64>::max() }, { 0, 0 } };
         case CheatType::SetGuestParameter:
             switch (_param1)
             {

--- a/src/openrct2/actions/CheatSetAction.h
+++ b/src/openrct2/actions/CheatSetAction.h
@@ -13,16 +13,16 @@
 
 class CheatSetAction final : public GameActionBase<GameCommand::Cheat>
 {
-    using ParametersRange = std::pair<std::pair<int32_t, int32_t>, std::pair<int32_t, int32_t>>;
+    using ParametersRange = std::pair<std::pair<int64_t, int64_t>, std::pair<int64_t, int64_t>>;
 
 private:
     NetworkCheatType_t _cheatType{ EnumValue(CheatType::Count) };
-    int32_t _param1{};
-    int32_t _param2{};
+    int64_t _param1{};
+    int64_t _param2{};
 
 public:
     CheatSetAction() = default;
-    CheatSetAction(CheatType cheatType, int32_t param1 = 0, int32_t param2 = 0);
+    CheatSetAction(CheatType cheatType, int64_t param1 = 0, int64_t param2 = 0);
 
     void AcceptParameters(GameActionParameterVisitor& visitor) override;
 

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "9"
+#define NETWORK_STREAM_VERSION "10"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 


### PR DESCRIPTION
This is a fix for #20364

I have simply changed the types in the game action parameters to int64_t and updated the limit to match.