### PR TITLE
Fix tab index being overwritten for scripted windows

### DIFF
--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -285,7 +285,6 @@ WindowBase* WindowCreate(
     w->max_height = height;
 
     w->focus = std::nullopt;
-    w->page = 0;
 
     ColourSchemeUpdate(w);
     w->Invalidate();

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -56,7 +56,7 @@ struct WindowBase
     TrackListVariables track_list;
     union
     {
-        int16_t page;
+        int16_t page{};
         TileInspectorPage tileInspectorPage;
     };
     uint16_t frame_no{};              // updated every tic for motion in windows sprites


### PR DESCRIPTION
The variable `page` would be overwritten discarding the page index passed from the script to create the window. Now page is default initialized in the constructor instead of overwriting it afterwards