### PR TITLE
Start centralizing all save related data in GameState_t

### DIFF
--- a/src/openrct2-ui/scripting/ScTitleSequence.hpp
+++ b/src/openrct2-ui/scripting/ScTitleSequence.hpp
@@ -14,6 +14,7 @@
 #    include <memory>
 #    include <openrct2/Context.h>
 #    include <openrct2/Game.h>
+#    include <openrct2/GameState.h>
 #    include <openrct2/OpenRCT2.h>
 #    include <openrct2/ParkImporter.h>
 #    include <openrct2/core/String.hpp>
@@ -253,7 +254,10 @@ namespace OpenRCT2::Scripting
                         auto parkImporter = ParkImporter::Create(handle->HintPath);
                         auto result = parkImporter->LoadFromStream(handle->Stream.get(), isScenario);
                         objectMgr.LoadObjects(result.RequiredObjects);
-                        parkImporter->Import();
+
+                        // TODO: Have a separate GameState and exchange once loaded.
+                        auto& gameState = GetGameState();
+                        parkImporter->Import(gameState);
 
                         auto old = gLoadKeepWindowsOpen;
 

--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -304,7 +304,9 @@ namespace OpenRCT2::Title
                     auto& objectManager = GetContext()->GetObjectManager();
                     objectManager.LoadObjects(result.RequiredObjects);
 
-                    parkImporter->Import();
+                    // TODO: Have a separate GameState and exchange once loaded.
+                    auto& gameState = GetGameState();
+                    parkImporter->Import(gameState);
                     MapAnimationAutoCreate();
                 }
                 PrepareParkForPlayback();
@@ -343,7 +345,10 @@ namespace OpenRCT2::Title
                     auto& objectManager = GetContext()->GetObjectManager();
                     objectManager.LoadObjects(result.RequiredObjects);
 
-                    parkImporter->Import();
+                    // TODO: Have a separate GameState and exchange once loaded.
+                    auto& gameState = GetGameState();
+
+                    parkImporter->Import(gameState);
                 }
                 PrepareParkForPlayback();
                 success = true;

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -36,6 +36,8 @@
 #include <openrct2/world/Footpath.h>
 #include <openrct2/world/Park.h>
 
+using namespace OpenRCT2;
+
 static constexpr StringId WINDOW_TITLE = STR_STRINGID;
 static constexpr int32_t WH = 157;
 static constexpr int32_t WW = 192;
@@ -1146,7 +1148,7 @@ private:
         int32_t guestEntryTime = peep->GetParkEntryTime();
         if (guestEntryTime != -1)
         {
-            int32_t timeInPark = (gCurrentTicks - guestEntryTime) >> 11;
+            int32_t timeInPark = (GetGameState().CurrentTicks - guestEntryTime) >> 11;
             auto ft = Formatter();
             ft.Add<uint16_t>(timeInPark & 0xFFFF);
             DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_TIME_IN_PARK, ft);
@@ -1233,7 +1235,7 @@ private:
         }
 
         // Every 2048 ticks do a full window_invalidate
-        int32_t numTicks = gCurrentTicks - guest->GetParkEntryTime();
+        int32_t numTicks = GetGameState().CurrentTicks - guest->GetParkEntryTime();
         if (!(numTicks & 0x7FF))
             Invalidate();
 

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -13,6 +13,7 @@
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/config/Config.h>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/entity/EntityRegistry.h>
@@ -27,6 +28,8 @@
 #include <openrct2/util/Util.h>
 #include <openrct2/world/Park.h>
 #include <vector>
+
+using namespace OpenRCT2;
 
 static constexpr StringId WINDOW_TITLE = STR_GUESTS;
 static constexpr int32_t WH = 330;
