### PR TITLE
Close #18632: Display land ownership on the water

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.8 (in development)
 ------------------------------------------------------------------------
+- Improved: [#18632] Land ownership and construction rights are now shown on top of the water.
 - Fix: [#21145] [Plugin] setInterval/setTimeout handle conflict.
 - Fix: [#21158] [Plugin] Potential crash using setInterval/setTimeout within the callback.
 - Fix: [#21178] Inca Lost City’s scenario description incorrectly states there are height restrictions.

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -240,9 +240,10 @@ public:
         MapInvalidateSelectionRect();
         gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE;
 
-        auto mapTile = ScreenGetMapXY(screenCoords, nullptr);
-
-        if (!mapTile.has_value())
+        // auto mapTile = ScreenGetMapXY(screenCoords, nullptr);
+        auto info = GetMapCoordinatesFromPos(
+            screenCoords, EnumsToFlags(ViewportInteractionItem::Terrain, ViewportInteractionItem::Water));
+        if (info.SpriteType == ViewportInteractionItem::None)
         {
             if (_landRightsCost != MONEY64_UNDEFINED)
             {
@@ -251,6 +252,7 @@ public:
             }
             return;
         }
+        auto mapTile = info.Loc;
 
         uint8_t state_changed = 0;
 
@@ -260,9 +262,9 @@ public:
             state_changed++;
         }
 
-        if (gMapSelectType != MAP_SELECT_TYPE_FULL)
+        if (gMapSelectType != MAP_SELECT_TYPE_FULL_LAND_RIGHTS)
         {
-            gMapSelectType = MAP_SELECT_TYPE_FULL;
+            gMapSelectType = MAP_SELECT_TYPE_FULL_LAND_RIGHTS;
             state_changed++;
         }
 
@@ -273,34 +275,34 @@ public:
         int16_t tool_length = (tool_size - 1) * 32;
 
         // Move to tool bottom left
-        mapTile->x -= (tool_size - 1) * 16;
-        mapTile->y -= (tool_size - 1) * 16;
-        mapTile = mapTile->ToTileStart();
+        mapTile.x -= (tool_size - 1) * 16;
+        mapTile.y -= (tool_size - 1) * 16;
+        mapTile = mapTile.ToTileStart();
 
-        if (gMapSelectPositionA.x != mapTile->x)
+        if (gMapSelectPositionA.x != mapTile.x)
         {
-            gMapSelectPositionA.x = mapTile->x;
+            gMapSelectPositionA.x = mapTile.x;
             state_changed++;
         }
 
-        if (gMapSelectPositionA.y != mapTile->y)
+        if (gMapSelectPositionA.y != mapTile.y)
         {
-            gMapSelectPositionA.y = mapTile->y;
+            gMapSelectPositionA.y = mapTile.y;
             state_changed++;
         }
 
-        mapTile->x += tool_length;
-        mapTile->y += tool_length;
+        mapTile.x += tool_length;
+        mapTile.y += tool_length;
 
-        if (gMapSelectPositionB.x != mapTile->x)
+        if (gMapSelectPositionB.x != mapTile.x)
         {
-            gMapSelectPositionB.x = mapTile->x;
+            gMapSelectPositionB.x = mapTile.x;
             state_changed++;
         }
 
-        if (gMapSelectPositionB.y != mapTile->y)
+        if (gMapSelectPositionB.y != mapTile.y)
         {
-            gMapSelectPositionB.y = mapTile->y;
+            gMapSelectPositionB.y = mapTile.y;
             state_changed++;
         }
 

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -240,7 +240,6 @@ public:
         MapInvalidateSelectionRect();
         gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE;
 
-        // auto mapTile = ScreenGetMapXY(screenCoords, nullptr);
         auto info = GetMapCoordinatesFromPos(
             screenCoords, EnumsToFlags(ViewportInteractionItem::Terrain, ViewportInteractionItem::Water));
         if (info.SpriteType == ViewportInteractionItem::None)

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -1258,14 +1258,29 @@ void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, con
                 const auto image_id = ImageId(SPR_TERRAIN_SELECTION_CORNER + Byte97B444[surfaceShape], fpId);
                 PaintAttachToPreviousPS(session, image_id, 0, 0);
             }
+            else if (mapSelectionType == MAP_SELECT_TYPE_FULL_LAND_RIGHTS)
+            {
+                auto [waterHeight, waterSurfaceShape] = SurfaceGetHeightAboveWater(tileElement, height, surfaceShape);
+
+                const auto fpId = FilterPaletteID::PaletteGlassLightPurple;
+                const auto imageId1 = ImageId(SPR_TERRAIN_SELECTION_CORNER + Byte97B444[surfaceShape], fpId);
+                PaintAttachToPreviousPS(session, imageId1, 0, 0);
+
+                const bool isUnderWater = (surfaceShape != waterSurfaceShape || height != waterHeight);
+                if (isUnderWater)
+                {
+                    const auto imageId2 = ImageId(SPR_TERRAIN_SELECTION_CORNER + Byte97B444[waterSurfaceShape], fpId);
+                    PaintStruct* backup = session.LastPS;
+                    PaintAddImageAsParent(session, imageId2, { 0, 0, waterHeight }, { 32, 32, 1 });
+                    session.LastPS = backup;
+                }
+            }
             else
             {
                 // The water tool should draw its grid _on_ the water, rather than on the surface under water.
                 auto [local_height, local_surfaceShape] = SurfaceGetHeightAboveWater(tileElement, height, surfaceShape);
 
-                const auto fpId = (mapSelectionType == MAP_SELECT_TYPE_FULL_LAND_RIGHTS)
-                    ? FilterPaletteID::PaletteGlassLightPurple
-                    : FilterPaletteID::PaletteWaterMarker;
+                const auto fpId = FilterPaletteID::PaletteWaterMarker;
                 const auto image_id = ImageId(SPR_TERRAIN_SELECTION_CORNER + Byte97B444[local_surfaceShape], fpId);
 
                 PaintStruct* backup = session.LastPS;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -536,9 +536,20 @@ int16_t TileElementHeight(const CoordsXY& loc)
         return MINIMUM_LAND_HEIGHT_BIG;
     }
 
-    uint16_t height = surfaceElement->GetBaseZ();
+    auto height = surfaceElement->GetBaseZ();
+    auto slope = surfaceElement->GetSlope();
 
-    uint32_t slope = surfaceElement->GetSlope();
+    return TileElementHeight(CoordsXYZ{ loc, height }, slope);
+}
+
+int16_t TileElementHeight(const CoordsXYZ& loc, uint8_t slope)
+{
+    // Off the map
+    if (!MapIsLocationValid(loc))
+        return MINIMUM_LAND_HEIGHT_BIG;
+
+    auto height = loc.z;
+
     uint8_t extra_height = (slope & TILE_ELEMENT_SLOPE_DOUBLE_HEIGHT) >> 4; // 0x10 is the 5th bit - sets slope to double height
     // Remove the extra height bit
     slope &= TILE_ELEMENT_SLOPE_ALL_CORNERS_UP;

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -79,6 +79,7 @@ enum
     MAP_SELECT_TYPE_CORNER_3,
     MAP_SELECT_TYPE_FULL,
     MAP_SELECT_TYPE_FULL_WATER,
+    MAP_SELECT_TYPE_FULL_LAND_RIGHTS,
     MAP_SELECT_TYPE_QUARTER_0,
     MAP_SELECT_TYPE_QUARTER_1,
     MAP_SELECT_TYPE_QUARTER_2,
@@ -191,6 +192,7 @@ void MapInvalidateMapSelectionTiles();
 void MapInvalidateSelectionRect();
 bool MapCheckCapacityAndReorganise(const CoordsXY& loc, size_t numElements = 1);
 int16_t TileElementHeight(const CoordsXY& loc);
+int16_t TileElementHeight(const CoordsXYZ& loc, uint8_t slope);
 int16_t TileElementWaterHeight(const CoordsXY& loc);
 void TileElementRemove(TileElement* tileElement);
 TileElement* TileElementInsert(const CoordsXYZ& loc, int32_t occupiedQuadrants, TileElementType type);


### PR DESCRIPTION
Using some ideas from @HtotheTML and @pfroud.

This changes the land ownership window to draw everything on top of the water, including the selection square. This makes it far easier to see what is available and owned.

![Pokey Park 2024-01-03 20-50-10](https://github.com/OpenRCT2/OpenRCT2/assets/1478678/528ae4c5-556f-4b33-985d-0d6fe12b3ed1)
![Bumbly Beach 2024-01-03 20-50-30](https://github.com/OpenRCT2/OpenRCT2/assets/1478678/2cac5117-ac5f-48e6-a140-a29e36018367)
