### PR TITLE
Paint/remove two colours

### DIFF
--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -197,7 +197,7 @@ struct PaintSessionCore
     uint32_t ViewFlags;
     uint32_t QuadrantBackIndex;
     uint32_t QuadrantFrontIndex;
-    ImageId TrackColours[4];
+    ImageId TrackColours[2];
     SupportHeight SupportSegments[9];
     SupportHeight Support;
     uint16_t WaterHeight;
@@ -281,7 +281,8 @@ extern CoordsXY gClipSelectionB;
 /** rct2: 0x00993CC4. The white ghost that indicates not-yet-built elements. */
 constexpr ImageId ConstructionMarker = ImageId(0).WithRemap(FilterPaletteID::PaletteGhost);
 constexpr ImageId HighlightMarker = ImageId(0).WithRemap(FilterPaletteID::PaletteGhost);
-constexpr ImageId TrackGhost = ImageId(0, FilterPaletteID::PaletteNull);
+constexpr ImageId TrackStationColour = ImageId(0, COLOUR_BLACK);
+constexpr ImageId ShopSupportColour = ImageId(0, COLOUR_DARK_BROWN);
 
 extern bool gShowDirtyVisuals;
 extern bool gPaintBoundingBoxes;

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -411,7 +411,8 @@ static void TrackPaintUtilDrawStationImpl(
         }
         PaintAddImageAsParent(session, imageId, { 0, 0, height + fenceOffsetA }, { 32, 8, 1 });
         // height -= 5 (height)
-        TrackPaintUtilDrawStationCovers(session, EDGE_NW, hasFence, stationObj, coverHeight);
+        TrackPaintUtilDrawStationCovers(
+            session, EDGE_NW, hasFence, stationObj, coverHeight, GetStationColourScheme(session, trackElement));
         // height += 5 (height + 5)
 
         if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 0)
@@ -460,7 +461,8 @@ static void TrackPaintUtilDrawStationImpl(
             PaintAddImageAsParent(session, imageId, { 31, 23, height + fenceOffsetB }, { 1, 8, 7 });
         }
         // height -= 7 (height)
-        TrackPaintUtilDrawStationCovers(session, EDGE_SE, hasFence, stationObj, coverHeight);
+        TrackPaintUtilDrawStationCovers(
+            session, EDGE_SE, hasFence, stationObj, coverHeight, GetStationColourScheme(session, trackElement));
         // height += 7 (height + 7)
 
         if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 0)
@@ -504,7 +506,8 @@ static void TrackPaintUtilDrawStationImpl(
         }
         PaintAddImageAsParent(session, imageId, { 0, 0, height + fenceOffsetA }, { 8, 32, 1 });
         // height -= 5 (height)
-        TrackPaintUtilDrawStationCovers(session, EDGE_NE, hasFence, stationObj, coverHeight);
+        TrackPaintUtilDrawStationCovers(
+            session, EDGE_NE, hasFence, stationObj, coverHeight, GetStationColourScheme(session, trackElement));
         // height += 5 (height + 5)
 
         if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 3)
@@ -554,7 +557,8 @@ static void TrackPaintUtilDrawStationImpl(
         }
 
         // height -= 7 (height)
-        TrackPaintUtilDrawStationCovers(session, EDGE_SW, hasFence, stationObj, coverHeight);
+        TrackPaintUtilDrawStationCovers(
+            session, EDGE_SW, hasFence, stationObj, coverHeight, GetStationColourScheme(session, trackElement));
         // height += 7 (height + 7)
 
         if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 3)
@@ -581,6 +585,7 @@ void TrackPaintUtilDrawStationInverted(
     if (stationObj != nullptr && stationObj->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS)
         return;
 
+    auto colour = GetStationColourScheme(session, trackElement);
     bool hasFence;
     ImageId imageId;
 
@@ -614,7 +619,7 @@ void TrackPaintUtilDrawStationInverted(
         }
         PaintAddImageAsParent(session, imageId, { 0, 0, height + 6 }, { 32, 8, 1 });
         // height -= 5 (height)
-        TrackPaintUtilDrawStationCovers2(session, EDGE_NW, hasFence, stationObj, height, stationVariant);
+        TrackPaintUtilDrawStationCovers2(session, EDGE_NW, hasFence, stationObj, height, stationVariant, colour);
         // height += 5 (height + 5)
 
         if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 0)
@@ -663,7 +668,7 @@ void TrackPaintUtilDrawStationInverted(
             PaintAddImageAsParent(session, imageId, { 31, 23, height + 8 }, { 1, 8, 7 });
         }
         // height -= 7 (height)
-        TrackPaintUtilDrawStationCovers2(session, EDGE_SE, hasFence, stationObj, height, stationVariant);
+        TrackPaintUtilDrawStationCovers2(session, EDGE_SE, hasFence, stationObj, height, stationVariant, colour);
         // height += 7 (height + 7)
 
         if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 0)
@@ -707,7 +712,7 @@ void TrackPaintUtilDrawStationInverted(
         }
         PaintAddImageAsParent(session, imageId, { 0, 0, height + 6 }, { 8, 32, 1 });
         // height -= 5 (height)
-        TrackPaintUtilDrawStationCovers2(session, EDGE_NE, hasFence, stationObj, height, stationVariant);
+        TrackPaintUtilDrawStationCovers2(session, EDGE_NE, hasFence, stationObj, height, stationVariant, colour);
         // height += 5 (height + 5)
 
         if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 3)
@@ -757,7 +762,7 @@ void TrackPaintUtilDrawStationInverted(
         }
 
         // height -= 7 (height)
-        TrackPaintUtilDrawStationCovers2(session, EDGE_SW, hasFence, stationObj, height, stationVariant);
+        TrackPaintUtilDrawStationCovers2(session, EDGE_SW, hasFence, stationObj, height, stationVariant, colour);
         // height += 7 (height + 7)
 
         if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 3)
@@ -774,14 +779,14 @@ void TrackPaintUtilDrawStationInverted(
 }
 
 bool TrackPaintUtilDrawStationCovers(
-    PaintSession& session, enum edge_t edge, bool hasFence, const StationObject* stationObject, uint16_t height)
+    PaintSession& session, enum edge_t edge, bool hasFence, const StationObject* stationObject, uint16_t height, ImageId colour)
 {
-    return TrackPaintUtilDrawStationCovers2(session, edge, hasFence, stationObject, height, STATION_VARIANT_BASIC);
+    return TrackPaintUtilDrawStationCovers2(session, edge, hasFence, stationObject, height, STATION_VARIANT_BASIC, colour);
 }
 
 bool TrackPaintUtilDrawStationCovers2(
     PaintSession& session, enum edge_t edge, bool hasFence, const StationObject* stationObject, uint16_t height,
-    uint8_t stationVariant)
+    uint8_t stationVariant, ImageId colour)
 {
     if (stationObject == nullptr)
     {
@@ -836,7 +841,7 @@ bool TrackPaintUtilDrawStationCovers2(
     PaintAddImageAsParent(session, imageId, offset, boundBox);
 
     // Glass
-    if (session.TrackColours[SCHEME_MISC] == TrackGhost && (stationObject->Flags & STATION_OBJECT_FLAGS::IS_TRANSPARENT))
+    if (colour == TrackStationColour && (stationObject->Flags & STATION_OBJECT_FLAGS::IS_TRANSPARENT))
     {
         imageId = ImageId(baseImageIndex + imageOffset + 12).WithTransparency(imageTemplate.GetPrimary());
         PaintAddImageAsChild(session, imageId, offset, boundBox);
@@ -852,14 +857,14 @@ void TrackPaintUtilDrawNarrowStationPlatform(
     const auto* stationObj = ride.GetStationObject();
     if (stationObj != nullptr && stationObj->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS)
         return;
-
+    auto colour = GetStationColourScheme(session, trackElement);
     if (direction & 1)
     {
         bool hasFence = TrackPaintUtilHasFence(EDGE_NE, position, trackElement, ride, session.CurrentRotation);
         ImageId imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
             (hasFence ? SPR_STATION_NARROW_EDGE_FENCED_NE : SPR_STATION_NARROW_EDGE_NE));
         PaintAddImageAsParent(session, imageId, { 0, 0, height + zOffset }, { 8, 32, 1 });
-        TrackPaintUtilDrawStationCovers(session, EDGE_NE, hasFence, stationObj, height);
+        TrackPaintUtilDrawStationCovers(session, EDGE_NE, hasFence, stationObj, height, colour);
 
         imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_NARROW_EDGE_SW);
         PaintAddImageAsParent(session, imageId, { 24, 0, height + zOffset }, { 8, 32, 1 });
@@ -870,7 +875,7 @@ void TrackPaintUtilDrawNarrowStationPlatform(
             imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_FENCE_NW_SE);
             PaintAddImageAsParent(session, imageId, { 31, 0, height + zOffset + 2 }, { 1, 32, 7 });
         }
-        TrackPaintUtilDrawStationCovers(session, EDGE_SW, hasFence, stationObj, height);
+        TrackPaintUtilDrawStationCovers(session, EDGE_SW, hasFence, stationObj, height, colour);
     }
     else
     {
@@ -878,7 +883,7 @@ void TrackPaintUtilDrawNarrowStationPlatform(
         ImageId imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
             (hasFence ? SPR_STATION_NARROW_EDGE_FENCED_NW : SPR_STATION_NARROW_EDGE_NW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height + zOffset }, { 32, 8, 1 });
-        TrackPaintUtilDrawStationCovers(session, EDGE_NW, hasFence, stationObj, height);
+        TrackPaintUtilDrawStationCovers(session, EDGE_NW, hasFence, stationObj, height, colour);
 
         imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_NARROW_EDGE_SE);
         PaintAddImageAsParent(session, imageId, { 0, 24, height + zOffset }, { 32, 8, 1 });
@@ -889,7 +894,7 @@ void TrackPaintUtilDrawNarrowStationPlatform(
             imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_FENCE_SW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 31, height + zOffset + 2 }, { 32, 1, 7 });
         }
-        TrackPaintUtilDrawStationCovers(session, EDGE_SE, hasFence, stationObj, height);
+        TrackPaintUtilDrawStationCovers(session, EDGE_SE, hasFence, stationObj, height, colour);
     }
 }
 
@@ -899,7 +904,7 @@ void TrackPaintUtilDrawPier(
 {
     if (stationObj != nullptr && stationObj->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS)
         return;
-
+    auto colour = GetStationColourScheme(session, trackElement);
     bool hasFence;
     ImageId imageId;
 
@@ -909,7 +914,7 @@ void TrackPaintUtilDrawPier(
         imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
             (hasFence ? SPR_STATION_PIER_EDGE_NE_FENCED : SPR_STATION_PIER_EDGE_NE));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 2, 0, height }, { 6, 32, 1 } });
-        TrackPaintUtilDrawStationCovers(session, EDGE_NE, hasFence, stationObj, height);
+        TrackPaintUtilDrawStationCovers(session, EDGE_NE, hasFence, stationObj, height, colour);
 
         imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_PIER_EDGE_SW);
         PaintAddImageAsParent(session, imageId, { 24, 0, height }, { 8, 32, 1 });
@@ -920,7 +925,7 @@ void TrackPaintUtilDrawPier(
             imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_PIER_FENCE_SW);
             PaintAddImageAsParent(session, imageId, { 31, 0, height + 2 }, { 1, 32, 7 });
         }
-        TrackPaintUtilDrawStationCovers(session, EDGE_SW, hasFence, stationObj, height);
+        TrackPaintUtilDrawStationCovers(session, EDGE_SW, hasFence, stationObj, height, colour);
     }
     else
     {
@@ -928,7 +933,7 @@ void TrackPaintUtilDrawPier(
         imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(
             (hasFence ? SPR_STATION_PIER_EDGE_NW_FENCED : SPR_STATION_PIER_EDGE_NW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 0, 2, height }, { 32, 6, 1 } });
-        TrackPaintUtilDrawStationCovers(session, EDGE_NW, hasFence, stationObj, height);
+        TrackPaintUtilDrawStationCovers(session, EDGE_NW, hasFence, stationObj, height, colour);
 
         imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_PIER_EDGE_SE);
         PaintAddImageAsParent(session, imageId, { 0, 24, height }, { 32, 8, 1 });
@@ -939,7 +944,7 @@ void TrackPaintUtilDrawPier(
             imageId = session.TrackColours[SCHEME_SUPPORTS].WithIndex(SPR_STATION_PIER_FENCE_SE);
             PaintAddImageAsParent(session, imageId, { 0, 31, height + 2 }, { 32, 1, 7 });
         }
-        TrackPaintUtilDrawStationCovers(session, EDGE_SE, hasFence, stationObj, height);
+        TrackPaintUtilDrawStationCovers(session, EDGE_SE, hasFence, stationObj, height, colour);
     }
 }
 
@@ -2066,8 +2071,8 @@ void TrackPaintUtilOnridePhotoSmallPaint(
     };
 
     bool takingPhoto = trackElement.IsTakingPhoto();
-    ImageId imageId = session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]);
-    ImageId flashImageId = session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][takingPhoto ? 2 : 1]);
+    ImageId imageId = GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][0]);
+    ImageId flashImageId = GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][takingPhoto ? 2 : 1]);
     switch (direction)
     {
         case 0:
@@ -2104,8 +2109,8 @@ void TrackPaintUtilOnridePhotoPaint(
     };
 
     bool takingPhoto = trackElement.IsTakingPhoto();
-    ImageId imageId = session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]);
-    ImageId flashImageId = session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][takingPhoto ? 2 : 1]);
+    ImageId imageId = GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][0]);
+    ImageId flashImageId = GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][takingPhoto ? 2 : 1]);
     switch (direction)
     {
         case 0:
@@ -2175,6 +2180,32 @@ void TrackPaintUtilLeftCorkscrewUpSupports(PaintSession& session, Direction dire
     }
 }
 
