### PR TITLE
Replace Macros and Notation in Cheats.h, common.h and Context.h.

### DIFF
--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -140,7 +140,7 @@ static const FinancialTooltipInfo FinanceTooltipInfoFromMoney(
 {
     if (!chartFrame.Contains(cursorPosition))
     {
-        return { {}, MONEY64_UNDEFINED };
+        return { {}, kMoney64Undefined };
     }
 
     const auto historyIndex = IndexForCursorAndHistory(historyCount, cursorPosition.x, chartFrame.GetLeft());
@@ -161,7 +161,7 @@ namespace Graph
         auto screenCoords = origCoords;
         for (int32_t i = count - 1; i >= 0; i--)
         {
-            if (history[i] != MONEY64_UNDEFINED && yearOver32 % 4 == 0)
+            if (history[i] != kMoney64Undefined && yearOver32 % 4 == 0)
             {
                 // Draw month text
                 auto ft = Formatter();
@@ -187,7 +187,7 @@ namespace Graph
         auto coords = origCoords;
         for (int32_t i = count - 1; i >= 0; i--)
         {
-            if (history[i] != MONEY64_UNDEFINED)
+            if (history[i] != kMoney64Undefined)
             {
                 coords.y = origCoords.y + 170 - 6 - ((((history[i] >> modifier) + offset) * 170) / 256);
 
@@ -217,7 +217,7 @@ namespace Graph
         auto coords = origCoords;
         for (int32_t i = count - 1; i >= 0; i--)
         {
-            if (history[i] != MONEY64_UNDEFINED)
+            if (history[i] != kMoney64Undefined)
             {
                 coords.y = origCoords.y + 170 - 6 - ((((history[i] >> modifier) + offset) * 170) / 256);
 
@@ -250,7 +250,7 @@ namespace Graph
 
         const auto info = FinanceTooltipInfoFromMoney(history, ChartMaxDataCount, modifier, offset, chartFrame, cursorPosition);
 
-        if (info.money == MONEY64_UNDEFINED)
+        if (info.money == kMoney64Undefined)
         {
             return;
         }

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -596,7 +596,7 @@ public:
         if (page == WINDOW_CHEATS_PAGE_MONEY && widgetIndex == WIDX_MONEY_SPINNER)
         {
             auto val = StringToMoney(std::string(text).c_str());
-            if (val != MONEY64_UNDEFINED)
+            if (val != kMoney64Undefined)
             {
                 _moneySpinnerValue = val;
             }
@@ -721,12 +721,12 @@ private:
                 break;
             case WIDX_YEAR_UP:
                 _yearSpinnerValue++;
-                _yearSpinnerValue = std::clamp(_yearSpinnerValue, 1, MAX_YEAR);
+                _yearSpinnerValue = std::clamp(_yearSpinnerValue, 1, kMaxYear);
                 InvalidateWidget(WIDX_YEAR_BOX);
                 break;
             case WIDX_YEAR_DOWN:
                 _yearSpinnerValue--;
-                _yearSpinnerValue = std::clamp(_yearSpinnerValue, 1, MAX_YEAR);
+                _yearSpinnerValue = std::clamp(_yearSpinnerValue, 1, kMaxYear);
                 InvalidateWidget(WIDX_YEAR_BOX);
                 break;
             case WIDX_MONTH_UP:
@@ -869,7 +869,7 @@ private:
                 CheatsSet(CheatType::OpenClosePark);
                 break;
             case WIDX_CREATE_DUCKS:
-                CheatsSet(CheatType::CreateDucks, CHEATS_DUCK_INCREMENT);
+                CheatsSet(CheatType::CreateDucks, kCheatsDuckIncrement);
                 break;
             case WIDX_REMOVE_DUCKS:
                 CheatsSet(CheatType::RemoveDucks);
@@ -936,22 +936,22 @@ private:
         }
         if (widgetIndex == WIDX_STAFF_SPEED_DROPDOWN_BUTTON)
         {
-            int32_t speed = CHEATS_STAFF_NORMAL_SPEED;
+            int32_t speed = kCheatsStaffNormalSpeed;
             switch (dropdownIndex)
             {
                 case 0:
                     gCheatsSelectedStaffSpeed = StaffSpeedCheat::None;
-                    speed = CHEATS_STAFF_NORMAL_SPEED;
+                    speed = kCheatsStaffNormalSpeed;
                     break;
 
                 case 1:
                     gCheatsSelectedStaffSpeed = StaffSpeedCheat::Frozen;
-                    speed = CHEATS_STAFF_FREEZE_SPEED;
+                    speed = kCheatsStaffFreezeSpeed;
                     break;
 
                 case 2:
                     gCheatsSelectedStaffSpeed = StaffSpeedCheat::Fast;
-                    speed = CHEATS_STAFF_FAST_SPEED;
+                    speed = kCheatsStaffFastSpeed;
             }
             CheatsSet(CheatType::SetStaffSpeed, speed);
         }
@@ -1010,7 +1010,7 @@ private:
                 CheatsSet(CheatType::SetGuestParameter, GUEST_PARAMETER_PREFERRED_RIDE_INTENSITY, 0);
                 break;
             case WIDX_TRAM_GUESTS:
-                CheatsSet(CheatType::GenerateGuests, CHEATS_TRAM_INCREMENT);
+                CheatsSet(CheatType::GenerateGuests, kCheatsTramIncrement);
                 break;
             case WIDX_REMOVE_ALL_GUESTS:
                 CheatsSet(CheatType::RemoveAllGuests);

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -72,7 +72,7 @@ public:
         WindowPushOthersBelow(*this);
 
         gLandToolSize = 2;
-        gClearSceneryCost = MONEY64_UNDEFINED;
+        gClearSceneryCost = kMoney64Undefined;
 
         gClearSmallScenery = true;
         gClearLargeScenery = false;
@@ -189,7 +189,7 @@ public:
         }
 
         // Draw cost amount
-        if (gClearSceneryCost != MONEY64_UNDEFINED && gClearSceneryCost != 0
+        if (gClearSceneryCost != kMoney64Undefined && gClearSceneryCost != 0
             && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
         {
             auto ft = Formatter();

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -636,7 +636,7 @@ public:
         for (int32_t i = 0; i < 64; i++)
         {
             auto balance = gCashHistory[i];
-            if (balance == MONEY64_UNDEFINED)
+            if (balance == kMoney64Undefined)
                 continue;
 
             // Modifier balance then keep halving until less than 127 pixels
@@ -695,7 +695,7 @@ public:
         for (int32_t i = 0; i < 64; i++)
         {
             auto balance = gameState.ParkValueHistory[i];
-            if (balance == MONEY64_UNDEFINED)
+            if (balance == kMoney64Undefined)
                 continue;
 
             // Modifier balance then keep halving until less than 255 pixels
@@ -755,7 +755,7 @@ public:
         for (int32_t i = 0; i < 64; i++)
         {
             auto balance = gameState.WeeklyProfitHistory[i];
-            if (balance == MONEY64_UNDEFINED)
+            if (balance == kMoney64Undefined)
                 continue;
 
             // Modifier balance then keep halving until less than 127 pixels

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -292,7 +292,7 @@ public:
                     break;
                 }
 
-                _windowFootpathCost = MONEY64_UNDEFINED;
+                _windowFootpathCost = kMoney64Undefined;
                 ToolCancel();
                 FootpathProvisionalUpdate();
                 MapInvalidateMapSelectionTiles();
@@ -309,7 +309,7 @@ public:
                     break;
                 }
 
-                _windowFootpathCost = MONEY64_UNDEFINED;
+                _windowFootpathCost = kMoney64Undefined;
                 ToolCancel();
                 FootpathProvisionalUpdate();
                 MapInvalidateMapSelectionTiles();
@@ -365,7 +365,7 @@ public:
         }
 
         FootpathProvisionalUpdate();
-        _windowFootpathCost = MONEY64_UNDEFINED;
+        _windowFootpathCost = kMoney64Undefined;
         Invalidate();
     }
 
@@ -498,7 +498,7 @@ public:
         screenCoords = this->windowPos
             + ScreenCoordsXY{ window_footpath_widgets[WIDX_CONSTRUCT].midX(),
                               window_footpath_widgets[WIDX_CONSTRUCT].bottom - 12 };
-        if (_windowFootpathCost != MONEY64_UNDEFINED)
+        if (_windowFootpathCost != kMoney64Undefined)
         {
             if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
             {
@@ -753,7 +753,7 @@ private:
     {
         FootpathProvisionalUpdate();
         _footpathConstructDirection = (direction - GetCurrentRotation()) & 3;
-        _windowFootpathCost = MONEY64_UNDEFINED;
+        _windowFootpathCost = kMoney64Undefined;
         WindowFootpathSetEnabledAndPressedWidgets();
     }
 
@@ -765,7 +765,7 @@ private:
     {
         FootpathProvisionalUpdate();
         gFootpathConstructSlope = slope;
-        _windowFootpathCost = MONEY64_UNDEFINED;
+        _windowFootpathCost = kMoney64Undefined;
         WindowFootpathSetEnabledAndPressedWidgets();
     }
 
@@ -1022,7 +1022,7 @@ private:
      */
     void WindowFootpathConstruct()
     {
-        _windowFootpathCost = MONEY64_UNDEFINED;
+        _windowFootpathCost = kMoney64Undefined;
         FootpathProvisionalUpdate();
 
         ObjectEntryIndex type;
@@ -1178,7 +1178,7 @@ private:
     {
         TileElement* tileElement;
 
-        _windowFootpathCost = MONEY64_UNDEFINED;
+        _windowFootpathCost = kMoney64Undefined;
         FootpathProvisionalUpdate();
 
         tileElement = FootpathGetTileElementToRemove();

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -82,8 +82,8 @@ public:
         gLandPaintMode = false;
         _selectedFloorTexture = 0;
         _selectedWallTexture = 0;
-        gLandToolRaiseCost = MONEY64_UNDEFINED;
-        gLandToolLowerCost = MONEY64_UNDEFINED;
+        gLandToolRaiseCost = kMoney64Undefined;
+        gLandToolLowerCost = kMoney64Undefined;
     }
 
     void OnClose() override
@@ -265,7 +265,7 @@ public:
         if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
         {
             // Draw raise cost amount
-            if (gLandToolRaiseCost != MONEY64_UNDEFINED && gLandToolRaiseCost != 0)
+            if (gLandToolRaiseCost != kMoney64Undefined && gLandToolRaiseCost != 0)
             {
                 auto ft = Formatter();
                 ft.Add<money64>(gLandToolRaiseCost);
@@ -274,7 +274,7 @@ public:
             screenCoords.y += 10;
 
             // Draw lower cost amount
-            if (gLandToolLowerCost != MONEY64_UNDEFINED && gLandToolLowerCost != 0)
+            if (gLandToolLowerCost != kMoney64Undefined && gLandToolLowerCost != 0)
             {
                 auto ft = Formatter();
                 ft.Add<money64>(gLandToolLowerCost);

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -228,7 +228,7 @@ public:
         }
 
         // Draw cost amount
-        if (_landRightsCost != MONEY64_UNDEFINED && _landRightsCost != 0 && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+        if (_landRightsCost != kMoney64Undefined && _landRightsCost != 0 && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
         {
             auto ft = Formatter();
             ft.Add<money64>(_landRightsCost);
@@ -247,9 +247,9 @@ public:
             screenCoords, EnumsToFlags(ViewportInteractionItem::Terrain, ViewportInteractionItem::Water));
         if (info.SpriteType == ViewportInteractionItem::None)
         {
-            if (_landRightsCost != MONEY64_UNDEFINED)
+            if (_landRightsCost != kMoney64Undefined)
             {
-                _landRightsCost = MONEY64_UNDEFINED;
+                _landRightsCost = kMoney64Undefined;
                 WindowInvalidateByClass(WindowClass::ClearScenery);
             }
             return;
@@ -318,7 +318,7 @@ public:
                                                            : LandBuyRightSetting::BuyConstructionRights);
         auto res = GameActions::Query(&landBuyRightsAction);
 
-        _landRightsCost = res.Error == GameActions::Status::Ok ? res.Cost : MONEY64_UNDEFINED;
+        _landRightsCost = res.Error == GameActions::Status::Ok ? res.Cost : kMoney64Undefined;
     }
 
     void OnToolAbort(WidgetIndex widgetIndex) override

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -1111,7 +1111,7 @@ private:
         screenCoords.y += 5;
 
         // Objective outcome
-        if (gameState.ScenarioCompletedCompanyValue != MONEY64_UNDEFINED)
+        if (gameState.ScenarioCompletedCompanyValue != kMoney64Undefined)
         {
             if (gameState.ScenarioCompletedCompanyValue == COMPANY_VALUE_ON_FAILED_OBJECTIVE)
             {

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -6168,7 +6168,7 @@ private:
 
         std::string strText{ text };
         money64 price = StringToMoney(strText.c_str());
-        if (price == MONEY64_UNDEFINED)
+        if (price == kMoney64Undefined)
         {
             return;
         }
@@ -6360,7 +6360,7 @@ private:
         screenCoords.y += 18;
 
         // Income per hour
-        if (ride->income_per_hour != MONEY64_UNDEFINED)
+        if (ride->income_per_hour != kMoney64Undefined)
         {
             auto ft = Formatter();
             ft.Add<money64>(ride->income_per_hour);
@@ -6371,14 +6371,14 @@ private:
 
         // Running cost per hour
         money64 costPerHour = ride->upkeep_cost * 16;
-        stringId = ride->upkeep_cost == MONEY64_UNDEFINED ? STR_RUNNING_COST_UNKNOWN : STR_RUNNING_COST_PER_HOUR;
+        stringId = ride->upkeep_cost == kMoney64Undefined ? STR_RUNNING_COST_UNKNOWN : STR_RUNNING_COST_PER_HOUR;
         auto ft = Formatter();
         ft.Add<money64>(costPerHour);
         DrawTextBasic(dpi, screenCoords, stringId, ft);
         screenCoords.y += LIST_ROW_HEIGHT;
 
         // Profit per hour
-        if (ride->profit != MONEY64_UNDEFINED)
+        if (ride->profit != kMoney64Undefined)
         {
             ft = Formatter();
             ft.Add<money64>(ride->profit);

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -223,7 +223,7 @@ public:
         WindowPushOthersRight(*this);
         ShowGridlines();
 
-        _currentTrackPrice = MONEY64_UNDEFINED;
+        _currentTrackPrice = kMoney64Undefined;
         _currentBrakeSpeed2 = 8;
         _currentSeatRotationAngle = 4;
 
@@ -1014,49 +1014,49 @@ public:
             case WIDX_LEFT_CURVE:
                 RideConstructionInvalidateCurrentTrack();
                 _currentTrackCurve = EnumValue(TrackCurve::Left);
-                _currentTrackPrice = MONEY64_UNDEFINED;
+                _currentTrackPrice = kMoney64Undefined;
                 WindowRideConstructionUpdateActiveElements();
                 break;
             case WIDX_RIGHT_CURVE:
                 RideConstructionInvalidateCurrentTrack();
                 _currentTrackCurve = EnumValue(TrackCurve::Right);
-                _currentTrackPrice = MONEY64_UNDEFINED;
+                _currentTrackPrice = kMoney64Undefined;
                 WindowRideConstructionUpdateActiveElements();
                 break;
             case WIDX_LEFT_CURVE_SMALL:
                 RideConstructionInvalidateCurrentTrack();
                 _currentTrackCurve = EnumValue(TrackCurve::LeftSmall);
-                _currentTrackPrice = MONEY64_UNDEFINED;
+                _currentTrackPrice = kMoney64Undefined;
                 WindowRideConstructionUpdateActiveElements();
                 break;
             case WIDX_RIGHT_CURVE_SMALL:
                 RideConstructionInvalidateCurrentTrack();
                 _currentTrackCurve = EnumValue(TrackCurve::RightSmall);
-                _currentTrackPrice = MONEY64_UNDEFINED;
+                _currentTrackPrice = kMoney64Undefined;
                 WindowRideConstructionUpdateActiveElements();
                 break;
             case WIDX_LEFT_CURVE_VERY_SMALL:
                 RideConstructionInvalidateCurrentTrack();
                 _currentTrackCurve = EnumValue(TrackCurve::LeftVerySmall);
-                _currentTrackPrice = MONEY64_UNDEFINED;
+                _currentTrackPrice = kMoney64Undefined;
                 WindowRideConstructionUpdateActiveElements();
                 break;
             case WIDX_RIGHT_CURVE_VERY_SMALL:
                 RideConstructionInvalidateCurrentTrack();
                 _currentTrackCurve = EnumValue(TrackCurve::RightVerySmall);
-                _currentTrackPrice = MONEY64_UNDEFINED;
+                _currentTrackPrice = kMoney64Undefined;
                 WindowRideConstructionUpdateActiveElements();
                 break;
             case WIDX_LEFT_CURVE_LARGE:
                 RideConstructionInvalidateCurrentTrack();
                 _currentTrackCurve = EnumValue(TrackCurve::LeftLarge);
-                _currentTrackPrice = MONEY64_UNDEFINED;
+                _currentTrackPrice = kMoney64Undefined;
                 WindowRideConstructionUpdateActiveElements();
                 break;
             case WIDX_RIGHT_CURVE_LARGE:
                 RideConstructionInvalidateCurrentTrack();
                 _currentTrackCurve = EnumValue(TrackCurve::RightLarge);
-                _currentTrackPrice = MONEY64_UNDEFINED;
+                _currentTrackPrice = kMoney64Undefined;
                 WindowRideConstructionUpdateActiveElements();
                 break;
             case WIDX_STRAIGHT:
@@ -1064,7 +1064,7 @@ public:
                 if (_currentTrackCurve != EnumValue(TrackCurve::None))
                     _currentTrackRollEnd = TrackRoll::None;
                 _currentTrackCurve = EnumValue(TrackCurve::None);
-                _currentTrackPrice = MONEY64_UNDEFINED;
+                _currentTrackPrice = kMoney64Undefined;
                 WindowRideConstructionUpdateActiveElements();
                 break;
             case WIDX_SLOPE_DOWN_STEEP:
@@ -1074,7 +1074,7 @@ public:
                     if (_currentTrackCurve == EnumValue(TrackCurve::Left) && _currentTrackRollEnd == TrackRoll::Left)
                     {
                         _currentTrackCurve = TrackElemType::LeftHalfBankedHelixDownLarge | RideConstructionSpecialPieceSelected;
-                        _currentTrackPrice = MONEY64_UNDEFINED;
+                        _currentTrackPrice = kMoney64Undefined;
                         WindowRideConstructionUpdateActiveElements();
                         break;
                     }
@@ -1082,14 +1082,14 @@ public:
                     {
                         _currentTrackCurve = TrackElemType::RightHalfBankedHelixDownLarge
                             | RideConstructionSpecialPieceSelected;
-                        _currentTrackPrice = MONEY64_UNDEFINED;
+                        _currentTrackPrice = kMoney64Undefined;
                         WindowRideConstructionUpdateActiveElements();
                         break;
                     }
                     if (_currentTrackCurve == EnumValue(TrackCurve::LeftSmall) && _currentTrackRollEnd == TrackRoll::Left)
                     {
                         _currentTrackCurve = TrackElemType::LeftHalfBankedHelixDownSmall | RideConstructionSpecialPieceSelected;
-                        _currentTrackPrice = MONEY64_UNDEFINED;
+                        _currentTrackPrice = kMoney64Undefined;
                         WindowRideConstructionUpdateActiveElements();
                         break;
                     }
@@ -1097,7 +1097,7 @@ public:
                     {
                         _currentTrackCurve = TrackElemType::RightHalfBankedHelixDownSmall
                             | RideConstructionSpecialPieceSelected;
-                        _currentTrackPrice = MONEY64_UNDEFINED;
+                        _currentTrackPrice = kMoney64Undefined;
                         WindowRideConstructionUpdateActiveElements();
                         break;
                     }
@@ -1108,7 +1108,7 @@ public:
                     {
                         _currentTrackCurve = TrackElemType::LeftQuarterBankedHelixLargeDown
                             | RideConstructionSpecialPieceSelected;
-                        _currentTrackPrice = MONEY64_UNDEFINED;
+                        _currentTrackPrice = kMoney64Undefined;
                         WindowRideConstructionUpdateActiveElements();
                         break;
                     }
@@ -1116,7 +1116,7 @@ public:
                     {
                         _currentTrackCurve = TrackElemType::RightQuarterBankedHelixLargeDown
                             | RideConstructionSpecialPieceSelected;
-                        _currentTrackPrice = MONEY64_UNDEFINED;
+                        _currentTrackPrice = kMoney64Undefined;
                         WindowRideConstructionUpdateActiveElements();
                         break;
                     }
@@ -1129,7 +1129,7 @@ public:
                         {
                             _currentTrackCurve = TrackElemType::LeftQuarterHelixLargeDown
                                 | RideConstructionSpecialPieceSelected;
-                            _currentTrackPrice = MONEY64_UNDEFINED;
+                            _currentTrackPrice = kMoney64Undefined;
                             WindowRideConstructionUpdateActiveElements();
                             break;
                         }
@@ -1137,7 +1137,7 @@ public:
                         {
                             _currentTrackCurve = TrackElemType::RightQuarterHelixLargeDown
                                 | RideConstructionSpecialPieceSelected;
-                            _currentTrackPrice = MONEY64_UNDEFINED;
+                            _currentTrackPrice = kMoney64Undefined;
                             WindowRideConstructionUpdateActiveElements();
                             break;
                         }
@@ -1213,28 +1213,28 @@ public:
                     if (_currentTrackCurve == EnumValue(TrackCurve::Left) && _currentTrackRollEnd == TrackRoll::Left)
                     {
                         _currentTrackCurve = TrackElemType::LeftHalfBankedHelixUpLarge | RideConstructionSpecialPieceSelected;
-                        _currentTrackPrice = MONEY64_UNDEFINED;
+                        _currentTrackPrice = kMoney64Undefined;
                         WindowRideConstructionUpdateActiveElements();
                         break;
                     }
                     if (_currentTrackCurve == EnumValue(TrackCurve::Right) && _currentTrackRollEnd == TrackRoll::Right)
                     {
                         _currentTrackCurve = TrackElemType::RightHalfBankedHelixUpLarge | RideConstructionSpecialPieceSelected;
-                        _currentTrackPrice = MONEY64_UNDEFINED;
+                        _currentTrackPrice = kMoney64Undefined;
                         WindowRideConstructionUpdateActiveElements();
                         break;
                     }
                     if (_currentTrackCurve == EnumValue(TrackCurve::LeftSmall) && _currentTrackRollEnd == TrackRoll::Left)
                     {
                         _currentTrackCurve = TrackElemType::LeftHalfBankedHelixUpSmall | RideConstructionSpecialPieceSelected;
-                        _currentTrackPrice = MONEY64_UNDEFINED;
+                        _currentTrackPrice = kMoney64Undefined;
                         WindowRideConstructionUpdateActiveElements();
                         break;
                     }
                     if (_currentTrackCurve == EnumValue(TrackCurve::RightSmall) && _currentTrackRollEnd == TrackRoll::Right)
                     {
                         _currentTrackCurve = TrackElemType::RightHalfBankedHelixUpSmall | RideConstructionSpecialPieceSelected;
-                        _currentTrackPrice = MONEY64_UNDEFINED;
+                        _currentTrackPrice = kMoney64Undefined;
                         WindowRideConstructionUpdateActiveElements();
                         break;
                     }
@@ -1245,7 +1245,7 @@ public:
                     {
                         _currentTrackCurve = TrackElemType::LeftQuarterBankedHelixLargeUp
                             | RideConstructionSpecialPieceSelected;
-                        _currentTrackPrice = MONEY64_UNDEFINED;
+                        _currentTrackPrice = kMoney64Undefined;
                         WindowRideConstructionUpdateActiveElements();
                         break;
                     }
@@ -1253,7 +1253,7 @@ public:
                     {
                         _currentTrackCurve = TrackElemType::RightQuarterBankedHelixLargeUp
                             | RideConstructionSpecialPieceSelected;
-                        _currentTrackPrice = MONEY64_UNDEFINED;
+                        _currentTrackPrice = kMoney64Undefined;
                         WindowRideConstructionUpdateActiveElements();
                         break;
                     }
@@ -1265,14 +1265,14 @@ public:
                         if (_currentTrackCurve == EnumValue(TrackCurve::Left))
                         {
                             _currentTrackCurve = TrackElemType::LeftQuarterHelixLargeUp | RideConstructionSpecialPieceSelected;
-                            _currentTrackPrice = MONEY64_UNDEFINED;
+                            _currentTrackPrice = kMoney64Undefined;
                             WindowRideConstructionUpdateActiveElements();
                             break;
                         }
                         if (_currentTrackCurve == EnumValue(TrackCurve::Right))
                         {
                             _currentTrackCurve = TrackElemType::RightQuarterHelixLargeUp | RideConstructionSpecialPieceSelected;
-                            _currentTrackPrice = MONEY64_UNDEFINED;
+                            _currentTrackPrice = kMoney64Undefined;
                             WindowRideConstructionUpdateActiveElements();
                             break;
                         }
@@ -1292,7 +1292,7 @@ public:
                 _currentTrackLiftHill ^= CONSTRUCTION_LIFT_HILL_SELECTED;
                 if ((_currentTrackLiftHill & CONSTRUCTION_LIFT_HILL_SELECTED) && !gCheatsEnableChainLiftOnAllTrack)
                     _currentTrackAlternative &= ~RIDE_TYPE_ALTERNATIVE_TRACK_PIECES;
-                _currentTrackPrice = MONEY64_UNDEFINED;
+                _currentTrackPrice = kMoney64Undefined;
                 WindowRideConstructionUpdateActiveElements();
                 break;
             case WIDX_BANK_LEFT:
@@ -1300,7 +1300,7 @@ public:
                 if (!_currentlyShowingBrakeOrBoosterSpeed)
                 {
                     _currentTrackRollEnd = TrackRoll::Left;
-                    _currentTrackPrice = MONEY64_UNDEFINED;
+                    _currentTrackPrice = kMoney64Undefined;
                     WindowRideConstructionUpdateActiveElements();
                 }
                 break;
@@ -1309,7 +1309,7 @@ public:
                 if (!_currentlyShowingBrakeOrBoosterSpeed)
                 {
                     _currentTrackRollEnd = TrackRoll::None;
-                    _currentTrackPrice = MONEY64_UNDEFINED;
+                    _currentTrackPrice = kMoney64Undefined;
                     WindowRideConstructionUpdateActiveElements();
                 }
                 else
@@ -1336,7 +1336,7 @@ public:
                 if (!_currentlyShowingBrakeOrBoosterSpeed)
                 {
                     _currentTrackRollEnd = TrackRoll::Right;
-                    _currentTrackPrice = MONEY64_UNDEFINED;
+                    _currentTrackPrice = kMoney64Undefined;
                     WindowRideConstructionUpdateActiveElements();
                 }
                 else
@@ -1363,7 +1363,7 @@ public:
             case WIDX_U_TRACK:
                 RideConstructionInvalidateCurrentTrack();
                 _currentTrackAlternative &= ~RIDE_TYPE_ALTERNATIVE_TRACK_PIECES;
-                _currentTrackPrice = MONEY64_UNDEFINED;
+                _currentTrackPrice = kMoney64Undefined;
                 WindowRideConstructionUpdateActiveElements();
                 break;
             case WIDX_O_TRACK:
@@ -1371,7 +1371,7 @@ public:
                 _currentTrackAlternative |= RIDE_TYPE_ALTERNATIVE_TRACK_PIECES;
                 if (!gCheatsEnableChainLiftOnAllTrack)
                     _currentTrackLiftHill &= ~CONSTRUCTION_LIFT_HILL_SELECTED;
-                _currentTrackPrice = MONEY64_UNDEFINED;
+                _currentTrackPrice = kMoney64Undefined;
                 WindowRideConstructionUpdateActiveElements();
                 break;
             case WIDX_SEAT_ROTATION_ANGLE_SPINNER_UP:
@@ -1413,7 +1413,7 @@ public:
             return;
 
         RideConstructionInvalidateCurrentTrack();
-        _currentTrackPrice = MONEY64_UNDEFINED;
+        _currentTrackPrice = kMoney64Undefined;
         track_type_t trackPiece = _specialElementDropdownState.Elements[selectedIndex].TrackType;
         switch (trackPiece)
         {
@@ -1553,7 +1553,7 @@ public:
             DrawTextBasic(dpi, screenCoords, STR_BUILD_THIS, {}, { TextAlignment::CENTRE });
 
         screenCoords.y += 11;
-        if (_currentTrackPrice != MONEY64_UNDEFINED && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+        if (_currentTrackPrice != kMoney64Undefined && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
         {
             auto ft = Formatter();
             ft.Add<money64>(_currentTrackPrice);
@@ -2172,8 +2172,8 @@ private:
         int32_t trackType, trackDirection, liftHillAndAlternativeState, properties;
         CoordsXYZ trackPos{};
 
-        _currentTrackPrice = MONEY64_UNDEFINED;
-        _trackPlaceCost = MONEY64_UNDEFINED;
+        _currentTrackPrice = kMoney64Undefined;
+        _trackPlaceCost = kMoney64Undefined;
         _trackPlaceErrorMessage = STR_NONE;
         RideConstructionInvalidateCurrentTrack();
         if (WindowRideConstructionUpdateState(
@@ -2204,7 +2204,7 @@ private:
         // Used by some functions
         if (res.Error != GameActions::Status::Ok)
         {
-            _trackPlaceCost = MONEY64_UNDEFINED;
+            _trackPlaceCost = kMoney64Undefined;
             _trackPlaceErrorMessage = std::get<StringId>(res.ErrorMessage);
         }
         else
@@ -2245,7 +2245,7 @@ private:
         CoordsXYE inputElement, outputElement;
         TrackBeginEnd trackBeginEnd;
 
-        _currentTrackPrice = MONEY64_UNDEFINED;
+        _currentTrackPrice = kMoney64Undefined;
         RideConstructionInvalidateCurrentTrack();
 
         // Select the track element that is to be deleted
@@ -2354,7 +2354,7 @@ private:
         _autoRotatingShop = false;
         _currentTrackPieceDirection = (_currentTrackPieceDirection + 1) & 3;
         RideConstructionInvalidateCurrentTrack();
-        _currentTrackPrice = MONEY64_UNDEFINED;
+        _currentTrackPrice = kMoney64Undefined;
         WindowRideConstructionUpdateActiveElements();
     }
 
@@ -2413,7 +2413,7 @@ private:
     void UpdateLiftHillSelected(TrackPitch slope)
     {
         _currentTrackPitchEnd = slope;
-        _currentTrackPrice = MONEY64_UNDEFINED;
+        _currentTrackPrice = kMoney64Undefined;
         if (_rideConstructionState == RideConstructionState::Front && !gCheatsEnableChainLiftOnAllTrack)
         {
             switch (slope)
@@ -3273,7 +3273,7 @@ void RideConstructionToolupdateConstruct(const ScreenCoordsXY& screenCoords)
                 &trackType, &trackDirection, &rideIndex, &liftHillAndAlternativeState, &trackPos, nullptr);
             _currentTrackPrice = PlaceProvisionalTrackPiece(
                 rideIndex, trackType, trackDirection, liftHillAndAlternativeState, trackPos);
-            if (_currentTrackPrice != MONEY64_UNDEFINED)
+            if (_currentTrackPrice != kMoney64Undefined)
                 break;
 
             _currentTrackBegin.z -= 8;
@@ -3298,7 +3298,7 @@ void RideConstructionToolupdateConstruct(const ScreenCoordsXY& screenCoords)
             rideIndex, trackType, trackDirection, liftHillAndAlternativeState, trackPos);
         mapCoords = trackPos;
         z = trackPos.z;
-        if (_currentTrackPrice != MONEY64_UNDEFINED)
+        if (_currentTrackPrice != kMoney64Undefined)
             break;
 
         _currentTrackBegin.z -= 8;
@@ -3528,7 +3528,7 @@ void RideConstructionTooldownConstruct(const ScreenCoordsXY& screenCoords)
             }
             else
             {
-                _trackPlaceCost = MONEY64_UNDEFINED;
+                _trackPlaceCost = kMoney64Undefined;
                 _trackPlaceErrorMessage = std::get<StringId>(mazeSetTrackResult.ErrorMessage);
             }
 
@@ -3585,7 +3585,7 @@ void RideConstructionTooldownConstruct(const ScreenCoordsXY& screenCoords)
         WindowEventMouseUpCall(w, WIDX_CONSTRUCT);
         gDisableErrorWindowSound = false;
 
-        if (_trackPlaceCost == MONEY64_UNDEFINED)
+        if (_trackPlaceCost == kMoney64Undefined)
         {
             StringId errorText = _trackPlaceErrorMessage;
             z -= 8;

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -600,7 +600,7 @@ public:
                     break;
                 case INFORMATION_TYPE_PROFIT:
                     formatSecondary = 0;
-                    if (ridePtr->profit != MONEY64_UNDEFINED)
+                    if (ridePtr->profit != kMoney64Undefined)
                     {
                         formatSecondary = STR_PROFIT_LABEL;
                         ft.Add<money64>(ridePtr->profit);
@@ -612,7 +612,7 @@ public:
                     break;
                 case INFORMATION_TYPE_TOTAL_PROFIT:
                     formatSecondary = 0;
-                    if (ridePtr->total_profit != MONEY64_UNDEFINED)
+                    if (ridePtr->total_profit != kMoney64Undefined)
                     {
                         formatSecondary = STR_RIDE_LIST_TOTAL_PROFIT_LABEL;
                         ft.Add<money64>(ridePtr->total_profit);
@@ -642,7 +642,7 @@ public:
                 }
                 case INFORMATION_TYPE_INCOME:
                     formatSecondary = 0;
-                    if (ridePtr->income_per_hour != MONEY64_UNDEFINED)
+                    if (ridePtr->income_per_hour != kMoney64Undefined)
                     {
                         formatSecondary = STR_RIDE_LIST_INCOME_LABEL;
                         ft.Add<money64>(ridePtr->income_per_hour);
@@ -650,7 +650,7 @@ public:
                     break;
                 case INFORMATION_TYPE_RUNNING_COST:
                     formatSecondary = STR_RIDE_LIST_RUNNING_COST_UNKNOWN;
-                    if (ridePtr->upkeep_cost != MONEY64_UNDEFINED)
+                    if (ridePtr->upkeep_cost != kMoney64Undefined)
                     {
                         formatSecondary = STR_RIDE_LIST_RUNNING_COST_LABEL;
                         ft.Add<money64>(ridePtr->upkeep_cost * 16);

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -193,7 +193,7 @@ public:
         _selectedScenery = {};
         _hoverCounter = 0;
         gSceneryGhostType = 0;
-        gSceneryPlaceCost = MONEY64_UNDEFINED;
+        gSceneryPlaceCost = kMoney64Undefined;
         gSceneryPlaceRotation = 0;
         gWindowSceneryPaintEnabled = 0; // repaint coloured scenery tool state
         gWindowSceneryEyedropperEnabled = false;
@@ -341,7 +341,7 @@ public:
         {
             _activeTabIndex = widgetIndex - WIDX_SCENERY_TAB_1;
             Invalidate();
-            gSceneryPlaceCost = MONEY64_UNDEFINED;
+            gSceneryPlaceCost = kMoney64Undefined;
 
             ContentUpdateScroll();
         }
@@ -782,7 +782,7 @@ public:
         }
 
         auto [name, price] = GetNameAndPrice(selectedSceneryEntry);
-        if (price != MONEY64_UNDEFINED && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+        if (price != kMoney64Undefined && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
         {
             auto ft = Formatter();
             ft.Add<money64>(price);
@@ -858,7 +858,7 @@ public:
         gWindowSceneryEyedropperEnabled = false;
         OpenRCT2::Audio::Play(OpenRCT2::Audio::SoundId::Click1, 0, ContextGetWidth() / 2);
         _hoverCounter = -16;
-        gSceneryPlaceCost = MONEY64_UNDEFINED;
+        gSceneryPlaceCost = kMoney64Undefined;
         Invalidate();
     }
 
@@ -1395,7 +1395,7 @@ private:
         gWindowSceneryEyedropperEnabled = false;
         OpenRCT2::Audio::Play(OpenRCT2::Audio::SoundId::Click1, 0, windowPos.x + (width / 2));
         _hoverCounter = -16;
-        gSceneryPlaceCost = MONEY64_UNDEFINED;
+        gSceneryPlaceCost = kMoney64Undefined;
         Invalidate();
     }
 
@@ -1412,8 +1412,8 @@ private:
     std::pair<StringId, money64> GetNameAndPrice(ScenerySelection selectedScenery)
     {
         StringId name = STR_UNKNOWN_OBJECT_TYPE;
-        money64 price = MONEY64_UNDEFINED;
-        if (selectedScenery.IsUndefined() && gSceneryPlaceCost != MONEY64_UNDEFINED)
+        money64 price = kMoney64Undefined;
+        if (selectedScenery.IsUndefined() && gSceneryPlaceCost != kMoney64Undefined)
         {
             price = gSceneryPlaceCost;
         }

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -411,7 +411,7 @@ private:
 
         auto action = GetClearAction();
         auto result = GameActions::Query(&action);
-        auto cost = (result.Error == GameActions::Status::Ok ? result.Cost : MONEY64_UNDEFINED);
+        auto cost = (result.Error == GameActions::Status::Ok ? result.Cost : kMoney64Undefined);
         if (gClearSceneryCost != cost)
         {
             gClearSceneryCost = cost;
@@ -430,9 +430,9 @@ private:
 
         if (!mapTile.has_value())
         {
-            if (gClearSceneryCost != MONEY64_UNDEFINED)
+            if (gClearSceneryCost != kMoney64Undefined)
             {
-                gClearSceneryCost = MONEY64_UNDEFINED;
+                gClearSceneryCost = kMoney64Undefined;
                 WindowInvalidateByClass(WindowClass::ClearScenery);
             }
             return state_changed;
@@ -530,8 +530,8 @@ private:
 
             if (!mapTile.has_value())
             {
-                money64 lower_cost = MONEY64_UNDEFINED;
-                money64 raise_cost = MONEY64_UNDEFINED;
+                money64 lower_cost = kMoney64Undefined;
+                money64 raise_cost = kMoney64Undefined;
 
                 if (gLandToolRaiseCost != raise_cost || gLandToolLowerCost != lower_cost)
                 {
@@ -607,8 +607,8 @@ private:
 
         if (!mapTile.has_value())
         {
-            money64 lower_cost = MONEY64_UNDEFINED;
-            money64 raise_cost = MONEY64_UNDEFINED;
+            money64 lower_cost = kMoney64Undefined;
+            money64 raise_cost = kMoney64Undefined;
 
             if (gLandToolRaiseCost != raise_cost || gLandToolLowerCost != lower_cost)
             {
@@ -746,10 +746,10 @@ private:
                 { gMapSelectPositionA.x, gMapSelectPositionA.y, gMapSelectPositionB.x, gMapSelectPositionB.y });
 
             auto res = GameActions::Query(&waterLowerAction);
-            money64 lowerCost = res.Error == GameActions::Status::Ok ? res.Cost : MONEY64_UNDEFINED;
+            money64 lowerCost = res.Error == GameActions::Status::Ok ? res.Cost : kMoney64Undefined;
 
             res = GameActions::Query(&waterRaiseAction);
-            money64 raiseCost = res.Error == GameActions::Status::Ok ? res.Cost : MONEY64_UNDEFINED;
+            money64 raiseCost = res.Error == GameActions::Status::Ok ? res.Cost : kMoney64Undefined;
 
             if (gWaterToolRaiseCost != raiseCost || gWaterToolLowerCost != lowerCost)
             {
@@ -767,10 +767,10 @@ private:
 
         if (info.SpriteType == ViewportInteractionItem::None)
         {
-            if (gWaterToolRaiseCost != MONEY64_UNDEFINED || gWaterToolLowerCost != MONEY64_UNDEFINED)
+            if (gWaterToolRaiseCost != kMoney64Undefined || gWaterToolLowerCost != kMoney64Undefined)
             {
-                gWaterToolRaiseCost = MONEY64_UNDEFINED;
-                gWaterToolLowerCost = MONEY64_UNDEFINED;
+                gWaterToolRaiseCost = kMoney64Undefined;
+                gWaterToolLowerCost = kMoney64Undefined;
                 WindowInvalidateByClass(WindowClass::Water);
             }
             return;
@@ -838,10 +838,10 @@ private:
             { gMapSelectPositionA.x, gMapSelectPositionA.y, gMapSelectPositionB.x, gMapSelectPositionB.y });
 
         auto res = GameActions::Query(&waterLowerAction);
-        money64 lowerCost = res.Error == GameActions::Status::Ok ? res.Cost : MONEY64_UNDEFINED;
+        money64 lowerCost = res.Error == GameActions::Status::Ok ? res.Cost : kMoney64Undefined;
 
         res = GameActions::Query(&waterRaiseAction);
-        money64 raiseCost = res.Error == GameActions::Status::Ok ? res.Cost : MONEY64_UNDEFINED;
+        money64 raiseCost = res.Error == GameActions::Status::Ok ? res.Cost : kMoney64Undefined;
 
         if (gWaterToolRaiseCost != raiseCost || gWaterToolLowerCost != lowerCost)
         {
@@ -955,7 +955,7 @@ private:
                         { mapTile, gSceneryPlaceZ, rotation }, quadrant, selection.EntryIndex, gWindowSceneryPrimaryColour,
                         gWindowScenerySecondaryColour, gWindowSceneryTertiaryColour);
 
-                    if (cost != MONEY64_UNDEFINED)
+                    if (cost != kMoney64Undefined)
                         break;
                     gSceneryPlaceZ += 8;
                 }
@@ -1046,7 +1046,7 @@ private:
                         { mapTile, gSceneryPlaceZ }, edge, selection.EntryIndex, gWindowSceneryPrimaryColour,
                         gWindowScenerySecondaryColour, gWindowSceneryTertiaryColour);
 
-                    if (cost != MONEY64_UNDEFINED)
+                    if (cost != kMoney64Undefined)
                         break;
                     gSceneryPlaceZ += 8;
                 }
@@ -1112,7 +1112,7 @@ private:
                         { mapTile, gSceneryPlaceZ, direction }, selection.EntryIndex, gWindowSceneryPrimaryColour,
                         gWindowScenerySecondaryColour, gWindowSceneryTertiaryColour);
 
-                    if (cost != MONEY64_UNDEFINED)
+                    if (cost != kMoney64Undefined)
                         break;
                     gSceneryPlaceZ += COORDS_Z_STEP;
                 }
@@ -1179,7 +1179,7 @@ private:
                 false);
             auto res = (flag & GAME_COMMAND_FLAG_APPLY) ? GameActions::Execute(&landSmoothAction)
                                                         : GameActions::Query(&landSmoothAction);
-            return res.Error == GameActions::Status::Ok ? res.Cost : MONEY64_UNDEFINED;
+            return res.Error == GameActions::Status::Ok ? res.Cost : kMoney64Undefined;
         }
 
         auto landRaiseAction = LandRaiseAction(
@@ -1188,7 +1188,7 @@ private:
         auto res = (flag & GAME_COMMAND_FLAG_APPLY) ? GameActions::Execute(&landRaiseAction)
                                                     : GameActions::Query(&landRaiseAction);
 
-        return res.Error == GameActions::Status::Ok ? res.Cost : MONEY64_UNDEFINED;
+        return res.Error == GameActions::Status::Ok ? res.Cost : kMoney64Undefined;
     }
 
     /**
@@ -1210,7 +1210,7 @@ private:
                 true);
             auto res = (flag & GAME_COMMAND_FLAG_APPLY) ? GameActions::Execute(&landSmoothAction)
                                                         : GameActions::Query(&landSmoothAction);
-            return res.Error == GameActions::Status::Ok ? res.Cost : MONEY64_UNDEFINED;
+            return res.Error == GameActions::Status::Ok ? res.Cost : kMoney64Undefined;
         }
 
         auto landLowerAction = LandLowerAction(
@@ -1219,7 +1219,7 @@ private:
         auto res = (flag & GAME_COMMAND_FLAG_APPLY) ? GameActions::Execute(&landLowerAction)
                                                     : GameActions::Query(&landLowerAction);
 
-        return res.Error == GameActions::Status::Ok ? res.Cost : MONEY64_UNDEFINED;
+        return res.Error == GameActions::Status::Ok ? res.Cost : kMoney64Undefined;
     }
 
     /**
@@ -1251,8 +1251,8 @@ private:
 
             SelectionRaiseLand(GAME_COMMAND_FLAG_APPLY);
 
-            gLandToolRaiseCost = MONEY64_UNDEFINED;
-            gLandToolLowerCost = MONEY64_UNDEFINED;
+            gLandToolRaiseCost = kMoney64Undefined;
+            gLandToolLowerCost = kMoney64Undefined;
         }
         else if (y_diff >= -tile_height)
         {
@@ -1260,8 +1260,8 @@ private:
 
             SelectionLowerLand(GAME_COMMAND_FLAG_APPLY);
 
-            gLandToolRaiseCost = MONEY64_UNDEFINED;
-            gLandToolLowerCost = MONEY64_UNDEFINED;
+            gLandToolRaiseCost = kMoney64Undefined;
+            gLandToolLowerCost = kMoney64Undefined;
         }
     }
 
@@ -1287,8 +1287,8 @@ private:
                 { gMapSelectPositionA.x, gMapSelectPositionA.y, gMapSelectPositionB.x, gMapSelectPositionB.y });
             GameActions::Execute(&waterRaiseAction);
 
-            gWaterToolRaiseCost = MONEY64_UNDEFINED;
-            gWaterToolLowerCost = MONEY64_UNDEFINED;
+            gWaterToolRaiseCost = kMoney64Undefined;
+            gWaterToolLowerCost = kMoney64Undefined;
 
             return;
         }
@@ -1302,8 +1302,8 @@ private:
             auto waterLowerAction = WaterLowerAction(
                 { gMapSelectPositionA.x, gMapSelectPositionA.y, gMapSelectPositionB.x, gMapSelectPositionB.y });
             GameActions::Execute(&waterLowerAction);
-            gWaterToolRaiseCost = MONEY64_UNDEFINED;
-            gWaterToolLowerCost = MONEY64_UNDEFINED;
+            gWaterToolRaiseCost = kMoney64Undefined;
+            gWaterToolLowerCost = kMoney64Undefined;
 
             return;
         }
@@ -1312,7 +1312,7 @@ private:
     /**
      *
      *  rct2: 0x006E24F6
-     * On failure returns MONEY64_UNDEFINED
+     * On failure returns kMoney64Undefined
      * On success places ghost scenery and returns cost to place proper
      */
     money64 TryPlaceGhostSmallScenery(
@@ -1327,7 +1327,7 @@ private:
         smallSceneryPlaceAction.SetFlags(GAME_COMMAND_FLAG_GHOST | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED);
         auto res = GameActions::Execute(&smallSceneryPlaceAction);
         if (res.Error != GameActions::Status::Ok)
-            return MONEY64_UNDEFINED;
+            return kMoney64Undefined;
 
         const auto placementData = res.GetData<SmallSceneryPlaceActionResult>();
 
@@ -1369,7 +1369,7 @@ private:
         });
         auto res = GameActions::Execute(&footpathAdditionPlaceAction);
         if (res.Error != GameActions::Status::Ok)
-            return MONEY64_UNDEFINED;
+            return kMoney64Undefined;
 
         return res.Cost;
     }
@@ -1396,7 +1396,7 @@ private:
 
         auto res = GameActions::Execute(&wallPlaceAction);
         if (res.Error != GameActions::Status::Ok)
-            return MONEY64_UNDEFINED;
+            return kMoney64Undefined;
 
         return res.Cost;
     }
@@ -1412,7 +1412,7 @@ private:
             GAME_COMMAND_FLAG_GHOST | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_NO_SPEND);
         auto res = GameActions::Execute(&sceneryPlaceAction);
         if (res.Error != GameActions::Status::Ok)
-            return MONEY64_UNDEFINED;
+            return kMoney64Undefined;
 
         const auto placementData = res.GetData<LargeSceneryPlaceActionResult>();
 
@@ -1445,7 +1445,7 @@ private:
             GAME_COMMAND_FLAG_GHOST | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_NO_SPEND);
         auto res = GameActions::Execute(&bannerPlaceAction);
         if (res.Error != GameActions::Status::Ok)
-            return MONEY64_UNDEFINED;
+            return kMoney64Undefined;
 
         gSceneryGhostPosition = loc;
         gSceneryGhostPosition.z += PATH_HEIGHT_STEP;

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -85,7 +85,7 @@ public:
         WindowPushOthersRight(*this);
         ShowGridlines();
         _miniPreview.resize(TRACK_MINI_PREVIEW_SIZE);
-        _placementCost = MONEY64_UNDEFINED;
+        _placementCost = kMoney64Undefined;
         _placementLoc.SetNull();
         _currentTrackPieceDirection = (2 - GetCurrentRotation()) & 3;
     }
@@ -168,7 +168,7 @@ public:
             return;
         }
 
-        money64 cost = MONEY64_UNDEFINED;
+        money64 cost = kMoney64Undefined;
 
         // Get base Z position
         mapZ = GetBaseZ(mapCoords);
@@ -193,7 +193,7 @@ public:
                     }
                 });
                 res = GameActions::Execute(&tdAction);
-                cost = res.Error == GameActions::Status::Ok ? res.Cost : MONEY64_UNDEFINED;
+                cost = res.Error == GameActions::Status::Ok ? res.Cost : kMoney64Undefined;
             }
         }
 
@@ -305,7 +305,7 @@ public:
         }
 
         // Price
-        if (_placementCost != MONEY64_UNDEFINED && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+        if (_placementCost != kMoney64Undefined && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
         {
             ft = Formatter();
             ft.Add<money64>(_placementCost);

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -54,8 +54,8 @@ public:
         WindowPushOthersBelow(*this);
 
         gLandToolSize = 1;
-        gWaterToolRaiseCost = MONEY64_UNDEFINED;
-        gWaterToolLowerCost = MONEY64_UNDEFINED;
+        gWaterToolRaiseCost = kMoney64Undefined;
+        gWaterToolLowerCost = kMoney64Undefined;
     }
 
     void OnClose() override
@@ -159,7 +159,7 @@ public:
         {
             // Draw raise cost amount
             screenCoords = { widgets[WIDX_PREVIEW].midX() + windowPos.x, widgets[WIDX_PREVIEW].bottom + windowPos.y + 5 };
-            if (gWaterToolRaiseCost != MONEY64_UNDEFINED && gWaterToolRaiseCost != 0)
+            if (gWaterToolRaiseCost != kMoney64Undefined && gWaterToolRaiseCost != 0)
             {
                 auto ft = Formatter();
                 ft.Add<money64>(gWaterToolRaiseCost);
@@ -168,7 +168,7 @@ public:
             screenCoords.y += 10;
 
             // Draw lower cost amount
-            if (gWaterToolLowerCost != MONEY64_UNDEFINED && gWaterToolLowerCost != 0)
+            if (gWaterToolLowerCost != kMoney64Undefined && gWaterToolLowerCost != 0)
             {
                 auto ft = Formatter();
                 ft.Add<money64>(gWaterToolLowerCost);

--- a/src/openrct2/Cheats.h
+++ b/src/openrct2/Cheats.h
@@ -123,12 +123,12 @@ enum
     OBJECT_UMBRELLA
 };
 
-constexpr auto CHEATS_GIVE_GUESTS_MONEY = 1000.00_GBP;
-#define CHEATS_TRAM_INCREMENT 250
-#define CHEATS_DUCK_INCREMENT 20
-#define CHEATS_STAFF_FAST_SPEED 0xFF
-#define CHEATS_STAFF_NORMAL_SPEED 0x60
-#define CHEATS_STAFF_FREEZE_SPEED 0
+constexpr auto kCheatsGiveGuestsMoney = 1000.00_GBP;
+constexpr int kCheatsTramIncrement = 250;
+constexpr int kCheatsDuckIncrement = 20;
+constexpr int kCheatsStaffFastSpeed = 0xFF;
+constexpr int kCheatsStaffNormalSpeed = 0x60;
+constexpr int kCheatsStaffFreezeSpeed = 0;
 
 void CheatsReset();
 const char* CheatsGetName(CheatType cheatType);

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -1089,14 +1089,14 @@ namespace OpenRCT2
         {
             // Ticks
             float scaledDeltaTime = deltaTime * _timeScale;
-            _ticksAccumulator = std::min(_ticksAccumulator + scaledDeltaTime, GAME_UPDATE_MAX_THRESHOLD);
+            _ticksAccumulator = std::min(_ticksAccumulator + scaledDeltaTime, kGameUpdateMaxThreshold);
 
             // Real Time.
-            _realtimeAccumulator = std::min(_realtimeAccumulator + deltaTime, GAME_UPDATE_MAX_THRESHOLD);
-            while (_realtimeAccumulator >= GAME_UPDATE_TIME_MS)
+            _realtimeAccumulator = std::min(_realtimeAccumulator + deltaTime, kGameUpdateMaxThreshold);
+            while (_realtimeAccumulator >= kGameUpdateTimeMS)
             {
                 gCurrentRealTimeTicks++;
-                _realtimeAccumulator -= GAME_UPDATE_TIME_MS;
+                _realtimeAccumulator -= kGameUpdateTimeMS;
             }
         }
 
@@ -1106,18 +1106,18 @@ namespace OpenRCT2
 
             _uiContext->ProcessMessages();
 
-            if (_ticksAccumulator < GAME_UPDATE_TIME_MS)
+            if (_ticksAccumulator < kGameUpdateTimeMS)
             {
-                const auto sleepTimeSec = (GAME_UPDATE_TIME_MS - _ticksAccumulator);
+                const auto sleepTimeSec = (kGameUpdateTimeMS - _ticksAccumulator);
                 Platform::Sleep(static_cast<uint32_t>(sleepTimeSec * 1000.f));
                 return;
             }
 
-            while (_ticksAccumulator >= GAME_UPDATE_TIME_MS)
+            while (_ticksAccumulator >= kGameUpdateTimeMS)
             {
                 Tick();
 
-                _ticksAccumulator -= GAME_UPDATE_TIME_MS;
+                _ticksAccumulator -= kGameUpdateTimeMS;
             }
 
             ContextHandleInput();
@@ -1138,7 +1138,7 @@ namespace OpenRCT2
 
             _uiContext->ProcessMessages();
 
-            while (_ticksAccumulator >= GAME_UPDATE_TIME_MS)
+            while (_ticksAccumulator >= kGameUpdateTimeMS)
             {
                 // Get the original position of each sprite
                 if (shouldDraw)
@@ -1146,7 +1146,7 @@ namespace OpenRCT2
 
                 Tick();
 
-                _ticksAccumulator -= GAME_UPDATE_TIME_MS;
+                _ticksAccumulator -= kGameUpdateTimeMS;
 
                 // Get the next position of each sprite
                 if (shouldDraw)
@@ -1158,7 +1158,7 @@ namespace OpenRCT2
 
             if (shouldDraw)
             {
-                const float alpha = std::min(_ticksAccumulator / GAME_UPDATE_TIME_MS, 1.0f);
+                const float alpha = std::min(_ticksAccumulator / kGameUpdateTimeMS, 1.0f);
                 tweener.Tween(alpha);
 
                 Draw();
@@ -1180,7 +1180,7 @@ namespace OpenRCT2
 
             // TODO: This variable has been never "variable" in time, some code expects
             // this to be 40Hz (25 ms). Refactor this once the UI is decoupled.
-            gCurrentDeltaTime = static_cast<uint16_t>(GAME_UPDATE_TIME_MS * 1000.0f);
+            gCurrentDeltaTime = static_cast<uint16_t>(kGameUpdateTimeMS * 1000.0f);
 
             if (GameIsNotPaused())
             {
@@ -1337,7 +1337,7 @@ namespace OpenRCT2
 
         void SetTimeScale(float newScale) override
         {
-            _timeScale = std::clamp(newScale, GAME_MIN_TIME_SCALE, GAME_MAX_TIME_SCALE);
+            _timeScale = std::clamp(newScale, kGameMinTimeScale, kGameMaxTimeScale);
         }
 
         float GetTimeScale() const override

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -176,17 +176,17 @@ namespace OpenRCT2
 namespace
 {
     // The number of logical update / ticks per second.
-    constexpr uint32_t GAME_UPDATE_FPS = 40;
+    constexpr uint32_t kGameUpdateFPS = 40;
     // The maximum amount of updates in case rendering is slower
-    constexpr uint32_t GAME_MAX_UPDATES = 4;
+    constexpr uint32_t kGameMaxUpdates = 4;
     // The game update interval in milliseconds, (1000 / 40fps) = 25ms
-    constexpr float GAME_UPDATE_TIME_MS = 1.0f / GAME_UPDATE_FPS;
+    constexpr float kGameUpdateTimeMS = 1.0f / kGameUpdateFPS;
     // The maximum threshold to advance.
-    constexpr float GAME_UPDATE_MAX_THRESHOLD = GAME_UPDATE_TIME_MS * GAME_MAX_UPDATES;
+    constexpr float kGameUpdateMaxThreshold = kGameUpdateTimeMS * kGameMaxUpdates;
 }; // namespace
 
-constexpr float GAME_MIN_TIME_SCALE = 0.1f;
-constexpr float GAME_MAX_TIME_SCALE = 5.0f;
+constexpr float kGameMinTimeScale = 0.1f;
+constexpr float kGameMaxTimeScale = 5.0f;
 
 void ContextInit();
 void ContextSetCurrentCursor(CursorID cursor);

--- a/src/openrct2/Date.cpp
+++ b/src/openrct2/Date.cpp
@@ -19,10 +19,10 @@
 
 using namespace OpenRCT2;
 
-constexpr int32_t MONTH_TICKS_INCREMENT = 4;
-constexpr int32_t MASK_WEEK_TICKS = 0x3FFF;
-constexpr int32_t MASK_FORTNIGHT_TICKS = 0x7FFF;
-constexpr int32_t MASK_MONTH_TICKS = 0xFFFF;
+constexpr int32_t kMonthTicksIncrement = 4;
+constexpr int32_t kMaskWeekTicks = 0x3FFF;
+constexpr int32_t kMaskFortnightTicks = 0x7FFF;
+constexpr int32_t kMaskMonthTicks = 0xFFFF;
 
 // rct2: 0x00993988
 static const int16_t days_in_month[MONTH_COUNT] = {
@@ -39,7 +39,7 @@ Date::Date(uint32_t monthsElapsed, uint16_t monthTicks)
 
 Date Date::FromYMD(int32_t year, int32_t month, int32_t day)
 {
-    year = std::clamp(year, 0, MAX_YEAR - 1);
+    year = std::clamp(year, 0, kMaxYear - 1);
     month = std::clamp(month, 0, static_cast<int>(MONTH_COUNT) - 1);
     auto daysInMonth = days_in_month[month];
     day = std::clamp(day, 0, daysInMonth - 1);
@@ -49,7 +49,7 @@ Date Date::FromYMD(int32_t year, int32_t month, int32_t day)
     int32_t monthTicks = 0;
     if (day != 0)
     {
-        monthTicks = ((day << 16) / daysInMonth) + MONTH_TICKS_INCREMENT;
+        monthTicks = ((day << 16) / daysInMonth) + kMonthTicksIncrement;
     }
 
     return Date(monthsElapsed, monthTicks);
@@ -57,8 +57,8 @@ Date Date::FromYMD(int32_t year, int32_t month, int32_t day)
 
 void Date::Update()
 {
-    int32_t monthTicks = _monthTicks + MONTH_TICKS_INCREMENT;
-    if (monthTicks > MASK_MONTH_TICKS)
+    int32_t monthTicks = _monthTicks + kMonthTicksIncrement;
+    if (monthTicks > kMaskMonthTicks)
     {
         _monthTicks = 0;
         _monthsElapsed++;
@@ -110,12 +110,12 @@ bool Date::IsDayStart() const
 
 bool Date::IsWeekStart() const
 {
-    return (_monthTicks & MASK_WEEK_TICKS) == 0;
+    return (_monthTicks & kMaskWeekTicks) == 0;
 }
 
 bool Date::IsFortnightStart() const
 {
-    return (_monthTicks & MASK_FORTNIGHT_TICKS) == 0;
+    return (_monthTicks & kMaskFortnightTicks) == 0;
 }
 
 bool Date::IsMonthStart() const

--- a/src/openrct2/Date.h
+++ b/src/openrct2/Date.h
@@ -11,8 +11,8 @@
 
 #include "common.h"
 
-constexpr int32_t MAX_YEAR = 8192;
-constexpr int32_t TICKS_PER_MONTH = 0x10000;
+constexpr int32_t kMaxYear = 8192;
+constexpr int32_t kTicksPerMonth = 0x10000;
 
 enum
 {

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -111,7 +111,7 @@ void GameState::InitAll(const TileCoordsXY& mapSize)
 }
 
 /**
- * Function will be called every GAME_UPDATE_TIME_MS.
+ * Function will be called every kGameUpdateTimeMS.
  * It has its own loop which might run multiple updates per call such as
  * when operating as a client it may run multiple updates to catch up with the server tick,
  * another influence can be the game speed setting.
@@ -120,7 +120,7 @@ void GameState::Tick()
 {
     PROFILED_FUNCTION();
 
-    // Normal game play will update only once every GAME_UPDATE_TIME_MS
+    // Normal game play will update only once every kGameUpdateTimeMS
     uint32_t numUpdates = 1;
 
     // 0x006E3AEC // screen_game_process_mouse_input();

--- a/src/openrct2/actions/ClearAction.cpp
+++ b/src/openrct2/actions/ClearAction.cpp
@@ -89,7 +89,7 @@ GameActions::Result ClearAction::QueryExecute(bool executing) const
             if (LocationValid({ x, y }) && MapCanClearAt({ x, y }))
             {
                 auto cost = ClearSceneryFromTile({ x, y }, executing);
-                if (cost != MONEY64_UNDEFINED)
+                if (cost != kMoney64Undefined)
                 {
                     noValidTiles = false;
                     totalCost += cost;

--- a/src/openrct2/actions/ParkSetDateAction.cpp
+++ b/src/openrct2/actions/ParkSetDateAction.cpp
@@ -45,7 +45,7 @@ void ParkSetDateAction::Serialise(DataSerialiser& stream)
 
 GameActions::Result ParkSetDateAction::Query() const
 {
-    if (_year < 0 || _year >= MAX_YEAR || _month < 0 || _month >= MONTH_COUNT || _day < 0 || _day >= 31)
+    if (_year < 0 || _year >= kMaxYear || _month < 0 || _month >= MONTH_COUNT || _day < 0 || _day >= 31)
     {
         return GameActions::Result(
             GameActions::Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_VALUE_OUT_OF_RANGE);

--- a/src/openrct2/actions/ParkSetEntranceFeeAction.h
+++ b/src/openrct2/actions/ParkSetEntranceFeeAction.h
@@ -14,7 +14,7 @@
 class ParkSetEntranceFeeAction final : public GameActionBase<GameCommand::SetParkEntranceFee>
 {
 private:
-    money64 _fee{ MONEY64_UNDEFINED };
+    money64 _fee{ kMoney64Undefined };
 
 public:
     ParkSetEntranceFeeAction() = default;

--- a/src/openrct2/actions/ParkSetLoanAction.h
+++ b/src/openrct2/actions/ParkSetLoanAction.h
@@ -14,7 +14,7 @@
 class ParkSetLoanAction final : public GameActionBase<GameCommand::SetCurrentLoan>
 {
 private:
-    money64 _value{ MONEY64_UNDEFINED };
+    money64 _value{ kMoney64Undefined };
 
 public:
     ParkSetLoanAction() = default;

--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -244,7 +244,7 @@ GameActions::Result RideCreateAction::Execute() const
             if (ShopItemHasCommonPrice(ShopItem::Admission))
             {
                 auto price = RideGetCommonPrice(*ride);
-                if (price != MONEY64_UNDEFINED)
+                if (price != kMoney64Undefined)
                 {
                     ride->price[0] = price;
                 }
@@ -258,7 +258,7 @@ GameActions::Result RideCreateAction::Execute() const
                 if (ShopItemHasCommonPrice(rideEntry->shop_item[i]))
                 {
                     auto price = ShopItemGetCommonPrice(ride, rideEntry->shop_item[i]);
-                    if (price != MONEY64_UNDEFINED)
+                    if (price != kMoney64Undefined)
                     {
                         ride->price[i] = price;
                     }
@@ -270,7 +270,7 @@ GameActions::Result RideCreateAction::Execute() const
         if (!rtd.HasFlag(RIDE_TYPE_FLAG_IS_SHOP_OR_FACILITY) && ShopItemHasCommonPrice(ShopItem::Photo))
         {
             auto price = ShopItemGetCommonPrice(ride, ShopItem::Photo);
-            if (price != MONEY64_UNDEFINED)
+            if (price != kMoney64Undefined)
             {
                 ride->price[1] = price;
             }
@@ -295,7 +295,7 @@ GameActions::Result RideCreateAction::Execute() const
     ride->music_tune_id = TUNE_ID_NULL;
 
     ride->breakdown_reason = 255;
-    ride->upkeep_cost = MONEY64_UNDEFINED;
+    ride->upkeep_cost = kMoney64Undefined;
     ride->reliability = RIDE_INITIAL_RELIABILITY;
     ride->unreliability_factor = 1;
     ride->inspection_interval = RIDE_INSPECTION_EVERY_30_MINUTES;
@@ -305,8 +305,8 @@ GameActions::Result RideCreateAction::Execute() const
     ride->no_primary_items_sold = 0;
     ride->no_secondary_items_sold = 0;
     ride->last_crash_type = RIDE_CRASH_TYPE_NONE;
-    ride->income_per_hour = MONEY64_UNDEFINED;
-    ride->profit = MONEY64_UNDEFINED;
+    ride->income_per_hour = kMoney64Undefined;
+    ride->profit = kMoney64Undefined;
     ride->connected_message_throttle = 0;
 
     ride->entrance_style = OBJECT_ENTRY_INDEX_NULL;

--- a/src/openrct2/actions/RideDemolishAction.cpp
+++ b/src/openrct2/actions/RideDemolishAction.cpp
@@ -186,7 +186,7 @@ money64 RideDemolishAction::MazeRemoveTrack(const CoordsXYZD& coords) const
         return execRes.Cost;
     }
 
-    return MONEY64_UNDEFINED;
+    return kMoney64Undefined;
 }
 
 money64 RideDemolishAction::DemolishTracks() const
@@ -250,7 +250,7 @@ money64 RideDemolishAction::DemolishTracks() const
                     {
                         const CoordsXYZ off = { DirOffsets[dir], 0 };
                         money64 removePrice = MazeRemoveTrack({ location + off, dir });
-                        if (removePrice != MONEY64_UNDEFINED)
+                        if (removePrice != kMoney64Undefined)
                         {
                             refundPrice += removePrice;
                         }

--- a/src/openrct2/actions/RideSetPriceAction.h
+++ b/src/openrct2/actions/RideSetPriceAction.h
@@ -15,7 +15,7 @@ class RideSetPriceAction final : public GameActionBase<GameCommand::SetRidePrice
 {
 private:
     RideId _rideIndex{ RideId::GetNull() };
-    money64 _price{ MONEY64_UNDEFINED };
+    money64 _price{ kMoney64Undefined };
     bool _primaryPrice{ true };
 
 public:

--- a/src/openrct2/actions/StaffHireNewAction.cpp
+++ b/src/openrct2/actions/StaffHireNewAction.cpp
@@ -207,18 +207,18 @@ GameActions::Result StaffHireNewAction::QueryExecute(bool execute) const
         switch (gCheatsSelectedStaffSpeed)
         {
             case StaffSpeedCheat::None:
-                newPeep->Energy = CHEATS_STAFF_NORMAL_SPEED;
-                newPeep->EnergyTarget = CHEATS_STAFF_NORMAL_SPEED;
+                newPeep->Energy = kCheatsStaffNormalSpeed;
+                newPeep->EnergyTarget = kCheatsStaffNormalSpeed;
                 break;
 
             case StaffSpeedCheat::Frozen:
-                newPeep->Energy = CHEATS_STAFF_FREEZE_SPEED;
-                newPeep->EnergyTarget = CHEATS_STAFF_FREEZE_SPEED;
+                newPeep->Energy = kCheatsStaffFreezeSpeed;
+                newPeep->EnergyTarget = kCheatsStaffFreezeSpeed;
                 break;
 
             case StaffSpeedCheat::Fast:
-                newPeep->Energy = CHEATS_STAFF_FAST_SPEED;
-                newPeep->EnergyTarget = CHEATS_STAFF_FAST_SPEED;
+                newPeep->Energy = kCheatsStaffFastSpeed;
+                newPeep->EnergyTarget = kCheatsStaffFastSpeed;
                 break;
         }
 

--- a/src/openrct2/common.h
+++ b/src/openrct2/common.h
@@ -86,23 +86,23 @@ constexpr money64 ToMoney64FromGBP(double money) noexcept
     return money * 10;
 }
 
-#define MONEY16_UNDEFINED static_cast<money16>(static_cast<uint16_t>(0xFFFF))
-#define MONEY32_UNDEFINED (static_cast<money32>(0x80000000))
-#define MONEY64_UNDEFINED (static_cast<money64>(0x8000000000000000))
+constexpr money16 kMoney16Undefined = static_cast<money16>(static_cast<uint16_t>(0xFFFF));
+constexpr money32 kMoney32Undefined = static_cast<money32>(0x80000000);
+constexpr money64 kMoney64Undefined = static_cast<money64>(0x8000000000000000);
 
 constexpr money16 ToMoney16(money64 value)
 {
-    return value == MONEY64_UNDEFINED ? MONEY16_UNDEFINED : value;
+    return value == kMoney64Undefined ? kMoney16Undefined : value;
 }
 
 constexpr money64 ToMoney64(money32 value)
 {
-    return value == MONEY32_UNDEFINED ? MONEY64_UNDEFINED : value;
+    return value == kMoney32Undefined ? kMoney64Undefined : value;
 }
 
 constexpr money64 ToMoney64(money16 value)
 {
-    return value == MONEY16_UNDEFINED ? MONEY64_UNDEFINED : value;
+    return value == kMoney16Undefined ? kMoney64Undefined : value;
 }
 
 // Note: Only valid for 5 decimal places.

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -7196,7 +7196,7 @@ Guest* Guest::Generate(const CoordsXYZ& coords)
         cash = 0;
     }
 
-    if (gameState.GuestInitialCash == MONEY64_UNDEFINED)
+    if (gameState.GuestInitialCash == kMoney64Undefined)
     {
         cash = 0;
     }

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -209,7 +209,7 @@ static int32_t ConsoleCommandRides(InteractiveConsole& console, const arguments_
                 else
                 {
                     auto res = SetOperatingSetting(RideId::FromUnderlying(ride_index), RideSetSetting::RideType, type);
-                    if (res == MONEY64_UNDEFINED)
+                    if (res == kMoney64Undefined)
                     {
                         if (!gCheatsAllowArbitraryRideTypeChanges)
                         {
@@ -1452,7 +1452,7 @@ static int32_t ConsoleCommandForceDate([[maybe_unused]] InteractiveConsole& cons
 
     // All cases involve providing a year, so grab that first
     year = atoi(argv[0].c_str());
-    if (year < 1 || year > MAX_YEAR)
+    if (year < 1 || year > kMaxYear)
     {
         return -1;
     }

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -135,7 +135,7 @@ void WindowUpdateAll()
     // Periodic update happens every second so 40 ticks.
     if (gCurrentRealTimeTicks >= gWindowUpdateTicks)
     {
-        gWindowUpdateTicks = gCurrentRealTimeTicks + GAME_UPDATE_FPS;
+        gWindowUpdateTicks = gCurrentRealTimeTicks + kGameUpdateFPS;
 
         WindowVisitEach([](WindowBase* w) { WindowEventPeriodicUpdateCall(w); });
     }

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -382,7 +382,7 @@ money64 StringToMoney(const char* string_to_monetise)
         else if (*src_ptr == decimal_char[0])
         {
             if (hasDecSep)
-                return MONEY64_UNDEFINED;
+                return kMoney64Undefined;
             hasDecSep = true;
 
             // Replace localised decimal separator with an English one.
@@ -393,7 +393,7 @@ money64 StringToMoney(const char* string_to_monetise)
         else if (*src_ptr == '-')
         {
             if (hasMinus)
-                return MONEY64_UNDEFINED;
+                return kMoney64Undefined;
             hasMinus = true;
         }
         else
@@ -412,12 +412,12 @@ money64 StringToMoney(const char* string_to_monetise)
     *dst_ptr = '\0';
 
     if (numNumbers == 0)
-        return MONEY64_UNDEFINED;
+        return kMoney64Undefined;
 
     if (hasMinus && processedString[0] != '-')
     {
         // If there is a minus sign, it has to be at position 0 in order to be valid.
-        return MONEY64_UNDEFINED;
+        return kMoney64Undefined;
     }
 
     // Due to the nature of strstr and strtok, decimals at the very beginning will be ignored, causing
@@ -445,7 +445,7 @@ money64 StringToMoney(const char* string_to_monetise)
  */
 void MoneyToString(money64 amount, char* buffer_to_put_value_to, size_t buffer_len, bool forceDecimals)
 {
-    if (amount == MONEY64_UNDEFINED)
+    if (amount == kMoney64Undefined)
     {
         snprintf(buffer_to_put_value_to, buffer_len, "0");
         return;

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -172,7 +172,7 @@ void FinancePayRideUpkeep()
         if (ride.status != RideStatus::Closed && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
         {
             auto upkeep = ride.upkeep_cost;
-            if (upkeep != MONEY64_UNDEFINED)
+            if (upkeep != kMoney64Undefined)
             {
                 ride.total_profit -= upkeep;
                 ride.window_invalidate_flags |= RIDE_INVALIDATE_RIDE_INCOME;
@@ -192,9 +192,9 @@ void FinanceResetHistory()
     auto& gameState = GetGameState();
     for (int32_t i = 0; i < FINANCE_GRAPH_SIZE; i++)
     {
-        gCashHistory[i] = MONEY64_UNDEFINED;
-        gameState.WeeklyProfitHistory[i] = MONEY64_UNDEFINED;
-        gameState.ParkValueHistory[i] = MONEY64_UNDEFINED;
+        gCashHistory[i] = kMoney64Undefined;
+        gameState.WeeklyProfitHistory[i] = kMoney64Undefined;
+        gameState.ParkValueHistory[i] = kMoney64Undefined;
     }
 
     for (uint32_t i = 0; i < EXPENDITURE_TABLE_MONTH_COUNT; ++i)
@@ -237,7 +237,7 @@ void FinanceInit()
     gameState.BankLoanInterestRate = 10;
     gameState.ParkValue = 0;
     gCompanyValue = 0;
-    gameState.ScenarioCompletedCompanyValue = MONEY64_UNDEFINED;
+    gameState.ScenarioCompletedCompanyValue = kMoney64Undefined;
     gameState.TotalAdmissions = 0;
     gameState.TotalIncomeFromAdmissions = 0;
     gameState.ScenarioCompletedBy = "?";
@@ -276,7 +276,7 @@ void FinanceUpdateDailyProfit()
         // Ride costs
         for (auto& ride : GetRideManager())
         {
-            if (ride.status != RideStatus::Closed && ride.upkeep_cost != MONEY64_UNDEFINED)
+            if (ride.status != RideStatus::Closed && ride.upkeep_cost != kMoney64Undefined)
             {
                 current_profit -= 2 * ride.upkeep_cost;
             }

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -435,7 +435,7 @@ namespace OpenRCT2
                 cs.ReadWrite(gameState.ScenarioParkRatingWarningDays);
 
                 cs.ReadWrite(gameState.ScenarioCompletedCompanyValue);
-                if (gameState.ScenarioCompletedCompanyValue == MONEY64_UNDEFINED
+                if (gameState.ScenarioCompletedCompanyValue == kMoney64Undefined
                     || gameState.ScenarioCompletedCompanyValue == COMPANY_VALUE_ON_FAILED_OBJECTIVE)
                 {
                     cs.Write("");

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -262,9 +262,9 @@ namespace RCT1
 
         money64 CorrectRCT1ParkValue(money32 oldParkValue)
         {
-            if (oldParkValue == MONEY32_UNDEFINED)
+            if (oldParkValue == kMoney32Undefined)
             {
-                return MONEY64_UNDEFINED;
+                return kMoney64Undefined;
             }
 
             if (_parkValueConversionFactor == 0)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1113,7 +1113,7 @@ void Ride::Update()
         income_per_hour = CalculateIncomePerHour();
         window_invalidate_flags |= RIDE_INVALIDATE_RIDE_INCOME;
 
-        if (upkeep_cost != MONEY64_UNDEFINED)
+        if (upkeep_cost != kMoney64Undefined)
             profit = income_per_hour - (upkeep_cost * 16);
     }
 
@@ -4330,7 +4330,7 @@ money64 RideGetCommonPrice(const Ride& forRide)
         }
     }
 
-    return MONEY64_UNDEFINED;
+    return kMoney64Undefined;
 }
 
 void Ride::SetNameToDefault()

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -903,7 +903,7 @@ enum
 };
 
 #define MAX_RIDE_MEASUREMENTS 8
-constexpr money64 RIDE_VALUE_UNDEFINED = MONEY64_UNDEFINED;
+constexpr money64 RIDE_VALUE_UNDEFINED = kMoney64Undefined;
 #define RIDE_INITIAL_RELIABILITY ((100 << 8) | 0xFF) // Upper byte is percentage, lower byte is "decimal".
 
 #define STATION_DEPART_FLAG (1 << 7)

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -641,7 +641,7 @@ void RideConstructionSetDefaultNextPiece()
     TrackBeginEnd trackBeginEnd;
     CoordsXYE xyElement;
     TileElement* tileElement;
-    _currentTrackPrice = MONEY64_UNDEFINED;
+    _currentTrackPrice = kMoney64Undefined;
 
     const TrackElementDescriptor* ted;
     switch (_rideConstructionState)
@@ -1204,7 +1204,7 @@ money64 SetOperatingSetting(RideId rideId, RideSetSetting setting, uint8_t value
 {
     auto rideSetSetting = RideSetSettingAction(rideId, setting, value);
     auto res = GameActions::Execute(&rideSetSetting);
-    return res.Error == GameActions::Status::Ok ? 0 : MONEY64_UNDEFINED;
+    return res.Error == GameActions::Status::Ok ? 0 : kMoney64Undefined;
 }
 
 money64 SetOperatingSettingNested(RideId rideId, RideSetSetting setting, uint8_t value, uint8_t flags)
@@ -1213,7 +1213,7 @@ money64 SetOperatingSettingNested(RideId rideId, RideSetSetting setting, uint8_t
     rideSetSetting.SetFlags(flags);
     auto res = flags & GAME_COMMAND_FLAG_APPLY ? GameActions::ExecuteNested(&rideSetSetting)
                                                : GameActions::QueryNested(&rideSetSetting);
-    return res.Error == GameActions::Status::Ok ? 0 : MONEY64_UNDEFINED;
+    return res.Error == GameActions::Status::Ok ? 0 : kMoney64Undefined;
 }
 
 /**

--- a/src/openrct2/ride/ShopItem.cpp
+++ b/src/openrct2/ride/ShopItem.cpp
@@ -141,7 +141,7 @@ money64 ShopItemGetCommonPrice(Ride* forRide, const ShopItem shopItem)
         }
     }
 
-    return MONEY64_UNDEFINED;
+    return kMoney64Undefined;
 }
 
 bool ShopItemHasCommonPrice(const ShopItem shopItem)

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1878,10 +1878,10 @@ static money64 TrackDesignCreateRide(int32_t type, int32_t subType, int32_t flag
 
     auto res = GameActions::ExecuteNested(&gameAction);
 
-    // Callee's of this function expect MONEY64_UNDEFINED in case of failure.
+    // Callee's of this function expect kMoney64Undefined in case of failure.
     if (res.Error != GameActions::Status::Ok)
     {
-        return MONEY64_UNDEFINED;
+        return kMoney64Undefined;
     }
 
     *outRideIndex = res.GetData<RideId>();
@@ -1905,7 +1905,7 @@ static bool TrackDesignPlacePreview(TrackDesignState& tds, TrackDesign* td6, mon
 
     RideId rideIndex;
     uint8_t rideCreateFlags = GAME_COMMAND_FLAG_APPLY | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_NO_SPEND;
-    if (TrackDesignCreateRide(td6->type, entry_index, rideCreateFlags, &rideIndex) == MONEY64_UNDEFINED)
+    if (TrackDesignCreateRide(td6->type, entry_index, rideCreateFlags, &rideIndex) == kMoney64Undefined)
     {
         return false;
     }

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -142,7 +142,7 @@ void ScenarioReset(GameState_t& gameState)
     gameState.TotalIncomeFromAdmissions = 0;
 
     gameState.ParkFlags &= ~PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT;
-    gameState.ScenarioCompletedCompanyValue = MONEY64_UNDEFINED;
+    gameState.ScenarioCompletedCompanyValue = kMoney64Undefined;
     gameState.ScenarioCompletedBy = "?";
 
     park.ResetHistories();
@@ -361,7 +361,7 @@ static void ScenarioUpdateDayNightCycle()
 
     if (gScreenFlags == SCREEN_FLAGS_PLAYING && gConfigGeneral.DayNightCycle)
     {
-        float monthFraction = GetDate().GetMonthTicks() / static_cast<float>(TICKS_PER_MONTH);
+        float monthFraction = GetDate().GetMonthTicks() / static_cast<float>(kTicksPerMonth);
         if (monthFraction < (1 / 8.0f))
         {
             gDayNightCycle = 0.0f;
@@ -881,7 +881,7 @@ static void ScenarioCheckObjective(GameState_t& gameState)
  */
 ObjectiveStatus Objective::Check(GameState_t& gameState) const
 {
-    if (gameState.ScenarioCompletedCompanyValue != MONEY64_UNDEFINED)
+    if (gameState.ScenarioCompletedCompanyValue != kMoney64Undefined)
     {
         return ObjectiveStatus::Undecided;
     }

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -1186,7 +1186,7 @@ DukValue ScriptEngine::GameActionResultToDuk(const GameAction& action, const Gam
         obj.Set("errorMessage", result.GetErrorMessage());
     }
 
-    if (result.Cost != MONEY64_UNDEFINED)
+    if (result.Cost != kMoney64Undefined)
     {
         obj.Set("cost", result.Cost);
     }

--- a/src/openrct2/scripting/bindings/world/ScScenario.hpp
+++ b/src/openrct2/scripting/bindings/world/ScScenario.hpp
@@ -263,7 +263,7 @@ namespace OpenRCT2::Scripting
         {
             const auto& gameState = GetGameState();
             auto ctx = GetContext()->GetScriptEngine().GetContext();
-            if (gameState.ScenarioCompletedCompanyValue == MONEY64_UNDEFINED
+            if (gameState.ScenarioCompletedCompanyValue == kMoney64Undefined
                 || gameState.ScenarioCompletedCompanyValue == COMPANY_VALUE_ON_FAILED_OBJECTIVE)
             {
                 return ToDuk(ctx, nullptr);
@@ -279,7 +279,7 @@ namespace OpenRCT2::Scripting
         std::string status_get() const
         {
             const auto& gameState = GetGameState();
-            if (gameState.ScenarioCompletedCompanyValue == MONEY64_UNDEFINED)
+            if (gameState.ScenarioCompletedCompanyValue == kMoney64Undefined)
                 return "inProgress";
             if (gameState.ScenarioCompletedCompanyValue == COMPANY_VALUE_ON_FAILED_OBJECTIVE)
                 return "failed";
@@ -290,7 +290,7 @@ namespace OpenRCT2::Scripting
             ThrowIfGameStateNotMutable();
             auto& gameState = GetGameState();
             if (value == "inProgress")
-                gameState.ScenarioCompletedCompanyValue = MONEY64_UNDEFINED;
+                gameState.ScenarioCompletedCompanyValue = kMoney64Undefined;
             else if (value == "failed")
                 gameState.ScenarioCompletedCompanyValue = COMPANY_VALUE_ON_FAILED_OBJECTIVE;
             else if (value == "completed")

--- a/src/openrct2/title/Command/Wait.cpp
+++ b/src/openrct2/title/Command/Wait.cpp
@@ -18,6 +18,6 @@ namespace OpenRCT2::Title
     int16_t WaitCommand::operator()(int16_t timer)
     {
         // Return number of game ticks this wait command lasts
-        return std::max<int16_t>(1, GAME_UPDATE_FPS * Milliseconds / 1000);
+        return std::max<int16_t>(1, kGameUpdateFPS * Milliseconds / 1000);
     }
 } // namespace OpenRCT2::Title

--- a/src/openrct2/windows/_legacy.cpp
+++ b/src/openrct2/windows/_legacy.cpp
@@ -44,7 +44,7 @@ money64 PlaceProvisionalTrackPiece(
 {
     auto ride = GetRide(rideIndex);
     if (ride == nullptr)
-        return MONEY64_UNDEFINED;
+        return kMoney64Undefined;
 
     RideConstructionRemoveGhosts();
     const auto& rtd = ride->GetRideTypeDescriptor();
@@ -56,7 +56,7 @@ money64 PlaceProvisionalTrackPiece(
         auto result = GameActions::Execute(&gameAction);
 
         if (result.Error != GameActions::Status::Ok)
-            return MONEY64_UNDEFINED;
+            return kMoney64Undefined;
 
         _unkF440C5 = { trackPos, static_cast<Direction>(trackDirection) };
         _currentTrackSelectionFlags |= TRACK_SELECTION_FLAG_TRACK;
@@ -83,7 +83,7 @@ money64 PlaceProvisionalTrackPiece(
     // This command must not be sent over the network
     auto res = GameActions::Execute(&trackPlaceAction);
     if (res.Error != GameActions::Status::Ok)
-        return MONEY64_UNDEFINED;
+        return kMoney64Undefined;
 
     int16_t z_begin, z_end;
     const auto& ted = GetTrackElementDescriptor(trackType);

--- a/src/openrct2/world/Entrance.cpp
+++ b/src/openrct2/world/Entrance.cpp
@@ -49,7 +49,7 @@ static money64 RideEntranceExitPlaceGhost(
     rideEntranceExitPlaceAction.SetFlags(GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_GHOST);
     auto res = GameActions::Execute(&rideEntranceExitPlaceAction);
 
-    return res.Error == GameActions::Status::Ok ? res.Cost : MONEY64_UNDEFINED;
+    return res.Error == GameActions::Status::Ok ? res.Cost : kMoney64Undefined;
 }
 
 /**
@@ -119,7 +119,7 @@ money64 RideEntranceExitPlaceGhost(
     RideConstructionRemoveGhosts();
     money64 result = RideEntranceExitPlaceGhost(ride.id, entranceExitCoords, direction, placeType, stationNum);
 
-    if (result != MONEY64_UNDEFINED)
+    if (result != kMoney64Undefined)
     {
         _currentTrackSelectionFlags |= TRACK_SELECTION_FLAG_ENTRANCE_OR_EXIT;
         gRideEntranceExitGhostPosition.x = entranceExitCoords.x;

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -149,7 +149,7 @@ money64 FootpathProvisionalSet(
     auto footpathPlaceAction = FootpathPlaceAction(footpathLoc, slope, type, railingsType, INVALID_DIRECTION, constructFlags);
     footpathPlaceAction.SetFlags(GAME_COMMAND_FLAG_GHOST | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED);
     auto res = GameActions::Execute(&footpathPlaceAction);
-    cost = res.Error == GameActions::Status::Ok ? res.Cost : MONEY64_UNDEFINED;
+    cost = res.Error == GameActions::Status::Ok ? res.Cost : kMoney64Undefined;
     if (res.Error == GameActions::Status::Ok)
     {
         gProvisionalFootpath.SurfaceIndex = type;


### PR DESCRIPTION
For https://github.com/OpenRCT2/OpenRCT2/issues/21432 and https://github.com/OpenRCT2/OpenRCT2/issues/21421.

Changes macros for constexpr.