### PR TITLE
Fix #21291: Wrong conditions for hungry guests warning

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -21,6 +21,7 @@
 - Fix: [#21178] Inca Lost City’s scenario description incorrectly states there are height restrictions.
 - Fix: [#21179] Additional missing land/construction rights tiles in Inca Lost City & Renovation.
 - Fix: [#21198] [Plugin] Setting brake or booster speeds on a tile element doesn’t work.
+- Fix: [#21291] Hungry guests heading to any flat ride do not count for warning threshold (original bug).
 
 0.4.7 (2023-12-31)
 ------------------------------------------------------------------------

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -1075,7 +1075,7 @@ void PeepProblemWarningsUpdate()
                     break;
                 }
                 ride = GetRide(peep->GuestHeadingToRideId);
-                if (ride != nullptr && !ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_FLAT_RIDE))
+                if (ride != nullptr && !ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_SELLS_FOOD))
                     hungerCounter++;
                 break;
 


### PR DESCRIPTION
In `PeepProblemWarningsUpdate()`, when determining the number of hungry guests that need help (in order to check whether the threshold for showing the warning about hungry guests is reached), guests that are heading towards any flat ride (checked using the `RIDE_TYPE_FLAG_FLAT_RIDE` on the ride the guest is heading to (if any)) are discarded.  
For thirsty guests (and those needing to go to the toilet) on the other hand, the more specific `RIDE_TYPE_FLAG_SELLS_DRINKS` (or `RIDE_TYPE_FLAG_IS_TOILET`) is used. (So, a guest that becomes thirsty while on its way to the merry-go-round would count for the threshold here.)

This PR makes the function use the more specific `RIDE_TYPE_FLAG_SELLS_FOOD` for hungry guests, so it's consistent with the other cases.

Closes #21291 