### PR TITLE
Update GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Git describe for shallow checkout
         id: ghd
-        uses: proudust/gh-describe@v1
+        uses: proudust/gh-describe@v2
       - name: Update GA environment
         run: echo "OPENRCT2_DESCRIBE=${{ steps.ghd.outputs.describe }}" >> $GITHUB_ENV
       - name: Install MSVC problem matcher

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Lint Commit Messages
@@ -55,7 +55,7 @@ jobs:
         shell: sh
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run clang-format
         run: scripts/check-code-formatting
   check-changelog-formatting:
@@ -66,7 +66,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run check-changelog-formatting
         run: scripts/check-changelog-formatting
   windows:
@@ -89,7 +89,7 @@ jobs:
              echo "CONFIGURATION=Release" >> "$GITHUB_ENV"
           fi
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Git describe for shallow checkout
         id: ghd
         uses: proudust/gh-describe@v1
@@ -106,7 +106,7 @@ jobs:
           build-symbols
           build-installer -i
       - name: Upload artifacts (CI)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: OpenRCT2-${{ runner.os }}-${{ matrix.platform }}
           path: artifacts
@@ -146,7 +146,7 @@ jobs:
             build_flags: -DBUILD_SHARED_LIBS=ON -DENABLE_SCRIPTING=ON
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
@@ -161,7 +161,7 @@ jobs:
           ninja -k0
       - name: Upload artifacts (CI)
         if: matrix.platform == 'NT5.1'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: OpenRCT2-Windows-${{ matrix.platform }}
           path: bin/openrct2.exe
@@ -187,7 +187,7 @@ jobs:
             run_tests: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
@@ -211,7 +211,7 @@ jobs:
           cd artifacts
           zip -rqy openrct2-macos.zip OpenRCT2.app
       - name: Upload artifacts (CI)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: OpenRCT2-${{ runner.os }}-${{ matrix.arch }}-cmake
           path: artifacts/openrct2-macos.zip
@@ -230,14 +230,14 @@ jobs:
     needs: macos-cmake
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: download x64 app bundle
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: OpenRCT2-${{ runner.os }}-x64-cmake
           path: macos_universal/x64
       - name: download arm64 app bundle
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: OpenRCT2-${{ runner.os }}-arm64-cmake
           path: macos_universal/arm64
@@ -257,7 +257,7 @@ jobs:
           cd artifacts
           zip -rqy openrct2-macos.zip OpenRCT2.app
       - name: Upload artifacts (CI)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: OpenRCT2-${{ runner.os }}-universal
           path: artifacts/openrct2-macos.zip
@@ -299,7 +299,7 @@ jobs:
             build_flags: -DFORCE32=ON -DENABLE_SCRIPTING=OFF -DCMAKE_CXX_FLAGS="-m32 -g1 -gz" -DWITH_TESTS=off
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
@@ -313,7 +313,7 @@ jobs:
       - name: Build artifacts
         run: . scripts/setenv -q && build-portable artifacts/OpenRCT2-${{ runner.os }}-${{ matrix.distro }}-${{ matrix.platform }}.tar.gz bin/install/usr
       - name: Upload artifacts (CI)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: OpenRCT2-${{ runner.os }}-${{ matrix.distro }}-${{ matrix.platform }}
           path: artifacts
@@ -337,7 +337,7 @@ jobs:
     container: openrct2/openrct2-build:12-focal
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
@@ -349,7 +349,7 @@ jobs:
       - name: Build AppImage
         run: . scripts/setenv -q && build-appimage
       - name: Upload artifacts (CI)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: OpenRCT2-AppImage
           path: artifacts
@@ -370,7 +370,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout image
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: OpenRCT2/openrct2-docker
       - name: Build image
@@ -395,7 +395,7 @@ jobs:
     container: openrct2/openrct2-build:12-jammy
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
@@ -411,7 +411,7 @@ jobs:
     container: openrct2/openrct2-build:12-jammy
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
@@ -437,7 +437,7 @@ jobs:
           xz -1v coverage.json
           xz -1v OpenRCT2Tests
       - name: Upload artifacts (CI)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: OpenRCT2-${{ runner.os }}-coverage
           path: |
@@ -452,7 +452,7 @@ jobs:
     container: openrct2/openrct2-build:12-android
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
@@ -468,7 +468,7 @@ jobs:
           mkdir -p artifacts
           mv src/openrct2-android/app/build/outputs/apk/release/app-release.apk artifacts/openrct2-arm.apk
       - name: Upload artifacts (CI)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: OpenRCT2-Android
           path: artifacts


### PR DESCRIPTION
Update of checkout v3->v4 addresses Node 16 deprecation.

Update of upload-artifacts v3->v4 improves performance, makes artifacts available as soon as they are completed (as opposed to current way of only becoming available once all jobs are done) and addresses Node 16 deprecation.