### PR TITLE
TrackDesign: Refactor entrances and constants

### DIFF
--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -506,7 +506,7 @@ private:
         // Draw entrance and exit preview.
         for (const auto& entrance : td6->entrance_elements)
         {
-            auto rotatedAndOffsetEntrance = origin + CoordsXY{ entrance.x, entrance.y }.Rotate(rotation);
+            auto rotatedAndOffsetEntrance = origin + entrance.Location.ToCoordsXY().Rotate(rotation);
 
             if (pass == 0)
             {
@@ -521,7 +521,7 @@ private:
                 if (DrawMiniPreviewIsPixelInBounds(pixelPosition))
                 {
                     uint8_t* pixel = DrawMiniPreviewGetPixelPtr(pixelPosition);
-                    uint8_t colour = entrance.isExit ? _PaletteIndexColourExit : _PaletteIndexColourEntrance;
+                    uint8_t colour = entrance.IsExit ? _PaletteIndexColourExit : _PaletteIndexColourEntrance;
                     for (int32_t i = 0; i < 4; i++)
                     {
                         pixel[338 + i] = colour; // x + 2, y + 2

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -61,6 +61,7 @@
 #include "platform/Crash.h"
 #include "platform/Platform.h"
 #include "profiling/Profiling.h"
+#include "rct2/RCT2.h"
 #include "ride/TrackData.h"
 #include "ride/TrackDesignRepository.h"
 #include "scenario/Scenario.h"

--- a/src/openrct2/Limits.h
+++ b/src/openrct2/Limits.h
@@ -21,6 +21,11 @@ namespace OpenRCT2::Limits
     constexpr uint16_t MaxTrainsPerRide = 255;
     constexpr uint16_t MaxCarsPerTrain = 255;
     constexpr const uint16_t MaxVehicleColours = MaxTrainsPerRide; // this should really be MaxTrainsPerRide * MaxCarsPerTrain
+    // MaxVehicleColours should be set to MaxTrainsPerRide or MaxCarsPerTrain, whichever is higher.
+    // Sadly, using std::max() will cause compilation failures when using MaxVehicleColours as an array size,
+    // hence the usage of static asserts.
+    static_assert(MaxVehicleColours >= MaxTrainsPerRide);
+    static_assert(MaxVehicleColours >= MaxCarsPerTrain);
     constexpr uint8_t MaxCircuitsPerRide = 20;
     constexpr uint8_t MaxAwards = RCT12::Limits::MaxAwards;
     constexpr uint8_t NumColourSchemes = RCT12::Limits::NumColourSchemes;

--- a/src/openrct2/actions/TrackDesignAction.cpp
+++ b/src/openrct2/actions/TrackDesignAction.cpp
@@ -14,7 +14,6 @@
 #include "../management/Research.h"
 #include "../object/ObjectManager.h"
 #include "../object/ObjectRepository.h"
-#include "../rct12/RCT12.h"
 #include "../ride/RideConstruction.h"
 #include "../ride/TrackDesign.h"
 #include "RideCreateAction.h"
@@ -249,17 +248,16 @@ GameActions::Result TrackDesignAction::Execute() const
         ride->entrance_style = gLastEntranceStyle;
     }
 
-    for (int32_t i = 0; i < RCT12::Limits::NumColourSchemes; i++)
+    for (int32_t i = 0; i < OpenRCT2::Limits::NumColourSchemes; i++)
     {
         ride->track_colour[i].main = _td.track_spine_colour[i];
         ride->track_colour[i].additional = _td.track_rail_colour[i];
         ride->track_colour[i].supports = _td.track_support_colour[i];
     }
 
-    for (size_t i = 0; i <= OpenRCT2::Limits::MaxTrainsPerRide; i++)
+    for (size_t i = 0; i < OpenRCT2::Limits::MaxVehicleColours; i++)
     {
-        auto tdIndex = i % std::size(_td.vehicle_colours);
-        ride->vehicle_colours[i] = _td.vehicle_colours[tdIndex];
+        ride->vehicle_colours[i] = _td.vehicle_colours[i];
     }
 
     for (int32_t count = 1; count == 1 || r.Error != GameActions::Status::Ok; ++count)

--- a/src/openrct2/actions/TrackDesignAction.cpp
+++ b/src/openrct2/actions/TrackDesignAction.cpp
@@ -241,8 +241,7 @@ GameActions::Result TrackDesignAction::Execute() const
     ride->lifecycle_flags |= RIDE_LIFECYCLE_NOT_CUSTOM_DESIGN;
     ride->colour_scheme_type = _td.colour_scheme;
 
-    auto stationIdentifier = GetStationIdentifierFromStyle(_td.entrance_style);
-    ride->entrance_style = objManager.GetLoadedObjectEntryIndex(stationIdentifier);
+    ride->entrance_style = objManager.GetLoadedObjectEntryIndex(_td.StationObjectIdentifier);
     if (ride->entrance_style == OBJECT_ENTRY_INDEX_NULL)
     {
         ride->entrance_style = gLastEntranceStyle;

--- a/src/openrct2/core/DataSerialiserTraits.h
+++ b/src/openrct2/core/DataSerialiserTraits.h
@@ -724,26 +724,20 @@ template<> struct DataSerializerTraitsT<TrackDesignEntranceElement>
 {
     static void encode(OpenRCT2::IStream* stream, const TrackDesignEntranceElement& val)
     {
-        stream->Write(&val.x);
-        stream->Write(&val.y);
-        stream->Write(&val.z);
-        stream->Write(&val.direction);
-        stream->Write(&val.isExit);
+        stream->Write(&val.Location);
+        stream->Write(&val.IsExit);
     }
     static void decode(OpenRCT2::IStream* stream, TrackDesignEntranceElement& val)
     {
-        stream->Read(&val.x);
-        stream->Read(&val.y);
-        stream->Read(&val.z);
-        stream->Read(&val.direction);
-        stream->Read(&val.isExit);
+        stream->Read(&val.Location);
+        stream->Read(&val.IsExit);
     }
     static void log(OpenRCT2::IStream* stream, const TrackDesignEntranceElement& val)
     {
         char msg[128] = {};
         snprintf(
-            msg, sizeof(msg), "TrackDesignEntranceElement(x = %d, y = %d, z = %d, dir = %d, isExit = %d)", val.x, val.y, val.z,
-            val.direction, val.isExit);
+            msg, sizeof(msg), "TrackDesignEntranceElement(x = %d, y = %d, z = %d, dir = %d, isExit = %d)", val.Location.x,
+            val.Location.y, val.Location.z, val.Location.direction, val.IsExit);
         stream->Write(msg, strlen(msg));
     }
 };

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2473,7 +2473,7 @@ namespace RCT1
         {
             const auto originalString = _s4.StringTable[stringId % 1024];
             auto originalStringView = std::string_view(
-                originalString, RCT2::GetRCT2StringBufferLen(originalString, USER_STRING_MAX_LENGTH));
+                originalString, RCT12::GetRCTStringBufferLen(originalString, USER_STRING_MAX_LENGTH));
             auto asUtf8 = RCT2StringToUTF8(originalStringView, RCT2LanguageId::EnglishUK);
             auto justText = RCT12RemoveFormattingUTF8(asUtf8);
             return justText.data();

--- a/src/openrct2/rct1/T4Importer.cpp
+++ b/src/openrct2/rct1/T4Importer.cpp
@@ -204,6 +204,7 @@ namespace RCT1
                 td->vehicle_colours[i] = td->vehicle_colours[0];
             }
 
+            td->StationObjectIdentifier = GetStationIdentifierFromStyle(RCT12_STATION_STYLE_PLAIN);
             td->depart_flags = td4Base.DepartFlags;
             td->number_of_trains = td4Base.NumberOfTrains;
             td->number_of_cars_per_train = td4Base.NumberOfCarsPerTrain;

--- a/src/openrct2/rct12/RCT12.cpp
+++ b/src/openrct2/rct12/RCT12.cpp
@@ -924,3 +924,35 @@ uint8_t ConvertToTD46Flags(const TrackDesignTrackElement& source)
 
     return trackFlags;
 }
+
+namespace RCT12
+{
+    size_t GetRCTStringBufferLen(const char* buffer, size_t maxBufferLen)
+    {
+        constexpr char MULTIBYTE = static_cast<char>(255);
+        size_t len = 0;
+        for (size_t i = 0; i < maxBufferLen; i++)
+        {
+            auto ch = buffer[i];
+            if (ch == MULTIBYTE)
+            {
+                i += 2;
+
+                // Check if reading two more bytes exceeds max buffer len
+                if (i < maxBufferLen)
+                {
+                    len += 3;
+                }
+            }
+            else if (ch == '\0')
+            {
+                break;
+            }
+            else
+            {
+                len++;
+            }
+        }
+        return len;
+    }
+} // namespace RCT12

--- a/src/openrct2/rct12/RCT12.cpp
+++ b/src/openrct2/rct12/RCT12.cpp
@@ -769,7 +769,7 @@ std::string_view GetStationIdentifierFromStyle(uint8_t style)
     {
         return _stationStyles[style];
     }
-    return {};
+    return _stationStyles[RCT12_STATION_STYLE_INVISIBLE];
 }
 
 uint8_t GetStationStyleFromIdentifier(u8string_view identifier)

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -914,3 +914,12 @@ enum class TD46Flags : uint8_t
 
 void ConvertFromTD46Flags(TrackDesignTrackElement& target, uint8_t flags);
 uint8_t ConvertToTD46Flags(const TrackDesignTrackElement& source);
