### PR TITLE
Add clang-tidy CI step

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,8 @@
+---
+Checks: >
+    *-,
+    cppcoreguidelines-macro-usage,
+    modernize-use-nullptr,
+    modernize-use-override
+WarningsAsErrors: true
+FormatStyle: 'file'

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,32 @@
+name: clang-tidy-check
+on:
+  pull_request:
+    paths-ignore:
+      - '.editorconfig'
+      - '.gitattributes'
+      - '.github/*_TEMPLATE/**'
+      - '.github/workflows/localisation.yml'
+      - '.gitignore'
+      - '.vscode/**'
+
+jobs:
+  clang-tidy-check:
+    runs-on: ubuntu-latest
+    container: openrct2/openrct2-build:12-jammy
+    steps:
+    - uses: actions/checkout@v4
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+          key: linux-clang
+    - name: Setup CCache environment
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+    - name: Get clang-tidy
+      run: |
+        apt-get update
+        apt-get install -y clang-tidy
+    - uses: ZehMatt/clang-tidy-annotations@v1
+      with:
+        build_dir: 'build'
+        cmake_args: '-G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Debug -DDISABLE_DISCORD_RPC=ON'


### PR DESCRIPTION
I've tried a few actions from the GitHub Marketplace and ended up writing my own custom action, it can be found here https://github.com/ZehMatt/clang-tidy-test

What this PR does: It adds a new workflow called clang-tidy-test which will run only on pull requests as it needs the information from the pull such as which files are modified and which lines. The custom action runs clang-tidy only on the modified files and also only shows errors/warnings on the modified lines. I enabled only a few clang-tidy checks for now as seen in the .clang-tidy file. The action is set to fail if there are any clang-tidy issues and will annotate the lines with the error/warning message and must be resolved by the user. 

I've added a test commit which I will remove if we plan to merge this.