### PR TITLE
Add #include <algorithm> to fix building with gcc 14

### DIFF
--- a/src/openrct2/core/FileWatcher.cpp
+++ b/src/openrct2/core/FileWatcher.cpp
@@ -7,6 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#include <algorithm>
 #include <array>
 #include <cstdio>
 #include <stdexcept>


### PR DESCRIPTION
With gcc 14 some C++ Standard Library headers have been changed to no longer include other headers that were used internally by the library. In OpenRCT2's case it is the `<algorithm>` header.

[Downstream Gentoo bug](https://bugs.gentoo.org/917016)

[GCC 14 porting guide](https://gcc.gnu.org/gcc-14/porting_to.html#header-dep-changes)