+
+namespace RCT12
+{
+    /**
+     * Iterates an RCT string buffer and returns the length of the string in bytes.
+     * Handles single and multi-byte strings.
+     */
+    size_t GetRCTStringBufferLen(const char* buffer, size_t maxBufferLen);
+} // namespace RCT12

--- a/src/openrct2/rct2/Limits.h
+++ b/src/openrct2/rct2/Limits.h
@@ -16,6 +16,7 @@ namespace RCT2::Limits
     constexpr uint8_t MaxStaff = 200;
     constexpr uint8_t MaxBanners = 250;
     constexpr uint8_t MaxTrainsPerRide = 32;
+    constexpr uint8_t MaxVehicleColours = 32;
     constexpr uint8_t DowntimeHistorySize = 8;
     constexpr uint16_t MaxEntities = 10000;
     constexpr uint16_t MaxEntitiesRCTCExtended = 15000; // Used in files marked with “classic flag” 0xF

--- a/src/openrct2/rct2/RCT2.cpp
+++ b/src/openrct2/rct2/RCT2.cpp
@@ -87,35 +87,6 @@ namespace RCT2
         }
     }
 
-    size_t GetRCT2StringBufferLen(const char* buffer, size_t maxBufferLen)
-    {
-        constexpr char MULTIBYTE = static_cast<char>(255);
-        size_t len = 0;
-        for (size_t i = 0; i < maxBufferLen; i++)
-        {
-            auto ch = buffer[i];
-            if (ch == MULTIBYTE)
-            {
-                i += 2;
-
-                // Check if reading two more bytes exceeds max buffer len
-                if (i < maxBufferLen)
-                {
-                    len += 3;
-                }
-            }
-            else if (ch == '\0')
-            {
-                break;
-            }
-            else
-            {
-                len++;
-            }
-        }
-        return len;
-    }
-
     uint8_t Ride::GetMinCarsPerTrain() const
     {
         return MinMaxCarsPerTrain >> 4;

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -72,11 +72,11 @@ namespace RCT2
         uint8_t Type; // 0x000
         // pointer to static info. for example, wild mouse type is 0x36, subtype is
         // 0x4c.
-        RCT12ObjectEntryIndex Subtype;                               // 0x001
-        uint16_t Pad002;                                             // 0x002
-        uint8_t Mode;                                                // 0x004
-        uint8_t ColourSchemeType;                                    // 0x005
-        RCT12VehicleColour VehicleColours[Limits::MaxTrainsPerRide]; // 0x006
+        RCT12ObjectEntryIndex Subtype;                                // 0x001
+        uint16_t Pad002;                                              // 0x002
+        uint8_t Mode;                                                 // 0x004
+        uint8_t ColourSchemeType;                                     // 0x005
+        RCT12VehicleColour VehicleColours[Limits::MaxVehicleColours]; // 0x006
         uint8_t Pad046[0x03]; // 0x046, Used to be track colours in RCT1 without expansions
         // 0 = closed, 1 = open, 2 = test
         uint8_t Status; // 0x049
@@ -256,33 +256,33 @@ namespace RCT2
         uint8_t BreakdownSoundModifier;                       // 0x1AC
         // Used to oscillate the sound when ride breaks down.
         // 0 = no change, 255 = max change
-        uint8_t NotFixedTimeout;                                  // 0x1AD
-        uint8_t LastCrashType;                                    // 0x1AE
-        uint8_t ConnectedMessageThrottle;                         // 0x1AF
-        money32 IncomePerHour;                                    // 0x1B0
-        money32 Profit;                                           // 0x1B4
-        uint8_t QueueTime[Limits::MaxStationsPerRide];            // 0x1B8
-        uint8_t TrackColourMain[Limits::NumColourSchemes];        // 0x1BC
-        uint8_t TrackColourAdditional[Limits::NumColourSchemes];  // 0x1C0
-        uint8_t TrackColourSupports[Limits::NumColourSchemes];    // 0x1C4
-        uint8_t Music;                                            // 0x1C8
-        uint8_t EntranceStyle;                                    // 0x1C9
-        uint16_t VehicleChangeTimeout;                            // 0x1CA
-        uint8_t NumBlockBrakes;                                   // 0x1CC
-        uint8_t LiftHillSpeed;                                    // 0x1CD
-        uint16_t GuestsFavourite;                                 // 0x1CE
-        uint32_t LifecycleFlags;                                  // 0x1D0
-        uint8_t VehicleColoursExtended[Limits::MaxTrainsPerRide]; // 0x1D4
-        uint16_t TotalAirTime;                                    // 0x1F4
-        uint8_t CurrentTestStation;                               // 0x1F6
-        uint8_t NumCircuits;                                      // 0x1F7
-        int16_t CableLiftX;                                       // 0x1F8
-        int16_t CableLiftY;                                       // 0x1FA
-        uint8_t CableLiftZ;                                       // 0x1FC
-        uint8_t Pad1FD;                                           // 0x1FD
-        uint16_t CableLift;                                       // 0x1FE
-        uint16_t QueueLength[Limits::MaxStationsPerRide];         // 0x200
-        uint8_t Pad208[0x58];                                     // 0x208
+        uint8_t NotFixedTimeout;                                   // 0x1AD
+        uint8_t LastCrashType;                                     // 0x1AE
+        uint8_t ConnectedMessageThrottle;                          // 0x1AF
+        money32 IncomePerHour;                                     // 0x1B0
+        money32 Profit;                                            // 0x1B4
+        uint8_t QueueTime[Limits::MaxStationsPerRide];             // 0x1B8
+        uint8_t TrackColourMain[Limits::NumColourSchemes];         // 0x1BC
+        uint8_t TrackColourAdditional[Limits::NumColourSchemes];   // 0x1C0
+        uint8_t TrackColourSupports[Limits::NumColourSchemes];     // 0x1C4
+        uint8_t Music;                                             // 0x1C8
+        uint8_t EntranceStyle;                                     // 0x1C9
+        uint16_t VehicleChangeTimeout;                             // 0x1CA
+        uint8_t NumBlockBrakes;                                    // 0x1CC
+        uint8_t LiftHillSpeed;                                     // 0x1CD
+        uint16_t GuestsFavourite;                                  // 0x1CE
+        uint32_t LifecycleFlags;                                   // 0x1D0
+        uint8_t VehicleColoursExtended[Limits::MaxVehicleColours]; // 0x1D4
+        uint16_t TotalAirTime;                                     // 0x1F4
+        uint8_t CurrentTestStation;                                // 0x1F6
+        uint8_t NumCircuits;                                       // 0x1F7
+        int16_t CableLiftX;                                        // 0x1F8
+        int16_t CableLiftY;                                        // 0x1FA
+        uint8_t CableLiftZ;                                        // 0x1FC
+        uint8_t Pad1FD;                                            // 0x1FD
+        uint16_t CableLift;                                        // 0x1FE
+        uint16_t QueueLength[Limits::MaxStationsPerRide];          // 0x200
+        uint8_t Pad208[0x58];                                      // 0x208
 
         uint8_t GetMinCarsPerTrain() const;
         uint8_t GetMaxCarsPerTrain() const;

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -298,6 +298,16 @@ namespace RCT2
         uint8_t direction; // 0x01
         int16_t x;         // 0x02
         int16_t y;         // 0x04
+
+        constexpr Direction GetDirection() const
+        {
+            return (direction & 0b00001111);
+        }
+
+        constexpr bool IsExit() const
+        {
+            return !!(direction >> 7);
+        }
     };
     assert_struct_size(TD6EntranceElement, 0x06);
 

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -1048,12 +1048,6 @@ namespace RCT2
     track_type_t RCT2TrackTypeToOpenRCT2(RCT12TrackType origTrackType, ride_type_t rideType, bool convertFlat);
     RCT12TrackType OpenRCT2TrackTypeToRCT2(track_type_t origTrackType);
 
