### PR TITLE
Raise maximum allowed misc entities to 1600

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Improved: [#18632] Land ownership and construction rights are now shown on top of the water.
 - Improved: [#20951] Activate OpenRCT2 window after using native file dialog on macOS.
+- Change: [#21225] Raise maximum allowed misc entities to 1600.
 - Fix: [#20255] Images from the last hovered-over coaster in the object selection are not freed.
 - Fix: [#20616] Confirmation button in the track designer’s quit prompt has the wrong text.
 - Fix: [#21145] [Plugin] setInterval/setTimeout handle conflict.

--- a/src/openrct2/entity/EntityRegistry.cpp
+++ b/src/openrct2/entity/EntityRegistry.cpp
@@ -275,7 +275,8 @@ static void EntityReset(EntityBase* entity)
     entity->Type = EntityType::Null;
 }
 
-static constexpr uint16_t MAX_MISC_SPRITES = 300;
+static constexpr uint16_t MAX_MISC_SPRITES = 1600;
+
 static void AddToEntityList(EntityBase* entity)
 {
     auto& list = gEntityLists[EnumValue(entity->Type)];

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "0"
+#define NETWORK_STREAM_VERSION "1"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 


### PR DESCRIPTION
The SV4/SV6 limit was 2.5% of the maximum entities limit, when the entity limit was raised for the new save format I think this was overlooked. 1600 misc entities is now roughly 2.5% of the new entity limit of 65k, 2.5% is technically 1638.375 but I don't think this has to be perfect, the old entity limit was 12000.

One example to why I raised it is bigger parks, litter and jumping fountains falls under the misc entities and that can be easily exhausted.