### PR TITLE
Close #21227: Sort entrance styles in dropdown

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#21062] [Plugin] Add API for managing a guest's items.
 - Improved: [#18632] Land ownership and construction rights are now shown on top of the water.
 - Improved: [#20951] Activate OpenRCT2 window after using native file dialog on macOS.
+- Improved: [#21227] Entrance style dropdown is now sorted alphabetically everywhere.
 - Change: [#21225] Raise maximum allowed misc entities to 1600.
 - Fix: [#20196] New scenarios start with an incorrect temperature.
 - Fix: [#20255] Images from the last hovered-over coaster in the object selection are not freed.

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -64,6 +64,7 @@
 #include <openrct2/world/Park.h>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 using namespace OpenRCT2;
@@ -624,7 +625,7 @@ struct EntranceTypeLabel
 {
     ObjectEntryIndex EntranceTypeId;
     StringId LabelId;
-    const char* LabelString;
+    u8string_view LabelString;
 };
 
 class RideWindow final : public Window
@@ -2015,12 +2016,12 @@ private:
             if (stationObj != nullptr)
             {
                 auto name = stationObj->NameStringId;
-                _entranceDropdownData.push_back({ i, name, ls.GetString(name) });
+                _entranceDropdownData.push_back({ i, name, u8string_view{ ls.GetString(name) } });
             }
         }
 
         std::sort(_entranceDropdownData.begin(), _entranceDropdownData.end(), [](auto& a, auto& b) {
-            return String::Compare(a.LabelString, b.LabelString, true) < 0;
+            return a.LabelString.compare(b.LabelString) < 0;
         });
 
         _entranceDropdownDataLanguage = ls.GetCurrentLanguage();

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -624,7 +624,7 @@ struct EntranceTypeLabel
 {
     ObjectEntryIndex EntranceTypeId;
     StringId LabelId;
-    const char* label_string;
+    const char* LabelString;
 };
 
 class RideWindow final : public Window
@@ -2020,7 +2020,7 @@ private:
         }
 
         std::sort(_entranceDropdownData.begin(), _entranceDropdownData.end(), [](auto& a, auto& b) {
-            return String::Compare(a.label_string, b.label_string, true) < 0;
+            return String::Compare(a.LabelString, b.LabelString, true) < 0;
         });
 
         _entranceDropdownDataLanguage = ls.GetCurrentLanguage();

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -609,7 +609,7 @@ struct RideTypeLabel
 {
     ride_type_t RideTypeId;
     StringId LabelId;
-    const char* LabelString;
+    u8string_view LabelString;
 };
 
 // Used for sorting the vehicle type dropdown.
@@ -617,7 +617,7 @@ struct VehicleTypeLabel
 {
     ObjectEntryIndex SubTypeId;
     StringId LabelId;
-    const char* LabelString;
+    u8string_view LabelString;
 };
 
 // Used for sorting the entrance type dropdown.
@@ -1807,11 +1807,11 @@ private:
         for (uint8_t i = 0; i < RIDE_TYPE_COUNT; i++)
         {
             auto name = GetRideTypeNameForDropdown(i);
-            _rideDropdownData.push_back({ i, name, ls.GetString(name) });
+            _rideDropdownData.push_back({ i, name, u8string_view{ ls.GetString(name) } });
         }
 
         std::sort(_rideDropdownData.begin(), _rideDropdownData.end(), [](auto& a, auto& b) {
-            return String::Compare(a.LabelString, b.LabelString, true) < 0;
+            return a.LabelString.compare(b.LabelString) < 0;
         });
 
         _rideDropdownDataLanguage = ls.GetCurrentLanguage();
@@ -1948,13 +1948,13 @@ private:
                 if (!RideEntryIsInvented(rideEntryIndex) && !gCheatsIgnoreResearchStatus)
                     continue;
 
-                _vehicleDropdownData.push_back(
-                    { rideEntryIndex, currentRideEntry->naming.Name, ls.GetString(currentRideEntry->naming.Name) });
+                auto name = currentRideEntry->naming.Name;
+                _vehicleDropdownData.push_back({ rideEntryIndex, name, u8string_view{ ls.GetString(name) } });
             }
         }
 
         std::sort(_vehicleDropdownData.begin(), _vehicleDropdownData.end(), [](auto& a, auto& b) {
-            return String::Compare(a.LabelString, b.LabelString, true) < 0;
+            return a.LabelString.compare(b.LabelString) < 0;
         });
 
         _vehicleDropdownExpanded = selectionShouldBeExpanded;

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -608,7 +608,7 @@ struct RideTypeLabel
 {
     ride_type_t RideTypeId;
     StringId LabelId;
-    const char* label_string;
+    const char* LabelString;
 };
 
 // Used for sorting the vehicle type dropdown.
@@ -616,7 +616,7 @@ struct VehicleTypeLabel
 {
     ObjectEntryIndex SubTypeId;
     StringId LabelId;
-    const char* label_string;
+    const char* LabelString;
 };
 
 // Used for sorting the entrance type dropdown.
@@ -1810,7 +1810,7 @@ private:
         }
 
         std::sort(_rideDropdownData.begin(), _rideDropdownData.end(), [](auto& a, auto& b) {
-            return String::Compare(a.label_string, b.label_string, true) < 0;
+            return String::Compare(a.LabelString, b.LabelString, true) < 0;
         });
 
         _rideDropdownDataLanguage = ls.GetCurrentLanguage();
@@ -1953,7 +1953,7 @@ private:
         }
 
         std::sort(_vehicleDropdownData.begin(), _vehicleDropdownData.end(), [](auto& a, auto& b) {
-            return String::Compare(a.label_string, b.label_string, true) < 0;
+            return String::Compare(a.LabelString, b.LabelString, true) < 0;
         });
 
         _vehicleDropdownExpanded = selectionShouldBeExpanded;


### PR DESCRIPTION
This PR changes the entrance style dropdown in the "paint" tab of the ride window to sort the available entrance styles according to some comparing function before displaying them.  
This makes the order in which they are displayed independent from the order in which the entrance objects were loaded. (Which varies depending on whether they were loaded from an `*.SC6` or a `*.park`.)  
As a result, the sorting criteria are now the same everywhere (old scenarios, new scenarios, track designer).

For the actual sorting, the enum values returned by `GetStationStyleFromIdentifier` from `src/openrct2/rct12/RCT12.cpp` are used. This leads to the same sorting as in RCT2 ("plain", "wooden" and "canvas tent" on top), with newly added styles at the bottom.

Closes #21227 