### PR TITLE
Reduce accessing global widgets Part 1

### DIFF
--- a/src/openrct2-ui/windows/StaffFirePrompt.cpp
+++ b/src/openrct2-ui/windows/StaffFirePrompt.cpp
@@ -32,7 +32,7 @@ enum WindowStaffFireWidgetIdx {
 };
 
 // 0x9AFB4C
-static Widget window_staff_fire_widgets[] = {
+static Widget _staffFireWidgets[] = {
     WINDOW_SHIM_WHITE(WINDOW_TITLE, WW, WH),
     MakeWidget({     10, WH - 20}, {85, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_YES               ),
     MakeWidget({WW - 95, WH - 20}, {85, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_SAVE_PROMPT_CANCEL),
@@ -51,7 +51,7 @@ public:
 
     void OnOpen() override
     {
-        widgets = window_staff_fire_widgets;
+        widgets = _staffFireWidgets;
         WindowInitScrollWidgets(*this);
     }
 

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -68,7 +68,7 @@ constexpr int32_t MAX_WW = 500;
 constexpr int32_t MAX_WH = 450;
 
 // clang-format off
-static Widget window_staff_list_widgets[] = {
+static Widget _staffListWidgets[] = {
     WINDOW_SHIM(WINDOW_TITLE, WW, WH),
     MakeWidget({  0, 43}, {    WW, WH - 43}, WindowWidgetType::Resize,    WindowColour::Secondary                                                 ), // tab content panel
     MakeTab   ({  3, 17},                                                                             STR_STAFF_HANDYMEN_TAB_TIP    ), // handymen tab
@@ -110,7 +110,7 @@ private:
 public:
     void OnOpen() override
     {
-        widgets = window_staff_list_widgets;
+        widgets = _staffListWidgets;
         WindowInitScrollWidgets(*this);
 
         widgets[WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER].type = WindowWidgetType::Empty;

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -32,7 +32,7 @@ enum WindowTextInputWidgetIdx
     WIDX_OKAY
 };
 
-static Widget window_text_input_widgets[] = {
+static Widget _textInputWidgets[] = {
     WINDOW_SHIM(STR_NONE, WW, WH),
     MakeWidget({ 170, 68 }, { 71, 14 }, WindowWidgetType::Button, WindowColour::Secondary, STR_CANCEL),
     MakeWidget({ 10, 68 }, { 71, 14 }, WindowWidgetType::Button, WindowColour::Secondary, STR_OK),
@@ -61,7 +61,7 @@ private:
 public:
     void OnOpen() override
     {
-        widgets = window_text_input_widgets;
+        widgets = _textInputWidgets;
         WindowInitScrollWidgets(*this);
         SetParentWindow(nullptr, 0);
     }

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -71,7 +71,7 @@ static constexpr int32_t WW = 320;
 static constexpr int32_t WH = 107;
 
 // clang-format off
-static Widget window_themes_widgets[] = {
+static Widget _themesWidgets[] = {
     WINDOW_SHIM(WINDOW_TITLE, WW, WH),
     MakeWidget({  0, 43}, {320,  64}, WindowWidgetType::Resize,       WindowColour::Secondary                                                                                     ), // tab content panel
     MakeTab   ({  3, 17},                                                                                                        STR_THEMES_TAB_SETTINGS_TIP        ), // settings tab
@@ -250,7 +250,7 @@ public:
 
     void OnOpen() override
     {
-        widgets = window_themes_widgets;
+        widgets = _themesWidgets;
 
         WindowThemesInitVars();
 
@@ -379,40 +379,40 @@ public:
             _colour_index_2 = -1;
         }
 
-        window_themes_widgets[WIDX_THEMES_LIST].right = width - 4;
-        window_themes_widgets[WIDX_THEMES_LIST].bottom = height - 0x0F;
+        widgets[WIDX_THEMES_LIST].right = width - 4;
+        widgets[WIDX_THEMES_LIST].bottom = height - 0x0F;
 
         if (_selected_tab == WINDOW_THEMES_TAB_SETTINGS)
         {
-            window_themes_widgets[WIDX_THEMES_HEADER_WINDOW].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_HEADER_PALETTE].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_LIST].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_RCT1_RIDE_LIGHTS].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_RCT1_PARK_LIGHTS].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_RCT1_SCENARIO_FONT].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_RCT1_BOTTOM_TOOLBAR].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_DUPLICATE_BUTTON].type = WindowWidgetType::Button;
-            window_themes_widgets[WIDX_THEMES_DELETE_BUTTON].type = WindowWidgetType::Button;
-            window_themes_widgets[WIDX_THEMES_RENAME_BUTTON].type = WindowWidgetType::Button;
-            window_themes_widgets[WIDX_THEMES_PRESETS].type = WindowWidgetType::DropdownMenu;
-            window_themes_widgets[WIDX_THEMES_PRESETS_DROPDOWN].type = WindowWidgetType::Button;
-            window_themes_widgets[WIDX_THEMES_COLOURBTN_MASK].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_HEADER_WINDOW].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_HEADER_PALETTE].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_LIST].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_RCT1_RIDE_LIGHTS].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_RCT1_PARK_LIGHTS].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_RCT1_SCENARIO_FONT].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_RCT1_BOTTOM_TOOLBAR].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_DUPLICATE_BUTTON].type = WindowWidgetType::Button;
+            widgets[WIDX_THEMES_DELETE_BUTTON].type = WindowWidgetType::Button;
+            widgets[WIDX_THEMES_RENAME_BUTTON].type = WindowWidgetType::Button;
+            widgets[WIDX_THEMES_PRESETS].type = WindowWidgetType::DropdownMenu;
+            widgets[WIDX_THEMES_PRESETS_DROPDOWN].type = WindowWidgetType::Button;
+            widgets[WIDX_THEMES_COLOURBTN_MASK].type = WindowWidgetType::Empty;
         }
         else if (_selected_tab == WINDOW_THEMES_TAB_FEATURES)
         {
-            window_themes_widgets[WIDX_THEMES_HEADER_WINDOW].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_HEADER_PALETTE].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_LIST].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_RCT1_RIDE_LIGHTS].type = WindowWidgetType::Checkbox;
-            window_themes_widgets[WIDX_THEMES_RCT1_PARK_LIGHTS].type = WindowWidgetType::Checkbox;
-            window_themes_widgets[WIDX_THEMES_RCT1_SCENARIO_FONT].type = WindowWidgetType::Checkbox;
-            window_themes_widgets[WIDX_THEMES_RCT1_BOTTOM_TOOLBAR].type = WindowWidgetType::Checkbox;
-            window_themes_widgets[WIDX_THEMES_DUPLICATE_BUTTON].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_DELETE_BUTTON].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_RENAME_BUTTON].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_PRESETS].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_PRESETS_DROPDOWN].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_COLOURBTN_MASK].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_HEADER_WINDOW].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_HEADER_PALETTE].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_LIST].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_RCT1_RIDE_LIGHTS].type = WindowWidgetType::Checkbox;
+            widgets[WIDX_THEMES_RCT1_PARK_LIGHTS].type = WindowWidgetType::Checkbox;
+            widgets[WIDX_THEMES_RCT1_SCENARIO_FONT].type = WindowWidgetType::Checkbox;
+            widgets[WIDX_THEMES_RCT1_BOTTOM_TOOLBAR].type = WindowWidgetType::Checkbox;
+            widgets[WIDX_THEMES_DUPLICATE_BUTTON].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_DELETE_BUTTON].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_RENAME_BUTTON].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_PRESETS].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_PRESETS_DROPDOWN].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_COLOURBTN_MASK].type = WindowWidgetType::Empty;
 
             WidgetSetCheckboxValue(*this, WIDX_THEMES_RCT1_RIDE_LIGHTS, ThemeGetFlags() & UITHEME_FLAG_USE_LIGHTS_RIDE);
             WidgetSetCheckboxValue(*this, WIDX_THEMES_RCT1_PARK_LIGHTS, ThemeGetFlags() & UITHEME_FLAG_USE_LIGHTS_PARK);
