### PR TITLE
Update supports calls in Heartline Twister Roller Coaster, shops, facilities and entrances

### DIFF
--- a/src/openrct2/paint/Supports.h
+++ b/src/openrct2/paint/Supports.h
@@ -42,6 +42,11 @@ enum class WoodenSupportTransitionType : uint8_t
     Up25DegToUp60Deg = 3,
     Up60DegToUp25Deg = 4,
     Up60Deg = 5,
+    FlatToUp60Deg = 7,
+    Up60DegToFlat = 8,
+    FlatToUp25DegRailway = 9,
+    Up25DegToFlatRailway = 10,
+    Up25DegRailway = 11,
     Scenery = 12,
 };
 

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -199,7 +199,8 @@ static void PaintRideEntranceExit(PaintSession& session, uint8_t direction, int3
     {
         supportsImageTemplate = ImageId().WithPrimary(COLOUR_SATURATED_BROWN);
     }
-    WoodenASupportsPaintSetup(session, direction & 1, 0, height, supportsImageTemplate);
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height, supportsImageTemplate);
 
     height += isExit ? 40 : 56;
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -327,7 +328,8 @@ static void PaintParkEntrance(PaintSession& session, uint8_t direction, int32_t 
     {
         supportsImageTemplate = ImageId().WithPrimary(COLOUR_SATURATED_BROWN);
     }
-    WoodenASupportsPaintSetup(session, direction & 1, 0, height, supportsImageTemplate);
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height, supportsImageTemplate);
 
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 80, 0x20);

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -1520,14 +1520,19 @@ void TrackPaintUtilRightQuarterTurn5TilesWoodenSupports(
 {
     if (trackSequence != 1 && trackSequence != 4)
     {
-        static constexpr uint8_t supportTypes[][7] = {
-            { 0, 0xFF, 4, 2, 0xFF, 4, 1 },
-            { 1, 0xFF, 5, 3, 0xFF, 5, 0 },
-            { 0, 0xFF, 2, 4, 0xFF, 2, 1 },
-            { 1, 0xFF, 3, 5, 0xFF, 3, 0 },
+        static constexpr std::optional<WoodenSupportSubType> supportTypes[][7] = {
+            { WoodenSupportSubType::NeSw, std::nullopt, WoodenSupportSubType::Corner2, WoodenSupportSubType::Corner0,
+              std::nullopt, WoodenSupportSubType::Corner2, WoodenSupportSubType::NwSe },
+            { WoodenSupportSubType::NwSe, std::nullopt, WoodenSupportSubType::Corner3, WoodenSupportSubType::Corner1,
+              std::nullopt, WoodenSupportSubType::Corner3, WoodenSupportSubType::NeSw },
+            { WoodenSupportSubType::NeSw, std::nullopt, WoodenSupportSubType::Corner0, WoodenSupportSubType::Corner2,
+              std::nullopt, WoodenSupportSubType::Corner0, WoodenSupportSubType::NwSe },
+            { WoodenSupportSubType::NwSe, std::nullopt, WoodenSupportSubType::Corner1, WoodenSupportSubType::Corner3,
+              std::nullopt, WoodenSupportSubType::Corner1, WoodenSupportSubType::NeSw },
         };
-        uint8_t supportType = supportTypes[direction][trackSequence];
-        WoodenASupportsPaintSetup(session, supportType, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+        auto supportType = supportTypes[direction][trackSequence].value();
+        WoodenASupportsPaintSetup(
+            session, WoodenSupportType::Truss, supportType, height, session.TrackColours[SCHEME_SUPPORTS]);
     }
 }
 

--- a/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
+++ b/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
@@ -34,7 +34,6 @@ static void HeartlineTwisterRCTrackFlat(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21356), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 26 } });
-                WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -43,7 +42,6 @@ static void HeartlineTwisterRCTrackFlat(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21357), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 26 } });
-                WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -52,7 +50,6 @@ static void HeartlineTwisterRCTrackFlat(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21360), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 26 } });
-                WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -61,7 +58,6 @@ static void HeartlineTwisterRCTrackFlat(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21361), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 26 } });
-                WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -77,7 +73,6 @@ static void HeartlineTwisterRCTrackFlat(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21296), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 26 } });
-                WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
             case 3:
