### PR TITLE
Fix: Research table in LL parks imported incompletely

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,6 @@
 0.4.9 (in development)
 ------------------------------------------------------------------------
-- Fix: [#18963] Research table in parks from Loopy Landscapes is imported incompletely.
+- Fix: [#18963] Research table in parks from Loopy Landscapes is imported incorrectly.
 - Fix: [#20907] RCT1/AA scenarios use the 4-across train for the Inverted Roller Coaster.
 - Fix: [#21332] Mini Helicopters and Monorail Cycles ride types are swapped in research within RCT1 scenarios.
 - Fix: [#21347] Too many options are hidden if the platform has no file picker.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.9 (in development)
 ------------------------------------------------------------------------
+- Fix: [#18963] Research table in parks from Loopy Landscapes is imported incompletely.
 - Fix: [#20907] RCT1/AA scenarios use the 4-across train for the Inverted Roller Coaster.
 - Fix: [#21332] Mini Helicopters and Monorail Cycles ride types are swapped in research within RCT1 scenarios.
 - Fix: [#21347] Too many options are hidden if the platform has no file picker.

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -738,8 +738,8 @@ namespace RCT1
         uint8_t Unk199C96[3];
         uint8_t WaterColour;
         uint16_t Unk199C9A;
-        ResearchItem ResearchItemsLL[180];
-        uint8_t Unk19A020[5468];
+        ResearchItem ResearchItemsLL[250];
+        uint8_t Unk19A0D9[5118];
         RCT12Banner Banners[Limits::MaxBanners];
         char StringTable[Limits::MaxUserStrings][Limits::MaxUserStringLength];
         uint32_t GameTimeCounter;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -451,8 +451,7 @@ namespace RCT1
                         break;
                     case RCT1_RESEARCH_TYPE_VEHICLE:
                         // For some bizarre reason, RCT1 research lists contain vehicles that aren't actually researched.
-                        // Extra bizarrely, this does not seem to apply to Loopy Landscapes saves/scenarios.
-                        if (rideTypeInResearch[researchItem->RelatedRide] || _gameVersion == FILE_VERSION_RCT1_LL)
+                        if (rideTypeInResearch[researchItem->RelatedRide])
                         {
                             AddEntryForVehicleType(static_cast<RideType>(researchItem->RelatedRide), researchItem->Item);
                         }


### PR DESCRIPTION
The code now imports up to 250 items (but will stop reading when it encounters the end-of-list-marker, like RCT1 does). The highest I have seen is 217, but I wanted to make some allowance for track part inventions and the like.