+ImageId GetStationColourScheme(PaintSession& session, const TrackElement& trackElement)
+{
+    if (trackElement.IsGhost())
+    {
+        return ConstructionMarker;
+    }
+    if (trackElement.IsHighlighted() || session.SelectedElement == reinterpret_cast<const TileElement*>(&trackElement))
+    {
+        return HighlightMarker;
+    }
+    return TrackStationColour;
+}
+
+ImageId GetShopSupportColourScheme(PaintSession& session, const TrackElement& trackElement)
+{
+    if (trackElement.IsGhost())
+    {
+        return ConstructionMarker;
+    }
+    if (trackElement.IsHighlighted() || session.SelectedElement == reinterpret_cast<const TileElement*>(&trackElement))
+    {
+        return HighlightMarker;
+    }
+    return ShopSupportColour;
+}
+
 /**
  *
  *  rct2: 0x006C4794
@@ -2230,22 +2261,16 @@ void PaintTrack(PaintSession& session, Direction direction, int32_t height, cons
         session.TrackColours[SCHEME_TRACK] = ImageId(
             0, ride->track_colour[trackColourScheme].main, ride->track_colour[trackColourScheme].additional);
         session.TrackColours[SCHEME_SUPPORTS] = ImageId(0, ride->track_colour[trackColourScheme].supports);
-        session.TrackColours[SCHEME_MISC] = ImageId(0, COLOUR_BLACK);
-        session.TrackColours[SCHEME_3] = ImageId(0, COLOUR_DARK_BROWN);
         if (trackElement.IsHighlighted() || session.SelectedElement == reinterpret_cast<const TileElement*>(&trackElement))
         {
             session.TrackColours[SCHEME_TRACK] = HighlightMarker;
             session.TrackColours[SCHEME_SUPPORTS] = HighlightMarker;
-            session.TrackColours[SCHEME_MISC] = HighlightMarker;
-            session.TrackColours[SCHEME_3] = HighlightMarker;
         }
         if (trackElement.IsGhost())
         {
             session.InteractionType = ViewportInteractionItem::None;
             session.TrackColours[SCHEME_TRACK] = ConstructionMarker;
             session.TrackColours[SCHEME_SUPPORTS] = ConstructionMarker;
-            session.TrackColours[SCHEME_MISC] = ConstructionMarker;
-            session.TrackColours[SCHEME_3] = ConstructionMarker;
         }
 
         if (ride->type >= RIDE_TYPE_COUNT)

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -210,10 +210,8 @@ enum
 
 enum
 {
-    SCHEME_TRACK = 0,
-    SCHEME_SUPPORTS = 1,
-    SCHEME_MISC = 2,
-    SCHEME_3 = 3,
+    SCHEME_TRACK,
+    SCHEME_SUPPORTS
 };
 
 enum
@@ -283,6 +281,9 @@ extern const uint8_t mapLeftEighthTurnToOrthogonal[5];
 
 extern const size_t MiniGolfPeepAnimationLengths[];
 
+ImageId GetStationColourScheme(PaintSession& session, const TrackElement& trackElement);
+ImageId GetShopSupportColourScheme(PaintSession& session, const TrackElement& trackElement);
+
 bool TrackPaintUtilHasFence(
     enum edge_t edge, const CoordsXY& position, const TrackElement& trackElement, const Ride& ride, uint8_t rotation);
 void TrackPaintUtilPaintFloor(
@@ -292,10 +293,11 @@ void TrackPaintUtilPaintFences(
     PaintSession& session, uint8_t edges, const CoordsXY& position, const TrackElement& trackElement, const Ride& ride,
     const ImageId colourFlags, uint16_t height, const uint32_t fenceSprites[4], uint8_t rotation);
 bool TrackPaintUtilDrawStationCovers(
-    PaintSession& session, enum edge_t edge, bool hasFence, const StationObject* stationObject, uint16_t height);
+    PaintSession& session, enum edge_t edge, bool hasFence, const StationObject* stationObject, uint16_t height,
+    ImageId colour);
 bool TrackPaintUtilDrawStationCovers2(
     PaintSession& session, enum edge_t edge, bool hasFence, const StationObject* stationObject, uint16_t height,
-    uint8_t stationVariant);
+    uint8_t stationVariant, ImageId colour);
 void TrackPaintUtilDrawNarrowStationPlatform(
     PaintSession& session, const Ride& ride, Direction direction, int32_t height, int32_t zOffset,
     const TrackElement& trackElement);

--- a/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
+++ b/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
@@ -210,8 +210,8 @@ static void AirPoweredVerticalRCTrackStation(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height - 2 },
-        { { 0, 2, height }, { 32, 28, 1 } });
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][1]),
+        { 0, 0, height - 2 }, { { 0, 2, height }, { 32, 28, 1 } });
     PaintAddImageAsChildRotated(
         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
         { { 0, 6, height }, { 32, 20, 1 } });

--- a/src/openrct2/ride/coaster/AlpineCoaster.cpp
+++ b/src/openrct2/ride/coaster/AlpineCoaster.cpp
@@ -116,8 +116,8 @@ namespace AlpineRC
                 { { 0, 6, height + 3 }, { 32, 20, 1 } });
         }
         PaintAddImageAsParentRotated(
-            session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][2]), { 0, 0, height - 2 },
-            { { 0, 2, height }, { 32, 28, 2 } });
+            session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][2]),
+            { 0, 0, height - 2 }, { { 0, 2, height }, { 32, 28, 2 } });
         DrawSupportsSideBySide(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], MetalSupportType::Boxed);
         TrackPaintUtilDrawStation2(session, ride, direction, height, trackElement, 4, 7);
         PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);

--- a/src/openrct2/ride/coaster/BobsleighCoaster.cpp
+++ b/src/openrct2/ride/coaster/BobsleighCoaster.cpp
@@ -114,7 +114,7 @@ static void BobsleighRCTrackStation(
         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
         { { 0, 6, height + 3 }, { 32, 20, 1 } });
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][1]), { 0, 0, height },
         { 32, 32, 1 });
     DrawSupportsSideBySide(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], MetalSupportType::Tubes);
     TrackPaintUtilDrawStation(session, ride, direction, height, trackElement);

--- a/src/openrct2/ride/coaster/BolligerMabillardTrack.hpp
+++ b/src/openrct2/ride/coaster/BolligerMabillardTrack.hpp
@@ -129,7 +129,7 @@ static void BolligerMabillardTrackStation(
             { { 0, 6, height + 3 }, { 32, 20, 1 } });
     }
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][1]), { 0, 0, height },
         { 32, 32, 1 });
     DrawSupportsSideBySide(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], supportType);
 

--- a/src/openrct2/ride/coaster/CompactInvertedCoaster.cpp
+++ b/src/openrct2/ride/coaster/CompactInvertedCoaster.cpp
@@ -108,7 +108,7 @@ static void CompactInvertedRCTrackStation(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]), { 0, 0, height },
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][0]), { 0, 0, height },
         { { 0, 2, height }, { 32, 28, 1 } });
     PaintAddImageAsParentRotated(
         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 0, height + 29 },

--- a/src/openrct2/ride/coaster/CorkscrewRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/CorkscrewRollerCoaster.cpp
@@ -143,7 +143,7 @@ static void CorkscrewRCTrackStation(
             { { 0, 6, height + 3 }, { 32, 20, 1 } });
     }
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][1]), { 0, 0, height },
         { 32, 32, 1 });
     DrawSupportsSideBySide(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], MetalSupportType::Tubes);
     TrackPaintUtilDrawStation2(session, ride, direction, height, trackElement, 9, 11);

--- a/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
@@ -161,8 +161,8 @@ static void FlyingRCTrackStation(
             { SPR_STATION_BASE_C_NW_SE, 27132, SPR_STATION_INVERTED_BAR_C_NW_SE },
         };
         PaintAddImageAsParentRotated(
-            session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]), { 0, 0, height },
-            { { 0, 2, height }, { 32, 28, 1 } });
+            session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][0]),
+            { 0, 0, height }, { { 0, 2, height }, { 32, 28, 1 } });
         PaintAddImageAsParentRotated(
             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 0, height + 24 },
             { { 0, 6, height + 24 }, { 32, 20, 3 } });
@@ -195,8 +195,8 @@ static void FlyingRCTrackStation(
                 { { 0, 6, height + 3 }, { 32, 20, 1 } });
         }
         PaintAddImageAsParentRotated(
-            session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][2]), { 0, 0, height },
-            { 32, 32, 1 });
+            session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][2]),
+            { 0, 0, height }, { 32, 32, 1 });
         DrawSupportsSideBySide(
             session, direction, height, session.TrackColours[SCHEME_SUPPORTS], MetalSupportType::TubesInverted);
         TrackPaintUtilDrawStation2(session, ride, direction, height, trackElement, 9, 11);

--- a/src/openrct2/ride/coaster/GigaCoaster.cpp
+++ b/src/openrct2/ride/coaster/GigaCoaster.cpp
@@ -193,7 +193,7 @@ static void GigaRCTrackStation(
             { { 0, 6, height + 3 }, { 32, 20, 1 } });
     }
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][1]), { 0, 0, height },
         { 32, 32, 1 });
     DrawSupportsSideBySide(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], MetalSupportType::Tubes);
     TrackPaintUtilDrawStation2(session, ride, direction, height, trackElement, 9, 11);

--- a/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
+++ b/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
@@ -109,7 +109,7 @@ static void HeartlineTwisterRCTrackStation(
         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
         { { 0, 6, height + 3 }, { 32, 20, 1 } });
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][1]), { 0, 0, height },
         { 32, 32, 1 });
     DrawSupportsSideBySide(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], MetalSupportType::Tubes);
     TrackPaintUtilDrawStation(session, ride, direction, height, trackElement);

--- a/src/openrct2/ride/coaster/InvertedHairpinCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedHairpinCoaster.cpp
@@ -94,7 +94,7 @@ static void InvertedHairpinRCTrackStation(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]), { 0, 0, height },
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][0]), { 0, 0, height },
         { { 0, 2, height }, { 32, 28, 1 } });
     PaintAddImageAsParentRotated(
         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 0, height + 24 },

--- a/src/openrct2/ride/coaster/InvertedImpulseCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedImpulseCoaster.cpp
@@ -65,7 +65,7 @@ static void InvertedImpulseRCTrackStation(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]), { 0, 0, height },
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][0]), { 0, 0, height },
         { { 0, 2, height }, { 32, 28, 1 } });
     PaintAddImageAsParentRotated(
         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 0, height + 29 },

--- a/src/openrct2/ride/coaster/InvertedRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedRollerCoaster.cpp
@@ -92,7 +92,7 @@ static void InvertedRCTrackStation(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]), { 0, 0, height },
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][0]), { 0, 0, height },
         { { 0, 2, height }, { 32, 28, 1 } });
     PaintAddImageAsParentRotated(
         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 0, height + 29 },

--- a/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
@@ -1886,7 +1886,7 @@ static void JuniorRCPaintStation(
         if (stationObj != nullptr && !(stationObj->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS))
         {
             // height -= 2 (height - 2)
-            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_SW_NE);
+            imageId = GetStationColourScheme(session, trackElement).WithIndex(SPR_STATION_BASE_B_SW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { { 0, 2, height }, { 32, 28, 1 } });
         }
 
@@ -1906,7 +1906,7 @@ static void JuniorRCPaintStation(
         if (stationObj != nullptr && !(stationObj->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS))
         {
             // height -= 2 (height - 2)
-            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_NW_SE);
+            imageId = GetStationColourScheme(session, trackElement).WithIndex(SPR_STATION_BASE_B_NW_SE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { { 2, 0, height }, { 28, 32, 1 } });
         }
 

--- a/src/openrct2/ride/coaster/LayDownRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LayDownRollerCoaster.cpp
@@ -142,8 +142,8 @@ static void LayDownRCTrackStation(
         };
 
         PaintAddImageAsParentRotated(
-            session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]), { 0, 0, height },
-            { { 0, 2, height }, { 32, 28, 1 } });
+            session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][0]),
+            { 0, 0, height }, { { 0, 2, height }, { 32, 28, 1 } });
         PaintAddImageAsParentRotated(
             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 0, height + 24 },
             { { 0, 6, height + 24 }, { 32, 20, 3 } });

--- a/src/openrct2/ride/coaster/LimLaunchedRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LimLaunchedRollerCoaster.cpp
@@ -56,7 +56,7 @@ static void LimLaunchedRCTrackStation(
             { { 0, 6, height + 3 }, { 32, 20, 1 } });
     }
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][1]), { 0, 0, height },
         { 32, 32, 1 });
     DrawSupportsSideBySide(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], MetalSupportType::Tubes);
     TrackPaintUtilDrawStation(session, ride, direction, height, trackElement);

--- a/src/openrct2/ride/coaster/LoopingRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LoopingRollerCoaster.cpp
@@ -117,7 +117,7 @@ static void LoopingRCTrackStation(
         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
         { { 0, 6, height + 3 }, { 32, 20, 1 } });
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][1]), { 0, 0, height },
         { 32, 32, 1 });
     DrawSupportsSideBySide(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], MetalSupportType::Tubes);
     TrackPaintUtilDrawStation(session, ride, direction, height, trackElement);

--- a/src/openrct2/ride/coaster/MineRide.cpp
+++ b/src/openrct2/ride/coaster/MineRide.cpp
@@ -71,7 +71,7 @@ static void MineRideTrackStation(
         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
         { { 0, 6, height + 3 }, { 32, 20, 1 } });
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][1]), { 0, 0, height },
         { 32, 32, 1 });
     DrawSupportsSideBySide(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], MetalSupportType::Tubes);
     TrackPaintUtilDrawStation2(session, ride, direction, height, trackElement, 9, 11);

--- a/src/openrct2/ride/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/ride/coaster/MineTrainCoaster.cpp
@@ -145,8 +145,8 @@ static void MineTrainRCTrackStation(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height - 2 },
-        { { 0, 2, height }, { 32, 28, 1 } });
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][1]),
+        { 0, 0, height - 2 }, { { 0, 2, height }, { 32, 28, 1 } });
     if (trackElement.GetTrackType() == TrackElemType::EndStation)
     {
         bool isClosed = trackElement.IsBrakeClosed();

--- a/src/openrct2/ride/coaster/MiniRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/MiniRollerCoaster.cpp
@@ -146,7 +146,7 @@ static void MiniRCTrackStation(
             { { 0, 6, height + 3 }, { 32, 20, 1 } });
     }
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][1]), { 0, 0, height },
         { 32, 32, 1 });
     DrawSupportsSideBySide(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], MetalSupportType::Tubes);
     TrackPaintUtilDrawStation2(session, ride, direction, height, trackElement, 9, 11);

--- a/src/openrct2/ride/coaster/MiniSuspendedCoaster.cpp
+++ b/src/openrct2/ride/coaster/MiniSuspendedCoaster.cpp
@@ -98,7 +98,7 @@ static void MiniSuspendedRCTrackStation(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]), { 0, 0, height },
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][0]), { 0, 0, height },
         { { 0, 2, height }, { 32, 28, 1 } });
     PaintAddImageAsParentRotated(
         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 6, height + 24 },

--- a/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
@@ -198,28 +198,29 @@ static void MultiDimensionRCTrackStation(
     }
     DrawSupportsSideBySide(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], MetalSupportType::TubesInverted);
 
+    auto stationColour = GetStationColourScheme(session, trackElement);
     const auto* stationObj = ride.GetStationObject();
     bool hasFence;
     if (direction == 0 || direction == 2)
     {
         hasFence = TrackPaintUtilHasFence(EDGE_NW, session.MapPosition, trackElement, ride, session.CurrentRotation);
-        TrackPaintUtilDrawStationCovers(session, EDGE_NW, hasFence, stationObj, height);
+        TrackPaintUtilDrawStationCovers(session, EDGE_NW, hasFence, stationObj, height, stationColour);
     }
     else
     {
         hasFence = TrackPaintUtilHasFence(EDGE_NE, session.MapPosition, trackElement, ride, session.CurrentRotation);
-        TrackPaintUtilDrawStationCovers(session, EDGE_NE, hasFence, stationObj, height);
+        TrackPaintUtilDrawStationCovers(session, EDGE_NE, hasFence, stationObj, height, stationColour);
     }
 
     if (direction == 0 || direction == 2)
     {
         hasFence = TrackPaintUtilHasFence(EDGE_SE, session.MapPosition, trackElement, ride, session.CurrentRotation);
-        TrackPaintUtilDrawStationCovers(session, EDGE_SE, hasFence, stationObj, height);
+        TrackPaintUtilDrawStationCovers(session, EDGE_SE, hasFence, stationObj, height, stationColour);
     }
     else
     {
         hasFence = TrackPaintUtilHasFence(EDGE_SW, session.MapPosition, trackElement, ride, session.CurrentRotation);
-        TrackPaintUtilDrawStationCovers(session, EDGE_SW, hasFence, stationObj, height);
+        TrackPaintUtilDrawStationCovers(session, EDGE_SW, hasFence, stationObj, height, stationColour);
     }
 
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);

--- a/src/openrct2/ride/coaster/ReverseFreefallCoaster.cpp
+++ b/src/openrct2/ride/coaster/ReverseFreefallCoaster.cpp
@@ -226,7 +226,7 @@ static void PaintReverseFreefallRCStation(
     if (direction == 0 || direction == 2)
     {
         // height -= 2 (height - 2)
-        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_SW_NE);
+        imageId = GetStationColourScheme(session, trackElement).WithIndex(SPR_STATION_BASE_B_SW_NE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { { 0, 2, height }, { 32, 28, 1 } });
         // height += 2 (height)
 
@@ -239,7 +239,7 @@ static void PaintReverseFreefallRCStation(
     else if (direction == 1 || direction == 3)
     {
         // height -= 2 (height - 2)
-        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_NW_SE);
+        imageId = GetStationColourScheme(session, trackElement).WithIndex(SPR_STATION_BASE_B_NW_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { { 2, 0, height }, { 28, 32, 1 } });
         // height += 2 (height)
 

--- a/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
@@ -107,7 +107,7 @@ static void ReverserRCTrackStation(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][1]), { 0, 0, height },
         { { 0, 2, height }, { 32, 27, 2 } });
     PaintAddImageAsChildRotated(
         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },

--- a/src/openrct2/ride/coaster/SingleRailRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/SingleRailRollerCoaster.cpp
@@ -120,8 +120,8 @@ namespace SingleRailRC
                 { { 0, 6, height + 3 }, { 32, 20, 1 } });
         }
         PaintAddImageAsParentRotated(
-            session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][2]), { 0, 0, height - 2 },
-            { { 0, 2, height }, { 32, 28, 2 } });
+            session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][2]),
+            { 0, 0, height - 2 }, { { 0, 2, height }, { 32, 28, 2 } });
         DrawSupportsSideBySide(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], MetalSupportType::Tubes);
         TrackPaintUtilDrawStation2(session, ride, direction, height, trackElement, 4, 7);
         PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);

--- a/src/openrct2/ride/coaster/StandUpRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/StandUpRollerCoaster.cpp
@@ -137,7 +137,7 @@ static void StandUpRCTrackStation(
             { { 0, 6, height + 3 }, { 32, 20, 1 } });
     }
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][1]), { 0, 0, height },
         { 32, 32, 1 });
     DrawSupportsSideBySide(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], MetalSupportType::Tubes);
     TrackPaintUtilDrawStation2(session, ride, direction, height, trackElement, 9, 11);

--- a/src/openrct2/ride/coaster/Steeplechase.cpp
+++ b/src/openrct2/ride/coaster/Steeplechase.cpp
@@ -92,8 +92,8 @@ static void SteeplechaseTrackStation(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height - 2 },
-        { { 0, 2, height }, { 32, 28, 3 } });
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][1]),
+        { 0, 0, height - 2 }, { { 0, 2, height }, { 32, 28, 3 } });
     PaintAddImageAsChildRotated(
         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 6, height },
         { { 0, 0, height }, { 32, 20, 3 } });

--- a/src/openrct2/ride/coaster/SuspendedSwingingCoaster.cpp
+++ b/src/openrct2/ride/coaster/SuspendedSwingingCoaster.cpp
@@ -85,7 +85,7 @@ static void SuspendedSwingingRCTrackStation(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]), { 0, 0, height },
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][0]), { 0, 0, height },
         { { 0, 2, height }, { 32, 28, 1 } });
     PaintAddImageAsParentRotated(
         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 0, height + 29 },

--- a/src/openrct2/ride/coaster/VirginiaReel.cpp
+++ b/src/openrct2/ride/coaster/VirginiaReel.cpp
@@ -432,7 +432,7 @@ static void PaintVirginiaReelStation(
 
     if (direction == 0 || direction == 2)
     {
-        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_SW_NE);
+        imageId = GetStationColourScheme(session, trackElement).WithIndex(SPR_STATION_BASE_B_SW_NE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { { 0, 2, height }, { 32, 28, 2 } });
 
         imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_VIRGINIA_REEL_FLAT_SW_NE);
@@ -442,7 +442,7 @@ static void PaintVirginiaReelStation(
     }
     else if (direction == 1 || direction == 3)
     {
-        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_NW_SE);
+        imageId = GetStationColourScheme(session, trackElement).WithIndex(SPR_STATION_BASE_B_NW_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { { 2, 0, height }, { 28, 32, 2 } });
 
         imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_VIRGINIA_REEL_FLAT_NW_SE);

--- a/src/openrct2/ride/coaster/WildMouse.cpp
+++ b/src/openrct2/ride/coaster/WildMouse.cpp
@@ -202,8 +202,8 @@ static void WildMouseTrackStation(
 
     int32_t trackType = trackElement.GetTrackType();
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(baseImageIds[direction]), { 0, 0, height - 2 },
-        { { 0, 2, height }, { 32, 28, 2 } });
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(baseImageIds[direction]),
+        { 0, 0, height - 2 }, { { 0, 2, height }, { 32, 28, 2 } });
     if (trackType == TrackElemType::EndStation)
     {
         bool isClosed = trackElement.IsBrakeClosed();

--- a/src/openrct2/ride/coaster/WoodenWildMouse.cpp
+++ b/src/openrct2/ride/coaster/WoodenWildMouse.cpp
@@ -157,8 +157,8 @@ static void WoodenWildMouseTrackStation(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height - 2 },
-        { { 0, 2, height }, { 32, 28, 1 } });
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][1]),
+        { 0, 0, height - 2 }, { { 0, 2, height }, { 32, 28, 1 } });
     PaintAddImageAsChildRotated(
         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 6, height },
         { { 0, 0, height }, { 32, 20, 1 } });

--- a/src/openrct2/ride/gentle/CarRide.cpp
+++ b/src/openrct2/ride/gentle/CarRide.cpp
@@ -337,12 +337,12 @@ static void PaintCarRideStation(
 
     if (direction == 0 || direction == 2)
     {
-        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_SW_NE);
+        imageId = GetStationColourScheme(session, trackElement).WithIndex(SPR_STATION_BASE_B_SW_NE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { { 0, 2, height }, { 32, 28, 1 } });
     }
     else if (direction == 1 || direction == 3)
     {
-        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_NW_SE);
+        imageId = GetStationColourScheme(session, trackElement).WithIndex(SPR_STATION_BASE_B_NW_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { { 2, 0, height }, { 28, 32, 1 } });
     }
 
@@ -489,7 +489,7 @@ static void PaintCarRideTrackSpinningTunnel(
         PaintUtilPushTunnelRight(session, height, TUNNEL_0);
     }
 
-    WoodenASupportsPaintSetup(session, (direction & 1), 0, height, session.TrackColours[SCHEME_MISC]);
+    WoodenASupportsPaintSetup(session, (direction & 1), 0, height, GetStationColourScheme(session, trackElement));
 
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);

--- a/src/openrct2/ride/gentle/Circus.cpp
+++ b/src/openrct2/ride/gentle/Circus.cpp
@@ -17,7 +17,8 @@
 #include "../Track.h"
 #include "../TrackPaint.h"
 
-static void PaintCircusTent(PaintSession& session, const Ride& ride, uint8_t direction, int8_t al, int8_t cl, uint16_t height)
+static void PaintCircusTent(
+    PaintSession& session, const Ride& ride, uint8_t direction, int8_t al, int8_t cl, uint16_t height, ImageId stationColour)
 {
     auto rideEntry = ride.GetRideEntry();
     if (rideEntry == nullptr)
@@ -31,10 +32,9 @@ static void PaintCircusTent(PaintSession& session, const Ride& ride, uint8_t dir
     }
 
     auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
-    auto imageFlags = session.TrackColours[SCHEME_MISC];
-    if (imageFlags != TrackGhost)
+    if (stationColour != TrackStationColour)
     {
-        imageTemplate = imageFlags;
+        imageTemplate = stationColour;
     }
     auto imageIndex = rideEntry->Cars[0].base_image_id + direction;
 
@@ -54,7 +54,7 @@ static void PaintCircus(
 
     int32_t edges = edges_3x3[trackSequence];
 
-    WoodenASupportsPaintSetup(session, (direction & 1), 0, height, session.TrackColours[SCHEME_MISC]);
+    WoodenASupportsPaintSetup(session, (direction & 1), 0, height, GetStationColourScheme(session, trackElement));
 
     const StationObject* stationObject = ride.GetStationObject();
 
@@ -64,25 +64,26 @@ static void PaintCircus(
         session, edges, session.MapPosition, trackElement, ride, session.TrackColours[SCHEME_SUPPORTS], height,
         fenceSpritesRope, session.CurrentRotation);
 
+    auto stationColour = GetStationColourScheme(session, trackElement);
     switch (trackSequence)
     {
         case 1:
-            PaintCircusTent(session, ride, direction, 32, 32, height);
+            PaintCircusTent(session, ride, direction, 32, 32, height, stationColour);
             break;
         case 3:
-            PaintCircusTent(session, ride, direction, 32, -32, height);
+            PaintCircusTent(session, ride, direction, 32, -32, height, stationColour);
             break;
         case 5:
-            PaintCircusTent(session, ride, direction, 0, -32, height);
+            PaintCircusTent(session, ride, direction, 0, -32, height, stationColour);
             break;
         case 6:
-            PaintCircusTent(session, ride, direction, -32, 32, height);
+            PaintCircusTent(session, ride, direction, -32, 32, height, stationColour);
             break;
         case 7:
-            PaintCircusTent(session, ride, direction, -32, -32, height);
+            PaintCircusTent(session, ride, direction, -32, -32, height, stationColour);
             break;
         case 8:
-            PaintCircusTent(session, ride, direction, -32, 0, height);
+            PaintCircusTent(session, ride, direction, -32, 0, height, stationColour);
             break;
     }
 

--- a/src/openrct2/ride/gentle/CrookedHouse.cpp
+++ b/src/openrct2/ride/gentle/CrookedHouse.cpp
@@ -46,7 +46,8 @@ static constexpr BoundBoxXY CrookedHouseData[] = {
  *  rct2: 0x0088ABA4
  */
 static void PaintCrookedHouseStructure(
-    PaintSession& session, uint8_t direction, int32_t x_offset, int32_t y_offset, uint32_t segment, int32_t height)
+    PaintSession& session, uint8_t direction, int32_t x_offset, int32_t y_offset, uint32_t segment, int32_t height,
+    ImageId stationColour)
 {
     const auto* tileElement = session.CurrentlyDrawnTileElement;
     if (tileElement == nullptr)
@@ -71,10 +72,9 @@ static void PaintCrookedHouseStructure(
     }
 
     const auto& boundBox = CrookedHouseData[segment];
-    auto imageTemplate = session.TrackColours[SCHEME_MISC];
     auto imageIndex = rideEntry->Cars[0].base_image_id + direction;
     PaintAddImageAsParent(
-        session, imageTemplate.WithIndex(imageIndex), { x_offset, y_offset, height + 3 },
+        session, stationColour.WithIndex(imageIndex), { x_offset, y_offset, height + 3 },
         { { boundBox.offset, height + 3 }, { boundBox.length, 127 } });
 
     session.CurrentlyDrawnEntity = nullptr;
@@ -88,26 +88,27 @@ static void PaintCrookedHouse(
 
     int32_t edges = edges_3x3[trackSequence];
 
-    WoodenASupportsPaintSetup(session, (direction & 1), 0, height, session.TrackColours[SCHEME_MISC]);
+    WoodenASupportsPaintSetup(session, (direction & 1), 0, height, GetStationColourScheme(session, trackElement));
 
     const StationObject* stationObject = ride.GetStationObject();
 
     TrackPaintUtilPaintFloor(session, edges, session.TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
     TrackPaintUtilPaintFences(
-        session, edges, session.MapPosition, trackElement, ride, session.TrackColours[SCHEME_MISC], height, fenceSpritesRope,
-        session.CurrentRotation);
+        session, edges, session.MapPosition, trackElement, ride, GetStationColourScheme(session, trackElement), height,
+        fenceSpritesRope, session.CurrentRotation);
 
+    auto stationColour = GetStationColourScheme(session, trackElement);
     switch (trackSequence)
     {
         case 3:
-            PaintCrookedHouseStructure(session, direction, 32, -32, 0, height);
+            PaintCrookedHouseStructure(session, direction, 32, -32, 0, height, stationColour);
             break;
         case 6:
-            PaintCrookedHouseStructure(session, direction, -32, 32, 4, height);
+            PaintCrookedHouseStructure(session, direction, -32, 32, 4, height, stationColour);
             break;
         case 7:
-            PaintCrookedHouseStructure(session, direction, -32, -32, 2, height);
+            PaintCrookedHouseStructure(session, direction, -32, -32, 2, height, stationColour);
             break;
     }
 

--- a/src/openrct2/ride/gentle/Dodgems.cpp
+++ b/src/openrct2/ride/gentle/Dodgems.cpp
@@ -51,7 +51,7 @@ static void PaintDodgems(
 
     int32_t edges = edges_4x4[relativeTrackSequence];
 
-    WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_MISC]);
+    WoodenASupportsPaintSetup(session, direction & 1, 0, height, GetStationColourScheme(session, trackElement));
 
     const StationObject* stationObject = ride.GetStationObject();
 

--- a/src/openrct2/ride/gentle/FerrisWheel.cpp
+++ b/src/openrct2/ride/gentle/FerrisWheel.cpp
@@ -59,7 +59,7 @@ static void PaintFerrisWheelRiders(
 }
 
 static void PaintFerrisWheelStructure(
-    PaintSession& session, const Ride& ride, uint8_t direction, int8_t axisOffset, uint16_t height)
+    PaintSession& session, const Ride& ride, uint8_t direction, int8_t axisOffset, uint16_t height, ImageId stationColour)
 {
     auto rideEntry = ride.GetRideEntry();
     if (rideEntry == nullptr)
@@ -78,10 +78,9 @@ static void PaintFerrisWheelStructure(
 
     auto supportsImageTemplate = session.TrackColours[SCHEME_TRACK];
     auto wheelImageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
-    auto wheelImageFlags = session.TrackColours[SCHEME_MISC];
-    if (wheelImageFlags != TrackGhost)
+    if (stationColour != TrackStationColour)
     {
-        wheelImageTemplate = wheelImageFlags;
+        wheelImageTemplate = stationColour;
     }
 
     auto imageOffset = vehicle != nullptr ? vehicle->Pitch % 8 : 0;
@@ -117,7 +116,8 @@ static void PaintFerrisWheel(
         edges = Edges1X4NeSw[relativeTrackSequence];
     }
 
-    WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_MISC]);
+    auto stationColour = GetStationColourScheme(session, trackElement);
+    WoodenASupportsPaintSetup(session, direction & 1, 0, height, stationColour);
 
     const StationObject* stationObject = ride.GetStationObject();
 
