### PR TITLE
Fix #20196: New scenarios start with an incorrect temperature

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Improved: [#18632] Land ownership and construction rights are now shown on top of the water.
 - Improved: [#20951] Activate OpenRCT2 window after using native file dialog on macOS.
 - Change: [#21225] Raise maximum allowed misc entities to 1600.
+- Fix: [#20196] New scenarios start with an incorrect temperature.
 - Fix: [#20255] Images from the last hovered-over coaster in the object selection are not freed.
 - Fix: [#20616] Confirmation button in the track designer’s quit prompt has the wrong text.
 - Fix: [#20628] Moving caret using Ctrl+left can move too far when using a multibyte grapheme.

--- a/src/openrct2/actions/ClimateSetAction.cpp
+++ b/src/openrct2/actions/ClimateSetAction.cpp
@@ -45,7 +45,7 @@ GameActions::Result ClimateSetAction::Query() const
 
 GameActions::Result ClimateSetAction::Execute() const
 {
-    OpenRCT2::GetGameState().Climate = ClimateType{ _climate };
+    ClimateReset(_climate);
 
     GfxInvalidateScreen();
 


### PR DESCRIPTION
Climates set and saved in scenario editor will now be correct upon first loading of scenario. Previously, a double save in the scenario editor was necessary to see the climate change in effect.