### PR TITLE
Raise lift speeds for RCT1 parity

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Improved: [#18632] Land ownership and construction rights are now shown on top of the water.
 - Improved: [#20951] Activate OpenRCT2 window after using native file dialog on macOS.
 - Improved: [#21227] Entrance style dropdown is now sorted alphabetically everywhere.
+- Change: [#21200] Raise maximum lift speeds of the Reverser Coaster, Side Friction Coaster, and Virginia Reel for RCT1 parity.
 - Change: [#21225] Raise maximum allowed misc entities to 1600.
 - Fix: [#20196] New scenarios start with an incorrect temperature.
 - Fix: [#20255] Images from the last hovered-over coaster in the object selection are not freed.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -46,7 +46,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "1"
+#define NETWORK_STREAM_VERSION "2"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/ride/coaster/meta/ReverserRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/ReverserRollerCoaster.h
@@ -35,7 +35,7 @@ constexpr RideTypeDescriptor ReverserRollerCoasterRTD =
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(Heights, { 18, 24, 8, 11, }),
     SET_FIELD(MaxMass, 15),
-    SET_FIELD(LiftData, { OpenRCT2::Audio::SoundId::LiftWood, 3, 4 }),
+    SET_FIELD(LiftData, { OpenRCT2::Audio::SoundId::LiftWood, 3, 5 }),
     SET_FIELD(RatingsMultipliers, { 48, 28, 7 }),
     SET_FIELD(UpkeepCosts, { 39, 20, 80, 10, 3, 10 }),
     SET_FIELD(BuildCosts, { 27.50_GBP, 3.00_GBP, 37, }),

--- a/src/openrct2/ride/coaster/meta/SideFrictionRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/SideFrictionRollerCoaster.h
@@ -37,7 +37,7 @@ constexpr RideTypeDescriptor SideFrictionRollerCoasterRTD =
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(Heights, { 18, 24, 4, 11, }),
     SET_FIELD(MaxMass, 15),
-    SET_FIELD(LiftData, { OpenRCT2::Audio::SoundId::LiftWood, 3, 4 }),
+    SET_FIELD(LiftData, { OpenRCT2::Audio::SoundId::LiftWood, 3, 5 }),
     SET_FIELD(RatingsMultipliers, { 48, 28, 7 }),
     SET_FIELD(UpkeepCosts, { 39, 20, 80, 10, 3, 10 }),
     SET_FIELD(BuildCosts, { 27.50_GBP, 3.00_GBP, 37, }),

--- a/src/openrct2/ride/coaster/meta/VirginiaReel.h
+++ b/src/openrct2/ride/coaster/meta/VirginiaReel.h
@@ -35,7 +35,7 @@ constexpr RideTypeDescriptor VirginiaReelRTD =
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(Heights, { 14, 24, 6, 7, }),
     SET_FIELD(MaxMass, 15),
-    SET_FIELD(LiftData, { OpenRCT2::Audio::SoundId::LiftClassic, 3, 4 }),
+    SET_FIELD(LiftData, { OpenRCT2::Audio::SoundId::LiftClassic, 3, 5 }),
     SET_FIELD(RatingsMultipliers, { 30, 15, 25 }),
     SET_FIELD(UpkeepCosts, { 39, 20, 80, 10, 3, 10 }),
     SET_FIELD(BuildCosts, { 26.50_GBP, 3.00_GBP, 25, }),


### PR DESCRIPTION
RCT1 had a universal lift speed of 5 mph (or 8 km/h) for all coasters and this could not be changed, in RCT2 the lift speed setting was added and as such introduced varying lift speeds for all coasters.

For most coasters they would still allow for 5 mph lifts for parity with RCT1 designs. However the reverser coaster, side friction coaster, and virginia reel all have a max lift speed of only 4 mph (or 6 km/h) which means this can break some RCT1 track designs. You can observe this in sprightly park from RCT1AA and good night park from RCT1LL as the coasters in both parks start at 5 mph lift speeds, but if you change them you can't change them back to 5 mph as it's limited to just 4 mph.

This PR fixes this by allowing the three ride types in question to have a max lift speed of 5mph.

![Screenshot_select-area_20240114084710](https://github.com/OpenRCT2/OpenRCT2/assets/42477864/37aadf20-747f-49bf-8151-db37993a0fc0)
![Screenshot_select-area_20240114092423](https://github.com/OpenRCT2/OpenRCT2/assets/42477864/f21a1f72-0454-4dfe-bcba-382b0746a005)