@@ -125,43 +125,42 @@ static void PaintFerrisWheel(
 
     ImageId imageId;
     uint8_t rotation = session.CurrentRotation;
-    auto colourFlags = session.TrackColours[SCHEME_MISC];
 
     if (edges & EDGE_NW && TrackPaintUtilHasFence(EDGE_NW, session.MapPosition, trackElement, ride, rotation))
     {
-        imageId = colourFlags.WithIndex(SPR_FENCE_ROPE_NW);
+        imageId = stationColour.WithIndex(SPR_FENCE_ROPE_NW);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { { 0, 2, height + 2 }, { 32, 1, 7 } });
     }
     if (edges & EDGE_NE && TrackPaintUtilHasFence(EDGE_NE, session.MapPosition, trackElement, ride, rotation))
     {
-        imageId = colourFlags.WithIndex(SPR_FENCE_ROPE_NE);
+        imageId = stationColour.WithIndex(SPR_FENCE_ROPE_NE);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { { 2, 0, height + 2 }, { 1, 32, 7 } });
     }
     if (edges & EDGE_SE && TrackPaintUtilHasFence(EDGE_SE, session.MapPosition, trackElement, ride, rotation))
     {
         // Bound box is slightly different from TrackPaintUtilPaintFences
-        imageId = colourFlags.WithIndex(SPR_FENCE_ROPE_SE);
+        imageId = stationColour.WithIndex(SPR_FENCE_ROPE_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 0, 29, height + 3 }, { 28, 1, 7 } });
     }
     if (edges & EDGE_SW && TrackPaintUtilHasFence(EDGE_SW, session.MapPosition, trackElement, ride, rotation))
     {
-        imageId = colourFlags.WithIndex(SPR_FENCE_ROPE_SW);
+        imageId = stationColour.WithIndex(SPR_FENCE_ROPE_SW);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 30, 0, height + 2 }, { 1, 32, 7 } });
     }
 
     switch (relativeTrackSequence)
     {
         case 1:
-            PaintFerrisWheelStructure(session, ride, direction, 48, height);
+            PaintFerrisWheelStructure(session, ride, direction, 48, height, stationColour);
             break;
         case 2:
-            PaintFerrisWheelStructure(session, ride, direction, 16, height);
+            PaintFerrisWheelStructure(session, ride, direction, 16, height, stationColour);
             break;
         case 0:
-            PaintFerrisWheelStructure(session, ride, direction, -16, height);
+            PaintFerrisWheelStructure(session, ride, direction, -16, height, stationColour);
             break;
         case 3:
-            PaintFerrisWheelStructure(session, ride, direction, -48, height);
+            PaintFerrisWheelStructure(session, ride, direction, -48, height, stationColour);
             break;
     }
 

