### PR TITLE
Close #21184: Draw selection square on water

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#21062] [Plugin] Add API for managing a guest's items.
 - Improved: [#18632] Land ownership and construction rights are now shown on top of the water.
 - Improved: [#20951] Activate OpenRCT2 window after using native file dialog on macOS.
+- Improved: [#21184] The construction marker for rides, paths and large scenery is not shown on top of the water.
 - Improved: [#21227] Entrance style dropdown is now sorted alphabetically everywhere.
 - Change: [#21200] Raise maximum lift speeds of the Reverser Coaster, Side Friction Coaster, and Virginia Reel for RCT1 parity.
 - Change: [#21225] Raise maximum allowed misc entities to 1600.

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -1311,6 +1311,17 @@ void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, con
 
             const auto image_id = ImageId(SPR_TERRAIN_SELECTION_CORNER + Byte97B444[surfaceShape], fpId);
             PaintAttachToPreviousPS(session, image_id, 0, 0);
+
+            auto [waterHeight, waterSurfaceShape] = SurfaceGetHeightAboveWater(tileElement, height, surfaceShape);
+            const bool isUnderWater = (surfaceShape != waterSurfaceShape || height != waterHeight);
+            if (isUnderWater)
+            {
+                const auto imageId2 = ImageId(SPR_TERRAIN_SELECTION_CORNER + Byte97B444[waterSurfaceShape], fpId);
+                PaintStruct* backup = session.LastPS;
+                PaintAddImageAsParent(session, imageId2, { 0, 0, waterHeight }, { 32, 32, 0 });
+                session.LastPS = backup;
+            }
+
             break;
         }
     }


### PR DESCRIPTION
Draws an additional selection square on top of the water for rides, paths and large scenery.

![afbeelding](https://github.com/OpenRCT2/OpenRCT2/assets/1478678/62b24633-0981-45ea-b02e-ac31b4bd4d9d)
