### PR TITLE
Fix #20747 handle staff speed permanency/serialization/apply for new s…

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Fix: [#20356] Cannot set tertiary colour on small scenery.
 - Fix: [#20679] Android: game crashes at launch.
 - Fix: [#20737] Spent money in player window underflows when getting refunds.
+- Fix: [#20747] Staff speed cheat not applying to newly hired staff, UI not showing the current applied speed.
 - Fix: [#20778] [Plugin] Incorrect target api when executing custom actions.
 - Fix: [#20807] Tertiary colour not copied with small scenery.
 

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -45,8 +45,8 @@ enum
 
 static StringId _staffSpeedNames[] =
 {
-    STR_FROZEN,
     STR_NORMAL,
+    STR_FROZEN,
     STR_FAST,
 };
 
@@ -361,7 +361,6 @@ class CheatsWindow final : public Window
 private:
     char _moneySpinnerText[MONEY_STRING_MAXLENGTH]{};
     money64 _moneySpinnerValue = CHEATS_MONEY_DEFAULT;
-    int32_t _selectedStaffSpeed = 1;
     int32_t _parkRatingSpinnerValue{};
     int32_t _yearSpinnerValue = 1;
     int32_t _monthSpinnerValue = 1;
@@ -509,7 +508,7 @@ public:
         // Current weather
         window_cheats_misc_widgets[WIDX_WEATHER].text = WeatherTypes[EnumValue(gClimateCurrent.Weather)];
         // Staff speed
-        window_cheats_misc_widgets[WIDX_STAFF_SPEED].text = _staffSpeedNames[_selectedStaffSpeed];
+        window_cheats_misc_widgets[WIDX_STAFF_SPEED].text = _staffSpeedNames[EnumValue(gCheatsSelectedStaffSpeed)];
 
         if (gScreenFlags & SCREEN_FLAGS_EDITOR)
         {
@@ -851,7 +850,7 @@ private:
                 WindowDropdownShowTextCustomWidth(
                     { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
                     colours[1], 0, Dropdown::Flag::StayOpen, 3, dropdownWidget->width() - 3);
-                Dropdown::SetChecked(_selectedStaffSpeed, true);
+                Dropdown::SetChecked(EnumValue(gCheatsSelectedStaffSpeed), true);
             }
         }
     }
@@ -934,18 +933,24 @@ private:
         }
         if (widgetIndex == WIDX_STAFF_SPEED_DROPDOWN_BUTTON)
         {
-            int32_t speed = CHEATS_STAFF_FAST_SPEED;
+            int32_t speed = CHEATS_STAFF_NORMAL_SPEED;
             switch (dropdownIndex)
             {
                 case 0:
+                    gCheatsSelectedStaffSpeed = StaffSpeedCheat::None;
+                    speed = CHEATS_STAFF_NORMAL_SPEED;
+                    break;
+
+                case 1:
+                    gCheatsSelectedStaffSpeed = StaffSpeedCheat::Frozen;
                     speed = CHEATS_STAFF_FREEZE_SPEED;
                     break;
-                case 1:
-                    speed = CHEATS_STAFF_NORMAL_SPEED;
-            }
 
+                case 2:
+                    gCheatsSelectedStaffSpeed = StaffSpeedCheat::Fast;
+                    speed = CHEATS_STAFF_FAST_SPEED;
+            }
             CheatsSet(CheatType::SetStaffSpeed, speed);
-            _selectedStaffSpeed = dropdownIndex;
         }
     }
 

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -55,6 +55,7 @@ bool gCheatsAllowTrackPlaceInvalidHeights = false;
 bool gCheatsAllowRegularPathAsQueue = false;
 bool gCheatsAllowSpecialColourSchemes = false;
 bool gCheatsMakeAllDestructible = false;
+StaffSpeedCheat gCheatsSelectedStaffSpeed = StaffSpeedCheat::None;
 
 void CheatsReset()
 {
@@ -83,6 +84,7 @@ void CheatsReset()
     gCheatsAllowRegularPathAsQueue = false;
     gCheatsAllowSpecialColourSchemes = false;
     gCheatsMakeAllDestructible = false;
+    gCheatsSelectedStaffSpeed = StaffSpeedCheat::None;
 }
 
 void CheatsSet(CheatType cheatType, int64_t param1 /* = 0*/, int64_t param2 /* = 0*/)
@@ -134,6 +136,7 @@ void CheatsSerialise(DataSerialiser& ds)
         CheatEntrySerialise(ds, CheatType::AllowRegularPathAsQueue, gCheatsAllowRegularPathAsQueue, count);
         CheatEntrySerialise(ds, CheatType::AllowSpecialColourSchemes, gCheatsAllowSpecialColourSchemes, count);
         CheatEntrySerialise(ds, CheatType::MakeDestructible, gCheatsMakeAllDestructible, count);
+        CheatEntrySerialise(ds, CheatType::SetStaffSpeed, gCheatsSelectedStaffSpeed, count);
 
         // Remember current position and update count.
         uint64_t endOffset = stream.GetPosition();
@@ -234,6 +237,9 @@ void CheatsSerialise(DataSerialiser& ds)
                     break;
                 case CheatType::MakeDestructible:
                     ds << gCheatsMakeAllDestructible;
+                    break;
+                case CheatType::SetStaffSpeed:
+                    ds << gCheatsSelectedStaffSpeed;
                     break;
                 default:
                     break;

--- a/src/openrct2/Cheats.h
+++ b/src/openrct2/Cheats.h
@@ -11,6 +11,13 @@
 
 #include "common.h"
 
+enum class StaffSpeedCheat
+{
+    None,
+    Frozen,
+    Fast,
+};
+
 extern bool gCheatsSandboxMode;
 extern bool gCheatsDisableClearanceChecks;
 extern bool gCheatsDisableSupportLimits;
@@ -36,6 +43,7 @@ extern bool gCheatsAllowTrackPlaceInvalidHeights;
 extern bool gCheatsAllowRegularPathAsQueue;
 extern bool gCheatsAllowSpecialColourSchemes;
 extern bool gCheatsMakeAllDestructible;
+extern StaffSpeedCheat gCheatsSelectedStaffSpeed;
 
 enum class CheatType : int32_t
 {

--- a/src/openrct2/actions/StaffHireNewAction.cpp
+++ b/src/openrct2/actions/StaffHireNewAction.cpp
@@ -201,10 +201,25 @@ GameActions::Result StaffHireNewAction::QueryExecute(bool execute) const
         newPeep->TrousersColour = colour;
 
         // Staff energy determines their walking speed
-        newPeep->Energy = 0x60;
-        newPeep->EnergyTarget = 0x60;
-        newPeep->StaffMowingTimeout = 0;
+        switch (gCheatsSelectedStaffSpeed)
+        {
+            case StaffSpeedCheat::None:
+                newPeep->Energy = CHEATS_STAFF_NORMAL_SPEED;
+                newPeep->EnergyTarget = CHEATS_STAFF_NORMAL_SPEED;
+                break;
 
+            case StaffSpeedCheat::Frozen:
+                newPeep->Energy = CHEATS_STAFF_FREEZE_SPEED;
+                newPeep->EnergyTarget = CHEATS_STAFF_FREEZE_SPEED;
+                break;
+
+            case StaffSpeedCheat::Fast:
+                newPeep->Energy = CHEATS_STAFF_FAST_SPEED;
+                newPeep->EnergyTarget = CHEATS_STAFF_FAST_SPEED;
+                break;
+        }
+
+        newPeep->StaffMowingTimeout = 0;
         newPeep->PatrolInfo = nullptr;
 
         res.SetData(StaffHireNewActionResult{ newPeep->Id });

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -9,10 +9,10 @@ struct ObjectRepositoryItem;
 namespace OpenRCT2
 {
     // Current version that is saved.
-    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 32;
+    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 33;
 
     // The minimum version that is forwards compatible with the current version.
-    constexpr uint32_t PARK_FILE_MIN_VERSION = 32;
+    constexpr uint32_t PARK_FILE_MIN_VERSION = 33;
 
     // The minimum version that is backwards compatible with the current version.
     // If this is increased beyond 0, uncomment the checks in ParkFile.cpp and Context.cpp!


### PR DESCRIPTION
Staff speed is now permanent through:
* Cheat window open/close
* Game save/load
* Is applied to newly hired staff

This PR deprecates #20734 