### PR TITLE
[Plugin] Fix widgets not redrawing correctly when updating disabled or visibility state. 

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Fix: [#20255] Images from the last hovered-over coaster in the object selection are not freed.
 - Fix: [#20616] Confirmation button in the track designer’s quit prompt has the wrong text.
 - Fix: [#21145] [Plugin] setInterval/setTimeout handle conflict.
+- Fix: [#21157] [Plugin] Widgets do not redraw correctly when updating disabled or visibility state. 
 - Fix: [#21158] [Plugin] Potential crash using setInterval/setTimeout within the callback.
 - Fix: [#21171] [Plugin] Crash creating entities with no more entity slots available.
 - Fix: [#21178] Inca Lost City’s scenario description incorrectly states there are height restrictions.

--- a/src/openrct2-ui/scripting/ScWidget.hpp
+++ b/src/openrct2-ui/scripting/ScWidget.hpp
@@ -323,6 +323,7 @@ namespace OpenRCT2::Scripting
                         WidgetSetDisabled(*w, _widgetIndex + 2, value);
                     }
                 }
+                Invalidate(widget);
             }
         }
 
@@ -355,6 +356,7 @@ namespace OpenRCT2::Scripting
                         WidgetSetVisible(*w, _widgetIndex + 2, value);
                     }
                 }
+                Invalidate(widget);
             }
         }
 

--- a/src/openrct2-ui/scripting/ScWidget.hpp
+++ b/src/openrct2-ui/scripting/ScWidget.hpp
@@ -146,22 +146,18 @@ namespace OpenRCT2::Scripting
                     auto buttonWidget = widget + 1;
                     buttonWidget->left += delta;
                     buttonWidget->right += delta;
-                    WidgetInvalidateByNumber(_class, _number, _widgetIndex + 1);
                 }
                 else if (widget->type == WindowWidgetType::Spinner)
                 {
                     auto upWidget = widget + 1;
                     upWidget->left += delta;
                     upWidget->right += delta;
-                    WidgetInvalidateByNumber(_class, _number, _widgetIndex + 1);
-
                     auto downWidget = widget + 2;
                     downWidget->left += delta;
                     downWidget->right += delta;
-                    WidgetInvalidateByNumber(_class, _number, _widgetIndex + 2);
                 }
 
-                Invalidate();
+                Invalidate(widget);
             }
         }
 
@@ -190,22 +186,18 @@ namespace OpenRCT2::Scripting
                     auto buttonWidget = widget + 1;
                     buttonWidget->top += delta;
                     buttonWidget->bottom += delta;
-                    WidgetInvalidateByNumber(_class, _number, _widgetIndex + 1);
                 }
                 else if (widget->type == WindowWidgetType::Spinner)
                 {
                     auto upWidget = widget + 1;
                     upWidget->top += delta;
                     upWidget->bottom += delta;
-                    WidgetInvalidateByNumber(_class, _number, _widgetIndex + 1);
-
                     auto downWidget = widget + 2;
                     downWidget->top += delta;
                     downWidget->bottom += delta;
-                    WidgetInvalidateByNumber(_class, _number, _widgetIndex + 2);
                 }
 
-                Invalidate();
+                Invalidate(widget);
             }
         }
 
@@ -233,22 +225,18 @@ namespace OpenRCT2::Scripting
                     auto buttonWidget = widget + 1;
                     buttonWidget->left += delta;
                     buttonWidget->right += delta;
-                    WidgetInvalidateByNumber(_class, _number, _widgetIndex + 1);
                 }
                 else if (widget->type == WindowWidgetType::Spinner)
                 {
                     auto upWidget = widget + 1;
                     upWidget->left += delta;
                     upWidget->right += delta;
-                    WidgetInvalidateByNumber(_class, _number, _widgetIndex + 1);
-
                     auto downWidget = widget + 2;
                     downWidget->left += delta;
                     downWidget->right += delta;
-                    WidgetInvalidateByNumber(_class, _number, _widgetIndex + 2);
                 }
 
-                Invalidate();
+                Invalidate(widget);
             }
         }
 
@@ -275,20 +263,16 @@ namespace OpenRCT2::Scripting
                 {
                     auto buttonWidget = widget + 1;
                     buttonWidget->bottom += delta;
-                    WidgetInvalidateByNumber(_class, _number, _widgetIndex + 1);
                 }
                 else if (widget->type == WindowWidgetType::Spinner)
                 {
                     auto upWidget = widget + 1;
                     upWidget->bottom += delta;
-                    WidgetInvalidateByNumber(_class, _number, _widgetIndex + 1);
-
                     auto downWidget = widget + 2;
                     downWidget->bottom += delta;
-                    WidgetInvalidateByNumber(_class, _number, _widgetIndex + 2);
                 }
 
-                Invalidate();
+                Invalidate(widget);
             }
         }
 
@@ -427,6 +411,23 @@ namespace OpenRCT2::Scripting
                 return w->classification == WindowClass::Custom;
             }
             return false;
+        }
+
+        void Invalidate(const Widget* widget)
+        {
+            if (widget != nullptr)
+            {
+                if (widget->type == WindowWidgetType::DropdownMenu)
+                {
+                    WidgetInvalidateByNumber(_class, _number, _widgetIndex + 1);
+                }
+                else if (widget->type == WindowWidgetType::Spinner)
+                {
+                    WidgetInvalidateByNumber(_class, _number, _widgetIndex + 1);
+                    WidgetInvalidateByNumber(_class, _number, _widgetIndex + 2);
+                }
+            }
+            Invalidate();
         }
 
         void Invalidate()


### PR DESCRIPTION
Hello, this should fix the drawing issues in software rendering mode that occur when plugin widgets toggle either the disabled state or the visibility state on or off. While the issue seems to have existed for a long time already, it came to light after Sadret released his Tetris plugin, which actively toggles the visibility of lots of widgets.

Before:
https://github.com/OpenRCT2/OpenRCT2/assets/20048660/0e188bf1-fe17-4b39-a87a-3af24dfd4bd9

After:
https://github.com/OpenRCT2/OpenRCT2/assets/20048660/4a9ef366-6974-4da8-a243-223c833a5231

Thank you for your time. :)