--- a/src/openrct2/ride/gentle/FlyingSaucers.cpp
+++ b/src/openrct2/ride/gentle/FlyingSaucers.cpp
@@ -42,7 +42,7 @@ static void PaintFlyingSaucers(
 
     int32_t edges = edges_4x4[relativeTrackSequence];
 
-    WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_MISC]);
+    WoodenASupportsPaintSetup(session, direction & 1, 0, height, GetStationColourScheme(session, trackElement));
 
     const StationObject* stationObject = ride.GetStationObject();
 

--- a/src/openrct2/ride/gentle/GhostTrain.cpp
+++ b/src/openrct2/ride/gentle/GhostTrain.cpp
@@ -384,7 +384,7 @@ static void PaintGhostTrainStation(
         SPR_STATION_BASE_B_NW_SE,
     };
 
-    imageId = session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction]);
+    imageId = GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height - 2 }, { { 0, 2, height }, { 32, 28, 3 } });
 
     imageId = session.TrackColours[SCHEME_TRACK].WithIndex(GhostTrainTrackPiecesFlat[direction]);
@@ -501,7 +501,7 @@ static void PaintGhostTrainTrackSpinningTunnel(
     auto tunnelImage = GetTunnelDoorsImageStraightFlat(trackElement, direction);
     PaintUtilPushTunnelRotated(session, direction, height, tunnelImage);
 
-    WoodenASupportsPaintSetup(session, (direction & 1), 0, height, session.TrackColours[SCHEME_MISC]);
+    WoodenASupportsPaintSetup(session, (direction & 1), 0, height, GetStationColourScheme(session, trackElement));
 
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);

--- a/src/openrct2/ride/gentle/HauntedHouse.cpp
+++ b/src/openrct2/ride/gentle/HauntedHouse.cpp
@@ -24,7 +24,8 @@ static constexpr BoundBoxXY HauntedHouseData[] = {
 };
 
 static void PaintHauntedHouseStructure(
-    PaintSession& session, const Ride& ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint8_t part, uint16_t height)
+    PaintSession& session, const Ride& ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint8_t part, uint16_t height,
+    ImageId stationColour)
 {
     uint8_t frameNum = 0;
 
@@ -41,18 +42,17 @@ static void PaintHauntedHouseStructure(
     }
 
     const auto& boundBox = HauntedHouseData[part];
-    auto imageTemplate = session.TrackColours[SCHEME_MISC];
     auto baseImageIndex = rideEntry->Cars[0].base_image_id;
     auto imageIndex = baseImageIndex + direction;
 
     auto bb = BoundBoxXYZ{ { boundBox.offset, height }, { boundBox.length, 127 } };
-    PaintAddImageAsParent(session, imageTemplate.WithIndex(imageIndex), { xOffset, yOffset, height }, bb);
+    PaintAddImageAsParent(session, stationColour.WithIndex(imageIndex), { xOffset, yOffset, height }, bb);
 
     if (session.DPI.zoom_level <= ZoomLevel{ 0 } && frameNum != 0)
     {
         imageIndex = baseImageIndex + 3 + ((direction & 3) * 18) + frameNum;
         PaintAddImageAsChild(
-            session, imageTemplate.WithIndex(imageIndex), { xOffset, yOffset, height },
+            session, stationColour.WithIndex(imageIndex), { xOffset, yOffset, height },
             { { boundBox.offset, height }, { boundBox.length, 127 } });
     }
 
@@ -68,26 +68,27 @@ static void PaintHauntedHouse(
 
     int32_t edges = edges_3x3[trackSequence];
 
-    WoodenASupportsPaintSetup(session, (direction & 1), 0, height, session.TrackColours[SCHEME_MISC]);
+    WoodenASupportsPaintSetup(session, (direction & 1), 0, height, GetStationColourScheme(session, trackElement));
 
     const StationObject* stationObject = ride.GetStationObject();
 
     TrackPaintUtilPaintFloor(session, edges, session.TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
     TrackPaintUtilPaintFences(
-        session, edges, session.MapPosition, trackElement, ride, session.TrackColours[SCHEME_MISC], height, fenceSpritesRope,
-        session.CurrentRotation);
+        session, edges, session.MapPosition, trackElement, ride, GetStationColourScheme(session, trackElement), height,
+        fenceSpritesRope, session.CurrentRotation);
 
+    auto stationColour = GetStationColourScheme(session, trackElement);
     switch (trackSequence)
     {
         case 3:
-            PaintHauntedHouseStructure(session, ride, direction, 32, -32, 0, height + 3);
+            PaintHauntedHouseStructure(session, ride, direction, 32, -32, 0, height + 3, stationColour);
             break;
         case 6:
-            PaintHauntedHouseStructure(session, ride, direction, -32, 32, 4, height + 3);
+            PaintHauntedHouseStructure(session, ride, direction, -32, 32, 4, height + 3, stationColour);
             break;
         case 7:
-            PaintHauntedHouseStructure(session, ride, direction, -32, -32, 2, height + 3);
+            PaintHauntedHouseStructure(session, ride, direction, -32, -32, 2, height + 3, stationColour);
             break;
     }
 

--- a/src/openrct2/ride/gentle/Maze.cpp
+++ b/src/openrct2/ride/gentle/Maze.cpp
@@ -61,10 +61,10 @@ static void MazePaintSetup(
 
     uint32_t rotation = session.CurrentRotation;
     // draw ground
-    auto imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_TERRAIN_DIRT);
+    auto imageId = GetStationColourScheme(session, trackElement).WithIndex(SPR_TERRAIN_DIRT);
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 0 });
 
-    WoodenASupportsPaintSetup(session, (rotation & 1) ? 0 : 1, 0, height, session.TrackColours[SCHEME_3]);
+    WoodenASupportsPaintSetup(session, (rotation & 1) ? 0 : 1, 0, height, GetShopSupportColourScheme(session, trackElement));
 
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL & ~SEGMENT_C4, 0xFFFF, 0);
 
@@ -85,7 +85,7 @@ static void MazePaintSetup(
             break;
     }
 
-    auto baseImage = session.TrackColours[SCHEME_MISC].WithIndex(baseImageId);
+    auto baseImage = GetStationColourScheme(session, trackElement).WithIndex(baseImageId);
 
     imageId = baseImage.WithIndexOffset(SprMazeOffsetWallCentre);
     if (mazeEntry & MAZE_ENTRY_FLAG_3)

--- a/src/openrct2/ride/gentle/MerryGoRound.cpp
+++ b/src/openrct2/ride/gentle/MerryGoRound.cpp
@@ -51,7 +51,8 @@ static void PaintRiders(
 }
 
 static void PaintCarousel(
-    PaintSession& session, const Ride& ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height)
+    PaintSession& session, const Ride& ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height,
+    ImageId stationColour)
 {
     height += 7;
 
@@ -83,10 +84,9 @@ static void PaintCarousel(
     BoundBoxXYZ bb = { { xOffset + 16, yOffset + 16, height }, { 24, 24, 48 } };
 
     auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
-    auto imageFlags = session.TrackColours[SCHEME_MISC];
-    if (imageFlags != TrackGhost)
+    if (stationColour != TrackStationColour)
     {
-        imageTemplate = imageFlags;
+        imageTemplate = stationColour;
     }
     auto imageOffset = rotationOffset & 0x1F;
     auto imageId = imageTemplate.WithIndex(rideEntry->Cars[0].base_image_id + imageOffset);
@@ -109,35 +109,36 @@ static void PaintMerryGoRound(
 
     int32_t edges = edges_3x3[trackSequence];
 
-    WoodenASupportsPaintSetup(session, (direction & 1), 0, height, session.TrackColours[SCHEME_MISC]);
+    WoodenASupportsPaintSetup(session, (direction & 1), 0, height, GetStationColourScheme(session, trackElement));
 
     const StationObject* stationObject = ride.GetStationObject();
 
     TrackPaintUtilPaintFloor(session, edges, session.TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
     TrackPaintUtilPaintFences(
-        session, edges, session.MapPosition, trackElement, ride, session.TrackColours[SCHEME_MISC], height, fenceSpritesRope,
-        session.CurrentRotation);
+        session, edges, session.MapPosition, trackElement, ride, GetStationColourScheme(session, trackElement), height,
+        fenceSpritesRope, session.CurrentRotation);
 
+    auto stationColour = GetStationColourScheme(session, trackElement);
     switch (trackSequence)
     {
         case 1:
-            PaintCarousel(session, ride, direction, 32, 32, height);
+            PaintCarousel(session, ride, direction, 32, 32, height, stationColour);
             break;
         case 3:
-            PaintCarousel(session, ride, direction, 32, -32, height);
+            PaintCarousel(session, ride, direction, 32, -32, height, stationColour);
             break;
         case 5:
-            PaintCarousel(session, ride, direction, 0, -32, height);
+            PaintCarousel(session, ride, direction, 0, -32, height, stationColour);
             break;
         case 6:
-            PaintCarousel(session, ride, direction, -32, 32, height);
+            PaintCarousel(session, ride, direction, -32, 32, height, stationColour);
             break;
         case 7:
-            PaintCarousel(session, ride, direction, -32, -32, height);
+            PaintCarousel(session, ride, direction, -32, -32, height, stationColour);
             break;
         case 8:
-            PaintCarousel(session, ride, direction, -32, 0, height);
+            PaintCarousel(session, ride, direction, -32, 0, height, stationColour);
             break;
     }
 

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -495,18 +495,18 @@ static void PaintMiniGolfTrackFlat(
     {
         if (direction & 1)
         {
-            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SprMiniGolfFlatFenceBackNwSe);
+            imageId = GetStationColourScheme(session, trackElement).WithIndex(SprMiniGolfFlatFenceBackNwSe);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 10, 0, height + 2 }, { 1, 32, 7 } });
 
-            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SprMiniGolfFlatFenceFrontNwSe);
+            imageId = GetStationColourScheme(session, trackElement).WithIndex(SprMiniGolfFlatFenceFrontNwSe);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 22, 0, height + 2 }, { 1, 32, 7 } });
         }
         else
         {
-            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SprMiniGolfFlatFenceBackSwNe);
+            imageId = GetStationColourScheme(session, trackElement).WithIndex(SprMiniGolfFlatFenceBackSwNe);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 0, 10, height + 2 }, { 32, 1, 7 } });
 
