### PR TITLE
Fix #20618: ignore tasks.json in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -304,7 +304,7 @@ discord-rpc
 #########################
 .vscode/*
 .vscode/settings.json
-!.vscode/tasks.json
+.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
 


### PR DESCRIPTION
#20618

The justification for this is that we should not have a rule to never ignore a file which we don't provide in the repo in the first place. 