### PR TITLE
Fix #21484: Upkeep costs for some rides/facilities/shops are not calculated correctly

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,6 @@ Checks: >
     modernize-use-override
 CheckOptions:
     - key: cppcoreguidelines-macro-usage.AllowedRegexp
-      value: 'validate_global_widx'
+      value: 'validate_global_widx|NETWORK_STREAM_VERSION'
 WarningsAsErrors: true
 FormatStyle: 'file'

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -32,6 +32,7 @@
 - Fix: [#21347] Too many options are hidden if the platform has no file picker.
 - Fix: [#21350] Maze and Mini Golf track designs from RCT1 not shown in track designs list.
 - Fix: [#21425] Additional missing/misplaced land & construction rights tiles in Japanese Coastal Reclaim.
+- Fix: [#21484] Upkeep costs for some rides/facilities/shops are not calculated correctly.
 - Fix: [#21498] Crash when the size of text can’t be determined.
 - Fix: [objects#262, objects#263, objects#265, objects#266, objects#267, objects#268, objects#270, objects#271, objects#283] Various errors in expansion pack objects (original bug).
 - Fix: [OpenSFX#18] B&M Roar sound effect not looping correctly.

--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -308,6 +308,7 @@ GameActions::Result RideCreateAction::Execute() const
     ride->income_per_hour = kMoney64Undefined;
     ride->profit = kMoney64Undefined;
     ride->connected_message_throttle = 0;
+    ride->drops = 0;
 
     ride->entrance_style = OBJECT_ENTRY_INDEX_NULL;
     if (rtd.HasFlag(RIDE_TYPE_FLAG_HAS_ENTRANCE_EXIT))

--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -148,6 +148,10 @@ GameActions::Result RideCreateAction::Execute() const
         station.Exit.SetNull();
         station.TrainAtStation = RideStation::NO_TRAIN;
         station.QueueTime = 0;
+        station.SegmentLength = 0;
+        station.QueueLength = 0;
+        station.Length = 0;
+        station.Height = 0;
     }
 
     std::fill(std::begin(ride->vehicles), std::end(ride->vehicles), EntityId::GetNull());

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -46,7 +46,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "4"
+#define NETWORK_STREAM_VERSION "5"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 


### PR DESCRIPTION
There are certain fields that were not zeroed upon ride creation which however influence the upkeep cost, I believe this has been an issue for a while now and it does have an impact on a wide range of ride types.

I've checked the provided save files and the upkeep cost will change eventually to the correct thing, this might take a few seconds depending on how many rides the park has this is due to how the ride ratings are done.

Closes #21484