### PR TITLE
Fix #20739: Build version info leaving stray pixels when moving camera

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -40,6 +40,7 @@
 - Fix: [#20659] Phantom rides remain when closing construction window while paused.
 - Fix: [#20684] Footpath additions getting removed by Miniature railway ghost elements.
 - Fix: [#20693] Incorrect information shown when hovering over station when another station before it was removed.
+- Fix: [#20739] Build version info on title screen leaving stray pixels when the camera is moved.
 
 0.4.5 (2023-05-08)
 ------------------------------------------------------------------------

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -448,12 +448,9 @@ void DrawOpenRCT2(DrawPixelInfo& dpi, const ScreenCoordsXY& screenCoords)
 
     // Write name and version information
     buffer += gVersionInfoFull;
-    GfxDrawString(dpi, screenCoords + ScreenCoordsXY(5, 5 - 13), buffer.c_str(), { COLOUR_BLACK });
 
-    // Invalidate screen area
+    GfxDrawString(dpi, screenCoords + ScreenCoordsXY(5, 5 - 13), buffer.c_str(), { COLOUR_BLACK });
     int16_t width = static_cast<int16_t>(GfxGetStringWidth(buffer, FontStyle::Medium));
-    GfxSetDirtyBlocks(
-        { screenCoords, screenCoords + ScreenCoordsXY{ width, 30 } }); // 30 is an arbitrary height to catch both strings
 
     // Write platform information
     buffer.assign("{OUTLINE}{WHITE}");
@@ -461,5 +458,11 @@ void DrawOpenRCT2(DrawPixelInfo& dpi, const ScreenCoordsXY& screenCoords)
     buffer.append(" (");
     buffer.append(OPENRCT2_ARCHITECTURE);
     buffer.append(")");
+
     GfxDrawString(dpi, screenCoords + ScreenCoordsXY(5, 5), buffer.c_str(), { COLOUR_BLACK });
+    width = std::max(width, static_cast<int16_t>(GfxGetStringWidth(buffer, FontStyle::Medium)));
+
+    // Invalidate screen area
+    GfxSetDirtyBlocks({ screenCoords - ScreenCoordsXY(0, 13),
+                        screenCoords + ScreenCoordsXY{ width + 5, 30 } }); // 30 is an arbitrary height to catch both strings
 }


### PR DESCRIPTION
Checked with debug invalidation, now the region is properly invalidated.

Closes #20739