-    /**
-     * Iterates an RCT2 string buffer and returns the length of the string in bytes.
-     * Handles single and multi-byte strings.
-     */
-    size_t GetRCT2StringBufferLen(const char* buffer, size_t maxBufferLen);
-
     struct FootpathMapping
     {
         std::string_view Original;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -2327,7 +2327,7 @@ namespace RCT2
         {
             const auto originalString = _s6.CustomStrings[stringId % 1024];
             auto originalStringView = std::string_view(
-                originalString, GetRCT2StringBufferLen(originalString, USER_STRING_MAX_LENGTH));
+                originalString, RCT12::GetRCTStringBufferLen(originalString, USER_STRING_MAX_LENGTH));
             auto asUtf8 = RCT2StringToUTF8(originalStringView, RCT2LanguageId::EnglishUK);
             auto justText = RCT12RemoveFormattingUTF8(asUtf8);
             return justText.data();

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1270,7 +1270,7 @@ namespace RCT2
             dst->mode = static_cast<RideMode>(src->Mode);
             dst->colour_scheme_type = src->ColourSchemeType;
 
-            for (uint8_t i = 0; i < Limits::MaxTrainsPerRide; i++)
+            for (uint8_t i = 0; i < Limits::MaxVehicleColours; i++)
             {
                 dst->vehicle_colours[i].Body = src->VehicleColours[i].BodyColour;
                 dst->vehicle_colours[i].Trim = src->VehicleColours[i].TrimColour;

--- a/src/openrct2/rct2/T6Exporter.cpp
+++ b/src/openrct2/rct2/T6Exporter.cpp
@@ -16,6 +16,7 @@
 #include "../localisation/StringIds.h"
 #include "../object/ObjectList.h"
 #include "../rct12/SawyerChunkWriter.h"
+#include "../rct2/RCT2.h"
 #include "../ride/Ride.h"
 #include "../ride/RideData.h"
 #include "../ride/Station.h"
@@ -56,10 +57,10 @@ namespace RCT2
         tempStream.WriteValue<uint32_t>(_trackDesign->flags);
         tempStream.WriteValue<uint8_t>(static_cast<uint8_t>(_trackDesign->ride_mode));
         tempStream.WriteValue<uint8_t>((_trackDesign->colour_scheme & 0x3) | (2 << 2));
-        for (auto& colour : _trackDesign->vehicle_colours)
+        for (auto i = 0; i < RCT2::Limits::MaxVehicleColours; i++)
         {
-            tempStream.WriteValue<uint8_t>(colour.Body);
-            tempStream.WriteValue<uint8_t>(colour.Trim);
+            tempStream.WriteValue<uint8_t>(_trackDesign->vehicle_colours[i].Body);
+            tempStream.WriteValue<uint8_t>(_trackDesign->vehicle_colours[i].Trim);
         }
         tempStream.WriteValue<uint8_t>(0);
         tempStream.WriteValue<uint8_t>(_trackDesign->entrance_style);
@@ -91,9 +92,9 @@ namespace RCT2
         tempStream.Write(&_trackDesign->vehicle_object.Entry, sizeof(RCTObjectEntry));
         tempStream.WriteValue<uint8_t>(_trackDesign->space_required_x);
         tempStream.WriteValue<uint8_t>(_trackDesign->space_required_y);
-        for (auto& colour : _trackDesign->vehicle_colours)
+        for (auto i = 0; i < RCT2::Limits::MaxVehicleColours; i++)
         {
-            tempStream.WriteValue<uint8_t>(colour.Tertiary);
+            tempStream.WriteValue<uint8_t>(_trackDesign->vehicle_colours[i].Tertiary);
         }
         tempStream.WriteValue<uint8_t>(_trackDesign->lift_hill_speed | (_trackDesign->num_circuits << 5));
 

--- a/src/openrct2/rct2/T6Exporter.cpp
+++ b/src/openrct2/rct2/T6Exporter.cpp
@@ -63,7 +63,8 @@ namespace RCT2
             tempStream.WriteValue<uint8_t>(_trackDesign->vehicle_colours[i].Trim);
         }
         tempStream.WriteValue<uint8_t>(0);
-        tempStream.WriteValue<uint8_t>(_trackDesign->entrance_style);
+        auto entranceStyle = GetStationStyleFromIdentifier(_trackDesign->StationObjectIdentifier);
+        tempStream.WriteValue<uint8_t>(entranceStyle);
         tempStream.WriteValue<uint8_t>(_trackDesign->total_air_time);
         tempStream.WriteValue<uint8_t>(_trackDesign->depart_flags);
         tempStream.WriteValue<uint8_t>(_trackDesign->number_of_trains);

--- a/src/openrct2/rct2/T6Exporter.cpp
+++ b/src/openrct2/rct2/T6Exporter.cpp
@@ -125,10 +125,12 @@ namespace RCT2
 
             for (const auto& entranceElement : _trackDesign->entrance_elements)
             {
-                tempStream.WriteValue<uint8_t>(entranceElement.z == -1 ? static_cast<uint8_t>(0x80) : entranceElement.z);
-                tempStream.WriteValue<uint8_t>(entranceElement.direction | (entranceElement.isExit << 7));
-                tempStream.WriteValue<int16_t>(entranceElement.x);
-                tempStream.WriteValue<int16_t>(entranceElement.y);
+                tempStream.WriteValue<uint8_t>(
+                    entranceElement.Location.z == -1 ? static_cast<uint8_t>(0x80) : entranceElement.Location.z);
+                tempStream.WriteValue<uint8_t>(entranceElement.Location.direction | (entranceElement.IsExit << 7));
+                auto xy = entranceElement.Location.ToCoordsXY();
+                tempStream.WriteValue<int16_t>(xy.x);
+                tempStream.WriteValue<int16_t>(xy.y);
             }
 
             tempStream.WriteValue<uint8_t>(0xFF);

--- a/src/openrct2/rct2/T6Importer.cpp
+++ b/src/openrct2/rct2/T6Importer.cpp
@@ -182,11 +182,10 @@ namespace RCT2
                     _stream.SetPosition(_stream.GetPosition() - 1);
                     _stream.Read(&t6EntranceElement, sizeof(TD6EntranceElement));
                     TrackDesignEntranceElement entranceElement{};
-                    entranceElement.z = (t6EntranceElement.z == -128) ? -1 : t6EntranceElement.z;
-                    entranceElement.direction = t6EntranceElement.direction & 0x7F;
-                    entranceElement.x = t6EntranceElement.x;
-                    entranceElement.y = t6EntranceElement.y;
-                    entranceElement.isExit = t6EntranceElement.direction >> 7;
+                    auto xy = CoordsXY(t6EntranceElement.x, t6EntranceElement.y);
+                    auto z = (t6EntranceElement.z == -128) ? -1 : t6EntranceElement.z;
+                    entranceElement.Location = TileCoordsXYZD(TileCoordsXY(xy), z, t6EntranceElement.GetDirection());
+                    entranceElement.IsExit = t6EntranceElement.IsExit();
                     td->entrance_elements.push_back(entranceElement);
                 }
             }

