### PR TITLE
Add a window method to resize spinners

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1909,22 +1909,13 @@ public:
             widgets[WIDX_SPEED_SETTING_SPINNER].text = STR_RIDE_CONSTRUCTION_BRAKE_SPEED_VELOCITY;
 
             widgets[WIDX_SPEED_SETTING_SPINNER].type = WindowWidgetType::Spinner;
-            widgets[WIDX_SPEED_SETTING_SPINNER].left = 12;
-            widgets[WIDX_SPEED_SETTING_SPINNER].right = 96;
-            widgets[WIDX_SPEED_SETTING_SPINNER].top = 138;
-            widgets[WIDX_SPEED_SETTING_SPINNER].bottom = 149;
             widgets[WIDX_SPEED_SETTING_SPINNER_UP].type = WindowWidgetType::Button;
             widgets[WIDX_SPEED_SETTING_SPINNER_UP].text = STR_NUMERIC_UP;
-            widgets[WIDX_SPEED_SETTING_SPINNER_UP].left = 84;
-            widgets[WIDX_SPEED_SETTING_SPINNER_UP].right = 95;
-            widgets[WIDX_SPEED_SETTING_SPINNER_UP].top = 139;
-            widgets[WIDX_SPEED_SETTING_SPINNER_UP].bottom = 148;
             widgets[WIDX_SPEED_SETTING_SPINNER_DOWN].type = WindowWidgetType::Button;
             widgets[WIDX_SPEED_SETTING_SPINNER_DOWN].text = STR_NUMERIC_DOWN;
-            widgets[WIDX_SPEED_SETTING_SPINNER_DOWN].left = 72;
-            widgets[WIDX_SPEED_SETTING_SPINNER_DOWN].right = 83;
-            widgets[WIDX_SPEED_SETTING_SPINNER_DOWN].top = 139;
-            widgets[WIDX_SPEED_SETTING_SPINNER_DOWN].bottom = 148;
+
+            ResizeSpinner(WIDX_SPEED_SETTING_SPINNER, { 12, 138 }, { 85, SPINNER_HEIGHT });
+
             hold_down_widgets |= (1uLL << WIDX_SPEED_SETTING_SPINNER_UP) | (1uLL << WIDX_SPEED_SETTING_SPINNER_DOWN);
         }
 

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -2148,3 +2148,23 @@ void WindowBase::ResizeFrameWithPage()
     widgets[3].right = width - 1;
     widgets[3].bottom = height - 1;
 }
+
+void WindowBase::ResizeSpinner(WidgetIndex widgetIndex, const ScreenCoordsXY& origin, const ScreenSize& size)
+{
+    auto right = origin.x + size.width - 1;
+    auto bottom = origin.y + size.height - 1;
+    widgets[widgetIndex].left = origin.x;
+    widgets[widgetIndex].top = origin.y;
+    widgets[widgetIndex].right = right;
+    widgets[widgetIndex].bottom = bottom;
+
+    widgets[widgetIndex + 1].left = right - size.height;
+    widgets[widgetIndex + 1].top = origin.y + 1;
+    widgets[widgetIndex + 1].right = right - 1;
+    widgets[widgetIndex + 1].bottom = bottom - 1;
+
+    widgets[widgetIndex + 2].left = right - size.height * 2;
+    widgets[widgetIndex + 2].top = origin.y + 1;
+    widgets[widgetIndex + 2].right = right - size.height - 1;
+    widgets[widgetIndex + 2].bottom = bottom - 1;
+}

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -44,6 +44,7 @@ constexpr uint8_t CloseButtonWidth = 10;
 #define LIST_ROW_HEIGHT 12
 #define TABLE_CELL_HEIGHT 12
 #define BUTTON_FACE_HEIGHT 12
+#define SPINNER_HEIGHT 12
 
 #define TEXT_INPUT_SIZE 1024
 #define TOP_TOOLBAR_HEIGHT 27

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -175,6 +175,8 @@ struct WindowBase
 
     void ResizeFrame();
     void ResizeFrameWithPage();
+
+    void ResizeSpinner(WidgetIndex widgetIndex, const ScreenCoordsXY& origin, const ScreenSize& size);
 };
 
 #ifdef __WARN_SUGGEST_FINAL_METHODS__


### PR DESCRIPTION
This addresses #20430 

It also works if you want to change the constant for the spinner height (ignore the fact that stuff isn't accommodating the new size):

![image](https://github.com/OpenRCT2/OpenRCT2/assets/7877312/b7ce6a81-02d2-433a-a250-bd8701f9bd0e)
