### PR TITLE
Update Android project to more recent tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
     name: Windows (${{ matrix.platform_name }}) using mingw
     runs-on: ubuntu-latest
     needs: check-code-formatting
-    container: openrct2/openrct2-build:11-mingw
+    container: openrct2/openrct2-build:12-mingw
     strategy:
       fail-fast: false
       matrix:
@@ -276,19 +276,19 @@ jobs:
             build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz -fno-var-tracking-assignments" -DWITH_TESTS=off -DDISABLE_FLAC=ON -DDISABLE_VORBIS=ON
           - platform: x86_64
             distro: focal
-            image: openrct2/openrct2-build:11-focal
+            image: openrct2/openrct2-build:12-focal
             build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g1 -gz" -DWITH_TESTS=off
           - platform: x86_64
             distro: jammy
-            image: openrct2/openrct2-build:11-jammy
+            image: openrct2/openrct2-build:12-jammy
             build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz -fno-var-tracking-assignments"
           - platform: x86_64
             distro: bullseye
-            image: openrct2/openrct2-build:11-bullseye
+            image: openrct2/openrct2-build:12-bullseye
             build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz -fno-var-tracking-assignments" -DWITH_TESTS=off
           - platform: i686
             distro: focal
-            image: openrct2/openrct2-build:11-focal32
+            image: openrct2/openrct2-build:12-focal32
             build_flags: -DFORCE32=ON -DENABLE_SCRIPTING=OFF -DCMAKE_CXX_FLAGS="-m32 -g1 -gz" -DWITH_TESTS=off
     steps:
       - name: Checkout
@@ -327,7 +327,7 @@ jobs:
     name: Linux (x86_64, AppImage)
     runs-on: ubuntu-latest
     needs: check-code-formatting
-    container: openrct2/openrct2-build:11-focal
+    container: openrct2/openrct2-build:12-focal
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -385,7 +385,7 @@ jobs:
     name: Linux (Debug, [http, network, flac, vorbis OpenGL] disabled) using clang
     runs-on: ubuntu-latest
     needs: check-code-formatting
-    container: openrct2/openrct2-build:11-jammy
+    container: openrct2/openrct2-build:12-jammy
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -401,7 +401,7 @@ jobs:
     name: Linux (Debug) using clang, coverage enabled
     runs-on: ubuntu-latest
     needs: check-code-formatting
-    container: openrct2/openrct2-build:11-jammy
+    container: openrct2/openrct2-build:12-jammy
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -442,7 +442,7 @@ jobs:
     name: Android
     runs-on: ubuntu-latest
     needs: check-code-formatting
-    container: openrct2/openrct2-build:11-android
+    container: openrct2/openrct2-build:12-android
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/src/openrct2-android/app/build.gradle
+++ b/src/openrct2-android/app/build.gradle
@@ -2,7 +2,9 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 31
-    ndkVersion "23.1.7779620" // Latest r23b (LTS), to be synced with CI container image
+    buildToolsVersion "34.0.0"
+    ndkVersion "26.1.10909125" // Latest r26b (LTS), to be synced with CI container image
+    namespace "io.openrct2"
     defaultConfig {
         applicationId 'io.openrct2'
         minSdkVersion 19
@@ -31,7 +33,6 @@ android {
     externalNativeBuild {
         cmake {
             path 'src/main/CMakeLists.txt'
-            version "3.18.1"
         }
     }
 

--- a/src/openrct2-android/app/src/main/AndroidManifest.xml
+++ b/src/openrct2-android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.openrct2">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/src/openrct2-android/build.gradle
+++ b/src/openrct2-android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath 'com.android.tools.build:gradle:8.3.0-alpha10'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/src/openrct2-android/gradle/wrapper/gradle-wrapper.properties
+++ b/src/openrct2-android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip


### PR DESCRIPTION
We still need to target the older Android API, as targeting the newer ones would require us to adopt the runtime permissions.

I hope to update other parts of Android build in the future, this is the first step.