### PR TITLE
Fix pathfinding over half height paths

### DIFF
--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -2287,7 +2287,8 @@ bool GuestPathfinding::IsValidPathZAndDirection(TileElement* tileElement, int32_
     }
     else
     {
-        if (currentZ != tileElement->BaseHeight)
+        if (currentZ != tileElement->BaseHeight && currentZ - 1 != tileElement->BaseHeight
+            && currentZ + 1 != tileElement->BaseHeight)
             return false;
     }
     return true;


### PR DESCRIPTION
It is possible to place and manually connect paths at invalid height units, to create a 'more gentle' slope. Guests can walk over this no problem.
However, pathfinding does not take this into account, and so you end up with situations where guests trying to reach a particular ride cannot get there, while guests that are just wandering around, can. 
This changes fixes that by, in case of nonsloped path, checking 1 unit above and below the current path's height, too.