### PR TITLE
Use descriptive error strings for two `GameAction::Result`s

### DIFF
--- a/src/openrct2/actions/TrackSetBrakeSpeedAction.cpp
+++ b/src/openrct2/actions/TrackSetBrakeSpeedAction.cpp
@@ -57,7 +57,7 @@ GameActions::Result TrackSetBrakeSpeedAction::QueryExecute(bool isExecuting) con
 
     if (!LocationValid(_loc))
     {
-        return GameActions::Result(GameActions::Status::NotOwned, STR_NONE, STR_NONE);
+        return GameActions::Result(GameActions::Status::NotOwned, STR_NONE, STR_LAND_NOT_OWNED_BY_PARK);
     }
 
     TileElement* tileElement = MapGetTrackElementAtOfType(_loc, _trackType);

--- a/src/openrct2/actions/TrackSetBrakeSpeedAction.cpp
+++ b/src/openrct2/actions/TrackSetBrakeSpeedAction.cpp
@@ -57,7 +57,7 @@ GameActions::Result TrackSetBrakeSpeedAction::QueryExecute(bool isExecuting) con
 
     if (!LocationValid(_loc))
     {
-        return GameActions::Result(GameActions::Status::NotOwned, STR_NONE, STR_LAND_NOT_OWNED_BY_PARK);
+        return GameActions::Result(GameActions::Status::NotOwned, STR_CANT_CHANGE_THIS, STR_LAND_NOT_OWNED_BY_PARK);
     }
 
     TileElement* tileElement = MapGetTrackElementAtOfType(_loc, _trackType);

--- a/src/openrct2/actions/TrackSetBrakeSpeedAction.cpp
+++ b/src/openrct2/actions/TrackSetBrakeSpeedAction.cpp
@@ -57,7 +57,7 @@ GameActions::Result TrackSetBrakeSpeedAction::QueryExecute(bool isExecuting) con
 
     if (!LocationValid(_loc))
     {
-        return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_CHANGE_THIS);
+        return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_CHANGE_THIS, STR_OFF_EDGE_OF_MAP);
     }
 
     TileElement* tileElement = MapGetTrackElementAtOfType(_loc, _trackType);

--- a/src/openrct2/actions/TrackSetBrakeSpeedAction.cpp
+++ b/src/openrct2/actions/TrackSetBrakeSpeedAction.cpp
@@ -57,7 +57,7 @@ GameActions::Result TrackSetBrakeSpeedAction::QueryExecute(bool isExecuting) con
 
     if (!LocationValid(_loc))
     {
-        return GameActions::Result(GameActions::Status::NotOwned, STR_CANT_CHANGE_THIS, STR_LAND_NOT_OWNED_BY_PARK);
+        return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_CHANGE_THIS);
     }
 
     TileElement* tileElement = MapGetTrackElementAtOfType(_loc, _trackType);

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -298,7 +298,7 @@ namespace OpenRCT2::TileInspector
         // Make sure there is enough space for the new element
         if (!MapCheckCapacityAndReorganise(loc))
         {
-            return GameActions::Result(GameActions::Status::NoFreeElements, STR_NONE, STR_NONE);
+            return GameActions::Result(GameActions::Status::NoFreeElements, STR_CANT_PASTE, STR_TILE_ELEMENT_LIMIT_REACHED);
         }
 
         auto tileLoc = TileCoordsXY(loc);


### PR DESCRIPTION
* Use `STR_LAND_NOT_OWNED_BY_PARK` when trying to set track brake speed at a location not owned by the park.
* Use `STR_TILE_ELEMENT_LIMIT_REACHED` when trying to paste but `MapCheckCapacityAndReorganise()` returned false.

See https://github.com/OpenRCT2/OpenRCT2/issues/15782#issuecomment-1890896571