### PR TITLE
Use __LP64__ for BitSet 64-bit blocksize conditional check

### DIFF
--- a/test/tests/BitSetTests.cpp
+++ b/test/tests/BitSetTests.cpp
@@ -90,7 +90,7 @@ TEST(BitTest, test_big)
     static_assert(size == 32u);
 
     bits.flip();
-#if defined(_M_X64) || defined(_M_ARM64) || defined(__x86_64__)
+#if defined(__LP64__) || defined(_WIN64)
     static_assert(std::is_same_v<decltype(bits)::BlockType, uint64_t>);
     static_assert(bits.data().size() == 4);
     ASSERT_EQ(bits.data()[0], ~0uLL);


### PR DESCRIPTION
The canonical way to check for 64-bit system is __LP64__ preprocessor define.  This allows to build and pass test suite on ppc64le.