### PR TITLE
Fix #21037: Animations broken in title sequence

### DIFF
--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -349,6 +349,7 @@ namespace OpenRCT2::Title
                     auto& gameState = GetGameState();
 
                     parkImporter->Import(gameState);
+                    MapAnimationAutoCreate();
                 }
                 PrepareParkForPlayback();
                 success = true;


### PR DESCRIPTION
Fixes #21037

Map animations were not created for parks loaded with the "LOAD" command (rather than the "LOADSC" command)