### PR TITLE
Fix #14781: Removing track under a ghost train while it's taking off …

### DIFF
--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -3413,7 +3413,7 @@ void Vehicle::UpdateDeparting()
 
         if (shouldLaunch)
         {
-            if (!(curFlags & VEHICLE_UPDATE_MOTION_TRACK_FLAG_3) || _vehicleStationIndex != current_station)
+            if (!(curFlags & VEHICLE_UPDATE_MOTION_TRACK_FLAG_3) || (_vehicleStationIndex != current_station && _vehicleStationIndex != STATION_INDEX_NULL))
             {
                 FinishDeparting();
                 return;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -3413,7 +3413,8 @@ void Vehicle::UpdateDeparting()
 
         if (shouldLaunch)
         {
-            if (!(curFlags & VEHICLE_UPDATE_MOTION_TRACK_FLAG_3) || (_vehicleStationIndex != current_station && _vehicleStationIndex != STATION_INDEX_NULL))
+            if (!(curFlags & VEHICLE_UPDATE_MOTION_TRACK_FLAG_3)
+                || (_vehicleStationIndex != current_station && _vehicleStationIndex != STATION_INDEX_NULL))
             {
                 FinishDeparting();
                 return;


### PR DESCRIPTION
…makes it get stuck in midair

Prohibit vehicles from departing when the station index is null