### PR TITLE
Fix #20964: Crash when invalid network group id is used

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Fix: [#20737] Spent money in player window underflows when getting refunds.
 - Fix: [#20778] [Plugin] Incorrect target api when executing custom actions.
 - Fix: [#20807] Tertiary colour not copied with small scenery.
+- Fix: [#20964] Crash when player connects to server with a group assigned that no longer exists.
 
 0.4.6 (2023-09-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -2643,7 +2643,10 @@ void NetworkBase::ServerHandleAuth(NetworkConnection& connection, NetworkPacket&
         if (connection.AuthStatus == NetworkAuth::Verified)
         {
             const NetworkGroup* group = GetGroupByID(GetGroupIDByHash(connection.Key.PublicKeyHash()));
-            passwordless = group->CanPerformAction(NetworkPermission::PasswordlessLogin);
+            if (group != nullptr)
+            {
+                passwordless = group->CanPerformAction(NetworkPermission::PasswordlessLogin);
+            }
         }
         if (gameversion != NetworkGetVersion())
         {
@@ -3649,6 +3652,11 @@ GameActions::Result NetworkModifyGroups(
         case ModifyGroupType::SetName:
         {
             NetworkGroup* group = network.GetGroupByID(groupId);
+            if (group == nullptr)
+            {
+                return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_RENAME_GROUP, STR_NONE);
+            }
+
             const char* oldName = group->GetName().c_str();
 
             if (strcmp(oldName, name.c_str()) == 0)


### PR DESCRIPTION
It is possible that the groups have been modified from the last time the player logged on, this guards against nullptr. Also added another missing nullptr check for good measure.

Closes #20964