### PR TITLE
Revise the scenery door close logic, after it's close

### DIFF
--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -6862,6 +6862,10 @@ static void AnimateSceneryDoor(const CoordsXYZD& doorLocation, const CoordsXYZ& 
         door->SetAnimationIsBackwards(isBackwards);
         door->SetAnimationFrame(6);
         play_scenery_door_close_sound(trackLocation, door);
+        if (isBackwards)
+        {
+            door->SetAnimationFrame(0);
+        }
     }
 }
 


### PR DESCRIPTION
Ensure the animation frame gose back to its original state
Fixes #18450 