### PR TITLE
Fix Android startup code

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Fix: [#18199] Dots in the game save's name no longer get truncated.
 - Fix: [#19722] “Forbid tree removal” restriction doesn't forbid removal of large scenery tree items.
 - Fix: [#20356] Cannot set tertiary colour on small scenery.
+- Fix: [#20679] Android: game crashes at launch.
 - Fix: [#20737] Spent money in player window underflows when getting refunds.
 - Fix: [#20778] [Plugin] Incorrect target api when executing custom actions.
 - Fix: [#20807] Tertiary colour not copied with small scenery.

--- a/src/openrct2-android/gradle.properties
+++ b/src/openrct2-android/gradle.properties
@@ -18,3 +18,4 @@
 # org.gradle.parallel=true
 android.enableJetifier=true
 android.useAndroidX=true
+org.gradle.jvmargs=-Xmx4096m

--- a/src/openrct2/platform/Platform.Android.cpp
+++ b/src/openrct2/platform/Platform.Android.cpp
@@ -27,7 +27,9 @@ AndroidClassLoader::~AndroidClassLoader()
 jobject AndroidClassLoader::_classLoader;
 jmethodID AndroidClassLoader::_findClassMethod;
 
-static std::shared_ptr<AndroidClassLoader> acl = std::make_shared<AndroidClassLoader>();
+// Initialized in JNI_OnLoad. Cannot be initialized here as JVM is not
+// available until after JNI_OnLoad is called.
+static std::shared_ptr<AndroidClassLoader> acl;
 
 namespace Platform
 {
@@ -180,6 +182,19 @@ namespace Platform
             env->NewStringUTF(std::string(name).c_str())));
     }
 } // namespace Platform
+
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* pjvm, void* reserved)
+{
+    // Due to an issue where JNI_OnLoad could be called multiple times, we need
+    // to make sure it is only initialized once.
+    // https://issuetracker.google.com/issues/220523932
+    // Otherwise JVM complains about jobject-s having incorrect serial numbers.
+    if (!acl)
+    {
+        acl = std::make_shared<AndroidClassLoader>();
+    }
+    return JNI_VERSION_1_6;
+}
 
 AndroidClassLoader::AndroidClassLoader()
 {


### PR DESCRIPTION
https://github.com/OpenRCT2/OpenRCT2/pull/20502 changed how startup is
handled. This affected Android as well and changed `AndroidClassLoader` to
be initialized statically, but this turns out to be problematic due to
JVM not being fully initialized in our context by this time.

To fix this, move `AndroidClassLoader` initialization to `JNI_OnLoad` call,
where JVM is fully available.

Additionally, guard against multiple calls to `JNI_OnLoad`, an issue
present on Linux-like systems (including Android).