### PR TITLE
Fix #19722: Forbid removal of large trees if scenario forbids it

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Change: [#20790] Default ride price set to free if park charges for entry.
 - Fix: [#20737] Spent money in player window underflows when getting refunds.
 - Fix: [#20778] [Plugin] Incorrect target api when executing custom actions.
+- Fix: [#19722] Forbid removal of large trees if scenario forbids tree removal
 
 0.4.6 (2023-09-03)
 ------------------------------------------------------------------------
@@ -10,7 +11,7 @@
 - Feature: [#20680] New title sequences (https://github.com/OpenRCT2/title-sequences/releases/tag/v0.4.6).
 - Feature: [OpenMusic#41] Official Title Theme by Allister Brimble.
 - Improved: [#20119, #20243] Add new colour presets to several roller coasters (using the new colours).
-- Improved: [#20393, #20410] Add Cyrillic characters Ґґ, Ѕѕ, Єє, Іі, Її, and Јј to the sprite font. 
+- Improved: [#20393, #20410] Add Cyrillic characters Ґґ, Ѕѕ, Єє, Іі, Її, and Јј to the sprite font.
 - Change: [#19785] OpenMusic is now selected by default when opening SC4/SC6 - or creating new - scenarios.
 - Change: [#20110] Fix a few RCT1 build height parity discrepancies.
 - Change: [#20550] Change SEK conversion rate from 1 GBP to 0.1 GBP.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,7 +3,7 @@
 - Change: [#20790] Default ride price set to free if park charges for entry.
 - Fix: [#20737] Spent money in player window underflows when getting refunds.
 - Fix: [#20778] [Plugin] Incorrect target api when executing custom actions.
-- Fix: [#19722] Forbid removal of large trees if scenario forbids tree removal
+- Fix: [#19722] “Forbid tree removal” restriction doesn't forbid removal of large scenery tree items.
 
 0.4.6 (2023-09-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/actions/LargeSceneryRemoveAction.cpp
+++ b/src/openrct2/actions/LargeSceneryRemoveAction.cpp
@@ -93,6 +93,17 @@ GameActions::Result LargeSceneryRemoveAction::Query() const
 
         if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && !gCheatsSandboxMode)
         {
+            if (gParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL)
+            {
+                if (sceneryEntry->HasFlag(LARGE_SCENERY_FLAG_IS_TREE))
+                {
+                    res.Error = GameActions::Status::NoClearance;
+                    res.ErrorTitle = STR_CANT_REMOVE_THIS;
+                    res.ErrorMessage = STR_FORBIDDEN_BY_THE_LOCAL_AUTHORITY;
+                    return res;
+                }
+            }
+
             if (!MapIsLocationOwned({ currentTile.x, currentTile.y, currentTile.z }))
             {
                 return GameActions::Result(GameActions::Status::NoClearance, STR_CANT_REMOVE_THIS, STR_LAND_NOT_OWNED_BY_PARK);

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "1"
+#define NETWORK_STREAM_VERSION "2"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/object/LargeSceneryEntry.h
+++ b/src/openrct2/object/LargeSceneryEntry.h
@@ -74,9 +74,14 @@ struct LargeSceneryEntry
     uint8_t scrolling_mode;
     LargeSceneryText* text;
     uint32_t text_image;
+
+    constexpr bool HasFlag(const uint16_t _flags) const
+    {
+        return (flags & _flags) != 0;
+    }
 };
 
-enum LARGE_SCENERY_FLAGS
+enum LARGE_SCENERY_FLAGS : uint16_t
 {
     LARGE_SCENERY_FLAG_HAS_PRIMARY_COLOUR = (1 << 0),          // 0x1
     LARGE_SCENERY_FLAG_HAS_SECONDARY_COLOUR = (1 << 1),        // 0x2


### PR DESCRIPTION
Previously only small trees were prevented from being removed in scenarios with the "forbid tree removal" flag. This change expands this behavior to similarly prevent large trees from being removed.

![NoRemoveBigTree_Screenshot_20230831_175615](https://github.com/OpenRCT2/OpenRCT2/assets/8496492/4343f3c0-fd35-459e-8f46-ab9f72de2962)
