### PR TITLE
Move gSamePriceThroughoutPark and gRideRatingUpdateStates to GameState_t

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -5914,23 +5914,24 @@ private:
 
     static void UpdateSamePriceThroughoutFlags(ShopItem shop_item)
     {
+        const auto& gameState = GetGameState();
+        const auto existingFlags = gameState.SamePriceThroughoutPark;
+
+        auto newFlags = existingFlags;
         if (GetShopItemDescriptor(shop_item).IsPhoto())
         {
-            auto newFlags = gSamePriceThroughoutPark;
-            if (gSamePriceThroughoutPark & EnumToFlag(shop_item))
+            if (existingFlags & EnumToFlag(shop_item))
                 newFlags &= ~EnumsToFlags(ShopItem::Photo, ShopItem::Photo2, ShopItem::Photo3, ShopItem::Photo4);
             else
                 newFlags |= EnumsToFlags(ShopItem::Photo, ShopItem::Photo2, ShopItem::Photo3, ShopItem::Photo4);
-            auto parkSetParameter = ParkSetParameterAction(ParkParameter::SamePriceInPark, newFlags);
-            GameActions::Execute(&parkSetParameter);
         }
         else
         {
-            auto newFlags = gSamePriceThroughoutPark;
             newFlags ^= EnumToFlag(shop_item);
-            auto parkSetParameter = ParkSetParameterAction(ParkParameter::SamePriceInPark, newFlags);
-            GameActions::Execute(&parkSetParameter);
         }
+
+        auto parkSetParameter = ParkSetParameterAction(ParkParameter::SamePriceInPark, newFlags);
+        GameActions::Execute(&parkSetParameter);
     }
 
     void IncomeTogglePrimaryPrice()

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -17,6 +17,7 @@
 #include "management/Finance.h"
 #include "management/NewsItem.h"
 #include "ride/Ride.h"
+#include "ride/RideRatings.h"
 #include "scenario/Scenario.h"
 #include "world/Banner.h"
 #include "world/Climate.h"
@@ -92,6 +93,7 @@ namespace OpenRCT2
         std::vector<Banner> Banners;
         // Ride storage for all the rides in the park, rides with RideId::Null are considered free.
         std::array<Ride, OpenRCT2::Limits::MaxRidesInPark> Rides{};
+        ::RideRatingUpdateStates RideRatingUpdateStates;
         std::vector<TileElement> TileElements;
 
         std::vector<ScenerySelection> RestrictedScenery;

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -101,6 +101,7 @@ namespace OpenRCT2
         colour_t StaffHandymanColour;
         colour_t StaffMechanicColour;
         colour_t StaffSecurityColour;
+        uint64_t SamePriceThroughoutPark{};
 
         uint8_t ResearchFundingLevel;
         uint8_t ResearchPriorities;

--- a/src/openrct2/actions/ParkSetParameterAction.cpp
+++ b/src/openrct2/actions/ParkSetParameterAction.cpp
@@ -73,7 +73,7 @@ GameActions::Result ParkSetParameterAction::Execute() const
             }
             break;
         case ParkParameter::SamePriceInPark:
-            gSamePriceThroughoutPark = _value;
+            gameState.SamePriceThroughoutPark = _value;
             WindowInvalidateByClass(WindowClass::Ride);
             break;
         default:

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -821,7 +821,7 @@ namespace OpenRCT2
                     cs.ReadWrite(gameState.StaffHandymanColour);
                     cs.ReadWrite(gameState.StaffMechanicColour);
                     cs.ReadWrite(gameState.StaffSecurityColour);
-                    cs.ReadWrite(gSamePriceThroughoutPark);
+                    cs.ReadWrite(gameState.SamePriceThroughoutPark);
 
                     // Finances
                     if (cs.GetMode() == OrcaStream::Mode::READING)

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -552,7 +552,7 @@ namespace OpenRCT2
                 cs.ReadWrite(gGrassSceneryTileLoopPosition);
                 cs.ReadWrite(gWidePathTileLoopPosition);
 
