### PR TITLE
Remove IsTitleEditor legacy code (and fix potential crash)

### DIFF
--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -285,7 +285,7 @@ public:
             }
             case WindowClass::ScenarioSelect:
                 return WindowScenarioselectOpen(
-                    reinterpret_cast<scenarioselect_callback>(intent->GetPointerExtra(INTENT_EXTRA_CALLBACK)), false);
+                    reinterpret_cast<scenarioselect_callback>(intent->GetPointerExtra(INTENT_EXTRA_CALLBACK)));
 
             case WindowClass::Null:
                 // Intent does not hold a window class

--- a/src/openrct2-ui/scripting/ScUi.hpp
+++ b/src/openrct2-ui/scripting/ScUi.hpp
@@ -304,12 +304,10 @@ namespace OpenRCT2::Scripting
             auto plugin = _scriptEngine.GetExecInfo().GetCurrentPlugin();
             auto callback = desc["callback"];
 
-            WindowScenarioselectOpen(
-                [this, plugin, callback](std::string_view path) {
-                    auto dukValue = GetScenarioFile(path);
-                    _scriptEngine.ExecutePluginCall(plugin, callback, { dukValue }, false);
-                },
-                false);
+            WindowScenarioselectOpen([this, plugin, callback](std::string_view path) {
+                auto dukValue = GetScenarioFile(path);
+                _scriptEngine.ExecutePluginCall(plugin, callback, { dukValue }, false);
+            });
         }
 
         void activateTool(const DukValue& desc)

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -392,12 +392,9 @@ public:
                     {
                         OpenRCT2::Audio::Play(OpenRCT2::Audio::SoundId::Click1, 0, windowPos.x + (width / 2));
                         gFirstTimeSaving = true;
+                        Close(); // The callback will likely close this window so this is perhaps overkill
                         _callback(listItem.scenario.scenario->Path);
-                        if (IsTitleEditor())
-                        {
-                            Close();
-                            return;
-                        }
+                        return;
                     }
                     break;
             }

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -112,15 +112,13 @@ class ScenarioSelectWindow final : public Window
 {
 private:
     bool _showLockedInformation = false;
-    bool _titleEditor = false;
     std::function<void(std::string_view)> _callback;
     std::vector<ScenarioListItem> _listItems;
     const ScenarioIndexEntry* _highlightedScenario = nullptr;
 
 public:
-    ScenarioSelectWindow(std::function<void(std::string_view)> callback, bool isTitleEditor)
-        : _titleEditor(isTitleEditor)
-        , _callback(callback)
+    ScenarioSelectWindow(std::function<void(std::string_view)> callback)
+        : _callback(callback)
     {
     }
 
@@ -134,11 +132,6 @@ public:
         InitTabs();
         InitialiseListItems();
         InitScrollWidgets();
-    }
-
-    bool IsTitleEditor() const
-    {
-        return _titleEditor;
     }
 
     void OnMouseUp(WidgetIndex widgetIndex) override
@@ -184,7 +177,7 @@ public:
                 continue;
 
             auto ft = Formatter();
-            if (gConfigGeneral.ScenarioSelectMode == SCENARIO_SELECT_MODE_ORIGIN || IsTitleEditor())
+            if (gConfigGeneral.ScenarioSelectMode == SCENARIO_SELECT_MODE_ORIGIN)
             {
                 ft.Add<StringId>(kScenarioOriginStringIds[i]);
             }
@@ -392,7 +385,7 @@ public:
                     {
                         OpenRCT2::Audio::Play(OpenRCT2::Audio::SoundId::Click1, 0, windowPos.x + (width / 2));
                         gFirstTimeSaving = true;
-                        Close(); // The callback will likely close this window so this is perhaps overkill
+                        // Callback will likely close this window! So should always return after it.
                         _callback(listItem.scenario.scenario->Path);
                         return;
                     }
@@ -554,12 +547,10 @@ private:
 
             if (!IsScenarioVisible(*scenario))
                 continue;
-            if (IsTitleEditor() && scenario->SourceGame == ScenarioSource::Other)
-                continue;
 
             // Category heading
             StringId headingStringId = STR_NONE;
