### PR TITLE
Close #16582: Translate in-game console help text

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3692,6 +3692,7 @@ STR_6619    :Object type cannot be restricted!
 STR_6620    :Object not found!
 STR_6621    :Restrict
 STR_6622    :Restrict object to the Scenario Editor and Sandbox mode.
+STR_6623    :Type ‘help’ for a list of available commands. Type ‘hide’ to hide the console.
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -21,6 +21,7 @@
 #include <openrct2/interface/Window.h>
 #include <openrct2/localisation/Language.h>
 #include <openrct2/localisation/LocalisationService.h>
+#include <openrct2/localisation/StringIds.h>
 
 using namespace OpenRCT2::Ui;
 
@@ -36,10 +37,10 @@ static int32_t InGameConsoleGetLineHeight()
     return FontGetLineHeight(InGameConsoleGetFontStyle());
 }
 
-InGameConsole::InGameConsole()
+void InGameConsole::WriteInitial()
 {
     InteractiveConsole::WriteLine(OPENRCT2_NAME " " OPENRCT2_VERSION);
-    InteractiveConsole::WriteLine("Type 'help' for a list of available commands. Type 'hide' to hide the console.");
+    InteractiveConsole::WriteLine(LanguageGetString(STR_CONSOLE_HELPER_TEXT));
     InteractiveConsole::WriteLine("");
     WritePrompt();
 }
@@ -176,6 +177,12 @@ void InGameConsole::ClearLine()
 
 void InGameConsole::Open()
 {
+    if (!_isInitialised)
+    {
+        WriteInitial();
+        _isInitialised = true;
+    }
+
     _isOpen = true;
     ScrollToEnd();
     RefreshCaret();

--- a/src/openrct2-ui/interface/InGameConsole.h
+++ b/src/openrct2-ui/interface/InGameConsole.h
@@ -26,6 +26,7 @@ namespace OpenRCT2::Ui
         static constexpr int32_t CONSOLE_EDGE_PADDING = 4;
         static constexpr int32_t CONSOLE_CARET_WIDTH = 6;
 
+        bool _isInitialised = false;
         bool _isOpen = false;
         ScreenCoordsXY _consoleTopLeft;
         ScreenCoordsXY _consoleBottomRight;
@@ -45,7 +46,7 @@ namespace OpenRCT2::Ui
         int32_t _caretScreenPosX = 0;
 
     public:
-        InGameConsole();
+        InGameConsole() = default;
         InGameConsole(const InGameConsole& src) = delete;
 
         bool IsOpen() const
@@ -71,6 +72,7 @@ namespace OpenRCT2::Ui
         void ClearInput();
         void ClearLine();
         void HistoryAdd(const u8string& src);
+        void WriteInitial();
         void WritePrompt();
         void ScrollToEnd();
         void Invalidate() const;

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -4035,6 +4035,8 @@ enum : uint16_t
     STR_RESTRICT_SCENERY = 6621,
     STR_RESTRICT_SCENERY_TIP = 6622,
 
+    STR_CONSOLE_HELPER_TEXT = 6623,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };


### PR DESCRIPTION
The console would get initialised _very_ early on, even before the language packs were loaded. Because of this, I had to create a separate function for writing the introduction text, otherwise it would segfault.