### PR TITLE
[Plugin] Fix incorrect target api when executing custom actions

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.7 (in development)
 ------------------------------------------------------------------------
 - Fix: [#20737] Spent money in player window underflows when getting refunds.
+- Fix: [#20778] [Plugin] Incorrect target api when executing custom actions.
 
 0.4.6 (2023-09-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -1069,7 +1069,7 @@ GameActions::Result ScriptEngine::QueryOrExecuteCustomGameAction(const CustomAct
         }
 
         std::vector<DukValue> pluginCallArgs;
-        if (GetTargetAPIVersion() <= API_VERSION_68_CUSTOM_ACTION_ARGS)
+        if (customActionInfo.Owner->GetTargetAPIVersion() <= API_VERSION_68_CUSTOM_ACTION_ARGS)
         {
             pluginCallArgs = { *dukArgs };
         }


### PR DESCRIPTION
Hello,

This fixes an issue where plugins that use the deprecated custom actions API would get incorrect parameters, because the target api check would return an incorrect version on subsequent calls. Only the first query callback would be executed in the correct context.

This issue would break plugins expecting the parameters from the deprecated API, such as [Spacek's MapMover](https://github.com/spacek531/map-mover-by-spacek)

Plugin snippet to reproduce the issue:
```js
registerPlugin({
	name: 'Test custom action',
	version: '1',
	authors: ['Basssiiie'],
	type: 'remote',
	licence: 'MIT',
	main() {		
		context.registerAction("test.action",
			function(args)
			{
				console.log("callback.query: " + JSON.stringify(args));
				return {};
			},
			function(args)
			{
				console.log("callback.execute: " + JSON.stringify(args));
				return {};
			}
		);
		
		ui.registerMenuItem("Call custom action", function()
		{
			context.executeAction("test.action", { myvalue: "hello world" });
		});
	},
});
```
Preferred and expected output:
```
'callback.query: {"myvalue":"hello world"}'
'callback.query: {"myvalue":"hello world"}'
'callback.execute: {"myvalue":"hello world"}'
```
Problematic output:
```
'callback.query: {"myvalue":"hello world"}'
'callback.query: {"action":"test.action","args":{"myvalue":"hello world"},"player":-1,"type":80,"isClientOnly":false}'
'callback.execute: {"action":"test.action","args":{"myvalue":"hello world"},"player":-1,"type":80,"isClientOnly":false}
```
Where the first call is using the old `API_VERSION_68_CUSTOM_ACTION_ARGS` and the second and third are using the newest API.

The fix was to replace the target API check that gets the target via the scripting engine context, with a check that checks directly with the custom action owner.

I have also quickly tested if any other users of `GetTargetApiVersion()` were affected, but they seem to be fine and always executed within valid a plugin context.

Thank you for your time.