### PR TITLE
Do not add new music styles to old parks automatically

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -30,6 +30,7 @@
 - Improved: [objects#329] Add RCT1AA lay-down coaster trains (for import only).
 - Change: [#7248] Small mini-maps are now centred in the map window.
 - Change: [#20240] Heavy snow and blizzards now make guests buy and use umbrellas.
+- Change: [#21043] The new music styles are no longer added to old parks automatically.
 - Change: [#21214] Wacky Worlds and Time Twister’s scenario names now match their park names.
 - Change: [#21991] UI themes JSON now use colour names and a translucency bool, instead of a number (old themes still work).
 - Change: [#22057] Reorder Time Twister’s scenarios and adjust their difficulty classification.

--- a/src/openrct2/rct12/RCT12.cpp
+++ b/src/openrct2/rct12/RCT12.cpp
@@ -760,16 +760,6 @@ static constexpr std::string_view _musicStyles[] = {
     "rct2.music.pirate",
     "rct2.music.rock3",
     "rct2.music.candy",
-    "openrct2.music.galaxy",
-    "openrct2.music.acid",
-    "openrct2.music.dodgems",
-    "openrct2.music.blizzard",
-    "openrct2.music.extraterrestrial",
-    "openrct2.music.fairground2",
-    "openrct2.music.ragtime2",
-    "openrct2.music.prehistoric",
-    "openrct2.music.mystic",
-    "openrct2.music.rock4",
 };
 
 std::string_view GetStationIdentifierFromStyle(uint8_t style)


### PR DESCRIPTION
For some reason, newly introduced music styles were added to existing SV4 and SV6 files. This didn’t make a great deal of sense, as we always leave the object selection intact as much as possible. (E.g. we don’t add new land types or station styles or anything else either.)

While investigating, it also seems like SV4, SV6, TD4 and TD6 loading still assumes that the music IDs are fixed, which hasn’t been the case for a long time. This is something I’d want to investigate further and maybe address in a future PR.