### PR TITLE
Fix check for tracktype

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Fix: [#21158] [Plugin] Potential crash using setInterval/setTimeout within the callback.
 - Fix: [#21171] [Plugin] Crash creating entities with no more entity slots available.
 - Fix: [#21178] Inca Lost City’s scenario description incorrectly states there are height restrictions.
+- Fix: [#21198] [Plugin] Setting brake or booster speeds on a tile element doesn’t work.
 
 0.4.7 (2023-12-31)
 ------------------------------------------------------------------------

--- a/src/openrct2/scripting/bindings/world/ScTileElement.cpp
+++ b/src/openrct2/scripting/bindings/world/ScTileElement.cpp
@@ -1017,7 +1017,7 @@ namespace OpenRCT2::Scripting
             if (el == nullptr)
                 throw DukException() << "Cannot set 'brakeBoosterSpeed' property, tile element is not a TrackElement.";
 
-            if (TrackTypeHasSpeedSetting(el->GetTrackType()))
+            if (!TrackTypeHasSpeedSetting(el->GetTrackType()))
                 throw DukException() << "Cannot set 'brakeBoosterSpeed' property, track element has no speed setting.";
 
             el->SetBrakeBoosterSpeed(value.as_uint());


### PR DESCRIPTION
The plugin handle for setting booster brake speed was wrong, it threw errors saying brakes don't have brake speeds. 