### PR TITLE
Fix #21208: Error messages disappear too quickly if the game runs for a while

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Improved: [#21356] Resize the title bar when moving between displays with different scaling factors on Windows systems.
 - Fix: [#18963] Research table in parks from Loopy Landscapes is imported incorrectly.
 - Fix: [#20907] RCT1/AA scenarios use the 4-across train for the Inverted Roller Coaster.
+- Fix: [#21208] Error message will stay open only for a brief moment when the game has been running a while.
 - Fix: [#21220] When creating a new park from a SC4 file, the localised park name is not applied.
 - Fix: [#21286] Cannot build unbanking turns with RCT1 vehicles.
 - Fix: [#21330] Tooltips from dropdown widgets have the wrong position.

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -542,6 +542,7 @@ void GameLoadInit()
     ContextBroadcastIntent(&intent);
 
     gWindowUpdateTicks = 0;
+    gCurrentRealTimeTicks = 0;
 
     LoadPalette();
 

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -49,7 +49,7 @@ int32_t gTextBoxFrameNo = 0;
 bool gUsingWidgetTextBox = false;
 TextInputSession* gTextInput;
 
-uint16_t gWindowUpdateTicks;
+uint32_t gWindowUpdateTicks;
 uint16_t gWindowMapFlashingFlags;
 colour_t gCurrentWindowColours[4];
 

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -480,7 +480,7 @@ using close_callback = void (*)();
 
 extern WindowBase* gWindowAudioExclusive;
 
-extern uint16_t gWindowUpdateTicks;
+extern uint32_t gWindowUpdateTicks;
 namespace MapFlashingFlags
 {
     constexpr uint16_t GuestListOpen = (1 << 0);


### PR DESCRIPTION
Finally found the root cause, the first issue is that gCurrentRealTimeTicks will be only set to zero on s6 import and the second issue is that gWindowUpdateTicks was only 16 bit, so after a while gCurrentRealTimeTicks was always bigger than gWindowUpdateTicks causing periodic calls to the periodic update event on windows.

Closes #21208