### PR TITLE
Fix #20255: Images not freed in Track Designs Manager

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Improved: [#18632] Land ownership and construction rights are now shown on top of the water.
 - Improved: [#20951] Activate OpenRCT2 window after using native file dialog on macOS.
+- Fix: [#20255] Images from the last hovered-over coaster in the object selection are not freed.
 - Fix: [#20616] Confirmation button in the track designer’s quit prompt has the wrong text.
 - Fix: [#21145] [Plugin] setInterval/setTimeout handle conflict.
 - Fix: [#21158] [Plugin] Potential crash using setInterval/setTimeout within the callback.

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -599,6 +599,12 @@ public:
             if (!objectSelectResult.Successful)
                 return;
 
+            if (_loadedObject != nullptr)
+            {
+                _loadedObject->Unload();
+                _loadedObject = nullptr;
+            }
+
             auto& objRepository = OpenRCT2::GetContext()->GetObjectRepository();
             _loadedObject = objRepository.LoadObject(listItem->repositoryItem);
             auto& objManager = OpenRCT2::GetContext()->GetObjectManager();


### PR DESCRIPTION
When clicking on a ride type in the track manager's object selection step, the global `_loadedObject` that was allocated for this ride when hovering over it (in `OnScrollMouseOver`) is not unloaded before being re-assigned a new value in `OnScrollMouseDown`, causing a memory leak. This eventually causes an assertion to fail when quitting the game.  
This PR adds the missing call to `Unload`.

Closes #20255
Closes #21190