### PR TITLE
Fix #21330: Tooltips from dropdown widgets have the wrong position

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#18963] Research table in parks from Loopy Landscapes is imported incorrectly.
 - Fix: [#20907] RCT1/AA scenarios use the 4-across train for the Inverted Roller Coaster.
+- Fix: [#21330] Tooltips from dropdown widgets have the wrong position.
 - Fix: [#21332] Mini Helicopters and Monorail Cycles ride types are swapped in research within RCT1 scenarios.
 - Fix: [#21347] Too many options are hidden if the platform has no file picker.
 

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1463,7 +1463,7 @@ void InputStateWidgetPressed(
         }
         return;
     }
-    else if (_inputState == InputState::DropdownActive && gDropdownIsColour)
+    else if (gDropdownIsColour)
     {
         // This is ordinarily covered in InputWidgetOver but the dropdown with colours is a special case.
         InputUpdateTooltip(w, widgetIndex, screenCoords);

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1463,6 +1463,11 @@ void InputStateWidgetPressed(
         }
         return;
     }
+    else if (_inputState == InputState::DropdownActive && gDropdownIsColour)
+    {
+        // This is ordinarily covered in InputWidgetOver but the dropdown with colours is a special case.
+        InputUpdateTooltip(w, widgetIndex, screenCoords);
+    }
 
     gDropdownHighlightedIndex = -1;
     WindowInvalidateByClass(WindowClass::Dropdown);


### PR DESCRIPTION
The issue is that tooltips from dropdowns are handled different than tooltips from hovering over the items, this now properly updates the position and follows the mouse like its supposed to.

Closes #21330