### PR TITLE
Use fullscreen triangles for fullscreen passes.

### DIFF
--- a/data/shaders/applypalette.vert
+++ b/data/shaders/applypalette.vert
@@ -1,5 +1,7 @@
 #version 150
 
+in int gl_VertexID;
+
 in vec4 vPosition;
 in vec2 vTextureCoordinate;
 
@@ -7,6 +9,6 @@ out vec2 fTextureCoordinate;
 
 void main()
 {
-    fTextureCoordinate = vTextureCoordinate;
-    gl_Position = vPosition;
+    fTextureCoordinate = vec2((gl_VertexID << 1) & 2, gl_VertexID & 2);
+    gl_Position = vec4(fTextureCoordinate * 2.0 + -1.0, 0.0, 1.0);
 }

--- a/data/shaders/applytransparency.vert
+++ b/data/shaders/applytransparency.vert
@@ -1,5 +1,7 @@
 #version 150
 
+in int gl_VertexID;
+
 in vec4 vPosition;
 in vec2 vTextureCoordinate;
 
@@ -7,6 +9,6 @@ out vec2 fTextureCoordinate;
 
 void main()
 {
-    fTextureCoordinate = vTextureCoordinate;
-    gl_Position = vPosition;
+    fTextureCoordinate = vec2((gl_VertexID << 1) & 2, gl_VertexID & 2);
+    gl_Position = vec4(fTextureCoordinate * 2.0 + -1.0, 0.0, 1.0);
 }

--- a/src/openrct2-ui/drawing/engines/opengl/ApplyPaletteShader.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/ApplyPaletteShader.cpp
@@ -11,60 +11,18 @@
 
 #    include "ApplyPaletteShader.h"
 
-namespace
-{
-    struct VDStruct
-    {
-        GLfloat position[2];
-        GLfloat texturecoordinate[2];
-    };
-} // namespace
-
-constexpr VDStruct VertexData[4] = {
-    { -1.0f, -1.0f, 0.0f, 0.0f },
-    { 1.0f, -1.0f, 1.0f, 0.0f },
-    { -1.0f, 1.0f, 0.0f, 1.0f },
-    { 1.0f, 1.0f, 1.0f, 1.0f },
-};
-
 ApplyPaletteShader::ApplyPaletteShader()
     : OpenGLShaderProgram("applypalette")
 {
     GetLocations();
-
-    glGenBuffers(1, &_vbo);
-    glGenVertexArrays(1, &_vao);
-
-    glBindBuffer(GL_ARRAY_BUFFER, _vbo);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(VertexData), VertexData, GL_STATIC_DRAW);
-
-    glBindVertexArray(_vao);
-    glVertexAttribPointer(
-        vPosition, 2, GL_FLOAT, GL_FALSE, sizeof(VDStruct), reinterpret_cast<void*>(offsetof(VDStruct, position)));
-    glVertexAttribPointer(
-        vTextureCoordinate, 2, GL_FLOAT, GL_FALSE, sizeof(VDStruct),
-        reinterpret_cast<void*>(offsetof(VDStruct, texturecoordinate)));
-
-    glEnableVertexAttribArray(vPosition);
-    glEnableVertexAttribArray(vTextureCoordinate);
-
     Use();
     glUniform1i(uTexture, 0);
-}
-
-ApplyPaletteShader::~ApplyPaletteShader()
-{
-    glDeleteBuffers(1, &_vbo);
-    glDeleteVertexArrays(1, &_vao);
 }
 
 void ApplyPaletteShader::GetLocations()
 {
     uTexture = GetUniformLocation("uTexture");
     uPalette = GetUniformLocation("uPalette");
-
-    vPosition = GetAttributeLocation("vPosition");
-    vTextureCoordinate = GetAttributeLocation("vTextureCoordinate");
 }
 
 void ApplyPaletteShader::SetTexture(GLuint texture)
@@ -79,8 +37,7 @@ void ApplyPaletteShader::SetPalette(const vec4* glPalette)
 
 void ApplyPaletteShader::Draw()
 {
-    glBindVertexArray(_vao);
-    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+    glDrawArrays(GL_TRIANGLES, 0, 3);
 }
 
 #endif /* DISABLE_OPENGL */

--- a/src/openrct2-ui/drawing/engines/opengl/ApplyPaletteShader.h
+++ b/src/openrct2-ui/drawing/engines/opengl/ApplyPaletteShader.h
@@ -18,15 +18,8 @@ private:
     GLuint uTexture;
     GLuint uPalette;
 