@@ -87,10 +82,13 @@ static void HeartlineTwisterRCTrackFlat(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21297), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 26 } });
-                WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
+
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_SUPPORTS]);
+
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_0);
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
@@ -136,7 +134,6 @@ static void HeartlineTwisterRCTrack25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21382), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 50 } });
-                WoodenASupportsPaintSetup(session, 6, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -145,7 +142,6 @@ static void HeartlineTwisterRCTrack25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21383), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 50 } });
-                WoodenASupportsPaintSetup(session, 7, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -154,7 +150,6 @@ static void HeartlineTwisterRCTrack25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21384), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 50 } });
-                WoodenASupportsPaintSetup(session, 6, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -163,7 +158,6 @@ static void HeartlineTwisterRCTrack25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21385), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 50 } });
-                WoodenASupportsPaintSetup(session, 7, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -178,7 +172,6 @@ static void HeartlineTwisterRCTrack25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21326), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 50 } });
-                WoodenASupportsPaintSetup(session, 6, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -187,7 +180,6 @@ static void HeartlineTwisterRCTrack25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21327), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 50 } });
-                WoodenASupportsPaintSetup(session, 7, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -196,7 +188,6 @@ static void HeartlineTwisterRCTrack25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21328), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 50 } });
-                WoodenASupportsPaintSetup(session, 6, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -205,10 +196,14 @@ static void HeartlineTwisterRCTrack25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21329), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 50 } });
-                WoodenASupportsPaintSetup(session, 7, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
+
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_SUPPORTS],
+        WoodenSupportTransitionType::Up25Deg);
+
     if (direction == 0 || direction == 3)
     {
         PaintUtilPushTunnelRotated(session, direction, height - 8, TUNNEL_1);
@@ -237,7 +232,6 @@ static void HeartlineTwisterRCTrack60DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21406), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 98 } });
-                WoodenASupportsPaintSetup(session, 6, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -246,7 +240,6 @@ static void HeartlineTwisterRCTrack60DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21407), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 98 } });
-                WoodenASupportsPaintSetup(session, 7, 22, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -255,7 +248,6 @@ static void HeartlineTwisterRCTrack60DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21408), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 98 } });
-                WoodenASupportsPaintSetup(session, 6, 23, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -264,7 +256,6 @@ static void HeartlineTwisterRCTrack60DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21409), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 98 } });
-                WoodenASupportsPaintSetup(session, 7, 24, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -279,7 +270,6 @@ static void HeartlineTwisterRCTrack60DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21350), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 98 } });
-                WoodenASupportsPaintSetup(session, 6, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -288,7 +278,6 @@ static void HeartlineTwisterRCTrack60DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21351), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 98 } });
-                WoodenASupportsPaintSetup(session, 7, 22, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -297,7 +286,6 @@ static void HeartlineTwisterRCTrack60DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21352), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 98 } });
-                WoodenASupportsPaintSetup(session, 6, 23, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -306,10 +294,14 @@ static void HeartlineTwisterRCTrack60DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21353), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 98 } });
-                WoodenASupportsPaintSetup(session, 7, 24, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
+
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_SUPPORTS],
+        WoodenSupportTransitionType::Up60Deg);
+
     if (direction == 0 || direction == 3)
     {
         PaintUtilPushTunnelRotated(session, direction, height - 8, TUNNEL_1);
@@ -338,7 +330,6 @@ static void HeartlineTwisterRCTrackFlatTo25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21366), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 42 } });
-                WoodenASupportsPaintSetup(session, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -347,7 +338,6 @@ static void HeartlineTwisterRCTrackFlatTo25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21367), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 42 } });
-                WoodenASupportsPaintSetup(session, 7, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -356,7 +346,6 @@ static void HeartlineTwisterRCTrackFlatTo25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21368), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 42 } });
-                WoodenASupportsPaintSetup(session, 6, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -365,7 +354,6 @@ static void HeartlineTwisterRCTrackFlatTo25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21369), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 42 } });
-                WoodenASupportsPaintSetup(session, 7, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -380,7 +368,6 @@ static void HeartlineTwisterRCTrackFlatTo25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21310), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 42 } });
-                WoodenASupportsPaintSetup(session, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -389,7 +376,6 @@ static void HeartlineTwisterRCTrackFlatTo25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21311), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 42 } });
-                WoodenASupportsPaintSetup(session, 7, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -398,7 +384,6 @@ static void HeartlineTwisterRCTrackFlatTo25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21312), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 42 } });
-                WoodenASupportsPaintSetup(session, 6, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -407,10 +392,14 @@ static void HeartlineTwisterRCTrackFlatTo25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21313), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 42 } });
-                WoodenASupportsPaintSetup(session, 7, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
+
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_SUPPORTS],
+        WoodenSupportTransitionType::FlatToUp25Deg);
+
     if (direction == 0 || direction == 3)
     {
         PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_0);
