### PR TITLE
 #21193: Move gParkValue and gParkValueHistory to GameState_t

### DIFF
--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -591,7 +591,7 @@ public:
         {
             // Park value and company value
             ft = Formatter();
-            ft.Add<money64>(gParkValue);
+            ft.Add<money64>(gameState.ParkValue);
             DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ 280, 279 }, STR_PARK_VALUE_LABEL, ft);
             ft = Formatter();
             ft.Add<money64>(gCompanyValue);
@@ -677,9 +677,11 @@ public:
         auto graphTopLeft = windowPos + ScreenCoordsXY{ pageWidget->left + 4, pageWidget->top + 15 };
         auto graphBottomRight = windowPos + ScreenCoordsXY{ pageWidget->right - 4, pageWidget->bottom - 4 };
 
+        const auto& gameState = GetGameState();
+
         // Park value
         auto ft = Formatter();
-        ft.Add<money64>(gParkValue);
+        ft.Add<money64>(gameState.ParkValue);
         DrawTextBasic(dpi, graphTopLeft - ScreenCoordsXY{ 0, 11 }, STR_FINANCES_PARK_VALUE, ft);
 
         // Graph

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -691,7 +691,7 @@ public:
         int32_t yAxisScale = 0;
         for (int32_t i = 0; i < 64; i++)
         {
-            auto balance = gParkValueHistory[i];
+            auto balance = gameState.ParkValueHistory[i];
             if (balance == MONEY64_UNDEFINED)
                 continue;
 
@@ -723,7 +723,7 @@ public:
 
         // X axis labels and values
         coords = graphTopLeft + ScreenCoordsXY{ 98, 17 };
-        Graph::Draw(dpi, gParkValueHistory, 64, coords, yAxisScale, 0);
+        Graph::Draw(dpi, gameState.ParkValueHistory, 64, coords, yAxisScale, 0);
     }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -469,18 +469,19 @@ public:
 
     OpenRCT2String OnTooltip(WidgetIndex widgetIndex, StringId fallback) override
     {
+        const auto& gameState = GetGameState();
         auto ft = Formatter();
 
-            switch (widgetIndex)
-            {
-                case WIDX_MONEY:
-                    ft.Add<money64>(gCurrentProfit);
-                    ft.Add<money64>(gParkValue);
-                    break;
-                case WIDX_PARK_RATING:
-                    ft.Add<int16_t>(GetGameState().ParkRating);
-                    break;
-            }
+        switch (widgetIndex)
+        {
+            case WIDX_MONEY:
+                ft.Add<money64>(gCurrentProfit);
+                ft.Add<money64>(gameState.ParkValue);
+                break;
+            case WIDX_PARK_RATING:
+                ft.Add<int16_t>(gameState.ParkRating);
+                break;
+        }
         return { fallback, ft };
     }
 

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -32,6 +32,7 @@ namespace OpenRCT2
         money64 ParkEntranceFee;
         uint32_t ParkSize;
         money64 ParkValue;
+        money64 ParkValueHistory[FINANCE_GRAPH_SIZE];
         ClimateType Climate;
         ClimateState ClimateCurrent;
         ClimateState ClimateNext;

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -31,6 +31,7 @@ namespace OpenRCT2
         uint16_t ParkRating;
         money64 ParkEntranceFee;
         uint32_t ParkSize;
+        money64 ParkValue;
         ClimateType Climate;
         ClimateState ClimateCurrent;
         ClimateState ClimateNext;

--- a/src/openrct2/actions/RideDemolishAction.cpp
+++ b/src/openrct2/actions/RideDemolishAction.cpp
@@ -155,7 +155,7 @@ GameActions::Result RideDemolishAction::DemolishRide(Ride& ride) const
     }
 
     ride.Delete();
