### PR TITLE
Fix #20253, #20799, #20841, #20903, #20915: Crash when displaying a Lay-Down RC’s half loop

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Fix: [#16453] Tile inspector invisibility shortcut does not use a game action.
 - Fix: [#18199] Dots in the game save's name no longer get truncated.
 - Fix: [#19722] “Forbid tree removal” restriction doesn't forbid removal of large scenery tree items.
+- Fix: [#20253] Crash when displaying a Lay-Down RC’s half loop.
 - Fix: [#20356] Cannot set tertiary colour on small scenery.
 - Fix: [#20679] Android: game crashes at launch.
 - Fix: [#20737] Spent money in player window underflows when getting refunds.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "8"
+#define NETWORK_STREAM_VERSION "9"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/ride/coaster/CorkscrewRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/CorkscrewRollerCoaster.cpp
@@ -10421,7 +10421,7 @@ static void LayDownRCTrackHalfLoopUninvertedDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    auto function = GetTrackPaintFunctionCorkscrewRC(TrackElemType::FlyerHalfLoopInvertedUp);
+    auto function = GetTrackPaintFunctionLayDownRC(TrackElemType::FlyerHalfLoopInvertedUp);
     function(session, ride, 3 - trackSequence, direction, height, trackElement);
     return;
 }


### PR DESCRIPTION
Closes https://github.com/OpenRCT2/OpenRCT2/issues/20841
Closes https://github.com/OpenRCT2/OpenRCT2/issues/20903
Closes https://github.com/OpenRCT2/OpenRCT2/issues/20915
Closes https://github.com/OpenRCT2/OpenRCT2/issues/20799 (I think, that one seems to be removed upstream)