### PR TITLE
Fix park boundaries for out-of-bounds monorails in Africa - Oasis & Blackpool Pleasure Beach

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,6 +24,7 @@
 - Fix: [#21198] [Plugin] Setting brake or booster speeds on a tile element doesn’t work.
 - Fix: [#21290] Sound keeps playing when paused from fast-forward mode.
 - Fix: [#21291] Hungry guests heading to any flat ride do not count for warning threshold (original bug).
+- Fix: [#21309] Africa - Oasis & Blackpool Pleasure Beach’s monorails are built outside the park’s land rights.
 - Fix: [#21316] Isolated land for sale tile on Extreme Hawaiian Island.
 
 0.4.7 (2023-12-31)

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2550,6 +2550,21 @@ namespace RCT1
                 case SC_ALTON_TOWERS:
                     FixLandOwnershipTilesWithOwnership({ { 11, 31 }, { 68, 112 }, { 72, 118 } }, OWNERSHIP_OWNED);
                     break;
+                case SC_BLACKPOOL_PLEASURE_BEACH:
+                    FixLandOwnershipTilesWithOwnership(
+                        { { 93, 23 },
+                          { 94, 23 },
+                          { 95, 23 },
+                          { 95, 24 },
+                          { 96, 24 },
+                          { 96, 25 },
+                          { 97, 25 },
+                          { 97, 26 },
+                          { 97, 27 },
+                          { 96, 28 } },
+                        OWNERSHIP_OWNED);
+                    FixLandOwnershipTilesWithOwnership({ { 94, 24 }, { 95, 25 } }, OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED);
+                    break;
                 case SC_FORT_ANACHRONISM:
                     FixLandOwnershipTiles({ { 36, 87 }, { 54, 29 }, { 53, 88 } });
                     break;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -873,6 +873,12 @@ namespace RCT2
                         { 46, 87 },
                     },
                     OWNERSHIP_OWNED);
+                  FixLandOwnershipTilesWithOwnership(
+                    {
+                        {  140, 58 }, {  141, 58 }, {  142, 58 }, { 143, 58 }, { 144, 58 }, { 145, 58 }, { 146, 58 }, { 147, 58 }, 
+                        {  140, 74 }, {  141, 74 }, {  142, 74 }, { 143, 74 }, { 144, 74 }, { 145, 74 }, { 146, 74 }, { 147, 74 }, 
+                    },
+                    OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED, true);
                 // clang-format on
             }
             else if (


### PR DESCRIPTION
The underground Monorail in Oasis leaves the construction rights boundaries; this adds construction rights to those locations. An extra tile of construction rights was added on one of the corners to make the two sides symmetrical, as before (terrain was changed to grass for visibility).
![undergrounda](https://github.com/OpenRCT2/OpenRCT2/assets/108596959/832783e8-f7f9-42d4-af15-b3da5d3a510c)
![undergroundb](https://github.com/OpenRCT2/OpenRCT2/assets/108596959/4b67bf77-0b17-421e-a244-be5eed902ec6)

The Monorail in Blackpool Pleasure Beach Passes through construction rights only terrain at ground level. The terrain is question is changed to owned land.
![monorail1](https://github.com/OpenRCT2/OpenRCT2/assets/108596959/facbcdb8-f3b7-475e-880f-8239a3e04ea8)
![monorail2](https://github.com/OpenRCT2/OpenRCT2/assets/108596959/99c2ecec-7cfc-498c-8dd7-d5867784a908)

Aside from these spots, the entirety of both monorail tracks are placed in locations where they could be built. In addition, the building the monorail on Blackpool Pleasure Beach passes over already has owned land tiles on it.