### PR TITLE
Fix #21418: Cannot place scenery high

### DIFF
--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -2436,7 +2436,7 @@ static Widget WindowSceneryBaseWidgets[] = {
 
             auto screenPos = sourceScreenPos;
             uint16_t maxPossibleHeight = ZoomLevel::max().ApplyTo(
-                std::numeric_limits<decltype(TileElement::BaseHeight)>::max() - 32);
+                std::numeric_limits<decltype(TileElement::BaseHeight)>::max() - 1);
             bool can_raise_item = false;
 
             const auto* sceneryEntry = OpenRCT2::ObjectManager::GetObjectEntry<SmallSceneryEntry>(sceneryIndex);
@@ -2666,7 +2666,7 @@ static Widget WindowSceneryBaseWidgets[] = {
 
             auto screenPos = sourceScreenPos;
             uint16_t maxPossibleHeight = ZoomLevel::max().ApplyTo(
-                std::numeric_limits<decltype(TileElement::BaseHeight)>::max() - 32);
+                std::numeric_limits<decltype(TileElement::BaseHeight)>::max() - 1);
 
             auto* wallEntry = OpenRCT2::ObjectManager::GetObjectEntry<WallSceneryEntry>(sceneryIndex);
             if (wallEntry != nullptr)


### PR DESCRIPTION
For https://github.com/OpenRCT2/OpenRCT2/issues/21418
Change the limits for small scenery and walls only. 
Multi-piece large scenery could cause problems and be placed incomplete. 