### PR TITLE
Fix #13473: Lower Circus default price to avoid instant guest complaint

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Feature: [#20853] [Plugin] Add “BaseTileElement.owner” which is saved in the park file.
 - Change: [#20790] Default ride price set to free if park charges for entry.
 - Change: [#20880] Restore removed default coaster colours.
+- Fix: [#13473] Guests complain that the default Circus price is too high.
 - Fix: [#15293] TTF fonts don’t format correctly with OpenGL.
 - Fix: [#16453] Tile inspector invisibility shortcut does not use a game action.
 - Fix: [#17774] Misplaced/missing land and construction rights tiles in RCT1 & RCT2 scenarios.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "10"
+#define NETWORK_STREAM_VERSION "11"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/ride/gentle/meta/Circus.h
+++ b/src/openrct2/ride/gentle/meta/Circus.h
@@ -42,7 +42,7 @@ constexpr RideTypeDescriptor CircusRTD =
     SET_FIELD(RatingsMultipliers, { 20, 10, 0 }),
     SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
     SET_FIELD(BuildCosts, { 62.50_GBP, 1.00_GBP, 1, }),
-    SET_FIELD(DefaultPrices, { 15, 0 }),
+    SET_FIELD(DefaultPrices, { 12, 0 }),
     SET_FIELD(DefaultMusic, {}),
     SET_FIELD(PhotoItem, ShopItem::Photo),
     SET_FIELD(BonusValue, 39),


### PR DESCRIPTION
The new price will prevent guests from complaining about the price being too high, which was caused by changes in the way flat rides handle value in OpenRCT2 as compared to Vanilla RCT2

 Fixes https://github.com/OpenRCT2/OpenRCT2/issues/13473