### PR TITLE
Fix #21054: `No entrance` style selected by default in track designer

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Improved: [#20951] Activate OpenRCT2 window after using native file dialog on macOS.
 - Fix: [#20255] Images from the last hovered-over coaster in the object selection are not freed.
 - Fix: [#20616] Confirmation button in the track designer’s quit prompt has the wrong text.
+- Fix: [#21054] “No entrance” style is selected by default in the track designer.
 - Fix: [#21145] [Plugin] setInterval/setTimeout handle conflict.
 - Fix: [#21157] [Plugin] Widgets do not redraw correctly when updating disabled or visibility state. 
 - Fix: [#21158] [Plugin] Potential crash using setInterval/setTimeout within the callback.

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -488,7 +488,6 @@ void FinishObjectSelection()
         gLastEntranceStyle = objManager.GetLoadedObjectEntryIndex("rct2.station.plain");
         if (gLastEntranceStyle == OBJECT_ENTRY_INDEX_NULL)
         {
-            // Fall back to first entrance object
             gLastEntranceStyle = 0;
         }
 

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -483,6 +483,15 @@ void FinishObjectSelection()
     {
         SetEveryRideTypeInvented();
         SetEveryRideEntryInvented();
+
+        auto& objManager = OpenRCT2::GetContext()->GetObjectManager();
+        gLastEntranceStyle = objManager.GetLoadedObjectEntryIndex("rct2.station.plain");
+        if (gLastEntranceStyle == OBJECT_ENTRY_INDEX_NULL)
+        {
+            // Fall back to first entrance object
+            gLastEntranceStyle = 0;
+        }
+
         gEditorStep = EditorStep::RollercoasterDesigner;
         GfxInvalidateScreen();
     }


### PR DESCRIPTION
This PR adds a bit of code to `FinishObjectSelection` in `src/openrct2/EditorObjectSelectionSession.cpp` to set the global variable `gLastEntranceStyle` to a sensible value when entering the track designer, similar to how it's done in `ScenarioReset` in `src/openrct2/scenario/Scenario.cpp`. Basically, it is attempted to set it to the "plain" station style, backing up to whatever is first in the list if that one could not be loaded.  
(That backup option may not actually be needed and better be replaced by an assert.)

Before, `gLastEntranceStyle` was set to 12 when entering the track designer (indicating the `no entrance` style), which is (as of now) not even available in the track designer by normal means.  
I am not 100% sure where that value came from. Possibly from loading the park in the title sequence.

Closes #21054 .