### PR TITLE
Fix #20684: Footpath additions getting removed by Miniature railway ghost elements

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -35,6 +35,7 @@
 - Fix: [#20607] Infinite loop when renaming rides with default names longer than 32 bytes.
 - Fix: [#20642] Track list is sometimes empty due to uninitialized data for the filter string.
 - Fix: [#20659] Phantom rides remain when closing construction window while paused.
+- Fix: [#20684] Footpath additions getting removed by Miniature railway ghost elements.
 
 0.4.5 (2023-05-08)
 ------------------------------------------------------------------------

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -258,16 +258,6 @@ GameActions::Result TrackPlaceAction::Query() const
         }
         costs += canBuild.Cost;
 
-        // When building a level crossing, remove any pre-existing path furniture.
-        if (crossingMode == CREATE_CROSSING_MODE_TRACK_OVER_PATH)
-        {
-            auto footpathElement = MapGetFootpathElement(mapLoc);
-            if (footpathElement != nullptr && footpathElement->AsPath()->HasAddition())
-            {
-                footpathElement->AsPath()->SetAddition(0);
-            }
-        }
-
         const auto clearanceData = canBuild.GetData<ConstructClearResult>();
         uint8_t mapGroundFlags = clearanceData.GroundFlags & (ELEMENT_IS_ABOVE_GROUND | ELEMENT_IS_UNDERGROUND);
         if (resultData.GroundFlags != 0 && (resultData.GroundFlags & mapGroundFlags) == 0)
@@ -477,6 +467,16 @@ GameActions::Result TrackPlaceAction::Execute() const
             return canBuild;
         }
         costs += canBuild.Cost;
+
+        // When building a level crossing, remove any pre-existing path furniture.
+        if (crossingMode == CREATE_CROSSING_MODE_TRACK_OVER_PATH && !(GetFlags() & GAME_COMMAND_FLAG_GHOST))
+        {
+            auto footpathElement = MapGetFootpathElement(mapLoc);
+            if (footpathElement != nullptr && footpathElement->AsPath()->HasAddition())
+            {
+                footpathElement->AsPath()->SetAddition(0);
+            }
+        }
 
         if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST) && !gCheatsDisableClearanceChecks)
         {

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "13"
+#define NETWORK_STREAM_VERSION "14"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 


### PR DESCRIPTION
There are two fixes to be precise, the footpath additions were removed in the Query method which is not supposed to mutate the game state, second it ignored if the ghost flag was set which is only supposed to show a preview.

Closes #20684