@@ -423,19 +423,19 @@ public:
         }
         else
         {
-            window_themes_widgets[WIDX_THEMES_HEADER_WINDOW].type = WindowWidgetType::TableHeader;
-            window_themes_widgets[WIDX_THEMES_HEADER_PALETTE].type = WindowWidgetType::TableHeader;
-            window_themes_widgets[WIDX_THEMES_LIST].type = WindowWidgetType::Scroll;
-            window_themes_widgets[WIDX_THEMES_RCT1_RIDE_LIGHTS].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_RCT1_PARK_LIGHTS].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_RCT1_SCENARIO_FONT].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_RCT1_BOTTOM_TOOLBAR].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_DUPLICATE_BUTTON].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_DELETE_BUTTON].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_RENAME_BUTTON].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_PRESETS].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_PRESETS_DROPDOWN].type = WindowWidgetType::Empty;
-            window_themes_widgets[WIDX_THEMES_COLOURBTN_MASK].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_HEADER_WINDOW].type = WindowWidgetType::TableHeader;
+            widgets[WIDX_THEMES_HEADER_PALETTE].type = WindowWidgetType::TableHeader;
+            widgets[WIDX_THEMES_LIST].type = WindowWidgetType::Scroll;
+            widgets[WIDX_THEMES_RCT1_RIDE_LIGHTS].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_RCT1_PARK_LIGHTS].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_RCT1_SCENARIO_FONT].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_RCT1_BOTTOM_TOOLBAR].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_DUPLICATE_BUTTON].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_DELETE_BUTTON].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_RENAME_BUTTON].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_PRESETS].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_PRESETS_DROPDOWN].type = WindowWidgetType::Empty;
+            widgets[WIDX_THEMES_COLOURBTN_MASK].type = WindowWidgetType::Empty;
         }
     }
 