@@ -439,7 +428,6 @@ static void HeartlineTwisterRCTrack25DegUpTo60DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21390), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 66 } });
-                WoodenASupportsPaintSetup(session, 6, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -448,7 +436,6 @@ static void HeartlineTwisterRCTrack25DegUpTo60DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21391), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 66 } });
-                WoodenASupportsPaintSetup(session, 7, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -457,7 +444,6 @@ static void HeartlineTwisterRCTrack25DegUpTo60DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21392), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 66 } });
-                WoodenASupportsPaintSetup(session, 6, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -466,7 +452,6 @@ static void HeartlineTwisterRCTrack25DegUpTo60DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21393), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 66 } });
-                WoodenASupportsPaintSetup(session, 7, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -481,7 +466,6 @@ static void HeartlineTwisterRCTrack25DegUpTo60DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21334), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 66 } });
-                WoodenASupportsPaintSetup(session, 6, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -490,7 +474,6 @@ static void HeartlineTwisterRCTrack25DegUpTo60DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21335), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 66 } });
-                WoodenASupportsPaintSetup(session, 7, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -499,7 +482,6 @@ static void HeartlineTwisterRCTrack25DegUpTo60DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21336), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 66 } });
-                WoodenASupportsPaintSetup(session, 6, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -508,10 +490,14 @@ static void HeartlineTwisterRCTrack25DegUpTo60DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21337), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 66 } });
-                WoodenASupportsPaintSetup(session, 7, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
+
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_SUPPORTS],
+        WoodenSupportTransitionType::Up25DegToUp60Deg);
+
     if (direction == 0 || direction == 3)
     {
         PaintUtilPushTunnelRotated(session, direction, height - 8, TUNNEL_1);
@@ -540,7 +526,6 @@ static void HeartlineTwisterRCTrack60DegUpTo25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21398), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 66 } });
-                WoodenASupportsPaintSetup(session, 6, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -549,7 +534,6 @@ static void HeartlineTwisterRCTrack60DegUpTo25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21399), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 66 } });
-                WoodenASupportsPaintSetup(session, 7, 18, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -558,7 +542,6 @@ static void HeartlineTwisterRCTrack60DegUpTo25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21400), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 66 } });
-                WoodenASupportsPaintSetup(session, 6, 19, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -567,7 +550,6 @@ static void HeartlineTwisterRCTrack60DegUpTo25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21401), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 66 } });
-                WoodenASupportsPaintSetup(session, 7, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -582,7 +564,6 @@ static void HeartlineTwisterRCTrack60DegUpTo25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21342), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 66 } });
-                WoodenASupportsPaintSetup(session, 6, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -591,7 +572,6 @@ static void HeartlineTwisterRCTrack60DegUpTo25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21343), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 66 } });
-                WoodenASupportsPaintSetup(session, 7, 18, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -600,7 +580,6 @@ static void HeartlineTwisterRCTrack60DegUpTo25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21344), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 66 } });
-                WoodenASupportsPaintSetup(session, 6, 19, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -609,10 +588,14 @@ static void HeartlineTwisterRCTrack60DegUpTo25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21345), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 66 } });
-                WoodenASupportsPaintSetup(session, 7, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
+
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_SUPPORTS],
+        WoodenSupportTransitionType::Up60DegToUp25Deg);
+
     if (direction == 0 || direction == 3)
     {
         PaintUtilPushTunnelRotated(session, direction, height - 8, TUNNEL_1);
@@ -641,7 +624,6 @@ static void HeartlineTwisterRCTrack25DegUpToFlat(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21374), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 34 } });
-                WoodenASupportsPaintSetup(session, 6, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -650,7 +632,6 @@ static void HeartlineTwisterRCTrack25DegUpToFlat(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21375), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 34 } });
-                WoodenASupportsPaintSetup(session, 7, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -659,7 +640,6 @@ static void HeartlineTwisterRCTrack25DegUpToFlat(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21376), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 34 } });
-                WoodenASupportsPaintSetup(session, 6, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -668,7 +648,6 @@ static void HeartlineTwisterRCTrack25DegUpToFlat(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21377), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 34 } });
-                WoodenASupportsPaintSetup(session, 7, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -683,7 +662,6 @@ static void HeartlineTwisterRCTrack25DegUpToFlat(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21318), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 34 } });
-                WoodenASupportsPaintSetup(session, 6, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -692,7 +670,6 @@ static void HeartlineTwisterRCTrack25DegUpToFlat(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21319), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 34 } });
-                WoodenASupportsPaintSetup(session, 7, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -701,7 +678,6 @@ static void HeartlineTwisterRCTrack25DegUpToFlat(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21320), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 34 } });
-                WoodenASupportsPaintSetup(session, 6, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -710,10 +686,14 @@ static void HeartlineTwisterRCTrack25DegUpToFlat(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21321), { 0, 0, height },
                     { { 0, 27, height }, { 32, 1, 34 } });
