### PR TITLE
Expose ride's ratings descriptor and modifiers via the API

### DIFF
--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -369,6 +369,14 @@ std::string RideObject::GetDescription() const
     return GetString(ObjectStringID::DESCRIPTION);
 }
 
+RideRatingsDescriptor RideObject::GetRatingsDescriptor() const
+{
+    auto rideType = _legacyType.GetFirstNonNullRideType();
+    const auto& ratingsData = GetRideTypeDescriptor(rideType).RatingsData;
+
+    return ratingsData;
+}
+
 std::string RideObject::GetCapacity() const
 {
     return GetString(ObjectStringID::CAPACITY);

--- a/src/openrct2/object/RideObject.h
+++ b/src/openrct2/object/RideObject.h
@@ -11,6 +11,7 @@
 
 #include "../core/IStream.hpp"
 #include "../drawing/ImageId.hpp"
+#include "../ride/RideData.h"
 #include "../ride/RideEntry.h"
 #include "../ride/RideTypes.h"
 #include "Object.h"
@@ -41,6 +42,7 @@ public:
     std::string GetDescription() const;
     std::string GetCapacity() const;
     ImageIndex GetPreviewImage(ride_type_t type);
+    RideRatingsDescriptor GetRatingsDescriptor() const;
 
     void SetRepositoryItem(ObjectRepositoryItem* item) const override;
 

--- a/src/openrct2/scripting/bindings/object/ScObject.hpp
+++ b/src/openrct2/scripting/bindings/object/ScObject.hpp
@@ -11,6 +11,7 @@
 
 #ifdef ENABLE_SCRIPTING
 
+#    include "../../../core/EnumMap.hpp"
 #    include "../../../Context.h"
 #    include "../../../common.h"
 #    include "../../../object/ObjectManager.h"
@@ -20,6 +21,7 @@
 #    include "../../Duktape.hpp"
 #    include "../../ScriptEngine.h"
 #    include "ScInstalledObject.hpp"
+#    include "../../../ride/RideData.h"
 
 #    include <memory>
 #    include <optional>
@@ -509,6 +511,52 @@ namespace OpenRCT2::Scripting
         }
     };
 
+    const static EnumMap<RatingsModifierType> RatingsModifierTypeToName{
+        { "NoModifier", RatingsModifierType::NoModifier },
+        { "BonusLength", RatingsModifierType::BonusLength },
+        { "BonusSynchronisation", RatingsModifierType::BonusSynchronisation },
+        { "BonusTrainLength", RatingsModifierType::BonusTrainLength },
+        { "BonusMaxSpeed", RatingsModifierType::BonusMaxSpeed },
+        { "BonusAverageSpeed", RatingsModifierType::BonusAverageSpeed },
+        { "BonusDuration", RatingsModifierType::BonusDuration },
+        { "BonusGForces", RatingsModifierType::BonusGForces },
+        { "BonusTurns", RatingsModifierType::BonusTurns },
+        { "BonusDrops", RatingsModifierType::BonusDrops },
+        { "BonusSheltered", RatingsModifierType::BonusSheltered },
+        { "BonusProximity", RatingsModifierType::BonusProximity },
+        { "BonusScenery", RatingsModifierType::BonusScenery },
+        { "BonusRotations", RatingsModifierType::BonusRotations },
+        { "BonusOperationOption", RatingsModifierType::BonusOperationOption },
+        { "BonusReversedTrains", RatingsModifierType::BonusReversedTrains },
+        { "BonusGoKartRace", RatingsModifierType::BonusGoKartRace },
+        { "BonusTowerRide", RatingsModifierType::BonusTowerRide },
+        { "BonusRotoDrop", RatingsModifierType::BonusRotoDrop },
+        { "BonusMazeSize", RatingsModifierType::BonusMazeSize },
+        { "BonusBoatHireNoCircuit", RatingsModifierType::BonusBoatHireNoCircuit },
+        { "BonusSlideUnlimitedRides", RatingsModifierType::BonusSlideUnlimitedRides },
+        { "BonusMotionSimulatorMode", RatingsModifierType::BonusMotionSimulatorMode },
+        { "Bonus3DCinemaMode", RatingsModifierType::Bonus3DCinemaMode },
+        { "BonusTopSpinMode", RatingsModifierType::BonusTopSpinMode },
+        { "BonusReversals", RatingsModifierType::BonusReversals },
+        { "BonusHoles", RatingsModifierType::BonusHoles },
+        { "BonusNumTrains", RatingsModifierType::BonusNumTrains },
+        { "BonusDownwardLaunch", RatingsModifierType::BonusDownwardLaunch },
+        { "BonusLaunchedFreefallSpecial", RatingsModifierType::BonusLaunchedFreefallSpecial },
+        { "RequirementLength", RatingsModifierType::RequirementLength },
+        { "RequirementDropHeight", RatingsModifierType::RequirementDropHeight },
+        { "RequirementNumDrops", RatingsModifierType::RequirementNumDrops },
+        { "RequirementMaxSpeed", RatingsModifierType::RequirementMaxSpeed },
+        { "RequirementNegativeGs", RatingsModifierType::RequirementNegativeGs },
+        { "RequirementLateralGs", RatingsModifierType::RequirementLateralGs },
+        { "RequirementInversions", RatingsModifierType::RequirementInversions },
+        { "RequirementUnsheltered", RatingsModifierType::RequirementUnsheltered },
+        { "RequirementReversals", RatingsModifierType::RequirementReversals },
+        { "RequirementHoles", RatingsModifierType::RequirementHoles },
+        { "RequirementStations", RatingsModifierType::RequirementStations },
+        { "RequirementSplashdown", RatingsModifierType::RequirementSplashdown },
+        { "PenaltyLateralGs", RatingsModifierType::PenaltyLateralGs },
+    };
+
     class ScRideObject : public ScObject
     {
     public:
@@ -542,6 +590,7 @@ namespace OpenRCT2::Scripting
             dukglue_register_property(ctx, &ScRideObject::maxHeight_get, nullptr, "maxHeight");
             dukglue_register_property(ctx, &ScRideObject::shopItem_get, nullptr, "shopItem");
             dukglue_register_property(ctx, &ScRideObject::shopItemSecondary_get, nullptr, "shopItemSecondary");
+            dukglue_register_property(ctx, &ScRideObject::ratingsModifiers_get, nullptr, "ratingsModifiers");
         }
 
     private:
