### PR TITLE
add small scenery tertiary colour to plugin API

### DIFF
--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -47,7 +47,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 79;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 80;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -47,7 +47,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 78;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 79;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;

--- a/src/openrct2/scripting/bindings/world/ScTileElement.cpp
+++ b/src/openrct2/scripting/bindings/world/ScTileElement.cpp
@@ -1422,6 +1422,12 @@ namespace OpenRCT2::Scripting
         auto* ctx = scriptEngine.GetContext();
         switch (_element->GetType())
         {
+            case TileElementType::SmallScenery:
+            {
+                auto* el = _element->AsSmallScenery();
+                duk_push_int(ctx, el->GetTertiaryColour());
+                break;
+            }
             case TileElementType::LargeScenery:
             {
                 auto* el = _element->AsLargeScenery();
@@ -1447,6 +1453,13 @@ namespace OpenRCT2::Scripting
         ThrowIfGameStateNotMutable();
         switch (_element->GetType())
         {
+            case TileElementType::SmallScenery:
+            {
+                auto* el = _element->AsSmallScenery();
+                el->SetTertiaryColour(value);
+                Invalidate();
+                break;
+            }
             case TileElementType::LargeScenery:
             {
                 auto* el = _element->AsLargeScenery();
@@ -2049,6 +2062,8 @@ namespace OpenRCT2::Scripting
         dukglue_register_property(ctx, &ScTileElement::primaryColour_get, &ScTileElement::primaryColour_set, "primaryColour");
         dukglue_register_property(
             ctx, &ScTileElement::secondaryColour_get, &ScTileElement::secondaryColour_set, "secondaryColour");
+        dukglue_register_property(
+            ctx, &ScTileElement::tertiaryColour_get, &ScTileElement::tertiaryColour_set, "tertiaryColour");
 
         // Wall | Large Scenery | Banner
         dukglue_register_property(ctx, &ScTileElement::bannerIndex_get, &ScTileElement::bannerIndex_set, "bannerIndex");
@@ -2116,10 +2131,6 @@ namespace OpenRCT2::Scripting
         // Small Scenery only
         dukglue_register_property(ctx, &ScTileElement::age_get, &ScTileElement::age_set, "age");
         dukglue_register_property(ctx, &ScTileElement::quadrant_get, &ScTileElement::quadrant_set, "quadrant");
-
-        // Wall only
-        dukglue_register_property(
-            ctx, &ScTileElement::tertiaryColour_get, &ScTileElement::tertiaryColour_set, "tertiaryColour");
 
         // Entrance only
         dukglue_register_property(


### PR DESCRIPTION
This is a follow-up to #20803 / #20356.
This change adds tertiary colour for small scenery objects to the plugin API.
No changelog entry added since it is imo already covered by the existing one for the above mentioned PR/issue.