### PR TITLE
Close OpenRCT2/OpenRCT2#20830: Display author field on scenery window

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3697,6 +3697,8 @@ STR_6591    :Staff member is currently fixing a ride and can’t be fired.
 STR_6592    :Staff member is currently inspecting a ride and can’t be fired.
 STR_6593    :Remove park fences
 STR_6594    :Tile Inspector: Toggle wall slope
+STR_6595    :{WINDOW_COLOUR_2}Author: {BLACK}{STRING}
+STR_6596    :{WINDOW_COLOUR_2}Authors: {BLACK}{STRING}
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.7 (in development)
 ------------------------------------------------------------------------
+- Feature: [#20830] Display author field on scenery window.
 - Feature: [#12078] Add shortcut key for toggling wall slope.
 - Feature: [#19919] Add diagonal brakes and diagonal block brakes to most coaster types.
 - Feature: [#20141] Add additional track pieces to the Giga Coaster.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,12 +1,12 @@
 0.4.7 (in development)
 ------------------------------------------------------------------------
-- Feature: [#20830] Display author field on scenery window.
 - Feature: [#12078] Add shortcut key for toggling wall slope.
 - Feature: [#19919] Add diagonal brakes and diagonal block brakes to most coaster types.
 - Feature: [#20141] Add additional track pieces to the Giga Coaster.
 - Feature: [OpenMusic#46] Added Mystic ride music style.
 - Feature: [OpenMusic#50] Added Rock style 4 ride music.
 - Feature: [#20825] Made setting the game speed a game action.
+- Feature: [#20830] Display author field on scenery window.
 - Feature: [#20853] [Plugin] Add “BaseTileElement.owner” which is saved in the park file.
 - Change: [#20790] Default ride price set to free if park charges for entry.
 - Fix: [#16453] Tile inspector invisibility shortcut does not use a game action.

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -801,19 +801,20 @@ public:
         if (sceneryObject != nullptr && sceneryObject->GetAuthors().size() > 0)
         {
             std::string authorsString;
-            for (size_t i = 0; i < sceneryObject->GetAuthors().size(); i++)
+            const auto& authors = sceneryObject->GetAuthors();
+            for (size_t i = 0; i < authors.size(); ++i)
             {
                 if (i > 0)
                 {
                     authorsString.append(", ");
                 }
-                authorsString.append(sceneryObject->GetAuthors()[i]);
+                authorsString.append(authors[i]);
             }
             ft = Formatter();
             ft.Add<const char*>(authorsString.c_str());
             DrawTextEllipsised(
-                dpi, { windowPos.x + 3, windowPos.y + height - 13 }, width - 19,
-                (sceneryObject->GetAuthors().size() == 1 ? STR_AUTHOR : STR_AUTHOR_PLURAL), ft);
+                dpi, windowPos + ScreenCoordsXY{ 3, height - 13 }, width - 19,
+                (sceneryObject->GetAuthors().size() == 1 ? STR_SCENERY_AUTHOR : STR_SCENERY_AUTHOR_PLURAL), ft);
         }
     }
 

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -811,7 +811,8 @@ public:
             }
             ft = Formatter();
             ft.Add<const char*>(authorsString.c_str());
-            DrawTextEllipsised(dpi, { windowPos.x + 3, windowPos.y + height - 13 }, width - 19, 
+            DrawTextEllipsised(
+                dpi, { windowPos.x + 3, windowPos.y + height - 13 }, width - 19, 
                 (sceneryObject->GetAuthors().size() == 1 ? STR_AUTHOR : STR_AUTHOR_PLURAL), ft);
         }
     }

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -812,7 +812,7 @@ public:
             ft = Formatter();
             ft.Add<const char*>(authorsString.c_str());
             DrawTextEllipsised(
-                dpi, { windowPos.x + 3, windowPos.y + height - 13 }, width - 19, 
+                dpi, { windowPos.x + 3, windowPos.y + height - 13 }, width - 19,
                 (sceneryObject->GetAuthors().size() == 1 ? STR_AUTHOR : STR_AUTHOR_PLURAL), ft);
         }
     }

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -422,12 +422,12 @@ public:
                     else
                     {
                         const auto& listWidget = widgets[WIDX_SCENERY_LIST];
-                        const auto nonListHeight = height - listWidget.height() + 2;
+                        const auto nonListHeight = height - listWidget.height() + 12;
 
                         const auto numRows = static_cast<int32_t>(CountRows());
                         const auto maxContentHeight = numRows * SCENERY_BUTTON_HEIGHT;
                         const auto maxWindowHeight = maxContentHeight + nonListHeight;
-                        const auto windowHeight = std::clamp(maxWindowHeight, _actualMinHeight, 463);
+                        const auto windowHeight = std::clamp(maxWindowHeight, _actualMinHeight, 473);
 
                         min_height = windowHeight;
                         max_height = windowHeight;
@@ -743,7 +743,7 @@ public:
 
         ResizeFrameWithPage();
         widgets[WIDX_SCENERY_LIST].right = windowWidth - 26;
-        widgets[WIDX_SCENERY_LIST].bottom = height - 14;
+        widgets[WIDX_SCENERY_LIST].bottom = height - 24;
 
         widgets[WIDX_SCENERY_ROTATE_OBJECTS_BUTTON].left = windowWidth - 25;
         widgets[WIDX_SCENERY_REPAINT_SCENERY_BUTTON].left = windowWidth - 25;
@@ -793,7 +793,27 @@ public:
 
         auto ft = Formatter();
         ft.Add<StringId>(name);
-        DrawTextEllipsised(dpi, { windowPos.x + 3, windowPos.y + height - 13 }, width - 19, STR_BLACK_STRING, ft);
+        DrawTextEllipsised(dpi, { windowPos.x + 3, windowPos.y + height - 23 }, width - 19, STR_BLACK_STRING, ft);
+
+        auto sceneryObjectType = GetObjectTypeFromSceneryType(selectedSceneryEntry.SceneryType);
+        auto& objManager = GetContext()->GetObjectManager();
+        auto sceneryObject = objManager.GetLoadedObject(sceneryObjectType, selectedSceneryEntry.EntryIndex);
+        if (sceneryObject != nullptr && sceneryObject->GetAuthors().size() > 0)
+        {
+            std::string authorsString;
+            for (size_t i = 0; i < sceneryObject->GetAuthors().size(); i++)
+            {
+                if (i > 0)
+                {
+                    authorsString.append(", ");
+                }
+                authorsString.append(sceneryObject->GetAuthors()[i]);
+            }
+            ft = Formatter();
+            ft.Add<const char*>(authorsString.c_str());
+            DrawTextEllipsised(dpi, { windowPos.x + 3, windowPos.y + height - 13 }, width - 19, 
+                (sceneryObject->GetAuthors().size() == 1 ? STR_AUTHOR : STR_AUTHOR_PLURAL), ft);
+        }
     }
 
     void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -4004,6 +4004,9 @@ enum : uint16_t
 
     STR_SHORTCUT_TOGGLE_WALL_SLOPE = 6594,
 
+    STR_AUTHOR = 6595,
+    STR_AUTHOR_PLURAL = 6596,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -4004,8 +4004,8 @@ enum : uint16_t
 
     STR_SHORTCUT_TOGGLE_WALL_SLOPE = 6594,
 
-    STR_AUTHOR = 6595,
-    STR_AUTHOR_PLURAL = 6596,
+    STR_SCENERY_AUTHOR = 6595,
+    STR_SCENERY_AUTHOR_PLURAL = 6596,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings


### PR DESCRIPTION
Closes https://github.com/OpenRCT2/OpenRCT2/issues/20830. Added display of author on the left bottom corner of the scenery  window (right below the scenery name). 
This included making the window a bit larger to avoid clutter and singular/plural functionality for the author string.

![plural](https://github.com/OpenRCT2/OpenRCT2/assets/8687318/7c4bc533-b98f-407f-8125-b48f7fc691b9)
![singular](https://github.com/OpenRCT2/OpenRCT2/assets/8687318/dbcb1c2a-a137-4306-a540-7642199a8c6d)