-            if (gConfigGeneral.ScenarioSelectMode == SCENARIO_SELECT_MODE_ORIGIN || IsTitleEditor())
+            if (gConfigGeneral.ScenarioSelectMode == SCENARIO_SELECT_MODE_ORIGIN)
             {
                 if (selected_tab != static_cast<uint8_t>(ScenarioSource::Real) && currentHeading != scenario->Category)
                 {
@@ -664,7 +655,7 @@ private:
 
     bool IsScenarioVisible(const ScenarioIndexEntry& scenario) const
     {
-        if (gConfigGeneral.ScenarioSelectMode == SCENARIO_SELECT_MODE_ORIGIN || IsTitleEditor())
+        if (gConfigGeneral.ScenarioSelectMode == SCENARIO_SELECT_MODE_ORIGIN)
         {
             if (static_cast<uint8_t>(scenario.SourceGame) != selected_tab)
             {
@@ -694,8 +685,6 @@ private:
             return false;
         if (selected_tab >= 6)
             return false;
-        if (IsTitleEditor())
-            return false;
 
         return true;
     }
@@ -707,10 +696,8 @@ private:
         for (size_t i = 0; i < numScenarios; i++)
         {
             const ScenarioIndexEntry* scenario = ScenarioRepositoryGetByIndex(i);
-            if (gConfigGeneral.ScenarioSelectMode == SCENARIO_SELECT_MODE_ORIGIN || IsTitleEditor())
+            if (gConfigGeneral.ScenarioSelectMode == SCENARIO_SELECT_MODE_ORIGIN)
             {
-                if (IsTitleEditor() && scenario->SourceGame == ScenarioSource::Other)
-                    continue;
                 showPages |= 1 << static_cast<uint8_t>(scenario->SourceGame);
             }
             else
@@ -774,30 +761,22 @@ private:
     }
 };
 
-WindowBase* WindowScenarioselectOpen(scenarioselect_callback callback, bool titleEditor)
+WindowBase* WindowScenarioselectOpen(scenarioselect_callback callback)
 {
-    return WindowScenarioselectOpen(
-        [callback](std::string_view scenario) { callback(std::string(scenario).c_str()); }, titleEditor);
+    return WindowScenarioselectOpen([callback](std::string_view scenario) { callback(std::string(scenario).c_str()); });
 }
 
-WindowBase* WindowScenarioselectOpen(std::function<void(std::string_view)> callback, bool titleEditor)
+WindowBase* WindowScenarioselectOpen(std::function<void(std::string_view)> callback)
 {
     auto* window = static_cast<ScenarioSelectWindow*>(WindowBringToFrontByClass(WindowClass::ScenarioSelect));
     if (window != nullptr)
     {
-        if (window->IsTitleEditor() != titleEditor)
-        {
-            WindowCloseByClass(WindowClass::ScenarioSelect);
-        }
-        else
-        {
-            return window;
-        }
+        return window;
     }
 
     int32_t screenWidth = ContextGetWidth();
     int32_t screenHeight = ContextGetHeight();
     ScreenCoordsXY screenPos = { (screenWidth - WW) / 2, std::max(TOP_TOOLBAR_HEIGHT + 1, (screenHeight - WH) / 2) };
-    window = WindowCreate<ScenarioSelectWindow>(WindowClass::ScenarioSelect, screenPos, WW, WH, 0, callback, titleEditor);
+    window = WindowCreate<ScenarioSelectWindow>(WindowClass::ScenarioSelect, screenPos, WW, WH, 0, callback);
     return window;
 }

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -134,7 +134,7 @@ public:
                 break;
             case WIDX_START_SERVER:
                 NetworkSetPassword(_password);
-                WindowScenarioselectOpen(ScenarioSelectCallback, false);
+                WindowScenarioselectOpen(ScenarioSelectCallback);
                 break;
             case WIDX_LOAD_SERVER:
                 NetworkSetPassword(_password);

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -132,7 +132,7 @@ public:
                 {
                     WindowCloseByClass(WindowClass::Loadsave);
                     WindowCloseByClass(WindowClass::ServerList);
-                    WindowScenarioselectOpen(WindowTitleMenuScenarioselectCallback, false);
+                    WindowScenarioselectOpen(WindowTitleMenuScenarioselectCallback);
                 }
                 break;
             case WIDX_CONTINUE_SAVED_GAME:

--- a/src/openrct2-ui/windows/Window.h
+++ b/src/openrct2-ui/windows/Window.h
@@ -101,8 +101,8 @@ void WindowGuestListRefreshList();
 WindowBase* WindowGuestListOpen();
 WindowBase* WindowGuestListOpenWithFilter(GuestListFilterType type, int32_t index);
 WindowBase* WindowStaffFirePromptOpen(Peep* peep);
-WindowBase* WindowScenarioselectOpen(scenarioselect_callback callback, bool titleEditor);
-WindowBase* WindowScenarioselectOpen(std::function<void(std::string_view)> callback, bool titleEditor);
+WindowBase* WindowScenarioselectOpen(scenarioselect_callback callback);
+WindowBase* WindowScenarioselectOpen(std::function<void(std::string_view)> callback);
 
 WindowBase* WindowErrorOpen(StringId title, StringId message, const class Formatter& formatter);
 WindowBase* WindowErrorOpen(std::string_view title, std::string_view message);


### PR DESCRIPTION
There once was a crash here but @ZehMatt fixed the other side of that. This just removes the source of the crash and also just removes the deadcode from the old title editor (pre plugin).