@@ -448,8 +448,8 @@ public:
         if (_selected_tab == WINDOW_THEMES_TAB_SETTINGS)
         {
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ 10, window_themes_widgets[WIDX_THEMES_PRESETS].top + 1 },
-                STR_THEMES_LABEL_CURRENT_THEME, {}, { colours[1] });
+                dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_THEMES_PRESETS].top + 1 }, STR_THEMES_LABEL_CURRENT_THEME, {},
+                { colours[1] });
 
             size_t activeAvailableThemeIndex = ThemeManagerGetAvailableThemeIndex();
             const utf8* activeThemeName = ThemeManagerGetAvailableThemeName(activeAvailableThemeIndex);
@@ -457,10 +457,8 @@ public:
             ft.Add<const utf8*>(activeThemeName);
 
             auto screenPos = windowPos
-                + ScreenCoordsXY{ window_themes_widgets[WIDX_THEMES_PRESETS].left + 1,
-                                  window_themes_widgets[WIDX_THEMES_PRESETS].top };
-            auto newWidth = windowPos.x + window_themes_widgets[WIDX_THEMES_PRESETS_DROPDOWN].left
-                - window_themes_widgets[WIDX_THEMES_PRESETS].left - 4;
+                + ScreenCoordsXY{ widgets[WIDX_THEMES_PRESETS].left + 1, widgets[WIDX_THEMES_PRESETS].top };
+            auto newWidth = windowPos.x + widgets[WIDX_THEMES_PRESETS_DROPDOWN].left - widgets[WIDX_THEMES_PRESETS].left - 4;
 
             DrawTextEllipsised(dpi, screenPos, newWidth, STR_STRING, ft, { colours[1] });
         }
@@ -672,8 +670,7 @@ public:
             return {};
 
         int32_t scrollHeight = GetColourSchemeTabCount() * _row_height;
-        int32_t i = scrollHeight - window_themes_widgets[WIDX_THEMES_LIST].bottom + window_themes_widgets[WIDX_THEMES_LIST].top
-            + 21;
+        int32_t i = scrollHeight - widgets[WIDX_THEMES_LIST].bottom + widgets[WIDX_THEMES_LIST].top + 21;
         if (i < 0)
             i = 0;
         if (i < scrolls[0].v_top)
@@ -706,23 +703,16 @@ public:
                     }
                     else
                     {
-                        window_themes_widgets[WIDX_THEMES_COLOURBTN_MASK].type = WindowWidgetType::ColourBtn;
-                        window_themes_widgets[WIDX_THEMES_COLOURBTN_MASK].left = _button_offset_x + _colour_index_2 * 12
-                            + window_themes_widgets[WIDX_THEMES_LIST].left;
-                        window_themes_widgets[WIDX_THEMES_COLOURBTN_MASK].top = _colour_index_1 * _row_height + _button_offset_y
-                            - scrolls[0].v_top + window_themes_widgets[WIDX_THEMES_LIST].top;
-                        window_themes_widgets[WIDX_THEMES_COLOURBTN_MASK].right = window_themes_widgets
-                                                                                      [WIDX_THEMES_COLOURBTN_MASK]
-                                                                                          .left
-                            + 12;
-                        window_themes_widgets[WIDX_THEMES_COLOURBTN_MASK].bottom = window_themes_widgets
-                                                                                       [WIDX_THEMES_COLOURBTN_MASK]
-                                                                                           .top
-                            + 12;
+                        widgets[WIDX_THEMES_COLOURBTN_MASK].type = WindowWidgetType::ColourBtn;
+                        widgets[WIDX_THEMES_COLOURBTN_MASK].left = _button_offset_x + _colour_index_2 * 12
+                            + widgets[WIDX_THEMES_LIST].left;
+                        widgets[WIDX_THEMES_COLOURBTN_MASK].top = _colour_index_1 * _row_height + _button_offset_y
+                            - scrolls[0].v_top + widgets[WIDX_THEMES_LIST].top;
+                        widgets[WIDX_THEMES_COLOURBTN_MASK].right = widgets[WIDX_THEMES_COLOURBTN_MASK].left + 12;
+                        widgets[WIDX_THEMES_COLOURBTN_MASK].bottom = widgets[WIDX_THEMES_COLOURBTN_MASK].top + 12;
 
                         uint8_t colour = ThemeGetColour(wc, _colour_index_2);
-                        WindowDropdownShowColour(
-                            this, &(window_themes_widgets[WIDX_THEMES_COLOURBTN_MASK]), colours[1], colour);
+                        WindowDropdownShowColour(this, &(widgets[WIDX_THEMES_COLOURBTN_MASK]), colours[1], colour);
                         WidgetInvalidate(*this, WIDX_THEMES_LIST);
                     }
                 }
