### PR TITLE
Fix #12299 Placing ride entrances/exits ignores the Disable Clearance Checks cheat

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -26,6 +26,7 @@
 - Fix: [#20807] Tertiary colour not copied with small scenery.
 - Fix: [#20964] Crash when player connects to server with a group assigned that no longer exists.
 - Fix: [#20995] TTF fonts don’t support hinting, outlines, or insets with OpenGL.
+- Fix: [#12299] Placing ride entrance/exits no longer ignores the Disable Clearance Checks cheat.
 
 0.4.6 (2023-09-03)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -26,7 +26,7 @@
 - Fix: [#20807] Tertiary colour not copied with small scenery.
 - Fix: [#20964] Crash when player connects to server with a group assigned that no longer exists.
 - Fix: [#20995] TTF fonts don’t support hinting, outlines, or insets with OpenGL.
-- Fix: [#12299] Placing ride entrance/exits no longer ignores the Disable Clearance Checks cheat.
+- Fix: [#12299] Placing ride entrances/exits ignores the Disable Clearance Checks cheat.
 
 0.4.6 (2023-09-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
+++ b/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
@@ -162,7 +162,8 @@ GameActions::Result RideEntranceExitPlaceAction::Execute() const
     }
 
     auto z = station.GetBaseZ();
-    if (!(GetFlags() & GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED) && !(GetFlags() & GAME_COMMAND_FLAG_GHOST))
+    if (!(GetFlags() & GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED) && !(GetFlags() & GAME_COMMAND_FLAG_GHOST)
+        && !gCheatsDisableClearanceChecks)
     {
         FootpathRemoveLitter({ _loc, z });
         WallRemoveAtZ({ _loc, z });

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "11"
+#define NETWORK_STREAM_VERSION "12"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 


### PR DESCRIPTION
This bug has been... bugging me (ey~) for years. 
You build some custom ride, make a fancy station building with layered walls, which you have to shovel in tile inspector for correct order, you want to change something about the ride and replace the entrance/exit, and BOOM gone are your walls, even though clearance checks were disabled. 
Now I fixed it.
And the same being true for trash is fine too, as with the litter editor plugin, you might very well want trash in your park in certain places, to make signs or pictures etc. 