### PR TITLE
Move gWidePathTileLoopPosition and gGrassSceneryTileLoopPosition to GameState_t

### DIFF
--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -103,6 +103,8 @@ namespace OpenRCT2
 
         News::ItemQueues NewsItems;
 
+        TileCoordsXY WidePathTileLoopPosition;
+
         colour_t StaffHandymanColour;
         colour_t StaffMechanicColour;
         colour_t StaffSecurityColour;

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -103,6 +103,7 @@ namespace OpenRCT2
 
         News::ItemQueues NewsItems;
 
+        uint16_t GrassSceneryTileLoopPosition;
         TileCoordsXY WidePathTileLoopPosition;
 
         colour_t StaffHandymanColour;

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -104,7 +104,7 @@ namespace OpenRCT2
         News::ItemQueues NewsItems;
 
         uint16_t GrassSceneryTileLoopPosition;
-        TileCoordsXY WidePathTileLoopPosition;
+        CoordsXY WidePathTileLoopPosition;
 
         colour_t StaffHandymanColour;
         colour_t StaffMechanicColour;

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -549,7 +549,7 @@ namespace OpenRCT2
                     cs.ReadWrite(gameState.LandPrice);
                     cs.ReadWrite(gameState.ConstructionRightsPrice);
                 }
-                cs.ReadWrite(gGrassSceneryTileLoopPosition);
+                cs.ReadWrite(gameState.GrassSceneryTileLoopPosition);
                 cs.ReadWrite(gameState.WidePathTileLoopPosition);
 
                 auto& rideRatings = gameState.RideRatingUpdateStates;

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -550,7 +550,7 @@ namespace OpenRCT2
                     cs.ReadWrite(gameState.ConstructionRightsPrice);
                 }
                 cs.ReadWrite(gGrassSceneryTileLoopPosition);
-                cs.ReadWrite(gWidePathTileLoopPosition);
+                cs.ReadWrite(gameState.WidePathTileLoopPosition);
 
                 auto& rideRatings = gameState.RideRatingUpdateStates;
                 if (os.GetHeader().TargetVersion >= 21)

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -448,7 +448,7 @@ namespace RCT2
             ImportRideRatingsCalcData();
             ImportRideMeasurements();
             gameState.NextGuestNumber = _s6.NextGuestIndex;
-            gGrassSceneryTileLoopPosition = _s6.GrassAndSceneryTilepos;
+            gameState.GrassSceneryTileLoopPosition = _s6.GrassAndSceneryTilepos;
             // unk_13CA73E
             // Pad13CA73F
             // unk_13CA740

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -496,8 +496,7 @@ namespace RCT2
 
             // Pad13CE730
             // rct1_scenario_flags
-            gWidePathTileLoopPosition.x = _s6.WidePathTileLoopX;
-            gWidePathTileLoopPosition.y = _s6.WidePathTileLoopY;
+            gameState.WidePathTileLoopPosition = { _s6.WidePathTileLoopX, _s6.WidePathTileLoopY };
             // Pad13CE778
 
             // Fix and set dynamic variables

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -759,10 +759,10 @@ void MapUpdatePathWideFlags()
     // Presumably update_path_wide_flags is too computationally expensive to call for every
     // tile every update, so gWidePathTileLoopX and gWidePathTileLoopY store the x and y
     // progress. A maximum of 128 calls is done per update.
