### PR TITLE
Fix #20845: Outdated message box in case of save failure

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Fix: [#20255] Images from the last hovered-over coaster in the object selection are not freed.
 - Fix: [#20616] Confirmation button in the track designer’s quit prompt has the wrong text.
 - Fix: [#20628] Moving caret using Ctrl+left can move too far when using a multibyte grapheme.
+- Fix: [#20845] Trying to save under a folder with no write permissions causes a crash.
 - Fix: [#21054] “No entrance” style is selected by default in the track designer.
 - Fix: [#21145] [Plugin] setInterval/setTimeout handle conflict.
 - Fix: [#21157] [Plugin] Widgets do not redraw correctly when updating disabled or visibility state. 

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -2587,26 +2587,6 @@ int32_t ScenarioSave(GameState_t& gameState, u8string_view path, int32_t flags)
         ft.Add<const char*>(e.what());
         ContextShowError(STR_FILE_DIALOG_TITLE_SAVE_SCENARIO, STR_STRING, ft);
         GfxInvalidateScreen();
-
-        auto ctx = OpenRCT2::GetContext();
-        auto uictx = ctx->GetUiContext();
-
-        std::string title = "Error while saving";
-        std::string message
-            = "There was an error while saving scenario.\nhttps://github.com/OpenRCT2/OpenRCT2/issues/17664\nWe would like to "
-              "collect more information about this issue, if this did not happen due to missing permissions, lack of space, "
-              "etc. please consider submitting a bug report. To collect information we would like to trigger an assert.";
-
-        std::string report_bug_button = "Report bug, trigger an assert, potentially terminating the game";
-        std::string skip_button = "Skip reporting, let me continue";
-
-        std::vector<std::string> buttons{ std::move(report_bug_button), std::move(skip_button) };
-        int choice = uictx->ShowMessageBox(title, message, buttons);
-
-        if (choice == 0)
-        {
-            Guard::Assert(false, "Error while saving: %s", e.what());
-        }
     }
 
     GfxInvalidateScreen();


### PR DESCRIPTION
Just going ahead with opening a PR for this since comments on old issues tend to not get read very often...

The message box that pops up after a save failure is not needed anymore as the underlying issue it was meant to help investigating was fixed quite a while ago with the merge of #18178 . Apparently it was just forgotten to remove the message box, as had been the plan according to [this](https://github.com/OpenRCT2/OpenRCT2/pull/17665/files#r935443662) discussion.  
(See also my comment [here](https://github.com/OpenRCT2/OpenRCT2/issues/20845#issuecomment-1894534657).)

The discussion in #20845 suggests that the message box lately did not even work correctly under Windows; I can however not test this myself.

Closes #20845 