@@ -812,7 +815,7 @@ private:
 
     bool IsRefreshOfGroupsRequired()
     {
-        uint32_t tick256 = Floor2(gCurrentTicks, 256);
+        uint32_t tick256 = Floor2(GetGameState().CurrentTicks, 256);
         if (_selectedView == _lastFindGroupsSelectedView)
         {
             if (_lastFindGroupsWait != 0 || _lastFindGroupsTick == tick256)
@@ -839,7 +842,7 @@ private:
 
     void RefreshGroups()
     {
-        _lastFindGroupsTick = Floor2(gCurrentTicks, 256);
+        _lastFindGroupsTick = Floor2(GetGameState().CurrentTicks, 256);
         _lastFindGroupsSelectedView = _selectedView;
         _lastFindGroupsWait = 320;
         _groups.clear();

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -39,6 +39,8 @@
 #include <string>
 #include <vector>
 
+using namespace OpenRCT2;
+
 #pragma region Widgets
 
 static constexpr StringId WINDOW_TITLE = STR_NONE;
@@ -264,6 +266,8 @@ static void Select(const char* path)
     char pathBuffer[MAX_PATH];
     SafeStrCpy(pathBuffer, path, sizeof(pathBuffer));
 
+    auto& gameState = GetGameState();
+
     switch (_type & 0x0F)
     {
         case (LOADSAVETYPE_LOAD | LOADSAVETYPE_GAME):
@@ -284,7 +288,7 @@ static void Select(const char* path)
 
         case (LOADSAVETYPE_SAVE | LOADSAVETYPE_GAME):
             SetAndSaveConfigPath(gConfigGeneral.LastSaveGameDirectory, pathBuffer);
-            if (ScenarioSave(pathBuffer, gConfigGeneral.SavePluginData ? 1 : 0))
+            if (ScenarioSave(gameState, pathBuffer, gConfigGeneral.SavePluginData ? 1 : 0))
             {
                 gScenarioSavePath = pathBuffer;
                 gCurrentLoadedPath = pathBuffer;
@@ -322,7 +326,7 @@ static void Select(const char* path)
         case (LOADSAVETYPE_SAVE | LOADSAVETYPE_LANDSCAPE):
             SetAndSaveConfigPath(gConfigGeneral.LastSaveLandscapeDirectory, pathBuffer);
             gScenarioFileName = std::string(String::ToStringView(pathBuffer, std::size(pathBuffer)));
-            if (ScenarioSave(pathBuffer, gConfigGeneral.SavePluginData ? 3 : 2))
+            if (ScenarioSave(gameState, pathBuffer, gConfigGeneral.SavePluginData ? 3 : 2))
             {
                 gCurrentLoadedPath = pathBuffer;
                 WindowCloseByClass(WindowClass::Loadsave);
@@ -343,7 +347,7 @@ static void Select(const char* path)
             gParkFlags &= ~PARK_FLAGS_SPRITES_INITIALISED;
             gEditorStep = EditorStep::Invalid;
             gScenarioFileName = std::string(String::ToStringView(pathBuffer, std::size(pathBuffer)));
-            int32_t success = ScenarioSave(pathBuffer, gConfigGeneral.SavePluginData ? 3 : 2);
+            int32_t success = ScenarioSave(gameState, pathBuffer, gConfigGeneral.SavePluginData ? 3 : 2);
             gParkFlags = parkFlagsBackup;
 
             if (success)

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -21,6 +21,7 @@
 #include <openrct2/Cheats.h>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/Input.h>
 #include <openrct2/Limits.h>
 #include <openrct2/OpenRCT2.h>
@@ -4661,7 +4662,7 @@ private:
             {
                 colour_t spriteColour = COLOUR_BLACK;
                 // Limit update rate of preview to avoid making people dizzy.
-                if ((gCurrentTicks % 64) == 0)
+                if ((GetGameState().CurrentTicks % 64) == 0)
                 {
                     spriteColour++;
                     if (spriteColour >= COLOUR_NUM_NORMAL)

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -647,7 +647,11 @@ namespace OpenRCT2
 
                 GameUnloadScripts();
                 _objectManager->LoadObjects(result.RequiredObjects);
-                parkImporter->Import();
+
+                // TODO: Have a separate GameState and exchange once loaded.
+                auto& gameState = ::GetGameState();
+                parkImporter->Import(gameState);
+
                 gScenarioSavePath = path;
                 gCurrentLoadedPath = path;
                 gFirstTimeSaving = true;

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -282,7 +282,10 @@ namespace Editor
             auto importer = ParkImporter::CreateParkFile(context->GetObjectRepository());
             auto loadResult = importer->Load(path);
             objManager.LoadObjects(loadResult.RequiredObjects);
-            importer->Import();
+
+            // TODO: Have a separate GameState and exchange once loaded.
+            auto& gameState = GetGameState();
+            importer->Import(gameState);
 
             AfterLoadCleanup(true);
             return true;

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -87,7 +87,6 @@ bool gIsAutosaveLoaded = false;
 
 bool gLoadKeepWindowsOpen = false;
 
-uint32_t gCurrentTicks;
 uint32_t gCurrentRealTimeTicks;
 
 #ifdef ENABLE_SCRIPTING

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -13,6 +13,7 @@
 #include "Context.h"
 #include "Editor.h"
 #include "FileClassifier.h"
+#include "GameState.h"
 #include "GameStateSnapshots.h"
 #include "Input.h"
 #include "OpenRCT2.h"
@@ -73,6 +74,8 @@
 #include <cstdio>
 #include <iterator>
 #include <memory>
+
+using namespace OpenRCT2;
 
 uint16_t gCurrentDeltaTime;
 uint8_t gGamePaused = 0;
@@ -638,7 +641,9 @@ void SaveGameCmd(u8string_view name /* = {} */)
 void SaveGameWithName(u8string_view name)
 {
     LOG_VERBOSE("Saving to %s", u8string(name).c_str());
-    if (ScenarioSave(name, gConfigGeneral.SavePluginData ? 1 : 0))
+
+    auto& gameState = GetGameState();
+    if (ScenarioSave(gameState, name, gConfigGeneral.SavePluginData ? 1 : 0))
     {
         LOG_VERBOSE("Saved to %s", u8string(name).c_str());
         gCurrentLoadedPath = name;
@@ -760,7 +765,9 @@ void GameAutosave()
         File::Copy(path, backupPath, true);
     }
 
-    if (!ScenarioSave(path, saveFlags))
+    auto& gameState = GetGameState();
+
+    if (!ScenarioSave(gameState, path, saveFlags))
         Console::Error::WriteLine("Could not autosave the scenario. Is the save folder writeable?");
 }
 

--- a/src/openrct2/Game.h
+++ b/src/openrct2/Game.h
@@ -134,7 +134,6 @@ enum
     ERROR_TYPE_FILE_LOAD = 255
 };
 
-extern uint32_t gCurrentTicks;
 extern uint32_t gCurrentRealTimeTicks;
 
 extern uint16_t gCurrentDeltaTime;

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -52,10 +52,15 @@ using namespace OpenRCT2::Scripting;
 
 static GameState_t _gameState{};
 
-GameState_t& GetGameState()
+namespace OpenRCT2
 {
-    return _gameState;
-}
+
+    GameState_t& GetGameState()
+    {
+        return _gameState;
+    }
+
+} // namespace OpenRCT2
 
 GameState::GameState()
 {
@@ -70,7 +75,7 @@ void GameState::InitAll(const TileCoordsXY& mapSize)
     PROFILED_FUNCTION();
 
     gInMapInitCode = true;
-    gCurrentTicks = 0;
+    GetGameState().CurrentTicks = 0;
 
     MapInit(mapSize);
     _park->Initialise();
@@ -137,7 +142,7 @@ void GameState::Tick()
     if (NetworkGetMode() == NETWORK_MODE_CLIENT && NetworkGetStatus() == NETWORK_STATUS_CONNECTED
         && NetworkGetAuthstatus() == NetworkAuth::Ok)
     {
-        numUpdates = std::clamp<uint32_t>(NetworkGetServerTick() - gCurrentTicks, 0, 10);
+        numUpdates = std::clamp<uint32_t>(NetworkGetServerTick() - GetGameState().CurrentTicks, 0, 10);
     }
     else
     {
@@ -287,7 +292,7 @@ void GameState::UpdateLogic()
     else if (NetworkGetMode() == NETWORK_MODE_CLIENT)
     {
         // Don't run past the server, this condition can happen during map changes.
-        if (NetworkGetServerTick() == gCurrentTicks)
+        if (NetworkGetServerTick() == GetGameState().CurrentTicks)
         {
             gInUpdateCode = false;
             return;
@@ -359,7 +364,7 @@ void GameState::UpdateLogic()
     NetworkProcessPending();
     NetworkFlush();
 
-    gCurrentTicks++;
+    GetGameState().CurrentTicks++;
     gSavedAge++;
 
 #ifdef ENABLE_SCRIPTING
@@ -383,7 +388,7 @@ void GameState::CreateStateSnapshot()
 
     auto& snapshot = snapshots->CreateSnapshot();
     snapshots->Capture(snapshot);
-    snapshots->LinkSnapshot(snapshot, gCurrentTicks, ScenarioRandState().s0);
+    snapshots->LinkSnapshot(snapshot, GetGameState().CurrentTicks, ScenarioRandState().s0);
 }
 
 void GameState::SetDate(Date newDate)

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -50,6 +50,13 @@
 using namespace OpenRCT2;
 using namespace OpenRCT2::Scripting;
 
+static GameState_t _gameState{};
+
+GameState_t& GetGameState()
+{
+    return _gameState;
+}
+
 GameState::GameState()
 {
     _park = std::make_unique<Park>();

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -54,12 +54,10 @@ static GameState_t _gameState{};
 
 namespace OpenRCT2
 {
-
     GameState_t& GetGameState()
     {
         return _gameState;
     }
-
 } // namespace OpenRCT2
 
 GameState::GameState()

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -59,5 +59,4 @@ namespace OpenRCT2
     private:
         void CreateStateSnapshot();
     };
-
 } // namespace OpenRCT2

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -23,6 +23,7 @@ namespace OpenRCT2
 
     struct GameState_t
     {
+        uint32_t CurrentTicks{};
     };
 
     GameState_t& GetGameState();

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -21,6 +21,12 @@ namespace OpenRCT2
 {
     class Park;
 
+    struct GameState_t
+    {
+    };
+
+    GameState_t& GetGameState();
+
     /**
      * Class to update the state of the map and park.
      */
@@ -52,4 +58,5 @@ namespace OpenRCT2
     private:
         void CreateStateSnapshot();
     };
+
 } // namespace OpenRCT2

--- a/src/openrct2/ParkImporter.h
+++ b/src/openrct2/ParkImporter.h
@@ -24,7 +24,8 @@ struct IObjectRepository;
 namespace OpenRCT2
 {
     struct IStream;
-}
+    struct GameState_t;
+} // namespace OpenRCT2
 
 struct ScenarioIndexEntry;
 
@@ -56,7 +57,7 @@ public:
     virtual ParkLoadResult LoadFromStream(
         OpenRCT2::IStream* stream, bool isScenario, bool skipObjectCheck = false, const u8string& path = {}) abstract;
 
-    virtual void Import() abstract;
+    virtual void Import(OpenRCT2::GameState_t& gameState) abstract;
     virtual bool GetDetails(ScenarioIndexEntry* dst) abstract;
 };
 

--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -252,9 +252,10 @@ namespace OpenRCT2
             auto& objManager = context->GetObjectManager();
             auto objects = objManager.GetPackableObjects();
 
+            auto& gameState = GetGameState();
             auto exporter = std::make_unique<ParkFileExporter>();
             exporter->ExportObjectsList = objects;
-            exporter->Export(replayData->parkData);
+            exporter->Export(gameState, replayData->parkData);
 
             replayData->timeRecorded = std::chrono::seconds(std::time(nullptr)).count();
 
@@ -535,7 +536,9 @@ namespace OpenRCT2
                 auto loadResult = importer->LoadFromStream(&data.parkData, false);
                 objManager.LoadObjects(loadResult.RequiredObjects);
 
-                importer->Import();
+                // TODO: Have a separate GameState and exchange once loaded.
+                auto& gameState = GetGameState();
+                importer->Import(gameState);
 
                 EntityTweener::Get().Reset();
 

--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -11,6 +11,7 @@
 
 #include "Context.h"
 #include "Game.h"
+#include "GameState.h"
 #include "GameStateSnapshots.h"
 #include "OpenRCT2.h"
 #include "ParkImporter.h"
@@ -145,7 +146,7 @@ namespace OpenRCT2
 
             auto ga = GameActions::Clone(action);
 
-            _currentRecording->commands.emplace(gCurrentTicks, std::move(ga), _commandId++);
+            _currentRecording->commands.emplace(tick, std::move(ga), _commandId++);
         }
 
         void AddChecksum(uint32_t tick, EntitiesChecksum&& checksum)
@@ -159,17 +160,19 @@ namespace OpenRCT2
             if (_mode == ReplayMode::NONE)
                 return;
 
-            if ((_mode == ReplayMode::RECORDING || _mode == ReplayMode::NORMALISATION) && gCurrentTicks == _nextChecksumTick)
+            const auto currentTicks = GetGameState().CurrentTicks;
+
+            if ((_mode == ReplayMode::RECORDING || _mode == ReplayMode::NORMALISATION) && currentTicks == _nextChecksumTick)
             {
                 EntitiesChecksum checksum = GetAllEntitiesChecksum();
-                AddChecksum(gCurrentTicks, std::move(checksum));
+                AddChecksum(currentTicks, std::move(checksum));
 
-                _nextChecksumTick = gCurrentTicks + ChecksumTicksDelta();
+                _nextChecksumTick = currentTicks + ChecksumTicksDelta();
             }
 
             if (_mode == ReplayMode::RECORDING)
             {
-                if (gCurrentTicks >= _currentRecording->tickEnd)
+                if (currentTicks >= _currentRecording->tickEnd)
                 {
                     StopRecording();
                     return;
@@ -185,7 +188,7 @@ namespace OpenRCT2
                 ReplayCommands();
 
                 // Normal playback will always end at the specific tick.
-                if (gCurrentTicks >= _currentReplay->tickEnd)
+                if (currentTicks >= _currentReplay->tickEnd)
                 {
                     StopPlayback();
                     return;
@@ -214,7 +217,7 @@ namespace OpenRCT2
 
             auto& snapshot = snapshots->CreateSnapshot();
             snapshots->Capture(snapshot);
-            snapshots->LinkSnapshot(snapshot, gCurrentTicks, ScenarioRandState().s0);
+            snapshots->LinkSnapshot(snapshot, GetGameState().CurrentTicks, ScenarioRandState().s0);
             DataSerialiser snapShotDs(true, snapshotStream);
             snapshots->SerialiseSnapshot(snapshot, snapShotDs);
         }
@@ -230,14 +233,16 @@ namespace OpenRCT2
             if (_mode != ReplayMode::NONE && _mode != ReplayMode::NORMALISATION)
                 return false;
 
+            const auto currentTicks = GetGameState().CurrentTicks;
+
             auto replayData = std::make_unique<ReplayRecordData>();
             replayData->magic = ReplayMagic;
             replayData->version = ReplayVersion;
             replayData->networkId = NetworkGetVersion();
             replayData->name = name;
-            replayData->tickStart = gCurrentTicks;
+            replayData->tickStart = currentTicks;
             if (maxTicks != k_MaxReplayTicks)
-                replayData->tickEnd = gCurrentTicks + maxTicks;
+                replayData->tickEnd = currentTicks + maxTicks;
             else
                 replayData->tickEnd = k_MaxReplayTicks;
 
@@ -266,7 +271,7 @@ namespace OpenRCT2
 
             _currentRecording = std::move(replayData);
             _recordType = rt;
-            _nextChecksumTick = gCurrentTicks + 1;
+            _nextChecksumTick = currentTicks + 1;
 
             return true;
         }
@@ -283,11 +288,13 @@ namespace OpenRCT2
                 return true;
             }
 
-            _currentRecording->tickEnd = gCurrentTicks;
+            const auto currentTicks = GetGameState().CurrentTicks;
+
+            _currentRecording->tickEnd = currentTicks;
 
             {
                 EntitiesChecksum checksum = GetAllEntitiesChecksum();
-                AddChecksum(gCurrentTicks, std::move(checksum));
+                AddChecksum(currentTicks, std::move(checksum));
             }
 
             TakeGameStateSnapshot(_currentRecording->gameStateSnapshots);
@@ -366,7 +373,7 @@ namespace OpenRCT2
             info.Version = data->version;
             info.TimeRecorded = data->timeRecorded;
             if (_mode == ReplayMode::RECORDING)
-                info.Ticks = gCurrentTicks - data->tickStart;
+                info.Ticks = GetGameState().CurrentTicks - data->tickStart;
             else if (_mode == ReplayMode::PLAYING)
                 info.Ticks = data->tickEnd - data->tickStart;
             info.NumCommands = static_cast<uint32_t>(data->commands.size());
@@ -384,9 +391,11 @@ namespace OpenRCT2
             GameStateSnapshot_t& replaySnapshot = snapshots->CreateSnapshot();
             snapshots->SerialiseSnapshot(replaySnapshot, ds);
 
+            const auto currentTicks = GetGameState().CurrentTicks;
+
             auto& localSnapshot = snapshots->CreateSnapshot();
             snapshots->Capture(localSnapshot);
-            snapshots->LinkSnapshot(localSnapshot, gCurrentTicks, ScenarioRandState().s0);
+            snapshots->LinkSnapshot(localSnapshot, currentTicks, ScenarioRandState().s0);
             try
             {
                 GameStateCompareData cmpData = snapshots->Compare(replaySnapshot, localSnapshot);
@@ -402,7 +411,7 @@ namespace OpenRCT2
                     std::string outputPath = GetContext()->GetPlatformEnvironment()->GetDirectoryPath(
                         DIRBASE::USER, DIRID::LOG_DESYNCS);
                     char uniqueFileName[128] = {};
-                    snprintf(uniqueFileName, sizeof(uniqueFileName), "replay_desync_%u.txt", gCurrentTicks);
+                    snprintf(uniqueFileName, sizeof(uniqueFileName), "replay_desync_%u.txt", currentTicks);
 
                     std::string outputFile = Path::Combine(outputPath, uniqueFileName);
                     snapshots->LogCompareDataToFile(outputFile, cmpData);
@@ -433,7 +442,7 @@ namespace OpenRCT2
                 return false;
             }
 
-            gCurrentTicks = replayData->tickStart;
+            GetGameState().CurrentTicks = replayData->tickStart;
 
             LoadAndCompareSnapshot(replayData->gameStateSnapshots);
 
@@ -495,7 +504,7 @@ namespace OpenRCT2
                 return false;
             }
 
-            _nextReplayTick = gCurrentTicks + 1;
+            _nextReplayTick = GetGameState().CurrentTicks + 1;
 
             return true;
         }
@@ -788,19 +797,21 @@ namespace OpenRCT2
             if (checksumIndex >= _currentReplay->checksums.size())
                 return;
 
+            const auto currentTicks = GetGameState().CurrentTicks;
+
             const auto& savedChecksum = _currentReplay->checksums[checksumIndex];
-            if (_currentReplay->checksums[checksumIndex].first == gCurrentTicks)
+            if (_currentReplay->checksums[checksumIndex].first == currentTicks)
             {
                 _currentReplay->checksumIndex++;
 
                 EntitiesChecksum checksum = GetAllEntitiesChecksum();
                 if (savedChecksum.second.raw != checksum.raw)
                 {
-                    uint32_t replayTick = gCurrentTicks - _currentReplay->tickStart;
+                    uint32_t replayTick = currentTicks - _currentReplay->tickStart;
 
                     // Detected different game state.
                     LOG_WARNING(
-                        "Different sprite checksum at tick %u (Replay Tick: %u) ; Saved: %s, Current: %s", gCurrentTicks,
+                        "Different sprite checksum at tick %u (Replay Tick: %u) ; Saved: %s, Current: %s", currentTicks,
                         replayTick, savedChecksum.second.ToString().c_str(), checksum.ToString().c_str());
 
                     _faultyChecksumIndex = checksumIndex;
@@ -809,8 +820,8 @@ namespace OpenRCT2
                 {
                     // Good state.
                     LOG_VERBOSE(
-                        "Good state at tick %u ; Saved: %s, Current: %s", gCurrentTicks,
-                        savedChecksum.second.ToString().c_str(), checksum.ToString().c_str());
+                        "Good state at tick %u ; Saved: %s, Current: %s", currentTicks, savedChecksum.second.ToString().c_str(),
+                        checksum.ToString().c_str());
                 }
             }
         }
@@ -820,6 +831,8 @@ namespace OpenRCT2
         {
             auto& replayQueue = _currentReplay->commands;
 
+            const auto currentTicks = GetGameState().CurrentTicks;
+
             while (replayQueue.begin() != replayQueue.end())
             {
                 const ReplayCommand& command = (*replayQueue.begin());
@@ -827,16 +840,16 @@ namespace OpenRCT2
                 if (_mode == ReplayMode::PLAYING)
                 {
                     // If this is a normal playback wait for the correct tick.
-                    if (command.tick != gCurrentTicks)
+                    if (command.tick != currentTicks)
                         break;
                 }
                 else if (_mode == ReplayMode::NORMALISATION)
                 {
                     // Allow one entry per tick.
-                    if (gCurrentTicks != _nextReplayTick)
+                    if (currentTicks != _nextReplayTick)
                         break;
 
-                    _nextReplayTick = gCurrentTicks + 1;
+                    _nextReplayTick = currentTicks + 1;
                 }
 
                 bool isPositionValid = false;

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -10,6 +10,7 @@
 #include "GameAction.h"
 
 #include "../Context.h"
+#include "../GameState.h"
 #include "../ReplayManager.h"
 #include "../core/Guard.hpp"
 #include "../core/Memory.hpp"
@@ -101,7 +102,7 @@ namespace GameActions
             return;
         }
 
-        const uint32_t currentTick = gCurrentTicks;
+        const uint32_t currentTick = GetGameState().CurrentTicks;
 
         while (_actionQueue.begin() != _actionQueue.end())
         {
@@ -251,7 +252,7 @@ namespace GameActions
 
         char temp[128] = {};
         snprintf(
-            temp, sizeof(temp), "[%s] Tick: %u, GA: %s (%08X) (", GetRealm(), gCurrentTicks, action->GetName(),
+            temp, sizeof(temp), "[%s] Tick: %u, GA: %s (%08X) (", GetRealm(), GetGameState().CurrentTicks, action->GetName(),
             EnumValue(action->GetType()));
 
         output.Write(temp, strlen(temp));
@@ -345,7 +346,7 @@ namespace GameActions
                     if (!(actionFlags & GameActions::Flags::ClientOnly) && !(flags & GAME_COMMAND_FLAG_NETWORKED))
                     {
                         LOG_VERBOSE("[%s] GameAction::Execute %s (Queue)", GetRealm(), action->GetName());
-                        Enqueue(action, gCurrentTicks);
+                        Enqueue(action, GetGameState().CurrentTicks);
 
                         return result;
                     }
@@ -415,7 +416,7 @@ namespace GameActions
                     }
                     if (recordAction)
                     {
-                        replayManager->AddGameAction(gCurrentTicks, action);
+                        replayManager->AddGameAction(GetGameState().CurrentTicks, action);
                     }
                 }
             }

