### PR TITLE
Activate OpenRCT2 window after using native file dialog on macOS

### DIFF
--- a/src/openrct2-ui/UiContext.macOS.mm
+++ b/src/openrct2-ui/UiContext.macOS.mm
@@ -129,6 +129,7 @@ namespace OpenRCT2::Ui
                 }
                 else
                 {
+                    SDL_RaiseWindow(window);
                     return std::string();
                 }
 
@@ -137,10 +138,12 @@ namespace OpenRCT2::Ui
                 panel.directoryURL = [NSURL fileURLWithPath:directory];
                 if ([panel runModal] == NSModalResponseCancel)
                 {
+                    SDL_RaiseWindow(window);
                     return std::string();
                 }
                 else
                 {
+                    SDL_RaiseWindow(window);
                     return panel.URL.path.UTF8String;
                 }
             }
@@ -158,10 +161,12 @@ namespace OpenRCT2::Ui
                 {
                     NSString* selectedPath = panel.URL.path;
                     const char* path = selectedPath.UTF8String;
+                    SDL_RaiseWindow(window);
                     return path;
                 }
                 else
                 {
+                    SDL_RaiseWindow(window);
                     return "";
                 }
             }


### PR DESCRIPTION
Currently on macOS, after selecting a file using the native file dialog, the main OpenRCT2 window doesn't become the active window. As a result, if the player tries to right-click drag immediately after picking a file, the cursor still appears, resulting in some strange behavior, as seen in the video below.

https://github.com/OpenRCT2/OpenRCT2/assets/49624366/e8cdc75e-aae7-4323-8fbb-e9c0ae2213fc

I have updated the code that interfaces with the file dialog so that the main window is activated after the file dialog is closed, which fixes the issue.