--- a/src/openrct2/rct2/T6Importer.cpp
+++ b/src/openrct2/rct2/T6Importer.cpp
@@ -86,7 +86,7 @@ namespace RCT2
                 td->vehicle_colours[i].Trim = td6.VehicleColours[i].TrimColour;
                 td->vehicle_colours[i].Tertiary = td6.VehicleAdditionalColour[i];
             }
-            td->entrance_style = td6.EntranceStyle;
+            td->StationObjectIdentifier = GetStationIdentifierFromStyle(td6.EntranceStyle);
             td->total_air_time = td6.TotalAirTime;
             td->depart_flags = td6.DepartFlags;
             td->number_of_trains = td6.NumberOfTrains;

--- a/src/openrct2/rct2/T6Importer.cpp
+++ b/src/openrct2/rct2/T6Importer.cpp
@@ -16,6 +16,7 @@
 #include "../object/ObjectRepository.h"
 #include "../object/RideObject.h"
 #include "../rct12/SawyerChunkReader.h"
+#include "../rct2/RCT2.h"
 #include "../ride/Ride.h"
 #include "../ride/RideData.h"
 #include "../ride/TrackDesign.h"
@@ -79,7 +80,7 @@ namespace RCT2
             td->ride_mode = static_cast<RideMode>(td6.RideMode);
             td->track_flags = 0;
             td->colour_scheme = td6.VersionAndColourScheme & 0x3;
