### PR TITLE
Fix pause and build path hotkeys not working when the toolbar is hidden.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Fix: [#21318] Virtual Floor for building scenery is not properly invalidated.
 - Fix: [#21330] Tooltips from dropdown widgets have the wrong position.
 - Fix: [#21332] Mini Helicopters and Monorail Cycles ride types are swapped in research within RCT1 scenarios.
+- Fix: [#21343] “Pause” and “Build Path” hotkeys do not work if top toolbar is hidden.
 - Fix: [#21347] Too many options are hidden if the platform has no file picker.
 - Fix: [#21425] Additional missing/misplaced land & construction rights tiles in Japanese Coastal Reclaim.
 - Fix: [OpenSFX#18] B&M Roar sound effect not looping correctly.

--- a/src/openrct2-ui/input/Shortcuts.cpp
+++ b/src/openrct2-ui/input/Shortcuts.cpp
@@ -25,6 +25,7 @@
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/actions/CheatSetAction.h>
 #include <openrct2/actions/LoadOrQuitAction.h>
+#include <openrct2/actions/PauseToggleAction.h>
 #include <openrct2/actions/TileModifyAction.h>
 #include <openrct2/audio/audio.h>
 #include <openrct2/config/Config.h>
@@ -254,12 +255,7 @@ static void ShortcutBuildPaths()
     {
         if (!(gScreenFlags & (SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER)))
         {
-            WindowBase* window = WindowFindByClass(WindowClass::TopToolbar);
-            if (window != nullptr)
-            {
-                window->Invalidate();
-                WindowEventMouseUpCall(window, WC_TOP_TOOLBAR__WIDX_PATH);
-            }
+            ContextOpenWindow(WindowClass::Footpath);
         }
     }
 }
@@ -783,12 +779,8 @@ void ShortcutManager::RegisterDefaultShortcuts()
     RegisterShortcut(ShortcutId::InterfacePause, STR_SHORTCUT_PAUSE_GAME, "PAUSE", []() {
         if (!(gScreenFlags & (SCREEN_FLAGS_TITLE_DEMO | SCREEN_FLAGS_SCENARIO_EDITOR | SCREEN_FLAGS_TRACK_MANAGER)))
         {
-            auto window = WindowFindByClass(WindowClass::TopToolbar);
-            if (window != nullptr)
-            {
-                window->Invalidate();
-                WindowEventMouseUpCall(window, WC_TOP_TOOLBAR__WIDX_PAUSE);
-            }
+            auto pauseToggleAction = PauseToggleAction();
+            GameActions::Execute(&pauseToggleAction);
         }
     });
     RegisterShortcut(ShortcutId::InterfaceDecreaseSpeed, STR_SHORTCUT_REDUCE_GAME_SPEED, "-", ShortcutReduceGameSpeed);


### PR DESCRIPTION
Fix for https://github.com/OpenRCT2/OpenRCT2/issues/21175

- [x] Pausing game
- [x] Build pathways