-    gParkValue = GetContext()->GetGameState()->GetPark().CalculateParkValue();
+    GetGameState().ParkValue = GetContext()->GetGameState()->GetPark().CalculateParkValue();
 
     // Close windows related to the demolished ride
     WindowCloseByNumber(WindowClass::RideConstruction, rideId.ToUnderlying());

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -561,7 +561,7 @@ static int32_t ConsoleCommandGet(InteractiveConsole& console, const arguments_t&
         }
         else if (argv[0] == "park_value")
         {
-            console.WriteFormatLine("park_value %d", gParkValue / 10);
+            console.WriteFormatLine("park_value %d", gameState.ParkValue / 10);
         }
         else if (argv[0] == "company_value")
         {

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -46,7 +46,6 @@ money64 gCurrentExpenditure;
 money64 gCurrentProfit;
 money64 gHistoricalProfit;
 money64 gCashHistory[FINANCE_GRAPH_SIZE];
-money64 gParkValueHistory[FINANCE_GRAPH_SIZE];
 money64 gExpenditureTable[EXPENDITURE_TABLE_MONTH_COUNT][static_cast<int32_t>(ExpenditureType::Count)];
 
 /**
@@ -195,7 +194,7 @@ void FinanceResetHistory()
     {
         gCashHistory[i] = MONEY64_UNDEFINED;
         gameState.WeeklyProfitHistory[i] = MONEY64_UNDEFINED;
-        gParkValueHistory[i] = MONEY64_UNDEFINED;
+        gameState.ParkValueHistory[i] = MONEY64_UNDEFINED;
     }
 
     for (uint32_t i = 0; i < EXPENDITURE_TABLE_MONTH_COUNT; ++i)

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -236,7 +236,7 @@ void FinanceInit()
     gHistoricalProfit = 0;
 
     gBankLoanInterestRate = 10;
-    gParkValue = 0;
+    gameState.ParkValue = 0;
     gCompanyValue = 0;
     gameState.ScenarioCompletedCompanyValue = MONEY64_UNDEFINED;
     gTotalAdmissions = 0;

--- a/src/openrct2/management/Finance.h
+++ b/src/openrct2/management/Finance.h
@@ -51,7 +51,6 @@ extern money64 gCurrentProfit;
 extern money64 gHistoricalProfit;
 
 extern money64 gCashHistory[FINANCE_GRAPH_SIZE];
-extern money64 gParkValueHistory[FINANCE_GRAPH_SIZE];
 extern money64 gExpenditureTable[EXPENDITURE_TABLE_MONTH_COUNT][static_cast<int32_t>(ExpenditureType::Count)];
 
 bool FinanceCheckMoneyRequired(uint32_t flags);

--- a/src/openrct2/network/NetworkServerAdvertiser.cpp
+++ b/src/openrct2/network/NetworkServerAdvertiser.cpp
@@ -301,14 +301,14 @@ private:
             { "players", numPlayers },
         };
 
-        auto& date = GetDate();
+        const auto& gameState = GetGameState();
+        const auto& date = GetDate();
         json_t mapSize = { { "x", gMapSize.x - 2 }, { "y", gMapSize.y - 2 } };
         json_t gameInfo = {
-            { "mapSize", mapSize },         { "day", date.GetMonthTicks() }, { "month", date.GetMonthsElapsed() },
-            { "guests", gNumGuestsInPark }, { "parkValue", gParkValue },
+            { "mapSize", mapSize },         { "day", date.GetMonthTicks() },      { "month", date.GetMonthsElapsed() },
+            { "guests", gNumGuestsInPark }, { "parkValue", gameState.ParkValue },
         };
 
-        auto& gameState = GetGameState();
         if (!(gameState.ParkFlags & PARK_FLAGS_NO_MONEY))
         {
             gameInfo["cash"] = gameState.Cash;

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -884,7 +884,7 @@ namespace OpenRCT2
                             cs.ReadWrite(award.Type);
                         });
                     }
-                    cs.ReadWrite(gParkValue);
+                    cs.ReadWrite(gameState.ParkValue);
                     cs.ReadWrite(gCompanyValue);
                     cs.ReadWrite(gameState.ParkSize);
                     cs.ReadWrite(gNumGuestsInPark);

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -935,7 +935,7 @@ namespace OpenRCT2
                         cs.ReadWrite(value);
                         return true;
                     });
-                    cs.ReadWriteArray(gParkValueHistory, [&cs](money64& value) {
+                    cs.ReadWriteArray(gameState.ParkValueHistory, [&cs](money64& value) {
                         cs.ReadWrite(value);
                         return true;
                     });

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1409,7 +1409,7 @@ namespace RCT1
             for (size_t i = 0; i < Limits::FinanceGraphSize; i++)
             {
                 gCashHistory[i] = ToMoney64(_s4.CashHistory[i]);
-                gParkValueHistory[i] = CorrectRCT1ParkValue(_s4.ParkValueHistory[i]);
+                gameState.ParkValueHistory[i] = CorrectRCT1ParkValue(_s4.ParkValueHistory[i]);
                 gameState.WeeklyProfitHistory[i] = ToMoney64(_s4.WeeklyProfitHistory[i]);
             }
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1403,7 +1403,7 @@ namespace RCT1
             gameState.InitialCash = ToMoney64(_s4.Cash);
 
             gCompanyValue = ToMoney64(_s4.CompanyValue);
-            gParkValue = CorrectRCT1ParkValue(_s4.ParkValue);
+            gameState.ParkValue = CorrectRCT1ParkValue(_s4.ParkValue);
             gCurrentProfit = ToMoney64(_s4.Profit);
 
             for (size_t i = 0; i < Limits::FinanceGraphSize; i++)

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -366,7 +366,7 @@ namespace RCT2
             {
                 gCashHistory[i] = ToMoney64(_s6.BalanceHistory[i]);
                 gameState.WeeklyProfitHistory[i] = ToMoney64(_s6.WeeklyProfitHistory[i]);
-                gParkValueHistory[i] = ToMoney64(_s6.ParkValueHistory[i]);
+                gameState.ParkValueHistory[i] = ToMoney64(_s6.ParkValueHistory[i]);
             }
 
             gameState.ScenarioCompletedCompanyValue = RCT12CompletedCompanyValueToOpenRCT2(_s6.CompletedCompanyValue);

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -360,7 +360,7 @@ namespace RCT2
             gameState.WeeklyProfitAverageDivisor = _s6.WeeklyProfitAverageDivisor;
             // Pad0135833A
 
-            gParkValue = ToMoney64(_s6.ParkValue);
+            gameState.ParkValue = ToMoney64(_s6.ParkValue);
 
             for (size_t i = 0; i < Limits::FinanceGraphSize; i++)
             {

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -105,7 +105,7 @@ void ScenarioReset(GameState_t& gameState)
 
     auto& park = GetContext()->GetGameState()->GetPark();
     gameState.ParkRating = park.CalculateParkRating();
-    gParkValue = park.CalculateParkValue();
+    gameState.ParkValue = park.CalculateParkValue();
     gCompanyValue = park.CalculateCompanyValue();
     gHistoricalProfit = gameState.InitialCash - gBankLoan;
     gameState.Cash = gameState.InitialCash;
@@ -634,7 +634,7 @@ ObjectiveStatus Objective::CheckParkValueBy() const
 {
     int32_t currentMonthYear = GetDate().GetMonthsElapsed();
     money64 objectiveParkValue = Currency;
-    money64 parkValue = gParkValue;
+    money64 parkValue = GetGameState().ParkValue;
 
     if (currentMonthYear == MONTH_COUNT * Year || AllowEarlyCompletion())
     {
@@ -818,7 +818,8 @@ ObjectiveStatus Objective::CheckFinish5RollerCoasters() const
 
 ObjectiveStatus Objective::CheckRepayLoanAndParkValue() const
 {
-    money64 parkValue = gParkValue;
+    const auto& gameState = GetGameState();
+    money64 parkValue = gameState.ParkValue;
     money64 currentLoan = gBankLoan;
 
     if (currentLoan <= 0 && parkValue >= Currency)

--- a/src/openrct2/scripting/bindings/world/ScPark.cpp
+++ b/src/openrct2/scripting/bindings/world/ScPark.cpp
@@ -169,15 +169,16 @@ namespace OpenRCT2::Scripting
 
     money64 ScPark::value_get() const
     {
-        return gParkValue;
+        return GetGameState().ParkValue;
     }
     void ScPark::value_set(money64 value)
     {
         ThrowIfGameStateNotMutable();
 
-        if (gParkValue != value)
+        auto& gameState = GetGameState();
+        if (gameState.ParkValue != value)
         {
-            gParkValue = value;
+            gameState.ParkValue = value;
             auto intent = Intent(INTENT_ACTION_UPDATE_CASH);
             ContextBroadcastIntent(&intent);
         }

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -52,7 +52,6 @@ money64 gConstructionRightsPrice;
 uint64_t gTotalAdmissions;
 money64 gTotalIncomeFromAdmissions;
 
-money64 gParkValue;
 money64 gCompanyValue;
 
 int16_t gParkRatingCasualtyPenalty;
@@ -241,7 +240,7 @@ uint16_t Park::GetParkRating() const
 
 money64 Park::GetParkValue() const
 {
-    return gParkValue;
+    return GetGameState().ParkValue;
 }
 
 money64 Park::GetCompanyValue() const
@@ -321,7 +320,7 @@ void Park::Update(const Date& date)
     if (currentTicks % 512 == 0)
     {
         gameState.ParkRating = CalculateParkRating();
-        gParkValue = CalculateParkValue();
+        gameState.ParkValue = CalculateParkValue();
         gCompanyValue = CalculateCompanyValue();
         gTotalRideValueForMoney = CalculateTotalRideValueForMoney();
         _suggestedGuestMaximum = CalculateSuggestedMaxGuests();
@@ -512,7 +511,7 @@ money64 Park::CalculateRideValue(const Ride& ride) const
 
 money64 Park::CalculateCompanyValue() const
 {
-    auto result = gParkValue - gBankLoan;
+    auto result = GetGameState().ParkValue - gBankLoan;
 
     // Clamp addition to prevent overflow
     result = AddClamp_money64(result, FinanceGetCurrentCash());
@@ -778,7 +777,7 @@ void Park::UpdateHistories()
     gameState.WeeklyProfitAverageDivisor = 0;
 
     // Update park value history
-    HistoryPushRecord<money64, std::size(gParkValueHistory)>(gParkValueHistory, gParkValue);
+    HistoryPushRecord<money64, std::size(gParkValueHistory)>(gParkValueHistory, gameState.ParkValue);
 
     // Invalidate relevant windows
     auto intent = Intent(INTENT_ACTION_UPDATE_GUEST_COUNT);

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -43,6 +43,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <type_traits>
 
 using namespace OpenRCT2;
 
@@ -777,7 +778,8 @@ void Park::UpdateHistories()
     gameState.WeeklyProfitAverageDivisor = 0;
 
     // Update park value history
-    HistoryPushRecord<money64, std::size(gParkValueHistory)>(gParkValueHistory, gameState.ParkValue);
+    HistoryPushRecord<money64, std::extent_v<decltype(GameState_t::ParkValueHistory)>>(
+        gameState.ParkValueHistory, gameState.ParkValue);
 
     // Invalidate relevant windows
     auto intent = Intent(INTENT_ACTION_UPDATE_GUEST_COUNT);

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -773,13 +773,14 @@ void Park::UpdateHistories()
     {
         currentWeeklyProfit /= gameState.WeeklyProfitAverageDivisor;
     }
-    HistoryPushRecord<money64, FINANCE_GRAPH_SIZE>(gameState.WeeklyProfitHistory, currentWeeklyProfit);
+    constexpr auto profitHistorySize = std::extent_v<decltype(GameState_t::WeeklyProfitHistory)>;
+    HistoryPushRecord<money64, profitHistorySize>(gameState.WeeklyProfitHistory, currentWeeklyProfit);
     gameState.WeeklyProfitAverageDividend = 0;
     gameState.WeeklyProfitAverageDivisor = 0;
 
     // Update park value history
-    HistoryPushRecord<money64, std::extent_v<decltype(GameState_t::ParkValueHistory)>>(
-        gameState.ParkValueHistory, gameState.ParkValue);
+    constexpr auto parkValueHistorySize = std::extent_v<decltype(GameState_t::WeeklyProfitHistory)>;
+    HistoryPushRecord<money64, parkValueHistorySize>(gameState.ParkValueHistory, gameState.ParkValue);
 
     // Invalidate relevant windows
     auto intent = Intent(INTENT_ACTION_UPDATE_GUEST_COUNT);

--- a/src/openrct2/world/Park.h
+++ b/src/openrct2/world/Park.h
@@ -98,7 +98,6 @@ extern money64 gConstructionRightsPrice;
 extern uint64_t gTotalAdmissions;
 extern money64 gTotalIncomeFromAdmissions;
 
-extern money64 gParkValue;
 extern money64 gCompanyValue;
 
 extern int16_t gParkRatingCasualtyPenalty;


### PR DESCRIPTION
This also adjusts one template argument in Park.cpp to get the array size instead of reading it from a constant that's not guaranteede to match.