### PR TITLE
Fix #16926 Grouped rides unlocking only the first entry.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -16,6 +16,7 @@
 - Fix: [#13473] Guests complain that the default Circus price is too high.
 - Fix: [#15293] TTF fonts don’t format correctly with OpenGL.
 - Fix: [#16453] Tile inspector invisibility shortcut does not use a game action.
+- Fix: [#16926] When multiple vehicles are grouped in research, only one of them is unlocked.
 - Fix: [#17774] Misplaced/missing land and construction rights tiles in RCT1 & RCT2 scenarios.
 - Fix: [#18199] Dots in the game save's name no longer get truncated.
 - Fix: [#19722] “Forbid tree removal” restriction doesn't forbid removal of large scenery tree items.


### PR DESCRIPTION
Fix rides without RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY only unlocking the first entry on stock RCT2 saves/scenarios which only included a research entry for the first vehicle and unlock the others at the same time. 

This makes the wooden coaster properly unlock its trains on stock scenarios and saves. This restores the correct stock behavior while maintaining the missing items research fix which is what broke this behavior.

This resolves #16926.