### PR TITLE
Fix parameter validation for cheat action

### DIFF
--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -792,7 +792,7 @@ private:
                 CheatsSet(CheatType::SetMoney, _moneySpinnerValue);
                 break;
             case WIDX_CLEAR_LOAN:
-                CheatsSet(CheatType::ClearLoan, CHEATS_MONEY_DEFAULT);
+                CheatsSet(CheatType::ClearLoan);
                 break;
         }
     }

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -392,6 +392,8 @@ ParametersRange CheatSetAction::GetParameterRange(CheatType cheatType) const
             [[fallthrough]];
         case CheatType::ResetCrashStatus:
             [[fallthrough]];
+        case CheatType::NoCapOnQueueLengthDummy:
+            [[fallthrough]];
         case CheatType::RemoveLitter:
             return { { 0, 0 }, { 0, 0 } };
         case CheatType::Count:

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -315,6 +315,14 @@ ParametersRange CheatSetAction::GetParameterRange(CheatType cheatType) const
             [[fallthrough]];
         case CheatType::AllowRegularPathAsQueue:
             [[fallthrough]];
+        case CheatType::UnlockAllPrices:
+            [[fallthrough]];
+        case CheatType::MakeDestructible:
+            [[fallthrough]];
+        case CheatType::AllowSpecialColourSchemes:
+            [[fallthrough]];
+        case CheatType::AllowTrackPlaceInvalidHeights:
+            [[fallthrough]];
         case CheatType::OpenClosePark:
             return { { 0, 1 }, { 0, 0 } };
         case CheatType::AddMoney:
@@ -357,12 +365,41 @@ ParametersRange CheatSetAction::GetParameterRange(CheatType cheatType) const
         case CheatType::ForceWeather:
             return { { 0, EnumValue(WeatherType::Count) - 1 }, { 0, 0 } };
         case CheatType::SetForcedParkRating:
-            return { { 0, 999 }, { 0, 0 } };
+            return { { -1, 999 }, { 0, 0 } };
         case CheatType::CreateDucks:
             return { { 0, 100 }, { 0, 0 } };
-        default:
+        case CheatType::RemoveDucks:
+            [[fallthrough]];
+        case CheatType::ClearLoan:
+            [[fallthrough]];
+        case CheatType::RemoveAllGuests:
+            [[fallthrough]];
+        case CheatType::OwnAllLand:
+            [[fallthrough]];
+        case CheatType::WinScenario:
+            [[fallthrough]];
+        case CheatType::HaveFun:
+            [[fallthrough]];
+        case CheatType::FixVandalism:
+            [[fallthrough]];
+        case CheatType::WaterPlants:
+            [[fallthrough]];
+        case CheatType::FixRides:
+            [[fallthrough]];
+        case CheatType::RenewRides:
+            [[fallthrough]];
+        case CheatType::TenMinuteInspections:
+            [[fallthrough]];
+        case CheatType::ResetCrashStatus:
+            [[fallthrough]];
+        case CheatType::RemoveLitter:
             return { { 0, 0 }, { 0, 0 } };
     }
+
+    // Should be unreachable unless new cheats are added, still have to return something
+    // to avoid compiler warnings.
+    Guard::Assert(false, "Missing validation parameter for cheat: %d", _cheatType.id);
+    return { { 0, 0 }, { 0, 0 } };
 }
 
 void CheatSetAction::SetGrassLength(int32_t length) const

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -394,6 +394,8 @@ ParametersRange CheatSetAction::GetParameterRange(CheatType cheatType) const
             [[fallthrough]];
         case CheatType::RemoveLitter:
             return { { 0, 0 }, { 0, 0 } };
+        case CheatType::Count:
+            break;
     }
 
     // Should be unreachable unless new cheats are added, still have to return something

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "11"
+#define NETWORK_STREAM_VERSION "12"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 


### PR DESCRIPTION
I made the default throw an assertion now instead of returning a default value, I tested every cheat to ensure the parameter range is correct and that the parameter range actually exists.

Closes #20500