### PR TITLE
Move Ui header items to OpenRCT2::Ui

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -637,12 +637,12 @@ static void InputScrollBegin(WindowBase& w, WidgetIndex widgetIndex, const Scree
 
     int32_t widget_width = widg.width() - 1;
     if (scroll.flags & VSCROLLBAR_VISIBLE)
-        widget_width -= SCROLLBAR_WIDTH + 1;
+        widget_width -= kScrollBarWidth + 1;
     int32_t widget_content_width = std::max(scroll.h_right - widget_width, 0);
 
     int32_t widget_height = widg.bottom - widg.top - 1;
     if (scroll.flags & HSCROLLBAR_VISIBLE)
-        widget_height -= SCROLLBAR_WIDTH + 1;
+        widget_height -= kScrollBarWidth + 1;
     int32_t widget_content_height = std::max(scroll.v_bottom - widget_height, 0);
 
     switch (scroll_area)
@@ -757,7 +757,7 @@ static void InputScrollPartUpdateHThumb(WindowBase& w, WidgetIndex widgetIndex, 
         newLeft *= x;
         x = widget.width() - 21;
         if (scroll.flags & VSCROLLBAR_VISIBLE)
-            x -= SCROLLBAR_WIDTH + 1;
+            x -= kScrollBarWidth + 1;
         newLeft /= x;
         x = newLeft;
         scroll.flags |= HSCROLLBAR_THUMB_PRESSED;
@@ -767,7 +767,7 @@ static void InputScrollPartUpdateHThumb(WindowBase& w, WidgetIndex widgetIndex, 
             newLeft = 0;
         x = widget.width() - 1;
         if (scroll.flags & VSCROLLBAR_VISIBLE)
-            x -= SCROLLBAR_WIDTH + 1;
+            x -= kScrollBarWidth + 1;
         x *= -1;
         x += scroll.h_right;
         if (x < 0)
@@ -796,7 +796,7 @@ static void InputScrollPartUpdateVThumb(WindowBase& w, WidgetIndex widgetIndex, 
         newTop *= y;
         y = widget.height() - 21;
         if (scroll.flags & HSCROLLBAR_VISIBLE)
-            y -= SCROLLBAR_WIDTH + 1;
+            y -= kScrollBarWidth + 1;
         newTop /= y;
         y = newTop;
         scroll.flags |= VSCROLLBAR_THUMB_PRESSED;
@@ -806,7 +806,7 @@ static void InputScrollPartUpdateVThumb(WindowBase& w, WidgetIndex widgetIndex, 
             newTop = 0;
         y = widget.height() - 1;
         if (scroll.flags & HSCROLLBAR_VISIBLE)
-            y -= SCROLLBAR_WIDTH + 1;
+            y -= kScrollBarWidth + 1;
         y *= -1;
         y += scroll.v_bottom;
         if (y < 0)
@@ -850,7 +850,7 @@ static void InputScrollPartUpdateHRight(WindowBase& w, WidgetIndex widgetIndex, 
         scroll.h_left += 3;
         int32_t newLeft = widget.width() - 1;
         if (scroll.flags & VSCROLLBAR_VISIBLE)
-            newLeft -= SCROLLBAR_WIDTH + 1;
+            newLeft -= kScrollBarWidth + 1;
         newLeft *= -1;
         newLeft += scroll.h_right;
         if (newLeft < 0)
@@ -893,7 +893,7 @@ static void InputScrollPartUpdateVBottom(WindowBase& w, WidgetIndex widgetIndex,
         scroll.v_top += 3;
         int32_t newTop = widget.height() - 1;
         if (scroll.flags & HSCROLLBAR_VISIBLE)
-            newTop -= SCROLLBAR_WIDTH + 1;
+            newTop -= kScrollBarWidth + 1;
         newTop *= -1;
         newTop += scroll.v_bottom;
         if (newTop < 0)

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -66,7 +66,7 @@ static Peep* ViewportInteractionGetClosestPeep(ScreenCoordsXY screenCoords, int3
  *
  *  rct2: 0x006ED9D0
  */
-InteractionInfo ViewportInteractionGetItemLeft(const ScreenCoordsXY& screenCoords)
+static InteractionInfo ViewportInteractionGetItemLeft(const ScreenCoordsXY& screenCoords)
 {
     InteractionInfo info{};
     // No click input for scenario editor or track manager
@@ -250,7 +250,7 @@ bool ViewportInteractionLeftClick(const ScreenCoordsXY& screenCoords)
  *
  *  rct2: 0x006EDE88
  */
-InteractionInfo ViewportInteractionGetItemRight(const ScreenCoordsXY& screenCoords)
+static InteractionInfo ViewportInteractionGetItemRight(const ScreenCoordsXY& screenCoords)
 {
     Ride* ride;
     int32_t i;

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -687,21 +687,21 @@ static void WidgetScrollDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widg
     // Horizontal scrollbar
     if (scroll.flags & HSCROLLBAR_VISIBLE)
         WidgetHScrollbarDraw(
-            dpi, scroll, topLeft.x, bottomRight.y - SCROLLBAR_WIDTH,
-            ((scroll.flags & VSCROLLBAR_VISIBLE) ? bottomRight.x - (SCROLLBAR_WIDTH + 1) : bottomRight.x), bottomRight.y,
+            dpi, scroll, topLeft.x, bottomRight.y - kScrollBarWidth,
+            ((scroll.flags & VSCROLLBAR_VISIBLE) ? bottomRight.x - (kScrollBarWidth + 1) : bottomRight.x), bottomRight.y,
             colour);
 
     // Vertical scrollbar
     if (scroll.flags & VSCROLLBAR_VISIBLE)
         WidgetVScrollbarDraw(
-            dpi, scroll, bottomRight.x - SCROLLBAR_WIDTH, topLeft.y, bottomRight.x,
-            ((scroll.flags & HSCROLLBAR_VISIBLE) ? bottomRight.y - (SCROLLBAR_WIDTH + 1) : bottomRight.y), colour);
+            dpi, scroll, bottomRight.x - kScrollBarWidth, topLeft.y, bottomRight.x,
+            ((scroll.flags & HSCROLLBAR_VISIBLE) ? bottomRight.y - (kScrollBarWidth + 1) : bottomRight.y), colour);
 
     // Contents
     if (scroll.flags & HSCROLLBAR_VISIBLE)
-        bottomRight.y -= (SCROLLBAR_WIDTH + 1);
+        bottomRight.y -= (kScrollBarWidth + 1);
     if (scroll.flags & VSCROLLBAR_VISIBLE)
-        bottomRight.x -= (SCROLLBAR_WIDTH + 1);
+        bottomRight.x -= (kScrollBarWidth + 1);
 
     bottomRight.y++;
     bottomRight.x++;
@@ -734,25 +734,25 @@ static void WidgetHScrollbarDraw(
 {
     colour &= 0x7F;
     // Trough
-    GfxFillRect(dpi, { { l + SCROLLBAR_WIDTH, t }, { r - SCROLLBAR_WIDTH, b } }, ColourMapA[colour].lighter);
-    GfxFillRect(dpi, { { l + SCROLLBAR_WIDTH, t }, { r - SCROLLBAR_WIDTH, b } }, 0x1000000 | ColourMapA[colour].mid_dark);
-    GfxFillRect(dpi, { { l + SCROLLBAR_WIDTH, t + 2 }, { r - SCROLLBAR_WIDTH, t + 2 } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(dpi, { { l + SCROLLBAR_WIDTH, t + 3 }, { r - SCROLLBAR_WIDTH, t + 3 } }, ColourMapA[colour].lighter);
-    GfxFillRect(dpi, { { l + SCROLLBAR_WIDTH, t + 7 }, { r - SCROLLBAR_WIDTH, t + 7 } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(dpi, { { l + SCROLLBAR_WIDTH, t + 8 }, { r - SCROLLBAR_WIDTH, t + 8 } }, ColourMapA[colour].lighter);
+    GfxFillRect(dpi, { { l + kScrollBarWidth, t }, { r - kScrollBarWidth, b } }, ColourMapA[colour].lighter);
+    GfxFillRect(dpi, { { l + kScrollBarWidth, t }, { r - kScrollBarWidth, b } }, 0x1000000 | ColourMapA[colour].mid_dark);
+    GfxFillRect(dpi, { { l + kScrollBarWidth, t + 2 }, { r - kScrollBarWidth, t + 2 } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(dpi, { { l + kScrollBarWidth, t + 3 }, { r - kScrollBarWidth, t + 3 } }, ColourMapA[colour].lighter);
+    GfxFillRect(dpi, { { l + kScrollBarWidth, t + 7 }, { r - kScrollBarWidth, t + 7 } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(dpi, { { l + kScrollBarWidth, t + 8 }, { r - kScrollBarWidth, t + 8 } }, ColourMapA[colour].lighter);
 
     // Left button
     {
         uint8_t flags = (scroll.flags & HSCROLLBAR_LEFT_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
-        GfxFillRectInset(dpi, { { l, t }, { l + (SCROLLBAR_WIDTH - 1), b } }, colour, flags);
+        GfxFillRectInset(dpi, { { l, t }, { l + (kScrollBarWidth - 1), b } }, colour, flags);
         GfxDrawString(dpi, { l + 1, t }, static_cast<const char*>(BlackLeftArrowString), {});
     }
 
     // Thumb
     {
-        int16_t left = std::max(l + SCROLLBAR_WIDTH, l + scroll.h_thumb_left - 1);
-        int16_t right = std::min(r - SCROLLBAR_WIDTH, l + scroll.h_thumb_right - 1);
+        int16_t left = std::max(l + kScrollBarWidth, l + scroll.h_thumb_left - 1);
+        int16_t right = std::min(r - kScrollBarWidth, l + scroll.h_thumb_right - 1);
         uint8_t flags = (scroll.flags & HSCROLLBAR_THUMB_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
         GfxFillRectInset(dpi, { { left, t }, { right, b } }, colour, flags);
@@ -762,7 +762,7 @@ static void WidgetHScrollbarDraw(
     {
         uint8_t flags = (scroll.flags & HSCROLLBAR_RIGHT_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
-        GfxFillRectInset(dpi, { { r - (SCROLLBAR_WIDTH - 1), t }, { r, b } }, colour, flags);
+        GfxFillRectInset(dpi, { { r - (kScrollBarWidth - 1), t }, { r, b } }, colour, flags);
         GfxDrawString(dpi, { r - 6, t }, static_cast<const char*>(BlackRightArrowString), {});
     }
 }
@@ -772,31 +772,31 @@ static void WidgetVScrollbarDraw(
 {
     colour &= 0x7F;
     // Trough
-    GfxFillRect(dpi, { { l, t + SCROLLBAR_WIDTH }, { r, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].lighter);
-    GfxFillRect(dpi, { { l, t + SCROLLBAR_WIDTH }, { r, b - SCROLLBAR_WIDTH } }, 0x1000000 | ColourMapA[colour].mid_dark);
-    GfxFillRect(dpi, { { l + 2, t + SCROLLBAR_WIDTH }, { l + 2, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(dpi, { { l + 3, t + SCROLLBAR_WIDTH }, { l + 3, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].lighter);
-    GfxFillRect(dpi, { { l + 7, t + SCROLLBAR_WIDTH }, { l + 7, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(dpi, { { l + 8, t + SCROLLBAR_WIDTH }, { l + 8, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].lighter);
+    GfxFillRect(dpi, { { l, t + kScrollBarWidth }, { r, b - kScrollBarWidth } }, ColourMapA[colour].lighter);
+    GfxFillRect(dpi, { { l, t + kScrollBarWidth }, { r, b - kScrollBarWidth } }, 0x1000000 | ColourMapA[colour].mid_dark);
+    GfxFillRect(dpi, { { l + 2, t + kScrollBarWidth }, { l + 2, b - kScrollBarWidth } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(dpi, { { l + 3, t + kScrollBarWidth }, { l + 3, b - kScrollBarWidth } }, ColourMapA[colour].lighter);
+    GfxFillRect(dpi, { { l + 7, t + kScrollBarWidth }, { l + 7, b - kScrollBarWidth } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(dpi, { { l + 8, t + kScrollBarWidth }, { l + 8, b - kScrollBarWidth } }, ColourMapA[colour].lighter);
 
     // Up button
     GfxFillRectInset(
-        dpi, { { l, t }, { r, t + (SCROLLBAR_WIDTH - 1) } }, colour,
+        dpi, { { l, t }, { r, t + (kScrollBarWidth - 1) } }, colour,
         ((scroll.flags & VSCROLLBAR_UP_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
     GfxDrawString(dpi, { l + 1, t - 1 }, static_cast<const char*>(BlackUpArrowString), {});
 
     // Thumb
     GfxFillRectInset(
         dpi,
-        { { l, std::max(t + SCROLLBAR_WIDTH, t + scroll.v_thumb_top - 1) },
-          { r, std::min(b - SCROLLBAR_WIDTH, t + scroll.v_thumb_bottom - 1) } },
+        { { l, std::max(t + kScrollBarWidth, t + scroll.v_thumb_top - 1) },
+          { r, std::min(b - kScrollBarWidth, t + scroll.v_thumb_bottom - 1) } },
         colour, ((scroll.flags & VSCROLLBAR_THUMB_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
 
     // Down button
     GfxFillRectInset(
-        dpi, { { l, b - (SCROLLBAR_WIDTH - 1) }, { r, b } }, colour,
+        dpi, { { l, b - (kScrollBarWidth - 1) }, { r, b } }, colour,
         ((scroll.flags & VSCROLLBAR_DOWN_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
-    GfxDrawString(dpi, { l + 1, b - (SCROLLBAR_WIDTH - 1) }, static_cast<const char*>(BlackDownArrowString), {});
+    GfxDrawString(dpi, { l + 1, b - (kScrollBarWidth - 1) }, static_cast<const char*>(BlackDownArrowString), {});
 }
 
 /**
@@ -952,15 +952,15 @@ void WidgetScrollGetPart(
     }
 
     const auto& scroll = w.scrolls[*scroll_id];
-    if ((scroll.flags & HSCROLLBAR_VISIBLE) && screenCoords.y >= (w.windowPos.y + widget->bottom - (SCROLLBAR_WIDTH + 1)))
+    if ((scroll.flags & HSCROLLBAR_VISIBLE) && screenCoords.y >= (w.windowPos.y + widget->bottom - (kScrollBarWidth + 1)))
     {
         // horizontal scrollbar
         int32_t rightOffset = 0;
-        int32_t iteratorLeft = widget->left + w.windowPos.x + SCROLLBAR_WIDTH;
-        int32_t iteratorRight = widget->right + w.windowPos.x - SCROLLBAR_WIDTH;
+        int32_t iteratorLeft = widget->left + w.windowPos.x + kScrollBarWidth;
+        int32_t iteratorRight = widget->right + w.windowPos.x - kScrollBarWidth;
         if (!(scroll.flags & VSCROLLBAR_VISIBLE))
         {
-            rightOffset = SCROLLBAR_WIDTH + 1;
+            rightOffset = kScrollBarWidth + 1;
         }
 
         if (screenCoords.x <= iteratorLeft)
@@ -971,7 +971,7 @@ void WidgetScrollGetPart(
         {
             *output_scroll_area = SCROLL_PART_NONE;
         }
-        else if (screenCoords.x >= iteratorRight + rightOffset - SCROLLBAR_WIDTH)
+        else if (screenCoords.x >= iteratorRight + rightOffset - kScrollBarWidth)
         {
             *output_scroll_area = SCROLL_PART_HSCROLLBAR_RIGHT;
         }
@@ -988,15 +988,15 @@ void WidgetScrollGetPart(
             *output_scroll_area = SCROLL_PART_HSCROLLBAR_THUMB;
         }
     }
-    else if ((scroll.flags & VSCROLLBAR_VISIBLE) && (screenCoords.x >= w.windowPos.x + widget->right - (SCROLLBAR_WIDTH + 1)))
+    else if ((scroll.flags & VSCROLLBAR_VISIBLE) && (screenCoords.x >= w.windowPos.x + widget->right - (kScrollBarWidth + 1)))
     {
         // vertical scrollbar
         int32_t bottomOffset = 0;
-        int32_t iteratorTop = widget->top + w.windowPos.y + SCROLLBAR_WIDTH;
+        int32_t iteratorTop = widget->top + w.windowPos.y + kScrollBarWidth;
         int32_t iteratorBottom = widget->bottom + w.windowPos.y;
         if (scroll.flags & HSCROLLBAR_VISIBLE)
         {
-            bottomOffset = (SCROLLBAR_WIDTH + 1);
+            bottomOffset = (kScrollBarWidth + 1);
         }
 
         if (screenCoords.y <= iteratorTop)
@@ -1007,7 +1007,7 @@ void WidgetScrollGetPart(
         {
             *output_scroll_area = SCROLL_PART_NONE;
         }
-        else if (screenCoords.y >= (iteratorBottom - bottomOffset - SCROLLBAR_WIDTH))
+        else if (screenCoords.y >= (iteratorBottom - bottomOffset - kScrollBarWidth))
         {
             *output_scroll_area = SCROLL_PART_VSCROLLBAR_BOTTOM;
         }

--- a/src/openrct2-ui/interface/Widget.h
+++ b/src/openrct2-ui/interface/Widget.h
@@ -18,10 +18,8 @@
 ImageId GetColourButtonImage(colour_t colour);
 Widget* GetWidgetByIndex(const WindowBase& w, WidgetIndex widgetIndex);
 
-
 constexpr auto kWidgetsEnd = Widget{ WindowWidgetType::Last, 0, 0, 0, 0, 0, 0, 0 };
 constexpr auto kBarBlink = (1u << 31);
-
 
 enum class WindowColour : uint8_t
 {
@@ -133,7 +131,6 @@ constexpr Widget MakeDropdownButtonWidget(
 
     return MakeWidget({ xPos, yPos }, { width, height }, WindowWidgetType::Button, colour, STR_DROPDOWN_GLYPH, tooltip);
 }
-
 
 void WidgetDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
 

--- a/src/openrct2-ui/interface/Widget.h
+++ b/src/openrct2-ui/interface/Widget.h
@@ -19,8 +19,8 @@ ImageId GetColourButtonImage(colour_t colour);
 Widget* GetWidgetByIndex(const WindowBase& w, WidgetIndex widgetIndex);
 
 
-constexpr auto WIDGETS_END = Widget{ WindowWidgetType::Last, 0, 0, 0, 0, 0, 0, 0 };
-#define BAR_BLINK (1u << 31)
+constexpr auto kWidgetsEnd = Widget{ WindowWidgetType::Last, 0, 0, 0, 0, 0, 0, 0 };
+constexpr auto kBarBlink = (1u << 31);
 
 
 enum class WindowColour : uint8_t
@@ -31,9 +31,9 @@ enum class WindowColour : uint8_t
     Quaternary,
 };
 
-constexpr uint8_t SCROLLBAR_WIDTH = 10;
+constexpr uint8_t kScrollBarWidth = 10;
 
-constexpr ScreenSize TAB_SIZE = { 31, 27 };
+constexpr ScreenSize kTabSize = { 31, 27 };
 
 constexpr Widget MakeWidget(
     const ScreenCoordsXY& origin, const ScreenSize& size, WindowWidgetType type, WindowColour colour,
@@ -78,7 +78,7 @@ constexpr Widget MakeRemapWidget(
 
 constexpr Widget MakeTab(const ScreenCoordsXY& origin, StringId tooltip = STR_NONE)
 {
-    const ScreenSize size = TAB_SIZE;
+    const ScreenSize size = kTabSize;
     const WindowWidgetType type = WindowWidgetType::Tab;
     const WindowColour colour = WindowColour::Secondary;
     const auto content = ImageId(ImageIndexUndefined);

--- a/src/openrct2-ui/interface/Widget.h
+++ b/src/openrct2-ui/interface/Widget.h
@@ -84,8 +84,10 @@ constexpr Widget MakeTab(const ScreenCoordsXY& origin, StringId tooltip = STR_NO
     return MakeWidget(origin, size, type, colour, content, tooltip);
 }
 
+// NOLINTBEGIN
 #define MakeSpinnerWidgets(...)                                                                                                \
     MakeWidget(__VA_ARGS__), MakeSpinnerIncreaseWidget(__VA_ARGS__), MakeSpinnerDecreaseWidget(__VA_ARGS__)
+// NOLINTEND
 
 constexpr Widget MakeSpinnerDecreaseWidget(
     const ScreenCoordsXY& origin, const ScreenSize& size, [[maybe_unused]] WindowWidgetType type, WindowColour colour,
@@ -111,6 +113,7 @@ constexpr Widget MakeSpinnerIncreaseWidget(
     return MakeWidget({ xPos, yPos }, { width, height }, WindowWidgetType::Button, colour, STR_NUMERIC_UP, tooltip);
 }
 
+// NOLINTNEXTLINE
 #define MakeDropdownWidgets(...) MakeDropdownBoxWidget(__VA_ARGS__), MakeDropdownButtonWidget(__VA_ARGS__)
 
 constexpr Widget MakeDropdownBoxWidget(

--- a/src/openrct2-ui/interface/Widget.h
+++ b/src/openrct2-ui/interface/Widget.h
@@ -9,8 +9,147 @@
 
 #pragma once
 
-#include <openrct2/drawing/ImageId.hpp>
+#include "Window.h"
+
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/interface/Widget.h>
+#include <openrct2/localisation/StringIds.h>
 
 ImageId GetColourButtonImage(colour_t colour);
 Widget* GetWidgetByIndex(const WindowBase& w, WidgetIndex widgetIndex);
+
+
+constexpr auto WIDGETS_END = Widget{ WindowWidgetType::Last, 0, 0, 0, 0, 0, 0, 0 };
+#define BAR_BLINK (1u << 31)
+
+
+enum class WindowColour : uint8_t
+{
+    Primary,
+    Secondary,
+    Tertiary,
+    Quaternary,
+};
+
+constexpr uint8_t SCROLLBAR_WIDTH = 10;
+
+constexpr ScreenSize TAB_SIZE = { 31, 27 };
+
+constexpr Widget MakeWidget(
+    const ScreenCoordsXY& origin, const ScreenSize& size, WindowWidgetType type, WindowColour colour,
+    uint32_t content = 0xFFFFFFFF, StringId tooltip = STR_NONE)
+{
+    Widget out = {};
+    out.left = origin.x;
+    out.right = origin.x + size.width - 1;
+    out.top = origin.y;
+    out.bottom = origin.y + size.height - 1;
+    out.type = type;
+    out.colour = static_cast<uint8_t>(colour);
+    out.content = content;
+    out.tooltip = tooltip;
+
+    return out;
+}
+
+constexpr Widget MakeWidget(
+    const ScreenCoordsXY& origin, const ScreenSize& size, WindowWidgetType type, WindowColour colour, ImageId image,
+    StringId tooltip = STR_NONE)
+{
+    Widget out = {};
+    out.left = origin.x;
+    out.right = origin.x + size.width - 1;
+    out.top = origin.y;
+    out.bottom = origin.y + size.height - 1;
+    out.type = type;
+    out.colour = static_cast<uint8_t>(colour);
+    out.image = image;
+    out.tooltip = tooltip;
+
+    return out;
+}
+
+constexpr Widget MakeRemapWidget(
+    const ScreenCoordsXY& origin, const ScreenSize& size, WindowWidgetType type, WindowColour colour, ImageIndex content,
+    StringId tooltip = STR_NONE)
+{
+    return MakeWidget(origin, size, type, colour, ImageId(content, FilterPaletteID::PaletteNull), tooltip);
+}
+
+constexpr Widget MakeTab(const ScreenCoordsXY& origin, StringId tooltip = STR_NONE)
+{
+    const ScreenSize size = TAB_SIZE;
+    const WindowWidgetType type = WindowWidgetType::Tab;
+    const WindowColour colour = WindowColour::Secondary;
+    const auto content = ImageId(ImageIndexUndefined);
+
+    return MakeWidget(origin, size, type, colour, content, tooltip);
+}
+
+#define MakeSpinnerWidgets(...)                                                                                                \
+    MakeWidget(__VA_ARGS__), MakeSpinnerIncreaseWidget(__VA_ARGS__), MakeSpinnerDecreaseWidget(__VA_ARGS__)
+
+constexpr Widget MakeSpinnerDecreaseWidget(
+    const ScreenCoordsXY& origin, const ScreenSize& size, [[maybe_unused]] WindowWidgetType type, WindowColour colour,
+    [[maybe_unused]] uint32_t content = 0xFFFFFFFF, StringId tooltip = STR_NONE)
+{
+    const int16_t xPos = origin.x + size.width - 26;
+    const int16_t yPos = origin.y + 1;
+    const uint16_t width = 13;
+    const uint16_t height = size.height - 2;
+
+    return MakeWidget({ xPos, yPos }, { width, height }, WindowWidgetType::Button, colour, STR_NUMERIC_DOWN, tooltip);
+}
+
+constexpr Widget MakeSpinnerIncreaseWidget(
+    const ScreenCoordsXY& origin, const ScreenSize& size, [[maybe_unused]] WindowWidgetType type, WindowColour colour,
+    [[maybe_unused]] uint32_t content = 0xFFFFFFFF, StringId tooltip = STR_NONE)
+{
+    const int16_t xPos = origin.x + size.width - 13;
+    const int16_t yPos = origin.y + 1;
+    const uint16_t width = 12;
+    const uint16_t height = size.height - 2;
+
+    return MakeWidget({ xPos, yPos }, { width, height }, WindowWidgetType::Button, colour, STR_NUMERIC_UP, tooltip);
+}
+
+#define MakeDropdownWidgets(...) MakeDropdownBoxWidget(__VA_ARGS__), MakeDropdownButtonWidget(__VA_ARGS__)
+
+constexpr Widget MakeDropdownBoxWidget(
+    const ScreenCoordsXY& origin, const ScreenSize& size, [[maybe_unused]] WindowWidgetType type, WindowColour colour,
+    [[maybe_unused]] uint32_t content = 0xFFFFFFFF, StringId tooltip = STR_NONE)
+{
+    return MakeWidget(origin, size, type, colour, content);
+}
+
+constexpr Widget MakeDropdownButtonWidget(
+    const ScreenCoordsXY& origin, const ScreenSize& size, [[maybe_unused]] WindowWidgetType type, WindowColour colour,
+    [[maybe_unused]] uint32_t content = 0xFFFFFFFF, StringId tooltip = STR_NONE)
+{
+    const int16_t xPos = origin.x + size.width - 11;
+    const int16_t yPos = origin.y + 1;
+    const uint16_t width = 11;
+    const uint16_t height = 10;
+
+    return MakeWidget({ xPos, yPos }, { width, height }, WindowWidgetType::Button, colour, STR_DROPDOWN_GLYPH, tooltip);
+}
+
+
+void WidgetDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
+
+bool WidgetIsDisabled(const WindowBase& w, WidgetIndex widgetIndex);
+bool WidgetIsHoldable(const WindowBase& w, WidgetIndex widgetIndex);
+bool WidgetIsVisible(const WindowBase& w, WidgetIndex widgetIndex);
+bool WidgetIsPressed(const WindowBase& w, WidgetIndex widgetIndex);
+bool WidgetIsHighlighted(const WindowBase& w, WidgetIndex widgetIndex);
+bool WidgetIsActiveTool(const WindowBase& w, WidgetIndex widgetIndex);
+void WidgetScrollGetPart(
+    WindowBase& w, const Widget* widget, const ScreenCoordsXY& screenCoords, ScreenCoordsXY& retScreenCoords,
+    int32_t* output_scroll_area, int32_t* scroll_id);
+
+void WidgetSetEnabled(WindowBase& w, WidgetIndex widgetIndex, bool enabled);
+void WidgetSetDisabled(WindowBase& w, WidgetIndex widgetIndex, bool value);
+void WidgetSetHoldable(WindowBase& w, WidgetIndex widgetIndex, bool value);
+void WidgetSetVisible(WindowBase& w, WidgetIndex widgetIndex, bool value);
+void WidgetSetPressed(WindowBase& w, WidgetIndex widgetIndex, bool value);
+void WidgetSetCheckboxValue(WindowBase& w, WidgetIndex widgetIndex, bool value);

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -10,6 +10,7 @@
 #include "Window.h"
 
 #include "Theme.h"
+#include "Widget.h"
 #include "openrct2/world/Location.hpp"
 
 #include <SDL.h>

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -508,11 +508,11 @@ namespace OpenRCT2::Ui::Windows
                     if (listView.GetScrollbars() == ScrollbarType::Horizontal
                         || listView.GetScrollbars() == ScrollbarType::Both)
                     {
-                        wheight -= SCROLLBAR_WIDTH + 1;
+                        wheight -= kScrollBarWidth + 1;
                     }
                     if (listView.GetScrollbars() == ScrollbarType::Vertical || listView.GetScrollbars() == ScrollbarType::Both)
                     {
-                        wwidth -= SCROLLBAR_WIDTH + 1;
+                        wwidth -= kScrollBarWidth + 1;
                     }
                     listView.Resize({ wwidth, wheight });
                     scrollIndex++;
@@ -931,7 +931,7 @@ namespace OpenRCT2::Ui::Windows
                 }
             }
 
-            widgetList.push_back(WIDGETS_END);
+            widgetList.push_back(kWidgetsEnd);
             widgets = widgetList.data();
 
             WindowInitScrollWidgets(*this);

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -70,12 +70,12 @@ static Widget _windowAboutOpenRCT2Widgets[] = {
     MakeWidget({168, 115 + 40}, {200, 14},     WindowWidgetType::Button,       WindowColour::Secondary, STR_CHANGELOG_ELLIPSIS), // changelog button
     MakeWidget({168, 115 + 60}, {200, 14},     WindowWidgetType::Button,       WindowColour::Secondary, STR_JOIN_DISCORD      ), // "join discord" button
     MakeWidget({168, 115 + 80}, {200, 14},     WindowWidgetType::Button,       WindowColour::Secondary, STR_CONTRIBUTORS_WINDOW_BUTTON), // "contributors" button
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget _windowAboutRCT2Widgets[] = {
     WIDGETS_MAIN,
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget *_windowAboutPageWidgets[] = {

--- a/src/openrct2-ui/windows/AssetPacks.cpp
+++ b/src/openrct2-ui/windows/AssetPacks.cpp
@@ -45,7 +45,7 @@ static Widget WindowAssetPacksWidgets[] = {
     MakeWidget({ 0, 0 }, { 0,   0 }, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_ARROW_UP), STR_INCREASE_PRIOTITY_TIP),
     MakeWidget({ 0, 0 }, { 0,   0 }, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_ARROW_DOWN), STR_DECREASE_PRIOTITY_TIP),
     MakeWidget({ 0, 0 }, { 0,   0 }, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_RELOAD), STR_RELOAD_ASSET_PACKS_TIP),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -67,7 +67,7 @@ static Widget window_banner_widgets[] = {
     MakeWidget({      5, WH - 16}, {12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,         STR_SELECT_MAIN_SIGN_COLOUR_TIP), // high money
     MakeWidget({     43, WH - 16}, {39, 12}, WindowWidgetType::DropdownMenu,  WindowColour::Secondary                                                     ), // high money
     MakeWidget({     70, WH - 15}, {11, 10}, WindowWidgetType::Button,    WindowColour::Secondary, STR_DROPDOWN_GLYPH, STR_SELECT_TEXT_COLOUR_TIP     ), // high money
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // clang-format on

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -48,7 +48,7 @@ static Widget _windowChangelogWidgets[] = {
     MakeWidget({0,  14}, {500, 382}, WindowWidgetType::Resize,      WindowColour::Secondary                               ), // content panel
     MakeWidget({3,  16}, {495, 366}, WindowWidgetType::Scroll,      WindowColour::Secondary, SCROLL_BOTH                  ), // scroll area
     MakeWidget({3, 473}, {300,  14}, WindowWidgetType::Placeholder, WindowColour::Secondary, STR_NEW_RELEASE_DOWNLOAD_PAGE), // changelog button
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // clang-format on

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -219,7 +219,7 @@ static Widget window_cheats_money_widgets[] =
     MakeSpinnerWidgets({120, 239}, CHEAT_SPINNER, WindowWidgetType::Spinner,  WindowColour::Secondary                        ), // Day box
     MakeWidget        ({ 11, 258}, CHEAT_BUTTON,  WindowWidgetType::Button,   WindowColour::Secondary, STR_DATE_SET          ), // Set Date
     MakeWidget        ({127, 258}, CHEAT_BUTTON,  WindowWidgetType::Button,   WindowColour::Secondary, STR_DATE_RESET        ), // Reset Date
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget window_cheats_guests_widgets[] =
@@ -252,7 +252,7 @@ static Widget window_cheats_guests_widgets[] =
     MakeWidget({127, 384}, CHEAT_BUTTON,  WindowWidgetType::Button,   WindowColour::Secondary, STR_SHOP_ITEM_PLURAL_UMBRELLA                                   ), // give guests umbrellas
     MakeWidget({ 11, 426}, CHEAT_BUTTON,  WindowWidgetType::Button,   WindowColour::Secondary, STR_CHEAT_LARGE_TRAM_GUESTS,     STR_CHEAT_LARGE_TRAM_GUESTS_TIP), // large tram
     MakeWidget({127, 426}, CHEAT_BUTTON,  WindowWidgetType::Button,   WindowColour::Secondary, STR_CHEAT_REMOVE_ALL_GUESTS,     STR_CHEAT_REMOVE_ALL_GUESTS_TIP), // remove all guests
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 //Strings for following moved to window_cheats_paint()
@@ -293,7 +293,7 @@ static Widget window_cheats_misc_widgets[] =
     MakeWidget        ({ 11, 407}, CHEAT_CHECK,  WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_ALLOW_PATH_AS_QUEUE,   STR_CHEAT_ALLOW_PATH_AS_QUEUE_TIP  ), // Allow regular footpaths as queue path
     MakeWidget        ({ 11, 428}, CHEAT_CHECK,  WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_ALLOW_SPECIAL_COLOUR_SCHEMES,   STR_CHEAT_ALLOW_SPECIAL_COLOUR_SCHEMES_TIP  ), // Allow special colours in dropdown
 
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 static Widget window_cheats_rides_widgets[] =
 {
@@ -319,7 +319,7 @@ static Widget window_cheats_rides_widgets[] =
     MakeWidget({ 11, 384}, CHEAT_CHECK,  WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_SHOW_VEHICLES_FROM_OTHER_TRACK_TYPES                                                 ), // Show vehicles from other track types
     MakeWidget({ 11, 405}, CHEAT_CHECK,  WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_DISABLE_TRAIN_LENGTH_LIMIT,           STR_CHEAT_DISABLE_TRAIN_LENGTH_LIMIT_TIP       ), // Disable train length limits
     MakeWidget({ 11, 426}, CHEAT_CHECK,  WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_IGNORE_RESEARCH_STATUS,               STR_CHEAT_IGNORE_RESEARCH_STATUS_TIP           ), // Ignore Research Status
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget *window_cheats_page_widgets[] =

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -58,7 +58,7 @@ static Widget window_clear_scenery_widgets[] = {
     MakeRemapWidget(
         { 67, 53 }, CLEAR_SCENERY_BUTTON, WindowWidgetType::FlatBtn, WindowColour::Secondary, SPR_G2_BUTTON_FOOTPATH,
         STR_CLEAR_SCENERY_REMOVE_FOOTPATHS_TIP), // footpaths
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 class CleanSceneryWindow final : public Window

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -41,7 +41,7 @@ static Widget window_custom_currency_widgets[] = {
     MakeWidget        ({120, 50}, { 81, 11}, WindowWidgetType::Button,   WindowColour::Secondary, STR_EMPTY          ),
     MakeWidget        ({220, 50}, {131, 11}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                 ),
     MakeWidget        ({339, 51}, { 11,  9}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // clang-format on

--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -40,7 +40,7 @@ static Widget window_debug_paint_widgets[] = {
     MakeWidget({8, 8 + 15 * 2}, {         185,            12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_DEBUG_PAINT_SHOW_SEGMENT_HEIGHTS),
     MakeWidget({8, 8 + 15 * 3}, {         185,            12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_DEBUG_PAINT_SHOW_BOUND_BOXES    ),
     MakeWidget({8, 8 + 15 * 4}, {         185,            12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_DEBUG_PAINT_SHOW_DIRTY_VISUALS  ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -39,7 +39,7 @@ static Widget window_ride_demolish_widgets[] =
     WINDOW_SHIM_WHITE(STR_DEMOLISH_RIDE, WW, WH),
     MakeWidget({     10, WH - 22}, {85, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_DEMOLISH          ),
     MakeWidget({WW - 95, WH - 22}, {85, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_SAVE_PROMPT_CANCEL),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -45,7 +45,7 @@ enum
 
 static Widget window_dropdown_widgets[] = {
     MakeWidget({ 0, 0 }, { 1, 1 }, WindowWidgetType::ImgBtn, WindowColour::Primary),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 int32_t gDropdownNumItems;

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -43,7 +43,7 @@ static Widget _editorBottomToolbarWidgets[] = {
     MakeWidget({  2, 2}, {196, 30}, WindowWidgetType::FlatBtn, WindowColour::Primary),
     MakeWidget({440, 0}, {200, 34}, WindowWidgetType::ImgBtn,  WindowColour::Primary),
     MakeWidget({442, 2}, {196, 30}, WindowWidgetType::FlatBtn, WindowColour::Primary),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -59,12 +59,12 @@ static Widget _inventionListWidgets[] = {
     MakeWidget({375, 343}, {220,  14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_MOVE_ALL_TOP                           ),
     MakeWidget({375, 358}, {220,  14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_MOVE_ALL_BOTTOM                        ),
     MakeWidget({375, 373}, {220,  14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_RANDOM_SHUFFLE,  STR_RANDOM_SHUFFLE_TIP),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget _inventionListDragWidgets[] = {
     MakeWidget({0, 0}, {150, 14}, WindowWidgetType::ImgBtn, WindowColour::Primary),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -219,7 +219,7 @@ static std::vector<Widget> _window_editor_object_selection_widgets = {
     MakeTab   ({  3, 17},                                                                                       STR_STRING_DEFINED_TOOLTIP       ),
     // Copied object type times...
 
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -126,13 +126,13 @@ static Widget window_editor_objective_options_main_widgets[] = {
     MakeWidget        ({ 98, 133}, {180,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_NONE,           STR_SELECT_WHICH_GROUP_THIS_SCENARIO_APPEARS_IN),
     MakeWidget        ({266, 134}, { 11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH, STR_SELECT_WHICH_GROUP_THIS_SCENARIO_APPEARS_IN),
     MakeWidget        ({370, 150}, { 75,  12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_CHANGE,         STR_CHANGE_DETAIL_NOTES_ABOUT_PARK_SCENARIO_TIP),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget window_editor_objective_options_rides_widgets[] = {
     MAIN_OBJECTIVE_OPTIONS_WIDGETS,
     MakeWidget({  3,  60}, {374, 161}, WindowWidgetType::Scroll, WindowColour::Secondary, SCROLL_VERTICAL),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget *window_editor_objective_options_widgets[] = {

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -135,7 +135,7 @@ static Widget window_editor_scenario_options_financial_widgets[] = {
     MakeSpinnerWidgets({168, 116}, {               70,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                            ), // NB: 3 widgets
     MakeWidget        ({  8, 133}, {WW_FINANCIAL - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_FORBID_MARKETING,   STR_FORBID_MARKETING_TIP          ),
     MakeWidget        ({  8, 116}, {WW_FINANCIAL - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_RCT1_INTEREST,      STR_RCT1_INTEREST_TIP             ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget window_editor_scenario_options_guests_widgets[] = {
@@ -150,7 +150,7 @@ static Widget window_editor_scenario_options_guests_widgets[] = {
     MakeSpinnerWidgets({268,  99}, {            70,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                                                ), // NB: 3 widgets
     MakeWidget        ({  8, 116}, {WW_GUESTS - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_GUESTS_PREFER_LESS_INTENSE_RIDES, STR_GUESTS_PREFER_LESS_INTENSE_RIDES_TIP),
     MakeWidget        ({  8, 133}, {WW_GUESTS - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_GUESTS_PREFER_MORE_INTENSE_RIDES, STR_GUESTS_PREFER_MORE_INTENSE_RIDES_TIP),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget window_editor_scenario_options_park_widgets[] = {
@@ -171,7 +171,7 @@ static Widget window_editor_scenario_options_park_widgets[] = {
     MakeWidget        ({  8, 150}, {WW_PARK - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_FORBID_HIGH_CONSTRUCTION, STR_FORBID_HIGH_CONSTRUCTION_TIP  ),
     MakeWidget        ({  8, 167}, {WW_PARK - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_HARD_PARK_RATING,         STR_HARD_PARK_RATING_TIP          ),
     MakeWidget        ({  8, 184}, {WW_PARK - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_HARD_GUEST_GENERATION,    STR_HARD_GUEST_GENERATION_TIP     ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget *window_editor_scenario_options_widgets[] = {

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -25,7 +25,7 @@ enum {
 
 static Widget window_error_widgets[] = {
     MakeWidget({0, 0}, {200, 42}, WindowWidgetType::ImgBtn, WindowColour::Primary),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -116,25 +116,25 @@ static Widget _windowFinancesSummaryWidgets[] =
     MAIN_FINANCES_WIDGETS(STR_FINANCIAL_SUMMARY, RSW_OTHER_TABS, RSH_SUMMARY, WW_OTHER_TABS, WH_SUMMARY),
     MakeWidget        ({130,  50}, {391, 211}, WindowWidgetType::Scroll,  WindowColour::Secondary, SCROLL_HORIZONTAL              ),
     MakeSpinnerWidgets({ 64, 279}, { 97,  14}, WindowWidgetType::Spinner, WindowColour::Secondary, STR_FINANCES_SUMMARY_LOAN_VALUE), // NB: 3 widgets.
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget _windowFinancesCashWidgets[] =
 {
     MAIN_FINANCES_WIDGETS(STR_FINANCIAL_GRAPH, RSW_OTHER_TABS, RSH_OTHER_TABS, WW_OTHER_TABS, WH_OTHER_TABS),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget _windowFinancesParkValueWidgets[] =
 {
     MAIN_FINANCES_WIDGETS(STR_PARK_VALUE_GRAPH, RSW_OTHER_TABS, RSH_OTHER_TABS, WW_OTHER_TABS, WH_OTHER_TABS),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget _windowFinancesProfitWidgets[] =
 {
     MAIN_FINANCES_WIDGETS(STR_PROFIT_GRAPH, RSW_OTHER_TABS, RSH_OTHER_TABS, WW_OTHER_TABS, WH_OTHER_TABS),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget _windowFinancesMarketingWidgets[] =
@@ -148,7 +148,7 @@ static Widget _windowFinancesMarketingWidgets[] =
     MakeWidget({8,  0}, {WW_OTHER_TABS - 16,  14}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, 0xFFFFFFFF,                           STR_START_THIS_MARKETING_CAMPAIGN),
     MakeWidget({8,  0}, {WW_OTHER_TABS - 16,  14}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, 0xFFFFFFFF,                           STR_START_THIS_MARKETING_CAMPAIGN),
     MakeWidget({8,  0}, {WW_OTHER_TABS - 16,  14}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, 0xFFFFFFFF,                           STR_START_THIS_MARKETING_CAMPAIGN),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget _windowFinancesResearchWidgets[] =
@@ -165,7 +165,7 @@ static Widget _windowFinancesResearchWidgets[] =
     MakeWidget({  8, 160}, {WW_RESEARCH - 14,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary, STR_RESEARCH_NEW_WATER_RIDES,         STR_RESEARCH_NEW_WATER_RIDES_TIP            ),
     MakeWidget({  8, 173}, {WW_RESEARCH - 14,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary, STR_RESEARCH_NEW_SHOPS_AND_STALLS,    STR_RESEARCH_NEW_SHOPS_AND_STALLS_TIP       ),
     MakeWidget({  8, 186}, {WW_RESEARCH - 14,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary, STR_RESEARCH_NEW_SCENERY_AND_THEMING, STR_RESEARCH_NEW_SCENERY_AND_THEMING_TIP    ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -112,7 +112,7 @@ static Widget window_footpath_widgets[] = {
     MakeWidget({ 3, 361}, {100, 54}, WindowWidgetType::Groupbox, WindowColour::Primary                                                                                      ),
     MakeWidget({13, 372}, { 36, 36}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_FOOTPATH_LAND),    STR_CONSTRUCT_FOOTPATH_ON_LAND_TIP             ),
     MakeWidget({57, 372}, { 36, 36}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_FOOTPATH_BRIDGE),  STR_CONSTRUCT_BRIDGE_OR_TUNNEL_FOOTPATH_TIP    ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 #pragma endregion

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -66,7 +66,7 @@ static Widget window_game_bottom_toolbar_widgets[] =
     MakeWidget({498,  0}, {142, 34}, WindowWidgetType::ImgBtn,      WindowColour::Primary                                                     ), // Right outset panel
     MakeWidget({500,  2}, {138, 30}, WindowWidgetType::ImgBtn,      WindowColour::Primary                                                     ), // Right inset panel
     MakeWidget({500,  2}, {138, 12}, WindowWidgetType::FlatBtn,     WindowColour::Primary                                                     ), // Date
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 uint8_t gToolbarDirtyFlags;
@@ -151,7 +151,7 @@ private:
         int16_t bar_width = (factor * 114) / 255;
         GfxFillRectInset(
             dpi, { coords + ScreenCoordsXY{ 1, 1 }, coords + ScreenCoordsXY{ 114, 9 } }, colours[1], INSET_RECT_F_30);
-        if (!(colour & BAR_BLINK) || GameIsPaused() || (gCurrentRealTimeTicks & 8))
+        if (!(colour & kBarBlink) || GameIsPaused() || (gCurrentRealTimeTicks & 8))
         {
             if (bar_width > 2)
             {

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -104,39 +104,39 @@ static Widget _guestWindowWidgetsOverview[] = {
     MakeWidget({167,  69}, { 24, 24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_RENAME),     STR_NAME_GUEST_TIP           ), // Rename Button
     MakeWidget({167,  93}, { 24, 24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_LOCATE),     STR_LOCATE_SUBJECT_TIP       ), // Locate Button
     MakeWidget({167, 117}, { 24, 24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_TRACK_PEEP), STR_TOGGLE_GUEST_TRACKING_TIP), // Track Button
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 
 static Widget _guestWindowWidgetsStats[] = {
     MAIN_GUEST_WIDGETS,
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget _guestWindowWidgetsRides[] = {
     MAIN_GUEST_WIDGETS,
     MakeWidget({ 3, 57 }, { 186, 87 }, WindowWidgetType::Scroll, WindowColour::Secondary, SCROLL_VERTICAL),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget _guestWindowWidgetsFinance[] = {
     MAIN_GUEST_WIDGETS,
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget _guestWindowWidgetsThoughts[] = {
     MAIN_GUEST_WIDGETS,
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget _guestWindowWidgetsInventory[] = {
     MAIN_GUEST_WIDGETS,
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget _guestWindowWidgetsDebug[] = {
     MAIN_GUEST_WIDGETS,
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // clang-format off

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -706,7 +706,7 @@ private:
             return;
         }
 
-        ViewportUpdateSmartFollowGuest(this, peep);
+        ViewportUpdateSmartFollowGuest(this, *peep);
         bool reCreateViewport = false;
         uint16_t origViewportFlags{};
         if (viewport != nullptr)

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -67,7 +67,7 @@ static Widget window_guest_list_widgets[] = {
     MakeTab   ({  3, 17},                                                                        STR_INDIVIDUAL_GUESTS_TIP    ), // tab 1
     MakeTab   ({ 34, 17},                                                                        STR_SUMMARISED_GUESTS_TIP    ), // tab 2
     MakeWidget({  3, 72}, {344, 255}, WindowWidgetType::Scroll,   WindowColour::Secondary, SCROLL_BOTH                                      ), // guest list
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -53,7 +53,7 @@ static Widget window_install_track_widgets[] = {
     MakeWidget({PREVIEW_BUTTONS_LEFT, 398}, { 22,  24}, WindowWidgetType::FlatBtn, WindowColour::Primary, ImageId(SPR_SCENERY),                          STR_TOGGLE_SCENERY_TIP),
     MakeWidget({ ACTION_BUTTONS_LEFT, 241}, { 97,  15}, WindowWidgetType::Button,  WindowColour::Primary, STR_INSTALL_NEW_TRACK_DESIGN_INSTALL                        ),
     MakeWidget({ ACTION_BUTTONS_LEFT, 259}, { 97,  15}, WindowWidgetType::Button,  WindowColour::Primary, STR_INSTALL_NEW_TRACK_DESIGN_CANCEL                         ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // clang-format on

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -49,7 +49,7 @@ static Widget window_land_widgets[] = {
     MakeRemapWidget({54,  63}, {16, 16}, WindowWidgetType::TrnBtn,  WindowColour::Secondary, SPR_LAND_TOOL_INCREASE,         STR_ADJUST_LARGER_LAND_TIP),   // increment size
     MakeWidget     ({ 2, 106}, {47, 36}, WindowWidgetType::FlatBtn, WindowColour::Secondary, 0xFFFFFFFF,                     STR_CHANGE_BASE_LAND_TIP),     // floor texture
     MakeWidget     ({49, 106}, {47, 36}, WindowWidgetType::FlatBtn, WindowColour::Secondary, 0xFFFFFFFF,                     STR_CHANGE_VERTICAL_LAND_TIP), // wall texture
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -48,7 +48,7 @@ static Widget window_land_rights_widgets[] = {
     MakeRemapWidget({54, 32}, {16, 16}, WindowWidgetType::TrnBtn,  WindowColour::Tertiary, SPR_LAND_TOOL_INCREASE,      STR_ADJUST_LARGER_LAND_RIGHTS_TIP ), // increment size
     MakeRemapWidget({22, 53}, {24, 24}, WindowWidgetType::FlatBtn, WindowColour::Tertiary, SPR_BUY_LAND_RIGHTS,         STR_BUY_LAND_RIGHTS_TIP           ), // land rights
     MakeRemapWidget({52, 53}, {24, 24}, WindowWidgetType::FlatBtn, WindowColour::Tertiary, SPR_BUY_CONSTRUCTION_RIGHTS, STR_BUY_CONSTRUCTION_RIGHTS_TIP   ), // construction rights
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -78,7 +78,7 @@ static Widget window_loadsave_widgets[] =
     MakeWidget({(WW - 5) / 2 + 1,      55}, {170,  14}, WindowWidgetType::TableHeader, WindowColour::Primary                                                               ), // WIDX_SORT_DATE
     MakeWidget({               4,      68}, {342, 303}, WindowWidgetType::Scroll,      WindowColour::Primary,   SCROLL_VERTICAL                                            ), // WIDX_SCROLL
     MakeWidget({               4, WH - 24}, {197,  19}, WindowWidgetType::Button,      WindowColour::Primary,   STR_FILEBROWSER_USE_SYSTEM_WINDOW                          ), // WIDX_BROWSE
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 
@@ -712,7 +712,7 @@ public:
 
         Widget* date_widget = &window_loadsave_widgets[WIDX_SORT_DATE];
         date_widget->right = width - 5;
-        date_widget->left = date_widget->right - (maxDateWidth + maxTimeWidth + (4 * DATE_TIME_GAP) + (SCROLLBAR_WIDTH + 1));
+        date_widget->left = date_widget->right - (maxDateWidth + maxTimeWidth + (4 * DATE_TIME_GAP) + (kScrollBarWidth + 1));
 
         window_loadsave_widgets[WIDX_SORT_NAME].left = 4;
         window_loadsave_widgets[WIDX_SORT_NAME].right = window_loadsave_widgets[WIDX_SORT_DATE].left - 1;
@@ -1093,7 +1093,7 @@ static Widget window_overwrite_prompt_widgets[] = {
     { WindowWidgetType::Button, 0, 10, 94, OVERWRITE_WH - 20, OVERWRITE_WH - 9, STR_FILEBROWSER_OVERWRITE_TITLE, STR_NONE },
     { WindowWidgetType::Button, 0, OVERWRITE_WW - 95, OVERWRITE_WW - 11, OVERWRITE_WH - 20, OVERWRITE_WH - 9,
       STR_SAVE_PROMPT_CANCEL, STR_NONE },
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 class OverwritePromptWindow final : public Window

--- a/src/openrct2-ui/windows/Main.cpp
+++ b/src/openrct2-ui/windows/Main.cpp
@@ -18,7 +18,7 @@
 // clang-format off
 static Widget _mainWidgets[] = {
     MakeWidget({0, 0}, {0, 0}, WindowWidgetType::Viewport, WindowColour::Primary, STR_VIEWPORT),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -125,7 +125,7 @@ static Widget window_map_widgets[] = {
     MakeWidget        ({ 58, 197}, {174,  12}, WindowWidgetType::Checkbox,  WindowColour::Secondary, STR_CONSTRUCTION_RIGHTS_SALE,    STR_SET_CONSTRUCTION_RIGHTS_TO_BE_AVAILABLE_TIP),
     MakeWidget        ({218,  45}, { 24,  24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_ROTATE_ARROW),                STR_ROTATE_OBJECTS_90                          ),
     MakeWidget        ({110, 189}, {131,  14}, WindowWidgetType::Button,    WindowColour::Secondary, STR_MAPGEN_WINDOW_TITLE,         STR_MAP_GENERATOR_TIP                          ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // used in transforming viewport view coordinates to minimap coordinates

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -142,7 +142,7 @@ static Widget MapWidgets[] = {
     MakeSpinnerWidgets({104,  88}, {95, 12}, WindowWidgetType::Spinner, WindowColour::Secondary                                                             ), // NB: 3 widgets
     MakeWidget        ({104, 106}, {47, 36}, WindowWidgetType::FlatBtn, WindowColour::Secondary, 0xFFFFFFFF,                 STR_CHANGE_BASE_LAND_TIP       ),
     MakeWidget        ({151, 106}, {47, 36}, WindowWidgetType::FlatBtn, WindowColour::Secondary, 0xFFFFFFFF,                 STR_CHANGE_VERTICAL_LAND_TIP   ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget RandomWidgets[] = {
@@ -150,7 +150,7 @@ static Widget RandomWidgets[] = {
     MakeWidget({155, 255}, { 90, 14}, WindowWidgetType::Button,   WindowColour::Secondary, STR_MAPGEN_ACTION_GENERATE      ),
     MakeWidget({  4,  52}, {195, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_MAPGEN_OPTION_RANDOM_TERRAIN),
     MakeWidget({  4,  70}, {195, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_MAPGEN_OPTION_PLACE_TREES   ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget SimplexWidgets[] = {
@@ -169,7 +169,7 @@ static Widget SimplexWidgets[] = {
     MakeWidget        ({102, 202}, { 47, 36}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, 0xFFFFFFFF,                       STR_CHANGE_BASE_LAND_TIP       ), // WIDX_SIMPLEX_FLOOR_TEXTURE
     MakeWidget        ({150, 202}, { 47, 36}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, 0xFFFFFFFF,                       STR_CHANGE_VERTICAL_LAND_TIP   ), // WIDX_SIMPLEX_WALL_TEXTURE
     MakeWidget        ({104, 239}, { 95, 12}, WindowWidgetType::Checkbox,      WindowColour::Secondary                                                                   ), // WIDX_SIMPLEX_PLACE_TREES_CHECKBOX
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget HeightmapWidgets[] = {
@@ -182,7 +182,7 @@ static Widget HeightmapWidgets[] = {
     MakeSpinnerWidgets({104, 124}, { 95, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary                             ), // WIDX_HEIGHTMAP_LOW{,_UP,_DOWN}
     MakeSpinnerWidgets({104, 142}, { 95, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary                             ), // WIDX_HEIGHTMAP_HIGH{,_UP,_DOWN}
     MakeSpinnerWidgets({104, 160}, { 95, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary                             ), // WIDX_HEIGHTMAP_WATER_LEVEL{,_UP,_DOWN}
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/MapTooltip.cpp
+++ b/src/openrct2-ui/windows/MapTooltip.cpp
@@ -20,7 +20,7 @@
 // clang-format off
 static Widget window_map_tooltip_widgets[] = {
     MakeWidget({0, 0}, {200, 30}, WindowWidgetType::ImgBtn, WindowColour::Primary),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // clang-format on

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -87,7 +87,7 @@ static Widget window_maze_construction_widgets[] = {
     MakeWidget({87, 178}, { 70, 12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_RIDE_CONSTRUCTION_EXIT,     STR_RIDE_CONSTRUCTION_EXIT_TIP                        ),
     MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
     MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -70,7 +70,7 @@ enum WindowMultiplayerWidgetIdx {
 
 static Widget window_multiplayer_information_widgets[] = {
     MAIN_MULTIPLAYER_WIDGETS,
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget window_multiplayer_players_widgets[] = {
@@ -80,7 +80,7 @@ static Widget window_multiplayer_players_widgets[] = {
     MakeWidget({259, 46}, {100,  15}, WindowWidgetType::TableHeader, WindowColour::Primary  , STR_LAST_ACTION), // Player name
     MakeWidget({359, 46}, { 42,  15}, WindowWidgetType::TableHeader, WindowColour::Primary  , STR_PING       ), // Player name
     MakeWidget({  3, 60}, {334, 177}, WindowWidgetType::Scroll,       WindowColour::Secondary, SCROLL_VERTICAL), // list
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget window_multiplayer_groups_widgets[] = {
@@ -93,7 +93,7 @@ static Widget window_multiplayer_groups_widgets[] = {
     MakeWidget({ 72, 80}, {175,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                    ), // selected group
     MakeWidget({236, 81}, { 11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH),
     MakeWidget({  3, 94}, {314, 207}, WindowWidgetType::Scroll,   WindowColour::Secondary, SCROLL_VERTICAL   ), // permissions list
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget window_multiplayer_options_widgets[] = {
@@ -101,7 +101,7 @@ static Widget window_multiplayer_options_widgets[] = {
     MakeWidget({3, 50}, {295, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_LOG_CHAT,              STR_LOG_CHAT_TIP             ),
     MakeWidget({3, 64}, {295, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_LOG_SERVER_ACTIONS,    STR_LOG_SERVER_ACTIONS_TIP   ),
     MakeWidget({3, 78}, {295, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_ALLOW_KNOWN_KEYS_ONLY, STR_ALLOW_KNOWN_KEYS_ONLY_TIP),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget *window_multiplayer_page_widgets[] = {

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -26,7 +26,7 @@ static Widget window_network_status_widgets[] = {
     MakeWidget({  0, 0}, {441, 91}, WindowWidgetType::Frame,    WindowColour::Primary                                   ), // panel / background
     MakeWidget({  1, 1}, {438, 14}, WindowWidgetType::Caption,  WindowColour::Primary, STR_NONE,    STR_WINDOW_TITLE_TIP), // title bar
     MakeWidget({427, 2}, { 11, 12}, WindowWidgetType::CloseBox, WindowColour::Primary, STR_CLOSE_X, STR_CLOSE_WINDOW_TIP), // close x button
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // clang-format on

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -52,7 +52,7 @@ static Widget window_new_campaign_widgets[] = {
     MakeWidget        ({ 14, 41}, {126, 14}, WindowWidgetType::Label,    WindowColour::Primary, STR_LENGTH_OF_TIME                         ), // weeks label
     MakeSpinnerWidgets({120, 41}, {100, 14}, WindowWidgetType::Spinner,  WindowColour::Primary, STR_EMPTY                                  ), // weeks (3 widgets)
     MakeWidget        ({ 14, 89}, {322, 14}, WindowWidgetType::Button,   WindowColour::Primary, STR_MARKETING_START_THIS_MARKETING_CAMPAIGN), // start button
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -223,7 +223,7 @@ static Widget window_new_ride_widgets[] = {
     MakeWidget({  4,  46},             {211, 14},          WindowWidgetType::TextBox,  WindowColour::Secondary                          ),
     MakeWidget({218,  46},             { 70, 14},          WindowWidgetType::Button,   WindowColour::Secondary, STR_OBJECT_SEARCH_CLEAR ),
     MakeWidget(GroupByTrackTypeOrigin, GroupTrackTypeSize, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_GROUP_BY_TRACK_TYPE,         STR_GROUP_BY_TRACK_TYPE_TIP  ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -42,7 +42,7 @@ static Widget window_news_widgets[] = {
     WINDOW_SHIM(WINDOW_TITLE, WW, WH),
     MakeWidget({372, 18}, { 24,  24}, WindowWidgetType::FlatBtn, WindowColour::Primary, ImageId(SPR_TAB_GEARS_0)), // settings
     MakeWidget({  4, 44}, {392, 252}, WindowWidgetType::Scroll,  WindowColour::Primary, SCROLL_VERTICAL), // scroll
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // clang-format on

--- a/src/openrct2-ui/windows/NewsOptions.cpp
+++ b/src/openrct2-ui/windows/NewsOptions.cpp
@@ -83,7 +83,7 @@ static Widget WindowNewsOptionsWidgets[] = {
     MakeWidget({ 0,  0}, {343,  14}, WindowWidgetType::Checkbox, WindowColour::Tertiary ),
     MakeWidget({ 0,  0}, {343,  14}, WindowWidgetType::Checkbox, WindowColour::Tertiary ),
     MakeWidget({ 0,  0}, {343,  14}, WindowWidgetType::Checkbox, WindowColour::Tertiary ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -285,7 +285,7 @@ static Widget window_object_load_error_widgets[] = {
 #ifndef DISABLE_HTTP
     MakeWidget({            300, 377}, {146,  14}, WindowWidgetType::Button,       WindowColour::Primary, STR_DOWNLOAD_ALL,            STR_DOWNLOAD_ALL_TIP ), // Download all button
 #endif
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -249,7 +249,7 @@ static Widget window_options_display_widgets[] = {
     MakeWidget        ({ 11, 176}, {143,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_USE_VSYNC,                         STR_USE_VSYNC_TIP                        ), // Use vsync
     MakeWidget        ({ 11, 191}, {280,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_MINIMISE_FULLSCREEN_ON_FOCUS_LOSS, STR_MINIMISE_FULLSCREEN_ON_FOCUS_LOSS_TIP), // Minimise fullscreen focus loss
     MakeWidget        ({ 11, 206}, {280,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_DISABLE_SCREENSAVER,               STR_DISABLE_SCREENSAVER_TIP              ), // Disable screensaver
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget window_options_rendering_widgets[] = {
@@ -273,7 +273,7 @@ static Widget window_options_rendering_widgets[] = {
     MakeWidget({10, FRAME_EFFECTS_START + 60}, {281, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_RENDER_WEATHER_EFFECTS,   STR_RENDER_WEATHER_EFFECTS_TIP  ), // Render weather effects
     MakeWidget({25, FRAME_EFFECTS_START + 75}, {266, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_DISABLE_LIGHTNING_EFFECT, STR_DISABLE_LIGHTNING_EFFECT_TIP), // Disable lightning effect
 #undef FRAME_EFFECTS_START
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget window_options_culture_widgets[] = {
@@ -296,7 +296,7 @@ static Widget window_options_culture_widgets[] = {
     MakeWidget({ 10, 128}, {145, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_DATE_FORMAT,        STR_DATE_FORMAT_TIP        ), // Date format
     MakeWidget({155, 128}, {145, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                     ),
     MakeWidget({288, 129}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,     STR_DATE_FORMAT_TIP        ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget window_options_audio_widgets[] = {
@@ -313,7 +313,7 @@ static Widget window_options_audio_widgets[] = {
     MakeWidget({155,  68}, {145, 13}, WindowWidgetType::Scroll,       WindowColour::Secondary, SCROLL_HORIZONTAL                             ), // Master volume
     MakeWidget({155,  83}, {145, 13}, WindowWidgetType::Scroll,       WindowColour::Secondary, SCROLL_HORIZONTAL                             ), // Sound effect volume
     MakeWidget({155,  98}, {145, 13}, WindowWidgetType::Scroll,       WindowColour::Secondary, SCROLL_HORIZONTAL                             ), // Music volume
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget window_options_controls_and_interface_widgets[] = {
@@ -344,7 +344,7 @@ static Widget window_options_controls_and_interface_widgets[] = {
     MakeWidget({ 24, TOOLBAR_GROUP_START + 61}, {162, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_MUTE_BUTTON_ON_TOOLBAR,          STR_MUTE_BUTTON_ON_TOOLBAR_TIP         ), // Mute
     MakeWidget({155, TOOLBAR_GROUP_START + 61}, {145, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_CHAT_BUTTON_ON_TOOLBAR,          STR_CHAT_BUTTON_ON_TOOLBAR_TIP         ), // Chat
     MakeWidget({ 24, TOOLBAR_GROUP_START + 76}, {122, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_ZOOM_BUTTON_ON_TOOLBAR,          STR_ZOOM_BUTTON_ON_TOOLBAR_TIP         ), // Zoom
-    WIDGETS_END,
+    kWidgetsEnd,
 #undef TOOLBAR_GROUP_START
 };
 
@@ -374,7 +374,7 @@ static Widget window_options_misc_widgets[] = {
     MakeWidget({ 10, TWEAKS_START + 62}, {165, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_DEFAULT_INSPECTION_INTERVAL, STR_DEFAULT_INSPECTION_INTERVAL_TIP),
     MakeWidget({175, TWEAKS_START + 61}, {125, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                                      ), // Default inspection time dropdown
     MakeWidget({288, TWEAKS_START + 62}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,       STR_DEFAULT_INSPECTION_INTERVAL_TIP       ), // Default inspection time dropdown button
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 #undef TWEAKS_START
@@ -397,7 +397,7 @@ static Widget window_options_advanced_widgets[] = {
     MakeWidget        ({ 24, 184}, {266, 14}, WindowWidgetType::Button,       WindowColour::Secondary, STR_NONE,                                  STR_STRING_TOOLTIP                           ), // RCT 1 path button
     MakeWidget        ({289, 184}, { 11, 14}, WindowWidgetType::Button,       WindowColour::Secondary, STR_CLOSE_X,                               STR_PATH_TO_RCT1_CLEAR_TIP                   ), // RCT 1 path clear button
     MakeWidget        ({ 24, 200}, {140, 14}, WindowWidgetType::Button,       WindowColour::Secondary, STR_ASSET_PACKS,                           STR_NONE                                     ), // Asset packs
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget *window_options_page_widgets[] = {

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -105,40 +105,40 @@ static Widget _entranceWidgets[] = {
     MakeWidget({205, 121}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_RENAME),                 STR_NAME_PARK_TIP                       ), // rename
     MakeWidget({210,  51}, { 14,  15}, WindowWidgetType::ImgBtn,        WindowColour::Secondary, ImageId(SPR_G2_RCT1_CLOSE_BUTTON_0), STR_CLOSE_PARK_TIP                      ),
     MakeWidget({210,  66}, { 14,  14}, WindowWidgetType::ImgBtn,        WindowColour::Secondary, ImageId(SPR_G2_RCT1_OPEN_BUTTON_0),  STR_OPEN_PARK_TIP                       ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget _ratingWidgets[] = {
     MAIN_PARK_WIDGETS(255),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget _guestsWidgets[] = {
     MAIN_PARK_WIDGETS(255),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget _priceWidgets[] = {
     MAIN_PARK_WIDGETS(230),
     MakeWidget        ({ 21, 50}, {126, 14}, WindowWidgetType::Label,   WindowColour::Secondary, STR_ADMISSION_PRICE),
     MakeSpinnerWidgets({147, 50}, { 76, 14}, WindowWidgetType::Spinner, WindowColour::Secondary                     ), // Price (3 widgets)
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget _statsWidgets[] = {
     MAIN_PARK_WIDGETS(230),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget _objectiveWidgets[] = {
     MAIN_PARK_WIDGETS(230),
     MakeWidget({7, 207}, {216, 14}, WindowWidgetType::Button, WindowColour::Secondary, STR_ENTER_NAME_INTO_SCENARIO_CHART), // enter name
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget _awardsWidgets[] = {
     MAIN_PARK_WIDGETS(230),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static std::array<Widget*, WINDOW_PARK_PAGE_COUNT> _pagedWidgets = {

--- a/src/openrct2-ui/windows/PatrolArea.cpp
+++ b/src/openrct2-ui/windows/PatrolArea.cpp
@@ -45,7 +45,7 @@ static Widget PatrolAreaWidgets[] = {
     MakeWidget     ({27, 17}, {44, 32}, WindowWidgetType::ImgBtn,  WindowColour::Primary , ImageId(SPR_LAND_TOOL_SIZE_0)                                           ), // preview box
     MakeRemapWidget({28, 18}, {16, 16}, WindowWidgetType::TrnBtn,  WindowColour::Tertiary, SPR_LAND_TOOL_DECREASE,      STR_ADJUST_SMALLER_PATROL_AREA_TIP), // decrement size
     MakeRemapWidget({54, 32}, {16, 16}, WindowWidgetType::TrnBtn,  WindowColour::Tertiary, SPR_LAND_TOOL_INCREASE,      STR_ADJUST_LARGER_PATROL_AREA_TIP ), // increment size
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -59,12 +59,12 @@ static Widget window_player_overview_widgets[] = {
     MakeWidget({179, 45}, { 12, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_LOCATE),         STR_LOCATE_PLAYER_TIP), // Locate button
     MakeWidget({179, 69}, { 12, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_DEMOLISH),       STR_KICK_PLAYER_TIP  ), // Kick button
     MakeWidget({  3, 60}, {175, 61}, WindowWidgetType::Viewport, WindowColour::Secondary                                           ), // Viewport
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget window_player_statistics_widgets[] = {
     WINDOW_PLAYER_COMMON_WIDGETS,
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget *window_player_page_widgets[] = {

--- a/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
@@ -38,7 +38,7 @@ static Widget window_ride_refurbish_widgets[] =
     WINDOW_SHIM_WHITE(STR_REFURBISH_RIDE, WW, WH),
     MakeWidget({ 10, WH - 22 }, { 85, 14 }, WindowWidgetType::Button, WindowColour::Primary, STR_REFURBISH),
     MakeWidget({ WW - 95, WH - 22 }, { 85, 14 }, WindowWidgetType::Button, WindowColour::Primary, STR_SAVE_PROMPT_CANCEL),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -73,7 +73,7 @@ static Widget window_research_development_widgets[] = {
     MakeWidget({  3,  47}, {WW_DEVELOPMENT - 10,  70}, WindowWidgetType::Groupbox, WindowColour::Tertiary , STR_CURRENTLY_IN_DEVELOPMENT                                  ),
     MakeWidget({  3, 124}, {WW_DEVELOPMENT - 10,  65}, WindowWidgetType::Groupbox, WindowColour::Tertiary , STR_LAST_DEVELOPMENT                                          ),
     MakeWidget({265, 161}, {                 24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Tertiary , 0xFFFFFFFF,                   STR_RESEARCH_SHOW_DETAILS_TIP   ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget window_research_funding_widgets[] = {
@@ -92,7 +92,7 @@ static Widget window_research_funding_widgets[] = {
     MakeWidget({  8, 160}, {WW_FUNDING - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_RESEARCH_NEW_WATER_RIDES,         STR_RESEARCH_NEW_WATER_RIDES_TIP            ),
     MakeWidget({  8, 173}, {WW_FUNDING - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_RESEARCH_NEW_SHOPS_AND_STALLS,    STR_RESEARCH_NEW_SHOPS_AND_STALLS_TIP       ),
     MakeWidget({  8, 186}, {WW_FUNDING - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_RESEARCH_NEW_SCENERY_AND_THEMING, STR_RESEARCH_NEW_SCENERY_AND_THEMING_TIP    ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget *window_research_page_widgets[] = {

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -257,7 +257,7 @@ static Widget _mainWidgets[] = {
     MakeWidget({296,  76}, { 14,  14}, WindowWidgetType::ImgBtn,        WindowColour::Secondary, ImageId(SPR_G2_RCT1_OPEN_BUTTON_0),  STR_OPEN_RIDE_TIP          ),
     MakeWidget({  3, 180}, {305,  12}, WindowWidgetType::DropdownMenu,      WindowColour::Secondary, STR_ARG_6_STRINGID                                     ),
     MakeWidget({297, 180}, { 11,  12}, WindowWidgetType::Button,        WindowColour::Secondary, STR_DROPDOWN_GLYPH                                     ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // 0x009ADDA8
@@ -269,7 +269,7 @@ static Widget _vehicleWidgets[] = {
     MakeWidget        ({  7, 154}, {302, 43}, WindowWidgetType::Scroll,   WindowColour::Secondary, STR_EMPTY                                         ),
     MakeSpinnerWidgets({  7, 203}, {145, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_RIDE_VEHICLE_COUNT, STR_MAX_VEHICLES_TIP      ),
     MakeSpinnerWidgets({164, 203}, {145, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_1_CAR_PER_TRAIN,    STR_MAX_CARS_PER_TRAIN_TIP),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // 0x009ADEFC
@@ -292,7 +292,7 @@ static Widget _operatingWidgets[] = {
     MakeWidget        ({297, 110}, { 11, 10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH                                                                  ),
     MakeWidget        ({ 21,  89}, {129, 12}, WindowWidgetType::Label,    WindowColour::Secondary, STR_NUMBER_OF_CIRCUITS,                 STR_NUMBER_OF_CIRCUITS_TIP                  ),
     MakeSpinnerWidgets({157,  89}, {152, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_NUMBER_OF_CIRCUITS_VALUE                                                        ), // NB: 3 widgets
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // 0x009AE190
@@ -303,7 +303,7 @@ static Widget _maintenanceWidgets[] = {
     MakeWidget({289, 108}, { 24, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, 0xFFFFFFFF,         STR_LOCATE_NEAREST_AVAILABLE_MECHANIC_TIP             ),
     MakeWidget({265, 108}, { 24, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION),   STR_REFURBISH_RIDE_TIP                                ),
     MakeWidget({241, 108}, { 24, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_NO_ENTRY),       STR_DEBUG_FORCE_BREAKDOWN_TIP                         ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // 0x009AE2A4
@@ -330,7 +330,7 @@ static Widget _colourWidgets[] = {
     MakeWidget({ 99, 190}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_ADDITIONAL_COLOUR_1_TIP           ),
     MakeWidget({119, 190}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_ADDITIONAL_COLOUR_2_TIP           ),
     MakeWidget({100,  74}, {239, 12}, WindowWidgetType::Checkbox,  WindowColour::Secondary, STR_RANDOM_COLOUR                                                 ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // 0x009AE4C8
@@ -339,7 +339,7 @@ static Widget _musicWidgets[] = {
     MakeWidget({  7, 47}, {302, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_PLAY_MUSIC,     STR_SELECT_MUSIC_TIP      ),
     MakeWidget({  7, 62}, {302, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_EMPTY                                     ),
     MakeWidget({297, 63}, { 11, 10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH, STR_SELECT_MUSIC_STYLE_TIP),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // 0x009AE5DC
@@ -350,7 +350,7 @@ static Widget _measurementWidgets[] = {
     MakeWidget({158, 127}, {154, 14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_RESET_SELECTION                             ),
     MakeWidget({  4, 177}, {154, 14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_DESIGN_SAVE                                 ),
     MakeWidget({158, 177}, {154, 14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_DESIGN_CANCEL                               ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // 0x009AE710
@@ -361,7 +361,7 @@ static Widget _graphsWidgets[] = {
     MakeWidget({ 76, 163}, { 73,  14}, WindowWidgetType::Button, WindowColour::Secondary, STR_RIDE_STATS_ALTITUDE, STR_SHOW_GRAPH_OF_ALTITUDE_AGAINST_TIME_TIP             ),
     MakeWidget({149, 163}, { 73,  14}, WindowWidgetType::Button, WindowColour::Secondary, STR_RIDE_STATS_VERT_G,   STR_SHOW_GRAPH_OF_VERTICAL_ACCELERATION_AGAINST_TIME_TIP),
     MakeWidget({222, 163}, { 73,  14}, WindowWidgetType::Button, WindowColour::Secondary, STR_RIDE_STATS_LAT_G,    STR_SHOW_GRAPH_OF_LATERAL_ACCELERATION_AGAINST_TIME_TIP ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // 0x009AE844
@@ -373,7 +373,7 @@ static Widget _incomeWidgets[] = {
     MakeWidget        ({ 19,  94}, {126, 14}, WindowWidgetType::Label,    WindowColour::Secondary                                                                    ),
     MakeSpinnerWidgets({147,  94}, {162, 14}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_RIDE_SECONDARY_PRICE_VALUE                                    ), // NB: 3 widgets
     MakeWidget        ({  5, 106}, {306, 13}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_SAME_PRICE_THROUGHOUT_PARK, STR_SAME_PRICE_THROUGHOUT_PARK_TIP),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // 0x009AE9C8
@@ -382,7 +382,7 @@ static Widget _customerWidgets[] = {
     MakeWidget({289,  54}, {24, 24}, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_SHOW_GUESTS_THOUGHTS_ABOUT_THIS_RIDE_ATTRACTION), STR_SHOW_GUESTS_THOUGHTS_ABOUT_THIS_RIDE_ATTRACTION_TIP),
     MakeWidget({289,  78}, {24, 24}, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_SHOW_GUESTS_ON_THIS_RIDE_ATTRACTION),             STR_SHOW_GUESTS_ON_THIS_RIDE_ATTRACTION_TIP            ),
     MakeWidget({289, 102}, {24, 24}, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_SHOW_GUESTS_QUEUING_FOR_THIS_RIDE_ATTRACTION),    STR_SHOW_GUESTS_QUEUING_FOR_THIS_RIDE_ATTRACTION_TIP   ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static const std::array PageWidgets = {
@@ -3631,9 +3631,9 @@ private:
     void MaintenanceDrawBar(DrawPixelInfo& dpi, const ScreenCoordsXY& coords, int32_t value, int32_t colour) const
     {
         GfxFillRectInset(dpi, { coords, coords + ScreenCoordsXY{ 149, 8 } }, colours[1], INSET_RECT_F_30);
-        if (colour & BAR_BLINK)
+        if (colour & kBarBlink)
         {
-            colour &= ~BAR_BLINK;
+            colour &= ~kBarBlink;
             if (GameIsNotPaused() && (gCurrentRealTimeTicks & 8))
                 return;
         }

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -151,7 +151,7 @@ static Widget _rideConstructionWidgets[] = {
     MakeWidget        ({118, 120}, {     89,  41}, WindowWidgetType::Groupbox, WindowColour::Primary  , STR_RIDE_CONSTRUCTION_SEAT_ROT                                                                        ),
     MakeSpinnerWidgets({123, 138}, {     58,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary, 0,                                                STR_RIDE_CONSTRUCTION_SELECT_SEAT_ROTATION_ANGLE_TIP),
     MakeWidget        ({161, 338}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_G2_SIMULATE),                         STR_SIMULATE_RIDE_TIP                               ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -77,7 +77,7 @@ static Widget _rideListWidgets[] = {
     MakeWidget({320, 62}, { 14,  14}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, ImageId(SPR_G2_RCT1_CLOSE_BUTTON_0)                                    ),
     MakeWidget({320, 76}, { 14,  14}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, ImageId(SPR_G2_RCT1_OPEN_BUTTON_0)                                     ),
     MakeWidget({315, 90}, { 24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_DEMOLISH),               STR_QUICK_DEMOLISH_RIDE           ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/SavePrompt.cpp
+++ b/src/openrct2-ui/windows/SavePrompt.cpp
@@ -45,7 +45,7 @@ static Widget _savePromptWidgets[] = {
     MakeWidget({  8, 35}, { 78, 14}, WindowWidgetType::Button,        WindowColour::Primary, STR_SAVE_PROMPT_SAVE     ), // save
     MakeWidget({ 91, 35}, { 78, 14}, WindowWidgetType::Button,        WindowColour::Primary, STR_SAVE_PROMPT_DONT_SAVE), // don't save
     MakeWidget({174, 35}, { 78, 14}, WindowWidgetType::Button,        WindowColour::Primary, STR_SAVE_PROMPT_CANCEL   ), // cancel
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 enum WindowQuitPromptWidgetIdx {
@@ -60,7 +60,7 @@ static Widget _quitPromptWidgets[] = {
     WINDOW_SHIM_WHITE(STR_QUIT_GAME_PROMPT_TITLE, WW_QUIT, WH_QUIT),
     MakeWidget({ 8, 19}, {78, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_OK    ), // ok
     MakeWidget({91, 19}, {78, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_CANCEL), // cancel
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static constexpr StringId window_save_prompt_labels[][2] = {

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -104,7 +104,7 @@ static Widget _scenarioSelectWidgets[] = {
     MakeRemapWidget({ 3, TabsStart + (TabHeight * 8) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 09
     MakeRemapWidget({ 3, TabsStart + (TabHeight * 8) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 10
     MakeWidget({ TabWidth + 3, WidgetsStart + 1 }, { WW - SidebarWidth, 362 }, WindowWidgetType::Scroll, WindowColour::Secondary, SCROLL_VERTICAL), // level list
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -94,7 +94,7 @@ static Widget WindowSceneryBaseWidgets[] = {
     MakeWidget     ({  4,  46}, {211, 14}, WindowWidgetType::TextBox,   WindowColour::Secondary                          ),
     MakeWidget     ({218,  46}, { 70, 14}, WindowWidgetType::Button,    WindowColour::Secondary, STR_OBJECT_SEARCH_CLEAR ),
     MakeWidget     ({539,  46}, { 70, 14}, WindowWidgetType::Button,    WindowColour::Secondary, STR_RESTRICT_SCENERY,   STR_RESTRICT_SCENERY_TIP ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 
@@ -1009,7 +1009,7 @@ private:
     int32_t GetNumColumns() const
     {
         const auto& listWidget = widgets[WIDX_SCENERY_LIST];
-        const auto contentWidth = listWidget.width() - SCROLLBAR_WIDTH;
+        const auto contentWidth = listWidget.width() - kScrollBarWidth;
         return contentWidth / SCENERY_BUTTON_WIDTH;
     }
 

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -48,7 +48,7 @@ static Widget _sceneryScatterWidgets[] = {
     MakeRemapWidget({ 7, 68}, {24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, SPR_G2_SCENERY_SCATTER_LOW,    STR_SCATTER_TOOL_DENSITY_LOW   ), // low amount
     MakeRemapWidget({31, 68}, {24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, SPR_G2_SCENERY_SCATTER_MEDIUM, STR_SCATTER_TOOL_DENSITY_MEDIUM), // medium amount
     MakeRemapWidget({55, 68}, {24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, SPR_G2_SCENERY_SCATTER_HIGH,   STR_SCATTER_TOOL_DENSITY_HIGH  ), // high amount
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -69,7 +69,7 @@ static Widget _serverListWidgets[] = {
     MakeWidget({  6, 53}, {101,  14}, WindowWidgetType::Button,   WindowColour::Secondary, STR_FETCH_SERVERS                      ), // fetch servers button
     MakeWidget({112, 53}, {101,  14}, WindowWidgetType::Button,   WindowColour::Secondary, STR_ADD_SERVER                         ), // add server button
     MakeWidget({218, 53}, {101,  14}, WindowWidgetType::Button,   WindowColour::Secondary, STR_START_SERVER                       ), // start server button
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 
@@ -252,7 +252,7 @@ public:
         }
         else
         {
-            const int32_t iconX = listWidget.width() - SCROLLBAR_WIDTH - 7 - 10;
+            const int32_t iconX = listWidget.width() - kScrollBarWidth - 7 - 10;
             showNetworkVersionTooltip = screenCoords.x > iconX;
         }
 
@@ -376,7 +376,7 @@ public:
             const int16_t numPlayersStringWidth = GfxGetStringWidth(players, FontStyle::Medium);
 
             // How much space we have for the server info depends on the size of everything rendered after.
-            const int16_t spaceAvailableForInfo = listWidgetWidth - numPlayersStringWidth - SCROLLBAR_WIDTH - 35;
+            const int16_t spaceAvailableForInfo = listWidgetWidth - numPlayersStringWidth - kScrollBarWidth - 35;
 
             // Are we showing the server's name or description?
             const char* serverInfoToShow = serverDetails.Name.c_str();
@@ -390,7 +390,7 @@ public:
             ft.Add<const char*>(serverInfoToShow);
             DrawTextEllipsised(dpi, screenCoords + ScreenCoordsXY{ 0, 3 }, spaceAvailableForInfo, STR_STRING, ft, { colour });
 
-            int32_t right = listWidgetWidth - 7 - SCROLLBAR_WIDTH;
+            int32_t right = listWidgetWidth - 7 - kScrollBarWidth;
 
             // Draw compatibility icon
             right -= 10;

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -58,7 +58,7 @@ static Widget _windowServerStartWidgets[] = {
     MakeWidget({ 6, 117 }, { 287, 14 }, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_ADVERTISE,STR_ADVERTISE_SERVER_TIP), // advertise checkbox
     MakeWidget({ 6, WH - 6 - 13 }, { 101, 14 }, WindowWidgetType::Button, WindowColour::Secondary,STR_NEW_GAME), // start server button
     MakeWidget({ 112, WH - 6 - 13 }, { 101, 14 }, WindowWidgetType::Button, WindowColour::Secondary, STR_LOAD_GAME), // None
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 class ServerStartWindow final : public Window

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -45,7 +45,7 @@ static Widget _shortcutWidgets[] = {
     MakeWidget({0,    43}, {350, 287}, WindowWidgetType::Resize, WindowColour::Secondary),
     MakeWidget({4,    47}, {412, 215}, WindowWidgetType::Scroll, WindowColour::Primary, SCROLL_VERTICAL,           STR_SHORTCUT_LIST_TIP        ),
     MakeWidget({4, WH-15}, {150,  12}, WindowWidgetType::Button, WindowColour::Primary, STR_SHORTCUT_ACTION_RESET, STR_SHORTCUT_ACTION_RESET_TIP),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 
@@ -62,7 +62,7 @@ enum
 static Widget window_shortcut_change_widgets[] = {
     WINDOW_SHIM(CHANGE_WINDOW_TITLE, CHANGE_WW, CHANGE_WH),
     MakeWidget({ 75, 56 }, { 100, 14 }, WindowWidgetType::Button, WindowColour::Primary, STR_SHORTCUT_REMOVE, STR_SHORTCUT_REMOVE_TIP),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 
@@ -310,7 +310,7 @@ public:
 
         // TODO: the line below is a workaround for what is presumably a bug with dpi->width
         //       see https://github.com/OpenRCT2/OpenRCT2/issues/11238 for details
-        const auto scrollWidth = width - SCROLLBAR_WIDTH - 10;
+        const auto scrollWidth = width - kScrollBarWidth - 10;
 
         for (size_t i = 0; i < _list.size(); ++i)
         {
@@ -457,7 +457,7 @@ private:
             x += 31;
         }
 
-        _widgets.push_back(WIDGETS_END);
+        _widgets.push_back(kWidgetsEnd);
         widgets = _widgets.data();
 
         WindowInitScrollWidgets(*this);
@@ -584,7 +584,7 @@ static Widget WindowResetShortcutKeysPromptWidgets[] = {
     MakeWidget(
         { RESET_PROMPT_WW - 95, RESET_PROMPT_WH - 22 }, { 85, 14 }, WindowWidgetType::Button, WindowColour::Primary,
         STR_SAVE_PROMPT_CANCEL),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 class ResetShortcutKeysPrompt final : public Window

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -51,7 +51,7 @@ static Widget _signWidgets[] = {
     MakeWidget({WW - 25,      67}, {24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_DEMOLISH), STR_DEMOLISH_SIGN_TIP          ), // demolish button
     MakeWidget({      5, WH - 16}, {12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,   STR_SELECT_MAIN_SIGN_COLOUR_TIP), // Main colour
     MakeWidget({     17, WH - 16}, {12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,   STR_SELECT_TEXT_COLOUR_TIP     ), // Text colour
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // clang-format on

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -96,7 +96,7 @@ static Widget _staffOverviewWidgets[] = {
     MakeWidget     ({WW - 25,      93}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_RENAME),     STR_NAME_STAFF_TIP    ), // Rename Button
     MakeWidget     ({WW - 25,     117}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_LOCATE),     STR_LOCATE_SUBJECT_TIP), // Locate Button
     MakeWidget     ({WW - 25,     141}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_DEMOLISH),   STR_FIRE_STAFF_TIP    ), // Fire Button
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 //0x9AF910
@@ -108,14 +108,14 @@ static Widget _staffOptionsWidgets[] = {
     MakeWidget     ({      5, 101}, {180,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary                                            ), // Checkbox 4
     MakeWidget     ({      5,  50}, {180,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                            ), // Costume Dropdown
     MakeWidget     ({WW - 17,  51}, { 11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH, STR_SELECT_COSTUME_TIP), // Costume Dropdown Button
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 
 // 0x9AF9F4
 static Widget _staffStatsWidgets[] = {
     MAIN_STAFF_WIDGETS,
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget* window_staff_page_widgets[] = {
@@ -1041,7 +1041,7 @@ private:
             return;
         }
 
-        for (WidgetIndex widgetIndex = WIDX_TAB_1; widgets[widgetIndex].type != WIDGETS_END.type; widgetIndex++)
+        for (WidgetIndex widgetIndex = WIDX_TAB_1; widgets[widgetIndex].type != kWidgetsEnd.type; widgetIndex++)
         {
             SetWidgetDisabled(widgetIndex, false);
         }

--- a/src/openrct2-ui/windows/StaffFirePrompt.cpp
+++ b/src/openrct2-ui/windows/StaffFirePrompt.cpp
@@ -36,7 +36,7 @@ static Widget _staffFireWidgets[] = {
     WINDOW_SHIM_WHITE(WINDOW_TITLE, WW, WH),
     MakeWidget({     10, WH - 20}, {85, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_YES               ),
     MakeWidget({WW - 95, WH - 20}, {85, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_SAVE_PROMPT_CANCEL),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // clang-format on

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -84,7 +84,7 @@ static Widget _staffListWidgets[] = {
     MakeWidget({243, 46}, {    24,      24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_DEMOLISH),    STR_QUICK_FIRE_STAFF          ), // quick fire staff
     MakeWidget({267, 46}, {    24,      24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_PATROL_BTN),  STR_SHOW_PATROL_AREA_TIP      ), // show staff patrol area tool
     MakeWidget({291, 46}, {    24,      24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_MAP),         STR_SHOW_STAFF_ON_MAP_TIP     ), // show staff on map button
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -37,7 +37,7 @@ static Widget _textInputWidgets[] = {
     WINDOW_SHIM(STR_NONE, WW, WH),
     MakeWidget({ 170, 68 }, { 71, 14 }, WindowWidgetType::Button, WindowColour::Secondary, STR_CANCEL),
     MakeWidget({ 10, 68 }, { 71, 14 }, WindowWidgetType::Button, WindowColour::Secondary, STR_OK),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 class TextInputWindow final : public Window

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -96,7 +96,7 @@ static Widget _themesWidgets[] = {
     MakeWidget({ 10, 69}, {290,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_THEMES_OPTION_RCT1_PARK_CONTROLS                                               ), // rct1 park lights
     MakeWidget({ 10, 84}, {290,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_THEMES_OPTION_RCT1_SCENARIO_SELECTION_FONT                                     ), // rct1 scenario font
     MakeWidget({ 10, 99}, {290,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_THEMES_OPTION_RCT1_BOTTOM_TOOLBAR                                              ), // rct1 bottom toolbar
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 #pragma region Tabs

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -271,7 +271,7 @@ constexpr ScreenCoordsXY CheckboxGroupOffset(
 
 static Widget DefaultWidgets[] = {
     MAIN_TILE_INSPECTOR_WIDGETS,
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 constexpr int32_t NumSurfaceProperties = 4;
@@ -288,7 +288,7 @@ static Widget SurfaceWidgets[] = {
     MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 3, 1), 1, 2), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SURFACE_CHECK_CORNER_S
     MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 3, 1), 0, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SURFACE_CHECK_CORNER_W
     MakeWidget(PropertyRowCol({ 12, 0 }, 4, 0), PropertyFullWidth, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_TILE_INSPECTOR_SURFACE_DIAGONAL), // WIDX_SURFACE_CHECK_DIAGONAL
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 constexpr int32_t NumPathProperties = 6;
@@ -309,7 +309,7 @@ static Widget PathWidgets[] = {
     MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 0, 2), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_PATH_CHECK_EDGE_W
     MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 1, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_PATH_CHECK_EDGE_NW
     MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 2, 0), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_PATH_CHECK_EDGE_N
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 constexpr int32_t NumTrackProperties = 5;
@@ -323,7 +323,7 @@ static Widget TrackWidgets[] = {
     MakeWidget(PropertyRowCol({ 12, 0}, 2, 0), PropertyFullWidth, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_TILE_INSPECTOR_TRACK_CHAIN_LIFT), // WIDX_TRACK_CHECK_CHAIN_LIFT
     MakeWidget(PropertyRowCol({ 12, 0}, 3, 0), PropertyFullWidth, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_TILE_INSPECTOR_TRACK_BRAKE_CLOSED), // WIDX_TRACK_CHECK_BRAKE_CLOSED
     MakeWidget(PropertyRowCol({ 12, 0}, 4, 0), PropertyFullWidth, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_TILE_INSPECTOR_TRACK_IS_INDESTRUCTIBLE), // WIDX_TRACK_CHECK_IS_INDESTRUCTIBLE
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 constexpr int32_t NumSceneryProperties = 4; // The checkbox groups both count for 2 rows
@@ -341,7 +341,7 @@ static Widget SceneryWidgets[] = {
     MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 2, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SCENERY_CHECK_COLLISION_E
     MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 1, 2), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SCENERY_CHECK_COLLISION_S
     MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 0, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SCENERY_CHECK_COLLISION_W
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 constexpr int32_t NumEntranceProperties = 2;
@@ -352,7 +352,7 @@ static Widget EntranceWidgets[] = {
     MAIN_TILE_INSPECTOR_WIDGETS,
     MakeSpinnerWidgets(PropertyRowCol({ 12, 0 }, 0, 1), PropertyButtonSize, WindowWidgetType::Spinner, WindowColour::Secondary), // WIDX_ENTRANCE_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
     MakeWidget(PropertyRowCol({ 12, 0 }, 1, 0),         PropertyButtonSize, WindowWidgetType::Button,  WindowColour::Secondary, STR_TILE_INSPECTOR_ENTRANCE_MAKE_USABLE, STR_TILE_INSPECTOR_ENTRANCE_MAKE_USABLE_TIP), // WIDX_ENTRANCE_BUTTON_MAKE_USABLE
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 constexpr int32_t NumWallProperties = 3;
@@ -365,7 +365,7 @@ static Widget WallWidgets[] = {
     MakeWidget(PropertyRowCol({ 12, 0 }, 1, 1),                         PropertyButtonSize, WindowWidgetType::DropdownMenu, WindowColour::Secondary), // WIDX_WALL_DROPDOWN_SLOPE
     MakeWidget(PropertyRowCol({ 12 + PropertyButtonSize.width - 12, 0 }, 1, 1), { 11,  12}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH), // WIDX_WALL_DROPDOWN_SLOPE_BUTTON
     MakeSpinnerWidgets(PropertyRowCol({ 12, 0 }, 2, 1),                 PropertyButtonSize, WindowWidgetType::Spinner,      WindowColour::Secondary), // WIDX_WALL_SPINNER_ANIMATION_FRAME{,_INCREASE,_DECREASE}
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 constexpr int32_t NumLargeSceneryProperties = 1;
@@ -375,7 +375,7 @@ constexpr int32_t LargeSceneryDetailsHeight = 20 + NumLargeSceneryDetails * 11;
 static Widget LargeSceneryWidgets[] = {
     MAIN_TILE_INSPECTOR_WIDGETS,
     MakeSpinnerWidgets(PropertyRowCol({ 12, 0 }, 0, 1), PropertyButtonSize, WindowWidgetType::Spinner, WindowColour::Secondary), // WIDX_LARGE_SCENERY_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 constexpr int32_t NumBannerProperties = 3;
@@ -390,7 +390,7 @@ static Widget BannerWidgets[] = {
     MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 1, 3), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_BANNER_CHECK_BLOCK_SW
     MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 1, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_BANNER_CHECK_BLOCK_NW
 
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget *PageWidgets[] = {

--- a/src/openrct2-ui/windows/TitleExit.cpp
+++ b/src/openrct2-ui/windows/TitleExit.cpp
@@ -22,7 +22,7 @@ enum WindowTitleExitWidgetIdx {
 
 static Widget _titleExitWidgets[] = {
     MakeWidget({0, 0}, {40, 64}, WindowWidgetType::ImgBtn, WindowColour::Tertiary, ImageId(SPR_MENU_EXIT), STR_EXIT),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/TitleLogo.cpp
+++ b/src/openrct2-ui/windows/TitleLogo.cpp
@@ -24,7 +24,7 @@ enum
 
 static Widget _titleLogoWidgets[] = {
     MakeWidget({ 0, 0 }, { WW + 1, WH + 1 }, WindowWidgetType::ImgBtn, WindowColour::Primary),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 class TitleLogoWindow final : public Window

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -51,7 +51,7 @@ static Widget _titleMenuWidgets[] = {
     MakeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WindowWidgetType::ImgBtn, WindowColour::Tertiary,  ImageId(SPR_G2_MENU_MULTIPLAYER), STR_SHOW_MULTIPLAYER_TIP),
     MakeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WindowWidgetType::ImgBtn, WindowColour::Tertiary,  ImageId(SPR_MENU_TOOLBOX),        STR_GAME_TOOLS_TIP),
     MakeWidget({0,                       0}, UpdateButtonDims, WindowWidgetType::Empty,  WindowColour::Secondary, STR_UPDATE_AVAILABLE),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/TitleOptions.cpp
+++ b/src/openrct2-ui/windows/TitleOptions.cpp
@@ -21,7 +21,7 @@ enum WindowTitleOptionsWidgetIdx {
 
 static Widget _windowTitleOptionsWidgets[] = {
     MakeWidget({0, 0}, {80, 15}, WindowWidgetType::Button, WindowColour::Tertiary, STR_OPTIONS, STR_OPTIONS_TIP),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -25,7 +25,7 @@ enum {
 
 static Widget _tooltipWidgets[] = {
     MakeWidget({0, 0}, {200, 32}, WindowWidgetType::ImgBtn, WindowColour::Primary),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // clang-format on

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -280,7 +280,7 @@ static Widget _topToolbarWidgets[] = {
     MakeRemapWidget({ 30, 0}, {30, TOP_TOOLBAR_HEIGHT + 1}, WindowWidgetType::TrnBtn, WindowColour::Primary   , SPR_G2_TOOLBAR_MULTIPLAYER, STR_SHOW_MULTIPLAYER_STATUS_TIP   ), // Network
     MakeRemapWidget({ 30, 0}, {30, TOP_TOOLBAR_HEIGHT + 1}, WindowWidgetType::TrnBtn, WindowColour::Primary   , SPR_TAB_TOOLBAR,            STR_TOOLBAR_CHAT_TIP              ), // Chat
     MakeWidget     ({  0, 0}, {10,                      1}, WindowWidgetType::Empty,  WindowColour::Primary                                                                   ), // Artificial widget separator
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -42,14 +42,14 @@ static Widget _trackManageWidgets[] = {
     WINDOW_SHIM(WINDOW_TITLE, WW, WH),
     MakeWidget({ 10, 24}, {110, 12}, WindowWidgetType::Button, WindowColour::Primary, STR_TRACK_MANAGE_RENAME),
     MakeWidget({130, 24}, {110, 12}, WindowWidgetType::Button, WindowColour::Primary, STR_TRACK_MANAGE_DELETE),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 static Widget _trackDeletePromptWidgets[] = {
     WINDOW_SHIM(STR_DELETE_FILE, WW_DELETE_PROMPT, WH_DELETE_PROMPT),
     MakeWidget({ 10, 54}, {110, 12}, WindowWidgetType::Button, WindowColour::Primary, STR_TRACK_MANAGE_DELETE),
     MakeWidget({130, 54}, {110, 12}, WindowWidgetType::Button, WindowColour::Primary, STR_CANCEL             ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 #pragma endregion

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -68,7 +68,7 @@ static Widget _trackPlaceWidgets[] = {
     MakeWidget({173,  59}, { 24, 24}, WindowWidgetType::FlatBtn, WindowColour::Primary, ImageId(SPR_MIRROR_ARROW),              STR_MIRROR_IMAGE_TIP                      ),
     MakeWidget({  4, 109}, {192, 12}, WindowWidgetType::Button,  WindowColour::Primary, STR_SELECT_A_DIFFERENT_DESIGN, STR_GO_BACK_TO_DESIGN_SELECTION_WINDOW_TIP),
     MakeWidget({  0,   0}, {  1,  1}, WindowWidgetType::Empty,   WindowColour::Primary),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // clang-format on

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -60,7 +60,7 @@ static Widget _trackListWidgets[] = {
     MakeWidget({224,  18}, {372, 219}, WindowWidgetType::FlatBtn,      WindowColour::Primary                                                                ),
     MakeWidget({572, 405}, { ROTATE_AND_SCENERY_BUTTON_SIZE, ROTATE_AND_SCENERY_BUTTON_SIZE}, WindowWidgetType::FlatBtn,      WindowColour::Primary  , ImageId(SPR_ROTATE_ARROW),        STR_ROTATE_90_TIP                  ),
     MakeWidget({572, 381}, { ROTATE_AND_SCENERY_BUTTON_SIZE, ROTATE_AND_SCENERY_BUTTON_SIZE}, WindowWidgetType::FlatBtn,      WindowColour::Primary  , ImageId(SPR_SCENERY),             STR_TOGGLE_SCENERY_TIP             ),
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // clang-format on

--- a/src/openrct2-ui/windows/Transparency.cpp
+++ b/src/openrct2-ui/windows/Transparency.cpp
@@ -85,7 +85,7 @@ static Widget _transparancyWidgets[] =
     MakeWidget({102, 42}, INVISIBLE_SIZE, WindowWidgetType::FlatBtn, WindowColour::Tertiary,  STR_NONE,                       STR_INVISIBLE_VEHICLES),
     MakeWidget({127, 42}, INVISIBLE_SIZE, WindowWidgetType::FlatBtn, WindowColour::Tertiary,  STR_NONE,                       STR_INVISIBLE_SUPPORTS),
 
-    { WIDGETS_END },
+    { kWidgetsEnd },
 };
 // clang-format on
 

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -58,7 +58,7 @@ static Widget _viewClippingWidgets[] = {
     MakeWidget        ({     11, 105}, {    158,  17}, WindowWidgetType::Button,   WindowColour::Primary, STR_VIEW_CLIPPING_SELECT_AREA                                               ), // selector
     MakeWidget        ({     11, 126}, {    158,  18}, WindowWidgetType::Button,   WindowColour::Primary, STR_VIEW_CLIPPING_CLEAR_SELECTION                                           ), // clear
 
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -50,7 +50,7 @@ static Widget _viewportWidgets[] =
     MakeWidget({WW - 25, 41}, VIEWPORT_BUTTON,   WindowWidgetType::FlatBtn,  WindowColour::Primary  , ImageId(SPR_G2_ZOOM_OUT), STR_ZOOM_OUT_TIP      ), // zoom out
     MakeWidget({WW - 25, 65}, VIEWPORT_BUTTON,   WindowWidgetType::FlatBtn,  WindowColour::Primary  , ImageId(SPR_LOCATE),      STR_LOCATE_SUBJECT_TIP), // locate
     MakeWidget({WW - 25, 89}, VIEWPORT_BUTTON,   WindowWidgetType::FlatBtn,  WindowColour::Primary  , ImageId(SPR_ROTATE_ARROW),STR_LOCATE_SUBJECT_TIP), // rotate
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 
 // clang-format on

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -39,7 +39,7 @@ static Widget _waterWidgets[] = {
     MakeWidget     ({16, 17}, {44, 32}, WindowWidgetType::ImgBtn, WindowColour::Primary , ImageId(SPR_LAND_TOOL_SIZE_0),   STR_NONE),                     // preview box
     MakeRemapWidget({17, 18}, {16, 16}, WindowWidgetType::TrnBtn, WindowColour::Tertiary, SPR_LAND_TOOL_DECREASE, STR_ADJUST_SMALLER_WATER_TIP), // decrement size
     MakeRemapWidget({43, 32}, {16, 16}, WindowWidgetType::TrnBtn, WindowColour::Tertiary, SPR_LAND_TOOL_INCREASE, STR_ADJUST_LARGER_WATER_TIP),  // increment size
-    WIDGETS_END,
+    kWidgetsEnd,
 };
 // clang-format on
 

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -78,7 +78,7 @@ static void ViewportPaintWeatherGloom(DrawPixelInfo& dpi);
 static void ViewportPaint(const Viewport* viewport, DrawPixelInfo& dpi, const ScreenRect& screenRect);
 static void ViewportUpdateFollowSprite(WindowBase* window);
 static void ViewportUpdateSmartFollowEntity(WindowBase* window);
-static void ViewportUpdateSmartFollowStaff(WindowBase* window, const Staff* peep);
+static void ViewportUpdateSmartFollowStaff(WindowBase* window, const Staff& peep);
 static void ViewportUpdateSmartFollowVehicle(WindowBase* window);
 static void ViewportInvalidate(const Viewport* viewport, const ScreenRect& screenRect);
 
@@ -759,13 +759,25 @@ void ViewportUpdateSmartFollowEntity(WindowBase* window)
             break;
 
         case EntityType::Guest:
-            ViewportUpdateSmartFollowGuest(window, entity->As<Guest>());
+        {
+            auto* guest = entity->As<Guest>();
+            if (guest == nullptr)
+            {
+                return;
+            }
+            ViewportUpdateSmartFollowGuest(window, *guest);
             break;
-
+        }
         case EntityType::Staff:
-            ViewportUpdateSmartFollowStaff(window, entity->As<Staff>());
+        {
+            auto* staff = entity->As<Staff>();
+            if (staff == nullptr)
+            {
+                return;
+            }
+            ViewportUpdateSmartFollowStaff(window, *staff);
             break;
-
+        }
         default: // All other types don't need any "smart" following; steam particle, duck, money effect, etc.
             window->focus = Focus(window->viewport_smart_follow_sprite);
             window->viewport_target_sprite = window->viewport_smart_follow_sprite;
@@ -773,12 +785,12 @@ void ViewportUpdateSmartFollowEntity(WindowBase* window)
     }
 }
 
-void ViewportUpdateSmartFollowGuest(WindowBase* window, const Guest* peep)
+void ViewportUpdateSmartFollowGuest(WindowBase* window, const Guest& peep)
 {
-    Focus focus = Focus(peep->Id);
-    window->viewport_target_sprite = peep->Id;
+    Focus focus = Focus(peep.Id);
+    window->viewport_target_sprite = peep.Id;
 
-    if (peep->State == PeepState::Picked)
+    if (peep.State == PeepState::Picked)
     {
         window->viewport_smart_follow_sprite = EntityId::GetNull();
         window->viewport_target_sprite = EntityId::GetNull();
@@ -787,16 +799,16 @@ void ViewportUpdateSmartFollowGuest(WindowBase* window, const Guest* peep)
     }
 
     bool overallFocus = true;
-    if (peep->State == PeepState::OnRide || peep->State == PeepState::EnteringRide
-        || (peep->State == PeepState::LeavingRide && peep->x == LOCATION_NULL))
+    if (peep.State == PeepState::OnRide || peep.State == PeepState::EnteringRide
+        || (peep.State == PeepState::LeavingRide && peep.x == LOCATION_NULL))
     {
-        auto ride = GetRide(peep->CurrentRide);
+        auto ride = GetRide(peep.CurrentRide);
         if (ride != nullptr && (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK))
         {
-            auto train = GetEntity<Vehicle>(ride->vehicles[peep->CurrentTrain]);
+            auto train = GetEntity<Vehicle>(ride->vehicles[peep.CurrentTrain]);
             if (train != nullptr)
             {
-                const auto car = train->GetCar(peep->CurrentCar);
+                const auto car = train->GetCar(peep.CurrentCar);
                 if (car != nullptr)
                 {
                     focus = Focus(car->Id);
@@ -807,9 +819,9 @@ void ViewportUpdateSmartFollowGuest(WindowBase* window, const Guest* peep)
         }
     }
 
-    if (peep->x == LOCATION_NULL && overallFocus)
+    if (peep.x == LOCATION_NULL && overallFocus)
     {
-        auto ride = GetRide(peep->CurrentRide);
+        auto ride = GetRide(peep.CurrentRide);
         if (ride != nullptr)
         {
             auto xy = ride->overall_view.ToTileCentre();
@@ -825,9 +837,9 @@ void ViewportUpdateSmartFollowGuest(WindowBase* window, const Guest* peep)
     window->focus = focus;
 }
 
-void ViewportUpdateSmartFollowStaff(WindowBase* window, const Staff* peep)
+void ViewportUpdateSmartFollowStaff(WindowBase* window, const Staff& peep)
 {
-    if (peep->State == PeepState::Picked)
+    if (peep.State == PeepState::Picked)
     {
         window->viewport_smart_follow_sprite = EntityId::GetNull();
         window->viewport_target_sprite = EntityId::GetNull();

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -76,6 +76,11 @@ InteractionInfo::InteractionInfo(const PaintStruct* ps)
 
 static void ViewportPaintWeatherGloom(DrawPixelInfo& dpi);
 static void ViewportPaint(const Viewport* viewport, DrawPixelInfo& dpi, const ScreenRect& screenRect);
+static void ViewportUpdateFollowSprite(WindowBase* window);
+static void ViewportUpdateSmartFollowEntity(WindowBase* window);
+static void ViewportUpdateSmartFollowStaff(WindowBase* window, const Staff* peep);
+static void ViewportUpdateSmartFollowVehicle(WindowBase* window);
+static void ViewportInvalidate(const Viewport* viewport, const ScreenRect& screenRect);
 
 /**
  * This is not a viewport function. It is used to setup many variables for
@@ -228,7 +233,7 @@ void ViewportRemove(Viewport* viewport)
     _viewports.erase(it);
 }
 
-Viewport* ViewportGetMain()
+static Viewport* ViewportGetMain()
 {
     auto mainWindow = WindowGetMain();
     if (mainWindow == nullptr)

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -136,7 +136,7 @@ void ViewportsInvalidate(int32_t x, int32_t y, int32_t z0, int32_t z1, ZoomLevel
 void ViewportsInvalidate(const CoordsXYZ& pos, int32_t width, int32_t minHeight, int32_t maxHeight, ZoomLevel maxZoom);
 void ViewportsInvalidate(const ScreenRect& screenRect, ZoomLevel maxZoom = ZoomLevel{ -1 });
 void ViewportUpdatePosition(WindowBase* window);
-void ViewportUpdateSmartFollowGuest(WindowBase* window, const Guest* peep);
+void ViewportUpdateSmartFollowGuest(WindowBase* window, const Guest& peep);
 void ViewportRotateSingle(WindowBase* window, int32_t direction);
 void ViewportRotateAll(int32_t direction);
 void ViewportRender(DrawPixelInfo& dpi, const Viewport* viewport, const ScreenRect& screenRect);

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -131,16 +131,12 @@ void ViewportInitAll();
 std::optional<ScreenCoordsXY> centre_2d_coordinates(const CoordsXYZ& loc, Viewport* viewport);
 void ViewportCreate(WindowBase* w, const ScreenCoordsXY& screenCoords, int32_t width, int32_t height, const Focus& focus);
 void ViewportRemove(Viewport* viewport);
-Viewport* ViewportGetMain();
+
 void ViewportsInvalidate(int32_t x, int32_t y, int32_t z0, int32_t z1, ZoomLevel maxZoom);
 void ViewportsInvalidate(const CoordsXYZ& pos, int32_t width, int32_t minHeight, int32_t maxHeight, ZoomLevel maxZoom);
 void ViewportsInvalidate(const ScreenRect& screenRect, ZoomLevel maxZoom = ZoomLevel{ -1 });
 void ViewportUpdatePosition(WindowBase* window);
-void ViewportUpdateFollowSprite(WindowBase* window);
-void ViewportUpdateSmartFollowEntity(WindowBase* window);
 void ViewportUpdateSmartFollowGuest(WindowBase* window, const Guest* peep);
-void ViewportUpdateSmartFollowStaff(WindowBase* window, const Staff* peep);
-void ViewportUpdateSmartFollowVehicle(WindowBase* window);
 void ViewportRotateSingle(WindowBase* window, int32_t direction);
 void ViewportRotateAll(int32_t direction);
 void ViewportRender(DrawPixelInfo& dpi, const Viewport* viewport, const ScreenRect& screenRect);
@@ -162,16 +158,12 @@ InteractionInfo GetMapCoordinatesFromPos(const ScreenCoordsXY& screenCoords, int
 InteractionInfo GetMapCoordinatesFromPosWindow(WindowBase* window, const ScreenCoordsXY& screenCoords, int32_t flags);
 
 InteractionInfo SetInteractionInfoFromPaintSession(PaintSession* session, uint32_t viewFlags, uint16_t filter);
-InteractionInfo ViewportInteractionGetItemLeft(const ScreenCoordsXY& screenCoords);
 bool ViewportInteractionLeftOver(const ScreenCoordsXY& screenCoords);
 bool ViewportInteractionLeftClick(const ScreenCoordsXY& screenCoords);
-InteractionInfo ViewportInteractionGetItemRight(const ScreenCoordsXY& screenCoords);
 bool ViewportInteractionRightOver(const ScreenCoordsXY& screenCoords);
 bool ViewportInteractionRightClick(const ScreenCoordsXY& screenCoords);
 
 CoordsXY ViewportInteractionGetTileStartAtCursor(const ScreenCoordsXY& screenCoords);
-
-void ViewportInvalidate(const Viewport* viewport, const ScreenRect& screenRect);
 
 std::optional<CoordsXY> ScreenGetMapXY(const ScreenCoordsXY& screenCoords, Viewport** viewport);
 std::optional<CoordsXY> ScreenGetMapXYWithZ(const ScreenCoordsXY& screenCoords, int32_t z);

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -9,8 +9,6 @@
 
 #pragma once
 
-#include "../drawing/Drawing.h"
-#include "../localisation/StringIds.h"
 #include "Window.h"
 
 enum class WindowWidgetType : uint8_t
@@ -41,9 +39,6 @@ enum class WindowWidgetType : uint8_t
     Last = 26,
 };
 
-constexpr auto WIDGETS_END = Widget{ WindowWidgetType::Last, 0, 0, 0, 0, 0, 0, 0 };
-#define BAR_BLINK (1u << 31)
-
 enum
 {
     SCROLL_HORIZONTAL = (1 << 0),
@@ -51,133 +46,4 @@ enum
     SCROLL_BOTH = SCROLL_HORIZONTAL | SCROLL_VERTICAL
 };
 
-enum class WindowColour : uint8_t
-{
-    Primary,
-    Secondary,
-    Tertiary,
-    Quaternary,
-};
-
-constexpr uint8_t SCROLLBAR_WIDTH = 10;
-
-constexpr ScreenSize TAB_SIZE = { 31, 27 };
-
-constexpr Widget MakeWidget(
-    const ScreenCoordsXY& origin, const ScreenSize& size, WindowWidgetType type, WindowColour colour,
-    uint32_t content = 0xFFFFFFFF, StringId tooltip = STR_NONE)
-{
-    Widget out = {};
-    out.left = origin.x;
-    out.right = origin.x + size.width - 1;
-    out.top = origin.y;
-    out.bottom = origin.y + size.height - 1;
-    out.type = type;
-    out.colour = static_cast<uint8_t>(colour);
-    out.content = content;
-    out.tooltip = tooltip;
-
-    return out;
-}
-
-constexpr Widget MakeWidget(
-    const ScreenCoordsXY& origin, const ScreenSize& size, WindowWidgetType type, WindowColour colour, ImageId image,
-    StringId tooltip = STR_NONE)
-{
-    Widget out = {};
-    out.left = origin.x;
-    out.right = origin.x + size.width - 1;
-    out.top = origin.y;
-    out.bottom = origin.y + size.height - 1;
-    out.type = type;
-    out.colour = static_cast<uint8_t>(colour);
-    out.image = image;
-    out.tooltip = tooltip;
-
-    return out;
-}
-
-constexpr Widget MakeRemapWidget(
-    const ScreenCoordsXY& origin, const ScreenSize& size, WindowWidgetType type, WindowColour colour, ImageIndex content,
-    StringId tooltip = STR_NONE)
-{
-    return MakeWidget(origin, size, type, colour, ImageId(content, FilterPaletteID::PaletteNull), tooltip);
-}
-
-constexpr Widget MakeTab(const ScreenCoordsXY& origin, StringId tooltip = STR_NONE)
-{
-    const ScreenSize size = TAB_SIZE;
-    const WindowWidgetType type = WindowWidgetType::Tab;
-    const WindowColour colour = WindowColour::Secondary;
-    const auto content = ImageId(ImageIndexUndefined);
-
-    return MakeWidget(origin, size, type, colour, content, tooltip);
-}
-
-#define MakeSpinnerWidgets(...)                                                                                                \
-    MakeWidget(__VA_ARGS__), MakeSpinnerIncreaseWidget(__VA_ARGS__), MakeSpinnerDecreaseWidget(__VA_ARGS__)
-
-constexpr Widget MakeSpinnerDecreaseWidget(
-    const ScreenCoordsXY& origin, const ScreenSize& size, [[maybe_unused]] WindowWidgetType type, WindowColour colour,
-    [[maybe_unused]] uint32_t content = 0xFFFFFFFF, StringId tooltip = STR_NONE)
-{
-    const int16_t xPos = origin.x + size.width - 26;
-    const int16_t yPos = origin.y + 1;
-    const uint16_t width = 13;
-    const uint16_t height = size.height - 2;
-
-    return MakeWidget({ xPos, yPos }, { width, height }, WindowWidgetType::Button, colour, STR_NUMERIC_DOWN, tooltip);
-}
-
-constexpr Widget MakeSpinnerIncreaseWidget(
-    const ScreenCoordsXY& origin, const ScreenSize& size, [[maybe_unused]] WindowWidgetType type, WindowColour colour,
-    [[maybe_unused]] uint32_t content = 0xFFFFFFFF, StringId tooltip = STR_NONE)
-{
-    const int16_t xPos = origin.x + size.width - 13;
-    const int16_t yPos = origin.y + 1;
-    const uint16_t width = 12;
-    const uint16_t height = size.height - 2;
-
-    return MakeWidget({ xPos, yPos }, { width, height }, WindowWidgetType::Button, colour, STR_NUMERIC_UP, tooltip);
-}
-
-#define MakeDropdownWidgets(...) MakeDropdownBoxWidget(__VA_ARGS__), MakeDropdownButtonWidget(__VA_ARGS__)
-
-constexpr Widget MakeDropdownBoxWidget(
-    const ScreenCoordsXY& origin, const ScreenSize& size, [[maybe_unused]] WindowWidgetType type, WindowColour colour,
-    [[maybe_unused]] uint32_t content = 0xFFFFFFFF, StringId tooltip = STR_NONE)
-{
-    return MakeWidget(origin, size, type, colour, content);
-}
-
-constexpr Widget MakeDropdownButtonWidget(
-    const ScreenCoordsXY& origin, const ScreenSize& size, [[maybe_unused]] WindowWidgetType type, WindowColour colour,
-    [[maybe_unused]] uint32_t content = 0xFFFFFFFF, StringId tooltip = STR_NONE)
-{
-    const int16_t xPos = origin.x + size.width - 11;
-    const int16_t yPos = origin.y + 1;
-    const uint16_t width = 11;
-    const uint16_t height = 10;
-
-    return MakeWidget({ xPos, yPos }, { width, height }, WindowWidgetType::Button, colour, STR_DROPDOWN_GLYPH, tooltip);
-}
-
 void WidgetScrollUpdateThumbs(WindowBase& w, WidgetIndex widget_index);
-void WidgetDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
-
-bool WidgetIsDisabled(const WindowBase& w, WidgetIndex widgetIndex);
-bool WidgetIsHoldable(const WindowBase& w, WidgetIndex widgetIndex);
-bool WidgetIsVisible(const WindowBase& w, WidgetIndex widgetIndex);
-bool WidgetIsPressed(const WindowBase& w, WidgetIndex widgetIndex);
-bool WidgetIsHighlighted(const WindowBase& w, WidgetIndex widgetIndex);
-bool WidgetIsActiveTool(const WindowBase& w, WidgetIndex widgetIndex);
-void WidgetScrollGetPart(
-    WindowBase& w, const Widget* widget, const ScreenCoordsXY& screenCoords, ScreenCoordsXY& retScreenCoords,
-    int32_t* output_scroll_area, int32_t* scroll_id);
-
-void WidgetSetEnabled(WindowBase& w, WidgetIndex widgetIndex, bool enabled);
-void WidgetSetDisabled(WindowBase& w, WidgetIndex widgetIndex, bool value);
-void WidgetSetHoldable(WindowBase& w, WidgetIndex widgetIndex, bool value);
-void WidgetSetVisible(WindowBase& w, WidgetIndex widgetIndex, bool value);
-void WidgetSetPressed(WindowBase& w, WidgetIndex widgetIndex, bool value);
-void WidgetSetCheckboxValue(WindowBase& w, WidgetIndex widgetIndex, bool value);


### PR DESCRIPTION
This is just a bit of moving things about. Most of the interface headers have large bits that should be in the libopenrct2-ui library rather than the libopenrct2 library. I noticed this whilst trying to put things in a OpenRCT2::Ui namespace (which will have to wait until more stuff is moved). Also noticed that we have a number of functions in headers that are just only used in one file.