### PR TITLE
Remove WindowUpdateAll from GameLoadInit

### DIFF
--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -495,7 +495,6 @@ void GameLoadInit()
     {
         intent = Intent(INTENT_ACTION_CLEAR_TILE_INSPECTOR_CLIPBOARD);
         ContextBroadcastIntent(&intent);
-        WindowUpdateAll();
     }
 
     OpenRCT2::Audio::StopTitleMusic();


### PR DESCRIPTION
There should be only one place where the call happens that is in Run(Fixed/Variable)Frame as in the primary loop otherwise the delayed deletion makes no sense.