### PR TITLE
Make ScenarioBegin() and ScenarioReset() take GameState_t

### DIFF
--- a/src/openrct2-ui/scripting/ScTitleSequence.hpp
+++ b/src/openrct2-ui/scripting/ScTitleSequence.hpp
@@ -269,7 +269,7 @@ namespace OpenRCT2::Scripting
                         }
 
                         if (isScenario)
-                            ScenarioBegin();
+                            ScenarioBegin(gameState);
                         else
                             GameLoadInit();
                         gLoadKeepWindowsOpen = old;

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -682,7 +682,7 @@ namespace OpenRCT2
                 }
                 else
                 {
-                    ScenarioBegin();
+                    ScenarioBegin(gameState);
 #ifndef DISABLE_NETWORK
                     if (_network.GetMode() == NETWORK_MODE_SERVER)
                     {

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -144,7 +144,8 @@ namespace Editor
             return;
         }
 
-        ScenarioReset();
+        auto& gameState = GetGameState();
+        ScenarioReset(gameState);
 
         gScreenFlags = SCREEN_FLAGS_SCENARIO_EDITOR;
         gEditorStep = EditorStep::ObjectiveSelection;

--- a/src/openrct2/command_line/ConvertCommand.cpp
+++ b/src/openrct2/command_line/ConvertCommand.cpp
@@ -93,6 +93,7 @@ exitcode_t CommandLine::HandleCommandConvert(CommandLineArgEnumerator* enumerato
     context->Initialise();
 
     auto& objManager = context->GetObjectManager();
+    auto& gameState = GetGameState();
 
     try
     {
@@ -102,7 +103,6 @@ exitcode_t CommandLine::HandleCommandConvert(CommandLineArgEnumerator* enumerato
         objManager.LoadObjects(loadResult.RequiredObjects);
 
         // TODO: Have a separate GameState and exchange once loaded.
-        auto& gameState = GetGameState();
         importer->Import(gameState);
     }
     catch (const std::exception& ex)
@@ -114,7 +114,7 @@ exitcode_t CommandLine::HandleCommandConvert(CommandLineArgEnumerator* enumerato
     if (sourceFileType == FileExtension::SC4 || sourceFileType == FileExtension::SC6)
     {
         // We are converting a scenario, so reset the park
-        ScenarioBegin();
+        ScenarioBegin(gameState);
     }
 
     try
@@ -124,8 +124,6 @@ exitcode_t CommandLine::HandleCommandConvert(CommandLineArgEnumerator* enumerato
         // HACK remove the main window so it saves the park with the
         //      correct initial view
         WindowCloseByClass(WindowClass::MainWindow);
-
-        auto& gameState = GetGameState();
 
         exporter->Export(gameState, destinationPath);
     }

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -91,10 +91,10 @@ static void ScenarioCheckObjective();
 
 using namespace OpenRCT2;
 
-void ScenarioBegin()
+void ScenarioBegin(GameState_t& gameState)
 {
     GameLoadInit();
-    ScenarioReset();
+    ScenarioReset(gameState);
 
     if (gScenarioObjective.Type != OBJECTIVE_NONE && !gLoadKeepWindowsOpen)
         ContextOpenWindowView(WV_PARK_OBJECTIVE);
@@ -102,7 +102,7 @@ void ScenarioBegin()
     gScreenAge = 0;
 }
 
-void ScenarioReset()
+void ScenarioReset(GameState_t& gameState)
 {
     // Set the scenario pseudo-random seeds
     Random::RCT2::Seed s{ 0x1234567F ^ Platform::GetTicks(), 0x789FABCD ^ Platform::GetTicks() };
@@ -112,7 +112,6 @@ void ScenarioReset()
     ScenerySetDefaultPlacementConfiguration();
     News::InitQueue();
 
-    auto& gameState = GetGameState();
     auto& park = GetContext()->GetGameState()->GetPark();
     gameState.ParkRating = park.CalculateParkRating();
     gParkValue = park.CalculateParkValue();
@@ -604,6 +603,8 @@ static ResultWithMessage ScenarioPrepareRidesForSave()
  */
 ResultWithMessage ScenarioPrepareForSave()
 {
+    auto& gameState = GetGameState();
+
     // This can return false if the goal is 'Finish 5 roller coaster' and there are too few.
     const auto prepareRidesResult = ScenarioPrepareRidesForSave();
     if (!prepareRidesResult.Successful)
@@ -612,9 +613,9 @@ ResultWithMessage ScenarioPrepareForSave()
     }
 
     if (gScenarioObjective.Type == OBJECTIVE_GUESTS_AND_RATING)
-        GetGameState().ParkFlags |= PARK_FLAGS_PARK_OPEN;
+        gameState.ParkFlags |= PARK_FLAGS_PARK_OPEN;
 
-    ScenarioReset();
+    ScenarioReset(gameState);
 
     return { true };
 }

--- a/src/openrct2/scenario/Scenario.h
+++ b/src/openrct2/scenario/Scenario.h
@@ -177,8 +177,8 @@ extern uint32_t gLastAutoSaveUpdate;
 
 extern std::string gScenarioFileName;
 
-void ScenarioBegin();
-void ScenarioReset();
+void ScenarioBegin(OpenRCT2::GameState_t& gameState);
+void ScenarioReset(OpenRCT2::GameState_t& gameState);
 void ScenarioUpdate();
 bool ScenarioCreateDucks();
 bool AllowEarlyCompletion();


### PR DESCRIPTION
Part of/related to #21193.

These functions are generally called immediately after `Import` and in turn do a lot with the gamestate, so it made sense to refactor these right away.