### PR TITLE
upload macos-x64 artifacts before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,14 +191,6 @@ jobs:
         run: |
           HOMEBREW_NO_ANALYTICS=1 brew install ninja pkg-config
           . scripts/setenv -q && build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=on ${{ matrix.build_flags }}
-      - name: Run Tests
-        if: ${{matrix.run_tests}}
-        run: . scripts/setenv -q && run-tests
-      - name: Test Summary
-        uses: test-summary/action@v2
-        with:
-          paths: "artifacts/test-**.xml"
-        if: ${{matrix.run_tests}}
       - name: Build artifacts
         run: |
           . scripts/setenv
@@ -213,6 +205,14 @@ jobs:
           name: OpenRCT2-${{ runner.os }}-${{ matrix.arch }}-cmake
           path: artifacts/openrct2-macos.zip
           if-no-files-found: error
+      - name: Run Tests
+        if: ${{matrix.run_tests}}
+        run: . scripts/setenv -q && run-tests
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: "artifacts/test-**.xml"
+        if: ${{matrix.run_tests}}
   macos-universal:
     name: macOS universal app bundle
     runs-on: macos-latest


### PR DESCRIPTION
Closes: https://github.com/OpenRCT2/OpenRCT2/issues/20933

I received a message from a macos-x64 user who wanted to try out the unified brake speed PR but could not find an artifact for it - because the artifact for macos-x64 is uploaded only if tests are successful. There are legitimate reasons why tests fail, so it is helpful to have the builds available even if the tests are unsuccessful. The Windows targets upload artifacts before testing, and this PR attempts to bring the macos-x64 build inline with that.