### PR TITLE
Add the ability to set guest energy to 0

### DIFF
--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -837,12 +837,15 @@ void Guest::Loc68FA89()
     }
     else
     {
-        newEnergy = std::min(PEEP_MAX_ENERGY_TARGET, newEnergy + 4);
+        if (newEnergy != 0)
+        {
+            newEnergy = std::min(PEEP_MAX_ENERGY_TARGET, newEnergy + 4);
+        }
         if (newEnergy > newTargetEnergy)
             newEnergy = newTargetEnergy;
     }
 
-    if (newEnergy < PEEP_MIN_ENERGY)
+    if (newEnergy < PEEP_MIN_ENERGY && newEnergy > 0)
         newEnergy = PEEP_MIN_ENERGY;
 
     /* Previous code here suggested maximum energy is 128. */
@@ -6857,13 +6860,13 @@ void Guest::UpdateSpriteType()
         return;
     }
 
-    if (Energy <= 64 && Happiness < 128)
+    if (Energy <= 64 && Energy > 0 && Happiness < 128)
     {
         SetSpriteType(PeepSpriteType::HeadDown);
         return;
     }
 
-    if (Energy <= 80 && Happiness < 128)
+    if (Energy <= 80 && Energy > 0 && Happiness < 128)
     {
         SetSpriteType(PeepSpriteType::ArmsCrossed);
         return;


### PR DESCRIPTION
I made it possible to set the energy of guests to 0, aka freezing them in place. Lots of sandbox players love to create scenes with frozen peeps and a lot (including myself) would want to have the ability to freeze the guests in place, like what's already possible with the staff members. I want to include this functionality in the Peep Editor plugin.