### PR TITLE
Fix disabled widgets sharing the same space as active widgets

### DIFF
--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -805,12 +805,19 @@ void WindowAlignTabs(WindowBase* w, WidgetIndex start_tab_id, WidgetIndex end_ta
 
     for (i = start_tab_id; i <= end_tab_id; i++)
     {
+        auto& widget = w->widgets[i];
         if (!WidgetIsDisabled(*w, i))
         {
-            auto& widget = w->widgets[i];
             widget.left = x;
             widget.right = x + tab_width;
             x += tab_width + 1;
+        }
+        else
+        {
+            // Workaround to not have two widgets share the same space otherwise WindowFindWidgetFromPoint
+            // can potentially return the disabled one which causes issues.
+            widget.left = 0;
+            widget.right = 0;
         }
     }
 }

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -814,8 +814,8 @@ void WindowAlignTabs(WindowBase* w, WidgetIndex start_tab_id, WidgetIndex end_ta
         }
         else
         {
-            // Workaround to not have two widgets share the same space otherwise WindowFindWidgetFromPoint
-            // can potentially return the disabled one which causes issues.
+            // Workaround #20535: Avoid disabled widgets from sharing the same space as active ones, otherwise
+            // WindowFindWidgetFromPoint could return the disabled one, causing issues.
             widget.left = 0;
             widget.right = 0;
         }


### PR DESCRIPTION
Because the window shares the same memory of the widgets there is a specific problem for disabled widgets. The easiest way to reproduce this bug is to do following
1. Load an ordinary scenario where money is enabled.
2. Open any ride window.
3. Load a scenario with no money.
4. Open any ride window and try to navigate to the graph, this will not work correctly.

This is more a workaround than a fix, ideally the state of each widget is per window and not global. This is also only done to the tabs so ordinary disabled widgets will stay in place.