### PR TITLE
Set default ride price to free if park entrance fee has been set

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.7 (in development)
 ------------------------------------------------------------------------
+- Change: [#20790] Default ride price set to free if park charges for entry
 - Fix: [#20737] Spent money in player window underflows when getting refunds.
 - Fix: [#20778] [Plugin] Incorrect target api when executing custom actions.
 

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,6 @@
 0.4.7 (in development)
 ------------------------------------------------------------------------
-- Change: [#20790] Default ride price set to free if park charges for entry
+- Change: [#20790] Default ride price set to free if park charges for entry.
 - Fix: [#20737] Spent money in player window underflows when getting refunds.
 - Fix: [#20778] [Plugin] Incorrect target api when executing custom actions.
 

--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -216,7 +216,7 @@ GameActions::Result RideCreateAction::Execute() const
 
         if (rideEntry->shop_item[0] == ShopItem::None)
         {
-            if (!ParkRidePricesUnlocked())
+            if (!ParkRidePricesUnlocked() || gParkEntranceFee > 0)
             {
                 ride->price[0] = 0;
             }

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "0"
+#define NETWORK_STREAM_VERSION "1"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 


### PR DESCRIPTION
In RCT1, if a park entrance fee was set, then the ride prices would default to 0 (you could still charge for rides, but the default would be to have free rides in these parks).
In RCT2, one could only charge for rides _or_ for park entrance, but not both.
OpenRCT2 brought back the ability to charge for both the park entrance and for rides, but the default ride prices are still being left as their defaults. Because guests are only willing to pay 1/4 as much for rides if they paid an entrance fee for the park, the default ride prices are generally much too high. In my view, the RCT1 behavior of defaulting rides to free in a pay-for-entrance park was a useful behavior.

This simple change brings back the RCT1 behavior. If a park entrance fee is in effect, then the rides will default to free (you can still change it to whatever you want if you desire). This only affects "rides" not shops.

Would love to have discussion on whether this is the behavior we think is best.

