### PR TITLE
Add scripting hook for when ride window opens

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -502,6 +502,7 @@ declare global {
         subscribe(hook: "vehicle.crash", callback: (e: VehicleCrashArgs) => void): IDisposable;
         subscribe(hook: "map.save", callback: () => void): IDisposable;
         subscribe(hook: "map.change", callback: () => void): IDisposable;
+        subscribe(hook: "window.open.ride", callback: () => void): IDisposable;
 
         /**
          * Can only be used in intransient plugins.
@@ -615,7 +616,7 @@ declare global {
         "interval.tick" | "interval.day" |
         "network.chat" | "network.action" | "network.join" | "network.leave" |
         "ride.ratings.calculate" | "action.location" | "vehicle.crash" |
-        "map.change" | "map.changed" | "map.save";
+        "map.change" | "map.changed" | "map.save" | "window.open.ride";
 
     type ExpenditureType =
         "ride_construction" |

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -6605,7 +6605,7 @@ private:
 
 #pragma region Scripting
 
-    #ifdef ENABLE_SCRIPTING
+#ifdef ENABLE_SCRIPTING
     void InvokeRideWindowOpen(const RideId rideId)
     {
         auto& hookEngine = OpenRCT2::GetContext()->GetScriptEngine().GetHookEngine();
@@ -6622,7 +6622,7 @@ private:
             hookEngine.Call(OpenRCT2::Scripting::HOOK_TYPE::WINDOW_OPEN_RIDE, e, true);
         }
     }
-    #endif
+#endif
 
 #pragma endregion
 };

--- a/src/openrct2/scripting/HookEngine.cpp
+++ b/src/openrct2/scripting/HookEngine.cpp
@@ -34,6 +34,7 @@ static const EnumMap<HOOK_TYPE> HooksLookupTable({
     { "map.change", HOOK_TYPE::MAP_CHANGE },
     { "map.changed", HOOK_TYPE::MAP_CHANGED },
     { "map.save", HOOK_TYPE::MAP_SAVE },
+    { "window.open.ride", HOOK_TYPE::WINDOW_OPEN_RIDE }
 });
 
 HOOK_TYPE OpenRCT2::Scripting::GetHookType(const std::string& name)

--- a/src/openrct2/scripting/HookEngine.h
+++ b/src/openrct2/scripting/HookEngine.h
@@ -44,6 +44,7 @@ namespace OpenRCT2::Scripting
         MAP_CHANGED,
         MAP_SAVE,
         COUNT,
+        WINDOW_OPEN_RIDE,
         UNDEFINED = -1,
     };
     constexpr size_t NUM_HOOK_TYPES = static_cast<size_t>(HOOK_TYPE::COUNT);


### PR DESCRIPTION
I'm currently writing a plugin in which I want to see when a ride window opens. This pull request adds the code to the source.

When a ride window is opened the 'window.open.ride' hook is called.