### PR TITLE
Move all construction related logic into OnOpen

### DIFF
--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -391,27 +391,31 @@ namespace OpenRCT2::Ui::Windows
         CustomWindow(std::shared_ptr<Plugin> owner, const CustomWindowDesc& desc)
             : _info(owner, desc)
         {
+        }
+
+        void OnOpen() override
+        {
             number = GetNewWindowNumber();
 
             // Set window tab
-            page = desc.TabIndex.value_or(0);
+            page = _info.Desc.TabIndex.value_or(0);
 
             // Set window colours
             colours[0] = COLOUR_GREY;
             colours[1] = COLOUR_GREY;
             colours[2] = COLOUR_GREY;
-            auto numColours = std::min(std::size(colours), std::size(desc.Colours));
+            auto numColours = std::min(std::size(colours), std::size(_info.Desc.Colours));
             for (size_t i = 0; i < numColours; i++)
             {
-                colours[i] = desc.Colours[i];
+                colours[i] = _info.Desc.Colours[i];
             }
 
-            if (desc.IsResizable())
+            if (_info.Desc.IsResizable())
             {
-                min_width = desc.MinWidth.value_or(0);
-                min_height = desc.MinHeight.value_or(0);
-                max_width = desc.MaxWidth.value_or(std::numeric_limits<uint16_t>::max());
-                max_height = desc.MaxHeight.value_or(std::numeric_limits<uint16_t>::max());
+                min_width = _info.Desc.MinWidth.value_or(0);
+                min_height = _info.Desc.MinHeight.value_or(0);
+                max_width = _info.Desc.MaxWidth.value_or(std::numeric_limits<uint16_t>::max());
+                max_height = _info.Desc.MaxHeight.value_or(std::numeric_limits<uint16_t>::max());
             }
             RefreshWidgets();
         }

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -492,8 +492,8 @@ static u8string OpenSystemFileBrowser(bool isSave)
 class LoadSaveWindow final : public Window
 {
 public:
-    LoadSaveWindow(int32_t _type)
-        : type(_type)
+    LoadSaveWindow(int32_t loadSaveType)
+        : type(loadSaveType)
     {
     }
 

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -492,33 +492,15 @@ static u8string OpenSystemFileBrowser(bool isSave)
 class LoadSaveWindow final : public Window
 {
 public:
-    LoadSaveWindow(int32_t type)
+    LoadSaveWindow(int32_t _type)
+        : type(_type)
     {
-        widgets = window_loadsave_widgets;
-
-        const auto uiContext = OpenRCT2::GetContext()->GetUiContext();
-        if (!uiContext->HasFilePicker())
-        {
-            disabled_widgets |= (1uLL << WIDX_BROWSE);
-            window_loadsave_widgets[WIDX_BROWSE].type = WindowWidgetType::Empty;
-        }
-
-        // TODO: Split LOADSAVETYPE_* into two proper enum classes (one for load/save, the other for the type)
-        const bool isSave = (type & 0x01) == LOADSAVETYPE_SAVE;
-        const auto path = GetDir(type);
-
-        const char* pattern = GetFilterPatternByType(type, isSave);
-        PopulateList(isSave, path, pattern);
-        no_list_items = static_cast<uint16_t>(_listItems.size());
-        selected_list_item = -1;
-
-        InitScrollWidgets();
-        ComputeMaxDateWidth();
     }
 
 private:
     int32_t maxDateWidth{ 0 };
     int32_t maxTimeWidth{ 0 };
+    int32_t type;
 
 public:
     void PopulateList(int32_t includeNewItem, const u8string& directory, std::string_view extensionPattern)
@@ -692,6 +674,26 @@ public:
 public:
     void OnOpen() override
     {
+        widgets = window_loadsave_widgets;
+
+        const auto uiContext = OpenRCT2::GetContext()->GetUiContext();
+        if (!uiContext->HasFilePicker())
+        {
+            disabled_widgets |= (1uLL << WIDX_BROWSE);
+            window_loadsave_widgets[WIDX_BROWSE].type = WindowWidgetType::Empty;
+        }
+
+        // TODO: Split LOADSAVETYPE_* into two proper enum classes (one for load/save, the other for the type)
+        const bool isSave = (type & 0x01) == LOADSAVETYPE_SAVE;
+        const auto path = GetDir(type);
+
+        const char* pattern = GetFilterPatternByType(type, isSave);
+        PopulateList(isSave, path, pattern);
+        no_list_items = static_cast<uint16_t>(_listItems.size());
+        selected_list_item = -1;
+
+        InitScrollWidgets();
+        ComputeMaxDateWidth();
         min_width = WW;
         min_height = WH / 2;
         max_width = WW * 2;
@@ -1120,6 +1122,10 @@ public:
     OverwritePromptWindow(const std::string_view name, const std::string_view path)
         : _name(name)
         , _path(path)
+    {
+    }
+
+    void OnOpen() override
     {
         widgets = window_overwrite_prompt_widgets;
         colours[0] = TRANSLUCENT(COLOUR_BORDEAUX_RED);

--- a/src/openrct2-ui/windows/MapTooltip.cpp
+++ b/src/openrct2-ui/windows/MapTooltip.cpp
@@ -36,7 +36,7 @@ static Formatter _mapTooltipArgs;
 class MapTooltip final : public Window
 {
 public:
-    MapTooltip()
+    void OnOpen() override
     {
         widgets = window_map_tooltip_widgets;
     }

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -161,7 +161,7 @@ private:
     ScreenCoordsXY InformationGetSize();
 
 public:
-    MultiplayerWindow();
+    void OnOpen() override;
 
     void SetPage(int32_t page_number);
 
@@ -193,7 +193,7 @@ WindowBase* WindowMultiplayerOpen()
     return window;
 }
 
-MultiplayerWindow::MultiplayerWindow()
+void MultiplayerWindow::OnOpen()
 {
     SetPage(WINDOW_MULTIPLAYER_PAGE_INFORMATION);
 }

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -116,7 +116,7 @@ static constexpr StringId ResearchStageNames[] = {
 class ResearchWindow final : public Window
 {
 public:
-    ResearchWindow()
+    void OnOpen() override
     {
         widgets = window_research_page_widgets[WINDOW_RESEARCH_PAGE_DEVELOPMENT];
         width = WW_DEVELOPMENT;

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -121,6 +121,7 @@ public:
         widgets = window_research_page_widgets[WINDOW_RESEARCH_PAGE_DEVELOPMENT];
         width = WW_DEVELOPMENT;
         height = WH_DEVELOPMENT;
+        ResearchUpdateUncompletedTypes();
     }
 
     void SetPage(int32_t newPageIndex)
@@ -152,11 +153,6 @@ public:
     }
 
 private:
-    void OnOpen() override
-    {
-        ResearchUpdateUncompletedTypes();
-    }
-
     void OnUpdate() override
     {
         // Tab animation

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -635,6 +635,10 @@ public:
     RideWindow(const Ride& ride)
     {
         rideId = ride.id;
+    }
+
+    virtual void OnOpen() override
+    {
         widgets = PageWidgets[WINDOW_RIDE_PAGE_MAIN];
         hold_down_widgets = PageHoldDownWidgets[WINDOW_RIDE_PAGE_MAIN];
 
@@ -648,9 +652,15 @@ public:
         max_width = 500;
         max_height = 450;
 
-        UpdateOverallView(ride);
+        auto ride = GetRide(rideId);
+        if (ride == nullptr)
+        {
+            Close();
+            return;
+        }
+        UpdateOverallView(*ride);
 
-        PopulateVehicleTypeDropdown(ride, true);
+        PopulateVehicleTypeDropdown(*ride, true);
     }
 
     virtual void OnClose() override


### PR DESCRIPTION
This is required as there is CreateWindow inbetween construction and use which resets/sets some variables. Its best to just blanket ban performing any logic or setting variables outside of the custom ones for the window.

Should fix issues with scripting where the min/max widths are not being respected.