### PR TITLE
Fix #21288: Overlapping text in the About window

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,7 +7,7 @@
 - Fix: [#21208] Error message will stay open only for a brief moment when the game has been running a while.
 - Fix: [#21220] When creating a new park from a SC4 file, the localised park name is not applied.
 - Fix: [#21286] Cannot build unbanking turns with RCT1 vehicles.
-- Fix: [#21288] Text overlaps in the "About 'OpenRCT2'" window for Arabic, Chinese, Japanese, Korean and Vietnamese.
+- Fix: [#21288] Text overlaps in the “About ‘OpenRCT2’” window for Arabic, Chinese, Japanese, Korean and Vietnamese.
 - Fix: [#21318] Virtual Floor for building scenery is not properly invalidated.
 - Fix: [#21330] Tooltips from dropdown widgets have the wrong position.
 - Fix: [#21332] Mini Helicopters and Monorail Cycles ride types are swapped in research within RCT1 scenarios.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Fix: [#21208] Error message will stay open only for a brief moment when the game has been running a while.
 - Fix: [#21220] When creating a new park from a SC4 file, the localised park name is not applied.
 - Fix: [#21286] Cannot build unbanking turns with RCT1 vehicles.
+- Fix: [#21288] Text overlaps in the "About 'OpenRCT2'" window for Arabic, Chinese, Japanese, Korean and Vietnamese.
 - Fix: [#21318] Virtual Floor for building scenery is not properly invalidated.
 - Fix: [#21330] Tooltips from dropdown widgets have the wrong position.
 - Fix: [#21332] Mini Helicopters and Monorail Cycles ride types are swapped in research within RCT1 scenarios.

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -22,7 +22,7 @@
 using namespace OpenRCT2;
 
 static constexpr int32_t WW = 400;
-static constexpr int32_t WH = 400;
+static constexpr int32_t WH = 450;
 static constexpr StringId WINDOW_TITLE = STR_ABOUT;
 static constexpr int32_t TABHEIGHT = 50;
 
@@ -51,10 +51,6 @@ enum WindowAboutWidgetIdx {
     WIDX_NEW_VERSION,
     WIDX_CHANGELOG,
     WIDX_JOIN_DISCORD,
-    WIDX_CONTRIBUTORS,
-    WIDX_COPYRIGHT,
-    WIDX_SPECIAL_THANKS,
-    WIDX_COMPANY_NAMES,
     WIDX_CONTRIBUTORS_BUTTON,
 };
 
@@ -73,13 +69,7 @@ static Widget _windowAboutOpenRCT2Widgets[] = {
     MakeWidget({168, 115 + 20}, {200, 14},     WindowWidgetType::Placeholder,  WindowColour::Secondary, STR_UPDATE_AVAILABLE  ), // "new version" button
     MakeWidget({168, 115 + 40}, {200, 14},     WindowWidgetType::Button,       WindowColour::Secondary, STR_CHANGELOG_ELLIPSIS), // changelog button
     MakeWidget({168, 115 + 60}, {200, 14},     WindowWidgetType::Button,       WindowColour::Secondary, STR_JOIN_DISCORD      ), // "join discord" button
-    MakeWidget({10, 250},       {WW - 20, 50}, WindowWidgetType::LabelCentred, WindowColour::Secondary, STR_ABOUT_OPENRCT2_DESCRIPTION_2), // More info
-    MakeWidget({10, 280},       {WW - 20, 50}, WindowWidgetType::LabelCentred, WindowColour::Secondary, STR_ABOUT_OPENRCT2_DESCRIPTION_3), // Copyright
-    MakeWidget({10, 360},       {WW - 20, 50}, WindowWidgetType::LabelCentred, WindowColour::Secondary, STR_ABOUT_SPECIAL_THANKS_1), // Special Thanks
-    MakeWidget({10, 375},       {WW - 20, 50}, WindowWidgetType::LabelCentred, WindowColour::Secondary, STR_ABOUT_SPECIAL_THANKS_2), // Company names
     MakeWidget({168, 115 + 80}, {200, 14},     WindowWidgetType::Button,       WindowColour::Secondary, STR_CONTRIBUTORS_WINDOW_BUTTON), // "contributors" button
-    MakeWidget({10, 310},       {WW - 20, 50}, WindowWidgetType::LabelCentred, WindowColour::Secondary, STR_ABOUT_OPENRCT2_TITLE), // Title Theme
-    MakeWidget({10, 338},       {WW - 20, 50}, WindowWidgetType::LabelCentred, WindowColour::Secondary, STR_ABOUT_FAIRGROUND_ORGAN), // Fairground organ
     WIDGETS_END,
 };
 
@@ -224,6 +214,25 @@ private:
             widgets[WIDX_NEW_VERSION].type = WindowWidgetType::Button;
             _windowAboutOpenRCT2Widgets[WIDX_NEW_VERSION].type = WindowWidgetType::Button;
         }
+
+        // Draw the rest of the text
+        Formatter ft2{};
+        TextPaint tp{ colours[1], TextAlignment::CENTRE };
+        auto textCoords = windowPos + ScreenCoordsXY((width / 2) - 1, 240);
+        auto textWidth = WW - 20;
+
+        textCoords += ScreenCoordsXY(
+            0, DrawTextWrapped(dpi, textCoords, textWidth, STR_ABOUT_OPENRCT2_DESCRIPTION_2, ft2, tp) + 5); // More info
+        textCoords += ScreenCoordsXY(
+            0, DrawTextWrapped(dpi, textCoords, textWidth, STR_ABOUT_OPENRCT2_DESCRIPTION_3, ft2, tp) + 5); // Copyright
+        textCoords += ScreenCoordsXY(
+            0, DrawTextWrapped(dpi, textCoords, textWidth, STR_ABOUT_OPENRCT2_TITLE, ft2, tp) + 5); // Title Theme
+        textCoords += ScreenCoordsXY(
+            0, DrawTextWrapped(dpi, textCoords, textWidth, STR_ABOUT_FAIRGROUND_ORGAN, ft2, tp) + 5); // Fairground organ
+        textCoords += ScreenCoordsXY(
+            0, DrawTextWrapped(dpi, textCoords, textWidth, STR_ABOUT_SPECIAL_THANKS_1, ft2, tp)); // Special Thanks
+        textCoords += ScreenCoordsXY(
+            0, DrawTextWrapped(dpi, textCoords, textWidth, STR_ABOUT_SPECIAL_THANKS_2, ft2, tp)); // Company names
     }
 
     /**


### PR DESCRIPTION
Fixes #21288.

* Before: every text snippet was a `LabelCentred` widget with hard coded absolute positions and heights.
* Now: draw these with `DrawTextWrapped` instead and calculate the positions depending on previous height (takes wrapping into account).

I didn't want to have different window heights depending on the selected language. That's why I decided set the about window height to `450` (from `400`). At this size the about window bearly fits at 100% scaling:

![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/a05d8d2b-312d-486a-91c4-ecf22c4433f5)

If more text is added in the future, this window should be reworked and have some kind of scroll viewer included.

| ar-EG | ca-ES | cs-CZ | da-DK |
|-------|-------|-------|-------|
| ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/7bd8f753-ef22-4d74-a532-dc529010f62a) | ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/c058a4ff-946b-4e47-ab28-4307caec4304) | ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/d1da8e32-a1dd-4798-a402-e99d97cdd5a4) | ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/802b3521-e9d7-41ab-b679-618323832988) |

| de-DE | en-GB | en-US | eo-ZZ |
|-------|-------|-------|-------|
| ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/74a94939-90ae-47cb-a856-d6c83fba7f60) | ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/56657133-3888-4997-b9a6-b6a7c237b6be) | ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/8e233acf-2aed-4978-8770-b167ab4b574e) | ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/8e64793a-39e8-499a-9f42-d83ffdfd2f9c) |

| es-ES | fi-FI | fr-CA | fr-FR |
|-------|-------|-------|-------|
| ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/bd8fd094-6084-45cd-9bf2-437933567451) | ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/50710c73-0658-4aa6-ba7f-2da1188b5372) | ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/79a6b483-8135-41ed-b874-03777b0c0a3e) | ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/61135de3-d395-4eb3-bd24-adea526683f6) |

| hu-HU | it-IT | ja-JP | ko-KR |
|-------|-------|-------|-------|
| ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/2deee152-649a-47bd-b15d-ac5ded6305c8) | ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/35278aed-577d-43d0-b5a2-af276fede4cc) | ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/bffb5094-c09b-420e-bb3a-407f5f0f9acc) | ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/8d5d9b03-2a74-4327-90ae-e1ef0d37e620) |

| nb-NO | nl-NL | pl-PL | pt-BR |
|-------|-------|-------|-------|
| ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/23fcc812-7e4d-48a4-96c6-bf8d3498ba1d) | ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/1c56b2d9-8f77-4b61-8f77-64dc1617986a) | ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/d10243ba-9de7-4ac9-8645-de1ee7b9cb3c) | ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/48bea1d8-7e8e-4948-b197-7370402d558b) |

| ru-RU | sv-SE | tr-TR | vi-VN |
|-------|-------|-------|-------|
| ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/b7a42ede-ec11-40c4-8790-d6ac304ed2ae) | ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/350c3914-c0b2-412b-85f9-99f08fdb439b) | ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/e171aa13-6b22-477e-ab10-56a9e288d6d2) | ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/04fb5dbe-b529-44a7-ae2a-783cc7200083) |

| zh-CN | zh-TW |
|-------|-------|
| ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/52327f4e-5438-421c-b68c-c13530312e57) | ![image](https://github.com/OpenRCT2/OpenRCT2/assets/12021771/f5647fff-fa5e-4427-ba98-17a931795aeb) |