--- a/src/openrct2/command_line/ConvertCommand.cpp
+++ b/src/openrct2/command_line/ConvertCommand.cpp
@@ -9,6 +9,7 @@
 
 #include "../Context.h"
 #include "../FileClassifier.h"
+#include "../GameState.h"
 #include "../OpenRCT2.h"
 #include "../ParkImporter.h"
 #include "../common.h"
@@ -21,6 +22,8 @@
 #include "CommandLine.hpp"
 
 #include <memory>
+
+using namespace OpenRCT2;
 
 static void WriteConvertFromAndToMessage(FileExtension sourceFileType, FileExtension destinationFileType);
 static u8string GetFileTypeFriendlyName(FileExtension fileType);
@@ -98,7 +101,9 @@ exitcode_t CommandLine::HandleCommandConvert(CommandLineArgEnumerator* enumerato
 
         objManager.LoadObjects(loadResult.RequiredObjects);
 
-        importer->Import();
+        // TODO: Have a separate GameState and exchange once loaded.
+        auto& gameState = GetGameState();
+        importer->Import(gameState);
     }
     catch (const std::exception& ex)
     {
@@ -120,7 +125,9 @@ exitcode_t CommandLine::HandleCommandConvert(CommandLineArgEnumerator* enumerato
         //      correct initial view
         WindowCloseByClass(WindowClass::MainWindow);
 
-        exporter->Export(destinationPath);
+        auto& gameState = GetGameState();
+
+        exporter->Export(gameState, destinationPath);
     }
     catch (const std::exception& ex)
     {

--- a/src/openrct2/drawing/Weather.cpp
+++ b/src/openrct2/drawing/Weather.cpp
@@ -10,6 +10,7 @@
 #include "Weather.h"
 
 #include "../Game.h"
+#include "../GameState.h"
 #include "../config/Config.h"
 #include "../interface/Viewport.h"
 #include "../ride/TrackDesign.h"
@@ -83,15 +84,17 @@ void DrawWeather(DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer)
 static void DrawLightRain(
     DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
 {
-    int32_t x_start = -static_cast<int32_t>(gCurrentTicks) + 8;
-    int32_t y_start = (gCurrentTicks * 3) + 7;
+    const auto currentTicks = GetGameState().CurrentTicks;
+
+    int32_t x_start = -static_cast<int32_t>(currentTicks) + 8;
+    int32_t y_start = (currentTicks * 3) + 7;
     y_start = -y_start;
     x_start += left;
     y_start += top;
     weatherDrawer->Draw(dpi, left, top, width, height, x_start, y_start, RainPattern);
 
-    x_start = -static_cast<int32_t>(gCurrentTicks) + 0x18;
-    y_start = (gCurrentTicks * 4) + 0x0D;
+    x_start = -static_cast<int32_t>(currentTicks) + 0x18;
+    y_start = (currentTicks * 4) + 0x0D;
     y_start = -y_start;
     x_start += left;
     y_start += top;
@@ -105,29 +108,31 @@ static void DrawLightRain(
 static void DrawHeavyRain(
     DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
 {
-    int32_t x_start = -static_cast<int32_t>(gCurrentTicks);
-    int32_t y_start = gCurrentTicks * 5;
+    const auto currentTicks = GetGameState().CurrentTicks;
+
+    int32_t x_start = -static_cast<int32_t>(currentTicks);
+    int32_t y_start = currentTicks * 5;
     y_start = -y_start;
     x_start += left;
     y_start += top;
     weatherDrawer->Draw(dpi, left, top, width, height, x_start, y_start, RainPattern);
 
-    x_start = -static_cast<int32_t>(gCurrentTicks) + 0x10;
-    y_start = (gCurrentTicks * 6) + 5;
+    x_start = -static_cast<int32_t>(currentTicks) + 0x10;
+    y_start = (currentTicks * 6) + 5;
     y_start = -y_start;
     x_start += left;
     y_start += top;
     weatherDrawer->Draw(dpi, left, top, width, height, x_start, y_start, RainPattern);
 
-    x_start = -static_cast<int32_t>(gCurrentTicks) + 8;
-    y_start = (gCurrentTicks * 3) + 7;
+    x_start = -static_cast<int32_t>(currentTicks) + 8;
+    y_start = (currentTicks * 3) + 7;
     y_start = -y_start;
     x_start += left;
     y_start += top;
     weatherDrawer->Draw(dpi, left, top, width, height, x_start, y_start, RainPattern);
 
-    x_start = -static_cast<int32_t>(gCurrentTicks) + 0x18;
-    y_start = (gCurrentTicks * 4) + 0x0D;
+    x_start = -static_cast<int32_t>(currentTicks) + 0x18;
+    y_start = (currentTicks * 4) + 0x0D;
     y_start = -y_start;
     x_start += left;
     y_start += top;
@@ -137,9 +142,11 @@ static void DrawHeavyRain(
 static void DrawLightSnow(
     DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
 {
-    const uint32_t t = gCurrentTicks / 2;
+    const auto currentTicks = GetGameState().CurrentTicks;
+
+    const uint32_t t = currentTicks / 2;
     const int32_t negT = -static_cast<int32_t>(t);
-    const double cosTick = static_cast<double>(gCurrentTicks) * 0.05;
+    const double cosTick = static_cast<double>(currentTicks) * 0.05;
 
     int32_t x_start = negT + 1 + (cos(1.0 + cosTick) * 6);
     int32_t y_start = t + 1;
@@ -159,29 +166,31 @@ static void DrawLightSnow(
 static void DrawHeavySnow(
     DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
 {
-    int32_t x_start = -static_cast<int32_t>(gCurrentTicks * 3) + 1;
-    int32_t y_start = gCurrentTicks + 23;
+    const auto currentTicks = GetGameState().CurrentTicks;
+
+    int32_t x_start = -static_cast<int32_t>(currentTicks * 3) + 1;
+    int32_t y_start = currentTicks + 23;
     y_start = -y_start;
     x_start += left;
     y_start += top;
     weatherDrawer->Draw(dpi, left, top, width, height, x_start, y_start, SnowPattern);
 
-    x_start = -static_cast<int32_t>(gCurrentTicks * 4) + 6;
-    y_start = gCurrentTicks + 5;
+    x_start = -static_cast<int32_t>(currentTicks * 4) + 6;
+    y_start = currentTicks + 5;
     y_start = -y_start;
     x_start += left;
     y_start += top;
     weatherDrawer->Draw(dpi, left, top, width, height, x_start, y_start, SnowPattern);
 
-    x_start = -static_cast<int32_t>(gCurrentTicks * 2) + 11;
-    y_start = gCurrentTicks + 18;
+    x_start = -static_cast<int32_t>(currentTicks * 2) + 11;
+    y_start = currentTicks + 18;
     y_start = -y_start;
     x_start += left;
     y_start += top;
     weatherDrawer->Draw(dpi, left, top, width, height, x_start, y_start, SnowPattern);
 
-    x_start = -static_cast<int32_t>(gCurrentTicks * 3) + 17;
-    y_start = gCurrentTicks + 11;
+    x_start = -static_cast<int32_t>(currentTicks * 3) + 17;
+    y_start = currentTicks + 11;
     y_start = -y_start;
     x_start += left;
     y_start += top;

--- a/src/openrct2/entity/Duck.cpp
+++ b/src/openrct2/entity/Duck.cpp
@@ -9,6 +9,7 @@
 #include "Duck.h"
 
 #include "../Game.h"
+#include "../GameState.h"
 #include "../audio/audio.h"
 #include "../core/DataSerialiser.h"
 #include "../localisation/Date.h"
@@ -22,6 +23,8 @@
 #include <algorithm>
 #include <iterator>
 #include <limits>
+
+using namespace OpenRCT2;
 
 constexpr int32_t DUCK_MAX_STATES = 5;
 
@@ -88,7 +91,9 @@ void Duck::Remove()
 
 void Duck::UpdateFlyToWater()
 {
-    if ((gCurrentTicks & 3) != 0)
+    const auto currentTicks = GetGameState().CurrentTicks;
+
+    if ((currentTicks & 3) != 0)
         return;
 
     frame++;
@@ -150,7 +155,9 @@ void Duck::UpdateFlyToWater()
 
 void Duck::UpdateSwim()
 {
-    if (((gCurrentTicks + Id.ToUnderlying()) & 3) != 0)
+    const auto currentTicks = GetGameState().CurrentTicks;
+
+    if (((currentTicks + Id.ToUnderlying()) & 3) != 0)
         return;
 
     uint32_t randomNumber = ScenarioRand();
@@ -246,7 +253,7 @@ void Duck::UpdateDoubleDrink()
 
 void Duck::UpdateFlyAway()
 {
-    if ((gCurrentTicks & 3) == 0)
+    if ((GetGameState().CurrentTicks & 3) == 0)
     {
         frame++;
         if (frame >= std::size(DuckAnimationFlyAway))

--- a/src/openrct2/entity/Fountain.cpp
+++ b/src/openrct2/entity/Fountain.cpp
@@ -10,6 +10,7 @@
 #include "Fountain.h"
 
 #include "../Game.h"
+#include "../GameState.h"
 #include "../core/DataSerialiser.h"
 #include "../object/PathAdditionEntry.h"
 #include "../paint/Paint.h"
@@ -20,6 +21,8 @@
 #include "../world/Map.h"
 #include "../world/Scenery.h"
 #include "EntityRegistry.h"
+
+using namespace OpenRCT2;
 
 enum class PATTERN
 {
@@ -86,11 +89,13 @@ template<> bool EntityBase::Is<JumpingFountain>() const
 
 void JumpingFountain::StartAnimation(const JumpingFountainType newType, const CoordsXY& newLoc, const TileElement* tileElement)
 {
+    const auto currentTicks = GetGameState().CurrentTicks;
+
     int32_t randomIndex;
     auto newZ = tileElement->GetBaseZ();
 
     // Change pattern approximately every 51 seconds
-    uint32_t pattern = (gCurrentTicks >> 11) & 7;
+    uint32_t pattern = (currentTicks >> 11) & 7;
     switch (static_cast<PATTERN>(pattern))
     {
         case PATTERN::CYCLIC_SQUARES:

--- a/src/openrct2/entity/Litter.cpp
+++ b/src/openrct2/entity/Litter.cpp
@@ -2,6 +2,7 @@
 
 #include "../Cheats.h"
 #include "../Game.h"
+#include "../GameState.h"
 #include "../core/DataSerialiser.h"
 #include "../localisation/StringIds.h"
 #include "../paint/Paint.h"
@@ -10,6 +11,8 @@
 #include "../world/Map.h"
 #include "EntityList.h"
 #include "EntityRegistry.h"
+
+using namespace OpenRCT2;
 
 template<> bool EntityBase::Is<Litter>() const
 {
@@ -86,7 +89,7 @@ void Litter::Create(const CoordsXYZD& litterPos, Type type)
     litter->SpriteData.HeightMax = 3;
     litter->SubType = type;
     litter->MoveTo(offsetLitterPos);
-    litter->creationTick = gCurrentTicks;
+    litter->creationTick = GetGameState().CurrentTicks;
 }
 
 /**
@@ -137,7 +140,7 @@ StringId Litter::GetName() const
 
 uint32_t Litter::GetAge() const
 {
-    return gCurrentTicks - creationTick;
+    return GetGameState().CurrentTicks - creationTick;
 }
 
 void Litter::Serialise(DataSerialiser& stream)

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -12,6 +12,7 @@
 #include "../Cheats.h"
 #include "../Context.h"
 #include "../Game.h"
+#include "../GameState.h"
 #include "../Input.h"
 #include "../OpenRCT2.h"
 #include "../actions/GameAction.h"
@@ -62,6 +63,7 @@
 #include <memory>
 #include <optional>
 
+using namespace OpenRCT2;
 using namespace OpenRCT2::Audio;
 
 uint8_t gGuestChangeModifier;
@@ -211,11 +213,13 @@ void PeepUpdateAll()
     if (gScreenFlags & SCREEN_FLAGS_EDITOR)
         return;
 
+    const auto currentTicks = GetGameState().CurrentTicks;
+
     int32_t i = 0;
     // Warning this loop can delete peeps
     for (auto peep : EntityList<Guest>())
     {
-        if (static_cast<uint32_t>(i & 0x7F) != (gCurrentTicks & 0x7F))
+        if (static_cast<uint32_t>(i & 0x7F) != (currentTicks & 0x7F))
         {
             peep->Update();
         }
@@ -234,7 +238,7 @@ void PeepUpdateAll()
 
     for (auto staff : EntityList<Staff>())
     {
-        if (static_cast<uint32_t>(i & 0x7F) != (gCurrentTicks & 0x7F))
+        if (static_cast<uint32_t>(i & 0x7F) != (currentTicks & 0x7F))
         {
             staff->Update();
         }
@@ -888,7 +892,7 @@ void Peep::SetState(PeepState new_state)
  */
 void Peep::UpdatePicked()
 {
-    if (gCurrentTicks & 0x1F)
+    if (GetGameState().CurrentTicks & 0x1F)
         return;
     SubState++;
     auto* guest = As<Guest>();

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -63,7 +63,6 @@
 #include <memory>
 #include <optional>
 
-using namespace OpenRCT2;
 using namespace OpenRCT2::Audio;
 
 uint8_t gGuestChangeModifier;
@@ -213,7 +212,7 @@ void PeepUpdateAll()
     if (gScreenFlags & SCREEN_FLAGS_EDITOR)
         return;
 
-    const auto currentTicks = GetGameState().CurrentTicks;
+    const auto currentTicks = OpenRCT2::GetGameState().CurrentTicks;
 
     int32_t i = 0;
     // Warning this loop can delete peeps
@@ -892,7 +891,7 @@ void Peep::SetState(PeepState new_state)
  */
 void Peep::UpdatePicked()
 {
-    if (GetGameState().CurrentTicks & 0x1F)
+    if (OpenRCT2::GetGameState().CurrentTicks & 0x1F)
         return;
     SubState++;
     auto* guest = As<Guest>();

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -11,6 +11,7 @@
 
 #include "../Context.h"
 #include "../Game.h"
+#include "../GameState.h"
 #include "../Input.h"
 #include "../actions/StaffSetOrdersAction.h"
 #include "../audio/audio.h"
@@ -48,6 +49,8 @@
 
 #include <algorithm>
 #include <iterator>
+
+using namespace OpenRCT2;
 
 // clang-format off
 const StringId StaffCostumeNames[] = {
@@ -487,7 +490,7 @@ bool Staff::DoHandymanPathFinding()
     Direction litterDirection = INVALID_DIRECTION;
     uint8_t validDirections = GetValidPatrolDirections(NextLoc);
 
-    if ((StaffOrders & STAFF_ORDERS_SWEEPING) && ((gCurrentTicks + Id.ToUnderlying()) & 0xFFF) > 110)
+    if ((StaffOrders & STAFF_ORDERS_SWEEPING) && ((GetGameState().CurrentTicks + Id.ToUnderlying()) & 0xFFF) > 110)
     {
         litterDirection = HandymanDirectionToNearestLitter();
     }

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -11,6 +11,7 @@
 
 #include "../Date.h"
 #include "../Game.h"
+#include "../GameState.h"
 #include "../OpenRCT2.h"
 #include "../actions/ParkSetResearchFundingAction.h"
 #include "../config/Config.h"
@@ -315,7 +316,7 @@ void ResearchUpdate()
         return;
     }
 
-    if (gCurrentTicks % 32 != 0)
+    if (GetGameState().CurrentTicks % 32 != 0)
     {
         return;
     }

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -11,6 +11,7 @@
 
 #include "../Context.h"
 #include "../Game.h"
+#include "../GameState.h"
 #include "../GameStateSnapshots.h"
 #include "../OpenRCT2.h"
 #include "../PlatformEnvironment.h"
@@ -38,6 +39,8 @@
 #include <algorithm>
 #include <iterator>
 #include <stdexcept>
+
+using namespace OpenRCT2;
 
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
@@ -783,12 +786,14 @@ bool NetworkBase::IsDesynchronised() const noexcept
 
 bool NetworkBase::CheckDesynchronizaton()
 {
+    const auto currentTicks = GetGameState().CurrentTicks;
+
     // Check synchronisation
     if (GetMode() == NETWORK_MODE_CLIENT && _serverState.state != NetworkServerStatus::Desynced
-        && !CheckSRAND(gCurrentTicks, ScenarioRandState().s0))
+        && !CheckSRAND(currentTicks, ScenarioRandState().s0))
     {
         _serverState.state = NetworkServerStatus::Desynced;
-        _serverState.desyncTick = gCurrentTicks;
+        _serverState.desyncTick = currentTicks;
 
         char str_desync[256];
         FormatStringLegacy(str_desync, 256, STR_MULTIPLAYER_DESYNC, nullptr);
@@ -1496,7 +1501,7 @@ void NetworkBase::Client_Send_GAME_ACTION(const GameAction* action)
     DataSerialiser stream(true);
     action->Serialise(stream);
 
-    packet << gCurrentTicks << action->GetType() << stream;
+    packet << GetGameState().CurrentTicks << action->GetType() << stream;
     _serverConnection->QueuePacket(std::move(packet));
 }
 
@@ -1507,7 +1512,7 @@ void NetworkBase::ServerSendGameAction(const GameAction* action)
     DataSerialiser stream(true);
     action->Serialise(stream);
 
-    packet << gCurrentTicks << action->GetType() << stream;
+    packet << GetGameState().CurrentTicks << action->GetType() << stream;
 
     SendPacketToClients(packet);
 }
@@ -1515,7 +1520,7 @@ void NetworkBase::ServerSendGameAction(const GameAction* action)
 void NetworkBase::ServerSendTick()
 {
     NetworkPacket packet(NetworkCommand::Tick);
-    packet << gCurrentTicks << ScenarioRandState().s0;
+    packet << GetGameState().CurrentTicks << ScenarioRandState().s0;
     uint32_t flags = 0;
     // Simple counter which limits how often a sprite checksum gets sent.
     // This can get somewhat expensive, so we don't want to push it every tick in release,
@@ -1542,7 +1547,7 @@ void NetworkBase::ServerSendTick()
 void NetworkBase::ServerSendPlayerInfo(int32_t playerId)
 {
     NetworkPacket packet(NetworkCommand::PlayerInfo);
-    packet << gCurrentTicks;
+    packet << GetGameState().CurrentTicks;
 
     auto* player = GetPlayerByID(playerId);
     if (player == nullptr)
@@ -1555,7 +1560,7 @@ void NetworkBase::ServerSendPlayerInfo(int32_t playerId)
 void NetworkBase::ServerSendPlayerList()
 {
     NetworkPacket packet(NetworkCommand::PlayerList);
-    packet << gCurrentTicks << static_cast<uint8_t>(player_list.size());
+    packet << GetGameState().CurrentTicks << static_cast<uint8_t>(player_list.size());
     for (auto& player : player_list)
     {
         player->Write(packet);
@@ -1849,7 +1854,7 @@ void NetworkBase::ProcessPlayerList()
         auto itPending = _pendingPlayerLists.begin();
         while (itPending != _pendingPlayerLists.end())
         {
-            if (itPending->first > gCurrentTicks)
+            if (itPending->first > GetGameState().CurrentTicks)
                 break;
 
             // List of active players found in the list.
@@ -1921,7 +1926,9 @@ void NetworkBase::ProcessPlayerList()
 
 void NetworkBase::ProcessPlayerInfo()
 {
-    auto range = _pendingPlayerInfo.equal_range(gCurrentTicks);
+    const auto currentTicks = GetGameState().CurrentTicks;
+
+    auto range = _pendingPlayerInfo.equal_range(currentTicks);
     for (auto it = range.first; it != range.second; it++)
     {
         auto* player = GetPlayerByID(it->second.Id);
@@ -1936,7 +1943,7 @@ void NetworkBase::ProcessPlayerInfo()
             player->CommandsRan = networkedInfo.CommandsRan;
         }
     }
-    _pendingPlayerInfo.erase(gCurrentTicks);
+    _pendingPlayerInfo.erase(currentTicks);
 }
 
 void NetworkBase::ProcessDisconnectedClients()
@@ -2750,7 +2757,7 @@ void NetworkBase::Client_Handle_MAP([[maybe_unused]] NetworkConnection& connecti
             GameLoadInit();
             GameLoadScripts();
             GameNotifyMapChanged();
-            _serverState.tick = gCurrentTicks;
+            _serverState.tick = GetGameState().CurrentTicks;
             // WindowNetworkStatusOpen("Loaded new map from network");
             _serverState.state = NetworkServerStatus::Ok;
             _clientMapLoaded = true;
@@ -4030,7 +4037,7 @@ NetworkAuth NetworkGetAuthstatus()
 }
 uint32_t NetworkGetServerTick()
 {
-    return gCurrentTicks;
+    return GetGameState().CurrentTicks;
 }
 void NetworkFlush()
 {

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -2797,7 +2797,10 @@ bool NetworkBase::LoadMap(IStream* stream)
         auto importer = ParkImporter::CreateParkFile(context.GetObjectRepository());
         auto loadResult = importer->LoadFromStream(stream, false);
         objManager.LoadObjects(loadResult.RequiredObjects);
-        importer->Import();
+
+        // TODO: Have a separate GameState and exchange once loaded.
+        auto& gameState = GetGameState();
+        importer->Import(gameState);
 
         EntityTweener::Get().Reset();
         MapAnimationAutoCreate();
@@ -2820,7 +2823,9 @@ bool NetworkBase::SaveMap(IStream* stream, const std::vector<const ObjectReposit
     {
         auto exporter = std::make_unique<ParkFileExporter>();
         exporter->ExportObjectsList = objects;
-        exporter->Export(*stream);
+
+        auto& gameState = GetGameState();
+        exporter->Export(gameState, *stream);
         result = true;
     }
     catch (const std::exception& e)

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -10,6 +10,7 @@
 #include "Painter.h"
 
 #include "../Game.h"
+#include "../GameState.h"
 #include "../Intro.h"
 #include "../OpenRCT2.h"
 #include "../ReplayManager.h"
@@ -94,7 +95,7 @@ void Painter::PaintReplayNotice(DrawPixelInfo& dpi, const char* text)
     auto stringWidth = GfxGetStringWidth(buffer, FontStyle::Medium);
     screenCoords.x = screenCoords.x - stringWidth;
 
-    if (((gCurrentTicks >> 1) & 0xF) > 4)
+    if (((GetGameState().CurrentTicks >> 1) & 0xF) > 4)
         GfxDrawString(dpi, screenCoords, buffer, { COLOUR_SATURATED_RED });
 
     // Make area dirty so the text doesn't get drawn over the last

--- a/src/openrct2/paint/tile_element/Paint.Banner.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Banner.cpp
@@ -10,6 +10,7 @@
 #include "../Paint.h"
 
 #include "../../Game.h"
+#include "../../GameState.h"
 #include "../../config/Config.h"
 #include "../../interface/Viewport.h"
 #include "../../localisation/Formatter.h"
@@ -24,6 +25,8 @@
 #include "../../world/Scenery.h"
 #include "../../world/TileInspector.h"
 #include "Paint.TileElement.h"
+
+using namespace OpenRCT2;
 
 // BannerBoundBoxes[rotation][0] is for the pole in the back
 // BannerBoundBoxes[rotation][1] is for the pole and the banner in the front
@@ -65,7 +68,7 @@ static void PaintBannerScrollingText(
     }
 
     auto stringWidth = GfxGetStringWidth(text, FontStyle::Tiny);
-    auto scroll = (gCurrentTicks / 2) % stringWidth;
+    auto scroll = (GetGameState().CurrentTicks / 2) % stringWidth;
     auto imageId = ScrollingTextSetup(session, STR_BANNER_TEXT_FORMAT, ft, scroll, scrollingMode, COLOUR_BLACK);
     PaintAddImageAsChild(session, imageId, { 0, 0, height + 22 }, { bbOffset, { 1, 1, 21 } });
 }

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -71,7 +71,7 @@ static void PaintRideEntranceExitScrollingText(
         FormatStringLegacy(text, sizeof(text), STR_BANNER_TEXT_FORMAT, ft.Data());
     }
     auto stringWidth = GfxGetStringWidth(text, FontStyle::Tiny);
-    auto scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;
+    auto scroll = stringWidth > 0 ? (GetGameState().CurrentTicks / 2) % stringWidth : 0;
 
     PaintAddImageAsChild(
         session, ScrollingTextSetup(session, STR_BANNER_TEXT_FORMAT, ft, scroll, stationObj.ScrollingMode, COLOUR_BLACK),
@@ -244,7 +244,7 @@ static void PaintParkEntranceScrollingText(
     }
 
     auto stringWidth = GfxGetStringWidth(text, FontStyle::Tiny);
-    auto scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;
+    auto scroll = stringWidth > 0 ? (GetGameState().CurrentTicks / 2) % stringWidth : 0;
     auto imageIndex = ScrollingTextSetup(
         session, STR_BANNER_TEXT_FORMAT, ft, scroll, scrollingMode + direction / 2, COLOUR_BLACK);
     auto textHeight = height + entrance.GetTextHeight();

--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
@@ -10,6 +10,7 @@
 #include "../Paint.h"
 
 #include "../../Game.h"
+#include "../../GameState.h"
 #include "../../config/Config.h"
 #include "../../core/Numerics.hpp"
 #include "../../core/String.hpp"
@@ -29,6 +30,8 @@
 #include "../Boundbox.h"
 #include "../Supports.h"
 #include "Paint.TileElement.h"
+
+using namespace OpenRCT2;
 
 // clang-format off
 static constexpr BoundBoxXY LargeSceneryBoundBoxes[] = {
@@ -323,7 +326,7 @@ static void PaintLargeSceneryScrollingText(
 
     auto scrollMode = sceneryEntry.scrolling_mode + ((direction + 1) & 3);
     auto stringWidth = GfxGetStringWidth(text, FontStyle::Tiny);
-    auto scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;
+    auto scroll = stringWidth > 0 ? (GetGameState().CurrentTicks / 2) % stringWidth : 0;
     auto imageId = ScrollingTextSetup(session, STR_SCROLLING_SIGN_TEXT, ft, scroll, scrollMode, textPaletteIndex);
     PaintAddImageAsChild(session, imageId, { 0, 0, height + 25 }, { bbOffset, { 1, 1, 21 } });
 }

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -11,6 +11,7 @@
 
 #include "../../Context.h"
 #include "../../Game.h"
+#include "../../GameState.h"
 #include "../../config/Config.h"
 #include "../../core/Numerics.hpp"
 #include "../../entity/PatrolArea.h"
@@ -330,7 +331,7 @@ static void PathPaintFencesAndQueueBanners(
             }
 
             uint16_t stringWidth = GfxGetStringWidth(gCommonStringFormatBuffer, FontStyle::Tiny);
-            uint16_t scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;
+            uint16_t scroll = stringWidth > 0 ? (GetGameState().CurrentTicks / 2) % stringWidth : 0;
 
             PaintAddImageAsChild(
                 session, ScrollingTextSetup(session, STR_BANNER_TEXT_FORMAT, ft, scroll, scrollingMode, COLOUR_BLACK),

--- a/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
@@ -10,6 +10,7 @@
 #include "../Paint.h"
 
 #include "../../Game.h"
+#include "../../GameState.h"
 #include "../../config/Config.h"
 #include "../../interface/Viewport.h"
 #include "../../localisation/Date.h"
@@ -22,6 +23,8 @@
 #include "../../world/TileInspector.h"
 #include "../Supports.h"
 #include "Paint.TileElement.h"
+
+using namespace OpenRCT2;
 
 static constexpr CoordsXY lengths[] = {
     { 12, 26 },
@@ -209,23 +212,25 @@ static void PaintSmallSceneryBody(
 
     if (sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_ANIMATED))
     {
+        const auto currentTicks = GetGameState().CurrentTicks;
+
         if (sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_VISIBLE_WHEN_ZOOMED) || (session.DPI.zoom_level <= ZoomLevel{ 1 }))
         {
             if (sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_FOUNTAIN_SPRAY_1))
             {
-                auto imageIndex = sceneryEntry->image + 4 + ((gCurrentTicks / 2) & 0xF);
+                auto imageIndex = sceneryEntry->image + 4 + ((currentTicks / 2) & 0xF);
                 auto imageId = imageTemplate.WithIndex(imageIndex);
                 PaintAddImageAsChild(session, imageId, offset, boundBox);
             }
             else if (sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_FOUNTAIN_SPRAY_4))
             {
-                auto imageIndex = sceneryEntry->image + 8 + ((gCurrentTicks / 2) & 0xF);
+                auto imageIndex = sceneryEntry->image + 8 + ((currentTicks / 2) & 0xF);
                 PaintAddImageAsChild(session, imageTemplate.WithIndex(imageIndex), offset, boundBox);
 
                 imageIndex = direction + sceneryEntry->image + 4;
                 PaintAddImageAsChild(session, imageTemplate.WithIndex(imageIndex), offset, boundBox);
 
-                imageIndex = sceneryEntry->image + 24 + ((gCurrentTicks / 2) & 0xF);
+                imageIndex = sceneryEntry->image + 24 + ((currentTicks / 2) & 0xF);
                 PaintAddImageAsChild(session, imageTemplate.WithIndex(imageIndex), offset, boundBox);
             }
             else if (sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_IS_CLOCK))
@@ -260,7 +265,7 @@ static void PaintSmallSceneryBody(
             }
             else if (sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_SWAMP_GOO))
             {
-                auto imageIndex = gCurrentTicks;
+                auto imageIndex = currentTicks;
                 imageIndex += session.SpritePosition.x / 4;
                 imageIndex += session.SpritePosition.y / 4;
                 imageIndex = sceneryEntry->image + ((imageIndex / 4) % 16);
@@ -269,7 +274,7 @@ static void PaintSmallSceneryBody(
             else if (sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_HAS_FRAME_OFFSETS))
             {
                 auto delay = sceneryEntry->animation_delay & 0xFF;
-                auto frame = gCurrentTicks;
+                auto frame = currentTicks;
                 if (!(sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_COG)))
                 {
                     frame += ((session.SpritePosition.x / 4) + (session.SpritePosition.y / 4));

--- a/src/openrct2/paint/tile_element/Paint.Wall.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Wall.cpp
@@ -10,6 +10,7 @@
 #include "../Paint.h"
 
 #include "../../Game.h"
+#include "../../GameState.h"
 #include "../../common.h"
 #include "../../config/Config.h"
 #include "../../drawing/Drawing.h"
@@ -27,6 +28,8 @@
 #include "../../world/TileInspector.h"
 #include "../../world/Wall.h"
 #include "Paint.TileElement.h"
+
+using namespace OpenRCT2;
 
 static constexpr uint8_t DirectionToDoorImageOffset0[] = {
     2, 2, 22, 26, 30, 34, 34, 34, 34, 34, 30, 26, 22, 2, 6, 2, 2, 2, 6, 10, 14, 18, 18, 18, 18, 18, 14, 10, 6, 2, 22, 2,
@@ -137,7 +140,7 @@ static void PaintWallWall(
 {
     PROFILED_FUNCTION();
 
-    auto frameNum = (wallEntry.flags2 & WALL_SCENERY_2_ANIMATED) ? (gCurrentTicks & 7) * 2 : 0;
+    auto frameNum = (wallEntry.flags2 & WALL_SCENERY_2_ANIMATED) ? (GetGameState().CurrentTicks & 7) * 2 : 0;
     auto imageIndex = wallEntry.image + imageOffset + frameNum;
     PaintAddImageAsParent(session, imageTemplate.WithIndex(imageIndex), offset, boundBox);
     if ((wallEntry.flags & WALL_SCENERY_HAS_GLASS) && !isGhost)
@@ -184,7 +187,7 @@ static void PaintWallScrollingText(
     }
 
     auto stringWidth = GfxGetStringWidth(signString, FontStyle::Tiny);
-    auto scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;
+    auto scroll = stringWidth > 0 ? (GetGameState().CurrentTicks / 2) % stringWidth : 0;
     auto imageId = ScrollingTextSetup(session, STR_SCROLLING_SIGN_TEXT, ft, scroll, scrollingMode, textPaletteIndex);
     PaintAddImageAsChild(session, imageId, { 0, 0, height + 8 }, { boundsOffset, { 1, 1, 13 } });
 }

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -143,23 +143,23 @@ namespace OpenRCT2
             ReadWritePackedObjectsChunk(*_os);
         }
 
-        void Import()
+        void Import(GameState_t& gameState)
         {
             auto& os = *_os;
-            ReadWriteTilesChunk(os);
-            ReadWriteBannersChunk(os);
-            ReadWriteRidesChunk(os);
-            ReadWriteEntitiesChunk(os);
-            ReadWriteScenarioChunk(os);
-            ReadWriteGeneralChunk(os);
-            ReadWriteParkChunk(os);
-            ReadWriteClimateChunk(os);
-            ReadWriteResearchChunk(os);
-            ReadWriteNotificationsChunk(os);
-            ReadWriteInterfaceChunk(os);
-            ReadWriteCheatsChunk(os);
-            ReadWriteRestrictedObjectsChunk(os);
-            ReadWritePluginStorageChunk(os);
+            ReadWriteTilesChunk(gameState, os);
+            ReadWriteBannersChunk(gameState, os);
+            ReadWriteRidesChunk(gameState, os);
+            ReadWriteEntitiesChunk(gameState, os);
+            ReadWriteScenarioChunk(gameState, os);
+            ReadWriteGeneralChunk(gameState, os);
+            ReadWriteParkChunk(gameState, os);
+            ReadWriteClimateChunk(gameState, os);
+            ReadWriteResearchChunk(gameState, os);
+            ReadWriteNotificationsChunk(gameState, os);
+            ReadWriteInterfaceChunk(gameState, os);
+            ReadWriteCheatsChunk(gameState, os);
+            ReadWriteRestrictedObjectsChunk(gameState, os);
+            ReadWritePluginStorageChunk(gameState, os);
             if (os.GetHeader().TargetVersion < 0x4)
             {
                 UpdateTrackElementsRideType();
@@ -169,7 +169,7 @@ namespace OpenRCT2
             gInitialCash = gCash;
         }
 
-        void Save(IStream& stream)
+        void Save(GameState_t& gameState, IStream& stream)
         {
             OrcaStream os(stream, OrcaStream::Mode::WRITING);
 
@@ -180,27 +180,27 @@ namespace OpenRCT2
 
             ReadWriteAuthoringChunk(os);
             ReadWriteObjectsChunk(os);
-            ReadWriteTilesChunk(os);
-            ReadWriteBannersChunk(os);
-            ReadWriteRidesChunk(os);
-            ReadWriteEntitiesChunk(os);
-            ReadWriteScenarioChunk(os);
-            ReadWriteGeneralChunk(os);
-            ReadWriteParkChunk(os);
-            ReadWriteClimateChunk(os);
-            ReadWriteResearchChunk(os);
-            ReadWriteNotificationsChunk(os);
-            ReadWriteInterfaceChunk(os);
-            ReadWriteCheatsChunk(os);
-            ReadWriteRestrictedObjectsChunk(os);
-            ReadWritePluginStorageChunk(os);
+            ReadWriteTilesChunk(gameState, os);
+            ReadWriteBannersChunk(gameState, os);
+            ReadWriteRidesChunk(gameState, os);
+            ReadWriteEntitiesChunk(gameState, os);
+            ReadWriteScenarioChunk(gameState, os);
+            ReadWriteGeneralChunk(gameState, os);
+            ReadWriteParkChunk(gameState, os);
+            ReadWriteClimateChunk(gameState, os);
+            ReadWriteResearchChunk(gameState, os);
+            ReadWriteNotificationsChunk(gameState, os);
+            ReadWriteInterfaceChunk(gameState, os);
+            ReadWriteCheatsChunk(gameState, os);
+            ReadWriteRestrictedObjectsChunk(gameState, os);
+            ReadWritePluginStorageChunk(gameState, os);
             ReadWritePackedObjectsChunk(os);
         }
 
-        void Save(const std::string_view path)
+        void Save(GameState_t& gameState, const std::string_view path)
         {
             FileStream fs(path, FILE_MODE_WRITE);
-            Save(fs);
+            Save(gameState, fs);
         }
 
         ScenarioIndexEntry ReadScenarioChunk()
@@ -415,12 +415,13 @@ namespace OpenRCT2
             }
         }
 
-        void ReadWriteScenarioChunk(OrcaStream& os)
+        void ReadWriteScenarioChunk(GameState_t& gameState, OrcaStream& os)
         {
             os.ReadWriteChunk(ParkFileChunkType::SCENARIO, [&os](OrcaStream::ChunkStream& cs) {
                 cs.ReadWrite(gScenarioCategory);
                 ReadWriteStringTable(cs, gScenarioName, "en-GB");
 
+                // TODO: Use the passed gameState instead of the global one.
                 auto& park = GetContext()->GetGameState()->GetPark();
                 ReadWriteStringTable(cs, park.Name, "en-GB");
 
@@ -464,10 +465,10 @@ namespace OpenRCT2
             });
         }
 
-        void ReadWriteGeneralChunk(OrcaStream& os)
+        void ReadWriteGeneralChunk(GameState_t& gameState, OrcaStream& os)
         {
             const auto version = os.GetHeader().TargetVersion;
-            auto found = os.ReadWriteChunk(ParkFileChunkType::GENERAL, [this, &os, &version](OrcaStream::ChunkStream& cs) {
+            auto found = os.ReadWriteChunk(ParkFileChunkType::GENERAL, [&](OrcaStream::ChunkStream& cs) {
                 // Only GAME_PAUSED_NORMAL from gGamePaused is relevant.
                 if (cs.GetMode() == OrcaStream::Mode::READING)
                 {
@@ -480,13 +481,14 @@ namespace OpenRCT2
                     const uint8_t isPaused = (gGamePaused & GAME_PAUSED_NORMAL);
                     cs.Write(isPaused);
                 }
-                cs.ReadWrite(GetGameState().CurrentTicks);
+                cs.ReadWrite(gameState.CurrentTicks);
                 if (cs.GetMode() == OrcaStream::Mode::READING)
                 {
                     uint16_t monthTicks;
                     uint32_t monthsElapsed;
                     cs.ReadWrite(monthTicks);
                     cs.ReadWrite(monthsElapsed);
+                    // TODO: Use the passed gameState instead of the global one.
                     GetContext()->GetGameState()->SetDate(Date(monthsElapsed, monthTicks));
                 }
                 else
@@ -600,7 +602,7 @@ namespace OpenRCT2
             cs.ReadWrite(calcData.StationFlags);
         }
 
-        void ReadWriteInterfaceChunk(OrcaStream& os)
+        void ReadWriteInterfaceChunk(GameState_t& gameState, OrcaStream& os)
         {
             os.ReadWriteChunk(ParkFileChunkType::INTERFACE, [](OrcaStream::ChunkStream& cs) {
                 cs.ReadWrite(gSavedView.x);
@@ -620,7 +622,7 @@ namespace OpenRCT2
             });
         }
 
-        void ReadWriteCheatsChunk(OrcaStream& os)
+        void ReadWriteCheatsChunk(GameState_t& gameState, OrcaStream& os)
         {
             os.ReadWriteChunk(ParkFileChunkType::CHEATS, [](OrcaStream::ChunkStream& cs) {
                 DataSerialiser ds(cs.GetMode() == OrcaStream::Mode::WRITING, cs.GetStream());
@@ -628,7 +630,7 @@ namespace OpenRCT2
             });
         }
 
-        void ReadWriteRestrictedObjectsChunk(OrcaStream& os)
+        void ReadWriteRestrictedObjectsChunk(GameState_t& gameState, OrcaStream& os)
         {
             os.ReadWriteChunk(ParkFileChunkType::RESTRICTED_OBJECTS, [](OrcaStream::ChunkStream& cs) {
                 auto& restrictedScenery = GetRestrictedScenery();
@@ -650,8 +652,9 @@ namespace OpenRCT2
             });
         }
 
-        void ReadWritePluginStorageChunk(OrcaStream& os)
+        void ReadWritePluginStorageChunk(GameState_t& gameState, OrcaStream& os)
         {
+            // TODO: Use the passed gameState instead of the global one.
             auto& park = GetContext()->GetGameState()->GetPark();
             if (os.GetMode() == OrcaStream::Mode::WRITING)
             {
@@ -775,7 +778,7 @@ namespace OpenRCT2
             });
         }
 
-        void ReadWriteClimateChunk(OrcaStream& os)
+        void ReadWriteClimateChunk(GameState_t& gameState, OrcaStream& os)
         {
             os.ReadWriteChunk(ParkFileChunkType::CLIMATE, [](OrcaStream::ChunkStream& cs) {
                 cs.ReadWrite(gClimate);
@@ -792,9 +795,10 @@ namespace OpenRCT2
             });
         }
 
-        void ReadWriteParkChunk(OrcaStream& os)
+        void ReadWriteParkChunk(GameState_t& gameState, OrcaStream& os)
         {
             os.ReadWriteChunk(ParkFileChunkType::PARK, [version = os.GetHeader().TargetVersion](OrcaStream::ChunkStream& cs) {
+                // TODO: Use the passed gameState instead of the global one.
                 auto& park = GetContext()->GetGameState()->GetPark();
                 cs.ReadWrite(park.Name);
                 cs.ReadWrite(gCash);
@@ -937,7 +941,7 @@ namespace OpenRCT2
             });
         }
 
-        void ReadWriteResearchChunk(OrcaStream& os)
+        void ReadWriteResearchChunk(GameState_t& gameState, OrcaStream& os)
         {
             os.ReadWriteChunk(ParkFileChunkType::RESEARCH, [](OrcaStream::ChunkStream& cs) {
                 // Research status
@@ -991,7 +995,7 @@ namespace OpenRCT2
             cs.ReadWrite(item.category);
         }
 
-        void ReadWriteNotificationsChunk(OrcaStream& os)
+        void ReadWriteNotificationsChunk(GameState_t& gameState, OrcaStream& os)
         {
             os.ReadWriteChunk(ParkFileChunkType::NOTIFICATIONS, [](OrcaStream::ChunkStream& cs) {
                 if (cs.GetMode() == OrcaStream::Mode::READING)
@@ -1047,7 +1051,7 @@ namespace OpenRCT2
             }
         }
 
-        void ReadWriteTilesChunk(OrcaStream& os)
+        void ReadWriteTilesChunk(GameState_t& gameState, OrcaStream& os)
         {
             auto* pathToSurfaceMap = _pathToSurfaceMap;
             auto* pathToQueueSurfaceMap = _pathToQueueSurfaceMap;
@@ -1061,6 +1065,7 @@ namespace OpenRCT2
 
                     if (cs.GetMode() == OrcaStream::Mode::READING)
                     {
+                        // TODO: Use the passed gameState instead of the global one.
                         OpenRCT2::GetContext()->GetGameState()->InitAll(gMapSize);
 
                         auto numElements = cs.Read<uint32_t>();
@@ -1167,7 +1172,7 @@ namespace OpenRCT2
             }
         }
 
-        void ReadWriteBannersChunk(OrcaStream& os)
+        void ReadWriteBannersChunk(GameState_t& gameState, OrcaStream& os)
         {
             os.ReadWriteChunk(ParkFileChunkType::BANNERS, [&os](OrcaStream::ChunkStream& cs) {
                 auto version = os.GetHeader().TargetVersion;
@@ -1245,7 +1250,7 @@ namespace OpenRCT2
             cs.ReadWrite(banner.position.y);
         }
 
-        void ReadWriteRidesChunk(OrcaStream& os)
+        void ReadWriteRidesChunk(GameState_t& gameState, OrcaStream& os)
         {
             const auto version = os.GetHeader().TargetVersion;
             os.ReadWriteChunk(ParkFileChunkType::RIDES, [this, &version](OrcaStream::ChunkStream& cs) {
@@ -1987,7 +1992,7 @@ namespace OpenRCT2
 
         template<typename... T> void ReadEntitiesOfTypes(OrcaStream& os, OrcaStream::ChunkStream& cs);
 
-        void ReadWriteEntitiesChunk(OrcaStream& os);
+        void ReadWriteEntitiesChunk(GameState_t& gameState, OrcaStream& os);
 
         static void ReadWriteStringTable(OrcaStream::ChunkStream& cs, std::string& value, const std::string_view lcode)
         {
@@ -2488,7 +2493,7 @@ namespace OpenRCT2
         (ReadEntitiesOfType<T>(os, cs), ...);
     }
 
-    void ParkFile::ReadWriteEntitiesChunk(OrcaStream& os)
+    void ParkFile::ReadWriteEntitiesChunk(GameState_t& gameState, OrcaStream& os)
     {
         os.ReadWriteChunk(ParkFileChunkType::ENTITIES, [this, &os](OrcaStream::ChunkStream& cs) {
             if (cs.GetMode() == OrcaStream::Mode::READING)
@@ -2513,17 +2518,17 @@ namespace OpenRCT2
     }
 } // namespace OpenRCT2
 
-void ParkFileExporter::Export(std::string_view path)
+void ParkFileExporter::Export(GameState_t& gameState, std::string_view path)
 {
     auto parkFile = std::make_unique<OpenRCT2::ParkFile>();
-    parkFile->Save(path);
+    parkFile->Save(gameState, path);
 }
 
-void ParkFileExporter::Export(IStream& stream)
+void ParkFileExporter::Export(GameState_t& gameState, IStream& stream)
 {
     auto parkFile = std::make_unique<OpenRCT2::ParkFile>();
     parkFile->ExportObjectsList = ExportObjectsList;
-    parkFile->Save(stream);
+    parkFile->Save(gameState, stream);
 }
 
 enum : uint32_t
@@ -2533,7 +2538,7 @@ enum : uint32_t
     S6_SAVE_FLAG_AUTOMATIC = 1u << 31,
 };
 
-int32_t ScenarioSave(u8string_view path, int32_t flags)
+int32_t ScenarioSave(GameState_t& gameState, u8string_view path, int32_t flags)
 {
     if (flags & S6_SAVE_FLAG_SCENARIO)
     {
@@ -2570,7 +2575,7 @@ int32_t ScenarioSave(u8string_view path, int32_t flags)
         {
             // s6exporter->SaveGame(path);
         }
-        parkFile->Save(path);
+        parkFile->Save(gameState, path);
         result = true;
     }
     catch (const std::exception& e)
@@ -2658,9 +2663,9 @@ public:
         return result;
     }
 
-    void Import() override
+    void Import(GameState_t& gameState) override
     {
-        _parkFile->Import();
+        _parkFile->Import(gameState);
         ResearchDetermineFirstOfType();
         GameFixSaveVars();
     }

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -480,7 +480,7 @@ namespace OpenRCT2
                     const uint8_t isPaused = (gGamePaused & GAME_PAUSED_NORMAL);
                     cs.Write(isPaused);
                 }
-                cs.ReadWrite(gCurrentTicks);
+                cs.ReadWrite(GetGameState().CurrentTicks);
                 if (cs.GetMode() == OrcaStream::Mode::READING)
                 {
                     uint16_t monthTicks;

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -8,6 +8,8 @@ struct ObjectRepositoryItem;
 
 namespace OpenRCT2
 {
+    struct GameState_t;
+
     // Current version that is saved.
     constexpr uint32_t PARK_FILE_CURRENT_VERSION = 33;
 
@@ -28,6 +30,6 @@ class ParkFileExporter
 public:
     std::vector<const ObjectRepositoryItem*> ExportObjectsList;
 
-    void Export(std::string_view path);
-    void Export(OpenRCT2::IStream& stream);
+    void Export(OpenRCT2::GameState_t& gameState, std::string_view path);
+    void Export(OpenRCT2::GameState_t& gameState, OpenRCT2::IStream& stream);
 };

--- a/src/openrct2/platform/Crash.cpp
+++ b/src/openrct2/platform/Crash.cpp
@@ -26,6 +26,7 @@
 
 #    include "../Context.h"
 #    include "../Game.h"
+#    include "../GameState.h"
 #    include "../OpenRCT2.h"
 #    include "../PlatformEnvironment.h"
 #    include "../Version.h"
@@ -183,7 +184,8 @@ static bool OnCrash(
         auto& objManager = ctx->GetObjectManager();
         exporter->ExportObjectsList = objManager.GetPackableObjects();
 
-        exporter->Export(saveFilePathUTF8.c_str());
+        auto& gameState = GetGameState();
+        exporter->Export(gameState, saveFilePathUTF8.c_str());
         savedGameDumped = true;
     }
     catch (const std::exception& e)

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -169,7 +169,7 @@ namespace RCT1
             return ParkLoadResult(GetRequiredObjects());
         }
 
-        void Import() override
+        void Import(GameState_t& gameState) override
         {
             Initialise();
 
@@ -183,7 +183,7 @@ namespace RCT1
             ImportFinance();
             ImportResearch();
             ImportParkName();
-            ImportParkFlags();
+            ImportParkFlags(gameState);
             ImportClimate();
             ImportScenarioNameDetails();
             ImportScenarioObjective();
@@ -2118,10 +2118,10 @@ namespace RCT1
             park.Name = std::move(parkName);
         }
 
-        void ImportParkFlags()
+        void ImportParkFlags(GameState_t& gameState)
         {
             // Date and srand
-            GetGameState().CurrentTicks = _s4.Ticks;
+            gameState.CurrentTicks = _s4.Ticks;
             ScenarioRandSeed(_s4.RandomA, _s4.RandomB);
             GetContext()->GetGameState()->SetDate(Date(_s4.Month, _s4.Day));
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2121,7 +2121,7 @@ namespace RCT1
         void ImportParkFlags()
         {
             // Date and srand
-            gCurrentTicks = _s4.Ticks;
+            GetGameState().CurrentTicks = _s4.Ticks;
             ScenarioRandSeed(_s4.RandomA, _s4.RandomB);
             GetContext()->GetGameState()->SetDate(Date(_s4.Month, _s4.Day));
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -77,6 +77,8 @@
 
 #include <algorithm>
 
+using namespace OpenRCT2;
+
 namespace RCT2
 {
 #define DECRYPT_MONEY(money) (static_cast<money32>(Numerics::rol32((money) ^ 0xF4EC9621, 13)))
@@ -250,7 +252,7 @@ namespace RCT2
             }
 
             OpenRCT2::GetContext()->GetGameState()->SetDate(OpenRCT2::Date(_s6.ElapsedMonths, _s6.CurrentDay));
-            gCurrentTicks = _s6.GameTicks1;
+            GetGameState().CurrentTicks = _s6.GameTicks1;
 
             ScenarioRandSeed(_s6.ScenarioSrand0, _s6.ScenarioSrand1);
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -227,7 +227,7 @@ namespace RCT2
             return false;
         }
 
-        void Import() override
+        void Import(GameState_t& gameState) override
         {
             Initialise();
 
@@ -252,7 +252,7 @@ namespace RCT2
             }
 
             OpenRCT2::GetContext()->GetGameState()->SetDate(OpenRCT2::Date(_s6.ElapsedMonths, _s6.CurrentDay));
-            GetGameState().CurrentTicks = _s6.GameTicks1;
+            gameState.CurrentTicks = _s6.GameTicks1;
 
             ScenarioRandSeed(_s6.ScenarioSrand0, _s6.ScenarioSrand1);
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -13,6 +13,7 @@
 #include "../Context.h"
 #include "../Editor.h"
 #include "../Game.h"
+#include "../GameState.h"
 #include "../Input.h"
 #include "../OpenRCT2.h"
 #include "../actions/ResultWithMessage.h"
@@ -1128,7 +1129,7 @@ void Ride::Update()
         // Breakdown updates originally were performed when (id == (gCurrentTicks / 2) & 0xFF)
         // with the increased MAX_RIDES the update is tied to the first byte of the id this allows
         // for identical balance with vanilla.
-        const auto updatingRideByte = static_cast<uint8_t>((gCurrentTicks / 2) & 0xFF);
+        const auto updatingRideByte = static_cast<uint8_t>((GetGameState().CurrentTicks / 2) & 0xFF);
         if (updatingRideByte == static_cast<uint8_t>(id.ToUnderlying()))
             RideBreakdownStatusUpdate(*this);
     }
@@ -1252,7 +1253,7 @@ static constexpr CoordsXY ride_spiral_slide_main_tile_offset[][4] = {
 
 void UpdateSpiralSlide(Ride& ride)
 {
-    if (gCurrentTicks & 3)
+    if (GetGameState().CurrentTicks & 3)
         return;
     if (ride.slide_in_use == 0)
         return;
@@ -1312,7 +1313,7 @@ static uint8_t _breakdownProblemProbabilities[] = {
  */
 static void RideInspectionUpdate(Ride& ride)
 {
-    if (gCurrentTicks & 2047)
+    if (GetGameState().CurrentTicks & 2047)
         return;
     if (gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER)
         return;
@@ -1377,7 +1378,8 @@ static int32_t GetAgePenalty(const Ride& ride)
  */
 static void RideBreakdownUpdate(Ride& ride)
 {
-    if (gCurrentTicks & 255)
+    const auto currentTicks = GetGameState().CurrentTicks;
+    if (currentTicks & 255)
         return;
 
     if (gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER)
@@ -1386,7 +1388,7 @@ static void RideBreakdownUpdate(Ride& ride)
     if (ride.lifecycle_flags & (RIDE_LIFECYCLE_BROKEN_DOWN | RIDE_LIFECYCLE_CRASHED))
         ride.downtime_history[0]++;
 
-    if (!(gCurrentTicks & 8191))
+    if (!(currentTicks & 8191))
     {
         int32_t totalDowntime = 0;
 
@@ -1889,7 +1891,7 @@ static bool RideMusicBreakdownEffect(Ride& ride)
     {
         if (ride.breakdown_reason_pending == BREAKDOWN_CONTROL_FAILURE)
         {
-            if (!(gCurrentTicks & 7))
+            if (!(GetGameState().CurrentTicks & 7))
                 if (ride.breakdown_sound_modifier != 255)
                     ride.breakdown_sound_modifier++;
         }
@@ -2029,13 +2031,15 @@ static void RideMeasurementUpdate(Ride& ride, RideMeasurement& measurement)
     if (measurement.current_item >= RideMeasurement::MAX_ITEMS)
         return;
 
+    const auto currentTicks = GetGameState().CurrentTicks;
+
     if (measurement.flags & RIDE_MEASUREMENT_FLAG_G_FORCES)
     {
         auto gForces = vehicle->GetGForces();
         gForces.VerticalG = std::clamp(gForces.VerticalG / 8, -127, 127);
         gForces.LateralG = std::clamp(gForces.LateralG / 8, -127, 127);
 
-        if (gCurrentTicks & 1)
+        if (currentTicks & 1)
         {
             gForces.VerticalG = (gForces.VerticalG + measurement.vertical[measurement.current_item]) / 2;
             gForces.LateralG = (gForces.LateralG + measurement.lateral[measurement.current_item]) / 2;
@@ -2048,7 +2052,7 @@ static void RideMeasurementUpdate(Ride& ride, RideMeasurement& measurement)
     auto velocity = std::min(std::abs((vehicle->velocity * 5) >> 16), 255);
     auto altitude = std::min(vehicle->z / 8, 255);
 
-    if (gCurrentTicks & 1)
+    if (currentTicks & 1)
     {
         velocity = (velocity + measurement.velocity[measurement.current_item]) / 2;
         altitude = (altitude + measurement.altitude[measurement.current_item]) / 2;
@@ -2057,7 +2061,7 @@ static void RideMeasurementUpdate(Ride& ride, RideMeasurement& measurement)
     measurement.velocity[measurement.current_item] = velocity & 0xFF;
     measurement.altitude[measurement.current_item] = altitude & 0xFF;
 
-    if (gCurrentTicks & 1)
+    if (currentTicks & 1)
     {
         measurement.current_item++;
         measurement.num_items = std::max(measurement.num_items, measurement.current_item);
@@ -2162,7 +2166,7 @@ std::pair<RideMeasurement*, OpenRCT2String> Ride::GetMeasurement()
         assert(measurement != nullptr);
     }
 
-    measurement->last_use_tick = gCurrentTicks;
+    measurement->last_use_tick = GetGameState().CurrentTicks;
     if (measurement->flags & 1)
     {
         return { measurement.get(), { STR_EMPTY, {} } };

--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -10,12 +10,15 @@
 #include "Station.h"
 
 #include "../Game.h"
+#include "../GameState.h"
 #include "../entity/Guest.h"
 #include "../scenario/Scenario.h"
 #include "../world/Location.hpp"
 #include "RideEntry.h"
 #include "Track.h"
 #include "Vehicle.h"
+
+using namespace OpenRCT2;
 
 static void RideUpdateStationBlockSection(Ride& ride, StationIndex stationIndex);
 static void RideUpdateStationDodgems(Ride& ride, StationIndex stationIndex);
@@ -151,10 +154,11 @@ static void RideUpdateStationNormal(Ride& ride, StationIndex stationIndex)
 {
     auto& station = ride.GetStation(stationIndex);
     int32_t time = station.Depart & STATION_DEPART_MASK;
+    const auto currentTicks = GetGameState().CurrentTicks;
     if ((ride.lifecycle_flags & (RIDE_LIFECYCLE_BROKEN_DOWN | RIDE_LIFECYCLE_CRASHED))
         || (ride.status == RideStatus::Closed && ride.num_riders == 0))
     {
-        if (time != 0 && time != 127 && !(gCurrentTicks & 7))
+        if (time != 0 && time != 127 && !(currentTicks & 7))
             time--;
 
         station.Depart = time;
@@ -169,7 +173,7 @@ static void RideUpdateStationNormal(Ride& ride, StationIndex stationIndex)
         }
         else
         {
-            if (time != 127 && !(gCurrentTicks & 31))
+            if (time != 127 && !(currentTicks & 31))
                 time--;
 
             station.Depart = time;

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -10,6 +10,7 @@
 #include "TrackPaint.h"
 
 #include "../Game.h"
+#include "../GameState.h"
 #include "../config/Config.h"
 #include "../drawing/Drawing.h"
 #include "../drawing/LightFX.h"
@@ -29,6 +30,7 @@
 #include "TrackData.h"
 #include "TrackDesign.h"
 
+using namespace OpenRCT2;
 using namespace OpenRCT2::TrackMetaData;
 
 /* rct2: 0x007667AC */
@@ -2020,7 +2022,7 @@ void TrackPaintUtilLeftQuarterTurn1TileTunnel(
 
 void TrackPaintUtilSpinningTunnelPaint(PaintSession& session, int8_t thickness, int16_t height, Direction direction)
 {
-    int32_t frame = gCurrentTicks >> 2 & 3;
+    int32_t frame = (GetGameState().CurrentTicks >> 2) & 3;
     auto colourFlags = session.SupportColours;
 
     auto colourFlags2 = session.TrackColours;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -12,6 +12,7 @@
 #include "../Context.h"
 #include "../Editor.h"
 #include "../Game.h"
+#include "../GameState.h"
 #include "../OpenRCT2.h"
 #include "../actions/RideSetStatusAction.h"
 #include "../audio/AudioChannel.h"
@@ -55,6 +56,7 @@
 #include <algorithm>
 #include <iterator>
 
+using namespace OpenRCT2;
 using namespace OpenRCT2::Audio;
 using namespace OpenRCT2::TrackMetaData;
 using namespace OpenRCT2::Math::Trigonometry;
@@ -1069,7 +1071,7 @@ static void UpdateSound(
         sound.Pan = sound_params->pan_x;
         sound.Channel->SetPan(DStoMixerPan(sound_params->pan_x));
     }
-    if (!(gCurrentTicks & 3) && sound_params->frequency != sound.Frequency)
+    if (!(GetGameState().CurrentTicks & 3) && sound_params->frequency != sound.Frequency)
     {
         sound.Frequency = sound_params->frequency;
         if (ShouldUpdateChannelRate<type>(id))
@@ -4909,7 +4911,7 @@ void Vehicle::UpdateHauntedHouseOperating()
 
     if (Pitch != 0)
     {
-        if (gCurrentTicks & 1)
+        if (GetGameState().CurrentTicks & 1)
         {
             Pitch++;
             Invalidate();
@@ -5422,11 +5424,12 @@ void Vehicle::UpdateSound()
         frictionSound.volume = std::min(208 + (ecx & 0xFF), 255);
     }
 
+    const auto currentTicks = GetGameState().CurrentTicks;
     switch (carEntry.sound_range)
     {
         case SOUND_RANGE_WHISTLE:
             screamSound.id = scream_sound_id;
-            if (!(gCurrentTicks & 0x7F))
+            if (!(currentTicks & 0x7F))
             {
                 if (velocity < 4.0_mph || scream_sound_id != OpenRCT2::Audio::SoundId::Null)
                 {
@@ -5448,7 +5451,7 @@ void Vehicle::UpdateSound()
 
         case SOUND_RANGE_BELL:
             screamSound.id = scream_sound_id;
-            if (!(gCurrentTicks & 0x7F))
+            if (!(currentTicks & 0x7F))
             {
                 if (velocity < 4.0_mph || scream_sound_id != OpenRCT2::Audio::SoundId::Null)
                 {
@@ -5724,7 +5727,7 @@ int32_t Vehicle::UpdateMotionDodgems()
     if (!(curRide->lifecycle_flags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN))
         || curRide->breakdown_reason_pending != BREAKDOWN_SAFETY_CUT_OUT)
     {
-        if (gCurrentTicks & 1 && var_34 != 0)
+        if ((GetGameState().CurrentTicks & 1) && var_34 != 0)
         {
             if (var_34 > 0)
             {
@@ -7669,7 +7672,7 @@ Loc6DAEB9:
             {
                 acceleration = -_vehicleVelocityF64E08 * 16;
             }
-            else if (!(gCurrentTicks & 0x0F))
+            else if (!(GetGameState().CurrentTicks & 0x0F))
             {
                 if (_vehicleF64E2C == 0)
                 {

--- a/src/openrct2/ride/VehiclePaint.cpp
+++ b/src/openrct2/ride/VehiclePaint.cpp
@@ -10,6 +10,7 @@
 #include "VehiclePaint.h"
 
 #include "../Game.h"
+#include "../GameState.h"
 #include "../drawing/Drawing.h"
 #include "../drawing/LightFX.h"
 #include "../entity/EntityRegistry.h"
@@ -23,6 +24,7 @@
 
 #include <iterator>
 
+using namespace OpenRCT2;
 using namespace OpenRCT2::Entity::Yaw;
 
 #pragma region VehicleBoundboxes
@@ -3799,7 +3801,7 @@ static void vehicle_visual_splash1_effect(PaintSession& session, int32_t z, cons
         return;
     }
     int32_t image_id = SPR_SPLASH_EFFECT_1_NE_0 + ((((vehicle->Orientation / 8) + session.CurrentRotation) & 3) * 8)
-        + ((gCurrentTicks / 2) & 7);
+        + ((GetGameState().CurrentTicks / 2) & 7);
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { { 0, 0, z }, { 0, 0, 0 } });
 }
 
@@ -3822,7 +3824,7 @@ static void vehicle_visual_splash2_effect(PaintSession& session, int32_t z, cons
         return;
     }
     int32_t image_id = SPR_SPLASH_EFFECT_3_NE_0 + ((((vehicle->Orientation / 8) + session.CurrentRotation) & 3) * 8)
-        + ((gCurrentTicks / 2) & 7);
+        + ((GetGameState().CurrentTicks / 2) & 7);
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { { 0, 0, z }, { 0, 0, 0 } });
 }
 
@@ -3845,7 +3847,7 @@ static void vehicle_visual_splash3_effect(PaintSession& session, int32_t z, cons
         return;
     }
     int32_t image_id = SPR_SPLASH_EFFECT_1_NE_0 + ((((vehicle->Orientation / 8) + session.CurrentRotation) & 3) * 8)
-        + ((gCurrentTicks / 2) & 7);
+        + ((GetGameState().CurrentTicks / 2) & 7);
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { { 0, 0, z }, { 0, 0, 0 } });
 }
 
@@ -3873,7 +3875,7 @@ static void vehicle_visual_splash4_effect(PaintSession& session, int32_t z, cons
         return;
     }
     int32_t image_id = SPR_SPLASH_EFFECT_5_NE_0 + ((((vehicle->Orientation / 8) + session.CurrentRotation) & 3) * 8)
-        + ((gCurrentTicks / 2) & 7);
+        + ((GetGameState().CurrentTicks / 2) & 7);
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { { 0, 0, z }, { 1, 1, 0 } });
 }
 
@@ -3905,7 +3907,7 @@ static void vehicle_visual_splash5_effect(PaintSession& session, int32_t z, cons
         return;
     }
     int32_t image_id = SPR_SPLASH_EFFECT_5_NE_0 + ((((vehicle->Orientation / 8) + session.CurrentRotation) & 3) * 8)
-        + ((gCurrentTicks / 2) & 7);
+        + ((GetGameState().CurrentTicks / 2) & 7);
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { { 0, 0, z }, { 1, 1, 0 } });
 }
 

--- a/src/openrct2/ride/water/RiverRapids.cpp
+++ b/src/openrct2/ride/water/RiverRapids.cpp
@@ -8,6 +8,7 @@
  *****************************************************************************/
 
 #include "../../Game.h"
+#include "../../GameState.h"
 #include "../../config/Config.h"
 #include "../../interface/Viewport.h"
 #include "../../paint/Paint.h"
@@ -18,6 +19,8 @@
 #include "../TrackPaint.h"
 #include "../Vehicle.h"
 #include "../VehiclePaint.h"
+
+using namespace OpenRCT2;
 
 #ifndef NO_VEHICLES
 // 0x0099279E:
@@ -690,7 +693,7 @@ static void PaintRiverRapidsTrackWaterfall(
 {
     ImageId imageId;
 
-    uint16_t frameNum = (gCurrentTicks / 2) & 7;
+    uint16_t frameNum = (GetGameState().CurrentTicks / 2) & 7;
 
     if (direction & 1)
     {
@@ -761,7 +764,7 @@ static void PaintRiverRapidsTrackRapids(
 {
     ImageId imageId;
 
-    uint16_t frameNum = (gCurrentTicks / 2) & 7;
+    uint16_t frameNum = (GetGameState().CurrentTicks / 2) & 7;
 
     if (direction & 1)
     {
@@ -813,7 +816,7 @@ static void PaintRiverRapidsTrackWhirlpool(
 {
     ImageId imageId;
 
-    uint8_t frameNum = (gCurrentTicks / 4) % 16;
+    uint8_t frameNum = (GetGameState().CurrentTicks / 4) % 16;
 
     if (direction & 1)
     {

--- a/src/openrct2/scenario/Scenario.h
+++ b/src/openrct2/scenario/Scenario.h
@@ -25,6 +25,11 @@ struct ResultWithMessage;
 
 using random_engine_t = Random::RCT2::Engine;
 
+namespace OpenRCT2
+{
+    struct GameState_t;
+}
+
 enum
 {
     SCENARIO_FLAGS_VISIBLE = (1 << 0),
@@ -184,7 +189,7 @@ random_engine_t::result_type ScenarioRand();
 uint32_t ScenarioRandMax(uint32_t max);
 
 ResultWithMessage ScenarioPrepareForSave();
-int32_t ScenarioSave(u8string_view path, int32_t flags);
+int32_t ScenarioSave(OpenRCT2::GameState_t& gameState, u8string_view path, int32_t flags);
 void ScenarioFailure();
 void ScenarioSuccess();
 void ScenarioSuccessSubmitName(const char* name);

--- a/src/openrct2/scripting/bindings/world/ScDate.hpp
+++ b/src/openrct2/scripting/bindings/world/ScDate.hpp
@@ -69,7 +69,7 @@ namespace OpenRCT2::Scripting
 
         uint32_t ticksElapsed_get() const
         {
-            return gCurrentTicks;
+            return GetGameState().CurrentTicks;
         }
 
         int32_t day_get() const

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -12,6 +12,7 @@
 #include "../Cheats.h"
 #include "../Context.h"
 #include "../Game.h"
+#include "../GameState.h"
 #include "../OpenRCT2.h"
 #include "../audio/AudioChannel.h"
 #include "../audio/AudioMixer.h"
@@ -30,6 +31,7 @@
 #include <iterator>
 #include <memory>
 
+using namespace OpenRCT2;
 using namespace OpenRCT2::Audio;
 
 constexpr int32_t MAX_THUNDER_INSTANCES = 2;
@@ -136,7 +138,7 @@ void ClimateUpdate()
             }
             gClimateUpdateTimer--;
         }
-        else if (!(gCurrentTicks & 0x7F))
+        else if (!(GetGameState().CurrentTicks & 0x7F))
         {
             if (gClimateCurrent.Temperature == gClimateNext.Temperature)
             {

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -11,6 +11,7 @@
 
 #include "../Context.h"
 #include "../Game.h"
+#include "../GameState.h"
 #include "../entity/EntityList.h"
 #include "../entity/Peep.h"
 #include "../interface/Viewport.h"
@@ -27,6 +28,8 @@
 #include "Footpath.h"
 #include "Map.h"
 #include "Scenery.h"
+
+using namespace OpenRCT2;
 
 using map_animation_invalidate_event_handler = bool (*)(const CoordsXYZ& loc);
 
@@ -192,7 +195,7 @@ static bool MapAnimationInvalidateSmallScenery(const CoordsXYZ& loc)
         if (sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_IS_CLOCK))
         {
             // Peep, looking at scenery
-            if (!(gCurrentTicks & 0x3FF) && GameIsNotPaused())
+            if (!(GetGameState().CurrentTicks & 0x3FF) && GameIsNotPaused())
             {
                 int32_t direction = tileElement->GetDirection();
                 auto quad = EntityTileList<Peep>(CoordsXY{ loc } - CoordsDirectionDelta[direction]);
@@ -480,7 +483,7 @@ static bool MapAnimationInvalidateWallDoor(const CoordsXYZ& loc)
     TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
 
-    if (gCurrentTicks & 1)
+    if (GetGameState().CurrentTicks & 1)
         return false;
 
     bool removeAnimation = true;

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -313,8 +313,10 @@ void Park::Update(const Date& date)
         UpdateHistories();
     }
 
+    const auto currentTicks = GetGameState().CurrentTicks;
+
     // Every ~13 seconds
-    if (gCurrentTicks % 512 == 0)
+    if (currentTicks % 512 == 0)
     {
         gParkRating = CalculateParkRating();
         gParkValue = CalculateParkValue();
@@ -329,7 +331,7 @@ void Park::Update(const Date& date)
     }
 
     // Every ~102 seconds
-    if (gCurrentTicks % 4096 == 0)
+    if (currentTicks % 4096 == 0)
     {
         gParkSize = CalculateParkSize();
         WindowInvalidateByClass(WindowClass::ParkInformation);

--- a/test/tests/PlayTests.cpp
+++ b/test/tests/PlayTests.cpp
@@ -49,7 +49,10 @@ static std::unique_ptr<IContext> localStartGame(const std::string& parkPath)
     auto importer = ParkImporter::CreateS6(context->GetObjectRepository());
     auto loadResult = importer->LoadSavedGame(parkPath.c_str(), false);
     context->GetObjectManager().LoadObjects(loadResult.RequiredObjects);
-    importer->Import();
+
+    // TODO: Have a separate GameState and exchange once loaded.
+    auto& gameState = GetGameState();
+    importer->Import(gameState);
 
     ResetEntitySpatialIndices();
 

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -83,7 +83,10 @@ static bool ImportS6(MemoryStream& stream, std::unique_ptr<IContext>& context, b
     auto importer = ParkImporter::CreateS6(context->GetObjectRepository());
     auto loadResult = importer->LoadFromStream(&stream, false);
     objManager.LoadObjects(loadResult.RequiredObjects);
-    importer->Import();
+
+    // TODO: Have a separate GameState and exchange once loaded.
+    auto& gameState = GetGameState();
+    importer->Import(gameState);
 
     GameInit(retainSpatialIndices);
 
@@ -99,7 +102,10 @@ static bool ImportPark(MemoryStream& stream, std::unique_ptr<IContext>& context,
     auto importer = ParkImporter::CreateParkFile(context->GetObjectRepository());
     auto loadResult = importer->LoadFromStream(&stream, false);
     objManager.LoadObjects(loadResult.RequiredObjects);
-    importer->Import();
+
+    // TODO: Have a separate GameState and exchange once loaded.
+    auto& gameState = GetGameState();
+    importer->Import(gameState);
 
     GameInit(retainSpatialIndices);
 
@@ -112,7 +118,9 @@ static bool ExportSave(MemoryStream& stream, std::unique_ptr<IContext>& context)
 
     auto exporter = std::make_unique<ParkFileExporter>();
     exporter->ExportObjectsList = objManager.GetPackableObjects();
-    exporter->Export(stream);
+
+    auto& gameState = GetGameState();
+    exporter->Export(gameState, stream);
 
     return true;
 }

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -123,7 +123,7 @@ static void RecordGameStateSnapshot(std::unique_ptr<IContext>& context, MemorySt
 
     auto& snapshot = snapshots->CreateSnapshot();
     snapshots->Capture(snapshot);
-    snapshots->LinkSnapshot(snapshot, gCurrentTicks, ScenarioRandState().s0);
+    snapshots->LinkSnapshot(snapshot, GetGameState().CurrentTicks, ScenarioRandState().s0);
     DataSerialiser snapShotDs(true, snapshotStream);
     snapshots->SerialiseSnapshot(snapshot, snapShotDs);
 }


### PR DESCRIPTION
I took the initiative to start the process of moving everything into a central place that is relevant to the save file. This is also how its done in OpenLoco, we need to move all the globals and everything that is going to be saved/loaded into the new struct GameState_t. I avoided touching the existing GameState class as that would end up in more refactor work, once we moved all the things we can look into cleaning up the game loop and get rid of the current GameState thing. There should be as little OOP usage as possible which also makes this struct trivial to copy then. After we have this done we can actually have save/load done in a separate thread and also have an in-game indicator that some work is done without halting the entire game. Moving all the globals and relevant things will be quite a bit of work but this is the only way forward. Also having this a separate state allows to load multiple parks at some point and potentially re-use the format for blueprints/new track format, it also makes the entire track format preview less painful by having a separate state for that.

I started with the first variable gCurrentTicks and layed out the groundworks for the import/export code, now we just need to shove more into it.