@@ -771,6 +820,22 @@ namespace OpenRCT2::Scripting
                 return EnumValue(entry->shop_item[1]);
             }
             return 0;
+        }
+
+       std::vector<std::string> ratingsModifiers_get() const
+        {
+
+            std::vector<std::string> ratingsModifiersNames;
+            auto entry = GetObject();
+            if (entry != nullptr)
+            {
+                for (auto& modifier : entry->GetRatingsDescriptor().Modifiers)
+                {
+                    auto typeStr = RatingsModifierTypeToName.find(modifier.Type)->first;
+                    ratingsModifiersNames.push_back(std::string{typeStr});
+                }
+            }
+            return ratingsModifiersNames;
         }
 
     protected:


### PR DESCRIPTION
Hey folks, it's my first PR here so wanted to get some early feedback on this.

### problem

The issue I'm looking to solve is making is easier for users to know how to build rides with good excitement, intensity, nausea ratings. When building a custom roller coaster it can be easy to miss the minimum length requirement and have the ride's ratings penalized, and not know why that happened. These ratings modifiers are present on every ride, although only viewable in the code.

### potential solution

One way to give users more insight when building custom roller coasters is to expose via the plugin API the ride modifiers and other related rating data for each ride type. Concretely, my thought is to expose the `RideRatingsDescriptor` type and subtypes to the plugin API (notably `RatingsModifierType` as this contains the bonuses and requirements).

My initial approach aims on building this into the API instead of the base game. This is to enable plugin developers to creatively use this data however they see fit, and so that vanilla openrct2 doesn't get bloated with an advanced feature like this built in.

I plan on building a plugin to utilize the ride ratings descriptors and modifiers data by initially displaying it when a ride is selected. With further work I could see future information exposed via the API to show which ratings modifiers are affecting the ratings, enabling users to see which modifiers they should work on improving.

Anyways, highly open to changing things around. C/++ is not my strong suit, but eager to learn more.

The current code in this PR simply returns an array of all ratings modifiers type names on a RideObject as a proof of concept. Its definitely not the final version. 

### Initial questions

- is this a useful addition to the codebase and API?
- should the internal `RideRatingsDescriptor` and subtypes be exposed via the API in generally the same structure?
- any recommendations for where the code should be located?
  - `RatingsModifierTypeToName` enum map should be an API layer concern in ScObject, or moved into RideData?

Potential API design (Typescript types)

```ts
interface RideObject {
  // ...
  rideRatingsDescriptor: RideRatingsDescriptor
}

// assume all fields not null

interface RideRatingsDescriptor {
  ratingsCalculationType: string or enum
  baseExcitement: number
  baseIntensity: number
  baseNausea: number
  unreliability: number
  rideShelter: number // not useful?
  relaxRequirementsIfInversion: boolean // not useful?
  ratingsModifiers: [RatingsModifier]
}

interface RatingsModifier {
  modifierType: string or enum
  threshold: number
  excitement: number
  intensity: number
  nausea: number
}
```

Open to any early feedback anyone might have!