-                WoodenASupportsPaintSetup(session, 7, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
+
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_SUPPORTS],
+        WoodenSupportTransitionType::Up25DegToFlat);
+
     if (direction == 0 || direction == 3)
     {
         PaintUtilPushTunnelRotated(session, direction, height - 8, TUNNEL_0);
@@ -791,7 +771,6 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21310), { 0, 0, height },
                         { { 0, 6, height + 23 }, { 32, 20, 0 } });
-                    WoodenASupportsPaintSetup(session, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -800,7 +779,6 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21311), { 0, 0, height },
                         { { 0, 6, height + 23 }, { 32, 20, 0 } });
-                    WoodenASupportsPaintSetup(session, 7, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -809,7 +787,6 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21312), { 0, 0, height },
                         { { 0, 6, height + 23 }, { 32, 20, 0 } });
-                    WoodenASupportsPaintSetup(session, 6, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -818,9 +795,13 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21313), { 0, 0, height },
                         { { 0, 6, height + 23 }, { 32, 20, 0 } });
-                    WoodenASupportsPaintSetup(session, 7, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS], WoodenSupportTransitionType::FlatToUp25Deg);
+
             if (direction == 0 || direction == 3)
             {
                 PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_0);
@@ -848,7 +829,6 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21312), { 0, 0, height + 16 },
                         { { 0, 27, height + 16 }, { 32, 1, 34 } });
-                    WoodenASupportsPaintSetup(session, 6, 5, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -863,7 +843,6 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21313), { 0, 0, height + 16 },
                         { { 0, 27, height + 16 }, { 32, 1, 34 } });
-                    WoodenASupportsPaintSetup(session, 7, 6, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -878,7 +857,6 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21310), { 0, 0, height + 16 },
                         { { 0, 27, height + 16 }, { 32, 1, 34 } });
-                    WoodenASupportsPaintSetup(session, 6, 7, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -893,9 +871,13 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21311), { 0, 0, height + 16 },
                         { { 0, 27, height + 16 }, { 32, 1, 34 } });
-                    WoodenASupportsPaintSetup(session, 7, 8, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS], WoodenSupportTransitionType::Up25DegToFlat);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
@@ -909,7 +891,6 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21302), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -918,7 +899,6 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21303), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -927,7 +907,6 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21304), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -936,9 +915,13 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21305), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
@@ -1062,7 +1045,6 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21312), { 0, 0, height + 16 },
                         { { 0, 27, height + 16 }, { 32, 1, 34 } });
-                    WoodenASupportsPaintSetup(session, 6, 5, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1077,7 +1059,6 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21313), { 0, 0, height + 16 },
                         { { 0, 27, height + 16 }, { 32, 1, 34 } });
-                    WoodenASupportsPaintSetup(session, 7, 6, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1092,7 +1073,6 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21310), { 0, 0, height + 16 },
                         { { 0, 27, height + 16 }, { 32, 1, 34 } });
