### PR TITLE
Move wall edge definitions from header to compilation unit

### DIFF
--- a/src/openrct2/actions/WallPlaceAction.cpp
+++ b/src/openrct2/actions/WallPlaceAction.cpp
@@ -119,7 +119,7 @@ GameActions::Result WallPlaceAction::Query() const
         targetHeight = surfaceElement->GetBaseZ();
 
         uint8_t slope = surfaceElement->GetSlope();
-        edgeSlope = LandSlopeToWallSlope[slope][_edge & 3];
+        edgeSlope = GetWallSlopeFromEdgeSlope(slope, _edge & 3);
         if (edgeSlope & EDGE_SLOPE_ELEVATED)
         {
             targetHeight += 16;
@@ -298,7 +298,7 @@ GameActions::Result WallPlaceAction::Execute() const
         targetHeight = surfaceElement->GetBaseZ();
 
         uint8_t slope = surfaceElement->GetSlope();
-        edgeSlope = LandSlopeToWallSlope[slope][_edge & 3];
+        edgeSlope = GetWallSlopeFromEdgeSlope(slope, _edge & 3);
         if (edgeSlope & EDGE_SLOPE_ELEVATED)
         {
             targetHeight += 16;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1777,7 +1777,7 @@ namespace RCT1
                         type = _wallTypeToEntryMap[type];
                         auto baseZ = src->BaseHeight * Limits::CoordsZStep;
                         auto clearanceZ = src->ClearanceHeight * Limits::CoordsZStep;
-                        auto edgeSlope = LandSlopeToWallSlope[slope][edge & 3];
+                        auto edgeSlope = GetWallSlopeFromEdgeSlope(slope, edge & 3);
                         if (edgeSlope & (EDGE_SLOPE_UPWARDS | EDGE_SLOPE_DOWNWARDS))
                         {
                             clearanceZ += LAND_HEIGHT_STEP;

--- a/src/openrct2/world/Wall.cpp
+++ b/src/openrct2/world/Wall.cpp
@@ -185,3 +185,51 @@ void WallElement::SetAnimationIsBackwards(bool isBackwards)
     if (isBackwards)
         animation |= WALL_ANIMATION_FLAG_DIRECTION_BACKWARD;
 }
+
+#pragma region Edge Slopes Table
+
+// clang-format off
+/** rct2: 0x009A3FEC */
+constexpr uint8_t LandSlopeToWallSlope[][NumOrthogonalDirections] = {
+    //  Top right                        Bottom right                   Bottom left                       Top left
+    { 0,                             0,                             0,                             0                             },
+    { 0,                             EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_DOWNWARDS,          0                             },
+    { 0,                             0,                             EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_DOWNWARDS          },
+    { 0,                             EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_DOWNWARDS          },
+    { EDGE_SLOPE_DOWNWARDS,          0,                             0,                             EDGE_SLOPE_UPWARDS            },
+    { EDGE_SLOPE_DOWNWARDS,          EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_DOWNWARDS,          EDGE_SLOPE_UPWARDS            },
+    { EDGE_SLOPE_DOWNWARDS,          0,                             EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_ELEVATED           },
+    { EDGE_SLOPE_DOWNWARDS,          EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_ELEVATED           },
+    { EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_DOWNWARDS,          0,                             0                             },
+    { EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_DOWNWARDS,          0                             },
+    { EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_DOWNWARDS,          EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_DOWNWARDS          },
+    { EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_DOWNWARDS          },
+    { EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_DOWNWARDS,          0,                             EDGE_SLOPE_UPWARDS            },
+    { EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_DOWNWARDS,          EDGE_SLOPE_UPWARDS            },
+    { EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_DOWNWARDS,          EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_ELEVATED           },
+    { EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_ELEVATED           },
+    { 0,                             0,                             0,                             0                             },
+    { 0,                             0,                             0,                             0                             },
+    { 0,                             0,                             0,                             0                             },
+    { 0,                             0,                             0,                             0                             },
+    { 0,                             0,                             0,                             0                             },
+    { 0,                             0,                             0,                             0                             },
+    { 0,                             0,                             0,                             0                             },
+    { EDGE_SLOPE_DOWNWARDS,          EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_UPWARDS_ELEVATED,   EDGE_SLOPE_DOWNWARDS_ELEVATED },
+    { 0,                             0,                             0,                             0                             },
+    { 0,                             0,                             0,                             0                             },
+    { 0,                             0,                             0,                             0                             },
+    { EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_UPWARDS_ELEVATED,   EDGE_SLOPE_DOWNWARDS_ELEVATED, EDGE_SLOPE_DOWNWARDS          },
+    { 0,                             0,                             0,                             0                             },
+    { EDGE_SLOPE_UPWARDS_ELEVATED,   EDGE_SLOPE_DOWNWARDS_ELEVATED, EDGE_SLOPE_DOWNWARDS,          EDGE_SLOPE_UPWARDS            },
+    { EDGE_SLOPE_DOWNWARDS_ELEVATED, EDGE_SLOPE_DOWNWARDS,          EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_UPWARDS_ELEVATED   },
+    { 0,                             0,                             0,                             0                             },
+};
+// clang-format on
+
+#pragma endregion
+
+uint8_t GetWallSlopeFromEdgeSlope(uint8_t Slope, uint8_t Edge)
+{
+    return LandSlopeToWallSlope[Slope][Edge];
+}

--- a/src/openrct2/world/Wall.cpp
+++ b/src/openrct2/world/Wall.cpp
@@ -189,8 +189,8 @@ void WallElement::SetAnimationIsBackwards(bool isBackwards)
 #pragma region Edge Slopes Table
 
 // clang-format off
-/** rct2: 0x009A3FEC */
-constexpr uint8_t LandSlopeToWallSlope[][NumOrthogonalDirections] = {
+// rct2: 0x009A3FEC
+constexpr static uint8_t LandSlopeToWallSlope[][NumOrthogonalDirections] = {
     //  Top right                        Bottom right                   Bottom left                       Top left
     { 0,                             0,                             0,                             0                             },
     { 0,                             EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_DOWNWARDS,          0                             },

--- a/src/openrct2/world/Wall.h
+++ b/src/openrct2/world/Wall.h
@@ -20,55 +20,14 @@ enum
     WALL_ANIMATION_FLAG_ALL_FLAGS = WALL_ANIMATION_FLAG_ACROSS_TRACK | WALL_ANIMATION_FLAG_DIRECTION_BACKWARD
 };
 
-#pragma region Edge Slopes Table
-
-// clang-format off
 enum EDGE_SLOPE
 {
-    EDGE_SLOPE_UPWARDS      = (1 << 0),
-    EDGE_SLOPE_DOWNWARDS    = (1 << 1),
-    EDGE_SLOPE_ELEVATED     = (1 << 2),
+    EDGE_SLOPE_UPWARDS = (1 << 0),
+    EDGE_SLOPE_DOWNWARDS = (1 << 1),
+    EDGE_SLOPE_ELEVATED = (1 << 2),
 
-    EDGE_SLOPE_UPWARDS_ELEVATED     = EDGE_SLOPE_UPWARDS | EDGE_SLOPE_ELEVATED,
-    EDGE_SLOPE_DOWNWARDS_ELEVATED   = EDGE_SLOPE_DOWNWARDS | EDGE_SLOPE_ELEVATED,
+    EDGE_SLOPE_UPWARDS_ELEVATED = EDGE_SLOPE_UPWARDS | EDGE_SLOPE_ELEVATED,
+    EDGE_SLOPE_DOWNWARDS_ELEVATED = EDGE_SLOPE_DOWNWARDS | EDGE_SLOPE_ELEVATED,
 };
 
-/** rct2: 0x009A3FEC */
-constexpr uint8_t LandSlopeToWallSlope[][NumOrthogonalDirections] = {
-    //  Top right                        Bottom right                   Bottom left                       Top left
-    { 0,                             0,                             0,                             0                             },
-    { 0,                             EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_DOWNWARDS,          0                             },
-    { 0,                             0,                             EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_DOWNWARDS          },
-    { 0,                             EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_DOWNWARDS          },
-    { EDGE_SLOPE_DOWNWARDS,          0,                             0,                             EDGE_SLOPE_UPWARDS            },
-    { EDGE_SLOPE_DOWNWARDS,          EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_DOWNWARDS,          EDGE_SLOPE_UPWARDS            },
-    { EDGE_SLOPE_DOWNWARDS,          0,                             EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_ELEVATED           },
-    { EDGE_SLOPE_DOWNWARDS,          EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_ELEVATED           },
-    { EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_DOWNWARDS,          0,                             0                             },
-    { EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_DOWNWARDS,          0                             },
-    { EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_DOWNWARDS,          EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_DOWNWARDS          },
-    { EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_DOWNWARDS          },
-    { EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_DOWNWARDS,          0,                             EDGE_SLOPE_UPWARDS            },
-    { EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_DOWNWARDS,          EDGE_SLOPE_UPWARDS            },
-    { EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_DOWNWARDS,          EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_ELEVATED           },
-    { EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_ELEVATED,           EDGE_SLOPE_ELEVATED           },
-    { 0,                             0,                             0,                             0                             },
-    { 0,                             0,                             0,                             0                             },
-    { 0,                             0,                             0,                             0                             },
-    { 0,                             0,                             0,                             0                             },
-    { 0,                             0,                             0,                             0                             },
-    { 0,                             0,                             0,                             0                             },
-    { 0,                             0,                             0,                             0                             },
-    { EDGE_SLOPE_DOWNWARDS,          EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_UPWARDS_ELEVATED,   EDGE_SLOPE_DOWNWARDS_ELEVATED },
-    { 0,                             0,                             0,                             0                             },
-    { 0,                             0,                             0,                             0                             },
-    { 0,                             0,                             0,                             0                             },
-    { EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_UPWARDS_ELEVATED,   EDGE_SLOPE_DOWNWARDS_ELEVATED, EDGE_SLOPE_DOWNWARDS          },
-    { 0,                             0,                             0,                             0                             },
-    { EDGE_SLOPE_UPWARDS_ELEVATED,   EDGE_SLOPE_DOWNWARDS_ELEVATED, EDGE_SLOPE_DOWNWARDS,          EDGE_SLOPE_UPWARDS            },
-    { EDGE_SLOPE_DOWNWARDS_ELEVATED, EDGE_SLOPE_DOWNWARDS,          EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_UPWARDS_ELEVATED   },
-    { 0,                             0,                             0,                             0                             },
-};
-// clang-format on
-
-#pragma endregion
+uint8_t GetWallSlopeFromEdgeSlope(uint8_t Slope, uint8_t Edge);


### PR DESCRIPTION
Move wall edge definitions from the Wall.h header to the Wall.cpp compilation unit. This will ensure there is only one source for these definitions, rather than it potentially being recreated in all 34 files the header is included. In addition, this should speed up compilation times a little bit.