### PR TITLE
Fix #20389: Reversed vehicles incorrectly banked on diagonal slopes

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,6 +24,7 @@
 - Fix: [#20361] Crash when using random map generation.
 - Fix: [#20364] Adding too much money with cheats causes an overflow.
 - Fix: [#20365] Money cheat input does not support negative values.
+- Fix: [#20389] Reversed vehicles are now correctly banked on diagonal slopes.
 - Fix: [#20413] Crash when attempting to navigate an empty console history.
 - Fix: [#20417] Plugin/custom windows are missing the left border in the title bar.
 - Fix: [#20429] Error window tooltip not closing after 8 seconds.

--- a/src/openrct2/ride/VehiclePaint.cpp
+++ b/src/openrct2/ride/VehiclePaint.cpp
@@ -3352,7 +3352,7 @@ static void VehiclePitchUp16BankedRight45(
 static void VehiclePitchUp16(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
-    switch (vehicle->bank_rotation)
+    switch (GetPaintBankRotation(vehicle))
     {
         case 0:
             VehiclePitchUp16Unbanked(session, vehicle, imageDirection, z, carEntry);
@@ -3594,7 +3594,7 @@ static void VehiclePitchDown16BankedRight45(
 static void VehiclePitchDown16(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
-    switch (vehicle->bank_rotation)
+    switch (GetPaintBankRotation(vehicle))
     {
         case 0:
             VehiclePitchDown16Unbanked(session, vehicle, imageDirection, z, carEntry);


### PR DESCRIPTION
In order to use the correct banking for reversed vehicles, all accesses to a vehicle's `bank_rotation` value in `VehiclePaint.cpp` are wrapped in a call to `GetPaintBankRotation`. (Which checks if the vehicle is reversed, and if so, looks up the correct banking in a mirror map.)
2 functions forgot to do that and instead accessed the `bank_rotation` directly (without a check for the vehicle being reversed).

This PR wraps these remaining two calls in `GetPaintBankRotation`.

Closes #20389.