### PR TITLE
Refactor GetInstallPath for linux

### DIFF
--- a/src/openrct2/platform/Platform.Linux.cpp
+++ b/src/openrct2/platform/Platform.Linux.cpp
@@ -97,25 +97,23 @@ namespace Platform
         }
         // 2. Try {${exeDir},${cwd},/}/{data,standard system app directories}
         // exeDir should come first to allow installing into build dir
-        std::vector<std::string> prefixes;
-        auto exePath = Platform::GetCurrentExecutablePath();
-        prefixes.push_back(Path::GetDirectory(exePath));
-        prefixes.push_back(GetCurrentWorkingDirectory());
-        prefixes.push_back("/");
-        static const char* SearchLocations[] = {
+        // clang-format off
+        const std::string prefixes[]{
+            Path::GetDirectory(Platform::GetCurrentExecutablePath()),
+            GetCurrentWorkingDirectory(),
+            "/"
+        };
+        static constexpr u8string_view SearchLocations[] = {
             "/data",
             "../share/openrct2",
-#    ifdef ORCT2_RESOURCE_DIR
-            // defined in CMakeLists.txt
-            ORCT2_RESOURCE_DIR,
-#    endif // ORCT2_RESOURCE_DIR
             "/usr/local/share/openrct2",
             "/var/lib/openrct2",
             "/usr/share/openrct2",
         };
+        // clang-format on
         for (const auto& prefix : prefixes)
         {
-            for (auto searchLocation : SearchLocations)
+            for (const auto searchLocation : SearchLocations)
             {
                 auto prefixedPath = Path::Combine(prefix, searchLocation);
                 LOG_VERBOSE("Looking for OpenRCT2 data in %s", prefixedPath.c_str());


### PR DESCRIPTION
simplify the Platform::GetInstallPath (linux) by removing unnecessary vector, removing unused #ifdef path and using string_views where appropriate. no vector was actually needed as the prefixes are fixed (same as the SearchLocations) - using a plain array avoids an unnecessary allocation (actually a couple as the old code was using push_back without reserve).

how it was tested?
run the game, check it finds path OK - PASS
run in the debugger, actually loop through OK - PASS