### PR TITLE
Fix #20607: Unicode string not limited properly

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -31,6 +31,7 @@
 - Fix: [#20456] Downward large half loops on flying coasters (fly-to-lie) are now correctly named.
 - Fix: [#20484] Console caret not properly updated when using command history.
 - Fix: [#20543] Crash using show segments height from debug paint options.
+- Fix: [#20607] Infinite loop when renaming rides with default names longer than 32 bytes.
 
 0.4.5 (2023-05-08)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -108,11 +108,8 @@ public:
 
     void SetText(std::string_view text, size_t maxLength)
     {
+        text = String::UTF8TruncateCodePoints(text, maxLength);
         _buffer = u8string{ text };
-        if (_buffer.size() > maxLength)
-        {
-            _buffer.resize(maxLength);
-        }
         _maxInputLength = maxLength;
         gTextInput = ContextStartTextInput(_buffer, maxLength);
     }

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -684,6 +684,23 @@ namespace String
         return trunc;
     }
 
+    std::string_view UTF8TruncateCodePoints(std::string_view v, size_t size)
+    {
+        size_t i = 0;
+        while (i < v.size() && size > 0)
+        {
+            auto length = UTF8GetCodePointSize(v.substr(i, v.size()));
+            if (!length.has_value())
+            {
+                return v.substr(0, i);
+            }
+            i += length.value();
+            size--;
+        }
+
+        return v.substr(0, i);
+    }
+
     std::string URLEncode(std::string_view value)
     {
         std::ostringstream escaped;

--- a/src/openrct2/core/String.hpp
+++ b/src/openrct2/core/String.hpp
@@ -179,6 +179,12 @@ namespace String
      */
     std::string_view UTF8Truncate(std::string_view v, size_t size);
 
+    /**
+     * Truncates a string to at most `size` codepoints,
+     * making sure not to cut in the middle of a sequence.
+     */
+    std::string_view UTF8TruncateCodePoints(std::string_view v, size_t size);
+
     // Escapes special characters in a string to the percentage equivalent that can be used in URLs.
     std::string URLEncode(std::string_view value);
 } // namespace String
@@ -220,7 +226,7 @@ public:
             {
                 const utf8* nextch;
                 GetNextCodepoint(&_str[_index], &nextch);
-                _index = nextch - _str.data();
+                _index = std::min<size_t>(nextch - _str.data(), _str.size());
             }
             return *this;
         }
@@ -231,7 +237,7 @@ public:
             {
                 const utf8* nextch;
                 GetNextCodepoint(&_str[_index], &nextch);
-                _index = nextch - _str.data();
+                _index = std::min<size_t>(nextch - _str.data(), _str.size());
             }
             return result;
         }
@@ -245,7 +251,7 @@ public:
     };
 
     CodepointView(std::string_view str)
-        : _str(str)
+        : _str(String::UTF8Truncate(str, str.size()))
     {
     }
 


### PR DESCRIPTION
This is a fix for #20607. 

The cause appears to be that the string is limited to 32 characters. The existing code just chops it at 32 bytes without regarding the size of unicode characters. This leads to an invalid unicode character at the end of the string, and down the line an iterator gets confused and runs on forever.

I've fixed the code to properly limit the length unicode string, respecting the variable unicode character sizes.

I've also added a clamp to the iterator to prevent it running on forever if this bug appears elsewhere. I tested this without the length limiting fix and it prevents a crash, although the last few characters of the string will behave weirdly until the user backspaces through them.