### PR TITLE
Use libsawyer's gxc to build g2.dat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,28 @@ jobs:
         uses: actions/checkout@v4
       - name: Run check-changelog-formatting
         run: scripts/check-changelog-formatting
+  g2dat:
+    name: g2.dat
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout OpenRCT2
+        uses: actions/checkout@v4
+        with:
+          path: OpenRCT2
+      - name: Download gxc
+        run: |
+          curl -Lo tools.tar.gz https://github.com/IntelOrca/libsawyer/releases/download/v1.3.0/libsawyer-tools-linux-x64.tar.gz
+          mkdir -p "$GITHUB_WORKSPACE/bin"
+          tar -C "$GITHUB_WORKSPACE/bin" -xf tools.tar.gz
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+      - name: Build g2.dat
+        run: |
+          gxc build g2.dat OpenRCT2/resources/g2/sprites.json
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: g2.dat
+          path: g2.dat
   windows:
     name: Windows
     runs-on: windows-latest


### PR DESCRIPTION
This adds a CI job which builds g2.dat, which is useful for jobs that cannot generate it on their own (e.g. cross-compilation for ARM64).

The whole job takes just 6 seconds to complete.