### PR TITLE
No longer limit banner count in intent

### DIFF
--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -497,7 +497,7 @@ public:
 
             case INTENT_ACTION_UPDATE_BANNER:
             {
-                uint8_t bannerIndex = static_cast<uint8_t>(intent.GetUIntExtra(INTENT_EXTRA_BANNER_INDEX));
+                rct_windownumber bannerIndex = static_cast<rct_windownumber>(intent.GetUIntExtra(INTENT_EXTRA_BANNER_INDEX));
 
                 WindowBase* w = WindowFindByNumber(WindowClass::Banner, bannerIndex);
                 if (w != nullptr)


### PR DESCRIPTION
If I'm not mistaken, the new save format supports more than 256 banners. However, if you actually have this many banners, the banner edit window would not update correctly as the data is cast down to 8 bits while processing the intent. 