### PR TITLE
String cleanup 2

### DIFF
--- a/src/openrct2-ui/input/ShortcutInput.cpp
+++ b/src/openrct2-ui/input/ShortcutInput.cpp
@@ -23,51 +23,51 @@ constexpr uint32_t UsefulModifiers = KMOD_SHIFT | KMOD_CTRL | KMOD_ALT | KMOD_GU
 
 static uint32_t ParseModifier(std::string_view text)
 {
-    if (String::Equals(text, "CTRL", true))
+    if (String::IEquals(text, "CTRL"))
     {
         return KMOD_CTRL;
     }
-    if (String::Equals(text, "LCTRL", true))
+    if (String::IEquals(text, "LCTRL"))
     {
         return KMOD_LCTRL;
     }
-    if (String::Equals(text, "RCTRL", true))
+    if (String::IEquals(text, "RCTRL"))
     {
         return KMOD_RCTRL;
     }
-    if (String::Equals(text, "SHIFT", true))
+    if (String::IEquals(text, "SHIFT"))
     {
         return KMOD_SHIFT;
     }
-    if (String::Equals(text, "LSHIFT", true))
+    if (String::IEquals(text, "LSHIFT"))
     {
         return KMOD_LSHIFT;
     }
-    if (String::Equals(text, "RSHIFT", true))
+    if (String::IEquals(text, "RSHIFT"))
     {
         return KMOD_RSHIFT;
     }
-    if (String::Equals(text, "ALT", true))
+    if (String::IEquals(text, "ALT"))
     {
         return KMOD_ALT;
     }
-    if (String::Equals(text, "LALT", true))
+    if (String::IEquals(text, "LALT"))
     {
         return KMOD_LALT;
     }
-    if (String::Equals(text, "RALT", true))
+    if (String::IEquals(text, "RALT"))
     {
         return KMOD_RALT;
     }
-    if (String::Equals(text, "GUI", true))
+    if (String::IEquals(text, "GUI"))
     {
         return KMOD_GUI;
     }
-    if (String::Equals(text, "LCTRL", true))
+    if (String::IEquals(text, "LCTRL"))
     {
         return KMOD_LGUI;
     }
-    if (String::Equals(text, "RGUI", true))
+    if (String::IEquals(text, "RGUI"))
     {
         return KMOD_RGUI;
     }
@@ -167,13 +167,13 @@ ShortcutInput::ShortcutInput(std::string_view value)
             Button = *number - 1;
         }
     }
-    else if (String::Equals(rem, "LMB", true))
+    else if (String::IEquals(rem, "LMB"))
     {
         Kind = InputDeviceKind::Mouse;
         Modifiers = modifiers;
         Button = 0;
     }
