### PR TITLE
Fix #21289: Map window does not layout properly

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Fix: [#21220] When creating a new park from a SC4 file, the localised park name is not applied.
 - Fix: [#21286] Cannot build unbanking turns with RCT1 vehicles.
 - Fix: [#21288] Text overlaps in the “About ‘OpenRCT2’” window for Arabic, Chinese, Japanese, Korean and Vietnamese.
+- Fix: [#21289] Text overlaps and overflows in the map window for some languages.
 - Fix: [#21310] Some half loop elements require more clearance than their upward/downward counterparts.
 - Fix: [#21318] Virtual Floor for building scenery is not properly invalidated.
 - Fix: [#21330] Tooltips from dropdown widgets have the wrong position.

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -138,9 +138,68 @@ static constexpr ScreenCoordsXY MiniMapOffsets[] = {
 };
 // clang-format on
 
+static constexpr StringId MapLabels[] = {
+    STR_MAP_RIDE,       STR_MAP_FOOD_STALL, STR_MAP_DRINK_STALL,  STR_MAP_SOUVENIR_STALL,
+    STR_MAP_INFO_KIOSK, STR_MAP_FIRST_AID,  STR_MAP_CASH_MACHINE, STR_MAP_TOILET,
+};
+
+static constexpr uint16_t RideKeyColours[] = {
+    MapColour(PALETTE_INDEX_61),  // COLOUR_KEY_RIDE
+    MapColour(PALETTE_INDEX_42),  // COLOUR_KEY_FOOD
+    MapColour(PALETTE_INDEX_20),  // COLOUR_KEY_DRINK
+    MapColour(PALETTE_INDEX_209), // COLOUR_KEY_SOUVENIR
+    MapColour(PALETTE_INDEX_136), // COLOUR_KEY_KIOSK
+    MapColour(PALETTE_INDEX_102), // COLOUR_KEY_FIRST_AID
+    MapColour(PALETTE_INDEX_55),  // COLOUR_KEY_CASH_MACHINE
+    MapColour(PALETTE_INDEX_161), // COLOUR_KEY_TOILETS
+};
+
+static constexpr uint8_t DefaultPeepMapColour = PALETTE_INDEX_20;
+static constexpr uint8_t GuestMapColour = PALETTE_INDEX_172;
+static constexpr uint8_t GuestMapColourAlternate = PALETTE_INDEX_21;
+static constexpr uint8_t StaffMapColour = PALETTE_INDEX_138;
+static constexpr uint8_t StaffMapColourAlternate = PALETTE_INDEX_10;
+
+static constexpr uint16_t WaterColour = MapColour(PALETTE_INDEX_195);
+
+static constexpr uint16_t ElementTypeMaskColour[] = {
+    0xFFFF, // TILE_ELEMENT_TYPE_SURFACE
+    0x0000, // TILE_ELEMENT_TYPE_PATH
+    0x00FF, // TILE_ELEMENT_TYPE_TRACK
+    0xFF00, // TILE_ELEMENT_TYPE_SMALL_SCENERY
+    0x0000, // TILE_ELEMENT_TYPE_ENTRANCE
+    0xFFFF, // TILE_ELEMENT_TYPE_WALL
+    0x0000, // TILE_ELEMENT_TYPE_LARGE_SCENERY
+    0xFFFF, // TILE_ELEMENT_TYPE_BANNER
+};
+
+static constexpr uint16_t ElementTypeAddColour[] = {
+    MapColour(PALETTE_INDEX_0),                     // TILE_ELEMENT_TYPE_SURFACE
+    MapColour(PALETTE_INDEX_17),                    // TILE_ELEMENT_TYPE_PATH
+    MapColour2(PALETTE_INDEX_183, PALETTE_INDEX_0), // TILE_ELEMENT_TYPE_TRACK
+    MapColour2(PALETTE_INDEX_0, PALETTE_INDEX_99),  // TILE_ELEMENT_TYPE_SMALL_SCENERY
+    MapColour(PALETTE_INDEX_186),                   // TILE_ELEMENT_TYPE_ENTRANCE
+    MapColour(PALETTE_INDEX_0),                     // TILE_ELEMENT_TYPE_WALL
+    MapColour(PALETTE_INDEX_99),                    // TILE_ELEMENT_TYPE_LARGE_SCENERY
+    MapColour(PALETTE_INDEX_0),                     // TILE_ELEMENT_TYPE_BANNER
+};
+
 class MapWindow final : public Window
 {
     uint8_t _rotation;
+    uint8_t _activeTool;
+    uint32_t _currentLine;
+    uint16_t _landRightsToolSize;
+    int32_t _firstColumnWidth;
+    std::vector<uint8_t> _mapImageData;
+    bool _mapWidthAndHeightLinked{ true };
+    bool _recalculateScrollbars = false;
+    enum class ResizeDirection
+    {
+        Both,
+        X,
+        Y,
+    } _resizeDirection{ ResizeDirection::Both };
 
 public:
     MapWindow()
@@ -1430,66 +1489,6 @@ private:
         width = std::max(min_width, width);
         _recalculateScrollbars = true;
     }
-
-    uint8_t _activeTool;
-    uint32_t _currentLine;
-    uint16_t _landRightsToolSize;
-    int32_t _firstColumnWidth;
-    std::vector<uint8_t> _mapImageData;
-    bool _mapWidthAndHeightLinked{ true };
-    bool _recalculateScrollbars = false;
-    enum class ResizeDirection
-    {
-        Both,
-        X,
-        Y,
-    } _resizeDirection{ ResizeDirection::Both };
-
-    static constexpr StringId MapLabels[] = {
-        STR_MAP_RIDE,       STR_MAP_FOOD_STALL, STR_MAP_DRINK_STALL,  STR_MAP_SOUVENIR_STALL,
-        STR_MAP_INFO_KIOSK, STR_MAP_FIRST_AID,  STR_MAP_CASH_MACHINE, STR_MAP_TOILET,
-    };
-
-    static constexpr uint16_t RideKeyColours[] = {
-        MapColour(PALETTE_INDEX_61),  // COLOUR_KEY_RIDE
-        MapColour(PALETTE_INDEX_42),  // COLOUR_KEY_FOOD
-        MapColour(PALETTE_INDEX_20),  // COLOUR_KEY_DRINK
-        MapColour(PALETTE_INDEX_209), // COLOUR_KEY_SOUVENIR
-        MapColour(PALETTE_INDEX_136), // COLOUR_KEY_KIOSK
-        MapColour(PALETTE_INDEX_102), // COLOUR_KEY_FIRST_AID
-        MapColour(PALETTE_INDEX_55),  // COLOUR_KEY_CASH_MACHINE
-        MapColour(PALETTE_INDEX_161), // COLOUR_KEY_TOILETS
-    };
-
-    static constexpr uint8_t DefaultPeepMapColour = PALETTE_INDEX_20;
-    static constexpr uint8_t GuestMapColour = PALETTE_INDEX_172;
-    static constexpr uint8_t GuestMapColourAlternate = PALETTE_INDEX_21;
-    static constexpr uint8_t StaffMapColour = PALETTE_INDEX_138;
-    static constexpr uint8_t StaffMapColourAlternate = PALETTE_INDEX_10;
-
-    static constexpr uint16_t WaterColour = MapColour(PALETTE_INDEX_195);
-
-    static constexpr uint16_t ElementTypeMaskColour[] = {
-        0xFFFF, // TILE_ELEMENT_TYPE_SURFACE
-        0x0000, // TILE_ELEMENT_TYPE_PATH
-        0x00FF, // TILE_ELEMENT_TYPE_TRACK
-        0xFF00, // TILE_ELEMENT_TYPE_SMALL_SCENERY
-        0x0000, // TILE_ELEMENT_TYPE_ENTRANCE
-        0xFFFF, // TILE_ELEMENT_TYPE_WALL
-        0x0000, // TILE_ELEMENT_TYPE_LARGE_SCENERY
-        0xFFFF, // TILE_ELEMENT_TYPE_BANNER
-    };
-
-    static constexpr uint16_t ElementTypeAddColour[] = {
-        MapColour(PALETTE_INDEX_0),                     // TILE_ELEMENT_TYPE_SURFACE
-        MapColour(PALETTE_INDEX_17),                    // TILE_ELEMENT_TYPE_PATH
-        MapColour2(PALETTE_INDEX_183, PALETTE_INDEX_0), // TILE_ELEMENT_TYPE_TRACK
-        MapColour2(PALETTE_INDEX_0, PALETTE_INDEX_99),  // TILE_ELEMENT_TYPE_SMALL_SCENERY
-        MapColour(PALETTE_INDEX_186),                   // TILE_ELEMENT_TYPE_ENTRANCE
-        MapColour(PALETTE_INDEX_0),                     // TILE_ELEMENT_TYPE_WALL
-        MapColour(PALETTE_INDEX_99),                    // TILE_ELEMENT_TYPE_LARGE_SCENERY
-        MapColour(PALETTE_INDEX_0),                     // TILE_ELEMENT_TYPE_BANNER
-    };
 };
 
 WindowBase* WindowMapOpen()

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -156,6 +156,11 @@ void WindowUpdateAll()
     windowManager->UpdateMouseWheel();
 }
 
+void WindowNotifyLanguageChange()
+{
+    WindowVisitEach([&](WindowBase* w) { w->OnLanguageChange(); });
+}
+
 static void WindowCloseSurplus(int32_t cap, WindowClass avoid_classification)
 {
     // find the amount of windows that are currently open

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -501,6 +501,7 @@ void WindowVisitEach(std::function<void(WindowBase*)> func);
 void WindowDispatchUpdateAll();
 void WindowUpdateAllViewports();
 void WindowUpdateAll();
+void WindowNotifyLanguageChange();
 
 void WindowSetWindowLimit(int32_t value);
 

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -167,6 +167,9 @@ struct WindowBase
     {
     }
     virtual CursorID OnCursor(WidgetIndex, const ScreenCoordsXY&, CursorID);
+    virtual void OnLanguageChange()
+    {
+    }
 
     void ResizeFrame();
     void ResizeFrameWithPage();

--- a/src/openrct2/localisation/Language.cpp
+++ b/src/openrct2/localisation/Language.cpp
@@ -12,6 +12,7 @@
 #include "../core/String.hpp"
 #include "../interface/FontFamilies.h"
 #include "../interface/Fonts.h"
+#include "../interface/Window.h"
 #include "../object/ObjectManager.h"
 #include "../platform/Platform.h"
 #include "LanguagePack.h"
@@ -85,6 +86,7 @@ bool LanguageOpen(int32_t id)
         // Objects and their localised strings need to be refreshed
         objectManager.ResetObjects();
         ScrollingTextInvalidate();
+        WindowNotifyLanguageChange();
         return true;
     }
     catch (const std::exception&)


### PR DESCRIPTION
Fixes #21289

Map window will now layout dynamically depending on the width of the text in each column.

Also fixes a small issue where the scrollbars for the map don't update properly when changing tabs.

I've added a window event so the window can be notified when the language changes and update its layout.  Currently its only used for this window but I think there are other bugs to do with changing languages that could use this in a fix.
