### PR TITLE
Fix #21498: Crash when the size of text can't be determined

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -31,7 +31,7 @@
 - Fix: [#21347] Too many options are hidden if the platform has no file picker.
 - Fix: [#21350] Maze and Mini Golf track designs from RCT1 not shown in track designs list.
 - Fix: [#21425] Additional missing/misplaced land & construction rights tiles in Japanese Coastal Reclaim.
-- Fix: [#21498] Crash when the size of text can't be determined.
+- Fix: [#21498] Crash when the size of text can’t be determined.
 - Fix: [objects#262, objects#263, objects#265, objects#266, objects#267, objects#268, objects#270, objects#271, objects#283] Various errors in expansion pack objects (original bug).
 - Fix: [OpenSFX#18] B&M Roar sound effect not looping correctly.
 

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -31,6 +31,7 @@
 - Fix: [#21347] Too many options are hidden if the platform has no file picker.
 - Fix: [#21350] Maze and Mini Golf track designs from RCT1 not shown in track designs list.
 - Fix: [#21425] Additional missing/misplaced land & construction rights tiles in Japanese Coastal Reclaim.
+- Fix: [#21498] Crash when the size of text can't be determined.
 - Fix: [objects#262, objects#263, objects#265, objects#266, objects#267, objects#268, objects#270, objects#271, objects#283] Various errors in expansion pack objects (original bug).
 - Fix: [OpenSFX#18] B&M Roar sound effect not looping correctly.
 

--- a/src/openrct2/paint/tile_element/Paint.Banner.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Banner.cpp
@@ -68,7 +68,7 @@ static void PaintBannerScrollingText(
     }
 
     auto stringWidth = GfxGetStringWidth(text, FontStyle::Tiny);
-    auto scroll = (GetGameState().CurrentTicks / 2) % stringWidth;
+    auto scroll = stringWidth > 0 ? (GetGameState().CurrentTicks / 2) % stringWidth : 0;
     auto imageId = ScrollingTextSetup(session, STR_BANNER_TEXT_FORMAT, ft, scroll, scrollingMode, COLOUR_BLACK);
     PaintAddImageAsChild(session, imageId, { 0, 0, height + 22 }, { bbOffset, { 1, 1, 21 } });
 }


### PR DESCRIPTION
We do it like this in couple other places this, I can't quite pin point the issue but most crash reports seem to be using Korean localisation, I tried using that language but it doesn't ever crash on my end, this at least prevents the crash.

Closes #21498