### PR TITLE
Replace usages of old WoodenBSupportsSetup() overload

### DIFF
--- a/src/openrct2/paint/Supports.cpp
+++ b/src/openrct2/paint/Supports.cpp
@@ -353,19 +353,19 @@ static constexpr UnkSupportsDescriptor Byte97B23C[] = {
     {{{0,  0,  0}, {1,  1,  8}},  0, 1},
     {{{0,  0,  0}, {1,  1,  8}},  0, 1},
     {{{0,  0,  0}, {1,  1,  8}},  0, 1},
+    {{{0,  0,  0}, {1,  1,  8}},  0, 1}, // ?
     {{{0,  0,  0}, {1,  1,  8}},  0, 1},
     {{{0,  0,  0}, {1,  1,  8}},  0, 1},
     {{{0,  0,  0}, {1,  1,  8}},  0, 1},
+    {{{0,  0,  0}, {1,  1,  8}},  0, 1}, // ?
     {{{0,  0,  0}, {1,  1,  8}},  0, 1},
     {{{0,  0,  0}, {1,  1,  8}},  0, 1},
     {{{0,  0,  0}, {1,  1,  8}},  0, 1},
+    {{{0,  0,  0}, {1,  1,  8}},  0, 1}, // ?
     {{{0,  0,  0}, {1,  1,  8}},  0, 1},
     {{{0,  0,  0}, {1,  1,  8}},  0, 1},
     {{{0,  0,  0}, {1,  1,  8}},  0, 1},
-    {{{0,  0,  0}, {1,  1,  8}},  0, 1},
-    {{{0,  0,  0}, {1,  1,  8}},  0, 1},
-    {{{0,  0,  0}, {1,  1,  8}},  0, 1},
-    {{{2,  2,  1}, {28, 28, 2}},  0, 1},
+    {{{2,  2,  1}, {28, 28, 2}},  0, 1}, // Large scenery (all directions)
     {{{0,  0,  0}, {1,  1,  8}},  0, 1}, // Flat to steep large 1
     {{{0,  0,  0}, {1,  1,  8}},  0, 1},
     {{{0,  0,  0}, {1,  1,  8}},  0, 1},
@@ -680,16 +680,32 @@ bool WoodenASupportsPaintSetup(
     return hasSupports;
 }
 
+static int32_t GetSpecialOffsetForTransitionType(WoodenSupportTransitionType transitionType, Direction direction)
+{
+    if (transitionType == WoodenSupportTransitionType::None)
+        return 0;
+
+    // "Special" values are an offset into tables like Byte97B23C, plus 1.
+    // Save for WoodenSupportTransitionType::LargeScenery, there are four entries (one per direction) for every
+    // transition type. While these tables will have to be refactored in due course, we can only do so once all
+    // drawing functions use WoodenSupportTransitionType instead of passing the "special" value directly.
+    int32_t specialOffset = 0;
+    if (transitionType < WoodenSupportTransitionType::Scenery)
+        specialOffset = (EnumValue(transitionType) * NumOrthogonalDirections) + direction;
+    else if (transitionType == WoodenSupportTransitionType::Scenery)
+        specialOffset = (EnumValue(transitionType) * NumOrthogonalDirections);
+    else
+        specialOffset = (EnumValue(transitionType) * NumOrthogonalDirections) + direction - 3;
+
+    return specialOffset + 1;
+}
+
 bool WoodenASupportsPaintSetup(
     PaintSession& session, WoodenSupportType supportType, WoodenSupportSubType subType, int32_t height, ImageId imageTemplate,
     WoodenSupportTransitionType transitionType, Direction direction)
 {
     int32_t oldSupportType = (EnumValue(supportType) * 6) + EnumValue(subType);
-    int32_t special = 0;
-    if (transitionType != WoodenSupportTransitionType::None)
-    {
-        special = (EnumValue(transitionType) * NumOrthogonalDirections) + direction + 1;
-    }
+    int32_t special = GetSpecialOffsetForTransitionType(transitionType, direction);
 
     return WoodenASupportsPaintSetup(session, oldSupportType, special, height, imageTemplate);
 }
@@ -829,11 +845,7 @@ bool WoodenBSupportsPaintSetup(
     WoodenSupportTransitionType transitionType, Direction direction)
 {
     int32_t oldSupportType = (EnumValue(supportType) * 6) + EnumValue(subType);
-    int32_t special = 0;
-    if (transitionType != WoodenSupportTransitionType::None)
-    {
-        special = (EnumValue(transitionType) * NumOrthogonalDirections) + direction + 1;
-    }
+    int32_t special = GetSpecialOffsetForTransitionType(transitionType, direction);
 
     return WoodenBSupportsPaintSetup(session, oldSupportType, special, height, imageTemplate);
 }

--- a/src/openrct2/paint/Supports.cpp
+++ b/src/openrct2/paint/Supports.cpp
@@ -730,7 +730,7 @@ bool WoodenASupportsPaintSetupRotated(
  *
  * @return (al) whether supports have been drawn
  */
-bool WoodenBSupportsPaintSetup(
+static bool WoodenBSupportsPaintSetup(
     PaintSession& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate)
 {
     if (!(session.Flags & PaintSessionFlags::PassedSurface))

--- a/src/openrct2/paint/Supports.h
+++ b/src/openrct2/paint/Supports.h
@@ -129,8 +129,6 @@ bool WoodenASupportsPaintSetupRotated(
     PaintSession& session, WoodenSupportType supportType, WoodenSupportSubType subType, Direction direction, int32_t height,
     ImageId imageTemplate, WoodenSupportTransitionType transitionType = WoodenSupportTransitionType::None);
 bool WoodenBSupportsPaintSetup(
-    PaintSession& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate);
-bool WoodenBSupportsPaintSetup(
     PaintSession& session, WoodenSupportType supportType, WoodenSupportSubType subType, int32_t height, ImageId imageTemplate,
     WoodenSupportTransitionType transitionType = WoodenSupportTransitionType::None, Direction direction = 0);
 bool WoodenBSupportsPaintSetupRotated(

--- a/src/openrct2/paint/Supports.h
+++ b/src/openrct2/paint/Supports.h
@@ -42,6 +42,7 @@ enum class WoodenSupportTransitionType : uint8_t
     Up25DegToUp60Deg = 3,
     Up60DegToUp25Deg = 4,
     Up60Deg = 5,
+    Scenery = 12,
 };
 
 // There are 13 types of metal supports. A graphic showing all of them is available here:

--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
@@ -61,15 +61,16 @@ static void PaintLargeScenerySupports(
     if (tile.flags & LARGE_SCENERY_TILE_FLAG_NO_SUPPORTS)
         return;
 
-    auto special = 0;
+    auto transitionType = WoodenSupportTransitionType::None;
     auto supportHeight = height;
     if (supportHeight & 0xF)
     {
         supportHeight &= ~0xF;
-        special = 49;
+        transitionType = WoodenSupportTransitionType::Scenery;
     }
 
-    WoodenBSupportsPaintSetup(session, (direction & 1), special, supportHeight, imageTemplate);
+    WoodenBSupportsPaintSetupRotated(
+        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, supportHeight, imageTemplate, transitionType);
 
     int32_t clearanceHeight = Ceil2(tileElement.GetClearanceZ() + 15, 16);
     if (tile.flags & LARGE_SCENERY_TILE_FLAG_ALLOW_SUPPORTS_ABOVE)

--- a/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
@@ -42,12 +42,12 @@ static void PaintSmallScenerySupports(
     if (sceneryEntry.HasFlag(SMALL_SCENERY_FLAG_NO_SUPPORTS))
         return;
 
-    auto special = 0;
+    auto transitionType = WoodenSupportTransitionType::None;
     auto supportHeight = height;
     if (supportHeight & 0xF)
     {
         supportHeight &= ~0xF;
-        special = 49;
+        transitionType = WoodenSupportTransitionType::Scenery;
     }
 
     auto supportImageTemplate = ImageId().WithRemap(0);
@@ -60,8 +60,9 @@ static void PaintSmallScenerySupports(
         supportImageTemplate = imageTemplate;
     }
 
-    auto supportType = (direction & 1) ? 1 : 0;
-    WoodenBSupportsPaintSetup(session, supportType, special, supportHeight, supportImageTemplate);
+    WoodenBSupportsPaintSetupRotated(
+        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, supportHeight, supportImageTemplate,
+        transitionType);
 }
 
 static void SetSupportHeights(

--- a/src/openrct2/ride/coaster/HybridCoaster.cpp
+++ b/src/openrct2/ride/coaster/HybridCoaster.cpp
@@ -1651,21 +1651,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -1693,21 +1681,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -1798,21 +1774,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -1840,21 +1804,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -1945,21 +1897,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
                 break;
@@ -1987,21 +1927,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
                 break;
@@ -2092,21 +2020,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -2134,21 +2050,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -2238,21 +2142,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 break;
             case 2:
@@ -2279,21 +2171,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 break;
             case 3:
@@ -2384,21 +2264,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
                 break;
@@ -2426,21 +2294,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
                 break;
@@ -2531,21 +2387,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
                 break;
@@ -2573,21 +2417,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
                 break;
@@ -2678,21 +2510,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
                 break;
@@ -2720,21 +2540,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
                 break;
@@ -2825,21 +2633,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
                 break;
@@ -2867,21 +2663,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
                 break;
@@ -2972,21 +2756,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
                 break;
@@ -3014,21 +2786,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
                 break;
@@ -3119,21 +2879,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
                 break;
@@ -3161,21 +2909,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
                 break;
@@ -3266,21 +3002,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
                 break;
@@ -3308,21 +3032,9 @@ namespace HybridRC
                             break;
                     }
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
                 break;
@@ -3739,21 +3451,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 28 }, { 32, 32, 0 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
                 break;
@@ -3767,21 +3467,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
                 break;
@@ -3830,21 +3518,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
                 break;
@@ -3862,21 +3538,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 28 }, { 32, 32, 0 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
                 break;
@@ -3929,21 +3593,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 28 }, { 32, 32, 0 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
                 break;
@@ -3957,21 +3609,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
                 break;
@@ -4020,21 +3660,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
                 break;
@@ -4052,21 +3680,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 28 }, { 32, 32, 0 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
                 break;
@@ -4119,21 +3735,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
                 break;
@@ -4147,21 +3751,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
                 break;
@@ -4210,21 +3802,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
                 break;
@@ -4242,21 +3822,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
                 break;
@@ -4309,21 +3877,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 36 }, { 32, 32, 0 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -4337,21 +3893,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -4400,21 +3944,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -4432,21 +3964,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 36 }, { 32, 32, 0 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -4498,21 +4018,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 36 }, { 32, 32, 0 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 break;
             case 2:
@@ -4525,21 +4033,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 break;
             case 3:
@@ -4587,21 +4083,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 break;
             case 2:
@@ -4618,21 +4102,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 36 }, { 32, 32, 0 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 break;
             case 3:
@@ -4685,21 +4157,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 28 }, { 32, 32, 0 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
                 break;
@@ -4713,21 +4173,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
                 break;
@@ -4776,21 +4224,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
                 break;
@@ -4808,21 +4244,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 28 }, { 32, 32, 0 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
                 break;
@@ -4875,21 +4299,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 28 }, { 32, 32, 0 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
                 break;
@@ -4903,21 +4315,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
                 break;
@@ -4966,21 +4366,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
                 break;
@@ -4998,21 +4386,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 28 }, { 32, 32, 0 } });
                         break;
                 }
-                switch (direction)
-                {
-                    case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
                 break;
@@ -12425,7 +11801,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 48 }, { 32, 32, 0 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(session, 2 + direction, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
                 break;
@@ -12439,8 +11817,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(
-                    session, 2 + (direction + 2) % 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
                 break;
@@ -12495,7 +11874,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(session, 2 + direction, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
                 break;
@@ -12513,8 +11894,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 48 }, { 32, 32, 0 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(
-                    session, 2 + (direction + 2) % 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
                 break;
@@ -12573,7 +11955,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 48 }, { 32, 32, 0 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(session, 2 + direction, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -12587,8 +11971,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(
-                    session, 2 + (direction + 2) % 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -12643,7 +12028,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(session, 2 + direction, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -12661,8 +12048,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 48 }, { 32, 32, 0 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(
-                    session, 2 + (direction + 2) % 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -12749,7 +12137,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 48 }, { 32, 32, 0 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(session, 2 + direction, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
                 break;
@@ -12763,7 +12153,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(session, 2 + (direction + 2) % 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
                 break;
@@ -12818,7 +12210,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(session, 2 + direction, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
                 break;
@@ -12836,7 +12230,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 48 }, { 32, 32, 0 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(session, 2 + (direction + 2) % 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
                 break;
@@ -12895,7 +12291,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 48 }, { 32, 32, 0 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(session, 2 + direction, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -12909,8 +12307,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(
-                    session, 2 + (direction + 2) % 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -12965,7 +12364,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(session, 2 + direction, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -12983,8 +12384,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 48 }, { 32, 32, 0 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(
-                    session, 2 + (direction + 2) % 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -13071,7 +12473,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 48 }, { 32, 32, 0 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(session, 2 + direction, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -13085,8 +12489,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(
-                    session, 2 + (direction + 2) % 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -13141,7 +12546,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(session, 2 + direction, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -13159,8 +12566,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 48 }, { 32, 32, 0 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(
-                    session, 2 + (direction + 2) % 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -13233,7 +12641,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(session, 2 + direction, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
                 break;
@@ -13247,7 +12657,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(session, 2 + (direction + 2) % 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
                 break;
@@ -13302,7 +12714,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(session, 2 + direction, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
                 break;
@@ -13320,7 +12734,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(session, 2 + (direction + 2) % 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
                 break;
@@ -13379,7 +12795,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(session, 2 + direction, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -13393,8 +12811,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(
-                    session, 2 + (direction + 2) % 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -13449,7 +12868,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(session, 2 + direction, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;
@@ -13467,8 +12888,9 @@ namespace HybridRC
                             { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
                         break;
                 }
-                WoodenBSupportsPaintSetup(
-                    session, 2 + (direction + 2) % 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
                 break;

--- a/src/openrct2/ride/coaster/SideFrictionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/SideFrictionRollerCoaster.cpp
@@ -1987,16 +1987,24 @@ static void SideFrictionRCTrackDiag25DegUp(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21868), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2011,16 +2019,24 @@ static void SideFrictionRCTrackDiag25DegUp(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21844), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2033,10 +2049,14 @@ static void SideFrictionRCTrackDiag25DegUp(
                 switch (direction)
                 {
                     case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -2045,10 +2065,14 @@ static void SideFrictionRCTrackDiag25DegUp(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21869), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2057,10 +2081,14 @@ static void SideFrictionRCTrackDiag25DegUp(
                 switch (direction)
                 {
                     case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -2069,10 +2097,14 @@ static void SideFrictionRCTrackDiag25DegUp(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21845), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2319,16 +2351,24 @@ static void SideFrictionRCTrackDiag25DegUpToFlat(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21862), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2343,16 +2383,24 @@ static void SideFrictionRCTrackDiag25DegUpToFlat(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21838), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2365,10 +2413,14 @@ static void SideFrictionRCTrackDiag25DegUpToFlat(
                 switch (direction)
                 {
                     case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -2377,10 +2429,14 @@ static void SideFrictionRCTrackDiag25DegUpToFlat(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21863), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2389,10 +2445,14 @@ static void SideFrictionRCTrackDiag25DegUpToFlat(
                 switch (direction)
                 {
                     case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -2401,10 +2461,14 @@ static void SideFrictionRCTrackDiag25DegUpToFlat(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21839), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2485,16 +2549,24 @@ static void SideFrictionRCTrackDiag25DegDown(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21869), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2509,16 +2581,24 @@ static void SideFrictionRCTrackDiag25DegDown(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21845), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2531,10 +2611,14 @@ static void SideFrictionRCTrackDiag25DegDown(
                 switch (direction)
                 {
                     case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -2543,10 +2627,14 @@ static void SideFrictionRCTrackDiag25DegDown(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21868), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2555,10 +2643,14 @@ static void SideFrictionRCTrackDiag25DegDown(
                 switch (direction)
                 {
                     case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -2567,10 +2659,14 @@ static void SideFrictionRCTrackDiag25DegDown(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21844), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2649,16 +2745,24 @@ static void SideFrictionRCTrackDiagFlatTo25DegDown(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21863), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2673,16 +2777,24 @@ static void SideFrictionRCTrackDiagFlatTo25DegDown(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21839), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2693,10 +2805,14 @@ static void SideFrictionRCTrackDiagFlatTo25DegDown(
                 switch (direction)
                 {
                     case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -2705,10 +2821,14 @@ static void SideFrictionRCTrackDiagFlatTo25DegDown(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21862), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2717,10 +2837,14 @@ static void SideFrictionRCTrackDiagFlatTo25DegDown(
                 switch (direction)
                 {
                     case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -2729,10 +2853,14 @@ static void SideFrictionRCTrackDiagFlatTo25DegDown(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21838), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -3172,16 +3300,24 @@ static void SideFrictionRCTrackDiag60DegUp(
                         session, direction,
                         session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_60_DEG_UP_DIR_0_B),
                         { -16, -16, height }, { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
 
@@ -3192,10 +3328,14 @@ static void SideFrictionRCTrackDiag60DegUp(
             switch (direction)
             {
                 case 0:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -3206,10 +3346,14 @@ static void SideFrictionRCTrackDiag60DegUp(
                         session, direction,
                         session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_60_DEG_UP_DIR_2_B),
                         { -16, -16, height }, { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -3270,16 +3414,24 @@ static void SideFrictionRCTrackDiag60DegUpTo25DegUp(
                         session, direction,
                         session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_60_DEG_UP_TO_25_DEG_UP_DIR_0_B),
                         { -16, -16, height }, { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -3289,10 +3441,14 @@ static void SideFrictionRCTrackDiag60DegUpTo25DegUp(
             switch (direction)
             {
                 case 0:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -3303,10 +3459,14 @@ static void SideFrictionRCTrackDiag60DegUpTo25DegUp(
                         session, direction,
                         session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_60_DEG_UP_TO_25_DEG_UP_DIR_2_B),
                         { -16, -16, height }, { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -3365,16 +3525,24 @@ static void SideFrictionRCTrackDiag25DegUpTo60DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(24033), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -3384,10 +3552,14 @@ static void SideFrictionRCTrackDiag25DegUpTo60DegUp(
             switch (direction)
             {
                 case 0:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -3397,10 +3569,14 @@ static void SideFrictionRCTrackDiag25DegUpTo60DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(24034), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);

--- a/src/openrct2/ride/coaster/SideFrictionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/SideFrictionRollerCoaster.cpp
@@ -1987,24 +1987,6 @@ static void SideFrictionRCTrackDiag25DegUp(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21868), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2019,27 +2001,14 @@ static void SideFrictionRCTrackDiag25DegUp(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21844), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
@@ -2048,16 +2017,6 @@ static void SideFrictionRCTrackDiag25DegUp(
             {
                 switch (direction)
                 {
-                    case 0:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21866), { -16, -16, height },
@@ -2065,14 +2024,6 @@ static void SideFrictionRCTrackDiag25DegUp(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21869), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2080,16 +2031,6 @@ static void SideFrictionRCTrackDiag25DegUp(
             {
                 switch (direction)
                 {
-                    case 0:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21842), { -16, -16, height },
@@ -2097,17 +2038,14 @@ static void SideFrictionRCTrackDiag25DegUp(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21845), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
@@ -2351,24 +2289,6 @@ static void SideFrictionRCTrackDiag25DegUpToFlat(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21862), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2383,27 +2303,14 @@ static void SideFrictionRCTrackDiag25DegUpToFlat(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21838), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
@@ -2412,16 +2319,6 @@ static void SideFrictionRCTrackDiag25DegUpToFlat(
             {
                 switch (direction)
                 {
-                    case 0:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21860), { -16, -16, height },
@@ -2429,14 +2326,6 @@ static void SideFrictionRCTrackDiag25DegUpToFlat(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21863), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2444,16 +2333,6 @@ static void SideFrictionRCTrackDiag25DegUpToFlat(
             {
                 switch (direction)
                 {
-                    case 0:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21836), { -16, -16, height },
@@ -2461,17 +2340,14 @@ static void SideFrictionRCTrackDiag25DegUpToFlat(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21839), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
@@ -2549,24 +2425,6 @@ static void SideFrictionRCTrackDiag25DegDown(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21869), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2581,27 +2439,14 @@ static void SideFrictionRCTrackDiag25DegDown(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21845), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
@@ -2610,16 +2455,6 @@ static void SideFrictionRCTrackDiag25DegDown(
             {
                 switch (direction)
                 {
-                    case 0:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21864), { -16, -16, height },
@@ -2627,14 +2462,6 @@ static void SideFrictionRCTrackDiag25DegDown(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21868), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2642,16 +2469,6 @@ static void SideFrictionRCTrackDiag25DegDown(
             {
                 switch (direction)
                 {
-                    case 0:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21840), { -16, -16, height },
@@ -2659,17 +2476,14 @@ static void SideFrictionRCTrackDiag25DegDown(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21844), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
@@ -2745,24 +2559,6 @@ static void SideFrictionRCTrackDiagFlatTo25DegDown(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21863), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2777,43 +2573,20 @@ static void SideFrictionRCTrackDiagFlatTo25DegDown(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21839), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             break;
         case 2:
             if (trackElement.HasChain())
             {
                 switch (direction)
                 {
-                    case 0:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21858), { -16, -16, height },
@@ -2821,14 +2594,6 @@ static void SideFrictionRCTrackDiagFlatTo25DegDown(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21862), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2836,16 +2601,6 @@ static void SideFrictionRCTrackDiagFlatTo25DegDown(
             {
                 switch (direction)
                 {
-                    case 0:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21834), { -16, -16, height },
@@ -2853,17 +2608,14 @@ static void SideFrictionRCTrackDiagFlatTo25DegDown(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21838), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             break;
         case 3:
             if (trackElement.HasChain())
@@ -3300,26 +3052,12 @@ static void SideFrictionRCTrackDiag60DegUp(
                         session, direction,
                         session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_60_DEG_UP_DIR_0_B),
                         { -16, -16, height }, { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
 
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
@@ -3327,16 +3065,6 @@ static void SideFrictionRCTrackDiag60DegUp(
         case 2:
             switch (direction)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
@@ -3346,16 +3074,13 @@ static void SideFrictionRCTrackDiag60DegUp(
                         session, direction,
                         session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_60_DEG_UP_DIR_2_B),
                         { -16, -16, height }, { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
             break;
@@ -3414,42 +3139,19 @@ static void SideFrictionRCTrackDiag60DegUpTo25DegUp(
                         session, direction,
                         session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_60_DEG_UP_TO_25_DEG_UP_DIR_0_B),
                         { -16, -16, height }, { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 2:
             switch (direction)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
@@ -3459,16 +3161,13 @@ static void SideFrictionRCTrackDiag60DegUpTo25DegUp(
                         session, direction,
                         session.TrackColours[SCHEME_TRACK].WithIndex(SPR_SIDE_FRICTION_DIAG_60_DEG_UP_TO_25_DEG_UP_DIR_2_B),
                         { -16, -16, height }, { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
@@ -3525,42 +3224,19 @@ static void SideFrictionRCTrackDiag25DegUpTo60DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(24033), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 2:
             switch (direction)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
@@ -3569,16 +3245,13 @@ static void SideFrictionRCTrackDiag25DegUpTo60DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(24034), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;

--- a/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
@@ -9504,16 +9504,24 @@ static void WoodenRCTrackDiag25DegUp(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24935), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -9534,16 +9542,24 @@ static void WoodenRCTrackDiag25DegUp(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24893), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -9556,10 +9572,14 @@ static void WoodenRCTrackDiag25DegUp(
                 switch (direction)
                 {
                     case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -9574,10 +9594,14 @@ static void WoodenRCTrackDiag25DegUp(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24936), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -9586,10 +9610,14 @@ static void WoodenRCTrackDiag25DegUp(
                 switch (direction)
                 {
                     case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -9604,10 +9632,14 @@ static void WoodenRCTrackDiag25DegUp(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24894), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -9688,16 +9720,24 @@ static void WoodenRCTrackDiag60DegUp(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24911), { -16, -16, height },
                         { { -16, -16, height + 91 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9707,10 +9747,14 @@ static void WoodenRCTrackDiag60DegUp(
             switch (direction)
             {
                 case 0:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -9725,10 +9769,14 @@ static void WoodenRCTrackDiag60DegUp(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24912), { -16, -16, height },
                         { { -16, -16, height + 91 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9994,16 +10042,24 @@ static void WoodenRCTrackDiag25DegUpTo60DegUp(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24899), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10013,10 +10069,14 @@ static void WoodenRCTrackDiag25DegUpTo60DegUp(
             switch (direction)
             {
                 case 0:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -10031,10 +10091,14 @@ static void WoodenRCTrackDiag25DegUpTo60DegUp(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24900), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10097,16 +10161,24 @@ static void WoodenRCTrackDiag60DegUpTo25DegUp(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24905), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10116,10 +10188,14 @@ static void WoodenRCTrackDiag60DegUpTo25DegUp(
             switch (direction)
             {
                 case 0:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -10134,10 +10210,14 @@ static void WoodenRCTrackDiag60DegUpTo25DegUp(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24906), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10219,16 +10299,24 @@ static void WoodenRCTrackDiag25DegUpToFlat(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24929), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -10249,16 +10337,24 @@ static void WoodenRCTrackDiag25DegUpToFlat(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24887), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -10271,10 +10367,14 @@ static void WoodenRCTrackDiag25DegUpToFlat(
                 switch (direction)
                 {
                     case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -10289,10 +10389,14 @@ static void WoodenRCTrackDiag25DegUpToFlat(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24930), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -10301,10 +10405,14 @@ static void WoodenRCTrackDiag25DegUpToFlat(
                 switch (direction)
                 {
                     case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -10319,10 +10427,14 @@ static void WoodenRCTrackDiag25DegUpToFlat(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24888), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -10422,16 +10534,24 @@ static void WoodenRCTrackDiag25DegDown(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24936), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -10452,16 +10572,24 @@ static void WoodenRCTrackDiag25DegDown(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24894), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -10474,10 +10602,14 @@ static void WoodenRCTrackDiag25DegDown(
                 switch (direction)
                 {
                     case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -10492,10 +10624,14 @@ static void WoodenRCTrackDiag25DegDown(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24935), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -10504,10 +10640,14 @@ static void WoodenRCTrackDiag25DegDown(
                 switch (direction)
                 {
                     case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -10522,10 +10662,14 @@ static void WoodenRCTrackDiag25DegDown(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24893), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -10606,16 +10750,24 @@ static void WoodenRCTrackDiag60DegDown(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24912), { -16, -16, height },
                         { { -16, -16, height + 91 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10625,10 +10777,14 @@ static void WoodenRCTrackDiag60DegDown(
             switch (direction)
             {
                 case 0:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -10643,10 +10799,14 @@ static void WoodenRCTrackDiag60DegDown(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24911), { -16, -16, height },
                         { { -16, -16, height + 91 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10726,16 +10886,24 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24930), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -10756,16 +10924,24 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24888), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -10776,10 +10952,14 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                 switch (direction)
                 {
                     case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -10794,10 +10974,14 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24929), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -10806,10 +10990,14 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                 switch (direction)
                 {
                     case 0:
-                        WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -10824,10 +11012,14 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24887), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenBSupportsPaintSetup(
+                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -10907,16 +11099,24 @@ static void WoodenRCTrackDiag25DegDownTo60DegDown(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24906), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10926,10 +11126,14 @@ static void WoodenRCTrackDiag25DegDownTo60DegDown(
             switch (direction)
             {
                 case 0:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -10944,10 +11148,14 @@ static void WoodenRCTrackDiag25DegDownTo60DegDown(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24905), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11010,16 +11218,24 @@ static void WoodenRCTrackDiag60DegDownTo25DegDown(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24900), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11029,10 +11245,14 @@ static void WoodenRCTrackDiag60DegDownTo25DegDown(
             switch (direction)
             {
                 case 0:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -11047,10 +11267,14 @@ static void WoodenRCTrackDiag60DegDownTo25DegDown(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24899), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11934,16 +12158,24 @@ static void WoodenRCTrackDiag25DegUpToLeftBank(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24959), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11953,10 +12185,14 @@ static void WoodenRCTrackDiag25DegUpToLeftBank(
             switch (direction)
             {
                 case 0:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -11971,10 +12207,14 @@ static void WoodenRCTrackDiag25DegUpToLeftBank(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24960), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -12037,16 +12277,24 @@ static void WoodenRCTrackDiag25DegUpToRightBank(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24965), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -12056,10 +12304,14 @@ static void WoodenRCTrackDiag25DegUpToRightBank(
             switch (direction)
             {
                 case 0:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -12074,10 +12326,14 @@ static void WoodenRCTrackDiag25DegUpToRightBank(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24966), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -12138,16 +12394,24 @@ static void WoodenRCTrackDiagLeftBankTo25DegDown(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24966), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             break;
@@ -12155,10 +12419,14 @@ static void WoodenRCTrackDiagLeftBankTo25DegDown(
             switch (direction)
             {
                 case 0:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -12173,10 +12441,14 @@ static void WoodenRCTrackDiagLeftBankTo25DegDown(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24965), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             break;
@@ -12236,16 +12508,24 @@ static void WoodenRCTrackDiagRightBankTo25DegDown(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24960), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             break;
@@ -12253,10 +12533,14 @@ static void WoodenRCTrackDiagRightBankTo25DegDown(
             switch (direction)
             {
                 case 0:
-                    WoodenBSupportsPaintSetup(session, 4, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenBSupportsPaintSetup(session, 5, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -12271,10 +12555,14 @@ static void WoodenRCTrackDiagRightBankTo25DegDown(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24959), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenBSupportsPaintSetup(session, 3, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenBSupportsPaintSetup(
+                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             break;

--- a/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
@@ -9504,26 +9504,11 @@ static void WoodenRCTrackDiag25DegUp(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24935), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
             }
             else
             {
@@ -9542,26 +9527,11 @@ static void WoodenRCTrackDiag25DegUp(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24893), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
@@ -9571,16 +9541,6 @@ static void WoodenRCTrackDiag25DegUp(
             {
                 switch (direction)
                 {
-                    case 0:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24067),
@@ -9594,14 +9554,6 @@ static void WoodenRCTrackDiag25DegUp(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24936), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -9609,16 +9561,6 @@ static void WoodenRCTrackDiag25DegUp(
             {
                 switch (direction)
                 {
-                    case 0:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24025),
@@ -9632,17 +9574,14 @@ static void WoodenRCTrackDiag25DegUp(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24894), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
@@ -9720,42 +9659,17 @@ static void WoodenRCTrackDiag60DegUp(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24911), { -16, -16, height },
                         { { -16, -16, height + 91 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
             break;
         case 2:
             switch (direction)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24043), { -16, -16, height },
@@ -9769,16 +9683,13 @@ static void WoodenRCTrackDiag60DegUp(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24912), { -16, -16, height },
                         { { -16, -16, height + 91 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
             break;
@@ -10042,42 +9953,17 @@ static void WoodenRCTrackDiag25DegUpTo60DegUp(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24899), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
         case 2:
             switch (direction)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24031), { -16, -16, height },
@@ -10091,16 +9977,13 @@ static void WoodenRCTrackDiag25DegUpTo60DegUp(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24900), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
@@ -10161,42 +10044,17 @@ static void WoodenRCTrackDiag60DegUpTo25DegUp(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24905), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
         case 2:
             switch (direction)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24037), { -16, -16, height },
@@ -10210,16 +10068,11 @@ static void WoodenRCTrackDiag60DegUpTo25DegUp(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24906), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
@@ -10299,26 +10152,11 @@ static void WoodenRCTrackDiag25DegUpToFlat(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24929), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
             }
             else
             {
@@ -10337,26 +10175,11 @@ static void WoodenRCTrackDiag25DegUpToFlat(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24887), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
@@ -10366,16 +10189,6 @@ static void WoodenRCTrackDiag25DegUpToFlat(
             {
                 switch (direction)
                 {
-                    case 0:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24061),
@@ -10389,14 +10202,6 @@ static void WoodenRCTrackDiag25DegUpToFlat(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24930), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -10404,16 +10209,6 @@ static void WoodenRCTrackDiag25DegUpToFlat(
             {
                 switch (direction)
                 {
-                    case 0:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24019),
@@ -10427,17 +10222,14 @@ static void WoodenRCTrackDiag25DegUpToFlat(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24888), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
@@ -10534,26 +10326,11 @@ static void WoodenRCTrackDiag25DegDown(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24936), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
             }
             else
             {
@@ -10572,26 +10349,11 @@ static void WoodenRCTrackDiag25DegDown(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24894), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
@@ -10601,16 +10363,6 @@ static void WoodenRCTrackDiag25DegDown(
             {
                 switch (direction)
                 {
-                    case 0:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24065),
@@ -10624,14 +10376,6 @@ static void WoodenRCTrackDiag25DegDown(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24935), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -10639,16 +10383,6 @@ static void WoodenRCTrackDiag25DegDown(
             {
                 switch (direction)
                 {
-                    case 0:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24023),
@@ -10662,17 +10396,14 @@ static void WoodenRCTrackDiag25DegDown(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24893), { -16, -16, height },
                             { { -16, -16, height + 43 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
@@ -10750,42 +10481,17 @@ static void WoodenRCTrackDiag60DegDown(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24912), { -16, -16, height },
                         { { -16, -16, height + 91 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
             break;
         case 2:
             switch (direction)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24041), { -16, -16, height },
@@ -10799,16 +10505,11 @@ static void WoodenRCTrackDiag60DegDown(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24911), { -16, -16, height },
                         { { -16, -16, height + 91 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
             break;
@@ -10886,26 +10587,11 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24930), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
             }
             else
             {
@@ -10924,26 +10610,11 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24888), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 2:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
+                WoodenBSupportsPaintSetupRotated(
+                    session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                    session.TrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 2:
@@ -10951,16 +10622,6 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
             {
                 switch (direction)
                 {
-                    case 0:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24059),
@@ -10974,14 +10635,6 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24929), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -10989,16 +10642,6 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
             {
                 switch (direction)
                 {
-                    case 0:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 1:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24017),
@@ -11012,17 +10655,14 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24887), { -16, -16, height },
                             { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
-                        break;
-                    case 3:
-                        WoodenBSupportsPaintSetup(
-                            session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             break;
         case 3:
             if (trackElement.HasChain())
@@ -11099,42 +10739,17 @@ static void WoodenRCTrackDiag25DegDownTo60DegDown(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24906), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
         case 2:
             switch (direction)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24035), { -16, -16, height },
@@ -11148,16 +10763,11 @@ static void WoodenRCTrackDiag25DegDownTo60DegDown(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24905), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
@@ -11218,42 +10828,17 @@ static void WoodenRCTrackDiag60DegDownTo25DegDown(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24900), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
         case 2:
             switch (direction)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24029), { -16, -16, height },
@@ -11267,16 +10852,11 @@ static void WoodenRCTrackDiag60DegDownTo25DegDown(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24899), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
             break;
@@ -12158,42 +11738,17 @@ static void WoodenRCTrackDiag25DegUpToLeftBank(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24959), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
         case 2:
             switch (direction)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24091), { -16, -16, height },
@@ -12207,16 +11762,11 @@ static void WoodenRCTrackDiag25DegUpToLeftBank(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24960), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
@@ -12277,42 +11827,17 @@ static void WoodenRCTrackDiag25DegUpToRightBank(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24965), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
         case 2:
             switch (direction)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24097), { -16, -16, height },
@@ -12326,16 +11851,11 @@ static void WoodenRCTrackDiag25DegUpToRightBank(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24966), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
             break;
@@ -12394,40 +11914,15 @@ static void WoodenRCTrackDiagLeftBankTo25DegDown(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24966), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             switch (direction)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24095), { -16, -16, height },
@@ -12441,16 +11936,13 @@ static void WoodenRCTrackDiagLeftBankTo25DegDown(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24965), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             break;
         case 3:
             switch (direction)
@@ -12508,40 +12000,15 @@ static void WoodenRCTrackDiagRightBankTo25DegDown(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24960), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 2:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             switch (direction)
             {
-                case 0:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 1:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner3, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24089), { -16, -16, height },
@@ -12555,16 +12022,11 @@ static void WoodenRCTrackDiagRightBankTo25DegDown(
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24959), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner0, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
-                    break;
-                case 3:
-                    WoodenBSupportsPaintSetup(
-                        session, WoodenSupportType::Truss, WoodenSupportSubType::Corner1, height + 16,
-                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+            WoodenBSupportsPaintSetupRotated(
+                session, WoodenSupportType::Truss, WoodenSupportSubType::Corner2, direction, height + 16,
+                session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             switch (direction)

--- a/src/openrct2/ride/transport/MiniatureRailway.cpp
+++ b/src/openrct2/ride/transport/MiniatureRailway.cpp
@@ -1846,27 +1846,6 @@ static void MiniatureRailwayTrackDiagFlat(
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
 
-enum
-{
-    WOOD_A = 0,
-    WOOD_B = 1,
-};
-
-static bool WoodenSupportsPaintSetup(
-    PaintSession& session, int32_t woodType, int32_t supportType, int32_t special, int32_t height, ImageId imageColourFlags)
-{
-    switch (woodType)
-    {
-        case WOOD_A:
-            return WoodenASupportsPaintSetup(session, supportType, special, height, imageColourFlags);
-
-        case WOOD_B:
-            return WoodenBSupportsPaintSetup(session, supportType, special, height, imageColourFlags);
-    }
-
-    return false;
-}
-
 /** rct2: 0x008AD230 */
 static void MiniatureRailwayTrackDiag25DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
@@ -1888,19 +1867,21 @@ static void MiniatureRailwayTrackDiag25DegUp(
     auto supportType = _diagSupportTypes[direction][trackSequence];
     if (supportType.has_value())
     {
-        // TODO: The supports are inconsistent for different rotations
-        int8_t supportFunction = WOOD_B;
-        if (supportType == WoodenSupportSubType::NeSw || supportType == WoodenSupportSubType::NwSe)
-        {
-            supportFunction = WOOD_A;
-        }
-
         const auto enumValue = EnumValue(supportType.value());
         floorImage = floors[enumValue].image_id;
         floorBoundSize = floors[enumValue].bound_size;
         floorBoundOffset = floors[enumValue].bound_offset;
-        hasSupports = WoodenSupportsPaintSetup(
-            session, supportFunction, enumValue, 0, height + heightDiff, session.TrackColours[SCHEME_SUPPORTS]);
+
+        if (trackSequence == 3)
+        {
+            hasSupports = WoodenASupportsPaintSetup(
+                session, enumValue, 0, height + heightDiff, session.TrackColours[SCHEME_SUPPORTS]);
+        }
+        else
+        {
+            hasSupports = WoodenBSupportsPaintSetup(
+                session, enumValue, 0, height + heightDiff, session.TrackColours[SCHEME_SUPPORTS]);
+        }
     }
 
     if (direction == 1 && trackSequence == 3)
@@ -2012,12 +1993,6 @@ static void MiniatureRailwayTrackDiag25DegUpToFlat(
         { 0, -8, -8, +8 },
     };
 
-    int8_t supportFunction = WOOD_B;
-    if (trackSequence == 3)
-    {
-        supportFunction = WOOD_A;
-    }
-
     bool hasSupports = false;
     auto supportType = _diagSupportTypes[direction][trackSequence];
 
@@ -2031,9 +2006,18 @@ static void MiniatureRailwayTrackDiag25DegUpToFlat(
         floorImage = floors[enumValue].image_id;
         floorBoundSize = floors[enumValue].bound_size;
         floorBoundOffset = floors[enumValue].bound_offset;
-        hasSupports = WoodenSupportsPaintSetup(
-            session, supportFunction, enumValue, 0, height + supportOffsets[direction][trackSequence],
-            session.TrackColours[SCHEME_SUPPORTS]);
+        if (trackSequence == 3)
+        {
+            hasSupports = WoodenASupportsPaintSetup(
+                session, enumValue, 0, height + supportOffsets[direction][trackSequence],
+                session.TrackColours[SCHEME_SUPPORTS]);
+        }
+        else
+        {
+            hasSupports = WoodenBSupportsPaintSetup(
+                session, enumValue, 0, height + supportOffsets[direction][trackSequence],
+                session.TrackColours[SCHEME_SUPPORTS]);
+        }
     }
 
     if (direction == 1 && trackSequence == 3)
@@ -2089,12 +2073,6 @@ static void MiniatureRailwayTrackDiag25DegDown(
         { 0, -8, -8, -8 },
     };
 
-    int8_t supportFunction = WOOD_B;
-    if (trackSequence == 3)
-    {
-        supportFunction = WOOD_A;
-    }
-
     bool hasSupports = false;
 
     uint32_t floorImage = 0;
@@ -2108,9 +2086,18 @@ static void MiniatureRailwayTrackDiag25DegDown(
         floorImage = floors[enumValue].image_id;
         floorBoundSize = floors[enumValue].bound_size;
         floorBoundOffset = floors[enumValue].bound_offset;
-        hasSupports = WoodenSupportsPaintSetup(
-            session, supportFunction, enumValue, 0, height + supportOffsets[direction][trackSequence],
-            session.TrackColours[SCHEME_SUPPORTS]);
+        if (trackSequence == 3)
+        {
+            hasSupports = WoodenASupportsPaintSetup(
+                session, enumValue, 0, height + supportOffsets[direction][trackSequence],
+                session.TrackColours[SCHEME_SUPPORTS]);
+        }
+        else
+        {
+            hasSupports = WoodenBSupportsPaintSetup(
+                session, enumValue, 0, height + supportOffsets[direction][trackSequence],
+                session.TrackColours[SCHEME_SUPPORTS]);
+        }
     }
 
     if (direction == 1 && trackSequence == 3)
@@ -2165,12 +2152,6 @@ static void MiniatureRailwayTrackDiagFlatTo25DegDown(
         { 0, -8, -8, -8 },
     };
 
-    int8_t supportFunction = WOOD_B;
-    if (trackSequence == 3)
-    {
-        supportFunction = WOOD_A;
-    }
-
     bool hasSupports = false;
     uint32_t floorImage = 0;
     CoordsXY floorBoundSize;
@@ -2183,9 +2164,18 @@ static void MiniatureRailwayTrackDiagFlatTo25DegDown(
         floorImage = floors[enumValue].image_id;
         floorBoundSize = floors[enumValue].bound_size;
         floorBoundOffset = floors[enumValue].bound_offset;
-        hasSupports = WoodenSupportsPaintSetup(
-            session, supportFunction, enumValue, 0, height + supportOffsets[direction][trackSequence],
-            session.TrackColours[SCHEME_SUPPORTS]);
+        if (trackSequence == 3)
+        {
+            hasSupports = WoodenASupportsPaintSetup(
+                session, enumValue, 0, height + supportOffsets[direction][trackSequence],
+                session.TrackColours[SCHEME_SUPPORTS]);
+        }
+        else
+        {
+            hasSupports = WoodenBSupportsPaintSetup(
+                session, enumValue, 0, height + supportOffsets[direction][trackSequence],
+                session.TrackColours[SCHEME_SUPPORTS]);
+        }
     }
 
     if (direction == 1 && trackSequence == 3)

--- a/src/openrct2/ride/transport/MiniatureRailway.cpp
+++ b/src/openrct2/ride/transport/MiniatureRailway.cpp
@@ -1880,7 +1880,8 @@ static void MiniatureRailwayTrackDiag25DegUp(
         else
         {
             hasSupports = WoodenBSupportsPaintSetup(
-                session, enumValue, 0, height + heightDiff, session.TrackColours[SCHEME_SUPPORTS]);
+                session, WoodenSupportType::Truss, supportType.value(), height + heightDiff,
+                session.TrackColours[SCHEME_SUPPORTS]);
         }
     }
 
@@ -2015,7 +2016,7 @@ static void MiniatureRailwayTrackDiag25DegUpToFlat(
         else
         {
             hasSupports = WoodenBSupportsPaintSetup(
-                session, enumValue, 0, height + supportOffsets[direction][trackSequence],
+                session, WoodenSupportType::Truss, supportType.value(), height + supportOffsets[direction][trackSequence],
                 session.TrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -2095,7 +2096,7 @@ static void MiniatureRailwayTrackDiag25DegDown(
         else
         {
             hasSupports = WoodenBSupportsPaintSetup(
-                session, enumValue, 0, height + supportOffsets[direction][trackSequence],
+                session, WoodenSupportType::Truss, supportType.value(), height + supportOffsets[direction][trackSequence],
                 session.TrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -2173,7 +2174,7 @@ static void MiniatureRailwayTrackDiagFlatTo25DegDown(
         else
         {
             hasSupports = WoodenBSupportsPaintSetup(
-                session, enumValue, 0, height + supportOffsets[direction][trackSequence],
+                session, WoodenSupportType::Truss, supportType.value(), height + supportOffsets[direction][trackSequence],
                 session.TrackColours[SCHEME_SUPPORTS]);
         }
     }


### PR DESCRIPTION
This PR refactors all remaining calls to WoodenBSupportsSetup() to use the WoodenSupportType enum. Together with WoodenBSupportsSetupRotated(), this allowed for a consolidation, removing almost 1000 lines.