### PR TITLE
Fix Syntax in EditorObjectSelectionSession.cpp and Marketing.cpp annotations

### DIFF
--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -46,9 +46,7 @@ static void SelectDesignerObjects();
 static void ReplaceSelectedWaterPalette(const ObjectRepositoryItem* item);
 
 /**
- * Master objects are objects that are not
- * optional / required dependants of an
- * object.
+ * Master objects are objects that are not optional / required dependants of an object.
  */
 static constexpr ResultWithMessage ObjectSelectionError(bool isMasterObject, StringId message)
 {

--- a/src/openrct2/management/Marketing.cpp
+++ b/src/openrct2/management/Marketing.cpp
@@ -93,7 +93,7 @@ static void MarketingRaiseFinishedNotification(const MarketingCampaign& campaign
 }
 
 /**
- * Update status of marketing campaigns and send produce a news item when they have finished.
+ * Update status of marketing campaigns and produce a news item when they have finished.
  *  rct2: 0x0069E0C1
  */
 void MarketingUpdate()
@@ -231,7 +231,7 @@ MarketingCampaign* MarketingGetCampaign(int32_t campaignType)
 
 void MarketingNewCampaign(const MarketingCampaign& campaign)
 {
-    // Do not allow same campaign twice, just overwrite
+    // Do not allow the same campaign twice, just overwrite
     auto currentCampaign = MarketingGetCampaign(campaign.Type);
     if (currentCampaign != nullptr)
     {


### PR DESCRIPTION
Fix syntax in annotations of code inside EditorObjectSelectionSession.cpp and Marketing.cpp