### PR TITLE
Fix #20659: Phantom rides when closing construction window while paused

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -33,6 +33,7 @@
 - Fix: [#20543] Crash using show segments height from debug paint options.
 - Fix: [#20607] Infinite loop when renaming rides with default names longer than 32 bytes.
 - Fix: [#20642] Track list is sometimes empty due to uninitialized data for the filter string.
+- Fix: [#20659] Phantom rides remain when closing construction window while paused.
 
 0.4.5 (2023-05-08)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -124,12 +124,9 @@ public:
         {
             if (currentRide->overall_view.IsNull())
             {
-                int32_t savedPausedState = gGamePaused;
-                gGamePaused = 0;
                 auto gameAction = RideDemolishAction(currentRide->id, RIDE_MODIFY_DEMOLISH);
                 gameAction.SetFlags(GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED);
                 GameActions::Execute(&gameAction);
-                gGamePaused = savedPausedState;
             }
             else
             {

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -294,11 +294,9 @@ public:
         }
         else
         {
-            int32_t previousPauseState = gGamePaused;
-            gGamePaused = 0;
             auto gameAction = RideDemolishAction(currentRide->id, RIDE_MODIFY_DEMOLISH);
+            gameAction.SetFlags(GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED);
             GameActions::Execute(&gameAction);
-            gGamePaused = previousPauseState;
         }
     }
 

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "12"
+#define NETWORK_STREAM_VERSION "13"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 


### PR DESCRIPTION
This should fix #20659 

The original code had a hacky work around to demolish the ghost ride while paused, but it doesn't work with the client server model. 

I also removed another instance of the hack in the maze construction code.