### PR TITLE
Added API for getAllPlugins

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -118,6 +118,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Wenzhao Qiu (qwzhaox) - Misc.
 * Tiago Reul (reul) - Misc.
 * Fredrik Tegnell (fredriktegnell) - Misc.
+* Alex Parisi (alex-parisi) - Added API for returning metadata from all registered plugins.
 
 ## Bug fixes & Refactors
 * (KirilAngelov)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.9 (in development)
 ------------------------------------------------------------------------
+- Feature: [#20709] [Plugin] Plugins can now check metadata from all registered plugins.
 - Feature: [#21376] Add option to reload an object (for object developers).
 - Improved: [#21356] Resize the title bar when moving between displays with different scaling factors on Windows systems.
 - Fix: [#18963] Research table in parks from Loopy Landscapes is imported incorrectly.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -56,7 +56,10 @@ declare global {
      * Plugin writers should check if ui is available using `typeof ui !== 'undefined'`.
      */
     var ui: Ui;
-
+    /**
+     * APIs for managing the installed plugins
+     */
+    var pluginManager: PluginManager;
     /**
      * Registers the plugin. This may only be called once.
      * @param metadata Information about the plugin and the entry point.
@@ -172,12 +175,6 @@ declare global {
      * Core APIs for storage and subscriptions.
      */
     interface Context {
-
-        /**
-         * Gets all of the currently registered plugins
-         */
-        getPlugins(): PluginMetadata[];
-
         /**
          * Gets the current version of the plugin api. This is an integer that increments
          * by 1 every time a change to the plugin api is made.
@@ -4953,5 +4950,12 @@ declare global {
         getAllObjects(type: "banner"): BannerObject[];
         getAllObjects(type: "scenery_group"): SceneryGroupObject[];
         getAllObjects(type: "music"): LoadedObject[];
+    }
+
+    /**
+     * Interface to handle the plugin manager
+     */
+    interface PluginManager {
+        getPlugins(): PluginMetadata[];
     }
 }

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -4956,6 +4956,6 @@ declare global {
      * Interface to handle the plugin manager
      */
     interface PluginManager {
-        getPlugins(): PluginMetadata[];
+        readonly plugins: PluginMetadata[];
     }
 }

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -172,6 +172,12 @@ declare global {
      * Core APIs for storage and subscriptions.
      */
     interface Context {
+
+        /**
+         * Gets all of the currently registered plugins
+         */
+        allPlugins(): PluginMetadata[];
+
         /**
          * Gets the current version of the plugin api. This is an integer that increments
          * by 1 every time a change to the plugin api is made.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -176,7 +176,7 @@ declare global {
         /**
          * Gets all of the currently registered plugins
          */
-        allPlugins(): PluginMetadata[];
+        getPlugins(): PluginMetadata[];
 
         /**
          * Gets the current version of the plugin api. This is an integer that increments

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -511,6 +511,7 @@
     <ClInclude Include="scripting\bindings\entity\ScPeep.hpp" />
     <ClInclude Include="scripting\bindings\entity\ScStaff.hpp" />
     <ClInclude Include="scripting\bindings\entity\ScVehicle.hpp" />
+    <ClInclude Include="scripting\bindings\game\ScPlugin.hpp" />
     <ClInclude Include="scripting\bindings\game\ScProfiler.hpp" />
     <ClInclude Include="scripting\bindings\network\ScPlayer.hpp" />
     <ClInclude Include="scripting\bindings\network\ScPlayerGroup.hpp" />

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -34,6 +34,7 @@
 #    include "bindings/game/ScConsole.hpp"
 #    include "bindings/game/ScContext.hpp"
 #    include "bindings/game/ScDisposable.hpp"
+#    include "bindings/game/ScPlugin.hpp"
 #    include "bindings/game/ScProfiler.hpp"
 #    include "bindings/network/ScNetwork.hpp"
 #    include "bindings/network/ScPlayer.hpp"
@@ -443,6 +444,7 @@ void ScriptEngine::Initialise()
     ScScenarioObjective::Register(ctx);
     ScPatrolArea::Register(ctx);
     ScStaff::Register(ctx);
+    ScPlugin::Register(ctx);
 
     dukglue_register_global(ctx, std::make_shared<ScCheats>(), "cheats");
     dukglue_register_global(ctx, std::make_shared<ScClimate>(), "climate");
@@ -452,6 +454,7 @@ void ScriptEngine::Initialise()
     dukglue_register_global(ctx, std::make_shared<ScMap>(ctx), "map");
     dukglue_register_global(ctx, std::make_shared<ScNetwork>(ctx), "network");
     dukglue_register_global(ctx, std::make_shared<ScPark>(ctx), "park");
+    dukglue_register_global(ctx, std::make_shared<ScPlugin>(), "pluginManager");
     dukglue_register_global(ctx, std::make_shared<ScProfiler>(ctx), "profiler");
     dukglue_register_global(ctx, std::make_shared<ScScenario>(), "scenario");
     dukglue_register_global(ctx, std::make_shared<ScObjectManager>(), "objectManager");

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -47,7 +47,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 82;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 83;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;

--- a/src/openrct2/scripting/bindings/game/ScContext.hpp
+++ b/src/openrct2/scripting/bindings/game/ScContext.hpp
@@ -45,43 +45,6 @@ namespace OpenRCT2::Scripting
         }
 
     private:
-        std::vector<DukValue> getPlugins()
-        {
-            // Get all of the plugins from the script engine
-            OpenRCT2::Scripting::ScriptEngine& scriptEngine = GetContext()->GetScriptEngine();
-            const auto& allPlugins = scriptEngine.GetPlugins();
-            auto ctx = scriptEngine.GetContext();
-            std::vector<DukValue> result;
-            duk_idx_t dukIdx = DUK_INVALID_INDEX;
-            // Iterate through all plugins and and cast their data to Duk objects
-            for (const auto& pluginPtr : allPlugins)
-            {
-                // Pull out metadata
-                OpenRCT2::Scripting::Plugin& plugin = *pluginPtr;
-                OpenRCT2::Scripting::PluginMetadata metadata = plugin.GetMetadata();
-                // Create object using Duk stack
-                dukIdx = duk_push_object(ctx);
-                // Name and Version
-                duk_push_string(ctx, metadata.Name.c_str());
-                duk_put_prop_string(ctx, dukIdx, "name");
-                duk_push_string(ctx, metadata.Version.c_str());
-                duk_put_prop_string(ctx, dukIdx, "version");
-                // Authors
-                duk_idx_t arrIdx = duk_push_array(ctx);
-                for (auto [s, i] = std::tuple{ metadata.Authors.begin(), 0 }; s != metadata.Authors.end(); s++, i++)
-                {
-                    auto& str = *s;
-                    duk_push_string(ctx, str.c_str());
-                    duk_put_prop_index(ctx, arrIdx, i);
-                }
-                duk_put_prop_string(ctx, dukIdx, "authors");
-                // Take from Duk stack
-                result.push_back(DukValue::take_from_stack(ctx, dukIdx));
-                dukIdx = DUK_INVALID_INDEX;
-            }
-            return result;
-        }
-
         int32_t apiVersion_get()
         {
             return OPENRCT2_PLUGIN_API_VERSION;
@@ -466,7 +429,6 @@ namespace OpenRCT2::Scripting
         static void Register(duk_context* ctx)
         {
             dukglue_register_property(ctx, &ScContext::apiVersion_get, nullptr, "apiVersion");
-            dukglue_register_method(ctx, &ScContext::getPlugins, "getPlugins");
             dukglue_register_property(ctx, &ScContext::configuration_get, nullptr, "configuration");
             dukglue_register_property(ctx, &ScContext::sharedStorage_get, nullptr, "sharedStorage");
             dukglue_register_method(ctx, &ScContext::getParkStorage, "getParkStorage");

--- a/src/openrct2/scripting/bindings/game/ScPlugin.hpp
+++ b/src/openrct2/scripting/bindings/game/ScPlugin.hpp
@@ -1,0 +1,68 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2023 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#ifdef ENABLE_SCRIPTING
+
+#    include "../../Duktape.hpp"
+#    include "../../ScriptEngine.h"
+#    include "../game/ScContext.hpp"
+
+namespace OpenRCT2::Scripting
+{
+    class ScPlugin
+    {
+    public:
+        static void Register(duk_context* ctx)
+        {
+            dukglue_register_method(ctx, &ScPlugin::getPlugins, "getPlugins");
+        }
+
+    private:
+        std::vector<DukValue> getPlugins()
+        {
+            // Get all of the plugins from the script engine
+            OpenRCT2::Scripting::ScriptEngine& scriptEngine = GetContext()->GetScriptEngine();
+            const auto& allPlugins = scriptEngine.GetPlugins();
+            auto ctx = scriptEngine.GetContext();
+            std::vector<DukValue> result;
+            duk_idx_t dukIdx = DUK_INVALID_INDEX;
+            // Iterate through all plugins and and cast their data to Duk objects
+            for (const auto& pluginPtr : allPlugins)
+            {
+                // Pull out metadata
+                OpenRCT2::Scripting::Plugin& plugin = *pluginPtr;
+                OpenRCT2::Scripting::PluginMetadata metadata = plugin.GetMetadata();
+                // Create object using Duk stack
+                dukIdx = duk_push_object(ctx);
+                // Name and Version
+                duk_push_string(ctx, metadata.Name.c_str());
+                duk_put_prop_string(ctx, dukIdx, "name");
+                duk_push_string(ctx, metadata.Version.c_str());
+                duk_put_prop_string(ctx, dukIdx, "version");
+                // Authors
+                duk_idx_t arrIdx = duk_push_array(ctx);
+                for (auto [s, i] = std::tuple{ metadata.Authors.begin(), 0 }; s != metadata.Authors.end(); s++, i++)
+                {
+                    auto& str = *s;
+                    duk_push_string(ctx, str.c_str());
+                    duk_put_prop_index(ctx, arrIdx, i);
+                }
+                duk_put_prop_string(ctx, dukIdx, "authors");
+                // Take from Duk stack
+                result.push_back(DukValue::take_from_stack(ctx, dukIdx));
+                dukIdx = DUK_INVALID_INDEX;
+            }
+            return result;
+        }
+    };
+} // namespace OpenRCT2::Scripting
+
+#endif

--- a/src/openrct2/scripting/bindings/game/ScPlugin.hpp
+++ b/src/openrct2/scripting/bindings/game/ScPlugin.hpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2023 OpenRCT2 developers
+ * Copyright (c) 2014-2024 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2


### PR DESCRIPTION
Added functionality to the Scripting API to allow Contexts to return a list of all registered plugins. Will be useful for designing a plugin-manager plugin.

To use, call `context.allPlugins()` in a plugin. This returns an object that contains useful metadata from each registered plugin. Additional metadata parameters can be added later if needed.