### PR TITLE
Fix #16453: Tile inspector invisibility shortcut does not use a game action

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -102,7 +102,7 @@ The following people are not part of the development team, but have been contrib
 * Karst van Galen Last (AuraSpecs) - Ride paint (bounding boxes, extra track pieces), soundtrack, sound effects, misc.
 * (8street) - Misc.
 * Umar Ahmed (umar-ahmed) - MacOS file watcher
-* Andrew Arnold (fidwell) - Added window support for more scenery groups.
+* Andrew Arnold (fidwell) - Misc.
 * Josh Trzebiatowski (trzejos) - Ride and scenery filtering
 * (kyphii) - Extended color selection, reversed ride vehicles, misc.
 * Phumdol Lookthipnapha (beam41) - Misc.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Fix: [#20737] Spent money in player window underflows when getting refunds.
 - Fix: [#20778] [Plugin] Incorrect target api when executing custom actions.
 - Fix: [#19722] “Forbid tree removal” restriction doesn't forbid removal of large scenery tree items.
+- Fix: [#16453] Tile inspector invisibility shortcut does not use a game action.
 
 0.4.6 (2023-09-03)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/input/Shortcuts.cpp
+++ b/src/openrct2-ui/input/Shortcuts.cpp
@@ -517,20 +517,10 @@ static void TileInspectorMouseDown(WidgetIndex widgetIndex)
 
 static void ShortcutToggleVisibility()
 {
-    // TODO: Once the tile inspector window has its own class, move this to its own function
-    if (windowTileInspectorSelectedIndex < 0)
-        return;
-
-    WindowBase* w = WindowFindByClass(WindowClass::TileInspector);
-    if (w == nullptr)
-        return;
-
-    extern TileCoordsXY windowTileInspectorTile;
-    TileElement* tileElement = MapGetNthElementAt(windowTileInspectorTile.ToCoordsXY(), windowTileInspectorSelectedIndex);
-    if (tileElement != nullptr)
+    WindowBase* window = WindowFindByClass(WindowClass::TileInspector);
+    if (window != nullptr)
     {
-        tileElement->SetInvisible(!tileElement->IsInvisible());
-        w->Invalidate();
+        WindowTileInspectorKeyboardShortcutToggleInvisibility();
     }
 }
 

--- a/src/openrct2-ui/input/Shortcuts.cpp
+++ b/src/openrct2-ui/input/Shortcuts.cpp
@@ -515,15 +515,6 @@ static void TileInspectorMouseDown(WidgetIndex widgetIndex)
     }
 }
 
-static void ShortcutToggleVisibility()
-{
-    WindowBase* window = WindowFindByClass(WindowClass::TileInspector);
-    if (window != nullptr)
-    {
-        WindowTileInspectorKeyboardShortcutToggleInvisibility();
-    }
-}
-
 static void ShortcutIncreaseElementHeight()
 {
     WindowBase* w = WindowFindByClass(WindowClass::TileInspector);
@@ -868,7 +859,7 @@ void ShortcutManager::RegisterDefaultShortcuts()
     RegisterShortcut(ShortcutId::WindowRideConstructionNext, STR_SHORTCUT_CONSTRUCTION_NEXT_TRACK, "NUMPAD 9", WindowRideConstructionKeyboardShortcutNextTrack);
     RegisterShortcut(ShortcutId::WindowRideConstructionBuild, STR_SHORTCUT_CONSTRUCTION_BUILD_CURRENT, "NUMPAD 0", ShortcutConstructionBuildCurrent);
     RegisterShortcut(ShortcutId::WindowRideConstructionDemolish, STR_SHORTCUT_CONSTRUCTION_DEMOLISH_CURRENT, "NUMPAD -", ShortcutConstructionDemolishCurrent);
-    RegisterShortcut(ShortcutId::WindowTileInspectorToggleInvisibility, STR_SHORTCUT_TOGGLE_INVISIBILITY, ShortcutToggleVisibility);
+    RegisterShortcut(ShortcutId::WindowTileInspectorToggleInvisibility, STR_SHORTCUT_TOGGLE_INVISIBILITY, WindowTileInspectorKeyboardShortcutToggleInvisibility);
     RegisterShortcut(ShortcutId::WindowTileInspectorCopy, STR_SHORTCUT_COPY_ELEMENT, std::bind(TileInspectorMouseUp, WC_TILE_INSPECTOR__WIDX_BUTTON_COPY));
     RegisterShortcut(ShortcutId::WindowTileInspectorPaste, STR_SHORTCUT_PASTE_ELEMENT, std::bind(TileInspectorMouseUp, WC_TILE_INSPECTOR__WIDX_BUTTON_PASTE));
     RegisterShortcut(ShortcutId::WindowTileInspectorRemove, STR_SHORTCUT_REMOVE_ELEMENT, std::bind(TileInspectorMouseUp, WC_TILE_INSPECTOR__WIDX_BUTTON_REMOVE));

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1697,6 +1697,14 @@ public:
         _elementCopied = false;
     }
 
+    void ToggleInvisibility()
+    {
+        if (windowTileInspectorSelectedIndex >= 0 && windowTileInspectorSelectedIndex < windowTileInspectorElementCount)
+        {
+            ToggleInvisibility(windowTileInspectorSelectedIndex);
+        }
+    }
+
 private:
     void SetPage(const TileInspectorPage p)
     {
@@ -2368,4 +2376,11 @@ void WindowTileInspectorClearClipboard()
     auto* window = WindowFindByClass(WindowClass::TileInspector);
     if (window != nullptr)
         static_cast<TileInspector*>(window)->ClearClipboard();
+}
+
+void WindowTileInspectorKeyboardShortcutToggleInvisibility()
+{
+    auto* window = WindowFindByClass(WindowClass::TileInspector);
+    if (window != nullptr)
+        static_cast<TileInspector*>(window)->ToggleInvisibility();
 }

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -680,6 +680,8 @@ void WindowFootpathKeyboardShortcutSlopeUp();
 void WindowFootpathKeyboardShortcutBuildCurrent();
 void WindowFootpathKeyboardShortcutDemolishCurrent();
 
+void WindowTileInspectorKeyboardShortcutToggleInvisibility();
+
 void WindowFollowSprite(WindowBase& w, EntityId spriteIndex);
 void WindowUnfollowSprite(WindowBase& w);
 


### PR DESCRIPTION
Refactored the Shortcuts class to call a method on TileInspector window class, instead of directly editing tile elements in the Shortcut class. This means that the invisibility shortcut will now use a game action, so it will work in multiplayer and for replays.

This implementation is based very closely on how the footpath window seems to handle shortcuts. I know ZehMatt mentioned in the issue that this system needs an overhaul, but at least this solution follows the current pattern.

Fixes #16453.