### PR TITLE
Fix #5677: Balloons pop when they hit something

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Change: [#20790] Default ride price set to free if park charges for entry.
 - Change: [#20880] Restore removed default coaster colours.
 - Change: [#21102] The money effect will now update even when the game is paused.
+- Fix: [#5677] Balloons pass through the ground and objects.
 - Fix: [#12299] Placing ride entrances/exits ignores the Disable Clearance Checks cheat.
 - Fix: [#13473] Guests complain that the default Circus price is too high.
 - Fix: [#15293] TTF fonts don’t format correctly with OpenGL.

--- a/src/openrct2/entity/Balloon.h
+++ b/src/openrct2/entity/Balloon.h
@@ -24,8 +24,9 @@ struct Balloon : EntityBase
     uint8_t colour;
     static void Create(const CoordsXYZ& balloonPos, int32_t colour, bool isPopped);
     void Update();
-    void Pop();
+    void Pop(bool playSound);
     void Press();
     void Serialise(DataSerialiser& stream);
     void Paint(PaintSession& session, int32_t imageDirection) const;
+    bool Collides() const;
 };

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -34,6 +34,7 @@
 #include "../drawing/Drawing.h"
 #include "../drawing/Font.h"
 #include "../drawing/Image.h"
+#include "../entity/Balloon.h"
 #include "../entity/EntityList.h"
 #include "../entity/EntityRegistry.h"
 #include "../entity/Staff.h"
@@ -1914,6 +1915,23 @@ static int32_t ConsoleCommandProfilerStop(
     return 0;
 }
 
+static int32_t ConsoleSpawnBalloon(InteractiveConsole& console, const arguments_t& argv)
+{
+    if (argv.size() < 3)
+    {
+        console.WriteLineError("Need arguments: <x> <y> <z> <colour>");
+        return 1;
+    }
+    int32_t x = COORDS_XY_STEP * atof(argv[0].c_str());
+    int32_t y = COORDS_XY_STEP * atof(argv[1].c_str());
+    int32_t z = COORDS_Z_STEP * atof(argv[2].c_str());
+    int32_t col = 28;
+    if (argv.size() > 3)
+        col = atoi(argv[3].c_str());
+    Balloon::Create({ x, y, z }, col, false);
+    return 0;
+}
+
 using console_command_func = int32_t (*)(InteractiveConsole& console, const arguments_t& argv);
 struct ConsoleCommand
 {
@@ -2006,6 +2024,7 @@ static constexpr ConsoleCommand console_command_table[] = {
     { "say", ConsoleCommandSay, "Say to other players.", "say <message>" },
     { "set", ConsoleCommandSet, "Sets the variable to the specified value.", "set <variable> <value>" },
     { "show_limits", ConsoleCommandShowLimits, "Shows the map data counts and limits.", "show_limits" },
+    { "spawn_balloon", ConsoleSpawnBalloon, "Spawns a balloon.", "spawn_balloon <x> <y> <z> <colour>" },
     { "staff", ConsoleCommandStaff, "Staff management.", "staff <subcommand>" },
     { "terminate", ConsoleCommandTerminate, "Calls std::terminate(), for testing purposes only.", "terminate" },
     { "variables", ConsoleCommandVariables, "Lists all the variables that can be used with get and sometimes set.",

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "12"
+#define NETWORK_STREAM_VERSION "13"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5983,3 +5983,15 @@ ResultWithMessage Ride::ChangeStatusCreateVehicles(bool isApplying, const Coords
 
     return { true };
 }
+
+uint8_t Ride::GetEntranceStyle() const
+{
+    if (const auto* stationObject = GetStationObject(); stationObject != nullptr)
+    {
+        return GetStationStyleFromIdentifier(stationObject->GetIdentifier());
+    }
+    else
+    {
+        return RCT12_STATION_STYLE_PLAIN;
+    }
+}

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -411,6 +411,8 @@ public:
     bool HasStation() const;
 
     bool FindTrackGap(const CoordsXYE& input, CoordsXYE* output) const;
+
+    uint8_t GetEntranceStyle() const;
 };
 void UpdateSpiralSlide(Ride& ride);
 void UpdateChairlift(Ride& ride);

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -83,17 +83,6 @@ static bool _trackDesignPlaceStateEntranceExitPlaced{};
 
 static void TrackDesignPreviewClearMap();
 
-static uint8_t TrackDesignGetEntranceStyle(const Ride& ride)
-{
-    const auto* stationObject = ride.GetStationObject();
-    if (stationObject == nullptr)
-        return RCT12_STATION_STYLE_PLAIN;
-
-    const auto objectName = stationObject->GetIdentifier();
-
-    return GetStationStyleFromIdentifier(objectName);
-}
-
 ResultWithMessage TrackDesign::CreateTrackDesign(TrackDesignState& tds, const Ride& ride)
 {
     type = ride.type;
@@ -134,7 +123,7 @@ ResultWithMessage TrackDesign::CreateTrackDesign(TrackDesignState& tds, const Ri
     lift_hill_speed = ride.lift_hill_speed;
     num_circuits = ride.num_circuits;
 
-    entrance_style = TrackDesignGetEntranceStyle(ride);
+    entrance_style = ride.GetEntranceStyle();
     max_speed = static_cast<int8_t>(ride.max_speed / 65536);
     average_speed = static_cast<int8_t>(ride.average_speed / 65536);
     ride_length = ride.GetTotalLength() / 65536;


### PR DESCRIPTION
Fix for #5677

Balloons will pop if they intersect with the bottom of any tile element, including the ground. 

This could potentially cause a slowdown when everyone drops balloons after you win a scenario (maybe not since the number of balloons is limited to a few hundred)

An alternate method could involve pre-computing the height at which the balloon should pop when the guest releases it. This wouldn't be up to date if players make changes to the map, but that could be acceptable to deal with most cases of balloons floating through things.