### PR TITLE
Windows: Build g2.dat on Arm64 machines and update readme

### DIFF
--- a/openrct2.proj
+++ b/openrct2.proj
@@ -107,8 +107,10 @@
   </Target>
 
   <!-- Target to build g2.dat containing OpenRCT2 sprites -->
+  <!-- Only Arm64 machines will build g2.dat for Arm64 -->
+  <!-- Note: Arm64 machines can build for x86, x64 and Arm64 -->
   <Target Name="g2" AfterTargets="Build" Inputs="@(g2Inputs)" Outputs="$(g2Output)"
-          Condition="'$(TestConfig)'!='true' and '$(Platform)'!='ARM64'">
+          Condition="'$(TestConfig)'!='true' and ('$(Platform)'!='ARM64' or '$(PROCESSOR_ARCHITECTURE)'=='ARM64')">
     <Message Text="Building g2.dat..." Importance="high" />
     <Exec Command="&quot;$(OutputExe)&quot; sprite build &quot;$(g2Output)&quot; &quot;$(RootDir)resources\g2\sprites.json&quot;"
           StandardOutputImportance="normal" />

--- a/readme.md
+++ b/readme.md
@@ -165,12 +165,14 @@ OpenRCT2 requires original files of RollerCoaster Tycoon 2 to play. It can be bo
   1. Check out the repository, this can be done using [GitHub Desktop](https://desktop.github.com) or [other tools](https://help.github.com/articles/which-remote-url-should-i-use)
   2. Open a new Developer Command Prompt for VS 2022
   3. Navigate to the repository (e.g. `cd C:\GitHub\OpenRCT2`)
-  4. To build the 64-bit version, use `msbuild openrct2.proj /t:build /p:platform=x64`
-
-     To build the 32-bit version, use `msbuild openrct2.proj /t:build /p:platform=Win32`
+  4. To build the x64 version, use `msbuild openrct2.proj /t:build /p:platform=x64`
+     To build the x86 version, use `msbuild openrct2.proj /t:build /p:platform=Win32`
+     To build the Arm64 version, use `msbuild openrct2.proj /t:build /p:platform=arm64`
+   
+     **Note:** The file `g2.dat` may not be generated on cross-compilation (e.g. building for Arm64 on a x64 machine). In this case `g2.dat` must be copied from a x86/x64 build.
   5. Run the game, `bin\openrct2`
 
-  Once you have ran msbuild once, further development can be done within Visual Studio by opening `openrct2.sln`. Make sure to select the correct target platform for which you ran the build in point #3 (`Win32` for the 32-bit version, `x64` for the 64-bit version), otherwise the build will fail in Visual Studio.
+  Once you have ran msbuild once, further development can be done within Visual Studio by opening `openrct2.sln`. Make sure to select the correct target platform for which you ran the build in point #3 (`Win32` for the x86 version, `x64` for the x64 version, `arm64` for the Arm64 version), otherwise the build will fail in Visual Studio.
 
   Other examples:
   ```


### PR DESCRIPTION
~This PR adds Arm64 to the build instructions for Windows. OpenRCT2 has native Windows Arm64 builds for a while now and it's easy to build them yourself (except for `g2.dat`).~

Edit: The readme now mentions how to build for Windows Arm64 and g2.dat will be build for Arm64 as well (if it is running on an Arm64 machine).