### PR TITLE
Refactor path support drawing

### DIFF
--- a/src/openrct2/paint/Supports.cpp
+++ b/src/openrct2/paint/Supports.cpp
@@ -1251,7 +1251,7 @@ bool MetalBSupportsPaintSetup(
  *
  * @return Whether supports were drawn
  */
-bool PathASupportsPaintSetup(
+bool PathBoxSupportsPaintSetup(
     PaintSession& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate,
     const FootpathPaintInfo& pathPaintInfo, bool* underground)
 {
@@ -1406,7 +1406,7 @@ bool PathASupportsPaintSetup(
  *
  * @return Whether supports were drawn
  */
-bool PathBSupportsPaintSetup(
+bool PathPoleSupportsPaintSetup(
     PaintSession& session, int32_t segment, int32_t special, int32_t height, ImageId imageTemplate,
     const FootpathPaintInfo& pathPaintInfo)
 {

--- a/src/openrct2/paint/Supports.cpp
+++ b/src/openrct2/paint/Supports.cpp
@@ -1252,13 +1252,10 @@ bool MetalBSupportsPaintSetup(
  * @return Whether supports were drawn
  */
 bool PathBoxSupportsPaintSetup(
-    PaintSession& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate,
-    const FootpathPaintInfo& pathPaintInfo, bool* underground)
+    PaintSession& session, WoodenSupportSubType supportType, bool isSloped, Direction slopeRotation, int32_t height,
+    ImageId imageTemplate, const FootpathPaintInfo& pathPaintInfo)
 {
-    if (underground != nullptr)
-    {
-        *underground = false; // AND
-    }
+    auto supportOrientationOffset = (supportType == WoodenSupportSubType::NwSe) ? 24 : 0;
 
     if (!(session.Flags & PaintSessionFlags::PassedSurface))
     {
@@ -1278,8 +1275,6 @@ bool PathBoxSupportsPaintSetup(
     int32_t supportLength = height - baseHeight;
     if (supportLength < 0)
     {
-        if (underground != nullptr)
-            *underground = true; // STC
         return false;
     }
 
@@ -1299,12 +1294,10 @@ bool PathBoxSupportsPaintSetup(
         heightSteps -= 2;
         if (heightSteps < 0)
         {
-            if (underground != nullptr)
-                *underground = true; // STC
             return false;
         }
 
-        uint32_t imageId = (supportType * 24) + word_97B3C4[session.Support.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK]
+        uint32_t imageId = supportOrientationOffset + word_97B3C4[session.Support.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK]
             + pathPaintInfo.BridgeImageId;
 
         PaintAddImageAsParent(
@@ -1322,12 +1315,10 @@ bool PathBoxSupportsPaintSetup(
         heightSteps -= 1;
         if (heightSteps < 0)
         {
-            if (underground != nullptr)
-                *underground = true; // STC
             return false;
         }
 
-        uint32_t ebx = (supportType * 24) + word_97B3C4[session.Support.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK]
+        uint32_t ebx = supportOrientationOffset + word_97B3C4[session.Support.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK]
             + pathPaintInfo.BridgeImageId;
 
         PaintAddImageAsParent(
@@ -1341,7 +1332,7 @@ bool PathBoxSupportsPaintSetup(
     {
         if (baseHeight & 0x10 || heightSteps == 1 || baseHeight + WATER_HEIGHT_STEP == session.WaterHeight)
         {
-            uint32_t imageId = (supportType * 24) + pathPaintInfo.BridgeImageId + 23;
+            uint32_t imageId = supportOrientationOffset + pathPaintInfo.BridgeImageId + 23;
 
             PaintAddImageAsParent(
                 session, imageTemplate.WithIndex(imageId), { 0, 0, baseHeight }, { 32, 32, ((heightSteps == 1) ? 7 : 12) });
@@ -1351,7 +1342,7 @@ bool PathBoxSupportsPaintSetup(
         }
         else
         {
-            uint32_t imageId = (supportType * 24) + pathPaintInfo.BridgeImageId + 22;
+            uint32_t imageId = supportOrientationOffset + pathPaintInfo.BridgeImageId + 22;
 
             PaintAddImageAsParent(
                 session, imageTemplate.WithIndex(imageId), { 0, 0, baseHeight }, { 32, 32, ((heightSteps == 2) ? 23 : 28) });
@@ -1361,13 +1352,11 @@ bool PathBoxSupportsPaintSetup(
         }
     }
 
-    if (special != 0)
+    if (isSloped)
     {
-        uint16_t specialIndex = (special - 1) & 0xFFFF;
+        ImageIndex imageIndex = pathPaintInfo.BridgeImageId + 55 + slopeRotation;
 
-        ImageIndex imageIndex = pathPaintInfo.BridgeImageId + 55 + specialIndex;
-
-        const UnkSupportsDescriptor& supportsDesc = Byte98D8D4[specialIndex];
+        const UnkSupportsDescriptor& supportsDesc = Byte98D8D4[slopeRotation];
         auto boundBox = supportsDesc.bounding_box;
         boundBox.offset.z += baseHeight;
 
@@ -1388,9 +1377,6 @@ bool PathBoxSupportsPaintSetup(
         }
     }
 
-    if (underground != nullptr)
-        *underground = false; // AND
-
     return hasSupports;
 }
 
@@ -1407,9 +1393,11 @@ bool PathBoxSupportsPaintSetup(
  * @return Whether supports were drawn
  */
 bool PathPoleSupportsPaintSetup(
-    PaintSession& session, int32_t segment, int32_t special, int32_t height, ImageId imageTemplate,
+    PaintSession& session, MetalSupportPlace supportPlace, bool isSloped, int32_t height, ImageId imageTemplate,
     const FootpathPaintInfo& pathPaintInfo)
 {
+    auto segment = EnumValue(supportPlace);
+
     SupportHeight* supportSegments = session.SupportSegments;
 
     if (!(session.Flags & PaintSessionFlags::PassedSurface))
@@ -1523,13 +1511,13 @@ bool PathPoleSupportsPaintSetup(
     supportSegments[segment].height = 0xFFFF;
     supportSegments[segment].slope = 0x20;
 
-    if (special != 0)
+    if (isSloped)
     {
-        int16_t si = special + baseHeight;
+        int16_t si = baseHeight + COORDS_Z_STEP;
 
         while (true)
         {
-            int16_t z = baseHeight + 16;
+            int16_t z = baseHeight + (2 * COORDS_Z_STEP);
             if (z > si)
             {
                 z = si;

--- a/src/openrct2/paint/Supports.h
+++ b/src/openrct2/paint/Supports.h
@@ -146,10 +146,10 @@ bool MetalBSupportsPaintSetup(
     PaintSession& session, MetalSupportType supportTypeMember, MetalSupportPlace placement, int32_t special, int32_t height,
     ImageId imageTemplate);
 bool PathBoxSupportsPaintSetup(
-    PaintSession& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate,
-    const FootpathPaintInfo& pathPaintInfo, bool* underground);
+    PaintSession& session, WoodenSupportSubType supportType, bool isSloped, Direction slopeRotation, int32_t height,
+    ImageId imageTemplate, const FootpathPaintInfo& pathPaintInfo);
 bool PathPoleSupportsPaintSetup(
-    PaintSession& session, int32_t segment, int32_t special, int32_t height, ImageId imageTemplate,
+    PaintSession& session, MetalSupportPlace supportPlace, bool isSloped, int32_t height, ImageId imageTemplate,
     const FootpathPaintInfo& pathPaintInfo);
 void DrawSupportsSideBySide(
     PaintSession& session, Direction direction, uint16_t height, ImageId colour, MetalSupportType type, int32_t special = 0);

--- a/src/openrct2/paint/Supports.h
+++ b/src/openrct2/paint/Supports.h
@@ -145,11 +145,11 @@ bool MetalASupportsPaintSetup(
 bool MetalBSupportsPaintSetup(
     PaintSession& session, MetalSupportType supportTypeMember, MetalSupportPlace placement, int32_t special, int32_t height,
     ImageId imageTemplate);
-bool PathASupportsPaintSetup(
+bool PathBoxSupportsPaintSetup(
     PaintSession& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate,
     const FootpathPaintInfo& pathPaintInfo, bool* underground);
-bool PathBSupportsPaintSetup(
-    PaintSession& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate,
+bool PathPoleSupportsPaintSetup(
+    PaintSession& session, int32_t segment, int32_t special, int32_t height, ImageId imageTemplate,
     const FootpathPaintInfo& pathPaintInfo);
 void DrawSupportsSideBySide(
     PaintSession& session, Direction direction, uint16_t height, ImageId colour, MetalSupportType type, int32_t special = 0);

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -832,6 +832,25 @@ static std::pair<uint8_t, uint8_t> PathPaintGetRotatedEdgesAndCorners(
     return std::make_pair(edges, corners);
 }
 
+static ImageIndex PathPaintGetBaseImage(
+    const PaintSession& session, const PathElement& pathElement, const FootpathPaintInfo& pathPaintInfo,
+    uint16_t rotatedEdgesAndCorners)
+{
+    ImageIndex surfaceBaseImageIndex = pathPaintInfo.SurfaceImageId;
+    if (pathElement.IsSloped())
+    {
+        auto directionOffset = (pathElement.GetSlopeDirection() + session.CurrentRotation)
+            & FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK;
+        surfaceBaseImageIndex += 16 + directionOffset;
+    }
+    else
+    {
+        surfaceBaseImageIndex += Byte98D6E0[rotatedEdgesAndCorners];
+    }
+
+    return surfaceBaseImageIndex;
+}
+
 static BoundBoxXYZ PathPaintGetBoundbox(const PaintSession& session, int32_t height, uint8_t edges)
 {
     CoordsXY boundBoxOffset = stru_98D804[edges].offset;
@@ -917,18 +936,7 @@ void PathPaintBoxSupport(
     auto [edges, corners] = PathPaintGetRotatedEdgesAndCorners(session, pathElement);
     uint16_t edi = edges | (corners << 4);
 
-    ImageIndex surfaceBaseImageIndex = pathPaintInfo.SurfaceImageId;
-    if (pathElement.IsSloped())
-    {
-        auto directionOffset = (pathElement.GetSlopeDirection() + session.CurrentRotation)
-            & FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK;
-        surfaceBaseImageIndex += 16 + directionOffset;
-    }
-    else
-    {
-        surfaceBaseImageIndex += Byte98D6E0[edi];
-    }
-
+    auto surfaceBaseImageIndex = PathPaintGetBaseImage(session, pathElement, pathPaintInfo, edi);
     auto boundbox = PathPaintGetBoundbox(session, height, edges);
 
     const bool hasPassedSurface = (session.Flags & PaintSessionFlags::PassedSurface) != 0;
@@ -981,18 +989,7 @@ void PathPaintPoleSupport(
     auto [edges, corners] = PathPaintGetRotatedEdgesAndCorners(session, pathElement);
     uint16_t edi = edges | (corners << 4);
 
-    ImageIndex surfaceBaseImageIndex = pathPaintInfo.SurfaceImageId;
-    if (pathElement.IsSloped())
-    {
-        auto directionOffset = (pathElement.GetSlopeDirection() + session.CurrentRotation)
-            & FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK;
-        surfaceBaseImageIndex += 16 + directionOffset;
-    }
-    else
-    {
-        surfaceBaseImageIndex += Byte98D6E0[edi];
-    }
-
+    auto surfaceBaseImageIndex = PathPaintGetBaseImage(session, pathElement, pathPaintInfo, edi);
     auto boundbox = PathPaintGetBoundbox(session, height, edges);
 
     // Below Surface

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -168,6 +168,39 @@ static void PathPaintQueueBanner(
     }
 }
 
+static void PathPaintSlopedFences(
+    PaintSession& session, const PathElement& pathElement, uint16_t height, ImageId imageId, bool isQueue)
+{
+    auto queueOffset = isQueue ? 14 : 0;
+    switch ((pathElement.GetSlopeDirection() + session.CurrentRotation) & FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK)
+    {
+        case 0:
+            PaintAddImageAsParent(
+                session, imageId.WithIndexOffset(8 + queueOffset), { 0, 4, height }, { { 0, 4, height + 2 }, { 32, 1, 23 } });
+            PaintAddImageAsParent(
+                session, imageId.WithIndexOffset(8 + queueOffset), { 0, 28, height }, { { 0, 28, height + 2 }, { 32, 1, 23 } });
+            break;
+        case 1:
+            PaintAddImageAsParent(
+                session, imageId.WithIndexOffset(7 + queueOffset), { 4, 0, height }, { { 4, 0, height + 2 }, { 1, 32, 23 } });
+            PaintAddImageAsParent(
+                session, imageId.WithIndexOffset(7 + queueOffset), { 28, 0, height }, { { 28, 0, height + 2 }, { 1, 32, 23 } });
+            break;
+        case 2:
+            PaintAddImageAsParent(
+                session, imageId.WithIndexOffset(9 + queueOffset), { 0, 4, height }, { { 0, 4, height + 2 }, { 32, 1, 23 } });
+            PaintAddImageAsParent(
+                session, imageId.WithIndexOffset(9 + queueOffset), { 0, 28, height }, { { 0, 28, height + 2 }, { 32, 1, 23 } });
+            break;
+        case 3:
+            PaintAddImageAsParent(
+                session, imageId.WithIndexOffset(6 + queueOffset), { 4, 0, height }, { { 4, 0, height + 2 }, { 1, 32, 23 } });
+            PaintAddImageAsParent(
+                session, imageId.WithIndexOffset(6 + queueOffset), { 28, 0, height }, { { 28, 0, height + 2 }, { 1, 32, 23 } });
+            break;
+    }
+}
+
 static void PathPaintFencesAndQueueBannersQueue(
     PaintSession& session, const PathElement& pathElement, uint16_t height, uint32_t connectedEdges, bool hasSupports,
     const FootpathPaintInfo& pathPaintInfo, ImageId imageTemplate)
@@ -176,33 +209,7 @@ static void PathPaintFencesAndQueueBannersQueue(
 
     if (pathElement.IsSloped())
     {
-        switch ((pathElement.GetSlopeDirection() + session.CurrentRotation) & FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK)
-        {
-            case 0:
-                PaintAddImageAsParent(
-                    session, imageId.WithIndexOffset(22), { 0, 4, height }, { { 0, 4, height + 2 }, { 32, 1, 23 } });
-                PaintAddImageAsParent(
-                    session, imageId.WithIndexOffset(22), { 0, 28, height }, { { 0, 28, height + 2 }, { 32, 1, 23 } });
-                break;
-            case 1:
-                PaintAddImageAsParent(
-                    session, imageId.WithIndexOffset(21), { 4, 0, height }, { { 4, 0, height + 2 }, { 1, 32, 23 } });
-                PaintAddImageAsParent(
-                    session, imageId.WithIndexOffset(21), { 28, 0, height }, { { 28, 0, height + 2 }, { 1, 32, 23 } });
-                break;
-            case 2:
-                PaintAddImageAsParent(
-                    session, imageId.WithIndexOffset(23), { 0, 4, height }, { { 0, 4, height + 2 }, { 32, 1, 23 } });
-                PaintAddImageAsParent(
-                    session, imageId.WithIndexOffset(23), { 0, 28, height }, { { 0, 28, height + 2 }, { 32, 1, 23 } });
-                break;
-            case 3:
-                PaintAddImageAsParent(
-                    session, imageId.WithIndexOffset(20), { 4, 0, height }, { { 4, 0, height + 2 }, { 1, 32, 23 } });
-                PaintAddImageAsParent(
-                    session, imageId.WithIndexOffset(20), { 28, 0, height }, { { 28, 0, height + 2 }, { 1, 32, 23 } });
-                break;
-        }
+        PathPaintSlopedFences(session, pathElement, height, imageId, true);
     }
     else
     {
@@ -361,33 +368,7 @@ static void PathPaintFencesAndQueueBannersNonQueue(
     auto slopeRailingsSupported = !(pathPaintInfo.SurfaceFlags & FOOTPATH_ENTRY_FLAG_NO_SLOPE_RAILINGS);
     if ((hasSupports || slopeRailingsSupported) && pathElement.IsSloped())
     {
-        switch ((pathElement.GetSlopeDirection() + session.CurrentRotation) & FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK)
-        {
-            case 0:
-                PaintAddImageAsParent(
-                    session, imageId.WithIndexOffset(8), { 0, 4, height }, { { 0, 4, height + 2 }, { 32, 1, 23 } });
-                PaintAddImageAsParent(
-                    session, imageId.WithIndexOffset(8), { 0, 28, height }, { { 0, 28, height + 2 }, { 32, 1, 23 } });
-                break;
-            case 1:
-                PaintAddImageAsParent(
-                    session, imageId.WithIndexOffset(7), { 4, 0, height }, { { 4, 0, height + 2 }, { 1, 32, 23 } });
-                PaintAddImageAsParent(
-                    session, imageId.WithIndexOffset(7), { 28, 0, height }, { { 28, 0, height + 2 }, { 1, 32, 23 } });
-                break;
-            case 2:
-                PaintAddImageAsParent(
-                    session, imageId.WithIndexOffset(9), { 0, 4, height }, { { 0, 4, height + 2 }, { 32, 1, 23 } });
-                PaintAddImageAsParent(
-                    session, imageId.WithIndexOffset(9), { 0, 28, height }, { { 0, 28, height + 2 }, { 32, 1, 23 } });
-                break;
-            case 3:
-                PaintAddImageAsParent(
-                    session, imageId.WithIndexOffset(6), { 4, 0, height }, { { 4, 0, height + 2 }, { 1, 32, 23 } });
-                PaintAddImageAsParent(
-                    session, imageId.WithIndexOffset(6), { 28, 0, height }, { { 28, 0, height + 2 }, { 1, 32, 23 } });
-                break;
-        }
+        PathPaintSlopedFences(session, pathElement, height, imageId, false);
     }
     else
     {

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -82,8 +82,8 @@ static constexpr BoundBoxXY stru_98D804[] = {
     { { 0, 0 }, { 32, 32 } },
 };
 
-static constexpr uint8_t Byte98D8A4[] = {
-    0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 1, 1, 0, 0, 1, 0
+static constexpr WoodenSupportSubType PathSupportOrientation[] = {
+    WoodenSupportSubType::NeSw, WoodenSupportSubType::NeSw, WoodenSupportSubType::NwSe, WoodenSupportSubType::NeSw, WoodenSupportSubType::NeSw, WoodenSupportSubType::NeSw, WoodenSupportSubType::NwSe, WoodenSupportSubType::NeSw, WoodenSupportSubType::NwSe, WoodenSupportSubType::NwSe, WoodenSupportSubType::NwSe, WoodenSupportSubType::NwSe, WoodenSupportSubType::NeSw, WoodenSupportSubType::NeSw, WoodenSupportSubType::NwSe, WoodenSupportSubType::NeSw,
 };
 // clang-format on
 
@@ -955,7 +955,7 @@ void PathPaintBoxSupport(
         }
         else
         {
-            bridgeBaseImageIndex = Byte98D8A4[edges] + pathPaintInfo.BridgeImageId + 49;
+            bridgeBaseImageIndex = EnumValue(PathSupportOrientation[edges]) + pathPaintInfo.BridgeImageId + 49;
         }
 
         PaintAddImageAsParent(session, imageTemplate.WithIndex(bridgeBaseImageIndex), { 0, 0, height }, boundbox);
@@ -968,14 +968,14 @@ void PathPaintBoxSupport(
 
     Sub6A3F61(session, pathElement, edi, height, pathPaintInfo, imageTemplate, sceneryImageTemplate, hasSupports);
 
-    uint16_t ax = 0;
+    Direction slopeDirection{};
     if (pathElement.IsSloped())
     {
-        ax = ((pathElement.GetSlopeDirection() + session.CurrentRotation) & 0x3) + 1;
+        slopeDirection = ((pathElement.GetSlopeDirection() + session.CurrentRotation) & 0x3);
     }
 
-    auto supportType = Byte98D8A4[edges] == 0 ? 0 : 1;
-    PathBoxSupportsPaintSetup(session, supportType, ax, height, imageTemplate, pathPaintInfo, nullptr);
+    PathBoxSupportsPaintSetup(
+        session, PathSupportOrientation[edges], pathElement.IsSloped(), slopeDirection, height, imageTemplate, pathPaintInfo);
 
     PathPaintSegmentSupportHeight(session, pathElement, height, edges, hasSupports);
 }
@@ -1024,17 +1024,11 @@ void PathPaintPoleSupport(
         session, pathElement, edi, height, pathPaintInfo, imageTemplate, sceneryImageTemplate,
         hasSupports); // TODO: arguments
 
-    uint16_t ax = 0;
-    if (pathElement.IsSloped())
-    {
-        ax = 8;
-    }
-
-    uint8_t supports[] = {
-        6,
-        8,
-        7,
-        5,
+    MetalSupportPlace supports[] = {
+        MetalSupportPlace::TopRightSide,
+        MetalSupportPlace::BottomRightSide,
+        MetalSupportPlace::BottomLeftSide,
+        MetalSupportPlace::TopLeftSide,
     };
 
     for (int8_t i = 3; i > -1; --i)
@@ -1047,7 +1041,7 @@ void PathPaintPoleSupport(
             {
                 imageTemplate = ImageId().WithPrimary(supportColour);
             }
-            PathPoleSupportsPaintSetup(session, supports[i], ax, height, imageTemplate, pathPaintInfo);
+            PathPoleSupportsPaintSetup(session, supports[i], pathElement.IsSloped(), height, imageTemplate, pathPaintInfo);
         }
     }
 

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -862,7 +862,7 @@ static BoundBoxXYZ PathPaintGetBoundbox(const PaintSession& session, int32_t hei
 {
     CoordsXY boundBoxOffset = stru_98D804[edges].offset;
     CoordsXY boundBoxSize = stru_98D804[edges].length;
-    
+
     const bool hasPassedSurface = (session.Flags & PaintSessionFlags::PassedSurface) != 0;
     if (!hasPassedSurface)
     {
@@ -871,7 +871,7 @@ static BoundBoxXYZ PathPaintGetBoundbox(const PaintSession& session, int32_t hei
         boundBoxSize.x = 26;
         boundBoxSize.y = 26;
     }
-    
+
     // By default, add 1 to the z bounding box to always clip above the surface
     uint8_t boundingBoxZOffset = 1;
 

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -975,7 +975,7 @@ void PathPaintBoxSupport(
     }
 
     auto supportType = Byte98D8A4[edges] == 0 ? 0 : 1;
-    PathASupportsPaintSetup(session, supportType, ax, height, imageTemplate, pathPaintInfo, nullptr);
+    PathBoxSupportsPaintSetup(session, supportType, ax, height, imageTemplate, pathPaintInfo, nullptr);
 
     PathPaintSegmentSupportHeight(session, pathElement, height, edges, hasSupports);
 }
@@ -1047,7 +1047,7 @@ void PathPaintPoleSupport(
             {
                 imageTemplate = ImageId().WithPrimary(supportColour);
             }
-            PathBSupportsPaintSetup(session, supports[i], ax, height, imageTemplate, pathPaintInfo);
+            PathPoleSupportsPaintSetup(session, supports[i], ax, height, imageTemplate, pathPaintInfo);
         }
     }
 

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -819,6 +819,52 @@ void PaintPath(PaintSession& session, uint16_t height, const PathElement& tileEl
     PaintLampLightEffects(session, tileElement, height);
 }
 
+static void PathPaintSegmentSupportHeight(
+    PaintSession& session, const PathElement& pathElement, int32_t height, uint8_t edges, bool hasSupports)
+{
+    height += 32;
+    if (pathElement.IsSloped())
+    {
+        height += 16;
+    }
+
+    PaintUtilSetGeneralSupportHeight(session, height, 0x20);
+
+    if (pathElement.IsQueue() || (pathElement.GetEdgesAndCorners() != 0xFF && hasSupports))
+    {
+        PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
+        return;
+    }
+
+    if (pathElement.GetEdgesAndCorners() == 0xFF)
+    {
+        PaintUtilSetSegmentSupportHeight(session, SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, 0xFFFF, 0);
+        return;
+    }
+
+    PaintUtilSetSegmentSupportHeight(session, SEGMENT_C4, 0xFFFF, 0);
+
+    if (edges & EDGE_NE)
+    {
+        PaintUtilSetSegmentSupportHeight(session, SEGMENT_CC, 0xFFFF, 0);
+    }
+
+    if (edges & EDGE_SE)
+    {
+        PaintUtilSetSegmentSupportHeight(session, SEGMENT_D4, 0xFFFF, 0);
+    }
+
+    if (edges & EDGE_SW)
+    {
+        PaintUtilSetSegmentSupportHeight(session, SEGMENT_D0, 0xFFFF, 0);
+    }
+
+    if (edges & EDGE_NW)
+    {
+        PaintUtilSetSegmentSupportHeight(session, SEGMENT_C8, 0xFFFF, 0);
+    }
+}
+
 void PathPaintBoxSupport(
     PaintSession& session, const PathElement& pathElement, int32_t height, const FootpathPaintInfo& pathPaintInfo,
     bool hasSupports, ImageId imageTemplate, ImageId sceneryImageTemplate)
@@ -914,47 +960,7 @@ void PathPaintBoxSupport(
     auto supportType = Byte98D8A4[edges] == 0 ? 0 : 1;
     PathASupportsPaintSetup(session, supportType, ax, height, imageTemplate, pathPaintInfo, nullptr);
 
-    height += 32;
-    if (pathElement.IsSloped())
-    {
-        height += 16;
-    }
-
-    PaintUtilSetGeneralSupportHeight(session, height, 0x20);
-
-    if (pathElement.IsQueue() || (pathElement.GetEdgesAndCorners() != 0xFF && hasSupports))
-    {
-        PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
-        return;
-    }
-
-    if (pathElement.GetEdgesAndCorners() == 0xFF)
-    {
-        PaintUtilSetSegmentSupportHeight(session, SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, 0xFFFF, 0);
-        return;
-    }
-
-    PaintUtilSetSegmentSupportHeight(session, SEGMENT_C4, 0xFFFF, 0);
-
-    if (edges & 1)
-    {
-        PaintUtilSetSegmentSupportHeight(session, SEGMENT_CC, 0xFFFF, 0);
-    }
-
-    if (edges & 2)
-    {
-        PaintUtilSetSegmentSupportHeight(session, SEGMENT_D4, 0xFFFF, 0);
-    }
-
-    if (edges & 4)
-    {
-        PaintUtilSetSegmentSupportHeight(session, SEGMENT_D0, 0xFFFF, 0);
-    }
-
-    if (edges & 8)
-    {
-        PaintUtilSetSegmentSupportHeight(session, SEGMENT_C8, 0xFFFF, 0);
-    }
+    PathPaintSegmentSupportHeight(session, pathElement, height, edges, hasSupports);
 }
 
 void PathPaintPoleSupport(
@@ -1073,45 +1079,5 @@ void PathPaintPoleSupport(
         }
     }
 
-    height += 32;
-    if (pathElement.IsSloped())
-    {
-        height += 16;
-    }
-
-    PaintUtilSetGeneralSupportHeight(session, height, 0x20);
-
-    if (pathElement.IsQueue() || (pathElement.GetEdgesAndCorners() != 0xFF && hasSupports))
-    {
-        PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
-        return;
-    }
-
-    if (pathElement.GetEdgesAndCorners() == 0xFF)
-    {
-        PaintUtilSetSegmentSupportHeight(session, SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, 0xFFFF, 0);
-        return;
-    }
-
-    PaintUtilSetSegmentSupportHeight(session, SEGMENT_C4, 0xFFFF, 0);
-
-    if (edges & EDGE_NE)
-    {
-        PaintUtilSetSegmentSupportHeight(session, SEGMENT_CC, 0xFFFF, 0);
-    }
-
-    if (edges & EDGE_SE)
-    {
-        PaintUtilSetSegmentSupportHeight(session, SEGMENT_D4, 0xFFFF, 0);
-    }
-
-    if (edges & EDGE_SW)
-    {
-        PaintUtilSetSegmentSupportHeight(session, SEGMENT_D0, 0xFFFF, 0);
-    }
-
-    if (edges & EDGE_NW)
-    {
-        PaintUtilSetSegmentSupportHeight(session, SEGMENT_C8, 0xFFFF, 0);
-    }
+    PathPaintSegmentSupportHeight(session, pathElement, height, edges, hasSupports);
 }

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -83,7 +83,22 @@ static constexpr BoundBoxXY stru_98D804[] = {
 };
 
 static constexpr WoodenSupportSubType PathSupportOrientation[] = {
-    WoodenSupportSubType::NeSw, WoodenSupportSubType::NeSw, WoodenSupportSubType::NwSe, WoodenSupportSubType::NeSw, WoodenSupportSubType::NeSw, WoodenSupportSubType::NeSw, WoodenSupportSubType::NwSe, WoodenSupportSubType::NeSw, WoodenSupportSubType::NwSe, WoodenSupportSubType::NwSe, WoodenSupportSubType::NwSe, WoodenSupportSubType::NwSe, WoodenSupportSubType::NeSw, WoodenSupportSubType::NeSw, WoodenSupportSubType::NwSe, WoodenSupportSubType::NeSw,
+    WoodenSupportSubType::NeSw, 
+    WoodenSupportSubType::NeSw, 
+    WoodenSupportSubType::NwSe, 
+    WoodenSupportSubType::NeSw,
+    WoodenSupportSubType::NeSw, 
+    WoodenSupportSubType::NeSw, 
+    WoodenSupportSubType::NwSe, 
+    WoodenSupportSubType::NeSw,
+    WoodenSupportSubType::NwSe, 
+    WoodenSupportSubType::NwSe, 
+    WoodenSupportSubType::NwSe, 
+    WoodenSupportSubType::NwSe,
+    WoodenSupportSubType::NeSw, 
+    WoodenSupportSubType::NeSw, 
+    WoodenSupportSubType::NwSe, 
+    WoodenSupportSubType::NeSw,
 };
 // clang-format on
 
@@ -866,10 +881,8 @@ static BoundBoxXYZ PathPaintGetBoundbox(const PaintSession& session, int32_t hei
     const bool hasPassedSurface = (session.Flags & PaintSessionFlags::PassedSurface) != 0;
     if (!hasPassedSurface)
     {
-        boundBoxOffset.x = 3;
-        boundBoxOffset.y = 3;
-        boundBoxSize.x = 26;
-        boundBoxSize.y = 26;
+        boundBoxOffset = { 3, 3 };
+        boundBoxSize = { 26, 26 };
     }
 
     // By default, add 1 to the z bounding box to always clip above the surface
@@ -877,12 +890,10 @@ static BoundBoxXYZ PathPaintGetBoundbox(const PaintSession& session, int32_t hei
 
     // If we are on the same tile as a straight track, add the offset 2 so we
     //  can clip above gravel part of the track sprite
-    if (session.TrackElementOnSameHeight != nullptr)
+    if (session.TrackElementOnSameHeight != nullptr
+        && session.TrackElementOnSameHeight->AsTrack()->GetTrackType() == TrackElemType::Flat)
     {
-        if (session.TrackElementOnSameHeight->AsTrack()->GetTrackType() == TrackElemType::Flat)
-        {
-            boundingBoxZOffset = 2;
-        }
+        boundingBoxZOffset = 2;
     }
 
     return BoundBoxXYZ({ boundBoxOffset, height + boundingBoxZOffset }, { boundBoxSize, 0 });

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -819,6 +819,19 @@ void PaintPath(PaintSession& session, uint16_t height, const PathElement& tileEl
     PaintLampLightEffects(session, tileElement, height);
 }
 
+static std::pair<uint8_t, uint8_t> PathPaintGetRotatedEdgesAndCorners(
+    const PaintSession& session, const PathElement& pathElement)
+{
+    // Rol edges around rotation
+    uint8_t edges = ((pathElement.GetEdges() << session.CurrentRotation) & 0xF)
+        | (((pathElement.GetEdges()) << session.CurrentRotation) >> 4);
+
+    uint8_t corners = (((pathElement.GetCorners()) << session.CurrentRotation) & 0xF)
+        | (((pathElement.GetCorners()) << session.CurrentRotation) >> 4);
+
+    return std::make_pair(edges, corners);
+}
+
 static BoundBoxXYZ PathPaintGetBoundbox(const PaintSession& session, int32_t height, uint8_t edges)
 {
     CoordsXY boundBoxOffset = stru_98D804[edges].offset;
@@ -901,13 +914,7 @@ void PathPaintBoxSupport(
 {
     PROFILED_FUNCTION();
 
-    // Rol edges around rotation
-    uint8_t edges = ((pathElement.GetEdges() << session.CurrentRotation) & 0xF)
-        | (((pathElement.GetEdges()) << session.CurrentRotation) >> 4);
-
-    uint8_t corners = (((pathElement.GetCorners()) << session.CurrentRotation) & 0xF)
-        | (((pathElement.GetCorners()) << session.CurrentRotation) >> 4);
-
+    auto [edges, corners] = PathPaintGetRotatedEdgesAndCorners(session, pathElement);
     uint16_t edi = edges | (corners << 4);
 
     ImageIndex surfaceBaseImageIndex = pathPaintInfo.SurfaceImageId;
@@ -971,13 +978,7 @@ void PathPaintPoleSupport(
 {
     PROFILED_FUNCTION();
 
-    // Rol edges around rotation
-    uint8_t edges = ((pathElement.GetEdges() << session.CurrentRotation) & 0xF)
-        | (((pathElement.GetEdges()) << session.CurrentRotation) >> 4);
-
-    uint8_t corners = (((pathElement.GetCorners()) << session.CurrentRotation) & 0xF)
-        | (((pathElement.GetCorners()) << session.CurrentRotation) >> 4);
-
+    auto [edges, corners] = PathPaintGetRotatedEdgesAndCorners(session, pathElement);
     uint16_t edi = edges | (corners << 4);
 
     ImageIndex surfaceBaseImageIndex = pathPaintInfo.SurfaceImageId;


### PR DESCRIPTION
As it says on the tin. Reduces code duplication, changes out integers for strong enums and bools and renames the PathA and PathB functions to reflect what they’re used for.

Commits should make sense if looked at one by one. Do not squash merge.