### PR TITLE
Reduce tileElement.AsType calls and pass by const ref

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -36,6 +36,7 @@
 - Fix: [#20642] Track list is sometimes empty due to uninitialized data for the filter string.
 - Fix: [#20659] Phantom rides remain when closing construction window while paused.
 - Fix: [#20684] Footpath additions getting removed by Miniature railway ghost elements.
+- Fix: [#20693] Incorrect information shown when hovering over station when another station before it was removed.
 
 0.4.5 (2023-05-08)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -126,7 +126,8 @@ InteractionInfo ViewportInteractionGetItemLeft(const ScreenCoordsXY& screenCoord
             }
             break;
         case ViewportInteractionItem::Ride:
-            RideSetMapTooltip(tileElement);
+            Guard::ArgumentNotNull(tileElement);
+            RideSetMapTooltip(*tileElement);
             break;
         case ViewportInteractionItem::ParkEntrance:
         {

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -52,12 +52,12 @@
 #include <openrct2/world/Surface.h>
 #include <openrct2/world/Wall.h>
 
-static void ViewportInteractionRemoveScenery(TileElement* tileElement, const CoordsXY& mapCoords);
-static void ViewportInteractionRemoveFootpath(TileElement* tileElement, const CoordsXY& mapCoords);
-static void ViewportInteractionRemovePathAddition(TileElement* tileElement, const CoordsXY& mapCoords);
-static void ViewportInteractionRemoveParkWall(TileElement* tileElement, const CoordsXY& mapCoords);
-static void ViewportInteractionRemoveLargeScenery(TileElement* tileElement, const CoordsXY& mapCoords);
-static void ViewportInteractionRemoveParkEntrance(TileElement* tileElement, CoordsXY mapCoords);
+static void ViewportInteractionRemoveScenery(const SmallSceneryElement& smallSceneryElement, const CoordsXY& mapCoords);
+static void ViewportInteractionRemoveFootpath(const PathElement& pathElement, const CoordsXY& mapCoords);
+static void ViewportInteractionRemovePathAddition(const PathElement& pathElement, const CoordsXY& mapCoords);
+static void ViewportInteractionRemoveParkWall(const WallElement& wallElement, const CoordsXY& mapCoords);
+static void ViewportInteractionRemoveLargeScenery(const LargeSceneryElement& largeSceneryElement, const CoordsXY& mapCoords);
+static void ViewportInteractionRemoveParkEntrance(const EntranceElement& entranceElement, CoordsXY mapCoords);
 static Peep* ViewportInteractionGetClosestPeep(ScreenCoordsXY screenCoords, int32_t maxDistance);
 
 /**
@@ -574,22 +574,22 @@ bool ViewportInteractionRightClick(const ScreenCoordsXY& screenCoords)
             RideModify(tileElement);
             break;
         case ViewportInteractionItem::Scenery:
-            ViewportInteractionRemoveScenery(info.Element, info.Loc);
+            ViewportInteractionRemoveScenery(*info.Element->AsSmallScenery(), info.Loc);
             break;
         case ViewportInteractionItem::Footpath:
-            ViewportInteractionRemoveFootpath(info.Element, info.Loc);
+            ViewportInteractionRemoveFootpath(*info.Element->AsPath(), info.Loc);
             break;
         case ViewportInteractionItem::PathAddition:
-            ViewportInteractionRemovePathAddition(info.Element, info.Loc);
+            ViewportInteractionRemovePathAddition(*info.Element->AsPath(), info.Loc);
             break;
         case ViewportInteractionItem::ParkEntrance:
-            ViewportInteractionRemoveParkEntrance(info.Element, info.Loc);
+            ViewportInteractionRemoveParkEntrance(*info.Element->AsEntrance(), info.Loc);
             break;
         case ViewportInteractionItem::Wall:
-            ViewportInteractionRemoveParkWall(info.Element, info.Loc);
+            ViewportInteractionRemoveParkWall(*info.Element->AsWall(), info.Loc);
             break;
         case ViewportInteractionItem::LargeScenery:
-            ViewportInteractionRemoveLargeScenery(info.Element, info.Loc);
+            ViewportInteractionRemoveLargeScenery(*info.Element->AsLargeScenery(), info.Loc);
             break;
         case ViewportInteractionItem::Banner:
             ContextOpenDetailWindow(WD_BANNER, info.Element->AsBanner()->GetIndex().ToUnderlying());
@@ -603,11 +603,11 @@ bool ViewportInteractionRightClick(const ScreenCoordsXY& screenCoords)
  *
  *  rct2: 0x006E08D2
  */
-static void ViewportInteractionRemoveScenery(TileElement* tileElement, const CoordsXY& mapCoords)
+static void ViewportInteractionRemoveScenery(const SmallSceneryElement& smallSceneryElement, const CoordsXY& mapCoords)
 {
     auto removeSceneryAction = SmallSceneryRemoveAction(
-        { mapCoords.x, mapCoords.y, tileElement->GetBaseZ() }, tileElement->AsSmallScenery()->GetSceneryQuadrant(),
-        tileElement->AsSmallScenery()->GetEntryIndex());
+        { mapCoords.x, mapCoords.y, smallSceneryElement.GetBaseZ() }, smallSceneryElement.GetSceneryQuadrant(),
+        smallSceneryElement.GetEntryIndex());
 
     GameActions::Execute(&removeSceneryAction);
 }
@@ -616,20 +616,17 @@ static void ViewportInteractionRemoveScenery(TileElement* tileElement, const Coo
  *
  *  rct2: 0x006A614A
  */
-static void ViewportInteractionRemoveFootpath(TileElement* tileElement, const CoordsXY& mapCoords)
+static void ViewportInteractionRemoveFootpath(const PathElement& pathElement, const CoordsXY& mapCoords)
 {
-    WindowBase* w;
-    TileElement* tileElement2;
-
-    auto z = tileElement->GetBaseZ();
-
-    w = WindowFindByClass(WindowClass::Footpath);
+    WindowBase* w = WindowFindByClass(WindowClass::Footpath);
     if (w != nullptr)
         FootpathProvisionalUpdate();
 
-    tileElement2 = MapGetFirstElementAt(mapCoords);
+    TileElement* tileElement2 = MapGetFirstElementAt(mapCoords);
     if (tileElement2 == nullptr)
         return;
+
+    auto z = pathElement.GetBaseZ();
     do
     {
         if (tileElement2->GetType() == TileElementType::Path && tileElement2->GetBaseZ() == z)
@@ -645,9 +642,9 @@ static void ViewportInteractionRemoveFootpath(TileElement* tileElement, const Co
  *
  *  rct2: 0x006A61AB
  */
-static void ViewportInteractionRemovePathAddition(TileElement* tileElement, const CoordsXY& mapCoords)
+static void ViewportInteractionRemovePathAddition(const PathElement& pathElement, const CoordsXY& mapCoords)
 {
-    auto footpathAdditionRemoveAction = FootpathAdditionRemoveAction({ mapCoords.x, mapCoords.y, tileElement->GetBaseZ() });
+    auto footpathAdditionRemoveAction = FootpathAdditionRemoveAction({ mapCoords.x, mapCoords.y, pathElement.GetBaseZ() });
     GameActions::Execute(&footpathAdditionRemoveAction);
 }
 
@@ -655,10 +652,10 @@ static void ViewportInteractionRemovePathAddition(TileElement* tileElement, cons
  *
  *  rct2: 0x00666C0E
  */
-void ViewportInteractionRemoveParkEntrance(TileElement* tileElement, CoordsXY mapCoords)
+void ViewportInteractionRemoveParkEntrance(const EntranceElement& entranceElement, CoordsXY mapCoords)
 {
-    int32_t rotation = tileElement->GetDirectionWithOffset(1);
-    switch (tileElement->AsEntrance()->GetSequenceIndex())
+    int32_t rotation = entranceElement.GetDirectionWithOffset(1);
+    switch (entranceElement.GetSequenceIndex())
     {
         case 1:
             mapCoords += CoordsDirectionDelta[rotation];
@@ -667,7 +664,7 @@ void ViewportInteractionRemoveParkEntrance(TileElement* tileElement, CoordsXY ma
             mapCoords -= CoordsDirectionDelta[rotation];
             break;
     }
-    auto parkEntranceRemoveAction = ParkEntranceRemoveAction({ mapCoords.x, mapCoords.y, tileElement->GetBaseZ() });
+    auto parkEntranceRemoveAction = ParkEntranceRemoveAction({ mapCoords.x, mapCoords.y, entranceElement.GetBaseZ() });
     GameActions::Execute(&parkEntranceRemoveAction);
 }
 
@@ -675,16 +672,16 @@ void ViewportInteractionRemoveParkEntrance(TileElement* tileElement, CoordsXY ma
  *
  *  rct2: 0x006E57A9
  */
-static void ViewportInteractionRemoveParkWall(TileElement* tileElement, const CoordsXY& mapCoords)
+static void ViewportInteractionRemoveParkWall(const WallElement& wallElement, const CoordsXY& mapCoords)
 {
-    auto* wallEntry = tileElement->AsWall()->GetEntry();
+    auto* wallEntry = wallElement.GetEntry();
     if (wallEntry->scrolling_mode != SCROLLING_MODE_NONE)
     {
-        ContextOpenDetailWindow(WD_SIGN_SMALL, tileElement->AsWall()->GetBannerIndex().ToUnderlying());
+        ContextOpenDetailWindow(WD_SIGN_SMALL, wallElement.GetBannerIndex().ToUnderlying());
     }
     else
     {
-        CoordsXYZD wallLocation = { mapCoords.x, mapCoords.y, tileElement->GetBaseZ(), tileElement->GetDirection() };
+        CoordsXYZD wallLocation = { mapCoords.x, mapCoords.y, wallElement.GetBaseZ(), wallElement.GetDirection() };
         auto wallRemoveAction = WallRemoveAction(wallLocation);
         GameActions::Execute(&wallRemoveAction);
     }
@@ -694,20 +691,20 @@ static void ViewportInteractionRemoveParkWall(TileElement* tileElement, const Co
  *
  *  rct2: 0x006B88DC
  */
-static void ViewportInteractionRemoveLargeScenery(TileElement* tileElement, const CoordsXY& mapCoords)
+static void ViewportInteractionRemoveLargeScenery(const LargeSceneryElement& largeSceneryElement, const CoordsXY& mapCoords)
 {
-    auto* sceneryEntry = tileElement->AsLargeScenery()->GetEntry();
+    auto* sceneryEntry = largeSceneryElement.GetEntry();
 
     if (sceneryEntry->scrolling_mode != SCROLLING_MODE_NONE)
     {
-        auto bannerIndex = tileElement->AsLargeScenery()->GetBannerIndex();
+        auto bannerIndex = largeSceneryElement.GetBannerIndex();
         ContextOpenDetailWindow(WD_SIGN, bannerIndex.ToUnderlying());
     }
     else
     {
         auto removeSceneryAction = LargeSceneryRemoveAction(
-            { mapCoords.x, mapCoords.y, tileElement->GetBaseZ(), tileElement->GetDirection() },
-            tileElement->AsLargeScenery()->GetSequenceIndex());
+            { mapCoords.x, mapCoords.y, largeSceneryElement.GetBaseZ(), largeSceneryElement.GetDirection() },
+            largeSceneryElement.GetSequenceIndex());
         GameActions::Execute(&removeSceneryAction);
     }
 }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2257,6 +2257,7 @@ void RideCheckAllReachable()
     {
         if (ride.connected_message_throttle != 0)
             ride.connected_message_throttle--;
+
         if (ride.status != RideStatus::Open || ride.connected_message_throttle != 0)
             continue;
 
@@ -2293,6 +2294,7 @@ static void RideEntranceExitConnected(Ride& ride)
 
         if (station_start.IsNull())
             continue;
+
         if (!entrance.IsNull() && !RideEntranceExitIsReachable(entrance))
         {
             // name of ride is parameter of the format string
@@ -2344,9 +2346,7 @@ static void RideShopConnected(const Ride& ride)
     auto track_type = trackElement->GetTrackType();
     auto ride2 = GetRide(trackElement->GetRideIndex());
     if (ride2 == nullptr)
-    {
         return;
-    }
 
     const auto& ted = GetTrackElementDescriptor(track_type);
     uint8_t entrance_directions = std::get<0>(ted.SequenceProperties) & 0xF;
@@ -2432,8 +2432,12 @@ static void RideStationSetMapTooltip(const TrackElement& trackElement)
 
     auto stationIndex = trackElement.GetStationIndex();
     for (int32_t i = stationIndex.ToUnderlying(); i >= 0; i--)
+    {
         if (ride->GetStations()[i].Start.IsNull())
+        {
             stationIndex = StationIndex::FromUnderlying(stationIndex.ToUnderlying() - 1);
+        }
+    }
 
     auto ft = Formatter();
     ft.Add<StringId>(STR_RIDE_MAP_TIP);
@@ -2457,15 +2461,21 @@ static void RideEntranceSetMapTooltip(const EntranceElement& entranceElement)
     // Get the station
     auto stationIndex = entranceElement.GetStationIndex();
     for (int32_t i = stationIndex.ToUnderlying(); i >= 0; i--)
+    {
         if (ride->GetStations()[i].Start.IsNull())
+        {
             stationIndex = StationIndex::FromUnderlying(stationIndex.ToUnderlying() - 1);
+        }
+    }
 
     if (entranceElement.GetEntranceType() == ENTRANCE_TYPE_RIDE_ENTRANCE)
     {
         // Get the queue length
         int32_t queueLength = 0;
         if (!ride->GetStation(stationIndex).Entrance.IsNull())
+        {
             queueLength = ride->GetStation(stationIndex).QueueLength;
+        }
 
         auto ft = Formatter();
         ft.Add<StringId>(STR_RIDE_MAP_TIP);
@@ -2498,8 +2508,12 @@ static void RideEntranceSetMapTooltip(const EntranceElement& entranceElement)
         // Get the station
         stationIndex = entranceElement.GetStationIndex();
         for (int32_t i = stationIndex.ToUnderlying(); i >= 0; i--)
+        {
             if (ride->GetStations()[i].Start.IsNull())
+            {
                 stationIndex = StationIndex::FromUnderlying(stationIndex.ToUnderlying() - 1);
+            }
+        }
 
         auto ft = Formatter();
         ft.Add<StringId>(ride->num_stations <= 1 ? STR_RIDE_EXIT : STR_RIDE_STATION_X_EXIT);

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2391,9 +2391,9 @@ static void RideShopConnected(const Ride& ride)
 
 #pragma region Interface
 
-static void RideTrackSetMapTooltip(TileElement* tileElement)
+static void RideTrackSetMapTooltip(const TrackElement& trackElement)
 {
-    auto rideIndex = tileElement->AsTrack()->GetRideIndex();
+    auto rideIndex = trackElement.GetRideIndex();
     auto ride = GetRide(rideIndex);
     if (ride != nullptr)
     {
@@ -2407,9 +2407,9 @@ static void RideTrackSetMapTooltip(TileElement* tileElement)
     }
 }
 
-static void RideQueueBannerSetMapTooltip(TileElement* tileElement)
+static void RideQueueBannerSetMapTooltip(const PathElement& pathElement)
 {
-    auto rideIndex = tileElement->AsPath()->GetRideIndex();
+    auto rideIndex = pathElement.GetRideIndex();
     auto ride = GetRide(rideIndex);
     if (ride != nullptr)
     {
@@ -2423,13 +2423,13 @@ static void RideQueueBannerSetMapTooltip(TileElement* tileElement)
     }
 }
 
-static void RideStationSetMapTooltip(TileElement* tileElement)
+static void RideStationSetMapTooltip(const TrackElement& trackElement)
 {
-    auto rideIndex = tileElement->AsTrack()->GetRideIndex();
+    auto rideIndex = trackElement.GetRideIndex();
     auto ride = GetRide(rideIndex);
     if (ride != nullptr)
     {
-        auto stationIndex = tileElement->AsTrack()->GetStationIndex();
+        auto stationIndex = trackElement.GetStationIndex();
         for (int32_t i = stationIndex.ToUnderlying(); i >= 0; i--)
             if (ride->GetStations()[i].Start.IsNull())
                 stationIndex = StationIndex::FromUnderlying(stationIndex.ToUnderlying() - 1);
@@ -2447,19 +2447,19 @@ static void RideStationSetMapTooltip(TileElement* tileElement)
     }
 }
 
-static void RideEntranceSetMapTooltip(TileElement* tileElement)
+static void RideEntranceSetMapTooltip(const EntranceElement& entranceElement)
 {
-    auto rideIndex = tileElement->AsEntrance()->GetRideIndex();
+    auto rideIndex = entranceElement.GetRideIndex();
     auto ride = GetRide(rideIndex);
     if (ride != nullptr)
     {
         // Get the station
-        auto stationIndex = tileElement->AsEntrance()->GetStationIndex();
+        auto stationIndex = entranceElement.GetStationIndex();
         for (int32_t i = stationIndex.ToUnderlying(); i >= 0; i--)
             if (ride->GetStations()[i].Start.IsNull())
                 stationIndex = StationIndex::FromUnderlying(stationIndex.ToUnderlying() - 1);
 
-        if (tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_RIDE_ENTRANCE)
+        if (entranceElement.GetEntranceType() == ENTRANCE_TYPE_RIDE_ENTRANCE)
         {
             // Get the queue length
             int32_t queueLength = 0;
@@ -2495,7 +2495,7 @@ static void RideEntranceSetMapTooltip(TileElement* tileElement)
         else
         {
             // Get the station
-            stationIndex = tileElement->AsEntrance()->GetStationIndex();
+            stationIndex = entranceElement.GetStationIndex();
             for (int32_t i = stationIndex.ToUnderlying(); i >= 0; i--)
                 if (ride->GetStations()[i].Start.IsNull())
                     stationIndex = StationIndex::FromUnderlying(stationIndex.ToUnderlying() - 1);
@@ -2515,26 +2515,27 @@ static void RideEntranceSetMapTooltip(TileElement* tileElement)
     }
 }
 
-void RideSetMapTooltip(TileElement* tileElement)
+void RideSetMapTooltip(const TileElement& tileElement)
 {
-    if (tileElement->GetType() == TileElementType::Entrance)
+    if (tileElement.GetType() == TileElementType::Entrance)
     {
-        RideEntranceSetMapTooltip(tileElement);
+        RideEntranceSetMapTooltip(*tileElement.AsEntrance());
     }
-    else if (tileElement->GetType() == TileElementType::Track)
+    else if (tileElement.GetType() == TileElementType::Track)
     {
-        if (tileElement->AsTrack()->IsStation())
+        const auto* trackElement = tileElement.AsTrack();
+        if (trackElement->IsStation())
         {
-            RideStationSetMapTooltip(tileElement);
+            RideStationSetMapTooltip(*trackElement);
         }
         else
         {
-            RideTrackSetMapTooltip(tileElement);
+            RideTrackSetMapTooltip(*trackElement);
         }
     }
-    else if (tileElement->GetType() == TileElementType::Path)
+    else if (tileElement.GetType() == TileElementType::Path)
     {
-        RideQueueBannerSetMapTooltip(tileElement);
+        RideQueueBannerSetMapTooltip(*tileElement.AsPath());
     }
 }
 

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -1027,7 +1027,7 @@ void RideMeasurementsUpdate();
 void RideBreakdownAddNewsItem(const Ride& ride);
 Staff* RideFindClosestMechanic(const Ride& ride, int32_t forInspection);
 int32_t RideInitialiseConstructionWindow(Ride& ride);
-void RideSetMapTooltip(TileElement* tileElement);
+void RideSetMapTooltip(const TileElement& tileElement);
 void RidePrepareBreakdown(Ride& ride, int32_t breakdownReason);
 TileElement* RideGetStationStartTrackElement(const Ride& ride, StationIndex stationIndex);
 TileElement* RideGetStationExitElement(const CoordsXYZ& elementPos);

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -293,6 +293,10 @@ public:
     const std::array<RideStation, OpenRCT2::Limits::MaxStationsPerRide>& GetStations() const;
     StationIndex GetStationIndex(const RideStation* station) const;
 
+    // Returns the logical station number from the given station. Index 0 = station 1, index 1 = station 2. It accounts for gaps
+    // in the station array. e.g. if only slot 0 and 2 are in use, index 2 returns 2 instead of 3.
+    StationIndex::UnderlyingType GetStationNumber(StationIndex in) const;
+
 public:
     uint16_t inversions;
     uint16_t holes;


### PR DESCRIPTION
A minor clean-up in the viewport interaction code: passing tile elements by const ref instead of by pointer (they weren't checked for null anyway), removing a few repeated `tileElement.AsType` calls, and reduce nesting by returning from functions earlier.

Technically, it does add a few `tileElement.AsType` calls for the `ViewportInteractionRemoveX` functions even when not really needed, but that's an implementation detail of these functions, and not something that's triggered a million times every tick.