-            for (auto i = 0; i < Limits::MaxTrainsPerRide; ++i)
+            for (auto i = 0; i < Limits::MaxVehicleColours; ++i)
             {
                 td->vehicle_colours[i].Body = td6.VehicleColours[i].BodyColour;
                 td->vehicle_colours[i].Trim = td6.VehicleColours[i].TrimColour;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2181,7 +2181,7 @@ std::pair<RideMeasurement*, OpenRCT2String> Ride::GetMeasurement()
 VehicleColour RideGetVehicleColour(const Ride& ride, int32_t vehicleIndex)
 {
     // Prevent indexing array out of bounds
-    vehicleIndex = std::min<int32_t>(vehicleIndex, OpenRCT2::Limits::MaxCarsPerTrain);
+    vehicleIndex = std::min<int32_t>(vehicleIndex, static_cast<int32_t>(std::size(ride.vehicle_colours)));
     return ride.vehicle_colours[vehicleIndex];
 }
 

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -119,7 +119,7 @@ struct Ride
     ObjectEntryIndex subtype;
     RideMode mode;
     uint8_t colour_scheme_type;
-    VehicleColour vehicle_colours[OpenRCT2::Limits::MaxTrainsPerRide + 1];
+    VehicleColour vehicle_colours[OpenRCT2::Limits::MaxVehicleColours];
     // 0 = closed, 1 = open, 2 = test
     RideStatus status;
     std::string custom_name;

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -47,8 +47,7 @@
 #include "../object/ObjectRepository.h"
 #include "../object/SmallSceneryEntry.h"
 #include "../object/StationObject.h"
-#include "../rct1/RCT1.h"
-#include "../rct1/Tables.h"
+#include "../rct2/RCT2.h"
 #include "../ride/RideConstruction.h"
 #include "../util/SawyerCoding.h"
 #include "../util/Util.h"
@@ -102,12 +101,12 @@ ResultWithMessage TrackDesign::CreateTrackDesign(TrackDesignState& tds, const Ri
     ride_mode = ride.mode;
     colour_scheme = ride.colour_scheme_type & 3;
 
-    for (int32_t i = 0; i < RCT2::Limits::MaxTrainsPerRide; i++)
+    for (size_t i = 0; i < std::size(vehicle_colours); i++)
     {
         vehicle_colours[i] = ride.vehicle_colours[i];
     }
 
-    for (int32_t i = 0; i < RCT12::Limits::NumColourSchemes; i++)
+    for (int32_t i = 0; i < OpenRCT2::Limits::NumColourSchemes; i++)
     {
         track_spine_colour[i] = ride.track_colour[i].main;
         track_rail_colour[i] = ride.track_colour[i].additional;
@@ -1998,7 +1997,7 @@ static bool TrackDesignPlacePreview(TrackDesignState& tds, TrackDesign* td6, mon
         ride->entrance_style = gLastEntranceStyle;
     }
 
-    for (int32_t i = 0; i < RCT12::Limits::NumColourSchemes; i++)
+    for (int32_t i = 0; i < OpenRCT2::Limits::NumColourSchemes; i++)
     {
         ride->track_colour[i].main = td6->track_spine_colour[i];
         ride->track_colour[i].additional = td6->track_rail_colour[i];
@@ -2009,7 +2008,7 @@ static bool TrackDesignPlacePreview(TrackDesignState& tds, TrackDesign* td6, mon
     // in the preview window
     if (!GetRideTypeDescriptor(td6->type).HasFlag(RIDE_TYPE_FLAG_HAS_TRACK))
     {
-        for (int32_t i = 0; i < RCT12::Limits::MaxVehicleColours; i++)
+        for (size_t i = 0; i < std::size(ride->vehicle_colours); i++)
         {
             ride->vehicle_colours[i] = td6->vehicle_colours[i];
         }

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -82,6 +82,15 @@ static bool _trackDesignPlaceStateEntranceExitPlaced{};
 
 static void TrackDesignPreviewClearMap();
 
+static u8string_view TrackDesignGetStationObjectIdentifier(const Ride& ride)
+{
+    const auto* stationObject = ride.GetStationObject();
+    if (stationObject == nullptr)
+        return "";
+
+    return stationObject->GetIdentifier();
+}
+
 ResultWithMessage TrackDesign::CreateTrackDesign(TrackDesignState& tds, const Ride& ride)
 {
     type = ride.type;
@@ -122,7 +131,7 @@ ResultWithMessage TrackDesign::CreateTrackDesign(TrackDesignState& tds, const Ri
     lift_hill_speed = ride.lift_hill_speed;
     num_circuits = ride.num_circuits;
 
-    entrance_style = ride.GetEntranceStyle();
+    StationObjectIdentifier = TrackDesignGetStationObjectIdentifier(ride);
     max_speed = static_cast<int8_t>(ride.max_speed / 65536);
     average_speed = static_cast<int8_t>(ride.average_speed / 65536);
     ride_length = ride.GetTotalLength() / 65536;
@@ -564,7 +573,7 @@ void TrackDesign::Serialise(DataSerialiser& stream)
     stream << DS_TAG(track_flags);
     stream << DS_TAG(colour_scheme);
     stream << DS_TAG(vehicle_colours);
-    stream << DS_TAG(entrance_style);
+    stream << DS_TAG(StationObjectIdentifier);
     stream << DS_TAG(total_air_time);
     stream << DS_TAG(depart_flags);
     stream << DS_TAG(number_of_trains);
@@ -1990,8 +1999,7 @@ static bool TrackDesignPlacePreview(TrackDesignState& tds, TrackDesign* td6, mon
 
     ride->custom_name = {};
 
-    auto stationIdentifier = GetStationIdentifierFromStyle(td6->entrance_style);
-    ride->entrance_style = objManager.GetLoadedObjectEntryIndex(stationIdentifier);
+    ride->entrance_style = objManager.GetLoadedObjectEntryIndex(td6->StationObjectIdentifier);
     if (ride->entrance_style == OBJECT_ENTRY_INDEX_NULL)
     {
         ride->entrance_style = gLastEntranceStyle;

--- a/src/openrct2/ride/TrackDesign.h
+++ b/src/openrct2/ride/TrackDesign.h
@@ -126,7 +126,7 @@ struct TrackDesign
     uint8_t track_flags;
     uint8_t colour_scheme;
     std::array<VehicleColour, OpenRCT2::Limits::MaxVehicleColours> vehicle_colours;
-    uint8_t entrance_style;
+    u8string StationObjectIdentifier{};
     uint8_t total_air_time;
     uint8_t depart_flags;
     uint8_t number_of_trains;

--- a/src/openrct2/ride/TrackDesign.h
+++ b/src/openrct2/ride/TrackDesign.h
@@ -41,11 +41,8 @@ struct TrackDesignState
 /* Track Entrance entry */
 struct TrackDesignEntranceElement
 {
-    int8_t z;
-    uint8_t direction;
-    int16_t x;
-    int16_t y;
-    bool isExit;
+    TileCoordsXYZD Location{};
+    bool IsExit{};
 };
 
 struct TrackDesignSceneryElement

--- a/src/openrct2/ride/TrackDesign.h
+++ b/src/openrct2/ride/TrackDesign.h
@@ -9,11 +9,10 @@
 
 #pragma once
 
+#include "../Limits.h"
 #include "../actions/GameActionResult.h"
 #include "../common.h"
 #include "../object/Object.h"
-#include "../rct12/RCT12.h"
-#include "../rct2/RCT2.h"
 #include "../world/Map.h"
 #include "VehicleColour.h"
 
@@ -126,7 +125,7 @@ struct TrackDesign
     RideMode ride_mode;
     uint8_t track_flags;
     uint8_t colour_scheme;
-    std::array<VehicleColour, RCT2::Limits::MaxTrainsPerRide> vehicle_colours;
+    std::array<VehicleColour, OpenRCT2::Limits::MaxVehicleColours> vehicle_colours;
     uint8_t entrance_style;
     uint8_t total_air_time;
     uint8_t depart_flags;
@@ -149,9 +148,9 @@ struct TrackDesign
     uint8_t intensity;
     uint8_t nausea;
     money64 upkeep_cost;
-    uint8_t track_spine_colour[RCT12::Limits::NumColourSchemes];
-    uint8_t track_rail_colour[RCT12::Limits::NumColourSchemes];
-    uint8_t track_support_colour[RCT12::Limits::NumColourSchemes];
+    uint8_t track_spine_colour[OpenRCT2::Limits::NumColourSchemes];
+    uint8_t track_rail_colour[OpenRCT2::Limits::NumColourSchemes];
+    uint8_t track_support_colour[OpenRCT2::Limits::NumColourSchemes];
     uint32_t flags2;
     ObjectEntryDescriptor vehicle_object;
     uint8_t space_required_x;

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -20,6 +20,7 @@
 #include "../object/LargeSceneryObject.h"
 #include "../object/ObjectList.h"
 #include "../object/ObjectManager.h"
+#include "../rct2/RCT2.h"
 #include "../util/SawyerCoding.h"
 #include "../util/Util.h"
 #include "../windows/Intent.h"

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -28,6 +28,7 @@
 #include "../platform/Platform.h"
 #include "../rct12/RCT12.h"
 #include "../rct12/SawyerChunkReader.h"
+#include "../rct2/RCT2.h"
 #include "Scenario.h"
 #include "ScenarioSources.h"
 

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -30,6 +30,7 @@
 #include <openrct2/object/ObjectManager.h>
 #include <openrct2/park/ParkFile.h>
 #include <openrct2/platform/Platform.h>
+#include <openrct2/rct2/RCT2.h>
 #include <openrct2/ride/Ride.h>
 #include <openrct2/scenario/Scenario.h>
 #include <openrct2/world/MapAnimation.h>


### PR DESCRIPTION
This is a further decoupling of the track design handling code and the TD4/TD6 import/export code. It is one of the bits necessary for the eventual NTDF implementation.

- Converting to and from a station style object is now done in the TD4/TD6 import/export code.
- Entrance elements now use a proper TileCoordsXYZD struct, rather than the big xy and small z coordinates used in TD6. Conversion to and from this is handled in the TD46 import/export code.
- TrackDesign.h now references OpenRCT2 limits, rather than RCT2 ones
- The size of `VehicleColours` was a topic of confusion. It needs to be as big as either the maximum of trains _or_ the maximum of cars per train, whichever is bigger. I thus replaced some references with the correct constant, and also made sure (via a static assert) that it will never be too small by accident.
- Some header cleanup - some files lacked RCT2.h imports (and relied on TrackDesign.h to do it for them)
- Moved a function that was used by both RCT1 and RCT2 code to its proper place in RCT12.cpp/RCT12.h - this was revealed during the aforementioned header cleanup. I’m willing to spin that off into a PR of its own if desired, though.