### PR TITLE
Fix regression from #21474 due to use-after-free bug

### DIFF
--- a/src/openrct2/world/Banner.cpp
+++ b/src/openrct2/world/Banner.cpp
@@ -51,9 +51,9 @@ void Banner::FormatTextTo(Formatter& ft, bool addColour) const
     if (addColour)
     {
         auto formatToken = FormatTokenFromTextColour(text_colour);
-        auto tokenText = FormatTokenToStringWithBraces(formatToken);
+        formattedTextBuffer = FormatTokenToStringWithBraces(formatToken);
         ft.Add<StringId>(STR_STRING_STRINGID);
-        ft.Add<const char*>(tokenText.data());
+        ft.Add<const char*>(formattedTextBuffer.data());
     }
 
     FormatTextTo(ft);

--- a/src/openrct2/world/Banner.h
+++ b/src/openrct2/world/Banner.h
@@ -36,6 +36,7 @@ struct Banner
     ObjectEntryIndex type = BANNER_NULL;
     uint8_t flags{};
     std::string text;
+    mutable std::string formattedTextBuffer;
     uint8_t colour{};
     RideId ride_index{};
     uint8_t text_colour{};


### PR DESCRIPTION
Because the lifetime of the std::string ends after it leaves the scope the pointer pushed to the formatter will become invalid, this is a rather hacky workaround but will prevent the game from randomly crashing. The ideal solution is to have the Formatter store the data in a proper way but there are still too many uses of Formatter::Common so this is currently not a viable option, also instead of trying to make it static or thread_local I decided to simple give each banner a buffer which has the least impact on performance.

Long term goal should be to have the Formatter internally store `std::vector<std::variant<StringId, std::string, Money64, ...>>` which also adds type safety and with a specialized vector container we can still avoid a lot of heap allocations.