### PR TITLE
Fix some include directives for posix

### DIFF
--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -15,6 +15,7 @@
 #include <stdexcept>
 #include <vector>
 #ifndef _WIN32
+#    include <alloca.h>
 #    include <unicode/ucnv.h>
 #    include <unicode/unistr.h>
 #    include <unicode/utypes.h>

--- a/src/openrct2/network/Socket.cpp
+++ b/src/openrct2/network/Socket.cpp
@@ -49,9 +49,10 @@
     #include <netdb.h>
     #include <netinet/in.h>
     #include <netinet/tcp.h>
-    #include <unistd.h>
     #include <sys/ioctl.h>
+    #include <sys/select.h>
     #include <sys/socket.h>
+    #include <sys/time.h>
     #include <unistd.h>
     #include "../common.h"
     using SOCKET = int32_t;


### PR DESCRIPTION
These are (strictly speaking) needed but seem to be commonly included indirectly. This is a small issue in my [SerenityOS port](https://github.com/SerenityOS/serenity/tree/master/Ports/openrct2).
Also removed a redundant one.