### PR TITLE
Fix #20496: Relax requirements for compact inverted coasters

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -33,6 +33,7 @@
 - Fix: [#20429] Error window tooltip not closing after 8 seconds.
 - Fix: [#20456] Downward large half loops on flying coasters (fly-to-lie) are now correctly named.
 - Fix: [#20484] Console caret not properly updated when using command history.
+- Fix: [#20496] Ride rating requirements for compact inverted coasters is no longer relaxed.
 - Fix: [#20543] Crash using show segments height from debug paint options.
 - Fix: [#20607] Infinite loop when renaming rides with default names longer than 32 bytes.
 - Fix: [#20642] Track list is sometimes empty due to uninitialized data for the filter string.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "16"
+#define NETWORK_STREAM_VERSION "17"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/ride/coaster/meta/CompactInvertedCoaster.h
+++ b/src/openrct2/ride/coaster/meta/CompactInvertedCoaster.h
@@ -59,7 +59,7 @@ constexpr RideTypeDescriptor CompactInvertedCoasterRTD =
         { RIDE_RATING(3, 15), RIDE_RATING(2, 80), RIDE_RATING(3, 20) },
         21,
         -1,
-        false,
+        true,
         {
             { RatingsModifierType::BonusLength,           6000,             764, 0, 0 },
             { RatingsModifierType::BonusSynchronisation,  0,                RIDE_RATING(0, 42), RIDE_RATING(0, 05), 0 },


### PR DESCRIPTION
Fixed #20496 where compact inverted coasters did not get the relaxed requirements when there were inversions since the boolean for it was originally set to false.