### PR TITLE
Fix mini helicopters & monorail bicycles being swapped in RCT1

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.9 (in development)
 ------------------------------------------------------------------------
 - Fix: [#20907] RCT1/AA scenarios use the 4-across train for the Inverted Roller Coaster.
+- Fix: [#21332] Mini helicopters & monorail cycles ride types being swapped in research within RCT1 scenarios.
 
 0.4.8 (2024-02-04)
 ------------------------------------------------------------------------

--- a/src/openrct2/rct1/Tables.cpp
+++ b/src/openrct2/rct1/Tables.cpp
@@ -765,7 +765,7 @@ namespace RCT1
             "rct2.ride.toffs",                       // RCT1_RIDE_TYPE_TOFFEE_APPLE_STALL
             "rct2.ride.vreel",                       // RCT1_RIDE_TYPE_VIRGINIA_REEL
             "rct2.ride.spboat",                      // RCT1_RIDE_TYPE_RIVER_RIDE
-            "rct2.ride.monbk",                       // RCT1_RIDE_TYPE_CYCLE_MONORAIL
+            "rct2.ride.helicar",                     // RCT1_RIDE_TYPE_CYCLE_MONORAIL
             "rct2.ride.vekst",                       // RCT1_RIDE_TYPE_FLYING_ROLLER_COASTER
             "rct2.ride.smono",                       // RCT1_RIDE_TYPE_SUSPENDED_MONORAIL
             "",                                      // RCT1_RIDE_TYPE_40
@@ -776,7 +776,7 @@ namespace RCT1
             "rct2.ride.gdrop1",                      // RCT1_RIDE_TYPE_ROTO_DROP
             "rct2.ride.fsauc",                       // RCT1_RIDE_TYPE_FLYING_SAUCERS
             "rct2.ride.chbuild",                     // RCT1_RIDE_TYPE_CROOKED_HOUSE
-            "rct2.ride.helicar",                     // RCT1_RIDE_TYPE_CYCLE_RAILWAY
+            "rct2.ride.monbk",                       // RCT1_RIDE_TYPE_CYCLE_RAILWAY
             "rct1.ride.inverted_trains",             // RCT1_RIDE_TYPE_SUSPENDED_LOOPING_ROLLER_COASTER
             "rct2.ride.cstboat",                     // RCT1_RIDE_TYPE_WATER_COASTER
             "rct2.ride.thcar",                       // RCT1_RIDE_TYPE_AIR_POWERED_VERTICAL_COASTER


### PR DESCRIPTION
Due to the confusing names of the ride types in RCT1, these two objects were accidentally swapped which would slightly mess with research in RCT1 scenarios that have them enabled.

For example, the monorail cycles are available by default and the mini helicopters are meant to be researchable in Fun Fortress in vanilla RCT1. While in OpenRCT2 they're both available by default.

This PR fixes that by placing the rides in their proper positions within the RCT1 ride type object table.

Incase you're confused, here's the names for the ride types in both RCT1 & RCT2 to clarify what the ride types are known as in both games.

Helicopters Ride Names
RCT1: Cycle Monorail
RCT2: Mini Helicopters

Bicycle Ride Names
RCT1: Cycle Railway
RCT2: Monorail Cycles