### PR TITLE
change SEK conversion rate from 1 GBP to 0.1 GBP

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Improved: [#20119, #20243] Add new colour presets to several roller coasters (using the new colours).
 - Improved: [#20393, #20410] Add Cyrillic characters Ґґ, Ѕѕ, Єє, Іі, Її, and Јј to the sprite font. 
 - Change: [#20110] Fix a few RCT1 build height parity discrepancies.
+- Change: [#20550] Change SEK conversion rate from 1 GBP to 0.1 GBP.
 - Fix: [#6152] Camera and UI are no longer locked at 40 Hz, providing a smoother experience.
 - Fix: [#9534] Screams no longer cut-off on steep diagonal drops.
 - Fix: [#19450] The correct element is now auto-suggested when building a Medium Half Loop backwards.

--- a/src/openrct2/localisation/Currency.cpp
+++ b/src/openrct2/localisation/Currency.cpp
@@ -23,7 +23,7 @@ CurrencyDescriptor CurrencyDescriptors[EnumValue(CurrencyType::Count)] = {
     {   "ESP",  10,     CurrencyAffix::Suffix,    "Pts",          CurrencyAffix::Suffix,    "Pts",  STR_PESETA          },  // Spanish Peseta
     {   "ITL",  1000,   CurrencyAffix::Prefix,    "L",            CurrencyAffix::Prefix,    "L",    STR_LIRA            },  // Italian Lira
     {   "NLG",  10,     CurrencyAffix::Prefix,    "\xC6\x92 ",    CurrencyAffix::Prefix,    "fl.",  STR_GUILDERS        },  // Dutch Guilder
-    {   "SEK",  10,     CurrencyAffix::Suffix,    " kr",          CurrencyAffix::Suffix,    " kr",  STR_KRONA           },  // Swedish Krona
+    {   "SEK",  100,    CurrencyAffix::Suffix,    " kr",          CurrencyAffix::Suffix,    " kr",  STR_KRONA           },  // Swedish Krona
     {   "EUR",  10,     CurrencyAffix::Prefix,    "\xE2\x82\xAC", CurrencyAffix::Suffix,    "EUR",  STR_EUROS           },  // Euro
     {   "KRW",  10000,  CurrencyAffix::Prefix,    "\xE2\x82\xA9", CurrencyAffix::Prefix,    "W",    STR_WON             },  // South Korean Won
     {   "RUB",  1000,   CurrencyAffix::Suffix,    "\xE2\x82\xBD", CurrencyAffix::Prefix,    "R ",   STR_ROUBLE          },  // Russian Rouble


### PR DESCRIPTION
1 SEK = 0.073 GBP
1 SEK has historically been between 0.07 GBP and 0.11 GBP (at least last 20 years).