### PR TITLE
Add guest and staff actions/animations to the API

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -110,6 +110,7 @@ The following people are not part of the development team, but have been contrib
 * Wenzhao Qiu (qwzhaox) - Misc.
 * Tiago Reul (reul) - Misc.
 * Fredrik Tegnell (fredriktegnell) - Misc.
+* Arjan van Dijk (Manticore-007) - Exposed actions/animations for guests and staff members to the plugin API.
 
 ## Bug fixes
 * (KirilAngelov)

--- a/contributors.md
+++ b/contributors.md
@@ -110,7 +110,7 @@ The following people are not part of the development team, but have been contrib
 * Wenzhao Qiu (qwzhaox) - Misc.
 * Tiago Reul (reul) - Misc.
 * Fredrik Tegnell (fredriktegnell) - Misc.
-* Arjan van Dijk (Manticore-007) - Exposed actions/animations for guests and staff members to the plugin API.
+* Arjan van Dijk (Manticore-007) - Add actions/animations for guests and staff members to the plugin API.
 
 ## Bug fixes
 * (KirilAngelov)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,7 +7,7 @@
 - Feature: [OpenMusic#50] Added Rock style 4 ride music.
 - Feature: [#20825] Made setting the game speed a game action.
 - Feature: [#20853] [Plugin] Add “BaseTileElement.owner” which is saved in the park file.
-- Feature: [#21020] [Plugin] Exposed triggerable actions/animations for guests and staff members to the API.
+- Feature: [#21020] [Plugin] Add triggerable actions/animations for guests and staff members to the API.
 - Change: [#20790] Default ride price set to free if park charges for entry.
 - Fix: [#16453] Tile inspector invisibility shortcut does not use a game action.
 - Fix: [#17774] Misplaced/missing land and construction rights tiles in RCT1 & RCT2 scenarios.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Feature: [OpenMusic#50] Added Rock style 4 ride music.
 - Feature: [#20825] Made setting the game speed a game action.
 - Feature: [#20853] [Plugin] Add “BaseTileElement.owner” which is saved in the park file.
+- Feature: [#21020] [Plugin] Exposed triggerable actions/animations for guests and staff members to the API.
 - Change: [#20790] Default ride price set to free if park charges for entry.
 - Fix: [#16453] Tile inspector invisibility shortcut does not use a game action.
 - Fix: [#17774] Misplaced/missing land and construction rights tiles in RCT1 & RCT2 scenarios.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -2765,7 +2765,38 @@ declare global {
          * The list of thoughts this guest has.
          */
         readonly thoughts: Thought[];
+
+        /**
+         * Triggers an action/animation of the selected guest.
+         */
+        action: GuestAction;
     }
+
+    type GuestAction =
+        "checkTime" |
+        "eatFood" |
+        "shakeHead" |
+        "emptyPockets" |
+        "sitEatFood" |
+        "sitCheckWatch" |
+        "sitLookLeft" |
+        "sitLookRight" |
+        "wow" |
+        "throwUp" |
+        "jump" |
+        "drown" |
+        "joy" |
+        "readMap" |
+        "wave" |
+        "wave2" |
+        "takePhoto" |
+        "clap" |
+        "disgust" |
+        "drawPicture" |
+        "beWatched" |
+        "withdrawMoney" |
+        "idle" |
+        "walk";
 
     /**
      * Represents a guest's thought. This is a copy of a thought at a given time
@@ -2955,6 +2986,27 @@ declare global {
          * Gets the patrol area for the staff member.
          */
         readonly patrolArea: PatrolArea;
+
+        /**
+         * Triggers an action/animation of the selected staff member.
+         */
+        action: StaffAction;
+    }
+
+    type StaffAction =
+        "sweep" |
+        "drown" |
+        "answer" |
+        "answer2" |
+        "inspect" |
+        "fix" |
+        "fix2" |
+        "fixGround" |
+        "fix3" |
+        "water" |
+        "emptyBin" |
+        "idle" |
+        "walk";
     }
 
     type StaffType = "handyman" | "mechanic" | "security" | "entertainer";

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -3007,7 +3007,6 @@ declare global {
         "emptyBin" |
         "idle" |
         "walk";
-    }
 
     type StaffType = "handyman" | "mechanic" | "security" | "entertainer";
 

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -47,7 +47,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 81;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 82;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;

--- a/src/openrct2/scripting/bindings/entity/ScGuest.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.cpp
@@ -485,8 +485,9 @@ namespace OpenRCT2::Scripting
         {
             if (!GuestActionMap.TryGet(value))
             {
-                return;
+                printf("ERROR: '%s' is not a valid guest action\n\n", value.c_str());
             }
+            else
             peep->Action = GuestActionMap[value];
             peep->ActionFrame = 0;
             peep->ActionSpriteImageOffset = 0;

--- a/src/openrct2/scripting/bindings/entity/ScGuest.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.cpp
@@ -488,11 +488,13 @@ namespace OpenRCT2::Scripting
                 printf("ERROR: '%s' is not a valid guest action\n\n", value.c_str());
             }
             else
-            peep->Action = GuestActionMap[value];
-            peep->ActionFrame = 0;
-            peep->ActionSpriteImageOffset = 0;
-            peep->UpdateCurrentActionSpriteType();
-            peep->Invalidate();
+            {
+                peep->Action = GuestActionMap[value];
+                peep->ActionFrame = 0;
+                peep->ActionSpriteImageOffset = 0;
+                peep->UpdateCurrentActionSpriteType();
+                peep->Invalidate();
+            }
         }
     }
 

--- a/src/openrct2/scripting/bindings/entity/ScGuest.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.cpp
@@ -480,12 +480,13 @@ namespace OpenRCT2::Scripting
     void ScGuest::action_set(const std::string value)
     {
         ThrowIfGameStateNotMutable();
+        auto ctx = GetContext()->GetScriptEngine().GetContext();
         auto peep = GetGuest();
         if (peep != nullptr)
         {
             if (!GuestActionMap.TryGet(value))
             {
-                printf("ERROR: '%s' is not a valid guest action\n\n", value.c_str());
+                duk_error(ctx, DUK_ERR_ERROR, "Invalid guest action");
             }
             else
             {

--- a/src/openrct2/scripting/bindings/entity/ScGuest.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.cpp
@@ -144,6 +144,32 @@ namespace OpenRCT2::Scripting
         { "here_we_are", PeepThoughtType::HereWeAre },
     });
 
+    static const DukEnumMap<PeepActionType> GuestActionMap({ { "checkTime", PeepActionType::CheckTime },
+                                                             { "eatFood", PeepActionType::EatFood },
+                                                             { "shakeHead", PeepActionType::ShakeHead },
+                                                             { "emptyPockets", PeepActionType::EmptyPockets },
+                                                             { "sitEatFood", PeepActionType::SittingEatFood },
+                                                             { "sitCheckWatch", PeepActionType::SittingCheckWatch },
+                                                             { "sitLookLeft", PeepActionType::SittingLookAroundLeft },
+                                                             { "sitLookRight", PeepActionType::SittingLookAroundRight },
+                                                             { "wow", PeepActionType::Wow },
+                                                             { "throwUp", PeepActionType::ThrowUp },
+                                                             { "jump", PeepActionType::Jump },
+                                                             { "drown", PeepActionType::Drowning },
+                                                             { "joy", PeepActionType::Joy },
+                                                             { "readMap", PeepActionType::ReadMap },
+                                                             { "wave", PeepActionType::Wave },
+                                                             { "wave2", PeepActionType::Wave2 },
+                                                             { "takePhoto", PeepActionType::TakePhoto },
+                                                             { "clap", PeepActionType::Clap },
+                                                             { "disgust", PeepActionType::Disgust },
+                                                             { "drawPicture", PeepActionType::DrawPicture },
+                                                             { "beWatched", PeepActionType::BeingWatched },
+                                                             { "withdrawMoney", PeepActionType::WithdrawMoney },
+
+                                                             { "idle", PeepActionType::Idle },
+                                                             { "walk", PeepActionType::Walking } });
+
     ScGuest::ScGuest(EntityId id)
         : ScPeep(id)
     {
@@ -169,6 +195,7 @@ namespace OpenRCT2::Scripting
         dukglue_register_property(ctx, &ScGuest::maxIntensity_get, &ScGuest::maxIntensity_set, "maxIntensity");
         dukglue_register_property(ctx, &ScGuest::nauseaTolerance_get, &ScGuest::nauseaTolerance_set, "nauseaTolerance");
         dukglue_register_property(ctx, &ScGuest::cash_get, &ScGuest::cash_set, "cash");
+        dukglue_register_property(ctx, &ScGuest::action_get, &ScGuest::action_set, "action");
         dukglue_register_property(ctx, &ScGuest::isInPark_get, nullptr, "isInPark");
         dukglue_register_property(ctx, &ScGuest::isLost_get, nullptr, "isLost");
         dukglue_register_property(ctx, &ScGuest::lostCountdown_get, &ScGuest::lostCountdown_set, "lostCountdown");
@@ -437,6 +464,34 @@ namespace OpenRCT2::Scripting
         if (peep != nullptr)
         {
             peep->CashInPocket = std::max(0, value);
+        }
+    }
+
+    std::string ScGuest::action_get() const
+    {
+        auto peep = GetGuest();
+        if (peep != nullptr)
+        {
+            return std::string(GuestActionMap[peep->Action]);
+        }
+        return {};
+    }
+
+    void ScGuest::action_set(const std::string value)
+    {
+        ThrowIfGameStateNotMutable();
+        auto peep = GetGuest();
+        if (peep != nullptr)
+        {
+            if (!GuestActionMap.TryGet(value))
+            {
+                return;
+            }
+            peep->Action = GuestActionMap[value];
+            peep->ActionFrame = 0;
+            peep->ActionSpriteImageOffset = 0;
+            peep->UpdateCurrentActionSpriteType();
+            peep->Invalidate();
         }
     }
 

--- a/src/openrct2/scripting/bindings/entity/ScGuest.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.hpp
@@ -95,6 +95,9 @@ namespace OpenRCT2::Scripting
         int32_t cash_get() const;
         void cash_set(int32_t value);
 
+        std::string action_get() const;
+        void action_set(std::string value);
+
         bool isInPark_get() const;
 
         bool isLost_get() const;

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -179,8 +179,9 @@ namespace OpenRCT2::Scripting
         {
             if (!StaffActionMap.TryGet(value))
             {
-                return;
+                printf("ERROR: '%s' is not a valid staff member action\n\n", value.c_str());
             }
+            else
             peep->Action = StaffActionMap[value];
             peep->ActionFrame = 0;
             peep->ActionSpriteImageOffset = 0;

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -182,11 +182,13 @@ namespace OpenRCT2::Scripting
                 printf("ERROR: '%s' is not a valid staff member action\n\n", value.c_str());
             }
             else
-            peep->Action = StaffActionMap[value];
-            peep->ActionFrame = 0;
-            peep->ActionSpriteImageOffset = 0;
-            peep->UpdateCurrentActionSpriteType();
-            peep->Invalidate();
+            {
+                peep->Action = StaffActionMap[value];
+                peep->ActionFrame = 0;
+                peep->ActionSpriteImageOffset = 0;
+                peep->UpdateCurrentActionSpriteType();
+                peep->Invalidate();
+            }
         }
     }
 

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -21,22 +21,20 @@ namespace OpenRCT2::Scripting
     {
     }
 
-    static const DukEnumMap<PeepActionType> StaffActionMap({
-          { "sweep", PeepActionType::StaffSweep },
-          { "drown", PeepActionType::Drowning },
-          { "answer", PeepActionType::StaffAnswerCall },
-          { "answer2", PeepActionType::StaffAnswerCall2 },
-          { "inspect", PeepActionType::StaffCheckboard },
-          { "fix", PeepActionType::StaffFix },
-          { "fix2", PeepActionType::StaffFix2 },
-          { "fixGround", PeepActionType::StaffFixGround },
-          { "fix3", PeepActionType::StaffFix3 },
-          { "water", PeepActionType::StaffWatering },
-          { "emptyBin", PeepActionType::StaffEmptyBin },
+    static const DukEnumMap<PeepActionType> StaffActionMap({ { "sweep", PeepActionType::StaffSweep },
+                                                             { "drown", PeepActionType::Drowning },
+                                                             { "answer", PeepActionType::StaffAnswerCall },
+                                                             { "answer2", PeepActionType::StaffAnswerCall2 },
+                                                             { "inspect", PeepActionType::StaffCheckboard },
+                                                             { "fix", PeepActionType::StaffFix },
+                                                             { "fix2", PeepActionType::StaffFix2 },
+                                                             { "fixGround", PeepActionType::StaffFixGround },
+                                                             { "fix3", PeepActionType::StaffFix3 },
+                                                             { "water", PeepActionType::StaffWatering },
+                                                             { "emptyBin", PeepActionType::StaffEmptyBin },
 
-          { "idle", PeepActionType::Idle },
-          { "walk", PeepActionType::Walking }
-});
+                                                             { "idle", PeepActionType::Idle },
+                                                             { "walk", PeepActionType::Walking } });
 
     void ScStaff::Register(duk_context* ctx)
     {
@@ -183,11 +181,11 @@ namespace OpenRCT2::Scripting
             {
                 return;
             }
-                peep->Action = StaffActionMap[value];
-                peep->ActionFrame = 0;
-                peep->ActionSpriteImageOffset = 0;
-                peep->UpdateCurrentActionSpriteType();
-                peep->Invalidate();
+            peep->Action = StaffActionMap[value];
+            peep->ActionFrame = 0;
+            peep->ActionSpriteImageOffset = 0;
+            peep->UpdateCurrentActionSpriteType();
+            peep->Invalidate();
         }
     }
 

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -22,20 +22,20 @@ namespace OpenRCT2::Scripting
     }
 
     static const DukEnumMap<PeepActionType> StaffActionMap({
-          { "sweeping", PeepActionType::StaffSweep },
-          { "drowning", PeepActionType::Drowning },
-          { "answering", PeepActionType::StaffAnswerCall },
-          { "answering_2", PeepActionType::StaffAnswerCall2 },
-          { "inspecting", PeepActionType::StaffCheckboard },
-          { "fixing", PeepActionType::StaffFix },
-          { "fixing_2", PeepActionType::StaffFix2 },
-          { "fixing_ground", PeepActionType::StaffFixGround },
-          { "fixing_3", PeepActionType::StaffFix3 },
-          { "watering", PeepActionType::StaffWatering },
-          { "emptying_bin", PeepActionType::StaffEmptyBin },
+          { "sweep", PeepActionType::StaffSweep },
+          { "drown", PeepActionType::Drowning },
+          { "answer", PeepActionType::StaffAnswerCall },
+          { "answer2", PeepActionType::StaffAnswerCall2 },
+          { "inspect", PeepActionType::StaffCheckboard },
+          { "fix", PeepActionType::StaffFix },
+          { "fix2", PeepActionType::StaffFix2 },
+          { "fixGround", PeepActionType::StaffFixGround },
+          { "fix3", PeepActionType::StaffFix3 },
+          { "water", PeepActionType::StaffWatering },
+          { "emptyBin", PeepActionType::StaffEmptyBin },
 
           { "idle", PeepActionType::Idle },
-          { "walking", PeepActionType::Walking }
+          { "walk", PeepActionType::Walking }
 });
 
     void ScStaff::Register(duk_context* ctx)

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -174,12 +174,13 @@ namespace OpenRCT2::Scripting
     void ScStaff::action_set(const std::string value)
     {
         ThrowIfGameStateNotMutable();
+        auto ctx = GetContext()->GetScriptEngine().GetContext();
         auto peep = GetStaff();
         if (peep != nullptr)
         {
             if (!StaffActionMap.TryGet(value))
             {
-                printf("ERROR: '%s' is not a valid staff member action\n\n", value.c_str());
+                duk_error(ctx, DUK_ERR_ERROR, "Invalid staff member action");
             }
             else
             {

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -21,6 +21,23 @@ namespace OpenRCT2::Scripting
     {
     }
 
+    static const DukEnumMap<PeepActionType> StaffActionMap({
+          { "sweeping", PeepActionType::StaffSweep },
+          { "drowning", PeepActionType::Drowning },
+          { "answering", PeepActionType::StaffAnswerCall },
+          { "answering_2", PeepActionType::StaffAnswerCall2 },
+          { "inspecting", PeepActionType::StaffCheckboard },
+          { "fixing", PeepActionType::StaffFix },
+          { "fixing_2", PeepActionType::StaffFix2 },
+          { "fixing_ground", PeepActionType::StaffFixGround },
+          { "fixing_3", PeepActionType::StaffFix3 },
+          { "watering", PeepActionType::StaffWatering },
+          { "emptying_bin", PeepActionType::StaffEmptyBin },
+
+          { "idle", PeepActionType::Idle },
+          { "walking", PeepActionType::Walking }
+});
+
     void ScStaff::Register(duk_context* ctx)
     {
         dukglue_set_base_class<ScPeep, ScStaff>(ctx);
@@ -29,6 +46,7 @@ namespace OpenRCT2::Scripting
         dukglue_register_property(ctx, &ScStaff::costume_get, &ScStaff::costume_set, "costume");
         dukglue_register_property(ctx, &ScStaff::patrolArea_get, nullptr, "patrolArea");
         dukglue_register_property(ctx, &ScStaff::orders_get, &ScStaff::orders_set, "orders");
+        dukglue_register_property(ctx, &ScStaff::action_get, &ScStaff::action_set, "action");
     }
 
     Staff* ScStaff::GetStaff() const
@@ -142,6 +160,34 @@ namespace OpenRCT2::Scripting
         if (peep != nullptr)
         {
             peep->StaffOrders = value;
+        }
+    }
+
+    std::string ScStaff::action_get() const
+    {
+        auto peep = GetStaff();
+        if (peep != nullptr)
+        {
+            return std::string(StaffActionMap[peep->Action]);
+        }
+        return {};
+    }
+
+    void ScStaff::action_set(const std::string value)
+    {
+        ThrowIfGameStateNotMutable();
+        auto peep = GetStaff();
+        if (peep != nullptr)
+        {
+            if (!StaffActionMap.TryGet(value))
+            {
+                return;
+            }
+                peep->Action = StaffActionMap[value];
+                peep->ActionFrame = 0;
+                peep->ActionSpriteImageOffset = 0;
+                peep->UpdateCurrentActionSpriteType();
+                peep->Invalidate();
         }
     }
 

--- a/src/openrct2/scripting/bindings/entity/ScStaff.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.hpp
@@ -63,6 +63,9 @@ namespace OpenRCT2::Scripting
 
         uint8_t orders_get() const;
         void orders_set(uint8_t value);
+
+        std::string action_get() const;
+        void action_set(std::string value);
     };
 
 } // namespace OpenRCT2::Scripting


### PR DESCRIPTION
I've added actions/animations of the guests and staff members to the API. Lots of sandbox players love the create scenes with frozen peeps and a lot (including myself) would find it very convenient to trigger certain animations by hand. I want to include this functionality in the Peep Editor plugin.

See feature request https://github.com/OpenRCT2/OpenRCT2/discussions/17965.

I screwed up some things so this is a new PR for #21020.