### PR TITLE
src/openrct2/core/FileStream.cpp: drop ftello64, fseeko64 

### DIFF
--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -265,3 +265,7 @@ else ()
     # Dummy target to ease invocation
     add_custom_target(${PROJECT_NAME}-headers-check)
 endif ()
+
+if (UNIX)
+    add_definitions(-D_FILE_OFFSET_BITS=64)
+endif ()

--- a/src/openrct2/core/FileStream.cpp
+++ b/src/openrct2/core/FileStream.cpp
@@ -21,11 +21,6 @@
 #    include <io.h>
 #endif
 
-#if defined(__linux__) && !defined(__ANDROID__)
-#    define ftello ftello64
-#    define fseeko fseeko64
-#endif
-
 #ifdef _MSC_VER
 #    define ftello _ftelli64
 #    define fseeko _fseeki64


### PR DESCRIPTION
The static usage definition of ftello64 and friends is not correct.
While this currently works on glibc, this breaks on musl, as musl
already is LFS aware.

The solution is to drop this and add instead '-D_FILE_OFFSET_BITS=64' to
the build system.

See for more information:
https://bugs.gentoo.org/903611#c0
https://bugs.gentoo.org/906989

Signed-off-by: Conrad Kostecki <conikost@gentoo.org>