-    else if (String::Equals(rem, "RMB", true))
+    else if (String::IEquals(rem, "RMB"))
     {
         Kind = InputDeviceKind::Mouse;
         Modifiers = modifiers;

--- a/src/openrct2-ui/interface/Theme.cpp
+++ b/src/openrct2-ui/interface/Theme.cpp
@@ -721,7 +721,7 @@ size_t ThemeGetIndexForName(const utf8* name)
     for (size_t i = 0; i < count; i++)
     {
         const utf8* tn = ThemeManagerGetAvailableThemeName(i);
-        if (String::Equals(tn, name, true))
+        if (String::IEquals(tn, name))
         {
             return i;
         }

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -574,7 +574,7 @@ namespace OpenRCT2
 
             try
             {
-                if (String::Equals(Path::GetExtension(path), ".sea", true))
+                if (String::IEquals(Path::GetExtension(path), ".sea"))
                 {
                     auto data = DecryptSea(fs::u8path(path));
                     auto ms = MemoryStream(data.data(), data.size(), MEMORY_ACCESS::READ);

--- a/src/openrct2/FileClassifier.cpp
+++ b/src/openrct2/FileClassifier.cpp
@@ -197,25 +197,25 @@ static bool TryClassifyAsTD4_TD6(OpenRCT2::IStream* stream, ClassifiedFileInfo* 
 FileExtension GetFileExtensionType(u8string_view path)
 {
     auto extension = Path::GetExtension(path);
-    if (String::Equals(extension, ".dat", true) || String::Equals(extension, ".pob", true))
+    if (String::IEquals(extension, ".dat") || String::IEquals(extension, ".pob"))
         return FileExtension::DAT;
-    if (String::Equals(extension, ".sc4", true))
+    if (String::IEquals(extension, ".sc4"))
         return FileExtension::SC4;
-    if (String::Equals(extension, ".sv4", true))
+    if (String::IEquals(extension, ".sv4"))
         return FileExtension::SV4;
-    if (String::Equals(extension, ".td4", true))
+    if (String::IEquals(extension, ".td4"))
         return FileExtension::TD4;
-    if (String::Equals(extension, ".sc6", true))
+    if (String::IEquals(extension, ".sc6"))
         return FileExtension::SC6;
-    if (String::Equals(extension, ".sea", true))
+    if (String::IEquals(extension, ".sea"))
         return FileExtension::SC6;
-    if (String::Equals(extension, ".sv6", true))
+    if (String::IEquals(extension, ".sv6"))
         return FileExtension::SV6;
-    if (String::Equals(extension, ".sv7", true))
+    if (String::IEquals(extension, ".sv7"))
         return FileExtension::SV6;
-    if (String::Equals(extension, ".td6", true))
+    if (String::IEquals(extension, ".td6"))
         return FileExtension::TD6;
-    if (String::Equals(extension, ".park", true))
+    if (String::IEquals(extension, ".park"))
         return FileExtension::PARK;
     return FileExtension::Unknown;
 }

--- a/src/openrct2/ParkImporter.cpp
+++ b/src/openrct2/ParkImporter.cpp
@@ -41,17 +41,16 @@ namespace ParkImporter
 
     bool ExtensionIsOpenRCT2ParkFile(std::string_view extension)
     {
-        return String::Equals(extension, ".park", true);
+        return String::IEquals(extension, ".park");
     }
 
     bool ExtensionIsRCT1(std::string_view extension)
     {
-        return String::Equals(extension, ".sc4", true) || String::Equals(extension, ".sv4", true);
+        return String::IEquals(extension, ".sc4") || String::IEquals(extension, ".sv4");
     }
 
     bool ExtensionIsScenario(std::string_view extension)
     {
-        return String::Equals(extension, ".sc4", true) || String::Equals(extension, ".sc6", true)
-            || String::Equals(extension, ".sea", true);
+        return String::IEquals(extension, ".sc4") || String::IEquals(extension, ".sc6") || String::IEquals(extension, ".sea");
     }
 } // namespace ParkImporter

--- a/src/openrct2/TrackImporter.cpp
+++ b/src/openrct2/TrackImporter.cpp
@@ -33,6 +33,6 @@ namespace TrackImporter
 
     bool ExtensionIsRCT1(const std::string& extension)
     {
-        return String::Equals(extension, ".td4", true);
+        return String::IEquals(extension, ".td4");
     }
 } // namespace TrackImporter

--- a/src/openrct2/command_line/SpriteCommands.cpp
+++ b/src/openrct2/command_line/SpriteCommands.cpp
@@ -49,9 +49,9 @@ const CommandLineCommand CommandLine::SpriteCommands[]
 
 static exitcode_t HandleSprite(CommandLineArgEnumerator* argEnumerator)
 {
-    if (String::Equals(_mode, SZ_CLOSEST, true))
+    if (String::IEquals(_mode, SZ_CLOSEST))
         gSpriteMode = ImportMode::Closest;
-    else if (String::Equals(_mode, SZ_DITHERING, true))
+    else if (String::IEquals(_mode, SZ_DITHERING))
         gSpriteMode = ImportMode::Dithering;
     Memory::Free(_mode);
 

--- a/src/openrct2/config/ConfigEnum.hpp
+++ b/src/openrct2/config/ConfigEnum.hpp
@@ -61,7 +61,7 @@ public:
     {
         for (const auto& entry : _entries)
         {
-            if (String::Equals(entry.Key, key, true))
+            if (String::IEquals(entry.Key, key))
             {
                 return entry.Value;
             }

--- a/src/openrct2/config/IniReader.cpp
+++ b/src/openrct2/config/IniReader.cpp
@@ -133,7 +133,7 @@ public:
         std::string value;
         if (TryGetString(name, &value))
         {
-            result = String::Equals(value, "true", true);
+            result = String::IEquals(value, "true");
         }
         return result;
     }

--- a/src/openrct2/core/Path.cpp
+++ b/src/openrct2/core/Path.cpp
@@ -108,7 +108,7 @@ namespace Path
 
     bool Equals(u8string_view a, u8string_view b)
     {
-        return Platform::ShouldIgnoreCase() ? String::IEquals(a,b) : String::Equals(a, b);
+        return Platform::ShouldIgnoreCase() ? String::IEquals(a, b) : String::Equals(a, b);
     }
 
     u8string ResolveCasing(u8string_view path)

--- a/src/openrct2/core/Path.cpp
+++ b/src/openrct2/core/Path.cpp
@@ -108,7 +108,7 @@ namespace Path
 
     bool Equals(u8string_view a, u8string_view b)
     {
-        return String::Equals(a, b, Platform::ShouldIgnoreCase());
+        return Platform::ShouldIgnoreCase() ? String::IEquals(a,b) : String::Equals(a, b);
     }
 
     u8string ResolveCasing(u8string_view path)

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -164,12 +164,12 @@ namespace String
         });
     }
 
-    bool Equals(std::string_view a, std::string_view b)
+    bool Equals(u8string_view a, u8string_view b)
     {
         return EqualsImpl(a, b, false);
     }
 
-    bool Equals(const std::string& a, const std::string& b)
+    bool Equals(const u8string& a, const u8string& b)
     {
         return EqualsImpl(a, b, false);
     }
@@ -189,12 +189,12 @@ namespace String
         return strcmp(a, b) == 0;
     }
 
-    bool IEquals(std::string_view a, std::string_view b)
+    bool IEquals(u8string_view a, u8string_view b)
     {
         return EqualsImpl(a, b, true);
     }
 
-    bool IEquals(const std::string& a, const std::string& b)
+    bool IEquals(const u8string& a, const u8string& b)
     {
         return EqualsImpl(a, b, true);
     }

--- a/src/openrct2/core/String.hpp
+++ b/src/openrct2/core/String.hpp
@@ -57,11 +57,11 @@ namespace String
     int32_t Compare(const std::string& a, const std::string& b, bool ignoreCase = false);
     int32_t Compare(const utf8* a, const utf8* b, bool ignoreCase = false);
 
-    bool Equals(std::string_view a, std::string_view b);
-    bool Equals(const std::string& a, const std::string& b);
+    bool Equals(u8string_view a, u8string_view b);
+    bool Equals(const u8string& a, const u8string& b);
     bool Equals(const utf8* a, const utf8* b, bool ignoreCase = false);
-    bool IEquals(std::string_view a, std::string_view b);
-    bool IEquals(const std::string& a, const std::string& b);
+    bool IEquals(u8string_view a, u8string_view b);
+    bool IEquals(const u8string& a, const u8string& b);
     bool IEquals(const utf8* a, const utf8* b);
 
     bool StartsWith(std::string_view str, std::string_view match, bool ignoreCase = false);

--- a/src/openrct2/core/String.hpp
+++ b/src/openrct2/core/String.hpp
@@ -56,21 +56,14 @@ namespace String
     bool IsNullOrEmpty(const utf8* str);
     int32_t Compare(const std::string& a, const std::string& b, bool ignoreCase = false);
     int32_t Compare(const utf8* a, const utf8* b, bool ignoreCase = false);
-    bool Equals(std::string_view a, std::string_view b, bool ignoreCase = false);
-    inline bool IEquals(std::string_view a, std::string_view b)
-    {
-        return Equals(a, b, true);
-    }
-    bool Equals(const std::string& a, const std::string& b, bool ignoreCase = false);
-    inline bool IEquals(const std::string& a, const std::string& b)
-    {
-        return Equals(a, b, true);
-    }
+
+    bool Equals(std::string_view a, std::string_view b);
+    bool Equals(const std::string& a, const std::string& b);
     bool Equals(const utf8* a, const utf8* b, bool ignoreCase = false);
-    inline bool IEquals(const utf8* a, const utf8* b)
-    {
-        return Equals(a, b, true);
-    }
+    bool IEquals(std::string_view a, std::string_view b);
+    bool IEquals(const std::string& a, const std::string& b);
+    bool IEquals(const utf8* a, const utf8* b);
+
     bool StartsWith(std::string_view str, std::string_view match, bool ignoreCase = false);
     bool EndsWith(std::string_view str, std::string_view match, bool ignoreCase = false);
     bool Contains(std::string_view haystack, std::string_view needle, bool ignoreCase = false);

--- a/src/openrct2/localisation/LanguagePack.cpp
+++ b/src/openrct2/localisation/LanguagePack.cpp
@@ -162,7 +162,7 @@ public:
         int32_t ooIndex = 0;
         for (const ScenarioOverride& scenarioOverride : _scenarioOverrides)
         {
-            if (String::Equals(scenarioOverride.filename.c_str(), scenarioFilename, true))
+            if (String::IEquals(scenarioOverride.filename.c_str(), scenarioFilename))
             {
                 if (scenarioOverride.strings[index].empty())
                 {
@@ -181,7 +181,7 @@ private:
     {
         for (auto& so : _scenarioOverrides)
         {
-            if (String::Equals(so.strings[0], scenarioIdentifier.c_str(), true))
+            if (String::IEquals(so.strings[0], scenarioIdentifier))
             {
                 return &so;
             }

--- a/src/openrct2/localisation/LanguagePack.cpp
+++ b/src/openrct2/localisation/LanguagePack.cpp
@@ -162,7 +162,7 @@ public:
         int32_t ooIndex = 0;
         for (const ScenarioOverride& scenarioOverride : _scenarioOverrides)
         {
-            if (String::IEquals(scenarioOverride.filename.c_str(), scenarioFilename))
+            if (String::IEquals(scenarioOverride.filename, scenarioFilename))
             {
                 if (scenarioOverride.strings[index].empty())
                 {

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -2113,7 +2113,7 @@ std::string NetworkBase::MakePlayerNameUnique(const std::string& name)
         // Check if there is already a player with this name in the server
         for (const auto& player : player_list)
         {
-            if (String::Equals(player->Name.c_str(), new_name.c_str(), true))
+            if (String::IEquals(player->Name.c_str(), new_name.c_str()))
             {
                 unique = false;
                 break;

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -2113,7 +2113,7 @@ std::string NetworkBase::MakePlayerNameUnique(const std::string& name)
         // Check if there is already a player with this name in the server
         for (const auto& player : player_list)
         {
-            if (String::IEquals(player->Name.c_str(), new_name.c_str()))
+            if (String::IEquals(player->Name, new_name))
             {
                 unique = false;
                 break;

--- a/src/openrct2/network/NetworkUser.cpp
+++ b/src/openrct2/network/NetworkUser.cpp
@@ -186,7 +186,7 @@ const NetworkUser* NetworkUserManager::GetUserByName(const std::string& name) co
     for (const auto& kvp : _usersByHash)
     {
         const auto& networkUser = kvp.second;
-        if (String::IEquals(name.c_str(), networkUser->Name.c_str()))
+        if (String::IEquals(name, networkUser->Name))
         {
             return networkUser.get();
         }

--- a/src/openrct2/network/NetworkUser.cpp
+++ b/src/openrct2/network/NetworkUser.cpp
@@ -186,7 +186,7 @@ const NetworkUser* NetworkUserManager::GetUserByName(const std::string& name) co
     for (const auto& kvp : _usersByHash)
     {
         const auto& networkUser = kvp.second;
-        if (String::Equals(name.c_str(), networkUser->Name.c_str(), true))
+        if (String::IEquals(name.c_str(), networkUser->Name.c_str()))
         {
             return networkUser.get();
         }

--- a/src/openrct2/network/ServerList.cpp
+++ b/src/openrct2/network/ServerList.cpp
@@ -118,7 +118,7 @@ void ServerList::Sort()
             [](const ServerListEntry& a, const ServerListEntry& b) {
                 if (a.Favourite == b.Favourite)
                 {
-                    return String::Equals(a.Address, b.Address, true);
+                    return String::IEquals(a.Address, b.Address);
                 }
                 return false;
             }),

--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -416,7 +416,7 @@ std::string ImageTable::FindLegacyObject(const std::string& name)
         while (scanner->Next())
         {
             auto currentName = Path::GetFileName(scanner->GetPathRelative());
-            if (String::Equals(currentName, name, true) || String::Equals(currentName, altName, true))
+            if (String::IEquals(currentName, name) || String::IEquals(currentName, altName))
             {
                 objectPath = scanner->GetPath();
                 break;

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -101,11 +101,11 @@ public:
     {
         std::unique_ptr<Object> object;
         auto extension = Path::GetExtension(path);
-        if (String::Equals(extension, ".json", true))
+        if (String::IEquals(extension, ".json"))
         {
             object = ObjectFactory::CreateObjectFromJsonFile(_objectRepository, path, false);
         }
-        else if (String::Equals(extension, ".parkobj", true))
+        else if (String::IEquals(extension, ".parkobj"))
         {
             object = ObjectFactory::CreateObjectFromZipFile(_objectRepository, path, false);
         }
@@ -267,11 +267,11 @@ public:
         Guard::ArgumentNotNull(ori, GUARD_LINE);
 
         auto extension = Path::GetExtension(ori->Path);
-        if (String::Equals(extension, ".json", true))
+        if (String::IEquals(extension, ".json"))
         {
             return ObjectFactory::CreateObjectFromJsonFile(*this, ori->Path, !gOpenRCT2NoGraphics);
         }
-        if (String::Equals(extension, ".parkobj", true))
+        if (String::IEquals(extension, ".parkobj"))
         {
             return ObjectFactory::CreateObjectFromZipFile(*this, ori->Path, !gOpenRCT2NoGraphics);
         }

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -745,12 +745,12 @@ namespace OpenRCT2
                     for (const auto* ori : ExportObjectsList)
                     {
                         auto extension = Path::GetExtension(ori->Path);
-                        if (String::Equals(extension, ".dat", true))
+                        if (String::IEquals(extension, ".dat"))
                         {
                             cs.Write(DESCRIPTOR_DAT);
                             cs.Write(&ori->ObjectEntry, sizeof(RCTObjectEntry));
                         }
-                        else if (String::Equals(extension, ".parkobj", true))
+                        else if (String::IEquals(extension, ".parkobj"))
                         {
                             cs.Write(DESCRIPTOR_PARKOBJ);
                             cs.Write(ori->Identifier);

--- a/src/openrct2/platform/Platform.Posix.cpp
+++ b/src/openrct2/platform/Platform.Posix.cpp
@@ -223,7 +223,7 @@ namespace Platform
                 // Find a file which matches by name (case insensitive)
                 for (int32_t i = 0; i < count; i++)
                 {
-                    if (String::Equals(files[i]->d_name, fileName.c_str(), true))
+                    if (String::IEquals(files[i]->d_name, fileName.c_str()))
                     {
                         result = Path::Combine(directory, std::string(files[i]->d_name));
                         break;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -129,11 +129,11 @@ namespace RCT1
         ParkLoadResult Load(const u8string& path) override
         {
             const auto extension = Path::GetExtension(path);
-            if (String::Equals(extension, ".sc4", true))
+            if (String::IEquals(extension, ".sc4"))
             {
                 return LoadScenario(path);
             }
-            if (String::Equals(extension, ".sv4", true))
+            if (String::IEquals(extension, ".sv4"))
             {
                 return LoadSavedGame(path);
             }

--- a/src/openrct2/rct1/T4Importer.cpp
+++ b/src/openrct2/rct1/T4Importer.cpp
@@ -40,7 +40,7 @@ namespace RCT1
         bool Load(const utf8* path) override
         {
             const auto extension = Path::GetExtension(path);
-            if (String::Equals(extension, ".td4", true))
+            if (String::IEquals(extension, ".td4"))
             {
                 _name = GetNameFromTrackPath(path);
                 auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_OPEN);

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -110,11 +110,11 @@ namespace RCT2
         ParkLoadResult Load(const u8string& path) override
         {
             const auto extension = Path::GetExtension(path);
-            if (String::Equals(extension, ".sc6", true))
+            if (String::IEquals(extension, ".sc6"))
             {
                 return LoadScenario(path);
             }
-            if (String::Equals(extension, ".sv6", true))
+            if (String::IEquals(extension, ".sv6"))
             {
                 return LoadSavedGame(path);
             }
@@ -586,8 +586,8 @@ namespace RCT2
                 // clang-format on
             }
             else if (
-                String::Equals(gScenarioFileName, "Six Flags Magic Mountain.SC6", true)
-                || String::Equals(gScenarioFileName, "six flags magic mountain.sea", true))
+                String::IEquals(gScenarioFileName, "Six Flags Magic Mountain.SC6")
+                || String::IEquals(gScenarioFileName, "six flags magic mountain.sea"))
             {
                 // clang-format off
                 FixLandOwnershipTilesWithOwnership(
@@ -611,8 +611,8 @@ namespace RCT2
                     OWNERSHIP_OWNED);
             }
             else if (
-                String::Equals(gScenarioFileName, "N America - Extreme Hawaiian Island.SC6", true)
-                || String::Equals(gScenarioFileName, "n america - extreme hawaiian island.sea", true))
+                String::IEquals(gScenarioFileName, "N America - Extreme Hawaiian Island.SC6")
+                || String::IEquals(gScenarioFileName, "n america - extreme hawaiian island.sea"))
             {
                 FixLandOwnershipTilesWithOwnership(
                     {
@@ -647,8 +647,8 @@ namespace RCT2
             {
                 return;
             }
-            if (String::Equals(_s6.ScenarioFilename, "Infernal Views.SC6", true)
-                || String::Equals(_s6.ScenarioFilename, "infernal views.sea", true))
+            if (String::IEquals(_s6.ScenarioFilename, "Infernal Views.SC6")
+                || String::IEquals(_s6.ScenarioFilename, "infernal views.sea"))
             {
                 auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ 45, 62 });
 
@@ -656,7 +656,7 @@ namespace RCT2
             }
             else if (
                 String::Equals(_s6.ScenarioFilename, "Six Flags Holland.SC6")
-                || String::Equals(_s6.ScenarioFilename, "six flags holland.sea", true))
+                || String::IEquals(_s6.ScenarioFilename, "six flags holland.sea"))
 
             {
                 auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ 126, 73 });

--- a/src/openrct2/rct2/T6Importer.cpp
+++ b/src/openrct2/rct2/T6Importer.cpp
@@ -44,7 +44,7 @@ namespace RCT2
         bool Load(const utf8* path) override
         {
             const auto extension = Path::GetExtension(path);
-            if (String::Equals(extension, ".td6", true))
+            if (String::IEquals(extension, ".td6"))
             {
                 _name = GetNameFromTrackPath(path);
                 auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_OPEN);

--- a/src/openrct2/ride/TrackDesignRepository.cpp
+++ b/src/openrct2/ride/TrackDesignRepository.cpp
@@ -157,7 +157,7 @@ public:
                     entryIsNotSeparate = true;
             }
 
-            if (entryIsNotSeparate || String::Equals(item.ObjectEntry, entry, true))
+            if (entryIsNotSeparate || String::IEquals(item.ObjectEntry, entry))
             {
                 count++;
             }
@@ -191,7 +191,7 @@ public:
                     entryIsNotSeparate = true;
             }
 
-            if (entryIsNotSeparate || String::Equals(item.ObjectEntry, entry, true))
+            if (entryIsNotSeparate || String::IEquals(item.ObjectEntry, entry))
             {
                 TrackDesignFileRef ref;
                 ref.name = GetNameFromTrackPath(item.Path);

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -173,7 +173,7 @@ protected:
 private:
     static std::unique_ptr<IStream> GetStreamFromRCT2Scenario(const std::string& path)
     {
-        if (String::Equals(Path::GetExtension(path), ".sea", true))
+        if (String::IEquals(Path::GetExtension(path), ".sea"))
         {
             auto data = DecryptSea(fs::u8path(path));
             auto ms = std::make_unique<MemoryStream>();
@@ -196,7 +196,7 @@ private:
         try
         {
             std::string extension = Path::GetExtension(path);
-            if (String::Equals(extension, ".park", true))
+            if (String::IEquals(extension, ".park"))
             {
                 // OpenRCT2 park
                 bool result = false;
@@ -218,7 +218,7 @@ private:
                 return result;
             }
 
-            if (String::Equals(extension, ".sc4", true))
+            if (String::IEquals(extension, ".sc4"))
             {
                 // RCT1 scenario
                 bool result = false;
@@ -389,7 +389,7 @@ public:
             const auto scenarioFilename = Path::GetFileName(scenario.Path);
 
             // Note: this is always case insensitive search for cross platform consistency
-            if (String::Equals(filename, scenarioFilename, true))
+            if (String::IEquals(filename, scenarioFilename))
             {
                 return &scenario;
             }
@@ -407,7 +407,7 @@ public:
                 continue;
 
             // Note: this is always case insensitive search for cross platform consistency
-            if (String::Equals(name, scenario->InternalName, true))
+            if (String::IEquals(name, scenario->InternalName))
             {
                 return &_scenarios[i];
             }
@@ -441,18 +441,18 @@ public:
             const std::string scenarioExtension = Path::GetExtension(scenarioFileName);
 
             // Check if this is an RCTC scenario that corresponds to a known RCT1/2 scenario or vice versa, see #12626
-            if (String::Equals(scenarioExtension, ".sea", true))
+            if (String::IEquals(scenarioExtension, ".sea"))
             {
                 // Get scenario using RCT2 style name of RCTC scenario
                 scenario = GetByFilename((scenarioBaseName + ".sc6").c_str());
             }
-            else if (String::Equals(scenarioExtension, ".sc6", true))
+            else if (String::IEquals(scenarioExtension, ".sc6"))
             {
                 // Get scenario using RCTC style name of RCT2 scenario
                 scenario = GetByFilename((scenarioBaseName + ".sea").c_str());
             }
             // gScenarioFileName .Park scenarios is the full file path instead of just <scenarioName.park>, so need to convert
-            else if (String::Equals(scenarioExtension, ".park", true))
+            else if (String::IEquals(scenarioExtension, ".park"))
             {
                 scenario = GetByFilename((scenarioBaseName + ".park").c_str());
             }
@@ -496,7 +496,7 @@ private:
             const auto scenarioFilename = Path::GetFileName(scenario.Path);
 
             // Note: this is always case insensitive search for cross platform consistency
-            if (String::Equals(filename, scenarioFilename, true))
+            if (String::IEquals(filename, scenarioFilename))
             {
                 return &scenario;
             }
@@ -681,7 +681,7 @@ private:
                     bool notFound = true;
                     for (auto& highscore : _highscores)
                     {
-                        if (String::Equals(scBasic.Path, highscore->fileName, true))
+                        if (String::IEquals(scBasic.Path, highscore->fileName))
                         {
                             notFound = false;
 

--- a/src/openrct2/scenario/ScenarioSources.cpp
+++ b/src/openrct2/scenario/ScenarioSources.cpp
@@ -368,7 +368,7 @@ namespace ScenarioSources
             for (size_t j = 0; j < ScenarioTitlesBySource[i].count; j++)
             {
                 const ScenarioTitleDescriptor* desc = &ScenarioTitlesBySource[i].titles[j];
-                if (String::Equals(name, desc->Title, true))
+                if (String::IEquals(name, desc->Title))
                 {
                     outDesc->title = desc->Title;
                     outDesc->id = desc->Id;

--- a/src/openrct2/title/TitleSequence.cpp
+++ b/src/openrct2/title/TitleSequence.cpp
@@ -320,7 +320,7 @@ namespace OpenRCT2::Title
         {
             auto name = zip->GetFileName(i);
             auto ext = Path::GetExtension(name);
-            if (String::Equals(ext, ".sv6", true) || String::Equals(ext, ".sc6", true) || String::Equals(ext, ".park", true))
+            if (String::IEquals(ext, ".sv6") || String::IEquals(ext, ".sc6") || String::IEquals(ext, ".park"))
             {
                 saves.push_back(std::move(name));
             }
@@ -348,7 +348,7 @@ namespace OpenRCT2::Title
                     const std::string relativePath = parts[1].data();
                     for (size_t i = 0; i < saves.size(); i++)
                     {
-                        if (String::Equals(relativePath, saves[i], true))
+                        if (String::IEquals(relativePath, saves[i]))
                         {
                             saveIndex = static_cast<uint8_t>(i);
                             break;

--- a/src/openrct2/title/TitleSequenceManager.cpp
+++ b/src/openrct2/title/TitleSequenceManager.cpp
@@ -169,7 +169,7 @@ namespace TitleSequenceManager
         auto filename = Path::GetFileName(path);
         for (size_t i = 0; i < std::size(PredefinedSequences); i++)
         {
-            if (String::Equals(filename, PredefinedSequences[i].Filename, true))
+            if (String::IEquals(filename, PredefinedSequences[i].Filename))
             {
                 return i;
             }
@@ -217,7 +217,7 @@ namespace TitleSequenceManager
     {
         TitleSequenceManagerItem item{};
 
-        if (String::Equals(Path::GetExtension(scanPath), u8".txt", true))
+        if (String::IEquals(Path::GetExtension(scanPath), u8".txt"))
         {
             // If we are given a .txt file, set the path to the containing directory
             item.Path = Path::GetDirectory(scanPath);
@@ -270,7 +270,7 @@ namespace TitleSequenceManager
     {
         for (const auto& pseq : TitleSequenceManager::PredefinedSequences)
         {
-            if (String::Equals(name, pseq.ConfigId, true))
+            if (String::IEquals(name, pseq.ConfigId))
             {
                 return true;
             }
@@ -315,7 +315,7 @@ const utf8* TitleSequenceManagerGetConfigID(size_t index)
     const auto filename = Path::GetFileName(item->Path);
     for (const auto& pseq : TitleSequenceManager::PredefinedSequences)
     {
-        if (String::Equals(filename, pseq.Filename, true))
+        if (String::IEquals(filename, pseq.Filename))
         {
             return pseq.ConfigId;
         }

--- a/test/tests/StringTest.cpp
+++ b/test/tests/StringTest.cpp
@@ -170,30 +170,56 @@ TEST_F(StringTest, StrLogicalCmp)
     EXPECT_LT(StrLogicalCmp("!", "a"), 0);
 }
 
-TEST_F(StringTest, IEquals)
+TEST_F(StringTest, IEqualsU8String)
 {
-    EXPECT_TRUE(String::IEquals("", ""));
-    EXPECT_TRUE(String::IEquals("Test", "Test"));
-    EXPECT_TRUE(String::IEquals("TesT", "Test"));
-    EXPECT_TRUE(String::IEquals("TEsT", "Test"));
+    EXPECT_TRUE(String::IEquals(u8string{ u8"" }, u8string{ u8"" }));
+    EXPECT_TRUE(String::IEquals(u8string{ u8"Test" }, u8string{ u8"Test" }));
+    EXPECT_TRUE(String::IEquals(u8string{ u8"TesT" }, u8string{ u8"Test" }));
+    EXPECT_TRUE(String::IEquals(u8string{ u8"TEsT" }, u8string{ u8"Test" }));
 
-    EXPECT_FALSE(String::IEquals("Test", "Message"));
-    EXPECT_FALSE(String::IEquals("Test", "TestMessage"));
-    EXPECT_FALSE(String::IEquals("", "Test"));
-    EXPECT_FALSE(String::IEquals("Test", ""));
+    EXPECT_FALSE(String::IEquals(u8string{ u8"Test" }, u8string{ u8"Message" }));
+    EXPECT_FALSE(String::IEquals(u8string{ u8"Test" }, u8string{ u8"TestMessage" }));
+    EXPECT_FALSE(String::IEquals(u8string{ u8"" }, u8string{ u8"Test" }));
+    EXPECT_FALSE(String::IEquals(u8string{ u8"Test" }, u8string{ u8"" }));
 }
 
-TEST_F(StringTest, Equals)
+TEST_F(StringTest, IEqualsU8StringView)
 {
-    EXPECT_TRUE(String::Equals("", ""));
-    EXPECT_TRUE(String::Equals("Test", "Test"));
+    EXPECT_TRUE(String::IEquals(u8string_view{ u8"" }, u8string_view{ u8"" }));
+    EXPECT_TRUE(String::IEquals(u8string_view{ u8"Test" }, u8string_view{ u8"Test" }));
+    EXPECT_TRUE(String::IEquals(u8string_view{ u8"TesT" }, u8string_view{ u8"Test" }));
+    EXPECT_TRUE(String::IEquals(u8string_view{ u8"TEsT" }, u8string_view{ u8"Test" }));
 
-    EXPECT_FALSE(String::Equals("TesT", "Test"));
-    EXPECT_FALSE(String::Equals("TEsT", "Test"));
-    EXPECT_FALSE(String::Equals("Test", "Message"));
-    EXPECT_FALSE(String::Equals("Test", "TestMessage"));
-    EXPECT_FALSE(String::Equals("", "Test"));
-    EXPECT_FALSE(String::Equals("Test", ""));
+    EXPECT_FALSE(String::IEquals(u8string_view{ u8"Test" }, u8string_view{ u8"Message" }));
+    EXPECT_FALSE(String::IEquals(u8string_view{ u8"Test" }, u8string_view{ u8"TestMessage" }));
+    EXPECT_FALSE(String::IEquals(u8string_view{ u8"" }, u8string_view{ u8"Test" }));
+    EXPECT_FALSE(String::IEquals(u8string_view{ u8"Test" }, u8string_view{ u8"" }));
+}
+
+TEST_F(StringTest, EqualsU8String)
+{
+    EXPECT_TRUE(String::Equals(u8string{ u8"" }, u8string{ u8"" }));
+    EXPECT_TRUE(String::Equals(u8string{ u8"Test" }, u8string{ u8"Test" }));
+
+    EXPECT_FALSE(String::Equals(u8string{ u8"TesT" }, u8string{ u8"Test" }));
+    EXPECT_FALSE(String::Equals(u8string{ u8"TEsT" }, u8string{ u8"Test" }));
+    EXPECT_FALSE(String::Equals(u8string{ u8"Test" }, u8string{ u8"Message" }));
+    EXPECT_FALSE(String::Equals(u8string{ u8"Test" }, u8string{ u8"TestMessage" }));
+    EXPECT_FALSE(String::Equals(u8string{ u8"" }, u8string{ u8"Test" }));
+    EXPECT_FALSE(String::Equals(u8string{ u8"Test" }, u8string{ u8"" }));
+}
+
+TEST_F(StringTest, EqualsU8StringView)
+{
+    EXPECT_TRUE(String::Equals(u8string_view{ u8"" }, u8string_view{ u8"" }));
+    EXPECT_TRUE(String::Equals(u8string_view{ u8"Test" }, u8string_view{ u8"Test" }));
+
+    EXPECT_FALSE(String::Equals(u8string_view{ u8"TesT" }, u8string_view{ u8"Test" }));
+    EXPECT_FALSE(String::Equals(u8string_view{ u8"TEsT" }, u8string_view{ u8"Test" }));
+    EXPECT_FALSE(String::Equals(u8string_view{ u8"Test" }, u8string_view{ u8"Message" }));
+    EXPECT_FALSE(String::Equals(u8string_view{ u8"Test" }, u8string_view{ u8"TestMessage" }));
+    EXPECT_FALSE(String::Equals(u8string_view{ u8"" }, u8string_view{ u8"Test" }));
+    EXPECT_FALSE(String::Equals(u8string_view{ u8"Test" }, u8string_view{ u8"" }));
 }
 
 class CodepointViewTest : public testing::Test

--- a/test/tests/StringTest.cpp
+++ b/test/tests/StringTest.cpp
@@ -170,6 +170,32 @@ TEST_F(StringTest, StrLogicalCmp)
     EXPECT_LT(StrLogicalCmp("!", "a"), 0);
 }
 
+TEST_F(StringTest, IEquals)
+{
+    EXPECT_TRUE(String::IEquals("", ""));
+    EXPECT_TRUE(String::IEquals("Test", "Test"));
+    EXPECT_TRUE(String::IEquals("TesT", "Test"));
+    EXPECT_TRUE(String::IEquals("TEsT", "Test"));
+
+    EXPECT_FALSE(String::IEquals("Test", "Message"));
+    EXPECT_FALSE(String::IEquals("Test", "TestMessage"));
+    EXPECT_FALSE(String::IEquals("", "Test"));
+    EXPECT_FALSE(String::IEquals("Test", ""));
+}
+
+TEST_F(StringTest, Equals)
+{
+    EXPECT_TRUE(String::Equals("", ""));
+    EXPECT_TRUE(String::Equals("Test", "Test"));
+
+    EXPECT_FALSE(String::Equals("TesT", "Test"));
+    EXPECT_FALSE(String::Equals("TEsT", "Test"));
+    EXPECT_FALSE(String::Equals("Test", "Message"));
+    EXPECT_FALSE(String::Equals("Test", "TestMessage"));
+    EXPECT_FALSE(String::Equals("", "Test"));
+    EXPECT_FALSE(String::Equals("Test", ""));
+}
+
 class CodepointViewTest : public testing::Test
 {
 };


### PR DESCRIPTION
Removes all remaining calls to Equals with the third parameter and instead uses IEquals, cleaned up the implementation quite a bit, for some reason the behavior of comparing std::string and std::string_view had also differences, now its one implementation for both.