### PR TITLE
Fix memory leak loading malformed `SawyerChunk`

### DIFF
--- a/src/openrct2/rct12/SawyerChunk.cpp
+++ b/src/openrct2/rct12/SawyerChunk.cpp
@@ -12,14 +12,9 @@
 #include "../core/Memory.hpp"
 #include "SawyerChunkReader.h"
 
-SawyerChunk::SawyerChunk(SAWYER_ENCODING encoding, void* data, size_t length)
+SawyerChunk::SawyerChunk(SAWYER_ENCODING encoding, std::unique_ptr<uint8_t[]> data, size_t length)
 {
     _encoding = encoding;
-    _data = data;
+    _data = std::move(data);
     _length = length;
-}
-
-SawyerChunk::~SawyerChunk()
-{
-    SawyerChunkReader::FreeChunk(_data);
 }

--- a/src/openrct2/rct12/SawyerChunk.h
+++ b/src/openrct2/rct12/SawyerChunk.h
@@ -11,6 +11,8 @@
 
 #include "../common.h"
 
+#include <memory>
+
 /**
  * The type of encoding / compression for a sawyer encoded chunk.
  */
@@ -28,14 +30,14 @@ enum class SAWYER_ENCODING : uint8_t
 class SawyerChunk final
 {
 private:
-    void* _data = nullptr;
+    std::unique_ptr<uint8_t[]> _data;
     size_t _length = 0;
     SAWYER_ENCODING _encoding = SAWYER_ENCODING::NONE;
 
 public:
     const void* GetData() const
     {
-        return _data;
+        return _data.get();
     }
     size_t GetLength() const
     {
@@ -46,6 +48,5 @@ public:
         return _encoding;
     }
 
-    SawyerChunk(SAWYER_ENCODING encoding, void* data, size_t length);
-    ~SawyerChunk();
+    SawyerChunk(SAWYER_ENCODING encoding, std::unique_ptr<uint8_t[]> data, size_t length);
 };

--- a/src/openrct2/rct12/SawyerChunkReader.cpp
+++ b/src/openrct2/rct12/SawyerChunkReader.cpp
@@ -71,7 +71,7 @@ std::shared_ptr<SawyerChunk> SawyerChunkReader::ReadChunk()
                     throw SawyerChunkException(EXCEPTION_MSG_CORRUPT_CHUNK_SIZE);
                 }
 
-                auto buffer = AllocateLargeTempBuffer();
+                auto buffer = std::make_unique<uint8_t[]>(MAX_UNCOMPRESSED_CHUNK_SIZE);
                 size_t uncompressedLength = DecodeChunk(
                     buffer.get(), MAX_UNCOMPRESSED_CHUNK_SIZE, compressedData.get(), header);
                 if (uncompressedLength == 0)
@@ -112,7 +112,7 @@ std::shared_ptr<SawyerChunk> SawyerChunkReader::ReadChunkTrack()
             throw SawyerChunkException(EXCEPTION_MSG_CORRUPT_CHUNK_SIZE);
         }
 
-        auto buffer = AllocateLargeTempBuffer();
+        auto buffer = std::make_unique<uint8_t[]>(MAX_UNCOMPRESSED_CHUNK_SIZE);
         SawyerCodingChunkHeader header{ CHUNK_ENCODING_RLE, compressedDataLength };
         size_t uncompressedLength = DecodeChunk(buffer.get(), MAX_UNCOMPRESSED_CHUNK_SIZE, compressedData.get(), header);
         if (uncompressedLength == 0)
@@ -180,7 +180,7 @@ size_t SawyerChunkReader::DecodeChunk(void* dst, size_t dstCapacity, const void*
 
 size_t SawyerChunkReader::DecodeChunkRLERepeat(void* dst, size_t dstCapacity, const void* src, size_t srcLength)
 {
-    auto immBuffer = AllocateLargeTempBuffer();
+    auto immBuffer = std::make_unique<uint8_t[]>(MAX_UNCOMPRESSED_CHUNK_SIZE);
     auto immLength = DecodeChunkRLE(immBuffer.get(), MAX_UNCOMPRESSED_CHUNK_SIZE, src, srcLength);
     auto size = DecodeChunkRepeat(dst, dstCapacity, immBuffer.get(), immLength);
     return size;
@@ -287,9 +287,4 @@ size_t SawyerChunkReader::DecodeChunkRotate(void* dst, size_t dstCapacity, const
         code = (code + 2) % 8;
     }
     return srcLength;
-}
-
-std::unique_ptr<uint8_t[]> SawyerChunkReader::AllocateLargeTempBuffer()
-{
-    return std::make_unique<uint8_t[]>(MAX_UNCOMPRESSED_CHUNK_SIZE);
 }

--- a/src/openrct2/rct12/SawyerChunkReader.h
+++ b/src/openrct2/rct12/SawyerChunkReader.h
@@ -91,6 +91,4 @@ private:
     static size_t DecodeChunkRLE(void* dst, size_t dstCapacity, const void* src, size_t srcLength);
     static size_t DecodeChunkRepeat(void* dst, size_t dstCapacity, const void* src, size_t srcLength);
     static size_t DecodeChunkRotate(void* dst, size_t dstCapacity, const void* src, size_t srcLength);
-
-    static std::unique_ptr<uint8_t[]> AllocateLargeTempBuffer();
 };

--- a/src/openrct2/rct12/SawyerChunkReader.h
+++ b/src/openrct2/rct12/SawyerChunkReader.h
@@ -85,11 +85,6 @@ public:
         return result;
     }
 
-    /**
-     * Frees the chunk data, to be used when destructing SawyerChunks
-     */
-    static void FreeChunk(void* data);
-
 private:
     static size_t DecodeChunk(void* dst, size_t dstCapacity, const void* src, const SawyerCodingChunkHeader& header);
     static size_t DecodeChunkRLERepeat(void* dst, size_t dstCapacity, const void* src, size_t srcLength);
@@ -97,6 +92,5 @@ private:
     static size_t DecodeChunkRepeat(void* dst, size_t dstCapacity, const void* src, size_t srcLength);
     static size_t DecodeChunkRotate(void* dst, size_t dstCapacity, const void* src, size_t srcLength);
 
-    static void* AllocateLargeTempBuffer();
-    static void FreeLargeTempBuffer(void* buffer);
+    static std::unique_ptr<uint8_t[]> AllocateLargeTempBuffer();
 };


### PR DESCRIPTION
A temporary buffer was not free'd after failing to parse in `SawyerChunkReader::ReadChunkTrack`. Fix this following the pattern used in `SawyerChunkReader::ReadChunk` by wrapping the relevant code in a `try` block with `FreeLargeTempBuffer` called when an exception is caught.

As an alternative fix, the buffer could be allocated outside the outer `try` block a freed in the corresponding `catch`. This would result in less nesting, and slightly more pleasing code, but would mean the buffer is unnecessarily allocated and freed on some error paths where it is never used.