### PR TITLE
Fix #21310: Clearance on half loop elements is not symmetrical

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Fix: [#21220] When creating a new park from a SC4 file, the localised park name is not applied.
 - Fix: [#21286] Cannot build unbanking turns with RCT1 vehicles.
 - Fix: [#21288] Text overlaps in the “About ‘OpenRCT2’” window for Arabic, Chinese, Japanese, Korean and Vietnamese.
+- Fix: [#21310] Some half loop elements require more clearance than their upward/downward counterparts.
 - Fix: [#21318] Virtual Floor for building scenery is not properly invalidated.
 - Fix: [#21330] Tooltips from dropdown widgets have the wrong position.
 - Fix: [#21332] Mini Helicopters and Monorail Cycles ride types are swapped in research within RCT1 scenarios.

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2622,7 +2622,7 @@ private:
             CoordsXY coords = originCoords + offsets.Rotate(trackDirection);
 
             int32_t baseZ = originZ + trackBlock->z;
-            int32_t clearanceZ = trackBlock->var_07 + clearanceHeight + baseZ + (4 * COORDS_Z_STEP);
+            int32_t clearanceZ = trackBlock->ClearanceZ + clearanceHeight + baseZ + (4 * COORDS_Z_STEP);
 
             auto centreTileCoords = TileCoordsXY{ coords };
             auto eastTileCoords = centreTileCoords + TileDirectionDelta[TILE_ELEMENT_DIRECTION_EAST];

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -232,7 +232,7 @@ GameActions::Result TrackPlaceAction::Query() const
 
         int32_t baseZ = Floor2(mapLoc.z, COORDS_Z_STEP);
 
-        int32_t clearanceZ = trackBlock->var_07;
+        int32_t clearanceZ = trackBlock->ClearanceZ;
         if (trackBlock->flags & RCT_PREVIEW_TRACK_FLAG_IS_VERTICAL && clearanceHeight > 24)
         {
             clearanceZ += 24;
@@ -450,7 +450,7 @@ GameActions::Result TrackPlaceAction::Execute() const
         auto quarterTile = trackBlock->var_08.Rotate(_origin.direction);
 
         int32_t baseZ = Floor2(mapLoc.z, COORDS_Z_STEP);
-        int32_t clearanceZ = trackBlock->var_07;
+        int32_t clearanceZ = trackBlock->ClearanceZ;
         if (trackBlock->flags & RCT_PREVIEW_TRACK_FLAG_IS_VERTICAL && clearanceHeight > 24)
         {
             clearanceZ += 24;

--- a/src/openrct2/ride/Track.h
+++ b/src/openrct2/ride/Track.h
@@ -79,7 +79,7 @@ struct PreviewTrack
     int16_t x;     // 0x01
     int16_t y;     // 0x03
     int16_t z;     // 0x05
-    uint8_t var_07;
+    uint8_t ClearanceZ;
     QuarterTile var_08;
     uint8_t flags;
 };

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -1095,7 +1095,7 @@ static constexpr PreviewTrack TrackBlocks055[] = {
 
 // HalfLoopUp
 static constexpr PreviewTrack TrackBlocks056[] = {
-    { 0, 0, 0, 0, 32, { 0b1111, 0b1100 }, 0 },
+    { 0, 0, 0, 0, 16, { 0b1111, 0b1100 }, 0 },
     { 1, -32, 0, 16, 16, { 0b1111, 0b1100 }, 0 },
     { 2, -64, 0, 32, 96,{ 0b0011, 0 }, 0 },
     { 3, -32, 0, 120, 16, { 0b1111, 0 }, 0 },
@@ -1104,7 +1104,7 @@ static constexpr PreviewTrack TrackBlocks056[] = {
 
 // HalfLoopDown
 static constexpr PreviewTrack TrackBlocks057[] = {
-    { 0, 0, 0, -32, 32, { 0b1111, 0 }, 0 },
+    { 0, 0, 0, -32, 16, { 0b1111, 0 }, 0 },
     { 1, -32, 0, -120, 96,{ 0b0011, 0 }, 0 },
     { 2, 0, 0, -136, 16, { 0b1111, 0b1100 }, 0 },
     { 3, 32, 0, -152, 16, { 0b1111, 0b1100 }, 0 },

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -2158,7 +2158,7 @@ static constexpr PreviewTrack TrackBlocks190[] = {
 
 // FlyerHalfLoopUninvertedUp
 static constexpr PreviewTrack TrackBlocks191[] = {
-    { 0, 0, 0, 0, 32, { 0b1111, 0b1100 }, 0 },
+    { 0, 0, 0, 0, 16, { 0b1111, 0b1100 }, 0 },
     { 1, -32, 0, 16, 16, { 0b1111, 0b1100 }, 0 },
     { 2, -64, 0, 32, 96,{ 0b0011, 0 }, 0 },
     { 3, -32, 0, 120, 16, { 0b1111, 0 }, 0 },
@@ -2167,7 +2167,7 @@ static constexpr PreviewTrack TrackBlocks191[] = {
 
 // FlyerHalfLoopInvertedDown
 static constexpr PreviewTrack TrackBlocks192[] = {
-    { 0, 0, 0, 0, 32, { 0b1111, 0 }, 0 },
+    { 0, 0, 0, 0, 16, { 0b1111, 0 }, 0 },
     { 1, -32, 0, -88, 96,{ 0b0011, 0 }, 0 },
     { 2, 0, 0, -104, 16, { 0b1111, 0b1100 }, 0 },
     { 3, 32, 0, -120, 16, { 0b1111, 0b1100 }, 0 },
@@ -2929,7 +2929,7 @@ static constexpr PreviewTrack TrackBlocksRightFlyerLargeHalfLoopUninvertedDown[]
 };
 
 static constexpr PreviewTrack TrackBlocksFlyerHalfLoopUpInverted[] = {
-    { 0, 0, 0, 0, 32, { 0b1111, 0b1100 }, 0 },
+    { 0, 0, 0, 0, 16, { 0b1111, 0b1100 }, 0 },
     { 1, -32, 0, 16, 16, { 0b1111, 0b1100 }, 0 },
     { 2, -64, 0, 32, 96,{ 0b0011, 0 }, 0 },
     { 3, -32, 0, 120, 32, { 0b1111, 0 }, 0 },

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -2863,7 +2863,7 @@ static constexpr PreviewTrack TrackBlocksRightFlyerLargeHalfLoopUninvertedUp[] =
 };
 
 static constexpr PreviewTrack TrackBlocksLeftFlyerLargeHalfLoopInvertedDown[] = {
-    { 0, 0, 0, 0, 24, { 0b1111, 0 }, 0 },
+    { 0, 0, 0, 0, 16, { 0b1111, 0 }, 0 },
     { 1, -32, 0, -184, 192, { 0b1111, 0 }, 0 },
     { 2, -64, 0, -128, 96, { 0b1111, 0 }, 0 },
     { 3, -32, -32, -184, 192, { 0b1111, 0 }, 0 },
@@ -2874,7 +2874,7 @@ static constexpr PreviewTrack TrackBlocksLeftFlyerLargeHalfLoopInvertedDown[] = 
 };
 
 static constexpr PreviewTrack TrackBlocksRightFlyerLargeHalfLoopInvertedDown[] = {
-    { 0, 0, 0, 0, 24, { 0b1111, 0 }, 0 },
+    { 0, 0, 0, 0, 16, { 0b1111, 0 }, 0 },
     { 1, -32, 0, -184, 192, { 0b1111, 0 }, 0 },
     { 2, -64, 0, -128, 96, { 0b1111, 0 }, 0 },
     { 3, -32, 32, -184, 192, { 0b1111, 0 }, 0 },
@@ -2907,7 +2907,7 @@ static constexpr PreviewTrack TrackBlocksRightFlyerLargeHalfLoopInvertedUp[] = {
 };
 
 static constexpr PreviewTrack TrackBlocksLeftFlyerLargeHalfLoopUninvertedDown[] = {
-    { 0, 0, 0, -32, 40, { 0b1111, 0 }, 0 },
+    { 0, 0, 0, -32, 32, { 0b1111, 0 }, 0 },
     { 1, -32, 0, -216, 192, { 0b1111, 0 }, 0 },
     { 2, -64, 0, -160, 96, { 0b1111, 0 }, 0 },
     { 3, -32, -32, -216, 192, { 0b1111, 0 }, 0 },
@@ -2918,7 +2918,7 @@ static constexpr PreviewTrack TrackBlocksLeftFlyerLargeHalfLoopUninvertedDown[] 
 };
 
 static constexpr PreviewTrack TrackBlocksRightFlyerLargeHalfLoopUninvertedDown[] = {
-    { 0, 0, 0, -32, 40, { 0b1111, 0 }, 0 },
+    { 0, 0, 0, -32, 32, { 0b1111, 0 }, 0 },
     { 1, -32, 0, -216, 192, { 0b1111, 0 }, 0 },
     { 2, -64, 0, -160, 96, { 0b1111, 0 }, 0 },
     { 3, -32, 32, -216, 192, { 0b1111, 0 }, 0 },

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -961,6 +961,7 @@ static constexpr PreviewTrack TrackBlocks039[] = {
     TRACK_BLOCK_END
 };
 
+// LeftVerticalLoop
 static constexpr PreviewTrack TrackBlocks040[] = {
     { 0, 0, 0, 0, 16, { 0b1111, 0b1100 }, 0 },
     { 1, -32, 0, 16, 16, { 0b1111, 0b1100 }, 0 },
@@ -975,6 +976,7 @@ static constexpr PreviewTrack TrackBlocks040[] = {
     TRACK_BLOCK_END
 };
 
+// RightVerticalLoop
 static constexpr PreviewTrack TrackBlocks041[] = {
     { 0, 0, 0, 0, 16, { 0b1111, 0b1100 }, 0 },
     { 1, -32, 0, 16, 16, { 0b1111, 0b1100 }, 0 },
@@ -1091,6 +1093,7 @@ static constexpr PreviewTrack TrackBlocks055[] = {
     TRACK_BLOCK_END
 };
 
+// HalfLoopUp
 static constexpr PreviewTrack TrackBlocks056[] = {
     { 0, 0, 0, 0, 32, { 0b1111, 0b1100 }, 0 },
     { 1, -32, 0, 16, 16, { 0b1111, 0b1100 }, 0 },
@@ -1099,6 +1102,7 @@ static constexpr PreviewTrack TrackBlocks056[] = {
     TRACK_BLOCK_END
 };
 
+// HalfLoopDown
 static constexpr PreviewTrack TrackBlocks057[] = {
     { 0, 0, 0, -32, 32, { 0b1111, 0 }, 0 },
     { 1, -32, 0, -120, 96,{ 0b0011, 0 }, 0 },
@@ -2076,6 +2080,7 @@ static constexpr PreviewTrack TrackBlocks182[] = {
     TRACK_BLOCK_END
 };
 
+// LeftLargeHalfLoopUp
 static constexpr PreviewTrack TrackBlocks183[] = {
     { 0, 0, 0, 0, 24, { 0b1111, 0b1100 }, 0 },
     { 1, -32, 0, 16, 40, { 0b1111, 0b1100 }, 0 },
@@ -2087,6 +2092,7 @@ static constexpr PreviewTrack TrackBlocks183[] = {
     TRACK_BLOCK_END
 };
 
+// RightLargeHalfLoopUp
 static constexpr PreviewTrack TrackBlocks184[] = {
     { 0, 0, 0, 0, 24, { 0b1111, 0b1100 }, 0 },
     { 1, -32, 0, 16, 40, { 0b1111, 0b1100 }, 0 },
@@ -2098,6 +2104,7 @@ static constexpr PreviewTrack TrackBlocks184[] = {
     TRACK_BLOCK_END
 };
 
+// LeftLargeHalfLoopDown
 static constexpr PreviewTrack TrackBlocks185[] = {
     { 0, 0, 0, -32, 24, { 0b1111, 0 }, 0 },
     { 1, -32, 0, -216, 192, { 0b1111, 0 }, 0 },
@@ -2109,6 +2116,7 @@ static constexpr PreviewTrack TrackBlocks185[] = {
     TRACK_BLOCK_END
 };
 
+// RightLargeHalfLoopDown
 static constexpr PreviewTrack TrackBlocks186[] = {
     { 0, 0, 0, -32, 24, { 0b1111, 0 }, 0 },
     { 1, -32, 0, -216, 192, { 0b1111, 0 }, 0 },
@@ -2148,6 +2156,7 @@ static constexpr PreviewTrack TrackBlocks190[] = {
     TRACK_BLOCK_END
 };
 
+// FlyerHalfLoopUninvertedUp
 static constexpr PreviewTrack TrackBlocks191[] = {
     { 0, 0, 0, 0, 32, { 0b1111, 0b1100 }, 0 },
     { 1, -32, 0, 16, 16, { 0b1111, 0b1100 }, 0 },
@@ -2156,6 +2165,7 @@ static constexpr PreviewTrack TrackBlocks191[] = {
     TRACK_BLOCK_END
 };
 
+// FlyerHalfLoopInvertedDown
 static constexpr PreviewTrack TrackBlocks192[] = {
     { 0, 0, 0, 0, 32, { 0b1111, 0 }, 0 },
     { 1, -32, 0, -88, 96,{ 0b0011, 0 }, 0 },

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -2106,7 +2106,7 @@ static constexpr PreviewTrack TrackBlocks184[] = {
 
 // LeftLargeHalfLoopDown
 static constexpr PreviewTrack TrackBlocks185[] = {
-    { 0, 0, 0, -32, 24, { 0b1111, 0 }, 0 },
+    { 0, 0, 0, -32, 16, { 0b1111, 0 }, 0 },
     { 1, -32, 0, -216, 192, { 0b1111, 0 }, 0 },
     { 2, -64, 0, -160, 96, { 0b1111, 0 }, 0 },
     { 3, -32, -32, -216, 192, { 0b1111, 0 }, 0 },
@@ -2118,7 +2118,7 @@ static constexpr PreviewTrack TrackBlocks185[] = {
 
 // RightLargeHalfLoopDown
 static constexpr PreviewTrack TrackBlocks186[] = {
-    { 0, 0, 0, -32, 24, { 0b1111, 0 }, 0 },
+    { 0, 0, 0, -32, 16, { 0b1111, 0 }, 0 },
     { 1, -32, 0, -216, 192, { 0b1111, 0 }, 0 },
     { 2, -64, 0, -160, 96, { 0b1111, 0 }, 0 },
     { 3, -32, 32, -216, 192, { 0b1111, 0 }, 0 },


### PR DESCRIPTION
This PR...  
* gives the 5th member of `struct PreviewTrack` (which indicates an element's height) a more meaningful name
* lowers this height value for each tile of every half loop element as necessary to match the value from its symmetrical counterparts

Closes #21310 