### PR TITLE
Exempt PRs with milestone or assignee from going stale, update to v8

### DIFF
--- a/.github/workflows/stale-backtrace-issues.yml
+++ b/.github/workflows/stale-backtrace-issues.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'OpenRCT2/OpenRCT2'
     steps:
-      - uses: actions/stale@v7
+      - uses: actions/stale@v8
         with:
           days-before-issue-stale: 60
           days-before-issue-close: 1

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -8,8 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'OpenRCT2/OpenRCT2'
     steps:
-      - uses: actions/stale@v7
+      - uses: actions/stale@v8
         with:
+          exempt-all-pr-assignees: true
+          exempt-all-pr-milestones: true
           days-before-issue-stale: -1
           days-before-issue-close: -1
           days-before-pr-stale: 31


### PR DESCRIPTION
This will avoid PRs going stale, there is no way to check for approval currently but if its approved then its most likely milestoned or has someone assigned.