### PR TITLE
Refactor small bits of PlatformEnvironment

### DIFF
--- a/src/openrct2/PlatformEnvironment.cpp
+++ b/src/openrct2/PlatformEnvironment.cpp
@@ -18,6 +18,8 @@
 
 using namespace OpenRCT2;
 
+using DIRBASE_VALUES = u8string[DIRBASE_COUNT];
+
 static constexpr const char* DirectoryNamesRCT2[] = {
     "Data",        // DATA
     "Landscapes",  // LANDSCAPE
@@ -203,7 +205,7 @@ private:
     }
 };
 
-std::unique_ptr<IPlatformEnvironment> OpenRCT2::CreatePlatformEnvironment(DIRBASE_VALUES basePaths)
+static std::unique_ptr<IPlatformEnvironment> CreatePlatformEnvironment(DIRBASE_VALUES basePaths)
 {
     return std::make_unique<PlatformEnvironment>(basePaths);
 }
@@ -257,7 +259,7 @@ std::unique_ptr<IPlatformEnvironment> OpenRCT2::CreatePlatformEnvironment()
         basePaths[static_cast<size_t>(DIRBASE::DOCUMENTATION)] = basePaths[static_cast<size_t>(DIRBASE::OPENRCT2)];
     }
 
-    auto env = OpenRCT2::CreatePlatformEnvironment(basePaths);
+    auto env = ::CreatePlatformEnvironment(basePaths);
 
     // Now load the config so we can get the RCT1 and RCT2 paths
     auto configPath = env->GetFilePath(PATHID::CONFIG);

--- a/src/openrct2/PlatformEnvironment.h
+++ b/src/openrct2/PlatformEnvironment.h
@@ -26,9 +26,10 @@ namespace OpenRCT2
         CONFIG,        // Base directory for OpenRCT2 configuration.
         CACHE,         // Base directory for OpenRCT2 cache files.
         DOCUMENTATION, // Base directory for OpenRCT2 doc files.
+
+        SIZE
     };
-    constexpr size_t DIRBASE_COUNT = 7;
-    using DIRBASE_VALUES = u8string[DIRBASE_COUNT];
+    constexpr size_t DIRBASE_COUNT = static_cast<size_t>(DIRBASE::SIZE);
 
     enum class DIRID
     {
@@ -88,7 +89,6 @@ namespace OpenRCT2
         virtual bool IsUsingClassic() const abstract;
     };
 
-    [[nodiscard]] std::unique_ptr<IPlatformEnvironment> CreatePlatformEnvironment(DIRBASE_VALUES basePaths);
     [[nodiscard]] std::unique_ptr<IPlatformEnvironment> CreatePlatformEnvironment();
 
 } // namespace OpenRCT2


### PR DESCRIPTION
while running through the platform environment setup in the debugger I found a couple things that could be interesting
done:
1. remove the CreatePlatformEnvironment(DIRBASE_VALUES) overload
now, maybe I'm a total fool and I've just removed something somehow used by some plugin or I don't know what that I'm totally oblivious to, but I felt like there was no need to have the second overload for creating the environment be exposed in the .h as it was never used anywhere else
2. automate the size used by the DIRBASE_COUNT value

not done, yet, awaiting some feedback, on: should I? shouldn't I?
3. avoid copying the strings in the PlatformEnvironment (either just create them in place or move them)
4. use either a Span-like object or just a plain ptr + size in the ctor for PlatformEnvironment (instead of the decaying array)

let me know if any ideas are interesting!

I'll try to annotate this PR with the ideas I have, using some comments on areas I would be targeting 