-            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SprMiniGolfFlatFenceFrontSwNe);
+            imageId = GetStationColourScheme(session, trackElement).WithIndex(SprMiniGolfFlatFenceFrontSwNe);
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 0, 22, height + 2 }, { 32, 1, 7 } });
         }
     }
@@ -529,10 +529,10 @@ static void PaintMiniGolfTrack25DegUp(
     PaintUtilSetSegmentSupportHeight(
         session, PaintUtilRotateSegments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
 
-    imageId = session.TrackColours[SCHEME_MISC].WithIndex(MiniGolfTrackSprites25DegUp[direction][1]);
+    imageId = GetStationColourScheme(session, trackElement).WithIndex(MiniGolfTrackSprites25DegUp[direction][1]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { { 0, 10, height + 2 }, { 32, 1, 15 } });
 
-    imageId = session.TrackColours[SCHEME_MISC].WithIndex(MiniGolfTrackSprites25DegUp[direction][2]);
+    imageId = GetStationColourScheme(session, trackElement).WithIndex(MiniGolfTrackSprites25DegUp[direction][2]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { { 0, 22, height + 2 }, { 32, 1, 15 } });
 
     switch (direction)
@@ -569,10 +569,10 @@ static void PaintMiniGolfTrackFlatTo25DegUp(
     PaintUtilSetSegmentSupportHeight(
         session, PaintUtilRotateSegments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
 
-    imageId = session.TrackColours[SCHEME_MISC].WithIndex(MiniGolfTrackSpritesFlatTo25DegUp[direction][1]);
+    imageId = GetStationColourScheme(session, trackElement).WithIndex(MiniGolfTrackSpritesFlatTo25DegUp[direction][1]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { { 0, 10, height + 2 }, { 32, 1, 11 } });
 
-    imageId = session.TrackColours[SCHEME_MISC].WithIndex(MiniGolfTrackSpritesFlatTo25DegUp[direction][2]);
+    imageId = GetStationColourScheme(session, trackElement).WithIndex(MiniGolfTrackSpritesFlatTo25DegUp[direction][2]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { { 0, 22, height + 2 }, { 32, 1, 11 } });
 
     switch (direction)
@@ -609,10 +609,10 @@ static void PaintMiniGolfTrack25DegUpToFlat(
     PaintUtilSetSegmentSupportHeight(
         session, PaintUtilRotateSegments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
 
-    imageId = session.TrackColours[SCHEME_MISC].WithIndex(MiniGolfTrackSprites25DegUpToFlat[direction][1]);
+    imageId = GetStationColourScheme(session, trackElement).WithIndex(MiniGolfTrackSprites25DegUpToFlat[direction][1]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { { 0, 10, height + 2 }, { 32, 1, 11 } });
 
-    imageId = session.TrackColours[SCHEME_MISC].WithIndex(MiniGolfTrackSprites25DegUpToFlat[direction][2]);
+    imageId = GetStationColourScheme(session, trackElement).WithIndex(MiniGolfTrackSprites25DegUpToFlat[direction][2]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { { 0, 22, height + 2 }, { 32, 1, 11 } });
 
     switch (direction)
@@ -675,19 +675,20 @@ static void PaintMiniGolfStation(
         hasFence = TrackPaintUtilHasFence(EDGE_NE, session.MapPosition, trackElement, ride, session.CurrentRotation);
         if (hasFence)
         {
-            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SprMiniGolfFlatFenceBackNwSe);
+            imageId = GetStationColourScheme(session, trackElement).WithIndex(SprMiniGolfFlatFenceBackNwSe);
             PaintAddImageAsParent(session, imageId, { -10, 0, height }, { { 0, 0, height + 2 }, { 1, 32, 7 } });
         }
 
         bool hasSWFence = TrackPaintUtilHasFence(EDGE_SW, session.MapPosition, trackElement, ride, session.CurrentRotation);
         if (hasSWFence)
         {
-            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SprMiniGolfFlatFenceFrontNwSe);
+            imageId = GetStationColourScheme(session, trackElement).WithIndex(SprMiniGolfFlatFenceFrontNwSe);
             PaintAddImageAsParent(session, imageId, { 10, 0, height }, { { 31, 0, height + 2 }, { 1, 32, 7 } });
         }
 
-        TrackPaintUtilDrawStationCovers(session, EDGE_NE, hasFence, stationObj, height);
-        TrackPaintUtilDrawStationCovers(session, EDGE_SW, hasSWFence, stationObj, height);
+        auto stationColour = GetStationColourScheme(session, trackElement);
+        TrackPaintUtilDrawStationCovers(session, EDGE_NE, hasFence, stationObj, height, stationColour);
+        TrackPaintUtilDrawStationCovers(session, EDGE_SW, hasSWFence, stationObj, height, stationColour);
 
         // Was leftwards tunnel in game, seems odd
         PaintUtilPushTunnelRight(session, height, TUNNEL_SQUARE_FLAT);
@@ -697,19 +698,20 @@ static void PaintMiniGolfStation(
         hasFence = TrackPaintUtilHasFence(EDGE_NW, session.MapPosition, trackElement, ride, session.CurrentRotation);
         if (hasFence)
         {
-            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SprMiniGolfFlatFenceBackSwNe);
+            imageId = GetStationColourScheme(session, trackElement).WithIndex(SprMiniGolfFlatFenceBackSwNe);
             PaintAddImageAsParent(session, imageId, { 0, -10, height }, { { 0, 0, height + 2 }, { 32, 1, 7 } });
         }
 
         bool hasSEFence = TrackPaintUtilHasFence(EDGE_SE, session.MapPosition, trackElement, ride, session.CurrentRotation);
         if (hasSEFence)
         {
-            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SprMiniGolfFlatFenceFrontSwNe);
+            imageId = GetStationColourScheme(session, trackElement).WithIndex(SprMiniGolfFlatFenceFrontSwNe);
             PaintAddImageAsParent(session, imageId, { 0, 10, height }, { { 0, 31, height + 2 }, { 32, 1, 7 } });
         }
 
-        TrackPaintUtilDrawStationCovers(session, EDGE_NW, hasFence, stationObj, height);
-        TrackPaintUtilDrawStationCovers(session, EDGE_SE, hasSEFence, stationObj, height);
+        auto stationColour = GetStationColourScheme(session, trackElement);
+        TrackPaintUtilDrawStationCovers(session, EDGE_NW, hasFence, stationObj, height, stationColour);
+        TrackPaintUtilDrawStationCovers(session, EDGE_SE, hasSEFence, stationObj, height, stationColour);
 
         PaintUtilPushTunnelLeft(session, height, TUNNEL_SQUARE_FLAT);
     }
@@ -745,7 +747,7 @@ static void PaintMiniGolfTrackLeftQuarterTurn1Tile(
             if (!shouldDrawFence)
                 break;
 
-            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SprMiniGolfQuarterTurn1TileFenceBackSwNw);
+            imageId = GetStationColourScheme(session, trackElement).WithIndex(SprMiniGolfQuarterTurn1TileFenceBackSwNw);
             PaintAddImageAsChild(session, imageId, { 0, 0, height }, { { 6, 2, height }, { 26, 24, 1 } });
 
             break;
@@ -754,7 +756,7 @@ static void PaintMiniGolfTrackLeftQuarterTurn1Tile(
             if (!shouldDrawFence)
                 break;
 
-            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SprMiniGolfQuarterTurn1TileFenceBackNwNe);
+            imageId = GetStationColourScheme(session, trackElement).WithIndex(SprMiniGolfQuarterTurn1TileFenceBackNwNe);
             PaintAddImageAsChild(session, imageId, { 0, 0, height }, { { 0, 0, height }, { 26, 26, 1 } });
             break;
 
@@ -763,7 +765,7 @@ static void PaintMiniGolfTrackLeftQuarterTurn1Tile(
             if (!shouldDrawFence)
                 break;
 
-            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SprMiniGolfQuarterTurn1TileFenceBackNeSe);
+            imageId = GetStationColourScheme(session, trackElement).WithIndex(SprMiniGolfQuarterTurn1TileFenceBackNeSe);
             PaintAddImageAsChild(session, imageId, { 0, 0, height }, { { 2, 6, height }, { 24, 26, 1 } });
             break;
 
@@ -773,7 +775,7 @@ static void PaintMiniGolfTrackLeftQuarterTurn1Tile(
             if (!shouldDrawFence)
                 break;
 
-            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SprMiniGolfQuarterTurn1TileFenceBackSeSw);
+            imageId = GetStationColourScheme(session, trackElement).WithIndex(SprMiniGolfQuarterTurn1TileFenceBackSeSw);
             PaintAddImageAsChild(session, imageId, { 0, 0, height }, { { 6, 6, height }, { 24, 24, 1 } });
             break;
     }
@@ -782,17 +784,17 @@ static void PaintMiniGolfTrackLeftQuarterTurn1Tile(
     {
         // TODO: The back fence uses the same x/y offsets, but uses another paint function. See if this occurs more often.
         TrackPaintUtilLeftQuarterTurn1TilePaint(
-            session, 0, height, 24, direction, session.TrackColours[SCHEME_MISC],
+            session, 0, height, 24, direction, GetStationColourScheme(session, trackElement),
             MiniGolfTrackSpritesQuarterTurn1TileFenceFront);
 
         switch (direction)
         {
             case 0:
-                imageId = session.TrackColours[SCHEME_MISC].WithIndex(SprMiniGolfQuarterTurn1TileFenceInsideSwNw);
+                imageId = GetStationColourScheme(session, trackElement).WithIndex(SprMiniGolfQuarterTurn1TileFenceInsideSwNw);
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 24, 0, height + 2 }, { 5, 5, 5 } });
                 break;
             case 2:
-                imageId = session.TrackColours[SCHEME_MISC].WithIndex(SprMiniGolfQuarterTurn1TileFenceInsideNeSe);
+                imageId = GetStationColourScheme(session, trackElement).WithIndex(SprMiniGolfQuarterTurn1TileFenceInsideNeSe);
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 0, 24, height + 2 }, { 5, 5, 5 } });
                 break;
         }

--- a/src/openrct2/ride/gentle/MiniHelicopters.cpp
+++ b/src/openrct2/ride/gentle/MiniHelicopters.cpp
@@ -25,7 +25,7 @@ static void PaintMiniHelicoptersTrackStation(
 
     if (direction == 0 || direction == 2)
     {
-        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_SW_NE);
+        imageId = GetStationColourScheme(session, trackElement).WithIndex(SPR_STATION_BASE_B_SW_NE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { { 0, 2, height }, { 32, 28, 1 } });
 
         imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_NE_SW);
@@ -33,7 +33,7 @@ static void PaintMiniHelicoptersTrackStation(
     }
     else if (direction == 1 || direction == 3)
     {
-        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_NW_SE);
+        imageId = GetStationColourScheme(session, trackElement).WithIndex(SPR_STATION_BASE_B_NW_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { { 2, 0, height }, { 28, 32, 1 } });
 
         imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_SE_NW);
@@ -330,7 +330,7 @@ static void PaintMiniHelicoptersTrackSpinningTunnel(
     TrackPaintUtilSpinningTunnelPaint(session, 1, height, direction);
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_0);
 
-    WoodenASupportsPaintSetup(session, (direction & 1), 0, height, session.TrackColours[SCHEME_MISC]);
+    WoodenASupportsPaintSetup(session, (direction & 1), 0, height, GetStationColourScheme(session, trackElement));
 
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);

--- a/src/openrct2/ride/gentle/MonorailCycles.cpp
+++ b/src/openrct2/ride/gentle/MonorailCycles.cpp
@@ -194,7 +194,7 @@ static void PaintMonorailCyclesStation(
 
     if (direction == 0 || direction == 2)
     {
-        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_SW_NE);
+        imageId = GetStationColourScheme(session, trackElement).WithIndex(SPR_STATION_BASE_B_SW_NE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { { 0, 2, height }, { 32, 28, 1 } });
 
         imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SprMonorailCyclesFlatSwNe);
@@ -202,7 +202,7 @@ static void PaintMonorailCyclesStation(
     }
     else if (direction == 1 || direction == 3)
     {
-        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_NW_SE);
+        imageId = GetStationColourScheme(session, trackElement).WithIndex(SPR_STATION_BASE_B_NW_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { { 2, 0, height }, { 28, 32, 1 } });
 
         imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SprMonorailCyclesFlatNwSe);

