### PR TITLE
#21193: Move gParkFlags to GameState_t, refactor uses

### DIFF
--- a/src/openrct2-ui/input/Shortcuts.cpp
+++ b/src/openrct2-ui/input/Shortcuts.cpp
@@ -20,6 +20,7 @@
 #include <openrct2/Context.h>
 #include <openrct2/Editor.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/Input.h>
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/actions/CheatSetAction.h>
@@ -283,7 +284,7 @@ static void ShortcutShowFinancialInformation()
         return;
 
     if (!(gScreenFlags & (SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER)))
-        if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
+        if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
             ContextOpenWindow(WindowClass::Finances);
 }
 

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -14,6 +14,7 @@
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/actions/CheatSetAction.h>
 #include <openrct2/actions/ParkSetDateAction.h>
@@ -28,10 +29,11 @@
 #include <openrct2/world/Park.h>
 #include <openrct2/world/Surface.h>
 
+using namespace OpenRCT2;
+using OpenRCT2::Date;
+
 constexpr auto CHEATS_MONEY_DEFAULT = 10000.00_GBP;
 constexpr auto CHEATS_MONEY_INCREMENT_DIV = 5000.00_GBP;
-
-using OpenRCT2::Date;
 
 // clang-format off
 enum
@@ -453,11 +455,12 @@ public:
         // Set title
         widgets[WIDX_TITLE].text = window_cheats_page_titles[page];
 
