### PR TITLE
Add RCTC Booster offsets into sprites.json

### DIFF
--- a/resources/g2/sprites.json
+++ b/resources/g2/sprites.json
@@ -2656,10 +2656,14 @@
         "palette": "keep"
     },
     {
-        "path": "track/intamin/booster_1.png"
+        "path": "track/intamin/booster_1.png",
+        "x_offset": -22,
+        "y_offset": -4
     },
     {
-        "path": "track/intamin/booster_2.png"
+        "path": "track/intamin/booster_2.png",
+        "x_offset": -22,
+        "y_offset": -4
     },
     {
         "path": "track/intamin/brake_horizontal_background_open.png",
@@ -6286,10 +6290,14 @@
         "palette": "keep"
     },
     {
-        "path": "track/mini/booster_1.png"
+        "path": "track/mini/booster_1.png",
+        "x_offset": -22,
+        "y_offset": -4
     },
     {
-        "path": "track/mini/booster_2.png"
+        "path": "track/mini/booster_2.png",
+        "x_offset": -22,
+        "y_offset": -4
     },
     {
         "path": "track/bm/brake_horizontal.png",
@@ -6328,10 +6336,14 @@
         "palette": "keep"
     },
     {
-        "path": "track/bm/booster_1.png"
+        "path": "track/bm/booster_1.png",
+        "x_offset": -22,
+        "y_offset": -4
     },
     {
-        "path": "track/bm/booster_2.png"
+        "path": "track/bm/booster_2.png",
+        "x_offset": -22,
+        "y_offset": -4
     },
     {
         "path": "track/railway/quarter_turn_3_tiles_sw_se_part_3.png",

--- a/resources/g2/sprites.json
+++ b/resources/g2/sprites.json
@@ -6337,13 +6337,13 @@
     },
     {
         "path": "track/bm/booster_1.png",
-        "x_offset": -22,
-        "y_offset": -4
+        "x_offset": -25,
+        "y_offset": -5
     },
     {
         "path": "track/bm/booster_2.png",
-        "x_offset": -22,
-        "y_offset": -4
+        "x_offset": -25,
+        "y_offset": -5
     },
     {
         "path": "track/railway/quarter_turn_3_tiles_sw_se_part_3.png",

--- a/src/openrct2/ride/coaster/BolligerMabillardTrack.hpp
+++ b/src/openrct2/ride/coaster/BolligerMabillardTrack.hpp
@@ -12637,25 +12637,19 @@ void BolligerMabillardTrackBooster(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    // These offsets could be moved to the g2.dat file when that supports offsets.
-    int8_t ne_sw_offsetX = 8;
-    int8_t ne_sw_offsetY = -17;
-    int8_t nw_se_offsetX = -17;
-    int8_t nw_se_offsetY = 8;
-
     switch (direction)
     {
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours.WithIndex(SPR_G2_BM_BOOSTER_NE_SW),
-                { ne_sw_offsetX, ne_sw_offsetY, height }, { { 0, 6, height }, { 32, 20, 3 } });
+                session, direction, session.TrackColours.WithIndex(SPR_G2_BM_BOOSTER_NE_SW), { 0, 0, height },
+                { { 0, 6, height }, { 32, 20, 3 } });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours.WithIndex(SPR_G2_BM_BOOSTER_NW_SE),
-                { nw_se_offsetX, nw_se_offsetY, height }, { { 0, 6, height }, { 32, 20, 3 } });
+                session, direction, session.TrackColours.WithIndex(SPR_G2_BM_BOOSTER_NW_SE), { 0, 0, height },
+                { { 0, 6, height }, { 32, 20, 3 } });
             break;
     }
     if (TrackPaintUtilShouldPaintSupports(session.MapPosition))

--- a/src/openrct2/ride/coaster/GigaCoaster.cpp
+++ b/src/openrct2/ride/coaster/GigaCoaster.cpp
@@ -9453,25 +9453,19 @@ static void GigaRCTrackBooster(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    // These offsets could be moved to the g2.dat file when that supports offsets.
-    int8_t ne_sw_offsetX = 7;
-    int8_t ne_sw_offsetY = -15;
-    int8_t nw_se_offsetX = -15;
-    int8_t nw_se_offsetY = 7;
-
     switch (direction)
     {
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours.WithIndex(SPR_G2_GIGA_RC_BOOSTER_NE_SW),
-                { ne_sw_offsetX, ne_sw_offsetY, height }, { { 0, 6, height }, { 32, 20, 3 } });
+                session, direction, session.TrackColours.WithIndex(SPR_G2_GIGA_RC_BOOSTER_NE_SW), { 0, 0, height },
+                { { 0, 6, height }, { 32, 20, 3 } });
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours.WithIndex(SPR_G2_GIGA_RC_BOOSTER_NW_SE),
-                { nw_se_offsetX, nw_se_offsetY, height }, { { 0, 6, height }, { 32, 20, 3 } });
+                session, direction, session.TrackColours.WithIndex(SPR_G2_GIGA_RC_BOOSTER_NW_SE), { 0, 0, height },
+                { { 0, 6, height }, { 32, 20, 3 } });
             break;
     }
     if (TrackPaintUtilShouldPaintSupports(session.MapPosition))

--- a/src/openrct2/ride/coaster/MiniRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/MiniRollerCoaster.cpp
@@ -9508,19 +9508,13 @@ static void MiniRCTrackBooster(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    // These offsets could be moved to the g2.dat file when that supports offsets.
-    int8_t ne_sw_offsetX = 7;
-    int8_t ne_sw_offsetY = -15;
-    int8_t nw_se_offsetX = -15;
-    int8_t nw_se_offsetY = 7;
-
     switch (direction)
     {
         case 0:
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours.WithIndex(SPR_G2_MINI_RC_BOOSTER_NE_SW),
-                { ne_sw_offsetX, ne_sw_offsetY, height }, { { 0, 6, height }, { 32, 20, 3 } });
+                session, direction, session.TrackColours.WithIndex(SPR_G2_MINI_RC_BOOSTER_NE_SW), { 0, 0, height },
+                { { 0, 6, height }, { 32, 20, 3 } });
             if (TrackPaintUtilShouldPaintSupports(session.MapPosition))
             {
                 MetalASupportsPaintSetup(
@@ -9530,8 +9524,8 @@ static void MiniRCTrackBooster(
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, session.TrackColours.WithIndex(SPR_G2_MINI_RC_BOOSTER_NW_SE),
-                { nw_se_offsetX, nw_se_offsetY, height }, { { 0, 6, height }, { 32, 20, 3 } });
+                session, direction, session.TrackColours.WithIndex(SPR_G2_MINI_RC_BOOSTER_NW_SE), { 0, 0, height },
+                { { 0, 6, height }, { 32, 20, 3 } });
             if (TrackPaintUtilShouldPaintSupports(session.MapPosition))
             {
                 MetalASupportsPaintSetup(


### PR DESCRIPTION
Add the offsets for the RCTC booster sprites into the sprites.json file. Fix for #20227 
