### PR TITLE
Ignore dead windows to determine insertion position

### DIFF
--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -244,6 +244,8 @@ WindowBase* WindowCreate(
     {
         for (auto it = g_window_list.begin(); it != g_window_list.end(); it++)
         {
+            if ((*it)->flags & WF_DEAD)
+                continue;
             if (!((*it)->flags & WF_STICK_TO_BACK))
             {
                 itDestPos = it;
@@ -254,6 +256,8 @@ WindowBase* WindowCreate(
     {
         for (auto it = g_window_list.rbegin(); it != g_window_list.rend(); it++)
         {
+            if ((*it)->flags & WF_DEAD)
+                continue;
             if (!((*it)->flags & WF_STICK_TO_FRONT))
             {
                 itDestPos = it.base();


### PR DESCRIPTION
Probably not a problem at all but dead windows should be typically ignored as if they don't exist.