+        auto& gameState = GetGameState();
         switch (page)
         {
             case WINDOW_CHEATS_PAGE_MONEY:
             {
-                auto moneyDisabled = (gParkFlags & PARK_FLAGS_NO_MONEY) != 0;
+                auto moneyDisabled = (gameState.ParkFlags & PARK_FLAGS_NO_MONEY) != 0;
                 SetCheckboxValue(WIDX_NO_MONEY, moneyDisabled);
                 SetWidgetDisabled(WIDX_ADD_SET_MONEY_GROUP, moneyDisabled);
                 SetWidgetDisabled(WIDX_MONEY_SPINNER, moneyDisabled);
@@ -478,8 +481,8 @@ public:
                 break;
             }
             case WINDOW_CHEATS_PAGE_MISC:
-                widgets[WIDX_OPEN_CLOSE_PARK].text = (gParkFlags & PARK_FLAGS_PARK_OPEN) ? STR_CHEAT_CLOSE_PARK
-                                                                                         : STR_CHEAT_OPEN_PARK;
+                widgets[WIDX_OPEN_CLOSE_PARK].text = (gameState.ParkFlags & PARK_FLAGS_PARK_OPEN) ? STR_CHEAT_CLOSE_PARK
+                                                                                                  : STR_CHEAT_OPEN_PARK;
                 SetCheckboxValue(WIDX_FORCE_PARK_RATING, ParkGetForcedRating() >= 0);
                 SetCheckboxValue(WIDX_FREEZE_WEATHER, gCheatsFreezeWeather);
                 SetCheckboxValue(WIDX_NEVERENDING_MARKETING, gCheatsNeverendingMarketing);
@@ -779,7 +782,7 @@ private:
         switch (widgetIndex)
         {
             case WIDX_NO_MONEY:
-                CheatsSet(CheatType::NoMoney, gParkFlags & PARK_FLAGS_NO_MONEY ? 0 : 1);
+                CheatsSet(CheatType::NoMoney, GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY ? 0 : 1);
                 break;
             case WIDX_MONEY_SPINNER:
                 MoneyToString(_moneySpinnerValue, _moneySpinnerText, MONEY_STRING_MAXLENGTH, false);

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -12,10 +12,13 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
+#include <openrct2/GameState.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/world/Park.h>
 #include <openrct2/world/Scenery.h>
+
+using namespace OpenRCT2;
 
 enum WindowClearSceneryWidgetIdx
 {
@@ -186,7 +189,8 @@ public:
         }
 
         // Draw cost amount
-        if (gClearSceneryCost != MONEY64_UNDEFINED && gClearSceneryCost != 0 && !(gParkFlags & PARK_FLAGS_NO_MONEY))
+        if (gClearSceneryCost != MONEY64_UNDEFINED && gClearSceneryCost != 0
+            && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
         {
             auto ft = Formatter();
             ft.Add<money64>(gClearSceneryCost);

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -11,12 +11,15 @@
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/actions/RideDemolishAction.h>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/windows/Intent.h>
 #include <openrct2/world/Park.h>
+
+using namespace OpenRCT2;
 
 static constexpr int32_t WW = 200;
 static constexpr int32_t WH = 100;
@@ -81,7 +84,8 @@ public:
         auto currentRide = GetRide(rideId);
         if (currentRide != nullptr)
         {
-            auto stringId = (gParkFlags & PARK_FLAGS_NO_MONEY) ? STR_DEMOLISH_RIDE_ID : STR_DEMOLISH_RIDE_ID_MONEY;
+            auto stringId = (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY) ? STR_DEMOLISH_RIDE_ID
+                                                                             : STR_DEMOLISH_RIDE_ID_MONEY;
             auto ft = Formatter();
             currentRide->FormatNameTo(ft);
             ft.Add<money64>(_demolishRideCost);

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -15,6 +15,7 @@
 #include <openrct2/Editor.h>
 #include <openrct2/EditorObjectSelectionSession.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/Input.h>
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/audio/audio.h>
@@ -26,6 +27,8 @@
 #include <openrct2/world/Park.h>
 #include <openrct2/world/Scenery.h>
 #include <string>
+
+using namespace OpenRCT2;
 
 // clang-format off
 enum {
@@ -99,7 +102,7 @@ public:
             }
             else if (!(gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER))
             {
-                if (GetNumFreeEntities() != MAX_ENTITIES || gParkFlags & PARK_FLAGS_SPRITES_INITIALISED)
+                if (GetNumFreeEntities() != MAX_ENTITIES || GetGameState().ParkFlags & PARK_FLAGS_SPRITES_INITIALISED)
                 {
                     HidePreviousStepButton();
                 }
@@ -134,7 +137,7 @@ public:
         if (widgetIndex == WIDX_PREVIOUS_STEP_BUTTON)
         {
             if ((gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER)
-                || (GetNumFreeEntities() == MAX_ENTITIES && !(gParkFlags & PARK_FLAGS_SPRITES_INITIALISED)))
+                || (GetNumFreeEntities() == MAX_ENTITIES && !(GetGameState().ParkFlags & PARK_FLAGS_SPRITES_INITIALISED)))
             {
                 ((this)->*(_previousButtonMouseUp[EnumValue(gEditorStep)]))();
             }

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -29,6 +29,8 @@
 #include <openrct2/sprites.h>
 #include <openrct2/world/Park.h>
 
+using namespace OpenRCT2;
+
 static constexpr StringId WINDOW_TITLE = STR_OBJECTIVE_SELECTION;
 static constexpr int32_t WH = 229;
 static constexpr int32_t WW = 450;
@@ -432,17 +434,16 @@ private:
     {
         int32_t numItems = 0, objectiveType;
         Widget* dropdownWidget;
-        uint32_t parkFlags;
 
         dropdownWidget = &widgets[WIDX_OBJECTIVE];
-        parkFlags = gParkFlags;
 
         for (auto i = 0; i < OBJECTIVE_COUNT; i++)
         {
             if (i == OBJECTIVE_NONE || i == OBJECTIVE_BUILD_THE_BEST)
                 continue;
 
-            const bool objectiveAllowedByMoneyUsage = !(parkFlags & PARK_FLAGS_NO_MONEY) || !ObjectiveNeedsMoney(i);
+            const bool objectiveAllowedByMoneyUsage = !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
+                || !ObjectiveNeedsMoney(i);
             // This objective can only work if the player can ask money for rides.
             const bool objectiveAllowedByPaymentSettings = (i != OBJECTIVE_MONTHLY_RIDE_INCOME) || ParkRidePricesUnlocked();
             if (objectiveAllowedByMoneyUsage && objectiveAllowedByPaymentSettings)
@@ -743,18 +744,17 @@ private:
      */
     void OnUpdateMain()
     {
-        uint32_t parkFlags;
         uint8_t objectiveType;
 
         frame_no++;
         OnPrepareDraw();
         InvalidateWidget(WIDX_TAB_1);
 
-        parkFlags = gParkFlags;
         objectiveType = gScenarioObjective.Type;
 
         // Check if objective is allowed by money and pay-per-ride settings.
-        const bool objectiveAllowedByMoneyUsage = !(parkFlags & PARK_FLAGS_NO_MONEY) || !ObjectiveNeedsMoney(objectiveType);
+        const bool objectiveAllowedByMoneyUsage = !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
+            || !ObjectiveNeedsMoney(objectiveType);
         // This objective can only work if the player can ask money for rides.
         const bool objectiveAllowedByPaymentSettings = (objectiveType != OBJECTIVE_MONTHLY_RIDE_INCOME)
             || ParkRidePricesUnlocked();

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -372,6 +372,7 @@ private:
 
     void FinancialMouseUp(WidgetIndex widgetIndex)
     {
+        auto& gameState = GetGameState();
         switch (widgetIndex)
         {
             case WIDX_CLOSE:
@@ -384,7 +385,7 @@ private:
                 break;
             case WIDX_NO_MONEY:
             {
-                auto newMoneySetting = (gParkFlags & PARK_FLAGS_NO_MONEY) ? 0 : 1;
+                auto newMoneySetting = (gameState.ParkFlags & PARK_FLAGS_NO_MONEY) ? 0 : 1;
                 auto scenarioSetSetting = ScenarioSetSettingAction(ScenarioSetSetting::NoMoney, newMoneySetting);
                 GameActions::Execute(&scenarioSetSetting);
                 Invalidate();
@@ -393,7 +394,8 @@ private:
             case WIDX_FORBID_MARKETING:
             {
                 auto scenarioSetSetting = ScenarioSetSettingAction(
-                    ScenarioSetSetting::ForbidMarketingCampaigns, gParkFlags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN ? 0 : 1);
+                    ScenarioSetSetting::ForbidMarketingCampaigns,
+                    gameState.ParkFlags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN ? 0 : 1);
                 GameActions::Execute(&scenarioSetSetting);
                 Invalidate();
                 break;
@@ -401,7 +403,7 @@ private:
             case WIDX_RCT1_INTEREST:
             {
                 auto scenarioSetSetting = ScenarioSetSettingAction(
-                    ScenarioSetSetting::UseRCT1Interest, gParkFlags & PARK_FLAGS_RCT1_INTEREST ? 0 : 1);
+                    ScenarioSetSetting::UseRCT1Interest, gameState.ParkFlags & PARK_FLAGS_RCT1_INTEREST ? 0 : 1);
                 GameActions::Execute(&scenarioSetSetting);
                 Invalidate();
                 break;
@@ -567,7 +569,8 @@ private:
 
         SetPressedTab();
 
-        if (gParkFlags & PARK_FLAGS_NO_MONEY)
+        auto& gameState = GetGameState();
+        if (gameState.ParkFlags & PARK_FLAGS_NO_MONEY)
         {
             SetWidgetPressed(WIDX_NO_MONEY, true);
             for (int32_t i = WIDX_INITIAL_CASH; i <= WIDX_RCT1_INTEREST; i++)
@@ -587,7 +590,7 @@ private:
             widgets[WIDX_MAXIMUM_LOAN_DECREASE].type = WindowWidgetType::Button;
             widgets[WIDX_FORBID_MARKETING].type = WindowWidgetType::Checkbox;
 
-            if (gParkFlags & PARK_FLAGS_RCT1_INTEREST)
+            if (gameState.ParkFlags & PARK_FLAGS_RCT1_INTEREST)
             {
                 widgets[WIDX_INTEREST_RATE].type = WindowWidgetType::Empty;
                 widgets[WIDX_INTEREST_RATE_INCREASE].type = WindowWidgetType::Empty;
@@ -604,7 +607,7 @@ private:
             }
         }
 
-        SetWidgetPressed(WIDX_FORBID_MARKETING, gParkFlags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN);
+        SetWidgetPressed(WIDX_FORBID_MARKETING, gameState.ParkFlags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN);
 
         widgets[WIDX_CLOSE].type = (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) ? WindowWidgetType::Empty
                                                                                  : WindowWidgetType::CloseBox;
@@ -675,6 +678,7 @@ private:
 
     void GuestsMouseUp(WidgetIndex widgetIndex)
     {
+        auto& gameState = GetGameState();
         switch (widgetIndex)
         {
             case WIDX_CLOSE:
@@ -688,7 +692,8 @@ private:
             case WIDX_GUEST_PREFER_LESS_INTENSE_RIDES:
             {
                 auto scenarioSetSetting = ScenarioSetSettingAction(
-                    ScenarioSetSetting::GuestsPreferLessIntenseRides, gParkFlags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES ? 0 : 1);
+                    ScenarioSetSetting::GuestsPreferLessIntenseRides,
+                    gameState.ParkFlags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES ? 0 : 1);
                 GameActions::Execute(&scenarioSetSetting);
                 Invalidate();
                 break;
@@ -696,7 +701,8 @@ private:
             case WIDX_GUEST_PREFER_MORE_INTENSE_RIDES:
             {
                 auto scenarioSetSetting = ScenarioSetSettingAction(
-                    ScenarioSetSetting::GuestsPreferMoreIntenseRides, gParkFlags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES ? 0 : 1);
+                    ScenarioSetSetting::GuestsPreferMoreIntenseRides,
+                    gameState.ParkFlags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES ? 0 : 1);
                 GameActions::Execute(&scenarioSetSetting);
                 Invalidate();
                 break;
@@ -838,7 +844,8 @@ private:
 
         SetPressedTab();
 
-        if (gParkFlags & PARK_FLAGS_NO_MONEY)
+        auto& gameState = GetGameState();
+        if (gameState.ParkFlags & PARK_FLAGS_NO_MONEY)
         {
             widgets[WIDX_CASH_PER_GUEST].type = WindowWidgetType::Empty;
             widgets[WIDX_CASH_PER_GUEST_INCREASE].type = WindowWidgetType::Empty;
@@ -851,8 +858,8 @@ private:
             widgets[WIDX_CASH_PER_GUEST_DECREASE].type = WindowWidgetType::Button;
         }
 
-        SetWidgetPressed(WIDX_GUEST_PREFER_LESS_INTENSE_RIDES, gParkFlags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES);
-        SetWidgetPressed(WIDX_GUEST_PREFER_MORE_INTENSE_RIDES, gParkFlags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES);
+        SetWidgetPressed(WIDX_GUEST_PREFER_LESS_INTENSE_RIDES, gameState.ParkFlags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES);
+        SetWidgetPressed(WIDX_GUEST_PREFER_MORE_INTENSE_RIDES, gameState.ParkFlags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES);
 
         widgets[WIDX_CLOSE].type = (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) ? WindowWidgetType::Empty
                                                                                  : WindowWidgetType::CloseBox;
@@ -921,6 +928,7 @@ private:
 
     void ParkMouseUp(WidgetIndex widgetIndex)
     {
+        auto& gameState = GetGameState();
         switch (widgetIndex)
         {
             case WIDX_CLOSE:
@@ -934,7 +942,7 @@ private:
             case WIDX_FORBID_TREE_REMOVAL:
             {
                 auto scenarioSetSetting = ScenarioSetSettingAction(
-                    ScenarioSetSetting::ForbidTreeRemoval, gParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL ? 0 : 1);
+                    ScenarioSetSetting::ForbidTreeRemoval, gameState.ParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL ? 0 : 1);
                 GameActions::Execute(&scenarioSetSetting);
                 Invalidate();
                 break;
@@ -942,7 +950,8 @@ private:
             case WIDX_FORBID_LANDSCAPE_CHANGES:
             {
                 auto scenarioSetSetting = ScenarioSetSettingAction(
-                    ScenarioSetSetting::ForbidLandscapeChanges, gParkFlags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES ? 0 : 1);
+                    ScenarioSetSetting::ForbidLandscapeChanges,
+                    gameState.ParkFlags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES ? 0 : 1);
                 GameActions::Execute(&scenarioSetSetting);
                 Invalidate();
                 break;
@@ -950,7 +959,8 @@ private:
             case WIDX_FORBID_HIGH_CONSTRUCTION:
             {
                 auto scenarioSetSetting = ScenarioSetSettingAction(
-                    ScenarioSetSetting::ForbidHighConstruction, gParkFlags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION ? 0 : 1);
+                    ScenarioSetSetting::ForbidHighConstruction,
+                    gameState.ParkFlags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION ? 0 : 1);
                 GameActions::Execute(&scenarioSetSetting);
                 Invalidate();
                 break;
@@ -958,7 +968,8 @@ private:
             case WIDX_HARD_PARK_RATING:
             {
                 auto scenarioSetSetting = ScenarioSetSettingAction(
-                    ScenarioSetSetting::ParkRatingHigherDifficultyLevel, gParkFlags & PARK_FLAGS_DIFFICULT_PARK_RATING ? 0 : 1);
+                    ScenarioSetSetting::ParkRatingHigherDifficultyLevel,
+                    gameState.ParkFlags & PARK_FLAGS_DIFFICULT_PARK_RATING ? 0 : 1);
                 GameActions::Execute(&scenarioSetSetting);
                 Invalidate();
                 break;
@@ -967,7 +978,7 @@ private:
             {
                 auto scenarioSetSetting = ScenarioSetSettingAction(
                     ScenarioSetSetting::GuestGenerationHigherDifficultyLevel,
-                    gParkFlags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION ? 0 : 1);
+                    gameState.ParkFlags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION ? 0 : 1);
                 GameActions::Execute(&scenarioSetSetting);
                 Invalidate();
                 break;
@@ -985,6 +996,7 @@ private:
         Widget* dropdownWidget;
         Widget* widget = &widgets[widgetIndex];
 
+        auto& gameState = GetGameState();
         switch (widgetIndex)
         {
             case WIDX_LAND_COST_INCREASE:
@@ -1079,9 +1091,9 @@ private:
                     { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height() - 1,
                     colours[1], 0, Dropdown::Flag::StayOpen, 3, dropdownWidget->width() - 3);
 
-                if (gParkFlags & PARK_FLAGS_UNLOCK_ALL_PRICES)
+                if (gameState.ParkFlags & PARK_FLAGS_UNLOCK_ALL_PRICES)
                     Dropdown::SetChecked(2, true);
-                else if (gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY)
+                else if (gameState.ParkFlags & PARK_FLAGS_PARK_FREE_ENTRY)
                     Dropdown::SetChecked(0, true);
                 else
                     Dropdown::SetChecked(1, true);
@@ -1137,7 +1149,8 @@ private:
 
         SetPressedTab();
 
-        if (gParkFlags & PARK_FLAGS_NO_MONEY)
+        auto& gameState = GetGameState();
+        if (gameState.ParkFlags & PARK_FLAGS_NO_MONEY)
         {
             for (int32_t i = WIDX_LAND_COST; i <= WIDX_ENTRY_PRICE_DECREASE; i++)
                 widgets[i].type = WindowWidgetType::Empty;
@@ -1167,11 +1180,11 @@ private:
             }
         }
 
-        SetWidgetPressed(WIDX_FORBID_TREE_REMOVAL, gParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL);
-        SetWidgetPressed(WIDX_FORBID_LANDSCAPE_CHANGES, gParkFlags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES);
-        SetWidgetPressed(WIDX_FORBID_HIGH_CONSTRUCTION, gParkFlags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION);
-        SetWidgetPressed(WIDX_HARD_PARK_RATING, gParkFlags & PARK_FLAGS_DIFFICULT_PARK_RATING);
-        SetWidgetPressed(WIDX_HARD_GUEST_GENERATION, gParkFlags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION);
+        SetWidgetPressed(WIDX_FORBID_TREE_REMOVAL, gameState.ParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL);
+        SetWidgetPressed(WIDX_FORBID_LANDSCAPE_CHANGES, gameState.ParkFlags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES);
+        SetWidgetPressed(WIDX_FORBID_HIGH_CONSTRUCTION, gameState.ParkFlags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION);
+        SetWidgetPressed(WIDX_HARD_PARK_RATING, gameState.ParkFlags & PARK_FLAGS_DIFFICULT_PARK_RATING);
+        SetWidgetPressed(WIDX_HARD_GUEST_GENERATION, gameState.ParkFlags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION);
 
         widgets[WIDX_CLOSE].type = (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) ? WindowWidgetType::Empty
                                                                                  : WindowWidgetType::CloseBox;
@@ -1221,11 +1234,12 @@ private:
             // Pay for park or rides label
             screenCoords = windowPos + ScreenCoordsXY{ payForParkOrRidesWidget.left + 1, payForParkOrRidesWidget.top };
 
+            auto& gameState = GetGameState();
             auto ft = Formatter();
             // Pay for park and/or rides value
-            if (gParkFlags & PARK_FLAGS_UNLOCK_ALL_PRICES)
+            if (gameState.ParkFlags & PARK_FLAGS_UNLOCK_ALL_PRICES)
                 ft.Add<StringId>(STR_PAID_ENTRY_PAID_RIDES);
-            else if (gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY)
+            else if (gameState.ParkFlags & PARK_FLAGS_PARK_FREE_ENTRY)
                 ft.Add<StringId>(STR_FREE_PARK_ENTER);
             else
                 ft.Add<StringId>(STR_PAY_PARK_ENTER);

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -230,7 +230,7 @@ private:
 
     void SetDisabledTabs()
     {
-        disabled_widgets = (gParkFlags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN) ? (1uLL << WIDX_TAB_5) : 0;
+        disabled_widgets = (GetGameState().ParkFlags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN) ? (1uLL << WIDX_TAB_5) : 0;
     }
 
 public:
@@ -536,6 +536,7 @@ public:
     void OnDrawSummary(DrawPixelInfo& dpi)
     {
         auto screenCoords = windowPos + ScreenCoordsXY{ 8, 51 };
+        auto& gameState = GetGameState();
 
         // Expenditure / Income heading
         DrawTextBasic(
@@ -564,7 +565,7 @@ public:
 
         // Loan and interest rate
         DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ 8, 279 }, STR_FINANCES_SUMMARY_LOAN);
-        if (!(gParkFlags & PARK_FLAGS_RCT1_INTEREST))
+        if (!(gameState.ParkFlags & PARK_FLAGS_RCT1_INTEREST))
         {
             auto ft = Formatter();
             ft.Add<uint16_t>(gBankLoanInterestRate);
@@ -573,8 +574,8 @@ public:
 
         // Current cash
         auto ft = Formatter();
-        ft.Add<money64>(GetGameState().Cash);
-        StringId stringId = GetGameState().Cash >= 0 ? STR_CASH_LABEL : STR_CASH_NEGATIVE_LABEL;
+        ft.Add<money64>(gameState.Cash);
+        StringId stringId = gameState.Cash >= 0 ? STR_CASH_LABEL : STR_CASH_NEGATIVE_LABEL;
         DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ 8, 294 }, stringId, ft);
 
         // Objective related financial information

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -15,6 +15,7 @@
 #include <openrct2/Cheats.h>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/Input.h>
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/actions/FootpathPlaceAction.h>
@@ -33,6 +34,7 @@
 #include <openrct2/world/Park.h>
 #include <openrct2/world/Surface.h>
 
+using namespace OpenRCT2;
 using namespace OpenRCT2::Ui;
 
 // clang-format off
@@ -498,7 +500,7 @@ public:
                               window_footpath_widgets[WIDX_CONSTRUCT].bottom - 12 };
         if (_windowFootpathCost != MONEY64_UNDEFINED)
         {
-            if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
+            if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
                 ft.Add<money64>(_windowFootpathCost);

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -89,9 +89,11 @@ private:
 
         // Figure out how much line height we have to work with.
         uint32_t line_height = FontGetLineHeight(FontStyle::Medium);
+        
+        auto& gameState = GetGameState();
 
         // Draw money
-        if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
+        if (!(gameState.ParkFlags & PARK_FLAGS_NO_MONEY))
         {
             Widget widget = window_game_bottom_toolbar_widgets[WIDX_MONEY];
             auto screenCoords = ScreenCoordsXY{ windowPos.x + widget.midX(),
@@ -101,9 +103,9 @@ private:
                 = (gHoverWidget.window_classification == WindowClass::BottomToolbar && gHoverWidget.widget_index == WIDX_MONEY
                        ? COLOUR_WHITE
                        : NOT_TRANSLUCENT(colours[0]));
-            StringId stringId = GetGameState().Cash < 0 ? STR_BOTTOM_TOOLBAR_CASH_NEGATIVE : STR_BOTTOM_TOOLBAR_CASH;
+            StringId stringId = gameState.Cash < 0 ? STR_BOTTOM_TOOLBAR_CASH_NEGATIVE : STR_BOTTOM_TOOLBAR_CASH;
             auto ft = Formatter();
-            ft.Add<money64>(GetGameState().Cash);
+            ft.Add<money64>(gameState.Cash);
             DrawTextBasic(dpi, screenCoords, stringId, ft, { colour, TextAlignment::CENTRE });
         }
 
@@ -419,7 +421,7 @@ public:
         {
             case WIDX_LEFT_OUTSET:
             case WIDX_MONEY:
-                if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
+                if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
                     ContextOpenWindow(WindowClass::Finances);
                 break;
             case WIDX_GUESTS:
@@ -499,7 +501,7 @@ public:
             = line_height * 3 + 1;
 
         // Reposition left widgets in accordance with line height... depending on whether there is money in play.
-        if (gParkFlags & PARK_FLAGS_NO_MONEY)
+        if (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
         {
             widgets[WIDX_MONEY].type = WindowWidgetType::Empty;
             widgets[WIDX_GUESTS].top = 1;

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -468,7 +468,7 @@ private:
             if (!WidgetIsDisabled(*this, WIDX_PICKUP))
                 Invalidate();
         }
-        if (gParkFlags & PARK_FLAGS_NO_MONEY)
+        if (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
         {
             newDisabledWidgets |= (1uLL << WIDX_TAB_4); // Disable finance tab if no money
         }

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -958,7 +958,7 @@ private:
 
     static GuestItem::CompareFunc GetGuestCompareFunc()
     {
-        return gParkFlags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES ? CompareGuestItem<true> : CompareGuestItem<false>;
+        return GetGameState().ParkFlags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES ? CompareGuestItem<true> : CompareGuestItem<false>;
     }
 };
 

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -12,6 +12,7 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
+#include <openrct2/GameState.h>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/object/ObjectManager.h>
@@ -261,7 +262,7 @@ public:
 
         screenCoords = { windowPos.x + previewWidget->midX(), windowPos.y + previewWidget->bottom + 5 };
 
-        if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
+        if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
         {
             // Draw raise cost amount
             if (gLandToolRaiseCost != MONEY64_UNDEFINED && gLandToolRaiseCost != 0)

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -14,6 +14,7 @@
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/Input.h>
 #include <openrct2/actions/LandBuyRightsAction.h>
 #include <openrct2/core/String.hpp>
@@ -21,6 +22,8 @@
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/world/Park.h>
+
+using namespace OpenRCT2;
 
 static constexpr StringId WINDOW_TITLE = STR_LAND_RIGHTS;
 static constexpr int32_t WH = 94;
@@ -225,7 +228,7 @@ public:
         }
 
         // Draw cost amount
-        if (_landRightsCost != MONEY64_UNDEFINED && _landRightsCost != 0 && !(gParkFlags & PARK_FLAGS_NO_MONEY))
+        if (_landRightsCost != MONEY64_UNDEFINED && _landRightsCost != 0 && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
         {
             auto ft = Formatter();
             ft.Add<money64>(_landRightsCost);

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -343,12 +343,12 @@ static void Select(const char* path)
         case (LOADSAVETYPE_SAVE | LOADSAVETYPE_SCENARIO):
         {
             SetAndSaveConfigPath(gConfigGeneral.LastSaveScenarioDirectory, pathBuffer);
-            int32_t parkFlagsBackup = gParkFlags;
-            gParkFlags &= ~PARK_FLAGS_SPRITES_INITIALISED;
+            int32_t parkFlagsBackup = gameState.ParkFlags;
+            gameState.ParkFlags &= ~PARK_FLAGS_SPRITES_INITIALISED;
             gEditorStep = EditorStep::Invalid;
             gScenarioFileName = std::string(String::ToStringView(pathBuffer, std::size(pathBuffer)));
             int32_t success = ScenarioSave(gameState, pathBuffer, gConfigGeneral.SavePluginData ? 3 : 2);
-            gParkFlags = parkFlagsBackup;
+            gameState.ParkFlags = parkFlagsBackup;
 
             if (success)
             {

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -15,6 +15,7 @@
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/audio/audio.h>
 #include <openrct2/config/Config.h>
@@ -38,6 +39,7 @@
 #include <openrct2/windows/Intent.h>
 #include <openrct2/world/Park.h>
 
+using namespace OpenRCT2;
 using namespace OpenRCT2::TrackMetaData;
 
 static constexpr StringId WindowTitle = STR_NONE;
@@ -843,7 +845,7 @@ private:
             widgets[WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP].type = WindowWidgetType::Groupbox;
             widgets[WIDX_LAST_DEVELOPMENT_GROUP].type = WindowWidgetType::Groupbox;
             widgets[WIDX_LAST_DEVELOPMENT_BUTTON].type = WindowWidgetType::FlatBtn;
-            if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
+            if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
                 widgets[WIDX_RESEARCH_FUNDING_BUTTON].type = WindowWidgetType::FlatBtn;
 
             newWidth = 300;
@@ -952,7 +954,7 @@ private:
         DrawTextBasic(dpi, screenPos + ScreenCoordsXY{ 0, 51 }, designCountStringId, ft);
 
         // Price
-        if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
+        if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
         {
             // Get price of ride
             int32_t startPieceId = GetRideTypeDescriptor(item.Type).StartTrackPiece;

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -35,6 +35,8 @@
 #include <openrct2/world/Entrance.h>
 #include <openrct2/world/Park.h>
 
+using namespace OpenRCT2;
+
 static constexpr StringId WINDOW_TITLE = STR_STRINGID;
 static constexpr int32_t WH = 224;
 
@@ -394,7 +396,7 @@ private:
     void SetDisabledTabs()
     {
         // Disable price tab if money is disabled
-        disabled_widgets = (gParkFlags & PARK_FLAGS_NO_MONEY) ? (1uLL << WIDX_TAB_4) : 0;
+        disabled_widgets = (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY) ? (1uLL << WIDX_TAB_4) : 0;
     }
 
     void PrepareWindowTitleText()
@@ -528,7 +530,7 @@ private:
             disabled_widgets &= ~((1uLL << WIDX_OPEN_OR_CLOSE) | (1uLL << WIDX_CLOSE_LIGHT) | (1uLL << WIDX_OPEN_LIGHT));
 
         // Only allow purchase of land when there is money
-        if (gParkFlags & PARK_FLAGS_NO_MONEY)
+        if (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
             widgets[WIDX_BUY_LAND_RIGHTS].type = WindowWidgetType::Empty;
         else
             widgets[WIDX_BUY_LAND_RIGHTS].type = WindowWidgetType::FlatBtn;
@@ -869,7 +871,7 @@ private:
         }
 
         // If the entry price is locked at free, disable the widget, unless the unlock_all_prices cheat is active.
-        if ((gParkFlags & PARK_FLAGS_NO_MONEY) || !ParkEntranceFeeUnlocked())
+        if ((GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY) || !ParkEntranceFeeUnlocked())
         {
             widgets[WIDX_PRICE].type = WindowWidgetType::LabelCentred;
             widgets[WIDX_INCREASE_PRICE].type = WindowWidgetType::Empty;
@@ -1046,7 +1048,7 @@ private:
         PrepareWindowTitleText();
 
         // Show name input button on scenario completion.
-        if (gParkFlags & PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT)
+        if (GetGameState().ParkFlags & PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT)
         {
             widgets[WIDX_ENTER_NAME].type = WindowWidgetType::Button;
             widgets[WIDX_ENTER_NAME].top = height - 19;

--- a/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
@@ -11,11 +11,14 @@
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/actions/RideDemolishAction.h>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/windows/Intent.h>
 #include <openrct2/world/Park.h>
+
+using namespace OpenRCT2;
 
 static constexpr int32_t WW = 200;
 static constexpr int32_t WH = 100;
@@ -80,7 +83,8 @@ public:
         auto currentRide = GetRide(rideId);
         if (currentRide != nullptr)
         {
-            auto stringId = (gParkFlags & PARK_FLAGS_NO_MONEY) ? STR_REFURBISH_RIDE_ID_NO_MONEY : STR_REFURBISH_RIDE_ID_MONEY;
+            auto stringId = (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY) ? STR_REFURBISH_RIDE_ID_NO_MONEY
+                                                                             : STR_REFURBISH_RIDE_ID_MONEY;
             auto ft = Formatter();
             currentRide->FormatNameTo(ft);
             ft.Add<money64>(_demolishRideCost / 2);

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -12,6 +12,7 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/actions/ParkSetResearchFundingAction.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Localisation.h>
@@ -22,6 +23,8 @@
 #include <openrct2/sprites.h>
 #include <openrct2/world/Park.h>
 #include <openrct2/world/Scenery.h>
+
+using namespace OpenRCT2;
 
 static constexpr int32_t WH_DEVELOPMENT = 196;
 static constexpr int32_t WW_DEVELOPMENT = 300;
@@ -535,7 +538,7 @@ void WindowResearchFundingPrepareDraw(WindowBase* w, WidgetIndex baseWidgetIndex
 {
     auto widgetOffset = GetWidgetIndexOffset(baseWidgetIndex, WIDX_RESEARCH_FUNDING);
 
-    if ((gParkFlags & PARK_FLAGS_NO_MONEY) || gResearchProgressStage == RESEARCH_STAGE_FINISHED_ALL)
+    if ((GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY) || gResearchProgressStage == RESEARCH_STAGE_FINISHED_ALL)
     {
         w->widgets[WIDX_RESEARCH_FUNDING + widgetOffset].type = WindowWidgetType::Empty;
         w->widgets[WIDX_RESEARCH_FUNDING_DROPDOWN_BUTTON + widgetOffset].type = WindowWidgetType::Empty;
@@ -579,7 +582,7 @@ void WindowResearchFundingPrepareDraw(WindowBase* w, WidgetIndex baseWidgetIndex
 
 void WindowResearchFundingDraw(WindowBase* w, DrawPixelInfo& dpi)
 {
-    if (gParkFlags & PARK_FLAGS_NO_MONEY)
+    if (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
         return;
 
     int32_t currentResearchLevel = gResearchFundingLevel;

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1270,7 +1270,7 @@ private:
         }
 
         if (rtd.HasFlag(RIDE_TYPE_FLAG_IS_CASH_MACHINE) || rtd.HasFlag(RIDE_TYPE_FLAG_IS_FIRST_AID)
-            || (gParkFlags & PARK_FLAGS_NO_MONEY) != 0)
+            || (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY) != 0)
             disabledTabs |= (1uLL << WIDX_TAB_9); // 0x1000
 
         if ((gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER) != 0)

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -18,6 +18,7 @@
 #include <openrct2/Cheats.h>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/Input.h>
 #include <openrct2/actions/MazeSetTrackAction.h>
 #include <openrct2/actions/RideDemolishAction.h>
@@ -46,6 +47,9 @@
 #include <openrct2/world/Footpath.h>
 #include <openrct2/world/Park.h>
 
+using namespace OpenRCT2;
+using namespace OpenRCT2::TrackMetaData;
+
 static constexpr StringId WINDOW_TITLE = STR_RIDE_CONSTRUCTION_WINDOW_TITLE;
 static constexpr int32_t WH = 394;
 static constexpr int32_t WW = 210;
@@ -53,8 +57,6 @@ static constexpr int32_t WW = 210;
 static constexpr uint16_t ARROW_PULSE_DURATION = 200;
 // Width of the group boxes, e.g. “Banking”
 static constexpr int32_t GW = WW - 6;
-
-using namespace OpenRCT2::TrackMetaData;
 
 #pragma region Widgets
 
@@ -1551,7 +1553,7 @@ public:
             DrawTextBasic(dpi, screenCoords, STR_BUILD_THIS, {}, { TextAlignment::CENTRE });
 
         screenCoords.y += 11;
-        if (_currentTrackPrice != MONEY64_UNDEFINED && !(gParkFlags & PARK_FLAGS_NO_MONEY))
+        if (_currentTrackPrice != MONEY64_UNDEFINED && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
         {
             auto ft = Formatter();
             ft.Add<money64>(_currentTrackPrice);

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -15,6 +15,7 @@
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/actions/RideDemolishAction.h>
 #include <openrct2/actions/RideSetStatusAction.h>
 #include <openrct2/config/Config.h>
@@ -27,6 +28,8 @@
 #include <openrct2/util/Util.h>
 #include <openrct2/windows/Intent.h>
 #include <openrct2/world/Park.h>
+
+using namespace OpenRCT2;
 
 static constexpr StringId WINDOW_TITLE = STR_NONE;
 static constexpr int32_t WH = 240;
@@ -297,7 +300,7 @@ public:
             int32_t selectedIndex = -1;
             for (int32_t type = INFORMATION_TYPE_STATUS; type <= lastType; type++)
             {
-                if ((gParkFlags & PARK_FLAGS_NO_MONEY))
+                if ((GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
                 {
                     if (ride_info_type_money_mapping[type])
                     {

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -14,6 +14,7 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
+#include <openrct2/GameState.h>
 #include <openrct2/Input.h>
 #include <openrct2/audio/audio.h>
 #include <openrct2/core/Guard.hpp>
@@ -781,7 +782,7 @@ public:
         }
 
         auto [name, price] = GetNameAndPrice(selectedSceneryEntry);
-        if (price != MONEY64_UNDEFINED && !(gParkFlags & PARK_FLAGS_NO_MONEY))
+        if (price != MONEY64_UNDEFINED && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
         {
             auto ft = Formatter();
             ft.Add<money64>(price);

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -15,6 +15,7 @@
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/Input.h>
 #include <openrct2/actions/PeepPickupAction.h>
 #include <openrct2/actions/StaffSetCostumeAction.h>
@@ -33,6 +34,8 @@
 #include <openrct2/windows/Intent.h>
 #include <openrct2/world/Footpath.h>
 #include <openrct2/world/Park.h>
+
+using namespace OpenRCT2;
 
 static constexpr StringId WINDOW_TITLE = STR_STRINGID;
 
@@ -927,7 +930,7 @@ private:
 
         auto screenCoords = windowPos + ScreenCoordsXY{ widgets[WIDX_RESIZE].left + 4, widgets[WIDX_RESIZE].top + 4 };
 
-        if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
+        if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
         {
             auto ft = Formatter();
             ft.Add<money64>(GetStaffWage(staff->AssignedStaffType));

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -14,6 +14,7 @@
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/Input.h>
 #include <openrct2/actions/PeepPickupAction.h>
 #include <openrct2/actions/StaffFireAction.h>
@@ -34,6 +35,8 @@
 #include <openrct2/world/Footpath.h>
 #include <openrct2/world/Park.h>
 #include <vector>
+
+using namespace OpenRCT2;
 
 enum
 {
@@ -286,7 +289,7 @@ public:
         DrawWidgets(dpi);
         DrawTabImages(dpi);
 
-        if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
+        if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
         {
             auto ft = Formatter();
             ft.Add<money64>(GetStaffWage(GetSelectedStaffType()));

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -23,6 +23,7 @@
 #include <openrct2/Context.h>
 #include <openrct2/Editor.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/Input.h>
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/ParkImporter.h>
@@ -3033,7 +3034,7 @@ public:
             widgets[WIDX_PAUSE].type = WindowWidgetType::Empty;
         }
 
-        if ((gParkFlags & PARK_FLAGS_NO_MONEY) || !gConfigInterface.ToolbarShowFinances)
+        if ((GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY) || !gConfigInterface.ToolbarShowFinances)
             widgets[WIDX_FINANCES].type = WindowWidgetType::Empty;
 
         if (gScreenFlags & SCREEN_FLAGS_EDITOR)

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -14,6 +14,7 @@
 #include <openrct2/Cheats.h>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/Input.h>
 #include <openrct2/actions/TrackDesignAction.h>
 #include <openrct2/audio/audio.h>
@@ -304,7 +305,7 @@ public:
         }
 
         // Price
-        if (_placementCost != MONEY64_UNDEFINED && !(gParkFlags & PARK_FLAGS_NO_MONEY))
+        if (_placementCost != MONEY64_UNDEFINED && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
         {
             ft = Formatter();
             ft.Add<money64>(_placementCost);

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -12,10 +12,13 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
+#include <openrct2/GameState.h>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/world/Park.h>
+
+using namespace OpenRCT2;
 
 static constexpr StringId WINDOW_TITLE = STR_WATER;
 static constexpr int32_t WH = 77;
@@ -152,7 +155,7 @@ public:
             DrawTextBasic(dpi, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, ft, { TextAlignment::CENTRE });
         }
 
-        if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
+        if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
         {
             // Draw raise cost amount
             screenCoords = { widgets[WIDX_PREVIEW].midX() + windowPos.x, widgets[WIDX_PREVIEW].bottom + windowPos.y + 5 };

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -109,7 +109,7 @@ namespace Editor
         OpenRCT2::GetContext()->GetGameState()->InitAll(DEFAULT_MAP_SIZE);
         gScreenFlags = SCREEN_FLAGS_SCENARIO_EDITOR;
         gEditorStep = EditorStep::ObjectSelection;
-        gParkFlags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
+        GetGameState().ParkFlags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
         gScenarioCategory = SCENARIO_CATEGORY_OTHER;
         ViewportInitAll();
         WindowBase* mainWindow = OpenEditorWindows();
@@ -323,22 +323,22 @@ namespace Editor
         gGuestChangeModifier = 0;
         if (fromSave)
         {
-            gParkFlags |= PARK_FLAGS_NO_MONEY;
+            gameState.ParkFlags |= PARK_FLAGS_NO_MONEY;
 
             if (gParkEntranceFee == 0)
             {
-                gParkFlags |= PARK_FLAGS_PARK_FREE_ENTRY;
+                gameState.ParkFlags |= PARK_FLAGS_PARK_FREE_ENTRY;
             }
             else
             {
-                gParkFlags &= ~PARK_FLAGS_PARK_FREE_ENTRY;
+                gameState.ParkFlags &= ~PARK_FLAGS_PARK_FREE_ENTRY;
             }
 
-            gParkFlags &= ~PARK_FLAGS_SPRITES_INITIALISED;
+            gameState.ParkFlags &= ~PARK_FLAGS_SPRITES_INITIALISED;
 
             gGuestInitialCash = std::clamp(gGuestInitialCash, 10.00_GBP, MAX_ENTRANCE_FEE);
 
-            GetGameState().InitialCash = std::min<money64>(GetGameState().InitialCash, 100000);
+            gameState.InitialCash = std::min<money64>(GetGameState().InitialCash, 100000);
             FinanceResetCashToInitial();
 
             gBankLoan = std::clamp<money64>(gBankLoan, 0.00_GBP, 5000000.00_GBP);

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -25,6 +25,7 @@ namespace OpenRCT2
     struct GameState_t
     {
         uint32_t CurrentTicks{};
+        uint64_t ParkFlags;
         ClimateType Climate;
         ClimateState ClimateNext;
         money64 Cash;

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -547,14 +547,16 @@ void CheatSetAction::Set10MinuteInspection() const
 
 void CheatSetAction::SetScenarioNoMoney(bool enabled) const
 {
+    auto& gameState = GetGameState();
     if (enabled)
     {
-        gParkFlags |= PARK_FLAGS_NO_MONEY;
+        gameState.ParkFlags |= PARK_FLAGS_NO_MONEY;
     }
     else
     {
-        gParkFlags &= ~PARK_FLAGS_NO_MONEY;
+        gameState.ParkFlags &= ~PARK_FLAGS_NO_MONEY;
     }
+
     // Invalidate all windows that have anything to do with finance
     WindowInvalidateByClass(WindowClass::Ride);
     WindowInvalidateByClass(WindowClass::Peep);

--- a/src/openrct2/actions/LandSetHeightAction.cpp
+++ b/src/openrct2/actions/LandSetHeightAction.cpp
@@ -10,6 +10,7 @@
 #include "LandSetHeightAction.h"
 
 #include "../Context.h"
+#include "../GameState.h"
 #include "../OpenRCT2.h"
 #include "../interface/Window.h"
 #include "../localisation/Localisation.h"
@@ -54,7 +55,8 @@ void LandSetHeightAction::Serialise(DataSerialiser& stream)
 
 GameActions::Result LandSetHeightAction::Query() const
 {
-    if (gParkFlags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES)
+    auto& gameState = GetGameState();
+    if (gameState.ParkFlags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES)
     {
         return GameActions::Result(GameActions::Status::Disallowed, STR_FORBIDDEN_BY_THE_LOCAL_AUTHORITY, STR_NONE);
     }
@@ -76,7 +78,7 @@ GameActions::Result LandSetHeightAction::Query() const
     money64 sceneryRemovalCost = 0;
     if (!gCheatsDisableClearanceChecks)
     {
-        if (gParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL)
+        if (gameState.ParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL)
         {
             // Check for obstructing large trees
             TileElement* tileElement = CheckTreeObstructions();

--- a/src/openrct2/actions/LargeSceneryRemoveAction.cpp
+++ b/src/openrct2/actions/LargeSceneryRemoveAction.cpp
@@ -10,6 +10,7 @@
 #include "LargeSceneryRemoveAction.h"
 
 #include "../Cheats.h"
+#include "../GameState.h"
 #include "../OpenRCT2.h"
 #include "../common.h"
 #include "../core/MemoryStream.h"
@@ -93,7 +94,7 @@ GameActions::Result LargeSceneryRemoveAction::Query() const
 
         if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && !gCheatsSandboxMode)
         {
-            if (gParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL)
+            if (GetGameState().ParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL)
             {
                 if (sceneryEntry->HasFlag(LARGE_SCENERY_FLAG_IS_TREE))
                 {

--- a/src/openrct2/actions/ParkMarketingAction.cpp
+++ b/src/openrct2/actions/ParkMarketingAction.cpp
@@ -10,6 +10,7 @@
 #include "ParkMarketingAction.h"
 
 #include "../Context.h"
+#include "../GameState.h"
 #include "../core/MemoryStream.h"
 #include "../localisation/StringIds.h"
 #include "../management/Finance.h"
@@ -20,6 +21,8 @@
 #include "../world/Park.h"
 
 #include <iterator>
+
+using namespace OpenRCT2;
 
 ParkMarketingAction::ParkMarketingAction(int32_t type, int32_t item, int32_t numWeeks)
     : _type(type)
@@ -52,7 +55,7 @@ GameActions::Result ParkMarketingAction::Query() const
     {
         return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_START_MARKETING_CAMPAIGN, STR_NONE);
     }
-    if (gParkFlags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN)
+    if (GetGameState().ParkFlags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN)
     {
         return GameActions::Result(
             GameActions::Status::Disallowed, STR_CANT_START_MARKETING_CAMPAIGN,

--- a/src/openrct2/actions/ParkSetEntranceFeeAction.cpp
+++ b/src/openrct2/actions/ParkSetEntranceFeeAction.cpp
@@ -10,10 +10,13 @@
 #include "ParkSetEntranceFeeAction.h"
 
 #include "../Cheats.h"
+#include "../GameState.h"
 #include "../core/MemoryStream.h"
 #include "../interface/Window.h"
 #include "../localisation/StringIds.h"
 #include "../world/Park.h"
+
+using namespace OpenRCT2;
 
 ParkSetEntranceFeeAction::ParkSetEntranceFeeAction(money64 fee)
     : _fee(fee)
@@ -39,7 +42,7 @@ void ParkSetEntranceFeeAction::Serialise(DataSerialiser& stream)
 
 GameActions::Result ParkSetEntranceFeeAction::Query() const
 {
-    bool noMoney = (gParkFlags & PARK_FLAGS_NO_MONEY) != 0;
+    bool noMoney = (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY) != 0;
     bool forceFreeEntry = !ParkEntranceFeeUnlocked();
     if (noMoney || forceFreeEntry)
     {

--- a/src/openrct2/actions/ParkSetParameterAction.cpp
+++ b/src/openrct2/actions/ParkSetParameterAction.cpp
@@ -9,10 +9,13 @@
 
 #include "ParkSetParameterAction.h"
 
+#include "../GameState.h"
 #include "../interface/Window.h"
 #include "../ride/ShopItem.h"
 #include "../util/Util.h"
 #include "../world/Park.h"
+
+using namespace OpenRCT2;
 
 ParkSetParameterAction::ParkSetParameterAction(ParkParameter parameter, uint64_t value)
     : _parameter(parameter)
@@ -51,19 +54,20 @@ GameActions::Result ParkSetParameterAction::Query() const
 
 GameActions::Result ParkSetParameterAction::Execute() const
 {
+    auto& gameState = GetGameState();
     switch (_parameter)
     {
         case ParkParameter::Close:
-            if (gParkFlags & PARK_FLAGS_PARK_OPEN)
+            if (gameState.ParkFlags & PARK_FLAGS_PARK_OPEN)
             {
-                gParkFlags &= ~PARK_FLAGS_PARK_OPEN;
+                gameState.ParkFlags &= ~PARK_FLAGS_PARK_OPEN;
                 WindowInvalidateByClass(WindowClass::ParkInformation);
             }
             break;
         case ParkParameter::Open:
-            if (!(gParkFlags & PARK_FLAGS_PARK_OPEN))
+            if (!(gameState.ParkFlags & PARK_FLAGS_PARK_OPEN))
             {
-                gParkFlags |= PARK_FLAGS_PARK_OPEN;
+                gameState.ParkFlags |= PARK_FLAGS_PARK_OPEN;
                 WindowInvalidateByClass(WindowClass::ParkInformation);
             }
             break;

--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -11,6 +11,7 @@
 
 #include "../Cheats.h"
 #include "../Context.h"
+#include "../GameState.h"
 #include "../core/Memory.hpp"
 #include "../core/MemoryStream.h"
 #include "../interface/Window.h"
@@ -26,6 +27,8 @@
 #include "../world/Park.h"
 
 #include <algorithm>
+
+using namespace OpenRCT2;
 
 RideCreateAction::RideCreateAction(
     int32_t rideType, ObjectEntryIndex subType, int32_t colour1, int32_t colour2, ObjectEntryIndex entranceObjectIndex)
@@ -207,7 +210,7 @@ GameActions::Result RideCreateAction::Execute() const
         price = 0;
     }
 
-    if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
+    if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
     {
         for (auto i = 0; i < RCT2::ObjectLimits::MaxShopItemsPerRideEntry; i++)
         {

--- a/src/openrct2/actions/ScenarioSetSettingAction.cpp
+++ b/src/openrct2/actions/ScenarioSetSettingAction.cpp
@@ -56,22 +56,22 @@ GameActions::Result ScenarioSetSettingAction::Execute() const
             {
                 if (_value != 0)
                 {
-                    gParkFlags |= PARK_FLAGS_NO_MONEY;
+                    gameState.ParkFlags |= PARK_FLAGS_NO_MONEY;
                 }
                 else
                 {
-                    gParkFlags &= ~PARK_FLAGS_NO_MONEY;
+                    gameState.ParkFlags &= ~PARK_FLAGS_NO_MONEY;
                 }
             }
             else
             {
                 if (_value != 0)
                 {
-                    gParkFlags |= PARK_FLAGS_NO_MONEY;
+                    gameState.ParkFlags |= PARK_FLAGS_NO_MONEY;
                 }
                 else
                 {
-                    gParkFlags &= ~PARK_FLAGS_NO_MONEY;
+                    gameState.ParkFlags &= ~PARK_FLAGS_NO_MONEY;
                 }
                 // Invalidate all windows that have anything to do with finance
                 WindowInvalidateByClass(WindowClass::Ride);
@@ -105,11 +105,11 @@ GameActions::Result ScenarioSetSettingAction::Execute() const
         case ScenarioSetSetting::ForbidMarketingCampaigns:
             if (_value != 0)
             {
-                gParkFlags |= PARK_FLAGS_FORBID_MARKETING_CAMPAIGN;
+                gameState.ParkFlags |= PARK_FLAGS_FORBID_MARKETING_CAMPAIGN;
             }
             else
             {
-                gParkFlags &= ~PARK_FLAGS_FORBID_MARKETING_CAMPAIGN;
+                gameState.ParkFlags &= ~PARK_FLAGS_FORBID_MARKETING_CAMPAIGN;
             }
             break;
         case ScenarioSetSetting::AverageCashPerGuest:
@@ -127,21 +127,21 @@ GameActions::Result ScenarioSetSettingAction::Execute() const
         case ScenarioSetSetting::GuestsPreferLessIntenseRides:
             if (_value != 0)
             {
-                gParkFlags |= PARK_FLAGS_PREF_LESS_INTENSE_RIDES;
+                gameState.ParkFlags |= PARK_FLAGS_PREF_LESS_INTENSE_RIDES;
             }
             else
             {
-                gParkFlags &= ~PARK_FLAGS_PREF_LESS_INTENSE_RIDES;
+                gameState.ParkFlags &= ~PARK_FLAGS_PREF_LESS_INTENSE_RIDES;
             }
             break;
         case ScenarioSetSetting::GuestsPreferMoreIntenseRides:
             if (_value != 0)
             {
-                gParkFlags |= PARK_FLAGS_PREF_MORE_INTENSE_RIDES;
+                gameState.ParkFlags |= PARK_FLAGS_PREF_MORE_INTENSE_RIDES;
             }
             else
             {
-                gParkFlags &= ~PARK_FLAGS_PREF_MORE_INTENSE_RIDES;
+                gameState.ParkFlags &= ~PARK_FLAGS_PREF_MORE_INTENSE_RIDES;
             }
             break;
         case ScenarioSetSetting::CostToBuyLand:
@@ -155,20 +155,20 @@ GameActions::Result ScenarioSetSettingAction::Execute() const
             {
                 if (_value == 0)
                 {
-                    gParkFlags |= PARK_FLAGS_PARK_FREE_ENTRY;
-                    gParkFlags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
+                    gameState.ParkFlags |= PARK_FLAGS_PARK_FREE_ENTRY;
+                    gameState.ParkFlags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
                     gParkEntranceFee = 0.00_GBP;
                 }
                 else if (_value == 1)
                 {
-                    gParkFlags &= ~PARK_FLAGS_PARK_FREE_ENTRY;
-                    gParkFlags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
+                    gameState.ParkFlags &= ~PARK_FLAGS_PARK_FREE_ENTRY;
+                    gameState.ParkFlags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
                     gParkEntranceFee = 10.00_GBP;
                 }
                 else
                 {
-                    gParkFlags |= PARK_FLAGS_PARK_FREE_ENTRY;
-                    gParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
+                    gameState.ParkFlags |= PARK_FLAGS_PARK_FREE_ENTRY;
+                    gameState.ParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
                     gParkEntranceFee = 10.00_GBP;
                 }
             }
@@ -176,18 +176,18 @@ GameActions::Result ScenarioSetSettingAction::Execute() const
             {
                 if (_value == 0)
                 {
-                    gParkFlags |= PARK_FLAGS_PARK_FREE_ENTRY;
-                    gParkFlags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
+                    gameState.ParkFlags |= PARK_FLAGS_PARK_FREE_ENTRY;
+                    gameState.ParkFlags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
                 }
                 else if (_value == 1)
                 {
-                    gParkFlags &= ~PARK_FLAGS_PARK_FREE_ENTRY;
-                    gParkFlags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
+                    gameState.ParkFlags &= ~PARK_FLAGS_PARK_FREE_ENTRY;
+                    gameState.ParkFlags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
                 }
                 else
                 {
-                    gParkFlags |= PARK_FLAGS_PARK_FREE_ENTRY;
-                    gParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
+                    gameState.ParkFlags |= PARK_FLAGS_PARK_FREE_ENTRY;
+                    gameState.ParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
                 }
                 WindowInvalidateByClass(WindowClass::ParkInformation);
                 WindowInvalidateByClass(WindowClass::Ride);
@@ -200,51 +200,51 @@ GameActions::Result ScenarioSetSettingAction::Execute() const
         case ScenarioSetSetting::ForbidTreeRemoval:
             if (_value != 0)
             {
-                gParkFlags |= PARK_FLAGS_FORBID_TREE_REMOVAL;
+                gameState.ParkFlags |= PARK_FLAGS_FORBID_TREE_REMOVAL;
             }
             else
             {
-                gParkFlags &= ~PARK_FLAGS_FORBID_TREE_REMOVAL;
+                gameState.ParkFlags &= ~PARK_FLAGS_FORBID_TREE_REMOVAL;
             }
             break;
         case ScenarioSetSetting::ForbidLandscapeChanges:
             if (_value != 0)
             {
-                gParkFlags |= PARK_FLAGS_FORBID_LANDSCAPE_CHANGES;
+                gameState.ParkFlags |= PARK_FLAGS_FORBID_LANDSCAPE_CHANGES;
             }
             else
             {
-                gParkFlags &= ~PARK_FLAGS_FORBID_LANDSCAPE_CHANGES;
+                gameState.ParkFlags &= ~PARK_FLAGS_FORBID_LANDSCAPE_CHANGES;
             }
             break;
         case ScenarioSetSetting::ForbidHighConstruction:
             if (_value != 0)
             {
-                gParkFlags |= PARK_FLAGS_FORBID_HIGH_CONSTRUCTION;
+                gameState.ParkFlags |= PARK_FLAGS_FORBID_HIGH_CONSTRUCTION;
             }
             else
             {
-                gParkFlags &= ~PARK_FLAGS_FORBID_HIGH_CONSTRUCTION;
+                gameState.ParkFlags &= ~PARK_FLAGS_FORBID_HIGH_CONSTRUCTION;
             }
             break;
         case ScenarioSetSetting::ParkRatingHigherDifficultyLevel:
             if (_value != 0)
             {
-                gParkFlags |= PARK_FLAGS_DIFFICULT_PARK_RATING;
+                gameState.ParkFlags |= PARK_FLAGS_DIFFICULT_PARK_RATING;
             }
             else
             {
-                gParkFlags &= ~PARK_FLAGS_DIFFICULT_PARK_RATING;
+                gameState.ParkFlags &= ~PARK_FLAGS_DIFFICULT_PARK_RATING;
             }
             break;
         case ScenarioSetSetting::GuestGenerationHigherDifficultyLevel:
             if (_value != 0)
             {
-                gParkFlags |= PARK_FLAGS_DIFFICULT_GUEST_GENERATION;
+                gameState.ParkFlags |= PARK_FLAGS_DIFFICULT_GUEST_GENERATION;
             }
             else
             {
-                gParkFlags &= ~PARK_FLAGS_DIFFICULT_GUEST_GENERATION;
+                gameState.ParkFlags &= ~PARK_FLAGS_DIFFICULT_GUEST_GENERATION;
             }
             break;
         case ScenarioSetSetting::AllowEarlyCompletion:
@@ -254,11 +254,11 @@ GameActions::Result ScenarioSetSettingAction::Execute() const
         {
             if (_value != 0)
             {
-                gParkFlags |= PARK_FLAGS_RCT1_INTEREST;
+                gameState.ParkFlags |= PARK_FLAGS_RCT1_INTEREST;
             }
             else
             {
-                gParkFlags &= ~PARK_FLAGS_RCT1_INTEREST;
+                gameState.ParkFlags &= ~PARK_FLAGS_RCT1_INTEREST;
             }
             break;
         }

--- a/src/openrct2/actions/SmallSceneryRemoveAction.cpp
+++ b/src/openrct2/actions/SmallSceneryRemoveAction.cpp
@@ -10,6 +10,7 @@
 #include "SmallSceneryRemoveAction.h"
 
 #include "../Cheats.h"
+#include "../GameState.h"
 #include "../OpenRCT2.h"
 #include "../common.h"
 #include "../core/MemoryStream.h"
@@ -76,7 +77,7 @@ GameActions::Result SmallSceneryRemoveAction::Query() const
     if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && !(GetFlags() & GAME_COMMAND_FLAG_GHOST) && !gCheatsSandboxMode)
     {
         // Check if allowed to remove item
-        if (gParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL)
+        if (GetGameState().ParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL)
         {
             if (entry->HasFlag(SMALL_SCENERY_FLAG_IS_TREE))
             {

--- a/src/openrct2/actions/SurfaceSetStyleAction.cpp
+++ b/src/openrct2/actions/SurfaceSetStyleAction.cpp
@@ -10,6 +10,7 @@
 #include "SurfaceSetStyleAction.h"
 
 #include "../Context.h"
+#include "../GameState.h"
 #include "../OpenRCT2.h"
 #include "../management/Finance.h"
 #include "../object/ObjectManager.h"
@@ -18,6 +19,8 @@
 #include "../world/Park.h"
 #include "../world/Surface.h"
 #include "../world/TileElement.h"
+
+using namespace OpenRCT2;
 
 SurfaceSetStyleAction::SurfaceSetStyleAction(MapRange range, ObjectEntryIndex surfaceStyle, ObjectEntryIndex edgeStyle)
     : _range(range)
@@ -83,7 +86,7 @@ GameActions::Result SurfaceSetStyleAction::Query() const
 
     // Do nothing if not in editor, sandbox mode or landscaping is forbidden
     if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && !gCheatsSandboxMode
-        && (gParkFlags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES))
+        && (GetGameState().ParkFlags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES))
     {
         return GameActions::Result(
             GameActions::Status::Disallowed, STR_CANT_CHANGE_LAND_TYPE, STR_FORBIDDEN_BY_THE_LOCAL_AUTHORITY);

--- a/src/openrct2/actions/WaterSetHeightAction.cpp
+++ b/src/openrct2/actions/WaterSetHeightAction.cpp
@@ -9,11 +9,14 @@
 
 #include "WaterSetHeightAction.h"
 
+#include "../GameState.h"
 #include "../OpenRCT2.h"
 #include "../management/Finance.h"
 #include "../world/ConstructionClearance.h"
 #include "../world/Park.h"
 #include "../world/Surface.h"
+
+using namespace OpenRCT2;
 
 WaterSetHeightAction::WaterSetHeightAction(const CoordsXY& coords, uint8_t height)
     : _coords(coords)
@@ -46,7 +49,7 @@ GameActions::Result WaterSetHeightAction::Query() const
     res.Position = { _coords, _height * COORDS_Z_STEP };
 
     if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && !gCheatsSandboxMode
-        && gParkFlags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES)
+        && GetGameState().ParkFlags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES)
     {
         return GameActions::Result(GameActions::Status::Disallowed, STR_NONE, STR_FORBIDDEN_BY_THE_LOCAL_AUTHORITY);
     }

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -63,6 +63,7 @@
 #include <memory>
 #include <optional>
 
+using namespace OpenRCT2;
 using namespace OpenRCT2::Audio;
 
 uint8_t gGuestChangeModifier;
@@ -1577,7 +1578,7 @@ void Peep::FormatNameTo(Formatter& ft) const
             ft.Add<StringId>(_staffNames[staffNameIndex]);
             ft.Add<uint32_t>(PeepId);
         }
-        else if (gParkFlags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES)
+        else if (GetGameState().ParkFlags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES)
         {
             auto realNameStringId = GetRealNameStringIDFromPeepID(PeepId);
             ft.Add<StringId>(realNameStringId);
@@ -1597,7 +1598,7 @@ std::string Peep::GetName() const
 {
     Formatter ft;
     FormatNameTo(ft);
-    return FormatStringID(STR_STRINGID, ft.Data());
+    return ::FormatStringID(STR_STRINGID, ft.Data());
 }
 
 bool Peep::SetName(std::string_view value)
@@ -1824,6 +1825,7 @@ static bool PeepInteractWithEntrance(Peep* peep, const CoordsXYE& coords, uint8_
             return true;
         }
 
+        auto& gameState = GetGameState();
         uint8_t entranceDirection = tile_element->GetDirection();
         if (entranceDirection != guest->PeepDirection)
         {
@@ -1843,7 +1845,7 @@ static bool PeepInteractWithEntrance(Peep* peep, const CoordsXYE& coords, uint8_
             if (!(guest->PeepFlags & PEEP_FLAGS_LEAVING_PARK))
             {
                 // If the park is open and leaving flag isn't set return to centre
-                if (gParkFlags & PARK_FLAGS_PARK_OPEN)
+                if (gameState.ParkFlags & PARK_FLAGS_PARK_OPEN)
                 {
                     PeepReturnToCentreOfTile(guest);
                     return true;
@@ -1876,7 +1878,7 @@ static bool PeepInteractWithEntrance(Peep* peep, const CoordsXYE& coords, uint8_
             return true;
         }
 
-        if (!(gParkFlags & PARK_FLAGS_PARK_OPEN))
+        if (!(gameState.ParkFlags & PARK_FLAGS_PARK_OPEN))
         {
             guest->State = PeepState::LeavingPark;
             guest->Var37 = 1;
@@ -2324,7 +2326,7 @@ static bool PeepInteractWithShop(Peep* peep, const CoordsXYE& coords)
         }
 
         auto cost = ride->price[0];
-        if (cost != 0 && !(gParkFlags & PARK_FLAGS_NO_MONEY))
+        if (cost != 0 && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
         {
             ride->total_profit += cost;
             ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_INCOME;
@@ -2589,7 +2591,7 @@ int32_t PeepCompare(const EntityId sprite_index_a, const EntityId sprite_index_b
 
     if (peep_a->Name == nullptr && peep_b->Name == nullptr)
     {
-        if (gParkFlags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES)
+        if (GetGameState().ParkFlags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES)
         {
             // Potentially could find a more optional way of sorting dynamic real names
         }
@@ -2619,14 +2621,15 @@ int32_t PeepCompare(const EntityId sprite_index_a, const EntityId sprite_index_b
  */
 void PeepUpdateNames(bool realNames)
 {
+    auto& gameState = GetGameState();
     if (realNames)
     {
-        gParkFlags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
+        gameState.ParkFlags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
         // Peep names are now dynamic
     }
     else
     {
-        gParkFlags &= ~PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
+        gameState.ParkFlags &= ~PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
         // Peep names are now dynamic
     }
 

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -569,11 +569,11 @@ static int32_t ConsoleCommandGet(InteractiveConsole& console, const arguments_t&
         }
         else if (argv[0] == "money")
         {
-            console.WriteFormatLine("money %d.%d0", GetGameState().Cash / 10, GetGameState().Cash % 10);
+            console.WriteFormatLine("money %d.%d0", gameState.Cash / 10, gameState.Cash % 10);
         }
         else if (argv[0] == "scenario_initial_cash")
         {
-            console.WriteFormatLine("scenario_initial_cash %d", GetGameState().InitialCash / 10);
+            console.WriteFormatLine("scenario_initial_cash %d", gameState.InitialCash / 10);
         }
         else if (argv[0] == "current_loan")
         {
@@ -616,48 +616,52 @@ static int32_t ConsoleCommandGet(InteractiveConsole& console, const arguments_t&
         else if (argv[0] == "guest_prefer_less_intense_rides")
         {
             console.WriteFormatLine(
-                "guest_prefer_less_intense_rides %d", (gParkFlags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES) != 0);
+                "guest_prefer_less_intense_rides %d", (gameState.ParkFlags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES) != 0);
         }
         else if (argv[0] == "guest_prefer_more_intense_rides")
         {
             console.WriteFormatLine(
-                "guest_prefer_more_intense_rides %d", (gParkFlags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES) != 0);
+                "guest_prefer_more_intense_rides %d", (gameState.ParkFlags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES) != 0);
         }
         else if (argv[0] == "forbid_marketing_campaigns")
         {
-            console.WriteFormatLine("forbid_marketing_campaigns %d", (gParkFlags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN) != 0);
+            console.WriteFormatLine(
+                "forbid_marketing_campaigns %d", (gameState.ParkFlags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN) != 0);
         }
         else if (argv[0] == "forbid_landscape_changes")
         {
-            console.WriteFormatLine("forbid_landscape_changes %d", (gParkFlags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES) != 0);
+            console.WriteFormatLine(
+                "forbid_landscape_changes %d", (gameState.ParkFlags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES) != 0);
         }
         else if (argv[0] == "forbid_tree_removal")
         {
-            console.WriteFormatLine("forbid_tree_removal %d", (gParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL) != 0);
+            console.WriteFormatLine("forbid_tree_removal %d", (gameState.ParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL) != 0);
         }
         else if (argv[0] == "forbid_high_construction")
         {
-            console.WriteFormatLine("forbid_high_construction %d", (gParkFlags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION) != 0);
+            console.WriteFormatLine(
+                "forbid_high_construction %d", (gameState.ParkFlags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION) != 0);
         }
         else if (argv[0] == "pay_for_rides")
         {
-            console.WriteFormatLine("pay_for_rides %d", (gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY) != 0);
+            console.WriteFormatLine("pay_for_rides %d", (gameState.ParkFlags & PARK_FLAGS_PARK_FREE_ENTRY) != 0);
         }
         else if (argv[0] == "no_money")
         {
-            console.WriteFormatLine("no_money %d", (gParkFlags & PARK_FLAGS_NO_MONEY) != 0);
+            console.WriteFormatLine("no_money %d", (gameState.ParkFlags & PARK_FLAGS_NO_MONEY) != 0);
         }
         else if (argv[0] == "difficult_park_rating")
         {
-            console.WriteFormatLine("difficult_park_rating %d", (gParkFlags & PARK_FLAGS_DIFFICULT_PARK_RATING) != 0);
+            console.WriteFormatLine("difficult_park_rating %d", (gameState.ParkFlags & PARK_FLAGS_DIFFICULT_PARK_RATING) != 0);
         }
         else if (argv[0] == "difficult_guest_generation")
         {
-            console.WriteFormatLine("difficult_guest_generation %d", (gParkFlags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION) != 0);
+            console.WriteFormatLine(
+                "difficult_guest_generation %d", (gameState.ParkFlags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION) != 0);
         }
         else if (argv[0] == "park_open")
         {
-            console.WriteFormatLine("park_open %d", (gParkFlags & PARK_FLAGS_PARK_OPEN) != 0);
+            console.WriteFormatLine("park_open %d", (gameState.ParkFlags & PARK_FLAGS_PARK_OPEN) != 0);
         }
         else if (argv[0] == "land_rights_cost")
         {
@@ -770,10 +774,11 @@ static int32_t ConsoleCommandSet(InteractiveConsole& console, const arguments_t&
             }
         }
 
+        auto& gameState = GetGameState();
         if (argv[0] == "money" && InvalidArguments(&invalidArgs, double_valid[0]))
         {
             money64 money = ToMoney64FromGBP(double_val[0]);
-            if (GetGameState().Cash != money)
+            if (gameState.Cash != money)
             {
                 auto cheatSetAction = CheatSetAction(CheatType::SetMoney, money);
                 cheatSetAction.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
@@ -943,7 +948,7 @@ static int32_t ConsoleCommandSet(InteractiveConsole& console, const arguments_t&
         }
         else if (argv[0] == "pay_for_rides" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
-            SET_FLAG(gParkFlags, PARK_FLAGS_PARK_FREE_ENTRY, int_val[0]);
+            SET_FLAG(gameState.ParkFlags, PARK_FLAGS_PARK_FREE_ENTRY, int_val[0]);
             console.Execute("get pay_for_rides");
         }
         else if (argv[0] == "no_money" && InvalidArguments(&invalidArgs, int_valid[0]))

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -9,6 +9,7 @@
 
 #include "Award.h"
 
+#include "../GameState.h"
 #include "../config/Config.h"
 #include "../entity/Guest.h"
 #include "../interface/Window.h"
@@ -22,6 +23,8 @@
 #include "NewsItem.h"
 
 #include <algorithm>
+
+using namespace OpenRCT2;
 
 constexpr uint8_t NEGATIVE = 0;
 constexpr uint8_t POSITIVE = 1;
@@ -178,7 +181,7 @@ static bool AwardIsDeservedBestValue(int32_t activeAwardTypes)
     if (activeAwardTypes & EnumToFlag(AwardType::MostDisappointing))
         return false;
 
-    if ((gParkFlags & PARK_FLAGS_NO_MONEY) || !ParkEntranceFeeUnlocked())
+    if ((GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY) || !ParkEntranceFeeUnlocked())
         return false;
 
     if (gTotalRideValueForMoney < 10.00_GBP)
@@ -228,7 +231,7 @@ static bool AwardIsDeservedWorstValue(int32_t activeAwardTypes)
 {
     if (activeAwardTypes & EnumToFlag(AwardType::BestValue))
         return false;
-    if (gParkFlags & PARK_FLAGS_NO_MONEY)
+    if (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
         return false;
 
     const auto parkEntranceFee = ParkGetEntranceFee();
@@ -621,7 +624,7 @@ void AwardUpdateAll()
     }
 
     // Only add new awards if park is open
-    if (gParkFlags & PARK_FLAGS_PARK_OPEN)
+    if (GetGameState().ParkFlags & PARK_FLAGS_PARK_OPEN)
     {
         // Set active award types as flags
         int32_t activeAwardTypes = 0;

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -58,7 +58,7 @@ money64 gExpenditureTable[EXPENDITURE_TABLE_MONTH_COUNT][static_cast<int32_t>(Ex
  */
 bool FinanceCheckMoneyRequired(uint32_t flags)
 {
-    if (gParkFlags & PARK_FLAGS_NO_MONEY)
+    if (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
         return false;
     if (gScreenFlags & SCREEN_FLAGS_EDITOR)
         return false;
@@ -88,7 +88,8 @@ bool FinanceCheckAffordability(money64 cost, uint32_t flags)
 void FinancePayment(money64 amount, ExpenditureType type)
 {
     // overflow check
-    GetGameState().Cash = AddClamp_money64(GetGameState().Cash, -amount);
+    auto& gameState = GetGameState();
+    gameState.Cash = AddClamp_money64(gameState.Cash, -amount);
 
     gExpenditureTable[0][static_cast<int32_t>(type)] -= amount;
     if (dword_988E60[static_cast<int32_t>(type)] & 1)
@@ -109,7 +110,7 @@ void FinancePayWages()
 {
     PROFILED_FUNCTION();
 
-    if (gParkFlags & PARK_FLAGS_NO_MONEY)
+    if (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
     {
         return;
     }
@@ -126,7 +127,7 @@ void FinancePayWages()
  **/
 void FinancePayResearch()
 {
-    if (gParkFlags & PARK_FLAGS_NO_MONEY)
+    if (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
     {
         return;
     }
@@ -141,7 +142,7 @@ void FinancePayResearch()
  */
 void FinancePayInterest()
 {
-    if (gParkFlags & PARK_FLAGS_NO_MONEY)
+    if (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
     {
         return;
     }
@@ -150,8 +151,9 @@ void FinancePayInterest()
     // that will overflow money64 if the loan is greater than (1 << 31) / (5 * current_interest_rate)
     const money64 current_loan = gBankLoan;
     const auto current_interest_rate = gBankLoanInterestRate;
-    const money64 interest_to_pay = (gParkFlags & PARK_FLAGS_RCT1_INTEREST) ? (current_loan / 2400)
-                                                                            : (current_loan * 5 * current_interest_rate) >> 14;
+    const money64 interest_to_pay = (GetGameState().ParkFlags & PARK_FLAGS_RCT1_INTEREST)
+        ? (current_loan / 2400)
+        : (current_loan * 5 * current_interest_rate) >> 14;
 
     FinancePayment(interest_to_pay, ExpenditureType::Interest);
 }
@@ -171,7 +173,7 @@ void FinancePayRideUpkeep()
             ride.Renew();
         }
 
-        if (ride.status != RideStatus::Closed && !(gParkFlags & PARK_FLAGS_NO_MONEY))
+        if (ride.status != RideStatus::Closed && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
         {
             auto upkeep = ride.upkeep_cost;
             if (upkeep != MONEY64_UNDEFINED)
@@ -257,7 +259,7 @@ void FinanceUpdateDailyProfit()
 
     money64 current_profit = 0;
 
-    if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
+    if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
     {
         // Staff costs
         for (auto peep : EntityList<Staff>())

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -316,12 +316,13 @@ void ResearchUpdate()
         return;
     }
 
-    if (GetGameState().CurrentTicks % 32 != 0)
+    auto& gameState = GetGameState();
+    if (gameState.CurrentTicks % 32 != 0)
     {
         return;
     }
 
-    if ((gParkFlags & PARK_FLAGS_NO_MONEY) && gResearchFundingLevel == RESEARCH_FUNDING_NONE)
+    if ((gameState.ParkFlags & PARK_FLAGS_NO_MONEY) && gResearchFundingLevel == RESEARCH_FUNDING_NONE)
     {
         researchLevel = RESEARCH_FUNDING_NORMAL;
     }

--- a/src/openrct2/network/NetworkServerAdvertiser.cpp
+++ b/src/openrct2/network/NetworkServerAdvertiser.cpp
@@ -307,9 +307,11 @@ private:
             { "mapSize", mapSize },         { "day", date.GetMonthTicks() }, { "month", date.GetMonthsElapsed() },
             { "guests", gNumGuestsInPark }, { "parkValue", gParkValue },
         };
-        if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
+
+        auto& gameState = GetGameState();
+        if (!(gameState.ParkFlags & PARK_FLAGS_NO_MONEY))
         {
-            gameInfo["cash"] = GetGameState().Cash;
+            gameInfo["cash"] = gameState.Cash;
         }
 
         root["gameInfo"] = gameInfo;

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -220,7 +220,7 @@ static void PaintParkEntranceScrollingText(
         return;
 
     auto ft = Formatter();
-    if (gParkFlags & PARK_FLAGS_PARK_OPEN)
+    if (GetGameState().ParkFlags & PARK_FLAGS_PARK_OPEN)
     {
         const auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
         auto name = park.Name.c_str();

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -806,7 +806,7 @@ namespace OpenRCT2
                     cs.ReadWrite(gBankLoan);
                     cs.ReadWrite(gMaxBankLoan);
                     cs.ReadWrite(gBankLoanInterestRate);
-                    cs.ReadWrite(gParkFlags);
+                    cs.ReadWrite(gameState.ParkFlags);
                     if (version <= 18)
                     {
                         money16 tempParkEntranceFee{};

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -171,7 +171,7 @@ namespace RCT1
 
         void Import(GameState_t& gameState) override
         {
-            Initialise();
+            Initialise(gameState);
 
             CreateAvailableObjectMappings();
 
@@ -313,7 +313,7 @@ namespace RCT1
             throw std::runtime_error("Unable to decode park.");
         }
 
-        void Initialise()
+        void Initialise(GameState_t& gameState)
         {
             // Avoid reusing the value used for last import
             _parkValueConversionFactor = 0;
@@ -326,7 +326,7 @@ namespace RCT1
             auto context = OpenRCT2::GetContext();
             context->GetGameState()->InitAll({ mapSize, mapSize });
             gEditorStep = EditorStep::ObjectSelection;
-            GetGameState().ParkFlags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
+            gameState.ParkFlags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
             gScenarioCategory = SCENARIO_CATEGORY_OTHER;
         }
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -75,9 +75,9 @@
 #include <memory>
 #include <vector>
 
-static constexpr ObjectEntryIndex ObjectEntryIndexIgnore = 254;
-
 using namespace OpenRCT2;
+
+static constexpr ObjectEntryIndex ObjectEntryIndexIgnore = 254;
 
 namespace RCT1
 {
@@ -326,7 +326,7 @@ namespace RCT1
             auto context = OpenRCT2::GetContext();
             context->GetGameState()->InitAll({ mapSize, mapSize });
             gEditorStep = EditorStep::ObjectSelection;
-            gParkFlags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
+            GetGameState().ParkFlags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
             gScenarioCategory = SCENARIO_CATEGORY_OTHER;
         }
 
@@ -2201,14 +2201,14 @@ namespace RCT1
             gStaffSecurityColour = RCT1::GetColour(_s4.SecurityGuardColour);
 
             // Flags
-            gParkFlags = _s4.ParkFlags;
-            gParkFlags &= ~PARK_FLAGS_ANTI_CHEAT_DEPRECATED;
-            gParkFlags |= PARK_FLAGS_RCT1_INTEREST;
+            gameState.ParkFlags = _s4.ParkFlags;
+            gameState.ParkFlags &= ~PARK_FLAGS_ANTI_CHEAT_DEPRECATED;
+            gameState.ParkFlags |= PARK_FLAGS_RCT1_INTEREST;
             // Loopy Landscape parks can set a flag to lock the entry price to free.
             // If this flag is not set, the player can ask money for both rides and entry.
             if (!(_s4.ParkFlags & RCT1_PARK_FLAGS_PARK_ENTRY_LOCKED_AT_FREE))
             {
-                gParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
+                gameState.ParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
             }
 
             gParkSize = _s4.ParkSize;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -263,15 +263,15 @@ namespace RCT2
             gameState.InitialCash = ToMoney64(_s6.InitialCash);
             gBankLoan = ToMoney64(_s6.CurrentLoan);
 
-            gParkFlags = _s6.ParkFlags & ~PARK_FLAGS_NO_MONEY_SCENARIO;
+            gameState.ParkFlags = _s6.ParkFlags & ~PARK_FLAGS_NO_MONEY_SCENARIO;
 
             // RCT2 used a different flag for `no money` when the park is a scenario
             if (_s6.Header.Type == S6_TYPE_SCENARIO)
             {
                 if (_s6.ParkFlags & PARK_FLAGS_NO_MONEY_SCENARIO)
-                    gParkFlags |= PARK_FLAGS_NO_MONEY;
+                    gameState.ParkFlags |= PARK_FLAGS_NO_MONEY;
                 else
-                    gParkFlags &= ~PARK_FLAGS_NO_MONEY;
+                    gameState.ParkFlags &= ~PARK_FLAGS_NO_MONEY;
             }
 
             gParkEntranceFee = _s6.ParkEntranceFee;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5313,7 +5313,7 @@ bool Ride::IsRide() const
 
 money64 RideGetPrice(const Ride& ride)
 {
-    if (gParkFlags & PARK_FLAGS_NO_MONEY)
+    if (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
         return 0;
     if (ride.IsRide())
     {

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -12,6 +12,7 @@
 #include "../Cheats.h"
 #include "../Context.h"
 #include "../Game.h"
+#include "../GameState.h"
 #include "../OpenRCT2.h"
 #include "../TrackImporter.h"
 #include "../actions/FootpathLayoutPlaceAction.h"
@@ -1935,10 +1936,11 @@ static bool TrackDesignPlacePreview(TrackDesignState& tds, TrackDesign* td6, mon
         }
     }
 
+    auto& gameState = GetGameState();
     _trackDesignDrawingPreview = true;
     uint8_t backup_rotation = _currentTrackPieceDirection;
-    uint32_t backup_park_flags = gParkFlags;
-    gParkFlags &= ~PARK_FLAGS_FORBID_HIGH_CONSTRUCTION;
+    uint32_t backup_park_flags = gameState.ParkFlags;
+    gameState.ParkFlags &= ~PARK_FLAGS_FORBID_HIGH_CONSTRUCTION;
     auto mapSize = TileCoordsXY{ gMapSize.x * 16, gMapSize.y * 16 };
 
     _currentTrackPieceDirection = 0;
@@ -1962,7 +1964,7 @@ static bool TrackDesignPlacePreview(TrackDesignState& tds, TrackDesign* td6, mon
     auto res = TrackDesignPlaceVirtual(
         tds, td6, PTD_OPERATION_PLACE_TRACK_PREVIEW, placeScenery, *ride,
         { mapSize.x, mapSize.y, z, _currentTrackPieceDirection });
-    gParkFlags = backup_park_flags;
+    gameState.ParkFlags = backup_park_flags;
 
     if (res.Error == GameActions::Status::Ok)
     {

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -60,6 +60,8 @@
 
 #include <algorithm>
 
+using namespace OpenRCT2;
+
 const StringId ScenarioCategoryStringIds[SCENARIO_CATEGORY_COUNT] = {
     STR_BEGINNER_PARKS, STR_CHALLENGING_PARKS,    STR_EXPERT_PARKS, STR_REAL_PARKS, STR_OTHER_PARKS,
     STR_DLC_PARKS,      STR_BUILD_YOUR_OWN_PARKS, STR_COMPETITIONS, STR_UCES_TM,    STR_UCES_KD,
@@ -152,7 +154,7 @@ void ScenarioReset()
     gTotalAdmissions = 0;
     gTotalIncomeFromAdmissions = 0;
 
-    gParkFlags &= ~PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT;
+    gameState.ParkFlags &= ~PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT;
     gScenarioCompletedCompanyValue = MONEY64_UNDEFINED;
     gScenarioCompletedBy = "?";
 
@@ -178,13 +180,13 @@ void ScenarioReset()
     gParkRatingCasualtyPenalty = 0;
 
     // Open park with free entry when there is no money
-    if (gParkFlags & PARK_FLAGS_NO_MONEY)
+    if (gameState.ParkFlags & PARK_FLAGS_NO_MONEY)
     {
-        gParkFlags |= PARK_FLAGS_PARK_OPEN;
+        gameState.ParkFlags |= PARK_FLAGS_PARK_OPEN;
         gParkEntranceFee = 0;
     }
 
-    gParkFlags |= PARK_FLAGS_SPRITES_INITIALISED;
+    gameState.ParkFlags |= PARK_FLAGS_SPRITES_INITIALISED;
     gGamePaused = false;
 }
 
@@ -220,7 +222,7 @@ void ScenarioSuccess()
     if (ScenarioRepositoryTryRecordHighscore(gScenarioFileName.c_str(), companyValue, nullptr))
     {
         // Allow name entry
-        gParkFlags |= PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT;
+        GetGameState().ParkFlags |= PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT;
         gScenarioCompanyValueRecord = companyValue;
     }
     ScenarioEnd();
@@ -236,7 +238,7 @@ void ScenarioSuccessSubmitName(const char* name)
     {
         gScenarioCompletedBy = name;
     }
-    gParkFlags &= ~PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT;
+    GetGameState().ParkFlags &= ~PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT;
 }
 
 /**
@@ -247,7 +249,7 @@ static void ScenarioCheckEntranceFeeTooHigh()
 {
     const auto max_fee = AddClamp_money64(gTotalRideValueForMoney, gTotalRideValueForMoney / 2);
 
-    if ((gParkFlags & PARK_FLAGS_PARK_OPEN) && ParkGetEntranceFee() > max_fee)
+    if ((GetGameState().ParkFlags & PARK_FLAGS_PARK_OPEN) && ParkGetEntranceFee() > max_fee)
     {
         if (!gParkEntrances.empty())
         {
@@ -319,7 +321,7 @@ static void ScenarioDayUpdate()
     }
 
     // Lower the casualty penalty
-    uint16_t casualtyPenaltyModifier = (gParkFlags & PARK_FLAGS_NO_MONEY) ? 40 : 7;
+    uint16_t casualtyPenaltyModifier = (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY) ? 40 : 7;
     gParkRatingCasualtyPenalty = std::max(0, gParkRatingCasualtyPenalty - casualtyPenaltyModifier);
 
     auto intent = Intent(INTENT_ACTION_UPDATE_DATE);
@@ -610,7 +612,7 @@ ResultWithMessage ScenarioPrepareForSave()
     }
 
     if (gScenarioObjective.Type == OBJECTIVE_GUESTS_AND_RATING)
-        gParkFlags |= PARK_FLAGS_PARK_OPEN;
+        GetGameState().ParkFlags |= PARK_FLAGS_PARK_OPEN;
 
     ScenarioReset();
 
@@ -732,7 +734,7 @@ ObjectiveStatus Objective::CheckGuestsAndRating() const
         else if (gScenarioParkRatingWarningDays == 29)
         {
             News::AddItemToQueue(News::ItemType::Graph, STR_PARK_HAS_BEEN_CLOSED_DOWN, 0, {});
-            gParkFlags &= ~PARK_FLAGS_PARK_OPEN;
+            GetGameState().ParkFlags &= ~PARK_FLAGS_PARK_OPEN;
             gGuestInitialHappiness = 50;
             return ObjectiveStatus::Failure;
         }

--- a/src/openrct2/scripting/bindings/world/ScPark.cpp
+++ b/src/openrct2/scripting/bindings/world/ScPark.cpp
@@ -285,17 +285,18 @@ namespace OpenRCT2::Scripting
     bool ScPark::getFlag(const std::string& key) const
     {
         auto mask = ParkFlagMap[key];
-        return (gParkFlags & mask) != 0;
+        return (GetGameState().ParkFlags & mask) != 0;
     }
 
     void ScPark::setFlag(const std::string& key, bool value)
     {
         ThrowIfGameStateNotMutable();
         auto mask = ParkFlagMap[key];
+        auto& gameState = GetGameState();
         if (value)
-            gParkFlags |= mask;
+            gameState.ParkFlags |= mask;
         else
-            gParkFlags &= ~mask;
+            gameState.ParkFlags &= ~mask;
         GfxInvalidateScreen();
     }
 

--- a/src/openrct2/world/ConstructionClearance.cpp
+++ b/src/openrct2/world/ConstructionClearance.cpp
@@ -10,6 +10,7 @@
 #include "ConstructionClearance.h"
 
 #include "../Game.h"
+#include "../GameState.h"
 #include "../localisation/Formatter.h"
 #include "../object/LargeSceneryEntry.h"
 #include "../object/SmallSceneryEntry.h"
@@ -20,6 +21,8 @@
 #include "Park.h"
 #include "Scenery.h"
 #include "Surface.h"
+
+using namespace OpenRCT2;
 
 static int32_t MapPlaceClearFunc(
     TileElement** tile_element, const CoordsXY& coords, uint8_t flags, money64* price, bool is_scenery)
@@ -32,13 +35,14 @@ static int32_t MapPlaceClearFunc(
 
     auto* scenery = (*tile_element)->AsSmallScenery()->GetEntry();
 
-    if (gParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL)
+    auto& gameState = GetGameState();
+    if (gameState.ParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL)
     {
         if (scenery != nullptr && scenery->HasFlag(SMALL_SCENERY_FLAG_IS_TREE))
             return 1;
     }
 
-    if (!(gParkFlags & PARK_FLAGS_NO_MONEY) && scenery != nullptr)
+    if (!(gameState.ParkFlags & PARK_FLAGS_NO_MONEY) && scenery != nullptr)
         *price += scenery->removal_price;
 
     if (flags & GAME_COMMAND_FLAG_GHOST)
@@ -185,7 +189,7 @@ GameActions::Result MapCanConstructWithClearAt(
             }
         }
 
-        if (gParkFlags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION && !isTree)
+        if (GetGameState().ParkFlags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION && !isTree)
         {
             const auto heightFromGround = pos.clearanceZ - tileElement->GetBaseZ();
 

--- a/src/openrct2/world/Park.h
+++ b/src/openrct2/world/Park.h
@@ -92,7 +92,6 @@ namespace OpenRCT2
     };
 } // namespace OpenRCT2
 
-extern uint64_t gParkFlags;
 extern uint16_t gParkRating;
 extern money64 gParkEntranceFee;
 extern uint32_t gParkSize;

--- a/test/tests/PlayTests.cpp
+++ b/test/tests/PlayTests.cpp
@@ -102,7 +102,7 @@ TEST_F(PlayTests, SecondGuestInQueueShouldNotRideIfNoFunds)
     // Open park for free but charging for rides
     execute<ParkSetParameterAction>(ParkParameter::Open);
     execute<ParkSetEntranceFeeAction>(0);
-    gParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
+    GetGameState().ParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
 
     // Find ferris wheel
     auto rideManager = GetRideManager();
@@ -163,7 +163,7 @@ TEST_F(PlayTests, CarRideWithOneCarOnlyAcceptsTwoGuests)
     // Open park for free but charging for rides
     execute<ParkSetParameterAction>(ParkParameter::Open);
     execute<ParkSetEntranceFeeAction>(0);
-    gParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
+    GetGameState().ParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
 
     // Find car ride
     auto rideManager = GetRideManager();


### PR DESCRIPTION
Also changed a few instances where GetGameState was called inside the same function. The change in `Peep.cpp` is needed because of a function conflict. FormatStringID exists both in the global and in the OpenRCT2 namespace.