### PR TITLE
Revert "Remove double load of Title Sequence in TitleScreen.cpp"

### DIFF
--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -144,6 +144,8 @@ void TitleScreen::Load()
 
     if (_sequencePlayer != nullptr)
     {
+        _sequencePlayer->Begin(_currentSequence);
+
         // Force the title sequence to load / update so we
         // don't see a blank screen for a split second.
         TryLoadSequence();


### PR DESCRIPTION
This reverts commit d233d0fc3d49cd0e594570e5b9e00a78653b20b1. 
Fixes #21127.