### PR TITLE
Add owner property to tile elements for scripting

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#20141] Add additional track pieces to the Giga Coaster.
 - Feature: [OpenMusic#46] Added Mystic ride music style.
 - Feature: [#20825] Made setting the game speed a game action.
+- Feature: [#20853] [Plugin] Add “BaseTileElement.owner” which is saved in the park file.
 - Change: [#20790] Default ride price set to free if park charges for entry.
 - Fix: [#20356] Cannot set tertiary colour on small scenery.
 - Fix: [#20737] Spent money in player window underflows when getting refunds.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1472,6 +1472,7 @@ declare global {
         occupiedQuadrants: number;
         isGhost: boolean;
         isHidden: boolean; /** Take caution when changing this field, it may invalidate TileElements you have stored in your script. */
+        owner: number;
     }
 
     interface SurfaceElement extends BaseTileElement {

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -47,7 +47,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 80;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 81;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;

--- a/src/openrct2/scripting/bindings/world/ScTileElement.cpp
+++ b/src/openrct2/scripting/bindings/world/ScTileElement.cpp
@@ -2033,6 +2033,20 @@ namespace OpenRCT2::Scripting
         }
     }
 
+    DukValue ScTileElement::owner_get() const
+    {
+        auto& scriptEngine = GetContext()->GetScriptEngine();
+        auto* ctx = scriptEngine.GetContext();
+        duk_push_uint(ctx, _element->GetOwner());
+        return DukValue::take_from_stack(ctx);
+    }
+
+    void ScTileElement::owner_set(uint8_t value)
+    {
+        ThrowIfGameStateNotMutable();
+        _element->SetOwner(value);
+    }
+
     void ScTileElement::Invalidate()
     {
         MapInvalidateTileFull(_coords);
@@ -2051,6 +2065,7 @@ namespace OpenRCT2::Scripting
             ctx, &ScTileElement::occupiedQuadrants_get, &ScTileElement::occupiedQuadrants_set, "occupiedQuadrants");
         dukglue_register_property(ctx, &ScTileElement::isGhost_get, &ScTileElement::isGhost_set, "isGhost");
         dukglue_register_property(ctx, &ScTileElement::isHidden_get, &ScTileElement::isHidden_set, "isHidden");
+        dukglue_register_property(ctx, &ScTileElement::owner_get, &ScTileElement::owner_set, "owner");
 
         // Track | Small Scenery | Wall | Entrance | Large Scenery | Banner
         dukglue_register_property(ctx, &ScTileElement::direction_get, &ScTileElement::direction_set, "direction");

--- a/src/openrct2/scripting/bindings/world/ScTileElement.hpp
+++ b/src/openrct2/scripting/bindings/world/ScTileElement.hpp
@@ -202,6 +202,9 @@ namespace OpenRCT2::Scripting
         DukValue direction_get() const;
         void direction_set(uint8_t value);
 
+        DukValue owner_get() const;
+        void owner_set(uint8_t value);
+
         void Invalidate();
 
     public:


### PR DESCRIPTION
This makes it easier for plugins to simulate multiple companies, example being, a plugin could create a few groups/companies and the owner would represent which group/company the tiles belong to, plugins could then hook into game actions to check if the tile is owned by the group the player is in and reject the action. The owner property is somewhat abstract so its up to the plugin on how to interpret this value.