### PR TITLE
Check station flags instead of hardcoded legacy IDs

### DIFF
--- a/src/openrct2/entity/Balloon.cpp
+++ b/src/openrct2/entity/Balloon.cpp
@@ -158,12 +158,8 @@ bool Balloon::Collides() const
             }
             else
             {
-                // all station platforms besides the plain and invisible ones are covered
-                auto style = GetRide(trackElement->GetRideIndex())->GetEntranceStyle();
-                if (style != RCT12_STATION_STYLE_PLAIN && style != RCT12_STATION_STYLE_INVISIBLE)
-                {
-                    check_ceiling = true;
-                }
+                auto* ride = GetRide(trackElement->GetRideIndex());
+                check_ceiling = (ride != nullptr) ? RideHasStationShelter(*ride) : false;
             }
         }
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5983,15 +5983,3 @@ ResultWithMessage Ride::ChangeStatusCreateVehicles(bool isApplying, const Coords
 
     return { true };
 }
-
-uint8_t Ride::GetEntranceStyle() const
-{
-    if (const auto* stationObject = GetStationObject(); stationObject != nullptr)
-    {
-        return GetStationStyleFromIdentifier(stationObject->GetIdentifier());
-    }
-    else
-    {
-        return RCT12_STATION_STYLE_PLAIN;
-    }
-}


### PR DESCRIPTION
#20483 introduced code that relied on RCT2 station type IDs to determine whether it was covered. This can break down very easily since anyone can make entrance styles now. Luckily, station objects simply have a flag that tells us whether it has a roof or not, so just use that.