### PR TITLE
Fix #20484: Console caret synchronised when using history

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -25,6 +25,7 @@
 - Fix: [#20417] Plugin/custom windows are missing the left border in the title bar.
 - Fix: [#20429] Error window tooltip not closing after 8 seconds.
 - Fix: [#20456] Downward large half loops on flying coasters (fly-to-lie) are now correctly named.
+- Fix: [#20484] Console caret not properly updated when using command history.
 
 0.4.5 (2023-05-08)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -80,6 +80,7 @@ void InGameConsole::Input(ConsoleInput input)
             }
             _consoleTextInputSession->Length = UTF8Length(_consoleCurrentLine.c_str());
             _consoleTextInputSession->SelectionStart = _consoleCurrentLine.size();
+            RefreshCaret(_consoleTextInputSession->SelectionStart);
             break;
         case ConsoleInput::HistoryNext:
             if (_consoleHistoryIndex + 1 < _consoleHistory.size())
@@ -94,6 +95,7 @@ void InGameConsole::Input(ConsoleInput input)
                 _consoleHistoryIndex = _consoleHistory.size();
                 ClearInput();
             }
+            RefreshCaret(_consoleTextInputSession->SelectionStart);
             break;
         case ConsoleInput::ScrollPrevious:
         {


### PR DESCRIPTION
Fix for #20484