### PR TITLE
Fix #21318: VirtualFloor not properly invalidated

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Fix: [#20907] RCT1/AA scenarios use the 4-across train for the Inverted Roller Coaster.
 - Fix: [#21220] When creating a new park from a SC4 file, the localised park name is not applied.
 - Fix: [#21286] Cannot build unbanking turns with RCT1 vehicles.
+- Fix: [#21318] Virtual Floor for building scenery is not properly invalidated.
 - Fix: [#21330] Tooltips from dropdown widgets have the wrong position.
 - Fix: [#21332] Mini Helicopters and Monorail Cycles ride types are swapped in research within RCT1 scenarios.
 - Fix: [#21347] Too many options are hidden if the platform has no file picker.

--- a/src/openrct2/paint/VirtualFloor.cpp
+++ b/src/openrct2/paint/VirtualFloor.cpp
@@ -122,6 +122,11 @@ void VirtualFloorInvalidate()
         }
     }
 
+    bool invalidateNewRegion
+        = (min_position.x != std::numeric_limits<int32_t>::max() && min_position.y != std::numeric_limits<int32_t>::max()
+           && max_position.x != std::numeric_limits<int32_t>::lowest()
+           && max_position.y != std::numeric_limits<int32_t>::lowest());
+
     // Apply the virtual floor size to the computed invalidation area.
     min_position.x -= _virtualFloorBaseSize + 16;
     min_position.y -= _virtualFloorBaseSize + 16;
@@ -157,9 +162,7 @@ void VirtualFloorInvalidate()
 
     LOG_VERBOSE("Min: %d %d, Max: %d %d", min_position.x, min_position.y, max_position.x, max_position.y);
 
-    // Invalidate new region if coordinates are set.
-    if (min_position.x != std::numeric_limits<int32_t>::max() && min_position.y != std::numeric_limits<int32_t>::max()
-        && max_position.x != std::numeric_limits<int32_t>::lowest() && max_position.y != std::numeric_limits<int32_t>::lowest())
+    if (invalidateNewRegion)
     {
         MapInvalidateRegion(min_position, max_position);
 


### PR DESCRIPTION
This PR changes the `VirtualFloorInvalidate` function to use a local variable to remember whether new base coordinates exist for the VirtualFloor.  
(Previously, it was attempted to deduce this by comparing them to some dummy values (max/min int32), but this would fail because the coordinates would actually be set to max/min int32 minus/plus the size of the floor.)

Closes #21318 