### PR TITLE
Windows: Add application manifest to enable PerMonitorV2

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.9 (in development)
 ------------------------------------------------------------------------
+- Improved: [#21356] Resize the title bar when moving between displays with different scaling factors on Windows systems.
 - Fix: [#18963] Research table in parks from Loopy Landscapes is imported incorrectly.
 - Fix: [#20907] RCT1/AA scenarios use the 4-across train for the Inverted Roller Coaster.
 - Fix: [#21332] Mini Helicopters and Monorail Cycles ride types are swapped in research within RCT1 scenarios.

--- a/src/openrct2-win/openrct2-win.manifest
+++ b/src/openrct2-win/openrct2-win.manifest
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- Windows 10 and newer -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+        </application>
+    </compatibility>
+
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+        <windowsSettings>
+            <!-- PerMonitorV2: Windows 10 version 1703 and newer-->
+            <!-- PerMonitor:   Windows 8.1 and newer -->
+            <!-- System-aware: Windows Vista and newer -->
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+            <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
+        </windowsSettings>
+    </application>
+</assembly>

--- a/src/openrct2-win/openrct2-win.vcxproj
+++ b/src/openrct2-win/openrct2-win.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <SolutionDir Condition="'$(SolutionDir)'==''">..\..\</SolutionDir>
@@ -74,6 +74,9 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="openrct2-win.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="openrct2-win.manifest" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>


### PR DESCRIPTION
By default OpenRCT2 is built with PerMonitor as DPI-awareness level. This means that Windows won't resize anything when moving a window between displays with different DPI scalings.

Unfortunately, the non client area (meaning titlebar, chrome, window buttons) are not resized either. So when OpenRCT2 is moved between displays, the titlebar remains as small or big relatively to the primary display.

Example, left 1920x1080 (125% scaling) and right 3840x2160 (200% scaling), notice how the tiltebar on the left is too big:
![PerMonitor](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/00b7f18e-855c-4b90-abcc-4c3a377018d1)

This PR adds a manifest file to tell Windows that OpenRCT2 has PerMonitorV2 awareness. That's basically the same as PerMonitor but Windows resizes the non client area correctly including some icons in common dialogs (like OpenFile):

![PerMonitorV2](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/27ee880c-68a6-4975-9cef-e3c2968e4f5f)