### PR TITLE
Fixed guests not entering park on upward slope

### DIFF
--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -1914,6 +1914,7 @@ static bool PeepInteractWithEntrance(Peep* peep, const CoordsXYE& coords, uint8_
                             continue;
                         }
                         found = true;
+
                         guest->z += 2; 
                         break;
                     }

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -1914,7 +1914,7 @@ static bool PeepInteractWithEntrance(Peep* peep, const CoordsXYE& coords, uint8_
                             continue;
                         }
                         found = true;
-                        guest->z += 4; 
+                        guest->z += 2; 
                         break;
                     }
 

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -1984,7 +1984,7 @@ static bool PeepInteractWithEntrance(Peep* peep, const CoordsXYE& coords, uint8_
         guest->Var37 = 1;
         auto destination = guest->GetDestination();
         destination += CoordsDirectionDelta[guest->PeepDirection];
-        guest->SetDestination(destination, 7);
+        guest->SetDestination(destination, 12);
         guest->MoveTo({ coords, guest->z });
     }
     return true;

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -1914,6 +1914,7 @@ static bool PeepInteractWithEntrance(Peep* peep, const CoordsXYE& coords, uint8_
                             continue;
                         }
                         found = true;
+                        guest->z += 4; 
                         break;
                     }
 
@@ -1984,7 +1985,7 @@ static bool PeepInteractWithEntrance(Peep* peep, const CoordsXYE& coords, uint8_
         guest->Var37 = 1;
         auto destination = guest->GetDestination();
         destination += CoordsDirectionDelta[guest->PeepDirection];
-        guest->SetDestination(destination, 12);
+        guest->SetDestination(destination, 7);
         guest->MoveTo({ coords, guest->z });
     }
     return true;

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -1914,8 +1914,7 @@ static bool PeepInteractWithEntrance(Peep* peep, const CoordsXYE& coords, uint8_
                             continue;
                         }
                         found = true;
-
-                        guest->z += 2; 
+                        guest->z += 2;
                         break;
                     }
 


### PR DESCRIPTION
Fixed guests not entering park on upward slope.

After some testing I found that increasing the destination tolerance for peeps moving through the park entrance prevents them from passing through the path.

Fixed issue #14486