### PR TITLE
Fix #20624: Clear scrolling text cache on language change

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Fix: [#20778] [Plugin] Incorrect target api when executing custom actions.
 - Fix: [#20807] Tertiary colour not copied with small scenery.
 - Fix: [#20964] Crash when player connects to server with a group assigned that no longer exists.
+- Fix: [#20624] Scrolling text glitches after language is changed.
 
 0.4.6 (2023-09-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/localisation/Language.cpp
+++ b/src/openrct2/localisation/Language.cpp
@@ -83,6 +83,7 @@ bool LanguageOpen(int32_t id)
         localisationService.OpenLanguage(id);
         // Objects and their localised strings need to be refreshed
         objectManager.ResetObjects();
+        ScrollingTextInvalidate();
         return true;
     }
     catch (const std::exception&)


### PR DESCRIPTION
Fix for #20624