### PR TITLE
Remove double load of Title Sequence in TitleScreen.cpp

### DIFF
--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -144,8 +144,6 @@ void TitleScreen::Load()
 
     if (_sequencePlayer != nullptr)
     {
-        _sequencePlayer->Begin(_currentSequence);
-
         // Force the title sequence to load / update so we
         // don't see a blank screen for a split second.
         TryLoadSequence();


### PR DESCRIPTION
The title screen loads the sequence (including the park file and script) twice, throwing away the data from the first load. This PR removes the first load.

This line was originally added to support the title sequence editor, although I'm not sure why. It introduced the double load even back then. 

The title sequence editor has now been removed and replaced with a plugin. Someone with the plugin should confirm that this change doesn't break anything, although a quick read of the code shows it seems unlikely as the plugin can't reach this codepath anyway.