### PR TITLE
Fix #20543: Crash using show segments height from debug paint option.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -29,6 +29,7 @@
 - Fix: [#20429] Error window tooltip not closing after 8 seconds.
 - Fix: [#20456] Downward large half loops on flying coasters (fly-to-lie) are now correctly named.
 - Fix: [#20484] Console caret not properly updated when using command history.
+- Fix: [#20543] Crash using show segments height from debug paint options.
 
 0.4.5 (2023-05-08)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -314,7 +314,7 @@ static void PaintTileElementBase(PaintSession& session, const CoordsXY& origCoor
         for (std::size_t sx = 0; sx < std::size(segmentPositions[sy]); sx++)
         {
             uint16_t segmentHeight = session.SupportSegments[segmentPositions[sy][sx]].height;
-            auto imageColourFlats = ImageId(SPR_LAND_TOOL_SIZE_1).WithTransparency(FilterPaletteID::PaletteDarken3);
+            auto imageColourFlats = ImageId(SPR_LAND_TOOL_SIZE_1).WithTransparency(FilterPaletteID::PaletteGlassBlack);
             if (segmentHeight == 0xFFFF)
             {
                 segmentHeight = session.Support.height;
@@ -329,13 +329,9 @@ static void PaintTileElementBase(PaintSession& session, const CoordsXY& origCoor
 
             int32_t xOffset = static_cast<int32_t>(sy) * 10;
             int32_t yOffset = -22 + static_cast<int32_t>(sx) * 10;
-            PaintStruct* ps = PaintAddImageAsParent(
+            PaintAddImageAsParent(
                 session, imageColourFlats, { xOffset, yOffset, segmentHeight },
                 { { xOffset + 1, yOffset + 16, segmentHeight }, { 10, 10, 1 } });
-            if (ps != nullptr)
-            {
-                ps->image_id = ps->image_id.WithTertiary(COLOUR_BORDEAUX_RED);
-            }
         }
     }
 }


### PR DESCRIPTION
The crash is caused by using a wrong combination of palette and tertiary color. I've looked at some older release where it worked.

This is what it looks like in 0.2.0:
![openrct2_2023-07-05_01-12-44b42783c4af84f6fe4](https://github.com/OpenRCT2/OpenRCT2/assets/5415177/1fb30cb8-6030-4a78-a18b-69a77e018c94)

This PR:
![openrct2_2023-07-05_01-13-26fbd5e4d6e8d883937](https://github.com/OpenRCT2/OpenRCT2/assets/5415177/418c51ce-57b7-4b35-815c-08378d81a24f)

So I think I got the intended behavior right, there seems to be some differences when it comes to height but this is not what this PR addresses.

Also the issue states that it triggers an assert in debug builds but it can also crash for release builds due to reading data out of bounds.

Closes #20543