--- a/src/openrct2/ride/gentle/ObservationTower.cpp
+++ b/src/openrct2/ride/gentle/ObservationTower.cpp
@@ -88,7 +88,7 @@ static void PaintObservationTowerBase(
     int32_t edges = edges_3x3[trackSequence];
     CoordsXY position = session.MapPosition;
 
-    WoodenASupportsPaintSetup(session, (direction & 1), 0, height, session.TrackColours[SCHEME_MISC]);
+    WoodenASupportsPaintSetup(session, (direction & 1), 0, height, GetStationColourScheme(session, trackElement));
 
     const StationObject* stationObject = ride.GetStationObject();
 

--- a/src/openrct2/ride/gentle/SpaceRings.cpp
+++ b/src/openrct2/ride/gentle/SpaceRings.cpp
@@ -34,7 +34,7 @@ static constexpr uint32_t SpaceRingsFenceSprites[] = {
 
 /** rct2: 0x00768A3B */
 static void PaintSpaceRingsStructure(
-    PaintSession& session, const Ride& ride, uint8_t direction, uint32_t segment, int32_t height)
+    PaintSession& session, const Ride& ride, uint8_t direction, uint32_t segment, int32_t height, ImageId stationColour)
 {
     uint32_t vehicleIndex = (segment - direction) & 0x3;
 
@@ -53,18 +53,17 @@ static void PaintSpaceRingsStructure(
             frameNum += static_cast<int8_t>(vehicle->Pitch) * 4;
         }
 
-        auto imageColourFlags = session.TrackColours[SCHEME_MISC];
         if ((ride.colour_scheme_type & 3) != RIDE_COLOUR_SCHEME_MODE_DIFFERENT_PER_TRAIN)
         {
             vehicleIndex = 0;
         }
 
-        if (imageColourFlags == TrackGhost)
+        if (stationColour == TrackStationColour)
         {
-            imageColourFlags = ImageId(0, ride.vehicle_colours[vehicleIndex].Body, ride.vehicle_colours[vehicleIndex].Trim);
+            stationColour = ImageId(0, ride.vehicle_colours[vehicleIndex].Body, ride.vehicle_colours[vehicleIndex].Trim);
         }
 
-        auto imageId = imageColourFlags.WithIndex(baseImageId + frameNum);
+        auto imageId = stationColour.WithIndex(baseImageId + frameNum);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { -10, -10, height }, { 20, 20, 23 } });
 
         if (vehicle != nullptr && vehicle->num_peeps > 0)
@@ -72,8 +71,8 @@ static void PaintSpaceRingsStructure(
             auto* rider = GetEntity<Guest>(vehicle->peep[0]);
             if (rider != nullptr)
             {
-                imageColourFlags = ImageId(0, rider->TshirtColour, rider->TrousersColour);
-                imageId = imageColourFlags.WithIndex(baseImageId + 352 + frameNum);
+                stationColour = ImageId(0, rider->TshirtColour, rider->TrousersColour);
+                imageId = stationColour.WithIndex(baseImageId + 352 + frameNum);
                 PaintAddImageAsChild(session, imageId, { 0, 0, height }, { { -10, -10, height }, { 20, 20, 23 } });
             }
         }
@@ -95,7 +94,8 @@ static void PaintSpaceRings(
 
     ImageId imageId;
 
-    WoodenASupportsPaintSetup(session, (direction & 1), 0, height, session.TrackColours[SCHEME_MISC]);
+    auto stationColour = GetStationColourScheme(session, trackElement);
+    WoodenASupportsPaintSetup(session, (direction & 1), 0, height, stationColour);
 
     const StationObject* stationObject = ride.GetStationObject();
     TrackPaintUtilPaintFloor(session, edges, session.TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
@@ -105,18 +105,18 @@ static void PaintSpaceRings(
         case 7:
             if (TrackPaintUtilHasFence(EDGE_SW, position, trackElement, ride, session.CurrentRotation))
             {
-                imageId = session.TrackColours[SCHEME_MISC].WithIndex(SprSpaceRingsFenceSw);
+                imageId = stationColour.WithIndex(SprSpaceRingsFenceSw);
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 29, 0, height + 2 }, { 1, 28, 7 } });
             }
             if (TrackPaintUtilHasFence(EDGE_SE, position, trackElement, ride, session.CurrentRotation))
             {
-                imageId = session.TrackColours[SCHEME_MISC].WithIndex(SprSpaceRingsFenceSe);
+                imageId = stationColour.WithIndex(SprSpaceRingsFenceSe);
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 0, 29, height + 2 }, { 28, 1, 7 } });
             }
             break;
         default:
             TrackPaintUtilPaintFences(
-                session, edges, position, trackElement, ride, session.TrackColours[SCHEME_MISC], height, SpaceRingsFenceSprites,
+                session, edges, position, trackElement, ride, stationColour, height, SpaceRingsFenceSprites,
                 session.CurrentRotation);
             break;
     }
@@ -124,16 +124,16 @@ static void PaintSpaceRings(
     switch (trackSequence)
     {
         case 0:
-            PaintSpaceRingsStructure(session, ride, direction, 0, height + 3);
+            PaintSpaceRingsStructure(session, ride, direction, 0, height + 3, stationColour);
             break;
         case 5:
-            PaintSpaceRingsStructure(session, ride, direction, 1, height + 3);
+            PaintSpaceRingsStructure(session, ride, direction, 1, height + 3, stationColour);
             break;
         case 7:
-            PaintSpaceRingsStructure(session, ride, direction, 2, height + 3);
+            PaintSpaceRingsStructure(session, ride, direction, 2, height + 3, stationColour);
             break;
         case 8:
-            PaintSpaceRingsStructure(session, ride, direction, 3, height + 3);
+            PaintSpaceRingsStructure(session, ride, direction, 3, height + 3, stationColour);
             break;
     }
 

--- a/src/openrct2/ride/gentle/SpiralSlide.cpp
+++ b/src/openrct2/ride/gentle/SpiralSlide.cpp
@@ -204,7 +204,7 @@ static void PaintSpiralSlide(
 
     int32_t edges = edges_2x2[trackSequence];
 
-    WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_MISC]);
+    WoodenASupportsPaintSetup(session, direction & 1, 0, height, GetStationColourScheme(session, trackElement));
 
     // Base
     const StationObject* stationObject = ride.GetStationObject();

--- a/src/openrct2/ride/shops/Facility.cpp
+++ b/src/openrct2/ride/shops/Facility.cpp
@@ -23,7 +23,8 @@ static void PaintFacility(
     const TrackElement& trackElement)
 {
     bool hasSupports = WoodenASupportsPaintSetupRotated(
-        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_3]);
+        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height,
+        GetShopSupportColourScheme(session, trackElement));
 
     auto rideEntry = ride.GetRideEntry();
     if (rideEntry == nullptr)
@@ -44,7 +45,7 @@ static void PaintFacility(
     auto imageId = imageTemplate.WithIndex(imageIndex);
     if (hasSupports)
     {
-        auto foundationImageTemplate = session.TrackColours[SCHEME_3];
+        auto foundationImageTemplate = GetShopSupportColourScheme(session, trackElement);
         auto foundationImageIndex = (direction & 1) ? SPR_FLOOR_PLANKS_90_DEG : SPR_FLOOR_PLANKS;
         auto foundationImageId = foundationImageTemplate.WithIndex(foundationImageIndex);
         PaintAddImageAsParent(session, foundationImageId, offset, bb);

--- a/src/openrct2/ride/shops/Shop.cpp
+++ b/src/openrct2/ride/shops/Shop.cpp
@@ -23,7 +23,8 @@ static void PaintShop(
     const TrackElement& trackElement)
 {
     bool hasSupports = WoodenASupportsPaintSetupRotated(
-        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_3]);
+        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height,
+        GetShopSupportColourScheme(session, trackElement));
 
     auto rideEntry = ride.GetRideEntry();
     if (rideEntry == nullptr)
@@ -40,7 +41,7 @@ static void PaintShop(
     auto imageIndex = firstCarEntry->base_image_id + direction;
     if (hasSupports)
     {
-        auto foundationImageTemplate = session.TrackColours[SCHEME_3];
+        auto foundationImageTemplate = GetShopSupportColourScheme(session, trackElement);
         auto foundationImageIndex = (direction & 1) ? SPR_FLOOR_PLANKS_90_DEG : SPR_FLOOR_PLANKS;
         auto foundationImageId = foundationImageTemplate.WithIndex(foundationImageIndex);
         PaintAddImageAsParent(session, foundationImageId, offset, bb);

--- a/src/openrct2/ride/thrill/3dCinema.cpp
+++ b/src/openrct2/ride/thrill/3dCinema.cpp
@@ -18,7 +18,8 @@
 #include "../Vehicle.h"
 
 static void Paint3dCinemaDome(
-    PaintSession& session, const Ride& ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height)
+    PaintSession& session, const Ride& ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height,
+    ImageId stationColour)
 {
     auto rideEntry = ride.GetRideEntry();
     if (rideEntry == nullptr)
@@ -31,10 +32,9 @@ static void Paint3dCinemaDome(
     }
 
     auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
-    auto imageFlags = session.TrackColours[SCHEME_MISC];
-    if (imageFlags != TrackGhost)
+    if (stationColour != TrackStationColour)
     {
-        imageTemplate = imageFlags;
+        imageTemplate = stationColour;
     }
 
     auto imageId = imageTemplate.WithIndex(rideEntry->Cars[0].base_image_id + direction);
@@ -56,36 +56,37 @@ static void Paint3dCinema(
 
     int32_t edges = edges_3x3[trackSequence];
 
+    auto stationColour = GetStationColourScheme(session, trackElement);
     WoodenASupportsPaintSetupRotated(
-        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_MISC]);
+        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height, stationColour);
 
     const StationObject* stationObject = ride.GetStationObject();
 
     TrackPaintUtilPaintFloor(session, edges, session.TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
     TrackPaintUtilPaintFences(
-        session, edges, session.MapPosition, trackElement, ride, session.TrackColours[SCHEME_MISC], height, fenceSpritesRope,
+        session, edges, session.MapPosition, trackElement, ride, stationColour, height, fenceSpritesRope,
         session.CurrentRotation);
 
     switch (trackSequence)
     {
         case 1:
-            Paint3dCinemaDome(session, ride, direction, 32, 32, height);
+            Paint3dCinemaDome(session, ride, direction, 32, 32, height, stationColour);
             break;
         case 3:
-            Paint3dCinemaDome(session, ride, direction, 32, -32, height);
+            Paint3dCinemaDome(session, ride, direction, 32, -32, height, stationColour);
             break;
         case 5:
-            Paint3dCinemaDome(session, ride, direction, 0, -32, height);
+            Paint3dCinemaDome(session, ride, direction, 0, -32, height, stationColour);
             break;
         case 6:
-            Paint3dCinemaDome(session, ride, direction, -32, 32, height);
+            Paint3dCinemaDome(session, ride, direction, -32, 32, height, stationColour);
             break;
         case 7:
-            Paint3dCinemaDome(session, ride, direction, -32, -32, height);
+            Paint3dCinemaDome(session, ride, direction, -32, -32, height, stationColour);
             break;
         case 8:
-            Paint3dCinemaDome(session, ride, direction, -32, 0, height);
+            Paint3dCinemaDome(session, ride, direction, -32, 0, height, stationColour);
             break;
     }
 

--- a/src/openrct2/ride/thrill/Enterprise.cpp
+++ b/src/openrct2/ride/thrill/Enterprise.cpp
@@ -70,8 +70,8 @@ static void PaintEnterpriseStructure(
     }
 
     auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
-    auto imageFlags = session.TrackColours[SCHEME_MISC];
-    if (imageFlags != TrackGhost)
+    auto imageFlags = GetStationColourScheme(session, trackElement);
+    if (imageFlags != TrackStationColour)
     {
         imageTemplate = imageFlags;
     }
@@ -96,7 +96,8 @@ static void PaintEnterprise(
     int32_t edges = edges_4x4[trackSequence];
 
     WoodenASupportsPaintSetupRotated(
-        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_MISC]);
+        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height,
+        GetStationColourScheme(session, trackElement));
 
     const StationObject* stationObject = ride.GetStationObject();
     TrackPaintUtilPaintFloor(session, edges, session.TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);

--- a/src/openrct2/ride/thrill/GoKarts.cpp
+++ b/src/openrct2/ride/thrill/GoKarts.cpp
@@ -372,15 +372,16 @@ static void PaintGoKartsStation(
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 2, 0, height }, { 28, 32, 1 } });
     }
 
+    auto stationColour = GetStationColourScheme(session, trackElement);
     if (direction == 0 || direction == 2)
     {
         hasFence = TrackPaintUtilHasFence(EDGE_NW, session.MapPosition, trackElement, ride, session.CurrentRotation);
-        TrackPaintUtilDrawStationCovers(session, EDGE_NW, hasFence, stationObj, height);
+        TrackPaintUtilDrawStationCovers(session, EDGE_NW, hasFence, stationObj, height, stationColour);
     }
     else
     {
         hasFence = TrackPaintUtilHasFence(EDGE_NE, session.MapPosition, trackElement, ride, session.CurrentRotation);
-        TrackPaintUtilDrawStationCovers(session, EDGE_NE, hasFence, stationObj, height);
+        TrackPaintUtilDrawStationCovers(session, EDGE_NE, hasFence, stationObj, height, stationColour);
     }
 
     imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][1]);
@@ -400,12 +401,12 @@ static void PaintGoKartsStation(
     if (direction == 0 || direction == 2)
     {
         hasFence = TrackPaintUtilHasFence(EDGE_SE, session.MapPosition, trackElement, ride, session.CurrentRotation);
-        TrackPaintUtilDrawStationCovers(session, EDGE_SE, hasFence, stationObj, height);
+        TrackPaintUtilDrawStationCovers(session, EDGE_SE, hasFence, stationObj, height, stationColour);
     }
     else
     {
         hasFence = TrackPaintUtilHasFence(EDGE_SW, session.MapPosition, trackElement, ride, session.CurrentRotation);
-        TrackPaintUtilDrawStationCovers(session, EDGE_SW, hasFence, stationObj, height);
+        TrackPaintUtilDrawStationCovers(session, EDGE_SW, hasFence, stationObj, height, stationColour);
     }
 
     if (trackElement.GetTrackType() == TrackElemType::EndStation)

--- a/src/openrct2/ride/thrill/LaunchedFreefall.cpp
+++ b/src/openrct2/ride/thrill/LaunchedFreefall.cpp
@@ -96,7 +96,8 @@ static void PaintLaunchedFreefallBase(
     int32_t edges = edges_3x3[trackSequence];
 
     WoodenASupportsPaintSetupRotated(
-        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_MISC]);
+        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height,
+        GetStationColourScheme(session, trackElement));
 
     const StationObject* stationObject = ride.GetStationObject();
 

