### PR TITLE
Render selection grid for Map ownership on the water

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,7 +1,7 @@
 0.4.8 (in development)
 ------------------------------------------------------------------------
 - Feature: [#21062] [Plugin] Add API for managing a guest's items.
-- Improved: [#18632] Land ownership and construction rights are now shown on top of the water.
+- Improved: [#18632, #21306] Land ownership and construction rights are now shown on top of the water.
 - Improved: [#20951] Activate OpenRCT2 window after using native file dialog on macOS.
 - Improved: [#21184] The construction marker for rides, paths and large scenery is now shown on top of the water.
 - Improved: [#21227] Entrance style dropdown is now sorted alphabetically everywhere.

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -430,12 +430,16 @@ public:
     {
         MapInvalidateSelectionRect();
         gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE;
-        auto mapCoords = ScreenGetMapXY(screenCoords, nullptr);
-        if (!mapCoords.has_value())
+
+        auto info = GetMapCoordinatesFromPos(
+            screenCoords, EnumsToFlags(ViewportInteractionItem::Terrain, ViewportInteractionItem::Water));
+        if (info.SpriteType == ViewportInteractionItem::None)
             return;
 
+        auto mapCoords = info.Loc;
+
         gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE;
-        gMapSelectType = MAP_SELECT_TYPE_FULL;
+        gMapSelectType = MAP_SELECT_TYPE_FULL_LAND_RIGHTS;
 
         int32_t landRightsToolSize = _landRightsToolSize;
         if (landRightsToolSize == 0)
@@ -443,11 +447,12 @@ public:
 
         int32_t size = (landRightsToolSize * 32) - 32;
         int32_t radius = (landRightsToolSize * 16) - 16;
-        mapCoords->x = (mapCoords->x - radius) & 0xFFE0;
-        mapCoords->y = (mapCoords->y - radius) & 0xFFE0;
-        gMapSelectPositionA = *mapCoords;
-        gMapSelectPositionB.x = mapCoords->x + size;
-        gMapSelectPositionB.y = mapCoords->y + size;
+        mapCoords.x -= radius;
+        mapCoords.y -= radius;
+        mapCoords = mapCoords.ToTileStart();
+        gMapSelectPositionA = mapCoords;
+        gMapSelectPositionB.x = mapCoords.x + size;
+        gMapSelectPositionB.y = mapCoords.y + size;
         MapInvalidateSelectionRect();
     }
 
@@ -687,7 +692,7 @@ public:
 
             MapInvalidateSelectionRect();
             gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE;
-            gMapSelectType = MAP_SELECT_TYPE_FULL;
+            gMapSelectType = MAP_SELECT_TYPE_FULL_LAND_RIGHTS;
             gMapSelectPositionA = mapCoords;
             gMapSelectPositionB = mapCoords + CoordsXY{ size, size };
             MapInvalidateSelectionRect();


### PR DESCRIPTION
This PR essentially does the same for the land rights tool in the Map window that we did earlier for the one in normal gameplay: make its grid draw on top of the water, and change the "catchment" to be on top of it as well:

![afbeelding](https://github.com/OpenRCT2/OpenRCT2/assets/1478678/47ab9ae0-fee5-4ccf-a16c-4a4a9afa4fbe)
