### PR TITLE
Filter certain game actions from being used in the replay system

### DIFF
--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -292,11 +292,14 @@ namespace GameActions
         uint16_t actionFlags = action->GetActionFlags();
         uint32_t flags = action->GetFlags();
 
+        // Some actions are not recorded in the replay.
+        const auto ignoreForReplays = (actionFlags & GameActions::Flags::IgnoreForReplays) != 0;
+
         auto* replayManager = OpenRCT2::GetContext()->GetReplayManager();
         if (replayManager != nullptr && (replayManager->IsReplaying() || replayManager->IsNormalising()))
         {
             // We only accept replay commands as long the replay is active.
-            if ((flags & GAME_COMMAND_FLAG_REPLAY) == 0)
+            if ((flags & GAME_COMMAND_FLAG_REPLAY) == 0 && !ignoreForReplays)
             {
                 // TODO: Introduce proper error.
                 auto result = GameActions::Result();
@@ -403,7 +406,7 @@ namespace GameActions
                     bool commandExecutes = (flags & GAME_COMMAND_FLAG_GHOST) == 0 && (flags & GAME_COMMAND_FLAG_NO_SPEND) == 0;
 
                     bool recordAction = false;
-                    if (replayManager != nullptr)
+                    if (replayManager != nullptr && !ignoreForReplays)
                     {
                         if (replayManager->IsRecording() && commandExecutes)
                             recordAction = true;

--- a/src/openrct2/actions/GameAction.h
+++ b/src/openrct2/actions/GameAction.h
@@ -28,6 +28,7 @@ namespace GameActions
         constexpr uint16_t AllowWhilePaused = 1 << 0;
         constexpr uint16_t ClientOnly = 1 << 1;
         constexpr uint16_t EditorOnly = 1 << 2;
+        constexpr uint16_t IgnoreForReplays = 1 << 3;
     } // namespace Flags
 
 } // namespace GameActions

--- a/src/openrct2/actions/GameSetSpeedAction.cpp
+++ b/src/openrct2/actions/GameSetSpeedAction.cpp
@@ -23,7 +23,7 @@ void GameSetSpeedAction::AcceptParameters(GameActionParameterVisitor& visitor)
 
 uint16_t GameSetSpeedAction::GetActionFlags() const
 {
-    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused | GameActions::Flags::IgnoreForReplays;
 }
 
 void GameSetSpeedAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/PauseToggleAction.cpp
+++ b/src/openrct2/actions/PauseToggleAction.cpp
@@ -11,7 +11,7 @@
 
 uint16_t PauseToggleAction::GetActionFlags() const
 {
-    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused | GameActions::Flags::IgnoreForReplays;
 }
 
 GameActions::Result PauseToggleAction::Query() const


### PR DESCRIPTION
I think when I started the replays both of the now filtered game actions didn't exist, those should not be recorded as they act more as system specific actions rather than game state influencing things.

This PR ensures that fast forward and pausing/unpausing work during replays and also aren't recorded.