### PR TITLE
Compile project as C++20

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -24,7 +24,7 @@
                 "/Library/Frameworks"
             ],
             "cStandard": "c11",
-            "cppStandard": "c++17"
+            "cppStandard": "c++20"
         },
         {
             "name": "Linux",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,7 +335,7 @@ else ()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDEBUG=${DEBUG_LEVEL}")
 
     # Enable char8_t<->char conversion :(
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-char8_t")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-char8_t -Wno-deprecated-declarations")
 
     if(APPLE)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=objc-method-access")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ endif ()
 include(CheckCXXCompilerFlag)
 include(GNUInstallDirs)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
@@ -277,6 +277,9 @@ if (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244") # C4244: 'conversion_type': conversion from 'type1' to 'type2', possible loss of data
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4068") # C4068: unknown pragma
 
+    # Enable char8_t<->char conversion :(
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:char8_t-")
+
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
     add_definitions(-D_SCL_SECURE_NO_WARNINGS)
     if (CMAKE_SIZEOF_VOID_P EQUAL 8 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")
@@ -330,6 +333,9 @@ else ()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstrict-aliasing -Werror -Wundef -Wmissing-declarations -Winit-self -Wall -Wextra -Wshadow")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas -Wno-missing-braces -Wno-comment -Wnonnull -Wno-unused-parameter -Wno-attributes")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDEBUG=${DEBUG_LEVEL}")
+
+    # Enable char8_t<->char conversion :(
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-char8_t")
 
     if(APPLE)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=objc-method-access")

--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -65,7 +65,7 @@
       <RuntimeLibrary Condition="'$(UseSharedLibs)'=='true'">MultiThreadedDLL</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <AdditionalOptions>/utf-8 /std:c++17 /permissive- /Zc:externConstexpr</AdditionalOptions>
+      <AdditionalOptions>/utf-8 /std:c++20 /permissive- /Zc:externConstexpr /Zc:char8_t-</AdditionalOptions>
     </ClCompile>
     <Link>
       <LargeAddressAware Condition="'$(Platform)'=='Win32'">true</LargeAddressAware>

--- a/readme.md
+++ b/readme.md
@@ -135,7 +135,7 @@ OpenRCT2 requires original files of RollerCoaster Tycoon 2 to play. It can be bo
 <details>
   <summary>Linux prerequisites</summary>
 
-  - gcc (>= 7.1) or clang (>= 8.0.0) (for C++17 support)
+  - gcc (>= 8.0) or clang (>= 10.0) (for C++20 support)
   - sdl2 (only for UI client)
   - freetype (can be disabled)
   - fontconfig (can be disabled)

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -1036,6 +1036,11 @@ private:
             footpathLoc, slope, type, gFootpathSelection.Railings, _footpathConstructDirection, constructFlags);
 
         footpathPlaceAction.SetCallback([footpathLoc](const GameAction* ga, const GameActions::Result* result) {
+            if (result->Error == GameActions::Status::Ok)
+            {
+                Audio::Play3D(OpenRCT2::Audio::SoundId::PlaceItem, result->Position);
+            }
+
             auto* self = static_cast<FootpathWindow*>(WindowFindByClass(WindowClass::Footpath));
             if (self == nullptr)
             {
@@ -1044,8 +1049,6 @@ private:
 
             if (result->Error == GameActions::Status::Ok)
             {
-                OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::PlaceItem, result->Position);
-
                 if (gFootpathConstructSlope == 0)
                 {
                     self->_footpathConstructValidDirections = INVALID_DIRECTION;

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -1034,18 +1034,25 @@ private:
 
         auto footpathPlaceAction = FootpathPlaceAction(
             footpathLoc, slope, type, gFootpathSelection.Railings, _footpathConstructDirection, constructFlags);
-        footpathPlaceAction.SetCallback([=](const GameAction* ga, const GameActions::Result* result) {
+
+        footpathPlaceAction.SetCallback([footpathLoc](const GameAction* ga, const GameActions::Result* result) {
+            auto* self = static_cast<FootpathWindow*>(WindowFindByClass(WindowClass::Footpath));
+            if (self == nullptr)
+            {
+                return;
+            }
+
             if (result->Error == GameActions::Status::Ok)
             {
                 OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::PlaceItem, result->Position);
 
                 if (gFootpathConstructSlope == 0)
                 {
-                    _footpathConstructValidDirections = INVALID_DIRECTION;
+                    self->_footpathConstructValidDirections = INVALID_DIRECTION;
                 }
                 else
                 {
-                    _footpathConstructValidDirections = _footpathConstructDirection;
+                    self->_footpathConstructValidDirections = self->_footpathConstructDirection;
                 }
 
                 if (gFootpathGroundFlags & ELEMENT_IS_UNDERGROUND)
@@ -1062,7 +1069,7 @@ private:
                     gFootpathConstructFromPosition.z += PATH_HEIGHT_STEP;
                 }
             }
-            WindowFootpathSetEnabledAndPressedWidgets();
+            self->WindowFootpathSetEnabledAndPressedWidgets();
         });
         GameActions::Execute(&footpathPlaceAction);
     }

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -104,11 +104,11 @@ private:
             return firstStrId;
         }
 
-        bool operator==(const FilterArguments& other)
+        bool operator==(const FilterArguments& other) const
         {
             return std::memcmp(args, other.args, sizeof(args)) == 0;
         }
-        bool operator!=(const FilterArguments& other)
+        bool operator!=(const FilterArguments& other) const
         {
             return !(*this == other);
         }

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -42,11 +42,11 @@ private:
         size_t Count{};
         size_t Total{};
 
-        bool operator==(const DownloadStatusInfo& rhs)
+        bool operator==(const DownloadStatusInfo& rhs) const
         {
             return Name == rhs.Name && Source == rhs.Source && Count == rhs.Count && Total == rhs.Total;
         }
-        bool operator!=(const DownloadStatusInfo& rhs)
+        bool operator!=(const DownloadStatusInfo& rhs) const
         {
             return !(*this == rhs);
         }

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -3230,9 +3230,10 @@ public:
             // Draw an overlay if clearance checks are disabled
             if (gCheatsDisableClearanceChecks)
             {
+                auto colour = static_cast<colour_t>(EnumValue(COLOUR_DARK_ORANGE) | EnumValue(COLOUR_FLAG_OUTLINE));
                 DrawTextBasic(
                     dpi, screenPos + ScreenCoordsXY{ 26, 2 }, STR_OVERLAY_CLEARANCE_CHECKS_DISABLED, {},
-                    { COLOUR_DARK_ORANGE | COLOUR_FLAG_OUTLINE, TextAlignment::RIGHT });
+                    { colour, TextAlignment::RIGHT });
             }
         }
 
