### PR TITLE
Fix another crash in track design manager when using a filter

### DIFF
--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -453,7 +453,7 @@ public:
         int32_t listItemIndex = selected_list_item;
         if (gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)
         {
-            if (_trackDesigns.empty() || listItemIndex == -1)
+            if (_filteredTrackIds.empty() || listItemIndex == -1)
                 return;
         }
         else


### PR DESCRIPTION
Missed that one, it all uses the filter so it needs to check this variable instead