### PR TITLE
Fix #20616 Confirmation button in track designer's quit prompt has the wrong text

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Improved: [#18632] Land ownership and construction rights are now shown on top of the water.
 - Improved: [#20951] Activate OpenRCT2 window after using native file dialog on macOS.
+- Fix: [#20616] Confirmation button in the track designer's quit prompt now says "OK".
 - Fix: [#21145] [Plugin] setInterval/setTimeout handle conflict.
 - Fix: [#21158] [Plugin] Potential crash using setInterval/setTimeout within the callback.
 - Fix: [#21171] [Plugin] Crash creating entities with no more entity slots available.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,7 +2,7 @@
 ------------------------------------------------------------------------
 - Improved: [#18632] Land ownership and construction rights are now shown on top of the water.
 - Improved: [#20951] Activate OpenRCT2 window after using native file dialog on macOS.
-- Fix: [#20616] Confirmation button in the track designer's quit prompt now says "OK".
+- Fix: [#20616] Confirmation button in the track designer’s quit prompt has the wrong text.
 - Fix: [#21145] [Plugin] setInterval/setTimeout handle conflict.
 - Fix: [#21158] [Plugin] Potential crash using setInterval/setTimeout within the callback.
 - Fix: [#21171] [Plugin] Crash creating entities with no more entity slots available.

--- a/src/openrct2-ui/windows/SavePrompt.cpp
+++ b/src/openrct2-ui/windows/SavePrompt.cpp
@@ -89,14 +89,10 @@ public:
 
     void OnOpen() override
     {
-        if (gScreenFlags & (SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER))
-        {
-            widgets = _quitPromptWidgets;
-        }
-        else
-        {
-            widgets = _savePromptWidgets;
-        }
+        bool canSave = !(gScreenFlags & (SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER));
+
+        widgets = canSave ? _savePromptWidgets : _quitPromptWidgets;
+
         InitScrollWidgets();
 
         // Pause the game if not network play.
@@ -108,17 +104,20 @@ public:
 
         WindowInvalidateByClass(WindowClass::TopToolbar);
 
-        StringId stringId = window_save_prompt_labels[EnumValue(_promptMode)][0];
-        if (stringId == STR_LOAD_GAME_PROMPT_TITLE && gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)
+        if (canSave)
         {
-            stringId = STR_LOAD_LANDSCAPE_PROMPT_TITLE;
+            StringId stringId = window_save_prompt_labels[EnumValue(_promptMode)][0];
+            if (stringId == STR_LOAD_GAME_PROMPT_TITLE && gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)
+            {
+                stringId = STR_LOAD_LANDSCAPE_PROMPT_TITLE;
+            }
+            else if (stringId == STR_QUIT_GAME_PROMPT_TITLE && gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)
+            {
+                stringId = STR_QUIT_SCENARIO_EDITOR;
+            }
+            widgets[WIDX_TITLE].text = stringId;
+            widgets[WIDX_LABEL].text = window_save_prompt_labels[EnumValue(_promptMode)][1];
         }
-        else if (stringId == STR_QUIT_GAME_PROMPT_TITLE && gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)
-        {
-            stringId = STR_QUIT_SCENARIO_EDITOR;
-        }
-        widgets[WIDX_TITLE].text = stringId;
-        widgets[WIDX_LABEL].text = window_save_prompt_labels[EnumValue(_promptMode)][1];
     }
 
     void OnClose() override


### PR DESCRIPTION
This PR changes the text of the confirmation button in the track designer's (and track design manager's) quit prompts to `STR_OK` (instead of `STR_SAVE_BEFORE_QUITTING`), as there is nothing to save.

For the save prompt (as shown when quitting a park or the scenario editor),  `SavePromptWindow::OnOpen` runs some logic to set a more specific title and button texts. For the pure quit prompt (with no save option), this logic was apparently ran unintended, with the effect of overwriting the text of the confirmation button.  
It is now wrapped in an `if` condition, running only in those cases where we actually have a "save" button.  
(See [this](https://github.com/OpenRCT2/OpenRCT2/issues/20616#issuecomment-1888021427) discussion.)

Closes #20616 