### PR TITLE
Allow tooltips to show up when an error window is present

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#21376] Add option to reload an object (for object developers).
 - Improved: [#21356] Resize the title bar when moving between displays with different scaling factors on Windows systems.
+- Improved: [#21388] Tooltips will now show even when an error message is present.
 - Fix: [#18963] Research table in parks from Loopy Landscapes is imported incorrectly.
 - Fix: [#20907] RCT1/AA scenarios use the 4-across train for the Inverted Roller Coaster.
 - Fix: [#21208] Error message will stay open only for a brief moment when the game has been running a while.

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -156,10 +156,6 @@ void WindowTooltipReset(const ScreenCoordsXY& screenCoords)
 
 void WindowTooltipShow(const OpenRCT2String& message, ScreenCoordsXY screenCoords)
 {
-    auto* w = WindowFindByClass(WindowClass::Error);
-    if (w != nullptr)
-        return;
-
     auto tooltipWindow = std::make_unique<TooltipWindow>(message, screenCoords);
     auto windowPos = tooltipWindow->windowPos;
     auto width = tooltipWindow->width;


### PR DESCRIPTION
While investigating #21208 I noticed this little oddity, there is no reason that tooltips and error can not co-exist, this removes the condition so now tooltips will show up even when an error message is present.