### PR TITLE
Close:13047 Track type normalising duplication in Game Actions

### DIFF
--- a/src/openrct2/actions/TrackRemoveAction.cpp
+++ b/src/openrct2/actions/TrackRemoveAction.cpp
@@ -43,6 +43,18 @@ uint16_t TrackRemoveAction::GetActionFlags() const
     return GameAction::GetActionFlags();
 }
 
+int32_t TrackRemoveAction::NormaliseTrackType(int32_t trackType) const
+{
+    switch (_trackType)
+    {
+        case TrackElemType::BeginStation:
+        case TrackElemType::MiddleStation:
+            return TrackElemType::EndStation;
+    }
+
+    return _trackType;
+}
+
 void TrackRemoveAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);
@@ -59,14 +71,7 @@ GameActions::Result TrackRemoveAction::Query() const
     res.Expenditure = ExpenditureType::RideConstruction;
 
     // Stations require some massaging of the track type for comparing
-    auto comparableTrackType = _trackType;
-    switch (_trackType)
-    {
-        case TrackElemType::BeginStation:
-        case TrackElemType::MiddleStation:
-            comparableTrackType = TrackElemType::EndStation;
-            break;
-    }
+    auto comparableTrackType = NormaliseTrackType(_trackType);
 
     bool found = false;
     bool isGhost = GetFlags() & GAME_COMMAND_FLAG_GHOST;
@@ -92,14 +97,7 @@ GameActions::Result TrackRemoveAction::Query() const
         if (tileElement->IsGhost() != isGhost)
             continue;
 
-        auto tileTrackType = tileElement->AsTrack()->GetTrackType();
-        switch (tileTrackType)
-        {
-            case TrackElemType::BeginStation:
-            case TrackElemType::MiddleStation:
-                tileTrackType = TrackElemType::EndStation;
-                break;
-        }
+        auto tileTrackType = NormaliseTrackType(tileElement->AsTrack()->GetTrackType());
 
         if (tileTrackType != comparableTrackType)
             continue;
@@ -260,14 +258,7 @@ GameActions::Result TrackRemoveAction::Execute() const
     res.Expenditure = ExpenditureType::RideConstruction;
 
     // Stations require some massaging of the track type for comparing
-    auto comparableTrackType = _trackType;
-    switch (_trackType)
-    {
-        case TrackElemType::BeginStation:
-        case TrackElemType::MiddleStation:
-            comparableTrackType = TrackElemType::EndStation;
-            break;
-    }
+    auto comparableTrackType = NormaliseTrackType(_trackType);
 
     bool found = false;
     bool isGhost = GetFlags() & GAME_COMMAND_FLAG_GHOST;
@@ -293,14 +284,7 @@ GameActions::Result TrackRemoveAction::Execute() const
         if (tileElement->IsGhost() != isGhost)
             continue;
 
-        auto tileTrackType = tileElement->AsTrack()->GetTrackType();
-        switch (tileTrackType)
-        {
-            case TrackElemType::BeginStation:
-            case TrackElemType::MiddleStation:
-                tileTrackType = TrackElemType::EndStation;
-                break;
-        }
+        auto tileTrackType = NormaliseTrackType(tileElement->AsTrack()->GetTrackType());
 
         if (tileTrackType != comparableTrackType)
             continue;

--- a/src/openrct2/actions/TrackRemoveAction.h
+++ b/src/openrct2/actions/TrackRemoveAction.h
@@ -26,6 +26,8 @@ public:
 
     uint16_t GetActionFlags() const override final;
 
+    int32_t NormaliseTrackType(int32_t trackType) const;
+
     void Serialise(DataSerialiser& stream) override;
     GameActions::Result Query() const override;
     GameActions::Result Execute() const override;


### PR DESCRIPTION
Refactored `TrackRemoveAction` class to remove duplicate code:
```
switch (_trackType)
{
    case TRACK_ELEM_BEGIN_STATION:
    case TRACK_ELEM_MIDDLE_STATION:
        comparableTrackType = TRACK_ELEM_END_STATION;
}
```