### PR TITLE
Return PathElement instead of TileElement on MapGetFootpathElement

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3330,7 +3330,7 @@ void RideConstructionToolupdateConstruct(const ScreenCoordsXY& screenCoords)
     if (_autoRotatingShop && _rideConstructionState == RideConstructionState::Place
         && ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_IS_SHOP_OR_FACILITY))
     {
-        TileElement* pathsByDir[NumOrthogonalDirections];
+        PathElement* pathsByDir[NumOrthogonalDirections];
 
         bool keepOrientation = false;
         for (int8_t i = 0; i < NumOrthogonalDirections; i++)
@@ -3344,8 +3344,7 @@ void RideConstructionToolupdateConstruct(const ScreenCoordsXY& screenCoords)
 
             pathsByDir[i] = MapGetFootpathElement(testLoc);
 
-            if (pathsByDir[i] != nullptr && (pathsByDir[i])->AsPath()->IsSloped()
-                && (pathsByDir[i])->AsPath()->GetSlopeDirection() != i)
+            if (pathsByDir[i] != nullptr && pathsByDir[i]->IsSloped() && pathsByDir[i]->GetSlopeDirection() != i)
             {
                 pathsByDir[i] = nullptr;
             }
@@ -3356,14 +3355,13 @@ void RideConstructionToolupdateConstruct(const ScreenCoordsXY& screenCoords)
                 pathsByDir[i] = MapGetFootpathElement({ *mapCoords + CoordsDirectionDelta[i], z - PATH_HEIGHT_STEP });
 
                 if (pathsByDir[i] != nullptr
-                    && (!(pathsByDir[i])->AsPath()->IsSloped()
-                        || (pathsByDir[i])->AsPath()->GetSlopeDirection() != DirectionReverse(i)))
+                    && (!pathsByDir[i]->IsSloped() || pathsByDir[i]->GetSlopeDirection() != DirectionReverse(i)))
                 {
                     pathsByDir[i] = nullptr;
                 }
             }
 
-            if (pathsByDir[i] != nullptr && (pathsByDir[i])->AsPath()->IsQueue())
+            if (pathsByDir[i] != nullptr && pathsByDir[i]->IsQueue())
             {
                 pathsByDir[i] = nullptr;
             }

--- a/src/openrct2/actions/FootpathAdditionRemoveAction.cpp
+++ b/src/openrct2/actions/FootpathAdditionRemoveAction.cpp
@@ -91,9 +91,7 @@ GameActions::Result FootpathAdditionRemoveAction::Query() const
 
 GameActions::Result FootpathAdditionRemoveAction::Execute() const
 {
-    auto tileElement = MapGetFootpathElement(_loc);
-    auto pathElement = tileElement->AsPath();
-
+    auto* pathElement = MapGetFootpathElement(_loc);
     if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
     {
         FootpathInterruptPeeps(_loc);

--- a/src/openrct2/actions/FootpathPlaceAction.cpp
+++ b/src/openrct2/actions/FootpathPlaceAction.cpp
@@ -493,13 +493,12 @@ void FootpathPlaceAction::RemoveIntersectingWalls(PathElement* pathElement) cons
         WallRemoveIntersectingWalls({ _loc, z, z + (6 * COORDS_Z_STEP) }, DirectionReverse(direction));
         WallRemoveIntersectingWalls({ _loc, z, z + (6 * COORDS_Z_STEP) }, direction);
         // Removing walls may have made the pointer invalid, so find it again
-        auto tileElement = MapGetFootpathElement(CoordsXYZ(_loc, z));
-        if (tileElement == nullptr)
+        pathElement = MapGetFootpathElement(CoordsXYZ(_loc, z));
+        if (pathElement == nullptr)
         {
             LOG_ERROR("Something went wrong. Could not refind footpath.");
             return;
         }
-        pathElement = tileElement->AsPath();
     }
 
     if (!(GetFlags() & GAME_COMMAND_FLAG_TRACK_DESIGN))

--- a/src/openrct2/actions/FootpathRemoveAction.cpp
+++ b/src/openrct2/actions/FootpathRemoveAction.cpp
@@ -125,7 +125,8 @@ TileElement* FootpathRemoveAction::GetFootpathElement() const
 {
     bool getGhostPath = GetFlags() & GAME_COMMAND_FLAG_GHOST;
 
-    TileElement* tileElement = MapGetFootpathElement(_loc);
+    // FIXME: This is a hack to get the footpath element. It should be done in a better way.
+    TileElement* tileElement = MapGetFootpathElement(_loc)->as<TileElement>();
     TileElement* footpathElement = nullptr;
     if (tileElement != nullptr)
     {

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -472,9 +472,9 @@ GameActions::Result TrackPlaceAction::Execute() const
         if (crossingMode == CREATE_CROSSING_MODE_TRACK_OVER_PATH && !(GetFlags() & GAME_COMMAND_FLAG_GHOST))
         {
             auto footpathElement = MapGetFootpathElement(mapLoc);
-            if (footpathElement != nullptr && footpathElement->AsPath()->HasAddition())
+            if (footpathElement != nullptr && footpathElement->HasAddition())
             {
-                footpathElement->AsPath()->SetAddition(0);
+                footpathElement->SetAddition(0);
             }
         }
 

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -357,7 +357,7 @@ void RideClearBlockedTiles(const Ride& ride)
                 if (footpathElement == nullptr)
                     continue;
 
-                footpathElement->AsPath()->SetIsBlockedByVehicle(false);
+                footpathElement->SetIsBlockedByVehicle(false);
             }
         }
     }

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -119,7 +119,7 @@ static bool entrance_has_direction(const EntranceElement& entranceElement, int32
     return entranceElement.GetDirections() & (1 << (direction & 3));
 }
 