-    TileCoordsXY& loopPosition = GetGameState().WidePathTileLoopPosition;
+    CoordsXY& loopPosition = GetGameState().WidePathTileLoopPosition;
     for (int32_t i = 0; i < 128; i++)
     {
-        FootpathUpdatePathWideFlags(loopPosition.ToCoordsXY());
+        FootpathUpdatePathWideFlags(loopPosition);
 
         // Next x, y tile
         loopPosition.x += COORDS_XY_STEP;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -88,7 +88,6 @@ CoordsXY gMapSelectPositionB;
 CoordsXYZ gMapSelectArrowPosition;
 uint8_t gMapSelectArrowDirection;
 
-TileCoordsXY gWidePathTileLoopPosition;
 uint16_t gGrassSceneryTileLoopPosition;
 
 std::vector<CoordsXY> gMapSelectionTiles;
@@ -464,7 +463,7 @@ void MapInit(const TileCoordsXY& size)
     auto& gameState = GetGameState();
 
     gGrassSceneryTileLoopPosition = 0;
-    gWidePathTileLoopPosition = {};
+    gameState.WidePathTileLoopPosition = {};
     gameState.MapSize = size;
     MapRemoveOutOfRangeElements();
     MapAnimationAutoCreate();
@@ -762,26 +761,23 @@ void MapUpdatePathWideFlags()
     // Presumably update_path_wide_flags is too computationally expensive to call for every
     // tile every update, so gWidePathTileLoopX and gWidePathTileLoopY store the x and y
     // progress. A maximum of 128 calls is done per update.
-    auto x = gWidePathTileLoopPosition.x;
-    auto y = gWidePathTileLoopPosition.y;
+    TileCoordsXY& loopPosition = GetGameState().WidePathTileLoopPosition;
     for (int32_t i = 0; i < 128; i++)
     {
-        FootpathUpdatePathWideFlags({ x, y });
+        FootpathUpdatePathWideFlags(loopPosition.ToCoordsXY());
 
         // Next x, y tile
-        x += COORDS_XY_STEP;
-        if (x >= MAXIMUM_MAP_SIZE_BIG)
+        loopPosition.x += COORDS_XY_STEP;
+        if (loopPosition.x >= MAXIMUM_MAP_SIZE_BIG)
         {
-            x = 0;
-            y += COORDS_XY_STEP;
-            if (y >= MAXIMUM_MAP_SIZE_BIG)
+            loopPosition.x = 0;
+            loopPosition.y += COORDS_XY_STEP;
+            if (loopPosition.y >= MAXIMUM_MAP_SIZE_BIG)
             {
-                y = 0;
+                loopPosition.y = 0;
             }
         }
     }
-    gWidePathTileLoopPosition.x = x;
-    gWidePathTileLoopPosition.y = y;
 }
 
 /**

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -88,8 +88,6 @@ CoordsXY gMapSelectPositionB;
 CoordsXYZ gMapSelectArrowPosition;
 uint8_t gMapSelectArrowDirection;
 
-uint16_t gGrassSceneryTileLoopPosition;
-
 std::vector<CoordsXY> gMapSelectionTiles;
 std::vector<PeepSpawn> gPeepSpawns;
 
@@ -462,7 +460,7 @@ void MapInit(const TileCoordsXY& size)
 
     auto& gameState = GetGameState();
 
-    gGrassSceneryTileLoopPosition = 0;
+    gameState.GrassSceneryTileLoopPosition = 0;
     gameState.WidePathTileLoopPosition = {};
     gameState.MapSize = size;
     MapRemoveOutOfRangeElements();
@@ -1263,7 +1261,7 @@ void MapUpdateTiles()
         int32_t x = 0;
         int32_t y = 0;
 
-        uint16_t interleaved_xy = gGrassSceneryTileLoopPosition;
+        uint16_t interleaved_xy = gameState.GrassSceneryTileLoopPosition;
         for (int32_t i = 0; i < 8; i++)
         {
             x = (x << 1) | (interleaved_xy & 1);
@@ -1290,7 +1288,7 @@ void MapUpdateTiles()
             }
         }
 
-        gGrassSceneryTileLoopPosition++;
+        gameState.GrassSceneryTileLoopPosition++;
     }
 }
 

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -107,7 +107,6 @@ enum
 extern const std::array<CoordsXY, 8> CoordsDirectionDelta;
 extern const TileCoordsXY TileDirectionDelta[];
 
-extern TileCoordsXY gWidePathTileLoopPosition;
 extern uint16_t gGrassSceneryTileLoopPosition;
 
 CoordsXY GetMapSizeUnits();

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -107,8 +107,6 @@ enum
 extern const std::array<CoordsXY, 8> CoordsDirectionDelta;
 extern const TileCoordsXY TileDirectionDelta[];
 
-extern uint16_t gGrassSceneryTileLoopPosition;
-
 CoordsXY GetMapSizeUnits();
 CoordsXY GetMapSizeMinus2();
 CoordsXY GetMapSizeMaxXY();


### PR DESCRIPTION
Move gWidePathTileLoopPosition and gGrassSceneryTileLoopPosition to GameState_t for [#21193](https://github.com/OpenRCT2/OpenRCT2/issues/21193)