--- a/src/openrct2/ride/thrill/MagicCarpet.cpp
+++ b/src/openrct2/ride/thrill/MagicCarpet.cpp
@@ -139,7 +139,8 @@ static void PaintMagicCarpetPendulum(
 }
 
 static void PaintMagicCarpetVehicle(
-    PaintSession& session, const Ride& ride, uint8_t direction, int32_t swing, CoordsXYZ offset, const BoundBoxXYZ& bb)
+    PaintSession& session, const Ride& ride, uint8_t direction, int32_t swing, CoordsXYZ offset, const BoundBoxXYZ& bb,
+    ImageId stationColour)
 {
     const auto* rideEntry = ride.GetRideEntry();
     if (rideEntry == nullptr)
@@ -165,10 +166,9 @@ static void PaintMagicCarpetVehicle(
 
     // Vehicle
     auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
-    auto imageFlags = session.TrackColours[SCHEME_MISC];
-    if (imageFlags != TrackGhost)
+    if (stationColour != TrackStationColour)
     {
-        imageTemplate = imageFlags;
+        imageTemplate = stationColour;
     }
     auto vehicleImageIndex = rideEntry->Cars[0].base_image_id + direction;
     PaintAddImageAsChild(session, imageTemplate.WithIndex(vehicleImageIndex), offset, bb);
@@ -181,7 +181,7 @@ static void PaintMagicCarpetVehicle(
 }
 
 static void PaintMagicCarpetStructure(
-    PaintSession& session, const Ride& ride, uint8_t direction, int8_t axisOffset, uint16_t height)
+    PaintSession& session, const Ride& ride, uint8_t direction, int8_t axisOffset, uint16_t height, ImageId stationColour)
 {
     auto swing = 0;
     auto* vehicle = GetFirstVehicle(ride);
@@ -201,7 +201,7 @@ static void PaintMagicCarpetStructure(
 
     PaintMagicCarpetFrame(session, Plane::Back, direction, offset, bb);
     PaintMagicCarpetPendulum(session, Plane::Back, swing, direction, offset, bb);
-    PaintMagicCarpetVehicle(session, ride, direction, swing, offset, bb);
+    PaintMagicCarpetVehicle(session, ride, direction, swing, offset, bb, stationColour);
     PaintMagicCarpetPendulum(session, Plane::Front, swing, direction, offset, bb);
     PaintMagicCarpetFrame(session, Plane::Front, direction, offset, bb);
 
@@ -247,20 +247,20 @@ static void PaintMagicCarpet(
             }
             break;
     }
-
+    auto stationColour = GetStationColourScheme(session, trackElement);
     switch (relativeTrackSequence)
     {
         case 3:
-            PaintMagicCarpetStructure(session, ride, direction, -48, height);
+            PaintMagicCarpetStructure(session, ride, direction, -48, height, stationColour);
             break;
         case 0:
-            PaintMagicCarpetStructure(session, ride, direction, -16, height);
+            PaintMagicCarpetStructure(session, ride, direction, -16, height, stationColour);
             break;
         case 2:
-            PaintMagicCarpetStructure(session, ride, direction, 16, height);
+            PaintMagicCarpetStructure(session, ride, direction, 16, height, stationColour);
             break;
         case 1:
-            PaintMagicCarpetStructure(session, ride, direction, 48, height);
+            PaintMagicCarpetStructure(session, ride, direction, 48, height, stationColour);
             break;
     }
 

--- a/src/openrct2/ride/thrill/MotionSimulator.cpp
+++ b/src/openrct2/ride/thrill/MotionSimulator.cpp
@@ -32,7 +32,7 @@ enum
 
 static void PaintMotionSimulatorVehicle(
     PaintSession& session, const Ride& ride, int8_t offsetX, int8_t offsetY, uint8_t direction, int32_t height,
-    const TrackElement& trackElement)
+    ImageId stationColour)
 {
     auto rideEntry = ride.GetRideEntry();
     if (rideEntry == nullptr)
@@ -65,10 +65,9 @@ static void PaintMotionSimulatorVehicle(
     }
 
     auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
-    auto imageFlags = session.TrackColours[SCHEME_MISC];
-    if (imageFlags != TrackGhost)
+    if (stationColour != TrackStationColour)
     {
-        imageTemplate = imageFlags;
+        imageTemplate = stationColour;
     }
     auto simulatorImageId = imageTemplate.WithIndex(imageIndex);
     auto stairsImageId = imageTemplate.WithIndex(SPR_MOTION_SIMULATOR_STAIRS_R0 + direction);
@@ -109,8 +108,9 @@ static void PaintMotionSimulator(
 
     int32_t edges = edges_2x2[trackSequence];
 
+    auto stationColour = GetStationColourScheme(session, trackElement);
     WoodenASupportsPaintSetupRotated(
-        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_MISC]);
+        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height, stationColour);
 
     const StationObject* stationObject = ride.GetStationObject();
 
@@ -123,13 +123,13 @@ static void PaintMotionSimulator(
     switch (trackSequence)
     {
         case 1:
-            PaintMotionSimulatorVehicle(session, ride, 16, -16, direction, height, trackElement);
+            PaintMotionSimulatorVehicle(session, ride, 16, -16, direction, height, stationColour);
             break;
         case 2:
-            PaintMotionSimulatorVehicle(session, ride, -16, 16, direction, height, trackElement);
+            PaintMotionSimulatorVehicle(session, ride, -16, 16, direction, height, stationColour);
             break;
         case 3:
-            PaintMotionSimulatorVehicle(session, ride, -16, -16, direction, height, trackElement);
+            PaintMotionSimulatorVehicle(session, ride, -16, -16, direction, height, stationColour);
             break;
     }
 

--- a/src/openrct2/ride/thrill/RotoDrop.cpp
+++ b/src/openrct2/ride/thrill/RotoDrop.cpp
@@ -108,7 +108,8 @@ static void PaintRotoDropBase(
     int32_t edges = edges_3x3[trackSequence];
 
     WoodenASupportsPaintSetupRotated(
-        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_MISC]);
+        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height,
+        GetStationColourScheme(session, trackElement));
 
     const StationObject* stationObject = ride.GetStationObject();
 

--- a/src/openrct2/ride/thrill/SwingingInverterShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingInverterShip.cpp
@@ -59,7 +59,7 @@ static constexpr uint32_t SwingingInverterShipFrameSprites[] = {
 };
 
 static void PaintSwingingInverterShipStructure(
-    PaintSession& session, const Ride& ride, uint8_t direction, int8_t axisOffset, uint16_t height)
+    PaintSession& session, const Ride& ride, uint8_t direction, int8_t axisOffset, uint16_t height, ImageId stationColour)
 {
     const auto* rideEntry = GetRideEntryByIndex(ride.subtype);
     if (rideEntry == nullptr)
@@ -100,10 +100,9 @@ static void PaintSwingingInverterShipStructure(
     }
 
     auto vehicleImageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
-    auto imageFlags = session.TrackColours[SCHEME_MISC];
-    if (imageFlags != TrackGhost)
+    if (stationColour != TrackStationColour)
     {
-        vehicleImageTemplate = imageFlags;
+        vehicleImageTemplate = stationColour;
     }
     auto frameImageTemplate = session.TrackColours[SCHEME_TRACK];
     auto vehicleImageId = vehicleImageTemplate.WithIndex(vehicleImageIndex);
@@ -181,19 +180,20 @@ static void PaintSwingingInverterShip(
         }
     }
 
+    auto stationColour = GetStationColourScheme(session, trackElement);
     switch (relativeTrackSequence)
     {
         case 1:
-            PaintSwingingInverterShipStructure(session, ride, direction, 48, height + 7);
+            PaintSwingingInverterShipStructure(session, ride, direction, 48, height + 7, stationColour);
             break;
         case 2:
-            PaintSwingingInverterShipStructure(session, ride, direction, 16, height + 7);
+            PaintSwingingInverterShipStructure(session, ride, direction, 16, height + 7, stationColour);
             break;
         case 0:
-            PaintSwingingInverterShipStructure(session, ride, direction, -16, height + 7);
+            PaintSwingingInverterShipStructure(session, ride, direction, -16, height + 7, stationColour);
             break;
         case 3:
-            PaintSwingingInverterShipStructure(session, ride, direction, -48, height + 7);
+            PaintSwingingInverterShipStructure(session, ride, direction, -48, height + 7, stationColour);
             break;
     }
 

--- a/src/openrct2/ride/thrill/SwingingShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingShip.cpp
@@ -84,7 +84,7 @@ static void PaintSwingingShipRiders(
 }
 
 static void PaintSwingingShipStructure(
-    PaintSession& session, const Ride& ride, uint8_t direction, int8_t axisOffset, uint16_t height)
+    PaintSession& session, const Ride& ride, uint8_t direction, int8_t axisOffset, uint16_t height, ImageId stationColour)
 {
     const auto* rideEntry = GetRideEntryByIndex(ride.subtype);
     if (rideEntry == nullptr)
@@ -123,10 +123,9 @@ static void PaintSwingingShipStructure(
 
     auto supportsImageTemplate = session.TrackColours[SCHEME_TRACK];
     auto vehicleImageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
-    auto imageFlags = session.TrackColours[SCHEME_MISC];
-    if (imageFlags != TrackGhost)
+    if (stationColour != TrackStationColour)
     {
-        vehicleImageTemplate = imageFlags;
+        vehicleImageTemplate = stationColour;
     }
 
     // Supports (back)
@@ -292,22 +291,23 @@ static void PaintSwingingShip(
             }
         }
     }
+    auto stationColour = GetStationColourScheme(session, trackElement);
     switch (relativeTrackSequence)
     {
         case 1:
-            PaintSwingingShipStructure(session, ride, direction, 64, height);
+            PaintSwingingShipStructure(session, ride, direction, 64, height, stationColour);
             break;
         case 2:
-            PaintSwingingShipStructure(session, ride, direction, 32, height);
+            PaintSwingingShipStructure(session, ride, direction, 32, height, stationColour);
             break;
         case 0:
-            PaintSwingingShipStructure(session, ride, direction, 0, height);
+            PaintSwingingShipStructure(session, ride, direction, 0, height, stationColour);
             break;
         case 3:
-            PaintSwingingShipStructure(session, ride, direction, -32, height);
+            PaintSwingingShipStructure(session, ride, direction, -32, height, stationColour);
             break;
         case 4:
-            PaintSwingingShipStructure(session, ride, direction, -64, height);
+            PaintSwingingShipStructure(session, ride, direction, -64, height, stationColour);
             break;
     }
 