-                    WoodenASupportsPaintSetup(session, 6, 7, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1107,9 +1087,13 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21311), { 0, 0, height + 16 },
                         { { 0, 27, height + 16 }, { 32, 1, 34 } });
-                    WoodenASupportsPaintSetup(session, 7, 8, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS], WoodenSupportTransitionType::Up25DegToFlat);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
             break;
@@ -1123,7 +1107,6 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21302), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1132,7 +1115,6 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21303), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1141,7 +1123,6 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21304), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1150,9 +1131,13 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21305), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
@@ -1166,7 +1151,6 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21310), { 0, 0, height },
                         { { 0, 6, height + 23 }, { 32, 20, 0 } });
-                    WoodenASupportsPaintSetup(session, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1175,7 +1159,6 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21311), { 0, 0, height },
                         { { 0, 6, height + 23 }, { 32, 20, 0 } });
-                    WoodenASupportsPaintSetup(session, 7, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1184,7 +1167,6 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21312), { 0, 0, height },
                         { { 0, 6, height + 23 }, { 32, 20, 0 } });
-                    WoodenASupportsPaintSetup(session, 6, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1193,9 +1175,13 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21313), { 0, 0, height },
                         { { 0, 6, height + 23 }, { 32, 20, 0 } });
-                    WoodenASupportsPaintSetup(session, 7, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS], WoodenSupportTransitionType::FlatToUp25Deg);
+
             if (direction == 0 || direction == 3)
             {
                 PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_0);
@@ -1227,7 +1213,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21422), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1236,7 +1221,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21425), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1245,7 +1229,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21428), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1254,9 +1237,13 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21431), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_0);
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
@@ -1271,7 +1258,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21423), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1280,7 +1266,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21426), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1289,7 +1274,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21429), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1298,9 +1282,13 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21432), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
@@ -1314,7 +1302,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21424), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1323,7 +1310,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21427), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1332,7 +1318,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21430), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1341,9 +1326,13 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21433), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
@@ -1357,7 +1346,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21430), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1366,7 +1354,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21433), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1375,7 +1362,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21424), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1384,9 +1370,13 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21427), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
@@ -1400,7 +1390,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21429), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1409,7 +1398,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21432), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1418,7 +1406,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21423), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1427,9 +1414,13 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21426), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
@@ -1443,7 +1434,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21428), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1452,7 +1442,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21431), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1461,7 +1450,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21422), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1470,9 +1458,13 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21425), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_0);
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
@@ -1497,7 +1489,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21446), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1506,7 +1497,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21449), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1515,7 +1505,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21452), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1524,9 +1513,13 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21455), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_0);
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
@@ -1541,7 +1534,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21447), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1550,7 +1542,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21450), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1559,7 +1550,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21453), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1568,9 +1558,13 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21456), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
@@ -1584,7 +1578,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21448), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1593,7 +1586,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21451), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1602,7 +1594,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21454), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1611,9 +1602,13 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21457), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
@@ -1627,7 +1622,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21454), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1636,7 +1630,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21457), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1645,7 +1638,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21448), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1654,9 +1646,13 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21451), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
@@ -1670,7 +1666,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21453), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1679,7 +1674,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21456), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1688,7 +1682,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21447), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1697,9 +1690,13 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21450), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
@@ -1713,7 +1710,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21452), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1722,7 +1718,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21455), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1731,7 +1726,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21446), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1740,9 +1734,13 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21449), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_0);
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
+++ b/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
@@ -1239,14 +1239,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 27, height }, { 32, 1, 26 } });
                     break;
             }
-
-            WoodenASupportsPaintSetupRotated(
-                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
-                session.TrackColours[SCHEME_SUPPORTS]);
-
-            PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_0);
-            PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 1:
             switch (direction)
@@ -1284,13 +1276,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 27, height }, { 32, 1, 26 } });
                     break;
             }
-
-            WoodenASupportsPaintSetupRotated(
-                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
-                session.TrackColours[SCHEME_SUPPORTS]);
-
-            PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 2:
             switch (direction)
@@ -1328,13 +1313,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 27, height }, { 32, 1, 26 } });
                     break;
             }