-    GLuint vPosition;
-    GLuint vTextureCoordinate;
-
-    GLuint _vbo;
-    GLuint _vao;
-
 public:
     ApplyPaletteShader();
-    ~ApplyPaletteShader() override;
 
     static void SetTexture(GLuint texture);
     void SetPalette(const vec4* glPalette);

--- a/src/openrct2-ui/drawing/engines/opengl/ApplyTransparencyShader.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/ApplyTransparencyShader.cpp
@@ -11,43 +11,10 @@
 
 #    include "ApplyTransparencyShader.h"
 
-namespace
-{
-    struct VDStruct
-    {
-        GLfloat position[2];
-        GLfloat texturecoordinate[2];
-    };
-} // namespace
-
-constexpr VDStruct VertexData[4] = {
-    { -1.0f, -1.0f, 0.0f, 0.0f },
-    { 1.0f, -1.0f, 1.0f, 0.0f },
-    { -1.0f, 1.0f, 0.0f, 1.0f },
-    { 1.0f, 1.0f, 1.0f, 1.0f },
-};
-
 ApplyTransparencyShader::ApplyTransparencyShader()
     : OpenGLShaderProgram("applytransparency")
 {
     GetLocations();
-
-    glGenBuffers(1, &_vbo);
-    glGenVertexArrays(1, &_vao);
-
-    glBindBuffer(GL_ARRAY_BUFFER, _vbo);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(VertexData), VertexData, GL_STATIC_DRAW);
-
-    glBindVertexArray(_vao);
-    glVertexAttribPointer(
-        vPosition, 2, GL_FLOAT, GL_FALSE, sizeof(VDStruct), reinterpret_cast<void*>(offsetof(VDStruct, position)));
-    glVertexAttribPointer(
-        vTextureCoordinate, 2, GL_FLOAT, GL_FALSE, sizeof(VDStruct),
-        reinterpret_cast<void*>(offsetof(VDStruct, texturecoordinate)));
-
-    glEnableVertexAttribArray(vPosition);
-    glEnableVertexAttribArray(vTextureCoordinate);
-
     Use();
     glUniform1i(uOpaqueTex, 0);
     glUniform1i(uOpaqueDepth, 1);
@@ -55,12 +22,6 @@ ApplyTransparencyShader::ApplyTransparencyShader()
     glUniform1i(uTransparentDepth, 3);
     glUniform1i(uPaletteTex, 4);
     glUniform1i(uBlendPaletteTex, 5);
-}
-
-ApplyTransparencyShader::~ApplyTransparencyShader()
-{
-    glDeleteBuffers(1, &_vbo);
-    glDeleteVertexArrays(1, &_vao);
 }
 
 void ApplyTransparencyShader::GetLocations()
@@ -71,9 +32,6 @@ void ApplyTransparencyShader::GetLocations()
     uTransparentDepth = GetUniformLocation("uTransparentDepth");
     uPaletteTex = GetUniformLocation("uPaletteTex");
     uBlendPaletteTex = GetUniformLocation("uBlendPaletteTex");
-
-    vPosition = GetAttributeLocation("vPosition");
-    vTextureCoordinate = GetAttributeLocation("vTextureCoordinate");
 }
 
 void ApplyTransparencyShader::SetTextures(
@@ -90,8 +48,7 @@ void ApplyTransparencyShader::SetTextures(
 
 void ApplyTransparencyShader::Draw()
 {
-    glBindVertexArray(_vao);
-    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+    glDrawArrays(GL_TRIANGLES, 0, 3);
 }
 
 #endif /* DISABLE_OPENGL */

--- a/src/openrct2-ui/drawing/engines/opengl/ApplyTransparencyShader.h
+++ b/src/openrct2-ui/drawing/engines/opengl/ApplyTransparencyShader.h
@@ -22,15 +22,8 @@ private:
     GLuint uPaletteTex;
     GLuint uBlendPaletteTex;
 
-    GLuint vPosition;
-    GLuint vTextureCoordinate;
-
-    GLuint _vbo;
-    GLuint _vao;
-
 public:
     ApplyTransparencyShader();
-    ~ApplyTransparencyShader() override;
 
     static void SetTextures(
         GLuint opaqueTex, GLuint opaqueDepth, GLuint transparentTex, GLuint transparentDepth, GLuint paletteTex,


### PR DESCRIPTION
Instead of using a vertex buffer with a quad triangle strip, generate a single fullscreen triangle in the vertex shader.  This has a number of advantages:

- Avoids fragment quad overshading along the diagonal.

- Avoids creating, filling, reading, and destroying a vertex buffer.