--- a/src/openrct2/ride/thrill/TopSpin.cpp
+++ b/src/openrct2/ride/thrill/TopSpin.cpp
@@ -60,7 +60,7 @@ static void PaintTopSpinRiders(
 
 static void PaintTopSpinSeat(
     PaintSession& session, const Ride& ride, const RideObjectEntry& rideEntry, const Vehicle* vehicle, Direction direction,
-    uint32_t armRotation, uint32_t seatRotation, const CoordsXYZ& offset, const BoundBoxXYZ& bb)
+    uint32_t armRotation, uint32_t seatRotation, const CoordsXYZ& offset, const BoundBoxXYZ& bb, ImageId stationColour)
 {
     if (armRotation >= std::size(TopSpinSeatHeightOffset))
         return;
@@ -101,11 +101,10 @@ static void PaintTopSpinSeat(
             break;
     }
 
-    auto imageFlags = session.TrackColours[SCHEME_MISC];
     auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
-    if (imageFlags != TrackGhost)
+    if (stationColour != TrackStationColour)
     {
-        imageTemplate = imageFlags;
+        imageTemplate = stationColour;
     }
 
     PaintAddImageAsChild(session, imageTemplate.WithIndex(seatImageIndex), seatCoords, bb);
@@ -116,8 +115,7 @@ static void PaintTopSpinSeat(
 }
 
 static void PaintTopSpinVehicle(
-    PaintSession& session, int32_t al, int32_t cl, const Ride& ride, uint8_t direction, int32_t height,
-    const TrackElement& tileElement)
+    PaintSession& session, int32_t al, int32_t cl, const Ride& ride, uint8_t direction, int32_t height, ImageId stationColour)
 {
     const auto* rideEntry = GetRideEntryByIndex(ride.subtype);
     if (rideEntry == nullptr)
@@ -149,12 +147,11 @@ static void PaintTopSpinVehicle(
     CoordsXYZ offset = { al, cl, height };
     BoundBoxXYZ bb = { { al + 16, cl + 16, height }, { 24, 24, 90 } };
 
-    auto imageFlags = session.TrackColours[SCHEME_MISC];
     auto supportImageTemplate = ImageId(0, ride.track_colour[0].main, ride.track_colour[0].supports);
     auto armImageTemplate = ImageId(0, ride.track_colour[0].main, ride.track_colour[0].additional);
-    if (imageFlags != TrackGhost)
+    if (stationColour != TrackStationColour)
     {
-        supportImageTemplate = imageFlags;
+        supportImageTemplate = stationColour;
         armImageTemplate = supportImageTemplate;
     }
 
@@ -167,7 +164,7 @@ static void PaintTopSpinVehicle(
     PaintAddImageAsChild(session, armImageTemplate.WithIndex(imageIndex), offset, bb);
 
     // Seat
-    PaintTopSpinSeat(session, ride, *rideEntry, vehicle, direction, armRotation, seatRotation, offset, bb);
+    PaintTopSpinSeat(session, ride, *rideEntry, vehicle, direction, armRotation, seatRotation, offset, bb, stationColour);
 
     // Right hand arm
     imageIndex = carEntry.base_image_id + 476 + armImageOffset + ((direction & 1) * 48);
@@ -189,36 +186,37 @@ static void PaintTopSpin(
 
     int32_t edges = edges_3x3[trackSequence];
 
+    auto stationColour = GetStationColourScheme(session, trackElement);
     WoodenASupportsPaintSetupRotated(
-        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_MISC]);
+        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height, stationColour);
 
     const StationObject* stationObject = ride.GetStationObject();
 
     TrackPaintUtilPaintFloor(session, edges, session.TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
     TrackPaintUtilPaintFences(
-        session, edges, session.MapPosition, trackElement, ride, session.TrackColours[SCHEME_MISC], height, fenceSpritesRope,
+        session, edges, session.MapPosition, trackElement, ride, stationColour, height, fenceSpritesRope,
         session.CurrentRotation);
 
     switch (trackSequence)
     {
         case 1:
-            PaintTopSpinVehicle(session, 32, 32, ride, direction, height, trackElement);
+            PaintTopSpinVehicle(session, 32, 32, ride, direction, height, stationColour);
             break;
         case 3:
-            PaintTopSpinVehicle(session, 32, -32, ride, direction, height, trackElement);
+            PaintTopSpinVehicle(session, 32, -32, ride, direction, height, stationColour);
             break;
         case 5:
-            PaintTopSpinVehicle(session, 0, -32, ride, direction, height, trackElement);
+            PaintTopSpinVehicle(session, 0, -32, ride, direction, height, stationColour);
             break;
         case 6:
-            PaintTopSpinVehicle(session, -32, 32, ride, direction, height, trackElement);
+            PaintTopSpinVehicle(session, -32, 32, ride, direction, height, stationColour);
             break;
         case 7:
-            PaintTopSpinVehicle(session, -32, -32, ride, direction, height, trackElement);
+            PaintTopSpinVehicle(session, -32, -32, ride, direction, height, stationColour);
             break;
         case 8:
-            PaintTopSpinVehicle(session, -32, 0, ride, direction, height, trackElement);
+            PaintTopSpinVehicle(session, -32, 0, ride, direction, height, stationColour);
             break;
     }
 

--- a/src/openrct2/ride/thrill/Twist.cpp
+++ b/src/openrct2/ride/thrill/Twist.cpp
@@ -21,7 +21,8 @@
 
 /** rct2: 0x0076E5C9 */
 static void PaintTwistStructure(
-    PaintSession& session, const Ride& ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height)
+    PaintSession& session, const Ride& ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height,
+    ImageId stationColour)
 {
     const auto* rideEntry = GetRideEntryByIndex(ride.subtype);
     Vehicle* vehicle = nullptr;
@@ -49,11 +50,10 @@ static void PaintTwistStructure(
         frameNum = frameNum % 216;
     }
 
-    auto imageFlags = session.TrackColours[SCHEME_MISC];
     auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
-    if (imageFlags != TrackGhost)
+    if (stationColour != TrackStationColour)
     {
-        imageTemplate = imageFlags;
+        imageTemplate = stationColour;
     }
 
     auto baseImageId = rideEntry->Cars[0].base_image_id;
@@ -91,29 +91,30 @@ static void PaintTwist(
 
     ImageId imageId;
 
+    auto stationColour = GetStationColourScheme(session, trackElement);
     WoodenASupportsPaintSetupRotated(
-        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_MISC]);
+        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height, stationColour);
 
     const StationObject* stationObject = ride.GetStationObject();
-    TrackPaintUtilPaintFloor(session, edges, session.TrackColours[SCHEME_MISC], height, floorSpritesCork, stationObject);
+    TrackPaintUtilPaintFloor(session, edges, stationColour, height, floorSpritesCork, stationObject);
 
     switch (trackSequence)
     {
         case 7:
             if (TrackPaintUtilHasFence(EDGE_SW, session.MapPosition, trackElement, ride, session.CurrentRotation))
             {
-                imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_FENCE_ROPE_SW);
+                imageId = stationColour.WithIndex(SPR_FENCE_ROPE_SW);
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 29, 0, height + 3 }, { 1, 28, 7 } });
             }
             if (TrackPaintUtilHasFence(EDGE_SE, session.MapPosition, trackElement, ride, session.CurrentRotation))
             {
-                imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_FENCE_ROPE_SE);
+                imageId = stationColour.WithIndex(SPR_FENCE_ROPE_SE);
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 0, 29, height + 3 }, { 28, 1, 7 } });
             }
             break;
         default:
             TrackPaintUtilPaintFences(
-                session, edges, session.MapPosition, trackElement, ride, session.TrackColours[SCHEME_MISC], height,
+                session, edges, session.MapPosition, trackElement, ride, GetStationColourScheme(session, trackElement), height,
                 fenceSpritesRope, session.CurrentRotation);
             break;
     }
@@ -121,22 +122,22 @@ static void PaintTwist(
     switch (trackSequence)
     {
         case 1:
-            PaintTwistStructure(session, ride, direction, 32, 32, height);
+            PaintTwistStructure(session, ride, direction, 32, 32, height, stationColour);
             break;
         case 3:
-            PaintTwistStructure(session, ride, direction, 32, -32, height);
+            PaintTwistStructure(session, ride, direction, 32, -32, height, stationColour);
             break;
         case 5:
-            PaintTwistStructure(session, ride, direction, 0, -32, height);
+            PaintTwistStructure(session, ride, direction, 0, -32, height, stationColour);
             break;
         case 6:
-            PaintTwistStructure(session, ride, direction, -32, 32, height);
+            PaintTwistStructure(session, ride, direction, -32, 32, height, stationColour);
             break;
         case 7:
-            PaintTwistStructure(session, ride, direction, -32, -32, height);
+            PaintTwistStructure(session, ride, direction, -32, -32, height, stationColour);
             break;
         case 8:
-            PaintTwistStructure(session, ride, direction, -32, 0, height);
+            PaintTwistStructure(session, ride, direction, -32, 0, height, stationColour);
             break;
     }
 

--- a/src/openrct2/ride/transport/Chairlift.cpp
+++ b/src/openrct2/ride/transport/Chairlift.cpp
@@ -193,8 +193,8 @@ static void ChairliftPaintStationNeSw(
     bool isEnd = ChairliftPaintUtilIsLastTrack(ride, trackElement, pos, trackType);
 
     const auto* stationObj = ride.GetStationObject();
-
-    WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_MISC]);
+    auto stationColour = GetStationColourScheme(session, trackElement);
+    WoodenASupportsPaintSetup(session, 0, 0, height, stationColour);
 
     if (!isStart && !isEnd)
     {
@@ -211,7 +211,7 @@ static void ChairliftPaintStationNeSw(
         imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_FENCE_METAL_NW);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { { 0, 2, height + 2 }, { 32, 1, 7 } });
     }
-    TrackPaintUtilDrawStationCovers(session, EDGE_NW, hasFence, stationObj, height);
+    TrackPaintUtilDrawStationCovers(session, EDGE_NW, hasFence, stationObj, height, stationColour);
 
     if ((direction == 2 && isStart) || (direction == 0 && isEnd))
     {
@@ -225,7 +225,7 @@ static void ChairliftPaintStationNeSw(
         imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_FENCE_METAL_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 0, 30, height + 2 }, { 32, 1, 27 } });
     }
-    TrackPaintUtilDrawStationCovers(session, EDGE_SE, hasFence, stationObj, height);
+    TrackPaintUtilDrawStationCovers(session, EDGE_SE, hasFence, stationObj, height, stationColour);
 
     bool drawFrontColumn = true;
     bool drawBackColumn = true;
@@ -285,8 +285,9 @@ static void ChairliftPaintStationSeNw(
     bool isEnd = ChairliftPaintUtilIsLastTrack(ride, trackElement, pos, trackType);
 
     const auto* stationObj = ride.GetStationObject();
+    auto stationColour = GetStationColourScheme(session, trackElement);
 
-    WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_MISC]);
+    WoodenASupportsPaintSetup(session, 1, 0, height, GetStationColourScheme(session, trackElement));
 
     if (!isStart && !isEnd)
     {
@@ -303,7 +304,7 @@ static void ChairliftPaintStationSeNw(
         imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_FENCE_METAL_NE);
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { { 2, 0, height + 2 }, { 1, 32, 7 } });
     }
-    TrackPaintUtilDrawStationCovers(session, EDGE_NE, hasFence, stationObj, height);
+    TrackPaintUtilDrawStationCovers(session, EDGE_NE, hasFence, stationObj, height, stationColour);
 
     if ((direction == 1 && isStart) || (direction == 3 && isEnd))
     {
@@ -317,7 +318,7 @@ static void ChairliftPaintStationSeNw(
         imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_FENCE_METAL_SW);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 30, 0, height + 2 }, { 1, 32, 27 } });
     }
-    TrackPaintUtilDrawStationCovers(session, EDGE_SW, hasFence, stationObj, height);
+    TrackPaintUtilDrawStationCovers(session, EDGE_SW, hasFence, stationObj, height, stationColour);
 
     bool drawRightColumn = true;
     bool drawLeftColumn = true;

--- a/src/openrct2/ride/transport/MiniatureRailway.cpp
+++ b/src/openrct2/ride/transport/MiniatureRailway.cpp
@@ -707,7 +707,7 @@ static void PaintMiniatureRailwayStation(
 
     WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
 
-    imageId = session.TrackColours[SCHEME_MISC].WithIndex(miniature_railway_station_floor[direction]);
+    imageId = GetStationColourScheme(session, trackElement).WithIndex(miniature_railway_station_floor[direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height - 2 }, { { 0, 2, height }, { 32, 28, 2 } });
 
     imageId = session.TrackColours[SCHEME_TRACK].WithIndex(miniature_railway_track_pieces_flat_station[direction]);

--- a/src/openrct2/ride/transport/Monorail.cpp
+++ b/src/openrct2/ride/transport/Monorail.cpp
@@ -433,12 +433,12 @@ static void PaintMonorailStation(
     {
         if (direction == 0 || direction == 2)
         {
-            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_SW_NE);
+            imageId = GetStationColourScheme(session, trackElement).WithIndex(SPR_STATION_BASE_B_SW_NE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { { 0, 2, height }, { 32, 28, 2 } });
         }
         else if (direction == 1 || direction == 3)
         {
-            imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_NW_SE);
+            imageId = GetStationColourScheme(session, trackElement).WithIndex(SPR_STATION_BASE_B_NW_SE);
             PaintAddImageAsParent(session, imageId, { 0, 0, height - 2 }, { { 2, 0, height }, { 28, 32, 2 } });
         }
     }

--- a/src/openrct2/ride/transport/SuspendedMonorail.cpp
+++ b/src/openrct2/ride/transport/SuspendedMonorail.cpp
@@ -65,7 +65,7 @@ static void SuspendedMonorailTrackStation(
     };
 
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][0]), { 0, 0, height },
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][0]), { 0, 0, height },
         { { 0, 2, height }, { 32, 28, 1 } });
     PaintAddImageAsParentRotated(
         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][1]), { 0, 0, height + 32 },

--- a/src/openrct2/ride/water/DinghySlide.cpp
+++ b/src/openrct2/ride/water/DinghySlide.cpp
@@ -257,7 +257,7 @@ static void DinghySlideTrackStation(
         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
         { { 0, 6, height + 3 }, { 32, 20, 1 } });
     PaintAddImageAsParentRotated(
-        session, direction, session.TrackColours[SCHEME_MISC].WithIndex(imageIds[direction][1]), { 0, 0, height },
+        session, direction, GetStationColourScheme(session, trackElement).WithIndex(imageIds[direction][1]), { 0, 0, height },
         { 32, 32, 1 });
 
     DrawSupportsSideBySide(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], MetalSupportType::Tubes);

--- a/src/openrct2/ride/water/LogFlume.cpp
+++ b/src/openrct2/ride/water/LogFlume.cpp
@@ -192,11 +192,11 @@ static void PaintLogFlumeTrackStation(
 
     if (direction & 1)
     {
-        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_NW_SE);
+        imageId = GetStationColourScheme(session, trackElement).WithIndex(SPR_STATION_BASE_B_NW_SE);
     }
     else
     {
-        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_SW_NE);
+        imageId = GetStationColourScheme(session, trackElement).WithIndex(SPR_STATION_BASE_B_SW_NE);
     }
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 });
 

--- a/src/openrct2/ride/water/SplashBoats.cpp
+++ b/src/openrct2/ride/water/SplashBoats.cpp
@@ -789,7 +789,7 @@ static void PaintSplashBoatsStation(
             (direction == 1 ? SPR_SPLASH_BOATS_FLAT_TOP_NW_SE : SPR_SPLASH_BOATS_FLAT_TOP_SE_NW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 6, 0, height + 3 }, { 20, 32, 1 } });
 
-        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_NW_SE);
+        imageId = GetStationColourScheme(session, trackElement).WithIndex(SPR_STATION_BASE_B_NW_SE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 });
     }
     else
@@ -798,7 +798,7 @@ static void PaintSplashBoatsStation(
             (direction == 0 ? SPR_SPLASH_BOATS_FLAT_TOP_SW_NE : SPR_SPLASH_BOATS_FLAT_TOP_NE_SW));
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 0, 6, height + 3 }, { 32, 20, 1 } });
 
-        imageId = session.TrackColours[SCHEME_MISC].WithIndex(SPR_STATION_BASE_B_SW_NE);
+        imageId = GetStationColourScheme(session, trackElement).WithIndex(SPR_STATION_BASE_B_SW_NE);
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 });
     }
 


### PR DESCRIPTION
The purpose of this PR was to add the additional colour to the supports colour scheme. By adding the additional colour to the supports colour scheme, wooden roller coaster track does not have to create a new colour scheme every time.

While investigating this, I identified where two ImageIds can be removed from PaintSessionCore. My understanding is that the smaller the size of PaintSessionCore, the faster the game can paint. I noticed that SCHEME_MISC and SCHEME_3 were always set to Black and Dark Brown respectively, except when they are set to ghost. I moved these into getter functions that take the TrackElement (for IsGhost()) and PaintSession (for the highlight type).

I get a 1fps boost when running debug on this scene:
![image](https://github.com/OpenRCT2/OpenRCT2/assets/3454156/9715d271-1dae-4d60-a718-4275a7677885)