-
-            WoodenASupportsPaintSetupRotated(
-                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
-                session.TrackColours[SCHEME_SUPPORTS]);
-
-            PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 3:
             switch (direction)
@@ -1372,13 +1350,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 27, height }, { 32, 1, 26 } });
                     break;
             }
-
-            WoodenASupportsPaintSetupRotated(
-                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
-                session.TrackColours[SCHEME_SUPPORTS]);
-
-            PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 4:
             switch (direction)
@@ -1416,13 +1387,6 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 27, height }, { 32, 1, 26 } });
                     break;
             }
-
-            WoodenASupportsPaintSetupRotated(
-                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
-                session.TrackColours[SCHEME_SUPPORTS]);
-
-            PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 5:
             switch (direction)
@@ -1460,16 +1424,15 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 27, height }, { 32, 1, 26 } });
                     break;
             }
-
-            WoodenASupportsPaintSetupRotated(
-                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
-                session.TrackColours[SCHEME_SUPPORTS]);
-
-            PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_0);
-            PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
     }
+
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_SUPPORTS]);
+
+    PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_0);
+    PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
+    PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
 
 /** rct2: 0x00876A5C */
@@ -1515,14 +1478,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 27, height }, { 32, 1, 26 } });
                     break;
             }
-
-            WoodenASupportsPaintSetupRotated(
-                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
-                session.TrackColours[SCHEME_SUPPORTS]);
-
-            PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_0);
-            PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 1:
             switch (direction)
@@ -1560,13 +1515,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 27, height }, { 32, 1, 26 } });
                     break;
             }
-
-            WoodenASupportsPaintSetupRotated(
-                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
-                session.TrackColours[SCHEME_SUPPORTS]);
-
-            PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 2:
             switch (direction)
@@ -1604,13 +1552,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 27, height }, { 32, 1, 26 } });
                     break;
             }
-
-            WoodenASupportsPaintSetupRotated(
-                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
-                session.TrackColours[SCHEME_SUPPORTS]);
-
-            PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 3:
             switch (direction)
@@ -1648,13 +1589,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 27, height }, { 32, 1, 26 } });
                     break;
             }
-
-            WoodenASupportsPaintSetupRotated(
-                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
-                session.TrackColours[SCHEME_SUPPORTS]);
-
-            PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 4:
             switch (direction)
@@ -1692,13 +1626,6 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 27, height }, { 32, 1, 26 } });
                     break;
             }
-
-            WoodenASupportsPaintSetupRotated(
-                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
-                session.TrackColours[SCHEME_SUPPORTS]);
-
-            PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
         case 5:
             switch (direction)
@@ -1736,16 +1663,15 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 27, height }, { 32, 1, 26 } });
                     break;
             }
-
-            WoodenASupportsPaintSetupRotated(
-                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
-                session.TrackColours[SCHEME_SUPPORTS]);
-
-            PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_0);
-            PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
             break;
     }
+
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_SUPPORTS]);
+
+    PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_0);
+    PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
+    PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
 
 TRACK_PAINT_FUNCTION GetTrackPaintFunctionHeartlineTwisterRC(int32_t trackType)

--- a/src/openrct2/ride/shops/Facility.cpp
+++ b/src/openrct2/ride/shops/Facility.cpp
@@ -22,7 +22,8 @@ static void PaintFacility(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    bool hasSupports = WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_3]);
+    bool hasSupports = WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_3]);
 
     auto rideEntry = ride.GetRideEntry();
     if (rideEntry == nullptr)

--- a/src/openrct2/ride/shops/Shop.cpp
+++ b/src/openrct2/ride/shops/Shop.cpp
@@ -22,7 +22,8 @@ static void PaintShop(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    bool hasSupports = WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_3]);
+    bool hasSupports = WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_3]);
 
     auto rideEntry = ride.GetRideEntry();
     if (rideEntry == nullptr)


### PR DESCRIPTION
I have a rather large branch that updates _all_ of the remaining support calls. But in order to make it easier to test, and because PRs like https://github.com/OpenRCT2/OpenRCT2/pull/20972 touch some of the same lines, I have decided to split it off into smaller chunks. This will also allow me to spend a bit more time on the individual track drawing files and consolidate the support calls in these a bit more too.