### PR TITLE
Added clang format for shaders

### DIFF
--- a/data/shaders/applytransparency.frag
+++ b/data/shaders/applytransparency.frag
@@ -1,11 +1,13 @@
 #version 150
 
+// clang-format off
 uniform usampler2D      uOpaqueTex;
 uniform sampler2D       uOpaqueDepth;
 uniform usampler2D      uTransparentTex;
 uniform sampler2D       uTransparentDepth;
 uniform usampler2D      uPaletteTex;
 uniform usampler2D      uBlendPaletteTex;
+// clang-format off
 
 in vec2 fTextureCoordinate;
 

--- a/data/shaders/drawline.vert
+++ b/data/shaders/drawline.vert
@@ -5,10 +5,12 @@ const float DEPTH_INCREMENT = 1.0 / float(1u << 22u);
 
 uniform ivec2 uScreenSize;
 
+// clang-format off
 in ivec4 vBounds;
 in ivec4 vClip;
 in uint  vColour;
 in int   vDepth;
+// clang-format on
 
 in mat4x2 vVertMat;
 

--- a/data/shaders/drawrect.frag
+++ b/data/shaders/drawrect.frag
@@ -1,5 +1,6 @@
 #version 150
 
+// clang-format off
 const int MASK_REMAP_COUNT          = 3;
 const int FLAG_NO_TEXTURE           = (1 << 2);
 const int FLAG_MASK                 = (1 << 3);
@@ -18,8 +19,9 @@ in vec3                 fTexColour;
 in vec3                 fTexMask;
 flat in vec3            fPalettes;
 
-in vec2 fPosition;
-in vec3 fPeelPos;
+in vec2                 fPosition;
+in vec3                 fPeelPos;
+// clang-format on
 
 out uint oColour;
 
@@ -49,17 +51,17 @@ void main()
         else
         {
             uint hint_thresh = uint(fFlags & 0xff00) >> 8;
-            if(hint_thresh > 0u)
+            if (hint_thresh > 0u)
             {
                 bool solidColor = texel > 180u;
                 texel = (texel > hint_thresh) ? fColour : 0u;
                 texel = texel << 8;
-                if(solidColor) 
+                if (solidColor)
                 {
                     texel += 1u;
                 }
             }
-            else 
+            else
             {
                 texel = fColour;
             }
@@ -101,7 +103,7 @@ void main()
     if ((fFlags & FLAG_MASK) != 0)
     {
         uint mask = texture(uTexture, fTexMask).r;
-        if ( mask == 0u )
+        if (mask == 0u)
         {
             discard;
         }

--- a/data/shaders/drawrect.vert
+++ b/data/shaders/drawrect.vert
@@ -5,6 +5,7 @@ const float DEPTH_INCREMENT = 1.0 / float(1u << 22u);
 
 uniform ivec2 uScreenSize;
 
+// clang-format off
 in ivec4 vClip;
 in int   vTexColourAtlas;
 in vec4  vTexColourBounds;
@@ -26,11 +27,13 @@ flat out uint  fColour;
 out vec3       fTexColour;
 out vec3       fTexMask;
 flat out vec3  fPalettes;
+// clang-format on
 
 void main()
 {
     // Clamp position by vClip, correcting interpolated values for the clipping
-    vec2 m = clamp(((vVertMat * vec4(vClip)) - (vVertMat * vec4(vBounds)))/vec2(vBounds.zw - vBounds.xy) + vVertVec, 0.0, 1.0);
+    vec2 m = clamp(
+        ((vVertMat * vec4(vClip)) - (vVertMat * vec4(vBounds))) / vec2(vBounds.zw - vBounds.xy) + vVertVec, 0.0, 1.0);
     vec2 pos = mix(vec2(vBounds.xy), vec2(vBounds.zw), m);
     fTexColour = vec3(mix(vTexColourBounds.xy, vTexColourBounds.zw, m), vTexColourAtlas);
     fTexMask = vec3(mix(vTexMaskBounds.xy, vTexMaskBounds.zw, m), vTexMaskAtlas);

--- a/scripts/check-code-formatting
+++ b/scripts/check-code-formatting
@@ -16,4 +16,4 @@ fi
 basedir="$($readlink_bin -f `dirname $0`/..)"
 cd $basedir
 
-scripts/run-clang-format.py -r src test --exclude src/thirdparty
+scripts/run-clang-format.py -r src test data/shaders --exclude src/thirdparty

--- a/scripts/run-clang-format.py
+++ b/scripts/run-clang-format.py
@@ -25,7 +25,7 @@ import traceback
 
 from functools import partial
 
-DEFAULT_EXTENSIONS = 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx'
+DEFAULT_EXTENSIONS = 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx,vert,frag'
 
 
 class ExitStatus:


### PR DESCRIPTION
This adds clang-format for shaders.

While we are talking about clang-format, I always get changes in tab spacing in the following two lines:

https://github.com/OpenRCT2/OpenRCT2/blob/042d555d9a793c69faf91523bb0d4ca07ce79b50/src/openrct2-win/openrct2-win.cpp#L16

https://github.com/OpenRCT2/OpenRCT2/blob/042d555d9a793c69faf91523bb0d4ca07ce79b50/src/openrct2/platform/Platform.Win32.cpp#L43

How come they don't appear on the server when CI is run?