-TileElement* MapGetFootpathElement(const CoordsXYZ& coords)
+PathElement* MapGetFootpathElement(const CoordsXYZ& coords)
 {
     TileElement* tileElement = MapGetFirstElementAt(coords);
     do
@@ -127,7 +127,7 @@ TileElement* MapGetFootpathElement(const CoordsXYZ& coords)
         if (tileElement == nullptr)
             break;
         if (tileElement->GetType() == TileElementType::Path && tileElement->GetBaseZ() == coords.z)
-            return tileElement;
+            return tileElement->AsPath();
     } while (!(tileElement++)->IsLastForTile());
 
     return nullptr;

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -17,6 +17,7 @@
 class FootpathObject;
 class FootpathSurfaceObject;
 class FootpathRailingsObject;
+struct PathElement;
 
 enum
 {
@@ -184,7 +185,7 @@ extern const std::array<CoordsXY, NumOrthogonalDirections> DirectionOffsets;
 extern const std::array<CoordsXY, NumOrthogonalDirections> BinUseOffsets;
 extern const std::array<CoordsXY, NumOrthogonalDirections * 2> BenchUseOffsets;
 
-TileElement* MapGetFootpathElement(const CoordsXYZ& coords);
+PathElement* MapGetFootpathElement(const CoordsXYZ& coords);
 void FootpathInterruptPeeps(const CoordsXYZ& footpathPos);
 money64 FootpathProvisionalSet(
     ObjectEntryIndex type, ObjectEntryIndex railingsType, const CoordsXYZ& footpathLoc, int32_t slope,

--- a/test/tests/TileElements.cpp
+++ b/test/tests/TileElements.cpp
@@ -59,7 +59,7 @@ uint8_t TileElementWantsFootpathConnection::_gScreenFlags;
 TEST_F(TileElementWantsFootpathConnection, FlatPath)
 {
     // Flat paths want to connect to other paths in any direction
-    const TileElement* const pathElement = MapGetFootpathElement(TileCoordsXYZ{ 19, 18, 14 }.ToCoordsXYZ());
+    const auto* pathElement = MapGetFootpathElement(TileCoordsXYZ{ 19, 18, 14 }.ToCoordsXYZ());
     ASSERT_NE(pathElement, nullptr);
     EXPECT_TRUE(TileElementWantsPathConnectionTowards({ 19, 18, 14, 0 }, nullptr));
     EXPECT_TRUE(TileElementWantsPathConnectionTowards({ 19, 18, 14, 1 }, nullptr));
@@ -71,7 +71,7 @@ TEST_F(TileElementWantsFootpathConnection, FlatPath)
 TEST_F(TileElementWantsFootpathConnection, SlopedPath)
 {
     // Sloped paths only want to connect in two directions, of which is one at a higher offset
-    const TileElement* const slopedPathElement = MapGetFootpathElement(TileCoordsXYZ{ 18, 18, 14 }.ToCoordsXYZ());
+    const auto* slopedPathElement = MapGetFootpathElement(TileCoordsXYZ{ 18, 18, 14 }.ToCoordsXYZ());
     ASSERT_NE(slopedPathElement, nullptr);
     ASSERT_TRUE(slopedPathElement->AsPath()->IsSloped());
     // Bottom and top of sloped path want a path connection
@@ -152,14 +152,15 @@ TEST_F(TileElementWantsFootpathConnection, MapEdge)
 {
     // Paths at the map edge should have edge flags turned on when placed in scenario editor
     // This tile is a single, unconnected footpath on the map edge - on load, GetEdges() returns 0
-    TileElement* pathElement = MapGetFootpathElement(TileCoordsXYZ{ 1, 4, 14 }.ToCoordsXYZ());
+    auto* pathElement = MapGetFootpathElement(TileCoordsXYZ{ 1, 4, 14 }.ToCoordsXYZ());
 
     // Enable flag to simulate enabling the scenario editor
     gScreenFlags |= SCREEN_FLAGS_SCENARIO_EDITOR;
 
     // Calculate the connected edges and set the appropriate edge flags
-    FootpathConnectEdges({ 16, 64 }, pathElement, 0);
-    auto edges = pathElement->AsPath()->GetEdges();
+    // FIXME: The footpath functions should only take PathElement and not TileElement.
+    FootpathConnectEdges({ 16, 64 }, pathElement->as<TileElement>(), 0);
+    auto edges = pathElement->GetEdges();
 
     // The tiles alongside in the Y direction are both on the map edge so should be marked as an edge
     EXPECT_TRUE(edges & (1 << 1));


### PR DESCRIPTION
First pass, the Footpath* functions should take PathElement as the parameter and not TileElement, there are a ton of AsPath calls which are quite pointless if we just pass the correct type from the beginning.