### PR TITLE
Fix: #20628: Stop caret left moving off the input string 

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Improved: [#20951] Activate OpenRCT2 window after using native file dialog on macOS.
 - Fix: [#20255] Images from the last hovered-over coaster in the object selection are not freed.
 - Fix: [#20616] Confirmation button in the track designer’s quit prompt has the wrong text.
+- Fix: [#20628] Moving caret using Ctrl+left for TTF fonts caused underflow.
 - Fix: [#21145] [Plugin] setInterval/setTimeout handle conflict.
 - Fix: [#21157] [Plugin] Widgets do not redraw correctly when updating disabled or visibility state. 
 - Fix: [#21158] [Plugin] Potential crash using setInterval/setTimeout within the callback.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,7 +4,7 @@
 - Improved: [#20951] Activate OpenRCT2 window after using native file dialog on macOS.
 - Fix: [#20255] Images from the last hovered-over coaster in the object selection are not freed.
 - Fix: [#20616] Confirmation button in the track designer’s quit prompt has the wrong text.
-- Fix: [#20628] Moving caret using Ctrl+left for TTF fonts caused underflow.
+- Fix: [#20628] Moving caret using Ctrl+left can move too far when using a multibyte grapheme.
 - Fix: [#21145] [Plugin] setInterval/setTimeout handle conflict.
 - Fix: [#21157] [Plugin] Widgets do not redraw correctly when updating disabled or visibility state. 
 - Fix: [#21158] [Plugin] Potential crash using setInterval/setTimeout within the callback.

--- a/src/openrct2-ui/TextComposition.cpp
+++ b/src/openrct2-ui/TextComposition.cpp
@@ -276,7 +276,8 @@ void TextComposition::CaretMoveToLeftToken()
             lastChar = selectionOffset;
             break;
         }
-
+        if (selectionOffset == 0)
+            break;
         ch--;
         selectionOffset--;
     }
@@ -295,12 +296,13 @@ void TextComposition::CaretMoveToLeftToken()
             break;
 
         lastChar = selectionOffset;
-
+        if (selectionOffset == 0)
+            break;
         ch--;
         selectionOffset--;
     }
 
-    _session.SelectionSize = std::max<size_t>(0, _session.SelectionSize - (selectionOffset - _session.SelectionStart));
+    _session.SelectionSize = _session.SelectionSize - (selectionOffset - _session.SelectionStart);
     _session.SelectionStart = selectionOffset == 0 ? 0 : lastChar;
 }
 


### PR DESCRIPTION
Should close [#20628](https://github.com/OpenRCT2/OpenRCT2/issues/20628).

The issue was caused by the code simply not checking whether `selectionOffset == 0` before performing a `selectionOffset--` after a while loop that would possibly run until `selectionOffset` is 0. The code meant to handle this by detecting negative values at the end by comparing the caret's new position with 0 using `std::max<size_t>` and getting the bigger number of it, but since the type of the value is `size_t`, which is unsigned, it blasted the caret away.

The new code simply check if `selectionOffset == 0` before a `selectionOffset--`.
I also removed the negative value detection at the end with since it doesn't make a lot of sense.

I have debugged with this code several times for Japanese, Korean, Vietnamese, English and Simplified Chinese and it looks like it's not going off the edge or does some unexpected behavior.