### PR TITLE
Fix #20365: Money cheat supports negative value entry

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -20,6 +20,7 @@
 - Fix: [#20417] Plugin/custom windows are missing the left border in the title bar.
 - Fix: [#20429] Error window tooltip not closing after 8 seconds.
 - Fix: [#20364] Adding too much money with cheats causes an overflow.
+- Fix: [#20365] Money cheat input does not support negative values.
 
 0.4.5 (2023-05-08)
 ------------------------------------------------------------------------

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -414,14 +414,10 @@ money64 StringToMoney(const char* string_to_monetise)
     if (numNumbers == 0)
         return MONEY64_UNDEFINED;
 
-    int64_t sign = 1;
-    if (hasMinus)
+    if (hasMinus && processedString[0] != '-')
     {
         // If there is a minus sign, it has to be at position 0 in order to be valid.
-        if (processedString[0] == '-')
-            sign = -1;
-        else
-            return MONEY64_UNDEFINED;
+        return MONEY64_UNDEFINED;
     }
 
     // Due to the nature of strstr and strtok, decimals at the very beginning will be ignored, causing
@@ -436,7 +432,7 @@ money64 StringToMoney(const char* string_to_monetise)
     auto number = std::stod(processedString, nullptr);
     number /= (currencyDesc->rate / 10.0);
 
-    return ToMoney64FromGBP(number) * sign;
+    return ToMoney64FromGBP(number);
 }
 
 /**


### PR DESCRIPTION
This is a fix for #20365 


`stod` already negated the number, so multiplying by the sign made the number always positive. This is fixed by removing the code to do that.