### PR TITLE
Match viewport position with cursor when using invert right mouse dragging

### DIFF
--- a/src/openrct2/Input.h
+++ b/src/openrct2/Input.h
@@ -76,6 +76,7 @@ struct WidgetRef
 extern uint8_t gInputPlaceObjectModifier;
 
 extern ScreenCoordsXY gInputDragLast;
+extern ScreenCoordsXY savedViewPosLast;
 
 extern WidgetRef gHoverWidget;
 extern WidgetRef gPressedWidget;


### PR DESCRIPTION
I figure that even though I change invert right mouse dragging to show cursor, but I never match the speed when the viewport move with mouse, so it not really feel like 'grab and drag'.

Non inverted right mouse dragging still work as before.

![img](https://github.com/OpenRCT2/OpenRCT2/assets/1791353/5daeaf39-ef13-4118-88d5-b784264831b0)
