### PR TITLE
Fix #21543: Game Crashing with invalid TrackIterator

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Improved: [#21424] Extra viewports can now rotate independently from the main viewport.
 - Fix: [#910] Extra viewport does not preserve the location when rotating.
+- Fix: [#21543] Crash with creating a TrackIterator with invalid arguments.
 
 0.4.9 (2024-03-02)
 ------------------------------------------------------------------------

--- a/src/openrct2/scripting/bindings/ride/ScTrackIterator.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScTrackIterator.cpp
@@ -23,6 +23,8 @@ using namespace OpenRCT2::TrackMetaData;
 std::shared_ptr<ScTrackIterator> ScTrackIterator::FromElement(const CoordsXY& position, int32_t elementIndex)
 {
     auto el = MapGetNthElementAt(position, elementIndex);
+    if (el == nullptr)
+        return nullptr;
     auto origin = GetTrackSegmentOrigin(CoordsXYE(position, el));
     if (!origin)
         return nullptr;


### PR DESCRIPTION
Check if el is a nullptr in ScTrackIterator::FromElement, for https://github.com/OpenRCT2/OpenRCT2/issues/21543