### PR TITLE
Fix high score showing money on No Money maps

### DIFF
--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -279,16 +279,6 @@ public:
             ft.Add<StringId>(STR_STRING);
             ft.Add<const char*>(completedByName.c_str());
 
-            // if (OpenRCT2::GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
-            // {
-            //     screenPos.y += DrawTextWrapped(dpi, screenPos, 170, STR_COMPLETED_BY, ft);
-            // }
-            // else
-            // {
-            //     ft.Add<money64>(scenario->Highscore->company_value);
-            //     screenPos.y += DrawTextWrapped(dpi, screenPos, 170, STR_COMPLETED_BY_WITH_COMPANY_VALUE, ft);
-            // }
-
             if (scenario->Highscore->company_value == MONEY64_UNDEFINED)
             {
                 screenPos.y += DrawTextWrapped(dpi, screenPos, 170, STR_COMPLETED_BY, ft);

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -12,7 +12,6 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
-#include <openrct2/GameState.h>
 #include <openrct2/audio/audio.h>
 #include <openrct2/config/Config.h>
 #include <openrct2/drawing/Drawing.h>
@@ -27,7 +26,6 @@
 #include <openrct2/scenario/ScenarioSources.h>
 #include <openrct2/sprites.h>
 #include <openrct2/util/Util.h>
-#include <openrct2/world/Park.h>
 #include <vector>
 
 static constexpr StringId WINDOW_TITLE = STR_SELECT_SCENARIO;

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -12,6 +12,7 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
+#include <openrct2/GameState.h>
 #include <openrct2/audio/audio.h>
 #include <openrct2/config/Config.h>
 #include <openrct2/drawing/Drawing.h>
@@ -26,6 +27,7 @@
 #include <openrct2/scenario/ScenarioSources.h>
 #include <openrct2/sprites.h>
 #include <openrct2/util/Util.h>
+#include <openrct2/world/Park.h>
 #include <vector>
 
 static constexpr StringId WINDOW_TITLE = STR_SELECT_SCENARIO;
@@ -276,8 +278,26 @@ public:
             ft = Formatter();
             ft.Add<StringId>(STR_STRING);
             ft.Add<const char*>(completedByName.c_str());
-            ft.Add<money64>(scenario->Highscore->company_value);
-            screenPos.y += DrawTextWrapped(dpi, screenPos, 170, STR_COMPLETED_BY_WITH_COMPANY_VALUE, ft);
+
+            // if (OpenRCT2::GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
+            // {
+            //     screenPos.y += DrawTextWrapped(dpi, screenPos, 170, STR_COMPLETED_BY, ft);
+            // }
+            // else
+            // {
+            //     ft.Add<money64>(scenario->Highscore->company_value);
+            //     screenPos.y += DrawTextWrapped(dpi, screenPos, 170, STR_COMPLETED_BY_WITH_COMPANY_VALUE, ft);
+            // }
+
+            if (scenario->Highscore->company_value == MONEY64_UNDEFINED)
+            {
+                screenPos.y += DrawTextWrapped(dpi, screenPos, 170, STR_COMPLETED_BY, ft);
+            }
+            else
+            {
+                ft.Add<money64>(scenario->Highscore->company_value);
+                screenPos.y += DrawTextWrapped(dpi, screenPos, 170, STR_COMPLETED_BY_WITH_COMPANY_VALUE, ft);
+            }
         }
     }
 

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -561,7 +561,6 @@ void CheatSetAction::SetScenarioNoMoney(bool enabled) const
     gameState.ScenarioCompletedCompanyValue = MONEY64_UNDEFINED;
     gCompanyValue = MONEY64_UNDEFINED;
 
-
     // Invalidate all windows that have anything to do with finance
     WindowInvalidateByClass(WindowClass::Ride);
     WindowInvalidateByClass(WindowClass::Peep);

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -558,6 +558,10 @@ void CheatSetAction::SetScenarioNoMoney(bool enabled) const
         gameState.ParkFlags &= ~PARK_FLAGS_NO_MONEY;
     }
 
+    gameState.ScenarioCompletedCompanyValue = MONEY64_UNDEFINED;
+    gCompanyValue = MONEY64_UNDEFINED;
+
+
     // Invalidate all windows that have anything to do with finance
     WindowInvalidateByClass(WindowClass::Ride);
     WindowInvalidateByClass(WindowClass::Peep);


### PR DESCRIPTION
Fix for https://github.com/OpenRCT2/OpenRCT2/issues/21298 where the highscores were being shown which involved money on maps that had no money involved.