### PR TITLE
Fix #21290: Sound keeps playing when paused from fast-forward mode

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -21,6 +21,7 @@
 - Fix: [#21178] Inca Lost City’s scenario description incorrectly states there are height restrictions.
 - Fix: [#21179] Additional missing land/construction rights tiles in Inca Lost City & Renovation.
 - Fix: [#21198] [Plugin] Setting brake or booster speeds on a tile element doesn’t work.
+- Fix: [#21290] Sound keeps playing when paused from fast-forward mode.
 - Fix: [#21291] Hungry guests heading to any flat ride do not count for warning threshold (original bug).
 
 0.4.7 (2023-12-31)

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -218,6 +218,10 @@ void GameState::Tick()
                 break;
             }
         }
+        // Don't call UpdateLogic again if the game was just paused.
+        isPaused |= GameIsPaused();
+        if (isPaused)
+            break;
     }
 
     NetworkFlush();


### PR DESCRIPTION
This PR adds a check in `Tick()` to stop further calls to `UpdateLogic()` if one of them processed a `PauseToggleAction`. (This would only happen with `gGameSpeed` > 1.)  
This prevents the sounds from restarting again that were stopped from the `PauseToggleAction`.

Closes #21290 