@@ -3295,9 +3296,8 @@ public:
             // Draw number of players.
             auto ft = Formatter();
             ft.Add<int32_t>(NetworkGetNumVisiblePlayers());
-            DrawTextBasic(
-                dpi, screenPos + ScreenCoordsXY{ 23, 1 }, STR_COMMA16, ft,
-                { COLOUR_WHITE | COLOUR_FLAG_OUTLINE, TextAlignment::RIGHT });
+            auto colour = static_cast<colour_t>(EnumValue(COLOUR_WHITE) | EnumValue(COLOUR_FLAG_OUTLINE));
+            DrawTextBasic(dpi, screenPos + ScreenCoordsXY{ 23, 1 }, STR_COMMA16, ft, { colour, TextAlignment::RIGHT });
         }
     }
 };

--- a/src/openrct2/drawing/Rect.cpp
+++ b/src/openrct2/drawing/Rect.cpp
@@ -30,18 +30,9 @@ void GfxFillRectInset(DrawPixelInfo& dpi, const ScreenRect& rect, int32_t colour
     const auto leftBottom = ScreenCoordsXY{ rect.GetLeft(), rect.GetBottom() };
     const auto rightTop = ScreenCoordsXY{ rect.GetRight(), rect.GetTop() };
     const auto rightBottom = ScreenCoordsXY{ rect.GetRight(), rect.GetBottom() };
-    if (colour & (COLOUR_FLAG_TRANSLUCENT | COLOUR_FLAG_8))
+    if (colour & COLOUR_FLAG_TRANSLUCENT)
     {
-        TranslucentWindowPalette palette;
-        if (colour & COLOUR_FLAG_8)
-        {
-            // TODO: This can't be added up
-            // palette = NOT_TRANSLUCENT(colour);
-            assert(false);
-            return;
-        }
-
-        palette = TranslucentWindowPalettes[BASE_COLOUR(colour)];
+        auto palette = TranslucentWindowPalettes[BASE_COLOUR(colour)];
 
         if (flags & INSET_RECT_FLAG_BORDER_NONE)
         {

--- a/src/openrct2/interface/Colour.h
+++ b/src/openrct2/interface/Colour.h
@@ -212,12 +212,11 @@ constexpr uint8_t COLOUR_NUM_NORMAL = 54;
 #define TEXT_COLOUR_254 (254)
 #define TEXT_COLOUR_255 (255)
 
-enum
+enum : colour_t
 {
     COLOUR_FLAG_OUTLINE = (1 << 5),
     COLOUR_FLAG_INSET = (1 << 6), // 64, 0x40
     COLOUR_FLAG_TRANSLUCENT = (1 << 7),
-    COLOUR_FLAG_8 = (1 << 8)
 };
 
 #define TRANSLUCENT(x) ((x) | static_cast<uint8_t>(COLOUR_FLAG_TRANSLUCENT))


### PR DESCRIPTION
For OpenLoco, we recently enabled C++20 support without `char8_t` support (cf. https://github.com/OpenLoco/OpenLoco/pull/2136). This provided a path to transitioning the codebase without extensive rewrites to accommodate the `char8_t` type, while enabling many benefits, such as [std::span](https://en.cppreference.com/w/cpp/container/span) and [designated initialisers](https://en.cppreference.com/w/cpp/language/aggregate_initialization) (cf. e.g. https://github.com/OpenLoco/OpenLoco/pull/2300). To my surprise, the same thing proved possible for the OpenRCT2 codebase, hence this PR.

I only encountered two minor issues while compiling locally (clang, macOS 14, ARM), both of which are addressed in this PR.

The first problem I encountered compiling as C++20, was the `COLOUR_FLAG_8` constant having been defined, but never set. Its definition is also outside the boundaries of a uint8_t, so its existence is also a bit odd. I decided to remove it entirely -- including the one code path that asserts for it *not* being set, ironically.

The second problem was that one part of the codebase (`ToolbarTop.cpp`) was using an `|` or operation on two different enumeration types. I've addressed this, but less cleanly than I would like. The enums could probably be revised into a structure similar to OpenLoco's `AdvancedColour` struct. I think that's best left to another PR, however.

In addition, CI revealed three more issues with gcc on Linux. They involved some comparison operators not having been marked `const`, and a lambda function that implicitly captured `this`, which is no longer allowed in C++20. These issues have been addressed as well.

Please squash merge.