### PR TITLE
Refactor FormatCodes stringification

### DIFF
--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -27,7 +27,6 @@
 
 #include "../common.h"
 #include "../localisation/ConversionTables.h"
-#include "../localisation/FormatCodes.h"
 #include "../localisation/Language.h"
 #include "../util/Util.h"
 #include "Memory.hpp"

--- a/src/openrct2/localisation/FormatCodes.cpp
+++ b/src/openrct2/localisation/FormatCodes.cpp
@@ -11,9 +11,7 @@
 
 #include "../core/EnumMap.hpp"
 
-#include <mutex>
 #include <string>
-#include <vector>
 
 // clang-format off
 static const EnumMap<FormatToken> FormatTokenMap = {
@@ -65,43 +63,24 @@ static const EnumMap<FormatToken> FormatTokenMap = {
 };
 // clang-format on
 
-std::string_view GetFormatTokenStringWithBraces(FormatToken token)
-{
-    // Ensure cache is thread safe
-    static std::mutex mutex;
-    std::lock_guard<std::mutex> guard(mutex);
-
-    static std::vector<std::string> cache;
-    auto index = static_cast<size_t>(token);
-    if (cache.size() <= index)
-    {
-        cache.resize(index + 1);
-    }
-    if (cache[index].empty())
-    {
-        cache[index] = "{" + std::string(FormatTokenToString(token)) + "}";
-    }
-    return cache[index];
-}
-
 FormatToken FormatTokenFromString(std::string_view token)
 {
     auto result = FormatTokenMap.find(token);
     return result != std::end(FormatTokenMap) ? result->second : FormatToken::Unknown;
 }
 
-std::string_view FormatTokenToString(FormatToken token, bool withBraces)
+std::string FormatTokenToString(FormatToken token)
 {
-    if (withBraces)
-    {
-        return GetFormatTokenStringWithBraces(token);
-    }
-
     auto it = FormatTokenMap.find(token);
     if (it != FormatTokenMap.end())
-        return it->first;
+        return std::string(it->first);
 
     return {};
+}
+
+std::string FormatTokenToStringWithBraces(FormatToken token)
+{
+    return "{" + FormatTokenToString(token) + "}";
 }
 
 bool FormatTokenTakesArgument(FormatToken token)

--- a/src/openrct2/localisation/FormatCodes.h
+++ b/src/openrct2/localisation/FormatCodes.h
@@ -9,8 +9,7 @@
 
 #pragma once
 
-#include "../common.h"
-
+#include <cstdint>
 #include <string_view>
 
 enum class FormatToken
@@ -75,9 +74,9 @@ enum class FormatToken
     OutlineDisable,
 };
 
-std::string_view GetFormatTokenStringWithBraces(FormatToken token);
 FormatToken FormatTokenFromString(std::string_view token);
-std::string_view FormatTokenToString(FormatToken token, bool withBraces = false);
+std::string FormatTokenToString(FormatToken token);
+std::string FormatTokenToStringWithBraces(FormatToken token);
 bool FormatTokenTakesArgument(FormatToken token);
 bool FormatTokenIsColour(FormatToken token);
 size_t FormatTokenGetTextColourIndex(FormatToken token);

--- a/src/openrct2/rct12/RCT12.cpp
+++ b/src/openrct2/rct12/RCT12.cpp
@@ -650,7 +650,7 @@ std::string ConvertFormattedStringToOpenRCT2(std::string_view buffer)
         auto token = GetFormatTokenFromRCT12Code(codepoint);
         if (token != FormatToken::Unknown)
         {
-            result += GetFormatTokenStringWithBraces(token);
+            result += FormatTokenToStringWithBraces(token);
         }
         else
         {

--- a/src/openrct2/world/Banner.cpp
+++ b/src/openrct2/world/Banner.cpp
@@ -51,7 +51,7 @@ void Banner::FormatTextTo(Formatter& ft, bool addColour) const
     if (addColour)
     {
         auto formatToken = FormatTokenFromTextColour(text_colour);
-        auto tokenText = FormatTokenToString(formatToken, true);
+        auto tokenText = FormatTokenToStringWithBraces(formatToken);
         ft.Add<StringId>(STR_STRING_STRINGID);
         ft.Add<const char*>(tokenText.data());
     }


### PR DESCRIPTION
While working on #21468, I briefly chased a red herring in FormatCodes.cpp due to a GCC 12 compiler bug. That turned out to not be necessary for #21468, so I'm present the cleanup in this separate PR instead.

The FormatCodes.cpp unit had several issues, including:

- `GetFormatTokenStringWithBraces` and `FormatTokenToString` call each other, relying on an nontransparent default parameter to not recurse indefinitely.
- `GetFormatTokenStringWithBraces` uses a static cache with a mutex on it to cache concatenated values. This is expensive, as mutexes involve syscalls i.e. a kernel context switch. Even a heap allocation is likely just cheaper.
- `GetFormatTokenStringWithBraces` uses string_views, but the strings involved are very short. Short strings (< 16 chars) can typically be allocated within std::string without involving heap memory at all.
- `FormatTokenToString` has a default parameter that's used to call into `GetFormatTokenStringWithBraces` in *only one place* in the code.

My solution has been to:

- Have `FormatTokenToString` return a std::string instead.
- Make `GetFormatTokenStringWithBraces` a simple concatenation function, removing the mutex and cache.
- Rename `GetFormatTokenStringWithBraces` to `FormatTokenToStringWithBraces` and use it instead of `FormatTokenToString` where appropriate.
