### PR TITLE
Calculate guests heading towards park after importing the save file

### DIFF
--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -345,6 +345,21 @@ void RCT2StringToUTF8Self(char* buffer, size_t length)
     }
 }
 
+static void FixGuestsHeadingToParkCount()
+{
+    uint32_t guestsHeadingToPark = 0;
+
+    for (auto* peep : EntityList<Guest>())
+    {
+        if (peep->OutsideOfPark && peep->State != PeepState::LeavingPark)
+        {
+            guestsHeadingToPark++;
+        }
+    }
+
+    gNumGuestsHeadingForPark = guestsHeadingToPark;
+}
+
 static void FixGuestCount()
 {
     // Recalculates peep count after loading a save to fix corrupted files
@@ -454,6 +469,8 @@ static void FixInvalidSurfaces()
 // For example recalculate guest count by looking at all the guests instead of trusting the value in the file.
 void GameFixSaveVars()
 {
+    FixGuestsHeadingToParkCount();
+
     FixGuestCount();
 
     FixPeepsWithInvalidRideReference();

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -364,13 +364,12 @@ static void FixGuestCount()
 {
     // Recalculates peep count after loading a save to fix corrupted files
     uint32_t guestCount = 0;
+
+    for (auto guest : EntityList<Guest>())
     {
-        for (auto guest : EntityList<Guest>())
+        if (!guest->OutsideOfPark)
         {
-            if (!guest->OutsideOfPark)
-            {
-                guestCount++;
-            }
+            guestCount++;
         }
     }
 

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -357,6 +357,11 @@ static void FixGuestsHeadingToParkCount()
         }
     }
 
+    if (gNumGuestsHeadingForPark != guestsHeadingToPark)
+    {
+        LOG_WARNING("Corrected bad amount of guests heading to park: %u -> %u", gNumGuestsHeadingForPark, guestsHeadingToPark);
+    }
+
     gNumGuestsHeadingForPark = guestsHeadingToPark;
 }
 
@@ -371,6 +376,11 @@ static void FixGuestCount()
         {
             guestCount++;
         }
+    }
+
+    if (gNumGuestsInPark != guestCount)
+    {
+        LOG_WARNING("Corrected bad amount of guests in park: %u -> %u", gNumGuestsInPark, guestCount);
     }
 
     gNumGuestsInPark = guestCount;

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -345,9 +345,7 @@ void RCT2StringToUTF8Self(char* buffer, size_t length)
     }
 }
 
-// OpenRCT2 workaround to recalculate some values which are saved redundantly in the save to fix corrupted files.
-// For example recalculate guest count by looking at all the guests instead of trusting the value in the file.
-void GameFixSaveVars()
+static void FixGuestCount()
 {
     // Recalculates peep count after loading a save to fix corrupted files
     uint32_t guestCount = 0;
@@ -362,7 +360,10 @@ void GameFixSaveVars()
     }
 
     gNumGuestsInPark = guestCount;
+}
 
+static void FixPeepsWithInvalidRideReference()
+{
     // Peeps to remove have to be cached here, as removing them from within the loop breaks iteration
     std::vector<Peep*> peepsToRemove;
 
@@ -412,9 +413,13 @@ void GameFixSaveVars()
     {
         ptr->Remove();
     }
+}
 
+static void FixInvalidSurfaces()
+{
     // Fixes broken saves where a surface element could be null
     // and broken saves with incorrect invisible map border tiles
+
     for (int32_t y = 0; y < MAXIMUM_MAP_SIZE_TECHNICAL; y++)
     {
         for (int32_t x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
@@ -443,6 +448,17 @@ void GameFixSaveVars()
             }
         }
     }
+}
+
+// OpenRCT2 workaround to recalculate some values which are saved redundantly in the save to fix corrupted files.
+// For example recalculate guest count by looking at all the guests instead of trusting the value in the file.
+void GameFixSaveVars()
+{
+    FixGuestCount();
+
+    FixPeepsWithInvalidRideReference();
+
+    FixInvalidSurfaces();
 
     ResearchFix();
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2911,15 +2911,6 @@ namespace RCT1
         }
 
         dst->SetItemFlags(src->GetItemFlags());
-
-        if (dst->OutsideOfPark && dst->State != PeepState::LeavingPark)
-        {
-            IncrementGuestsHeadingForPark();
-        }
-        else
-        {
-            IncrementGuestsInPark();
-        }
     }
 
     template<> void S4Importer::ImportEntity<Staff>(const RCT12EntityBase& srcBase)


### PR DESCRIPTION
This is a work-around to make parks like #20748 work again after loading them, the real cause is still unknown. Also cleaned up a bit the GameFixSaveVars function.

While doing this I also noticed that the park is loaded twice, will create a new issue for it.