-                auto& rideRatings = RideRatingGetUpdateStates();
+                auto& rideRatings = gameState.RideRatingUpdateStates;
                 if (os.GetHeader().TargetVersion >= 21)
                 {
                     cs.ReadWriteArray(rideRatings, [this, &cs](RideRatingUpdateState& calcData) {

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2236,10 +2236,10 @@ namespace RCT1
 
             gameState.ParkSize = _s4.ParkSize;
             gameState.TotalRideValueForMoney = _s4.TotalRideValueForMoney;
-            gSamePriceThroughoutPark = 0;
+            gameState.SamePriceThroughoutPark = 0;
             if (_gameVersion == FILE_VERSION_RCT1_LL)
             {
-                gSamePriceThroughoutPark = _s4.SamePriceThroughout;
+                gameState.SamePriceThroughoutPark = _s4.SamePriceThroughout;
             }
         }
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1613,7 +1613,7 @@ namespace RCT2
             const auto& src = _s6.RideRatingsCalcData;
             // S6 has only one state, ensure we reset all states before reading the first one.
             RideRatingResetUpdateStates();
-            auto& rideRatingStates = RideRatingGetUpdateStates();
+            auto& rideRatingStates = GetGameState().RideRatingUpdateStates;
             auto& dst = rideRatingStates[0];
             dst = {};
             dst.Proximity = { src.ProximityX, src.ProximityY, src.ProximityZ };

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -403,7 +403,8 @@ namespace RCT2
             // Pad013587FC
             gParkRatingCasualtyPenalty = _s6.ParkRatingCasualtyPenalty;
             gameState.MapSize = { _s6.MapSize, _s6.MapSize };
-            gSamePriceThroughoutPark = _s6.SamePriceThroughout | (static_cast<uint64_t>(_s6.SamePriceThroughoutExtended) << 32);
+            gameState.SamePriceThroughoutPark = _s6.SamePriceThroughout
+                | (static_cast<uint64_t>(_s6.SamePriceThroughoutExtended) << 32);
             gameState.SuggestedGuestMaximum = _s6.SuggestedMaxGuests;
             gameState.ScenarioParkRatingWarningDays = _s6.ParkRatingWarningDays;
             gLastEntranceStyle = _s6.LastEntranceStyle;

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -78,8 +78,6 @@ struct ShelteredEights
     uint8_t TotalShelteredEighths;
 };
 
-static RideRatingUpdateStates gRideRatingUpdateStates;
-
 // Amount of updates allowed per updating state on the current tick.
 // The total amount would be MaxRideRatingSubSteps * RideRatingMaxUpdateStates which
 // would be currently 80, this is the worst case of sub-steps and may break out earlier.
@@ -153,17 +151,13 @@ static void RideRatingsApplyRequirementStations(RatingTuple& ratings, const Ride
 static void RideRatingsApplyRequirementSplashdown(RatingTuple& ratings, const Ride& ride, RatingsModifier modifier);
 static void RideRatingsApplyPenaltyLateralGs(RatingTuple& ratings, const Ride& ride, RatingsModifier modifier);
 
-RideRatingUpdateStates& RideRatingGetUpdateStates()
-{
-    return gRideRatingUpdateStates;
-}
-
 void RideRatingResetUpdateStates()
 {
     RideRatingUpdateState nullState{};
     nullState.State = RIDE_RATINGS_STATE_FIND_NEXT_RIDE;
 
-    std::fill(gRideRatingUpdateStates.begin(), gRideRatingUpdateStates.end(), nullState);
+    auto& updateStates = GetGameState().RideRatingUpdateStates;
+    std::fill(updateStates.begin(), updateStates.end(), nullState);
 }
 
 /**
@@ -197,7 +191,7 @@ void RideRatingsUpdateAll()
     if (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)
         return;
 
-    for (auto& updateState : gRideRatingUpdateStates)
+    for (auto& updateState : GetGameState().RideRatingUpdateStates)
     {
         for (size_t i = 0; i < MaxRideRatingUpdateSubSteps; ++i)
         {
@@ -237,7 +231,8 @@ static void ride_ratings_update_state(RideRatingUpdateState& state)
 
 static bool RideRatingIsUpdatingRide(RideId id)
 {
-    return std::any_of(gRideRatingUpdateStates.begin(), gRideRatingUpdateStates.end(), [id](auto& state) {
+    const auto& updateStates = GetGameState().RideRatingUpdateStates;
+    return std::any_of(updateStates.begin(), updateStates.end(), [id](auto& state) {
         return state.CurrentRide == id && state.State != RIDE_RATINGS_STATE_FIND_NEXT_RIDE;
     });
 }

--- a/src/openrct2/ride/RideRatings.h
+++ b/src/openrct2/ride/RideRatings.h
@@ -55,10 +55,8 @@ struct RideRatingUpdateState
 };
 
 static constexpr size_t RideRatingMaxUpdateStates = 4;
-
 using RideRatingUpdateStates = std::array<RideRatingUpdateState, RideRatingMaxUpdateStates>;
 
-RideRatingUpdateStates& RideRatingGetUpdateStates();
 void RideRatingResetUpdateStates();
 
 void RideRatingsUpdateRide(const Ride& ride);

--- a/src/openrct2/ride/ShopItem.cpp
+++ b/src/openrct2/ride/ShopItem.cpp
@@ -9,18 +9,19 @@
 
 #include "ShopItem.h"
 
+#include "../GameState.h"
 #include "../common.h"
 #include "../entity/Guest.h"
 #include "../localisation/StringIds.h"
 #include "../ride/RideEntry.h"
 #include "../sprites.h"
 
+using namespace OpenRCT2;
+
 ShopItem& operator++(ShopItem& d, int)
 {
     return d = (d == ShopItem::Count) ? ShopItem::Balloon : ShopItem(EnumValue(d) + 1);
 }
-
-uint64_t gSamePriceThroughoutPark;
 
 // clang-format off
 /** rct2: 0x00982164 (cost, base value, hot and cold value); 0x00982358 (default price) */
@@ -146,7 +147,7 @@ money64 ShopItemGetCommonPrice(Ride* forRide, const ShopItem shopItem)
 
 bool ShopItemHasCommonPrice(const ShopItem shopItem)
 {
-    return (gSamePriceThroughoutPark & EnumToFlag(shopItem)) != 0;
+    return (GetGameState().SamePriceThroughoutPark & EnumToFlag(shopItem)) != 0;
 }
 
 bool ShopItemDescriptor::IsFood() const

--- a/src/openrct2/ride/ShopItem.h
+++ b/src/openrct2/ride/ShopItem.h
@@ -128,8 +128,6 @@ enum
     SHOP_ITEM_FLAG_IS_RECOLOURABLE = (1 << 5),
 };
 
-extern uint64_t gSamePriceThroughoutPark;
-
 money64 ShopItemGetCommonPrice(Ride* forRide, const ShopItem shopItem);
 bool ShopItemHasCommonPrice(const ShopItem shopItem);
 


### PR DESCRIPTION
Move gSamePriceThroughoutPark and gRideRatingUpdateStates to GameState_t for [#21193](https://github.com/OpenRCT2/OpenRCT2/issues/21193)