@@ -779,8 +769,7 @@ public:
                     int32_t colour = colours[1];
 
                     auto leftTop = ScreenCoordsXY{ 0, screenCoords.y + _row_height - 2 };
-                    auto rightBottom = ScreenCoordsXY{ window_themes_widgets[WIDX_THEMES_LIST].right,
-                                                       screenCoords.y + _row_height - 2 };
+                    auto rightBottom = ScreenCoordsXY{ widgets[WIDX_THEMES_LIST].right, screenCoords.y + _row_height - 2 };
                     auto yPixelOffset = ScreenCoordsXY{ 0, 1 };
 
                     if (colour & COLOUR_FLAG_TRANSLUCENT)

--- a/src/openrct2-ui/windows/TitleExit.cpp
+++ b/src/openrct2-ui/windows/TitleExit.cpp
@@ -20,7 +20,7 @@ enum WindowTitleExitWidgetIdx {
     WIDX_EXIT,
 };
 
-static Widget window_title_exit_widgets[] = {
+static Widget _titleExitWidgets[] = {
     MakeWidget({0, 0}, {40, 64}, WindowWidgetType::ImgBtn, WindowColour::Tertiary, ImageId(SPR_MENU_EXIT), STR_EXIT),
     WIDGETS_END,
 };
@@ -30,7 +30,7 @@ class TitleExitWindow final : public Window
 {
     void OnOpen() override
     {
-        widgets = window_title_exit_widgets;
+        widgets = _titleExitWidgets;
         InitScrollWidgets();
     }
 

--- a/src/openrct2-ui/windows/TitleLogo.cpp
+++ b/src/openrct2-ui/windows/TitleLogo.cpp
@@ -22,7 +22,7 @@ enum
     WIDX_LOGO
 };
 
-static Widget window_title_logo_widgets[] = {
+static Widget _titleLogoWidgets[] = {
     MakeWidget({ 0, 0 }, { WW + 1, WH + 1 }, WindowWidgetType::ImgBtn, WindowColour::Primary),
     WIDGETS_END,
 };
@@ -36,7 +36,7 @@ public:
      */
     void OnOpen() override
     {
-        widgets = window_title_logo_widgets;
+        widgets = _titleLogoWidgets;
         WindowInitScrollWidgets(*this);
         colours[0] = TRANSLUCENT(COLOUR_GREY);
         colours[1] = TRANSLUCENT(COLOUR_GREY);

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -45,7 +45,7 @@ enum
 static constexpr ScreenSize MenuButtonDims = { 82, 82 };
 static constexpr ScreenSize UpdateButtonDims = { MenuButtonDims.width * 4, 28 };
 
-static Widget window_title_menu_widgets[] = {
+static Widget _titleMenuWidgets[] = {
     MakeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WindowWidgetType::ImgBtn, WindowColour::Tertiary,  ImageId(SPR_MENU_NEW_GAME),       STR_START_NEW_GAME_TIP),
     MakeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WindowWidgetType::ImgBtn, WindowColour::Tertiary,  ImageId(SPR_MENU_LOAD_GAME),      STR_CONTINUE_SAVED_GAME_TIP),
     MakeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WindowWidgetType::ImgBtn, WindowColour::Tertiary,  ImageId(SPR_G2_MENU_MULTIPLAYER), STR_SHOW_MULTIPLAYER_TIP),
@@ -91,7 +91,7 @@ private:
 public:
     void OnOpen() override
     {
-        widgets = window_title_menu_widgets;
+        widgets = _titleMenuWidgets;
 
 #ifdef DISABLE_NETWORK
         widgets[WIDX_MULTIPLAYER].type = WindowWidgetType::Empty;

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -23,7 +23,7 @@ enum {
     WIDX_BACKGROUND
 };
 
-static Widget window_tooltip_widgets[] = {
+static Widget _tooltipWidgets[] = {
     MakeWidget({0, 0}, {200, 32}, WindowWidgetType::ImgBtn, WindowColour::Primary),
     WIDGETS_END,
 };
@@ -43,8 +43,9 @@ public:
         width = textWidth + 3;
         height = ((_tooltipNumLines + 1) * FontGetLineHeight(FontStyle::Small)) + 4;
 
-        window_tooltip_widgets[WIDX_BACKGROUND].right = width;
-        window_tooltip_widgets[WIDX_BACKGROUND].bottom = height;
+        widgets = _tooltipWidgets;
+        widgets[WIDX_BACKGROUND].right = width;
+        widgets[WIDX_BACKGROUND].bottom = height;
 
         int32_t screenWidth = ContextGetWidth();
         int32_t screenHeight = ContextGetHeight();
@@ -66,7 +67,6 @@ public:
 
     void OnOpen() override
     {
-        widgets = window_tooltip_widgets;
         ResetTooltipNotShown();
     }
 

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -250,7 +250,7 @@ static constexpr int32_t right_aligned_widgets_order[] = {
 
 #pragma endregion
 
-static Widget window_top_toolbar_widgets[] = {
+static Widget _topToolbarWidgets[] = {
     MakeRemapWidget({  0, 0}, {30, TOP_TOOLBAR_HEIGHT + 1}, WindowWidgetType::TrnBtn, WindowColour::Primary   , SPR_TOOLBAR_PAUSE,          STR_PAUSE_GAME_TIP                ), // Pause
     MakeRemapWidget({ 60, 0}, {30, TOP_TOOLBAR_HEIGHT + 1}, WindowWidgetType::TrnBtn, WindowColour::Primary   , SPR_TOOLBAR_FILE,           STR_DISC_AND_GAME_OPTIONS_TIP     ), // File menu
     MakeRemapWidget({250, 0}, {30, TOP_TOOLBAR_HEIGHT + 1}, WindowWidgetType::TrnBtn, WindowColour::Primary   , SPR_G2_TOOLBAR_MUTE,        STR_TOOLBAR_MUTE_TIP              ), // Mute
@@ -3189,7 +3189,7 @@ public:
 
         ScreenCoordsXY screenPos{};
         // Draw staff button image (setting masks to the staff colours)
-        if (window_top_toolbar_widgets[WIDX_STAFF].type != WindowWidgetType::Empty)
+        if (widgets[WIDX_STAFF].type != WindowWidgetType::Empty)
         {
             screenPos = { windowPos.x + widgets[WIDX_STAFF].left, windowPos.y + widgets[WIDX_STAFF].top };
             imgId = SPR_TOOLBAR_STAFF;
@@ -3199,7 +3199,7 @@ public:
         }
 
         // Draw fast forward button
-        if (window_top_toolbar_widgets[WIDX_FASTFORWARD].type != WindowWidgetType::Empty)
+        if (widgets[WIDX_FASTFORWARD].type != WindowWidgetType::Empty)
         {
             screenPos = { windowPos.x + widgets[WIDX_FASTFORWARD].left + 0, windowPos.y + widgets[WIDX_FASTFORWARD].top + 0 };
             if (WidgetIsPressed(*this, WIDX_FASTFORWARD))
@@ -3217,7 +3217,7 @@ public:
         }
 
         // Draw cheats button
-        if (window_top_toolbar_widgets[WIDX_CHEATS].type != WindowWidgetType::Empty)
+        if (widgets[WIDX_CHEATS].type != WindowWidgetType::Empty)
         {
             screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_CHEATS].left - 1, widgets[WIDX_CHEATS].top - 1 };
             if (WidgetIsPressed(*this, WIDX_CHEATS))
@@ -3318,7 +3318,7 @@ WindowBase* WindowTopToolbarOpen()
         WindowClass::TopToolbar, ScreenCoordsXY(0, 0), ContextGetWidth(), TOP_TOOLBAR_HEIGHT + 1,
         WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_NO_BACKGROUND);
 
-    window->widgets = window_top_toolbar_widgets;
+    window->widgets = _topToolbarWidgets;
 
     WindowInitScrollWidgets(*window);
 

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -38,14 +38,14 @@ enum {
     WIDX_PROMPT_CANCEL = 4,
 };
 
-static Widget window_track_manage_widgets[] = {
+static Widget _trackManageWidgets[] = {
     WINDOW_SHIM(WINDOW_TITLE, WW, WH),
     MakeWidget({ 10, 24}, {110, 12}, WindowWidgetType::Button, WindowColour::Primary, STR_TRACK_MANAGE_RENAME),
     MakeWidget({130, 24}, {110, 12}, WindowWidgetType::Button, WindowColour::Primary, STR_TRACK_MANAGE_DELETE),
     WIDGETS_END,
 };
 
-static Widget window_track_delete_prompt_widgets[] = {
+static Widget _trackDeletePromptWidgets[] = {
     WINDOW_SHIM(STR_DELETE_FILE, WW_DELETE_PROMPT, WH_DELETE_PROMPT),
     MakeWidget({ 10, 54}, {110, 12}, WindowWidgetType::Button, WindowColour::Primary, STR_TRACK_MANAGE_DELETE),
     MakeWidget({130, 54}, {110, 12}, WindowWidgetType::Button, WindowColour::Primary, STR_CANCEL             ),
@@ -112,7 +112,7 @@ WindowBase* WindowTrackManageOpen(TrackDesignFileRef* tdFileRef)
 
 void TrackDesignManageWindow::OnOpen()
 {
-    widgets = window_track_manage_widgets;
+    widgets = _trackManageWidgets;
     WindowInitScrollWidgets(*this);
 
     auto* trackDesignListWindow = WindowFindByClass(WindowClass::TrackDesignList);
@@ -204,7 +204,7 @@ static void WindowTrackDeletePromptOpen(TrackDesignFileRef* tdFileRef)
 
 void TrackDeletePromptWindow::OnOpen()
 {
-    widgets = window_track_delete_prompt_widgets;
+    widgets = _trackDeletePromptWidgets;
     WindowInitScrollWidgets(*this);
 }
 

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -61,7 +61,7 @@ enum {
 
 validate_global_widx(WC_TRACK_DESIGN_PLACE, WIDX_ROTATE);
 
-static Widget window_track_place_widgets[] = {
+static Widget _trackPlaceWidgets[] = {
     WINDOW_SHIM(WINDOW_TITLE, WW, WH),
     MakeWidget({173,  83}, { 24, 24}, WindowWidgetType::FlatBtn, WindowColour::Primary, ImageId(SPR_ROTATE_ARROW),              STR_ROTATE_90_TIP                         ),
     MakeWidget({173,  59}, { 24, 24}, WindowWidgetType::FlatBtn, WindowColour::Primary, ImageId(SPR_MIRROR_ARROW),              STR_MIRROR_IMAGE_TIP                      ),
@@ -77,7 +77,7 @@ class TrackDesignPlaceWindow final : public Window
 public:
     void OnOpen() override
     {
-        widgets = window_track_place_widgets;
+        widgets = _trackPlaceWidgets;
         WindowInitScrollWidgets(*this);
         ToolSet(*this, WIDX_PRICE, Tool::Crosshair);
         InputSetFlag(INPUT_FLAG_6, true);

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -51,7 +51,7 @@ enum {
 
 validate_global_widx(WC_TRACK_DESIGN_LIST, WIDX_ROTATE);
 
-static Widget window_track_list_widgets[] = {
+static Widget _trackListWidgets[] = {
     WINDOW_SHIM(WINDOW_TITLE, WW, WH),
     MakeWidget({  4,  18}, {218,  13}, WindowWidgetType::TableHeader, WindowColour::Primary  , STR_SELECT_OTHER_RIDE                                       ),
     MakeWidget({  4,  32}, {124,  13}, WindowWidgetType::TextBox,     WindowColour::Secondary                                                              ),
@@ -202,8 +202,8 @@ public:
     void OnOpen() override
     {
         String::Set(_filterString, sizeof(_filterString), "");
-        window_track_list_widgets[WIDX_FILTER_STRING].string = _filterString;
-        widgets = window_track_list_widgets;
+        _trackListWidgets[WIDX_FILTER_STRING].string = _filterString;
+        widgets = _trackListWidgets;
 
         if (gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)
         {
@@ -373,21 +373,21 @@ public:
         Formatter::Common().Add<StringId>(stringId);
         if (gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)
         {
-            window_track_list_widgets[WIDX_TITLE].text = STR_TRACK_DESIGNS;
-            window_track_list_widgets[WIDX_TRACK_LIST].tooltip = STR_CLICK_ON_DESIGN_TO_RENAME_OR_DELETE_IT;
+            widgets[WIDX_TITLE].text = STR_TRACK_DESIGNS;
+            widgets[WIDX_TRACK_LIST].tooltip = STR_CLICK_ON_DESIGN_TO_RENAME_OR_DELETE_IT;
         }
         else
         {
-            window_track_list_widgets[WIDX_TITLE].text = STR_SELECT_DESIGN;
-            window_track_list_widgets[WIDX_TRACK_LIST].tooltip = STR_CLICK_ON_DESIGN_TO_BUILD_IT_TIP;
+            widgets[WIDX_TITLE].text = STR_SELECT_DESIGN;
+            widgets[WIDX_TRACK_LIST].tooltip = STR_CLICK_ON_DESIGN_TO_BUILD_IT_TIP;
         }
 
         if ((gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER) || selected_list_item != 0)
         {
             pressed_widgets |= 1uLL << WIDX_TRACK_PREVIEW;
             disabled_widgets &= ~(1uLL << WIDX_TRACK_PREVIEW);
-            window_track_list_widgets[WIDX_ROTATE].type = WindowWidgetType::FlatBtn;
-            window_track_list_widgets[WIDX_TOGGLE_SCENERY].type = WindowWidgetType::FlatBtn;
+            widgets[WIDX_ROTATE].type = WindowWidgetType::FlatBtn;
+            widgets[WIDX_TOGGLE_SCENERY].type = WindowWidgetType::FlatBtn;
             if (gTrackDesignSceneryToggle)
             {
                 pressed_widgets &= ~(1uLL << WIDX_TOGGLE_SCENERY);
@@ -401,19 +401,17 @@ public:
         {
             pressed_widgets &= ~(1uLL << WIDX_TRACK_PREVIEW);
             disabled_widgets |= (1uLL << WIDX_TRACK_PREVIEW);
-            window_track_list_widgets[WIDX_ROTATE].type = WindowWidgetType::Empty;
-            window_track_list_widgets[WIDX_TOGGLE_SCENERY].type = WindowWidgetType::Empty;
+            widgets[WIDX_ROTATE].type = WindowWidgetType::Empty;
+            widgets[WIDX_TOGGLE_SCENERY].type = WindowWidgetType::Empty;
         }
 
         // When debugging tools are on, shift everything up a bit to make room for displaying the path.
         const int32_t bottomMargin = gConfigGeneral.DebuggingTools ? (WINDOW_PADDING + DEBUG_PATH_HEIGHT) : WINDOW_PADDING;
-        window_track_list_widgets[WIDX_TRACK_LIST].bottom = height - bottomMargin;
-        window_track_list_widgets[WIDX_ROTATE].bottom = height - bottomMargin;
-        window_track_list_widgets[WIDX_ROTATE].top = window_track_list_widgets[WIDX_ROTATE].bottom
-            - ROTATE_AND_SCENERY_BUTTON_SIZE;
-        window_track_list_widgets[WIDX_TOGGLE_SCENERY].bottom = window_track_list_widgets[WIDX_ROTATE].top;
-        window_track_list_widgets[WIDX_TOGGLE_SCENERY].top = window_track_list_widgets[WIDX_TOGGLE_SCENERY].bottom
-            - ROTATE_AND_SCENERY_BUTTON_SIZE;
+        widgets[WIDX_TRACK_LIST].bottom = height - bottomMargin;
+        widgets[WIDX_ROTATE].bottom = height - bottomMargin;
+        widgets[WIDX_ROTATE].top = widgets[WIDX_ROTATE].bottom - ROTATE_AND_SCENERY_BUTTON_SIZE;
+        widgets[WIDX_TOGGLE_SCENERY].bottom = widgets[WIDX_ROTATE].top;
+        widgets[WIDX_TOGGLE_SCENERY].top = widgets[WIDX_TOGGLE_SCENERY].bottom - ROTATE_AND_SCENERY_BUTTON_SIZE;
     }
 
     void OnUpdate() override

--- a/src/openrct2-ui/windows/Transparency.cpp
+++ b/src/openrct2-ui/windows/Transparency.cpp
@@ -63,7 +63,7 @@ static constexpr ScreenSize INVISIBLE_SIZE = {24, 12};
 
 #pragma endregion
 
-static Widget window_transparency_main_widgets[] =
+static Widget _transparancyWidgets[] =
 {
     WINDOW_SHIM(WINDOW_TITLE, WW, WH),
     MakeWidget({  2, 17}, HIDE_SIZE,      WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_BUTTON_HIDE_VEGETATION),  STR_SEE_THROUGH_VEGETATION),
@@ -92,7 +92,7 @@ private:
 public:
     void OnOpen() override
     {
-        widgets = window_transparency_main_widgets;
+        widgets = _transparancyWidgets;
         WindowPushOthersBelow(*this);
 
         auto* w = WindowGetMain();

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -48,7 +48,7 @@ static constexpr StringId WINDOW_TITLE = STR_VIEW_CLIPPING_TITLE;
 static constexpr int32_t WW = 180;
 static constexpr int32_t WH = 155;
 
-static Widget window_view_clipping_widgets[] = {
+static Widget _viewClippingWidgets[] = {
     WINDOW_SHIM(WINDOW_TITLE, WW, WH),
     MakeWidget        ({     11,  19}, {    159,  11}, WindowWidgetType::Checkbox, WindowColour::Primary, STR_VIEW_CLIPPING_HEIGHT_ENABLE,       STR_VIEW_CLIPPING_HEIGHT_ENABLE_TIP  ), // clip enable/disable check box
     MakeWidget        ({      5,  36}, {WW - 10,  48}, WindowWidgetType::Groupbox, WindowColour::Primary, STR_VIEW_CLIPPING_VERTICAL_CLIPPING                                         ),
@@ -343,7 +343,7 @@ public:
 
     void OnOpen() override
     {
-        this->widgets = window_view_clipping_widgets;
+        this->widgets = _viewClippingWidgets;
         this->hold_down_widgets = (1uLL << WIDX_CLIP_HEIGHT_INCREASE) | (1uL << WIDX_CLIP_HEIGHT_DECREASE);
         WindowInitScrollWidgets(*this);
 

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -40,7 +40,7 @@ static constexpr ScreenSize VIEWPORT_BUTTON = {24, 24};
 
 #pragma endregion
 
-static Widget window_viewport_widgets[] =
+static Widget _viewportWidgets[] =
 {
     WINDOW_SHIM(WINDOW_TITLE, WW, WH),
     MakeWidget({      0, 14}, { WW - 1, WH - 1}, WindowWidgetType::Resize,   WindowColour::Secondary                                         ), // resize
@@ -73,7 +73,7 @@ public:
     {
         GetFreeViewportNumber();
 
-        widgets = window_viewport_widgets;
+        widgets = _viewportWidgets;
 
         // Create viewport
         ViewportCreate(this, windowPos, width, height, Focus(TileCoordsXYZ(128, 128, 0).ToCoordsXYZ()));
@@ -175,7 +175,7 @@ public:
 
     void OnPrepareDraw() override
     {
-        Widget* viewportWidget = &window_viewport_widgets[WIDX_VIEWPORT];
+        Widget* viewportWidget = &widgets[WIDX_VIEWPORT];
 
         ResizeFrameWithPage();
         widgets[WIDX_ZOOM_IN].left = width - 27;

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -31,7 +31,7 @@ enum WindowWaterWidgetIdx {
     WIDX_INCREMENT
 };
 
-static Widget window_water_widgets[] = {
+static Widget _waterWidgets[] = {
     WINDOW_SHIM(WINDOW_TITLE, WW, WH),
     MakeWidget     ({16, 17}, {44, 32}, WindowWidgetType::ImgBtn, WindowColour::Primary , ImageId(SPR_LAND_TOOL_SIZE_0),   STR_NONE),                     // preview box
     MakeRemapWidget({17, 18}, {16, 16}, WindowWidgetType::TrnBtn, WindowColour::Tertiary, SPR_LAND_TOOL_DECREASE, STR_ADJUST_SMALLER_WATER_TIP), // decrement size
@@ -45,7 +45,7 @@ class WaterWindow final : public Window
 public:
     void OnOpen() override
     {
-        widgets = window_water_widgets;
+        widgets = _waterWidgets;
         hold_down_widgets = (1uLL << WIDX_INCREMENT) | (1uLL << WIDX_DECREMENT);
         WindowInitScrollWidgets(*this);
         WindowPushOthersBelow(*this);
@@ -140,8 +140,8 @@ public:
 
     void OnDraw(DrawPixelInfo& dpi) override
     {
-        auto screenCoords = ScreenCoordsXY{ windowPos.x + window_water_widgets[WIDX_PREVIEW].midX(),
-                                            windowPos.y + window_water_widgets[WIDX_PREVIEW].midY() };
+        auto screenCoords = ScreenCoordsXY{ windowPos.x + widgets[WIDX_PREVIEW].midX(),
+                                            windowPos.y + widgets[WIDX_PREVIEW].midY() };
 
         DrawWidgets(dpi);
         // Draw number for tool sizes bigger than 7
@@ -155,8 +155,7 @@ public:
         if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
         {
             // Draw raise cost amount
-            screenCoords = { window_water_widgets[WIDX_PREVIEW].midX() + windowPos.x,
-                             window_water_widgets[WIDX_PREVIEW].bottom + windowPos.y + 5 };
+            screenCoords = { widgets[WIDX_PREVIEW].midX() + windowPos.x, widgets[WIDX_PREVIEW].bottom + windowPos.y + 5 };
             if (gWaterToolRaiseCost != MONEY64_UNDEFINED && gWaterToolRaiseCost != 0)
             {
                 auto ft = Formatter();


### PR DESCRIPTION
If we want to be able to switch to a std::vector of widgets we need to ensure that the only assignment of w->widgets is done with the globals.