### PR TITLE
Fix using iterators that are deleted by the plugin

### DIFF
--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -1678,6 +1678,12 @@ void ScriptEngine::UpdateIntervals()
             continue;
         }
 
+        if (interval.Deleted)
+        {
+            // There is a chance that in one of the callbacks it deletes another interval.
+            continue;
+        }
+
         ExecutePluginCall(interval.Owner, interval.Callback, {}, false);
 
         interval.LastTimestamp = timestamp;

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -1634,7 +1634,7 @@ void ScriptEngine::RemoveInterval(const std::shared_ptr<Plugin>& plugin, Interva
     // Only allow owner or REPL (nullptr) to remove intervals
     if (plugin == nullptr || interval.Owner == plugin)
     {
-        _intervals.erase(it);
+        interval.Deleted = true;
     }
 }
 
@@ -1653,21 +1653,37 @@ void ScriptEngine::UpdateIntervals()
     }
     _lastIntervalTimestamp = timestamp;
 
-    for (auto it = _intervals.begin(), itNext = it; it != _intervals.end(); it = itNext)
+    // Erase all intervals marked as deleted.
+    for (auto it = _intervals.begin(); it != _intervals.end();)
     {
-        itNext++;
-
         auto& interval = it->second;
 
-        if (timestamp >= interval.LastTimestamp + interval.Delay)
+        if (interval.Deleted)
         {
-            ExecutePluginCall(interval.Owner, interval.Callback, {}, false);
+            it = _intervals.erase(it);
+        }
+        else
+        {
+            it++;
+        }
+    }
 
-            interval.LastTimestamp = timestamp;
-            if (!interval.Repeat)
-            {
-                _intervals.erase(it);
-            }
+    // Execute all intervals that are due.
+    for (auto it = _intervals.begin(); it != _intervals.end(); it++)
+    {
+        auto& interval = it->second;
+
+        if (timestamp < interval.LastTimestamp + interval.Delay)
+        {
+            continue;
+        }
+
+        ExecutePluginCall(interval.Owner, interval.Callback, {}, false);
+
+        interval.LastTimestamp = timestamp;
+        if (!interval.Repeat)
+        {
+            interval.Deleted = true;
         }
     }
 }

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -134,6 +134,7 @@ namespace OpenRCT2::Scripting
         int64_t LastTimestamp{};
         DukValue Callback;
         bool Repeat{};
+        bool Deleted{};
     };
 
     class ScriptEngine


### PR DESCRIPTION
There was a slight oversight on my end when doing #21188, in case the plugin asks for the interval to be deleted then the reference would be no longer valid also causing a crash. I simply made this a two phase operation, first delete the ones marked as deleted and in the next iteration execute the callback if the interval is due.

It was pretty random and caught this in a debug build while doing something else, this now fixes it for real.