### PR TITLE
Fix launcher wording

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,7 +70,7 @@ RollerCoaster Tycoon 2 was originally written by Chris Sawyer in x86 assembly an
 
 OpenRCT2 requires original files of RollerCoaster Tycoon 2 to play. It can be bought at either [Steam](https://store.steampowered.com/app/285330/) or [GOG.com](https://www.gog.com/game/rollercoaster_tycoon_2). If you have the original RollerCoaster Tycoon and its expansion packs, you can [point OpenRCT2 to these](https://github.com/OpenRCT2/OpenRCT2/wiki/Loading-RCT1-scenarios-and-data) in order to play the original scenarios.
 
-[OpenRCT2.org](https://openrct2.org/downloads) offers precompiled builds and installers of the latest master and the develop branch. There is also a cross platform [Launcher](https://github.com/IntelOrca/OpenLauncher/releases) available that will automatically update your build of the game so that you always have the latest version.
+[OpenRCT2.org](https://openrct2.org/downloads) offers precompiled builds and installers of the latest master and the develop branch. There is also a [Launcher](https://github.com/IntelOrca/OpenLauncher/releases) available for Windows and Linux that will automatically update your build of the game so that you always have the latest version.
 
 [Flathub](https://flathub.org/) offers flatpaks for Linux distributions that support this application distribution system:
 * [Latest release](https://flathub.org/apps/details/io.openrct2.OpenRCT2)


### PR DESCRIPTION
Although the launcher is available for more than one platform the word "cross platform" might confuse users of macOS and other platforms.