### PR TITLE
Pass DrawPixelInfo by reference

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -99,18 +99,18 @@ public:
     void ResetPalette();
     void StartNewDraw();
 
-    void Clear(DrawPixelInfo* dpi, uint8_t paletteIndex) override;
-    void FillRect(DrawPixelInfo* dpi, uint32_t colour, int32_t x, int32_t y, int32_t w, int32_t h) override;
+    void Clear(DrawPixelInfo& dpi, uint8_t paletteIndex) override;
+    void FillRect(DrawPixelInfo& dpi, uint32_t colour, int32_t x, int32_t y, int32_t w, int32_t h) override;
     void FilterRect(
-        DrawPixelInfo* dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) override;
-    void DrawLine(DrawPixelInfo* dpi, uint32_t colour, const ScreenLine& line) override;
-    void DrawSprite(DrawPixelInfo* dpi, const ImageId imageId, int32_t x, int32_t y) override;
+        DrawPixelInfo& dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) override;
+    void DrawLine(DrawPixelInfo& dpi, uint32_t colour, const ScreenLine& line) override;
+    void DrawSprite(DrawPixelInfo& dpi, const ImageId imageId, int32_t x, int32_t y) override;
     void DrawSpriteRawMasked(
-        DrawPixelInfo* dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) override;
-    void DrawSpriteSolid(DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) override;
-    void DrawGlyph(DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette) override;
+        DrawPixelInfo& dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) override;
+    void DrawSpriteSolid(DrawPixelInfo& dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) override;
+    void DrawGlyph(DrawPixelInfo& dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette) override;
     void DrawTTFBitmap(
-        DrawPixelInfo* dpi, TextDrawInfo* info, ImageIndex image, const void* pixels, int32_t width, int32_t height, int32_t x,
+        DrawPixelInfo& dpi, TextDrawInfo* info, ImageIndex image, const void* pixels, int32_t width, int32_t height, int32_t x,
         int32_t y, uint8_t hinting_threshold) override;
 
     void FlushCommandBuffers();
@@ -118,7 +118,7 @@ public:
     void FlushLines();
     void FlushRectangles();
     void HandleTransparency();
-    void CalculcateClipping(DrawPixelInfo* dpi);
+    void CalculcateClipping(DrawPixelInfo& dpi);
 };
 
 class OpenGLWeatherDrawer final : public IWeatherDrawer
@@ -161,7 +161,7 @@ public:
                     int32_t pixelX = xPixelOffset % dpi.width;
                     int32_t pixelY = (xPixelOffset / dpi.width) % dpi.height;
 
-                    _drawingContext->DrawLine(&dpi, patternPixel, { { pixelX, pixelY }, { pixelX + 1, pixelY + 1 } });
+                    _drawingContext->DrawLine(dpi, patternPixel, { { pixelX, pixelY }, { pixelX + 1, pixelY + 1 } });
                 }
             }
 
@@ -285,7 +285,7 @@ public:
         assert(_screenFramebuffer != nullptr);
 
         _drawingContext->StartNewDraw();
-        _drawingContext->CalculcateClipping(&_bitsDPI);
+        _drawingContext->CalculcateClipping(_bitsDPI);
     }
 
     void EndDraw() override
@@ -323,7 +323,7 @@ public:
 
     void PaintWindows() override
     {
-        _drawingContext->CalculcateClipping(&_bitsDPI);
+        _drawingContext->CalculcateClipping(_bitsDPI);
 
         WindowUpdateAllViewports();
         WindowDrawAll(_bitsDPI, 0, 0, _width, _height);
@@ -331,7 +331,7 @@ public:
 
     void PaintWeather() override
     {
-        _drawingContext->CalculcateClipping(&_bitsDPI);
+        _drawingContext->CalculcateClipping(_bitsDPI);
 
         DrawWeather(_bitsDPI, &_weatherDrawer);
     }
@@ -509,7 +509,7 @@ void OpenGLDrawingContext::StartNewDraw()
     _swapFramebuffer->Clear();
 }
 
-void OpenGLDrawingContext::Clear(DrawPixelInfo* dpi, uint8_t paletteIndex)
+void OpenGLDrawingContext::Clear(DrawPixelInfo& dpi, uint8_t paletteIndex)
 {
     CalculcateClipping(dpi);
 
@@ -517,7 +517,7 @@ void OpenGLDrawingContext::Clear(DrawPixelInfo* dpi, uint8_t paletteIndex)
 }
 
 void OpenGLDrawingContext::FillRect(
-    DrawPixelInfo* dpi, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom)
+    DrawPixelInfo& dpi, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
     CalculcateClipping(dpi);
 
@@ -552,7 +552,7 @@ void OpenGLDrawingContext::FillRect(
 }
 
 void OpenGLDrawingContext::FilterRect(
-    DrawPixelInfo* dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom)
+    DrawPixelInfo& dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
     CalculcateClipping(dpi);
 
@@ -575,7 +575,7 @@ void OpenGLDrawingContext::FilterRect(
     command.depth = _drawCount++;
 }
 
-void OpenGLDrawingContext::DrawLine(DrawPixelInfo* dpi, uint32_t colour, const ScreenLine& line)
+void OpenGLDrawingContext::DrawLine(DrawPixelInfo& dpi, uint32_t colour, const ScreenLine& line)
 {
     CalculcateClipping(dpi);
 
@@ -587,7 +587,7 @@ void OpenGLDrawingContext::DrawLine(DrawPixelInfo* dpi, uint32_t colour, const S
     command.depth = _drawCount++;
 }
 
-void OpenGLDrawingContext::DrawSprite(DrawPixelInfo* dpi, const ImageId imageId, int32_t x, int32_t y)
+void OpenGLDrawingContext::DrawSprite(DrawPixelInfo& dpi, const ImageId imageId, int32_t x, int32_t y)
 {
     CalculcateClipping(dpi);
 
@@ -597,19 +597,19 @@ void OpenGLDrawingContext::DrawSprite(DrawPixelInfo* dpi, const ImageId imageId,
         return;
     }
 
-    if (dpi->zoom_level > ZoomLevel{ 0 })
+    if (dpi.zoom_level > ZoomLevel{ 0 })
     {
         if (g1Element->flags & G1_FLAG_HAS_ZOOM_SPRITE)
         {
             DrawPixelInfo zoomedDPI;
-            zoomedDPI.bits = dpi->bits;
-            zoomedDPI.x = dpi->x >> 1;
-            zoomedDPI.y = dpi->y >> 1;
-            zoomedDPI.height = dpi->height >> 1;
-            zoomedDPI.width = dpi->width >> 1;
-            zoomedDPI.pitch = dpi->pitch;
-            zoomedDPI.zoom_level = dpi->zoom_level - 1;
-            DrawSprite(&zoomedDPI, imageId.WithIndex(imageId.GetIndex() - g1Element->zoomed_offset), x >> 1, y >> 1);
+            zoomedDPI.bits = dpi.bits;
+            zoomedDPI.x = dpi.x >> 1;
+            zoomedDPI.y = dpi.y >> 1;
+            zoomedDPI.height = dpi.height >> 1;
+            zoomedDPI.width = dpi.width >> 1;
+            zoomedDPI.pitch = dpi.pitch;
+            zoomedDPI.zoom_level = dpi.zoom_level - 1;
+            DrawSprite(zoomedDPI, imageId.WithIndex(imageId.GetIndex() - g1Element->zoomed_offset), x >> 1, y >> 1);
             return;
         }
         if (g1Element->flags & G1_FLAG_NO_ZOOM_DRAW)
@@ -622,11 +622,11 @@ void OpenGLDrawingContext::DrawSprite(DrawPixelInfo* dpi, const ImageId imageId,
     int32_t top = y + g1Element->y_offset;
 
     int32_t zoom_mask;
-    if (dpi->zoom_level >= ZoomLevel{ 0 })
-        zoom_mask = dpi->zoom_level.ApplyTo(0xFFFFFFFF);
+    if (dpi.zoom_level >= ZoomLevel{ 0 })
+        zoom_mask = dpi.zoom_level.ApplyTo(0xFFFFFFFF);
     else
         zoom_mask = 0xFFFFFFFF;
-    if (dpi->zoom_level != ZoomLevel{ 0 } && (g1Element->flags & G1_FLAG_RLE_COMPRESSION))
+    if (dpi.zoom_level != ZoomLevel{ 0 } && (g1Element->flags & G1_FLAG_RLE_COMPRESSION))
     {
         top -= ~zoom_mask;
     }
@@ -642,7 +642,7 @@ void OpenGLDrawingContext::DrawSprite(DrawPixelInfo* dpi, const ImageId imageId,
     int32_t right = left + g1Element->width;
     int32_t bottom = top + g1Element->height;
 
-    if (dpi->zoom_level != ZoomLevel{ 0 } && (g1Element->flags & G1_FLAG_RLE_COMPRESSION))
+    if (dpi.zoom_level != ZoomLevel{ 0 } && (g1Element->flags & G1_FLAG_RLE_COMPRESSION))
     {
         bottom += top & ~zoom_mask;
     }
@@ -656,15 +656,15 @@ void OpenGLDrawingContext::DrawSprite(DrawPixelInfo* dpi, const ImageId imageId,
         std::swap(top, bottom);
     }
 
-    left -= dpi->x;
-    top -= dpi->y;
-    right -= dpi->x;
-    bottom -= dpi->y;
+    left -= dpi.x;
+    top -= dpi.y;
+    right -= dpi.x;
+    bottom -= dpi.y;
 
-    left = dpi->zoom_level.ApplyInversedTo(left);
-    top = dpi->zoom_level.ApplyInversedTo(top);
-    right = dpi->zoom_level.ApplyInversedTo(right);
-    bottom = dpi->zoom_level.ApplyInversedTo(bottom);
+    left = dpi.zoom_level.ApplyInversedTo(left);
+    top = dpi.zoom_level.ApplyInversedTo(top);
+    right = dpi.zoom_level.ApplyInversedTo(right);
+    bottom = dpi.zoom_level.ApplyInversedTo(bottom);
 
     left += _spriteOffset.x;
     top += _spriteOffset.y;
@@ -738,7 +738,7 @@ void OpenGLDrawingContext::DrawSprite(DrawPixelInfo* dpi, const ImageId imageId,
 }
 
 void OpenGLDrawingContext::DrawSpriteRawMasked(
-    DrawPixelInfo* dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage)
+    DrawPixelInfo& dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage)
 {
     CalculcateClipping(dpi);
 
@@ -771,15 +771,15 @@ void OpenGLDrawingContext::DrawSpriteRawMasked(
         std::swap(top, bottom);
     }
 
-    left -= dpi->x;
-    top -= dpi->y;
-    right -= dpi->x;
-    bottom -= dpi->y;
+    left -= dpi.x;
+    top -= dpi.y;
+    right -= dpi.x;
+    bottom -= dpi.y;
 
-    left = dpi->zoom_level.ApplyInversedTo(left);
-    top = dpi->zoom_level.ApplyInversedTo(top);
-    right = dpi->zoom_level.ApplyInversedTo(right);
-    bottom = dpi->zoom_level.ApplyInversedTo(bottom);
+    left = dpi.zoom_level.ApplyInversedTo(left);
+    top = dpi.zoom_level.ApplyInversedTo(top);
+    right = dpi.zoom_level.ApplyInversedTo(right);
+    bottom = dpi.zoom_level.ApplyInversedTo(bottom);
 
     left += _spriteOffset.x;
     top += _spriteOffset.y;
@@ -800,7 +800,7 @@ void OpenGLDrawingContext::DrawSpriteRawMasked(
     command.depth = _drawCount++;
 }
 
-void OpenGLDrawingContext::DrawSpriteSolid(DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour)
+void OpenGLDrawingContext::DrawSpriteSolid(DrawPixelInfo& dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour)
 {
     CalculcateClipping(dpi);
 
@@ -852,7 +852,7 @@ void OpenGLDrawingContext::DrawSpriteSolid(DrawPixelInfo* dpi, const ImageId ima
     command.depth = _drawCount++;
 }
 
-void OpenGLDrawingContext::DrawGlyph(DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette)
+void OpenGLDrawingContext::DrawGlyph(DrawPixelInfo& dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette)
 {
     CalculcateClipping(dpi);
 
@@ -878,15 +878,15 @@ void OpenGLDrawingContext::DrawGlyph(DrawPixelInfo* dpi, const ImageId image, in
         std::swap(top, bottom);
     }
 
-    left -= dpi->x;
-    top -= dpi->y;
-    right -= dpi->x;
-    bottom -= dpi->y;
+    left -= dpi.x;
+    top -= dpi.y;
+    right -= dpi.x;
+    bottom -= dpi.y;
 
-    left = dpi->zoom_level.ApplyInversedTo(left);
-    top = dpi->zoom_level.ApplyInversedTo(top);
-    right = dpi->zoom_level.ApplyInversedTo(right);
-    bottom = dpi->zoom_level.ApplyInversedTo(bottom);
+    left = dpi.zoom_level.ApplyInversedTo(left);
+    top = dpi.zoom_level.ApplyInversedTo(top);
+    right = dpi.zoom_level.ApplyInversedTo(right);
+    bottom = dpi.zoom_level.ApplyInversedTo(bottom);
 
     left += _spriteOffset.x;
     top += _spriteOffset.y;
@@ -908,7 +908,7 @@ void OpenGLDrawingContext::DrawGlyph(DrawPixelInfo* dpi, const ImageId image, in
 }
 
 void OpenGLDrawingContext::DrawTTFBitmap(
-    DrawPixelInfo* dpi, TextDrawInfo* info, ImageIndex image, const void* pixels, int32_t width, int32_t height, int32_t x,
+    DrawPixelInfo& dpi, TextDrawInfo* info, ImageIndex image, const void* pixels, int32_t width, int32_t height, int32_t x,
     int32_t y, uint8_t hinting_threshold)
 {
     CalculcateClipping(dpi);
@@ -1067,24 +1067,24 @@ void OpenGLDrawingContext::HandleTransparency()
     _commandBuffers.transparent.clear();
 }
 
-void OpenGLDrawingContext::CalculcateClipping(DrawPixelInfo* dpi)
+void OpenGLDrawingContext::CalculcateClipping(DrawPixelInfo& dpi)
 {
     auto screenDPI = _engine.GetDPI();
     auto bytesPerRow = screenDPI->GetBytesPerRow();
-    auto bitsOffset = static_cast<size_t>(dpi->bits - screenDPI->bits);
+    auto bitsOffset = static_cast<size_t>(dpi.bits - screenDPI->bits);
 #    ifndef NDEBUG
     auto bitsSize = static_cast<size_t>(screenDPI->height) * bytesPerRow;
     assert(bitsOffset < bitsSize);
 #    endif
 
-    _clipLeft = static_cast<int32_t>(bitsOffset % bytesPerRow) + dpi->remX;
-    _clipTop = static_cast<int32_t>(bitsOffset / bytesPerRow) + dpi->remY;
-    _clipRight = _clipLeft + dpi->zoom_level.ApplyInversedTo(dpi->width);
-    _clipBottom = _clipTop + dpi->zoom_level.ApplyInversedTo(dpi->height);
-    _offsetX = _clipLeft - dpi->x;
-    _offsetY = _clipTop - dpi->y;
-    _spriteOffset.x = _clipLeft - dpi->remX;
-    _spriteOffset.y = _clipTop - dpi->remY;
+    _clipLeft = static_cast<int32_t>(bitsOffset % bytesPerRow) + dpi.remX;
+    _clipTop = static_cast<int32_t>(bitsOffset / bytesPerRow) + dpi.remY;
+    _clipRight = _clipLeft + dpi.zoom_level.ApplyInversedTo(dpi.width);
+    _clipBottom = _clipTop + dpi.zoom_level.ApplyInversedTo(dpi.height);
+    _offsetX = _clipLeft - dpi.x;
+    _offsetY = _clipTop - dpi.y;
+    _spriteOffset.x = _clipLeft - dpi.remX;
+    _spriteOffset.y = _clipTop - dpi.remY;
 }
 
 #endif /* DISABLE_OPENGL */

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -829,12 +829,12 @@ static void WidgetDrawImage(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widge
         // Draw greyed out (light border bottom right shadow)
         colour = w.colours[widget.colour];
         colour = ColourMapA[NOT_TRANSLUCENT(colour)].lighter;
-        GfxDrawSpriteSolid(&dpi, image, screenCoords + ScreenCoordsXY{ 1, 1 }, colour);
+        GfxDrawSpriteSolid(dpi, image, screenCoords + ScreenCoordsXY{ 1, 1 }, colour);
 
         // Draw greyed out (dark)
         colour = w.colours[widget.colour];
         colour = ColourMapA[NOT_TRANSLUCENT(colour)].mid_light;
-        GfxDrawSpriteSolid(&dpi, image, screenCoords, colour);
+        GfxDrawSpriteSolid(dpi, image, screenCoords, colour);
     }
     else
     {

--- a/src/openrct2-ui/scripting/ScGraphicsContext.hpp
+++ b/src/openrct2-ui/scripting/ScGraphicsContext.hpp
@@ -175,7 +175,7 @@ namespace OpenRCT2::Scripting
 
         void clear()
         {
-            GfxClear(&_dpi, _fill);
+            GfxClear(_dpi, _fill);
         }
 
         void clip(int32_t x, int32_t y, int32_t width, int32_t height)

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -275,7 +275,7 @@ static Widget _inventionListDragWidgets[] = {
 
             // Draw background
             uint8_t paletteIndex = ColourMapA[colours[1]].mid_light;
-            GfxClear(&dpi, paletteIndex);
+            GfxClear(dpi, paletteIndex);
 
             int16_t boxWidth = widgets[WIDX_RESEARCH_ORDER_SCROLL].width();
             int32_t itemY = -SCROLLABLE_ROW_HEIGHT;

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -720,7 +720,7 @@ static std::vector<Widget> _window_editor_object_selection_widgets = {
             bool ridePage = (GetSelectedObjectType() == ObjectType::Ride);
 
             uint8_t paletteIndex = ColourMapA[colours[1]].mid_light;
-            GfxClear(&dpi, paletteIndex);
+            GfxClear(dpi, paletteIndex);
 
             screenCoords.y = 0;
             for (size_t i = 0; i < _listItems.size(); i++)

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -775,7 +775,7 @@ static constexpr ScreenCoordsXY MiniMapOffsets[] = {
 
         void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
         {
-            GfxClear(&dpi, PALETTE_INDEX_10);
+            GfxClear(dpi, PALETTE_INDEX_10);
 
             G1Element g1temp = {};
             g1temp.offset = _mapImageData.data();

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -652,12 +652,12 @@ static uint64_t PressedWidgets[WINDOW_MAPGEN_PAGE_COUNT] = {
                 // Draw greyed out (light border bottom right shadow)
                 auto colour = colours[widget.colour];
                 colour = ColourMapA[NOT_TRANSLUCENT(colour)].lighter;
-                GfxDrawSpriteSolid(&dpi, image, pos + ScreenCoordsXY{ 1, 1 }, colour);
+                GfxDrawSpriteSolid(dpi, image, pos + ScreenCoordsXY{ 1, 1 }, colour);
 
                 // Draw greyed out (dark)
                 colour = colours[widget.colour];
                 colour = ColourMapA[NOT_TRANSLUCENT(colour)].mid_light;
-                GfxDrawSpriteSolid(&dpi, image, pos, colour);
+                GfxDrawSpriteSolid(dpi, image, pos, colour);
             }
             else
             {

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -479,7 +479,7 @@ static Widget window_new_ride_widgets[] = {
                 return;
             }
 
-            GfxClear(&dpi, ColourMapA[colours[1]].mid_light);
+            GfxClear(dpi, ColourMapA[colours[1]].mid_light);
 
             ScreenCoordsXY coords{ 1, 1 };
             RideSelection* listItem = _windowNewRideListItems;
@@ -497,7 +497,7 @@ static Widget window_new_ride_widgets[] = {
                 // Draw ride image with feathered border
                 auto mask = ImageId(SPR_NEW_RIDE_MASK);
                 auto rideImage = ImageId(GetRideImage(*listItem));
-                GfxDrawSpriteRawMasked(&dpi, coords + ScreenCoordsXY{ 2, 2 }, mask, rideImage);
+                GfxDrawSpriteRawMasked(dpi, coords + ScreenCoordsXY{ 2, 2 }, mask, rideImage);
 
                 // Next position
                 coords.x += 116;

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -2116,10 +2116,10 @@ static Widget *window_options_page_widgets[] = {
 
                 // Draw greyed out (light border bottom right shadow)
                 GfxDrawSpriteSolid(
-                    &dpi, ImageId(spriteIndex), screenCoords + ScreenCoordsXY{ 1, 1 }, ColourMapA[window_colour].lighter);
+                    dpi, ImageId(spriteIndex), screenCoords + ScreenCoordsXY{ 1, 1 }, ColourMapA[window_colour].lighter);
 
                 // Draw greyed out (dark)
-                GfxDrawSpriteSolid(&dpi, ImageId(spriteIndex), screenCoords, ColourMapA[window_colour].mid_light);
+                GfxDrawSpriteSolid(dpi, ImageId(spriteIndex), screenCoords, ColourMapA[window_colour].mid_light);
             }
         }
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4739,7 +4739,7 @@ static_assert(std::size(RatingNames) == 6);
                         windowPos + ScreenCoordsXY{ entrancePreviewWidget.left + 1, entrancePreviewWidget.top + 1 },
                         entrancePreviewWidget.width(), entrancePreviewWidget.height()))
                 {
-                    GfxClear(&clippedDpi, PALETTE_INDEX_12);
+                    GfxClear(clippedDpi, PALETTE_INDEX_12);
 
                     auto stationObj = ride->GetStationObject();
                     if (stationObj != nullptr && stationObj->BaseImageId != ImageIndexUndefined)
@@ -5763,7 +5763,7 @@ static_assert(std::size(RatingNames) == 6);
 
         void GraphsOnScrollDraw(DrawPixelInfo& dpi, int32_t scrollIndex)
         {
-            GfxClear(&dpi, ColourMapA[COLOUR_SATURATED_GREEN].darker);
+            GfxClear(dpi, ColourMapA[COLOUR_SATURATED_GREEN].darker);
 
             auto widget = &widgets[WIDX_GRAPH];
             auto ride = GetRide(rideId);

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -401,7 +401,7 @@ static Widget _scenarioSelectWidgets[] = {
         void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
         {
             uint8_t paletteIndex = ColourMapA[colours[1]].mid_light;
-            GfxClear(&dpi, paletteIndex);
+            GfxClear(dpi, paletteIndex);
 
             StringId highlighted_format = ScenarioSelectUseSmallFont() ? STR_WHITE_STRING : STR_WINDOW_COLOUR_2_STRINGID;
             StringId unhighlighted_format = ScenarioSelectUseSmallFont() ? STR_WHITE_STRING : STR_BLACK_STRING;

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -1635,7 +1635,7 @@ static Widget WindowSceneryBaseWidgets[] = {
 
         void ContentScrollDraw(DrawPixelInfo& dpi)
         {
-            GfxClear(&dpi, ColourMapA[colours[1]].mid_light);
+            GfxClear(dpi, ColourMapA[colours[1]].mid_light);
 
             auto numColumns = GetNumColumns();
             auto tabIndex = _activeTabIndex;

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -335,7 +335,7 @@ static Widget _serverListWidgets[] = {
         void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
         {
             uint8_t paletteIndex = ColourMapA[colours[1]].mid_light;
-            GfxClear(&dpi, paletteIndex);
+            GfxClear(dpi, paletteIndex);
 
             auto& listWidget = widgets[WIDX_LIST];
             int32_t listWidgetWidth = listWidget.width();

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -759,7 +759,7 @@ static WindowClass window_themes_tab_7_classes[] = {
             if ((colours[1] & 0x80) == 0)
                 // GfxFillRect(dpi, dpi->x, dpi->y, dpi->x + dpi->width - 1, dpi->y + dpi->height - 1,
                 // ColourMapA[colours[1]].mid_light);
-                GfxClear(&dpi, ColourMapA[colours[1]].mid_light);
+                GfxClear(dpi, ColourMapA[colours[1]].mid_light);
             screenCoords.y = 0;
             for (int32_t i = 0; i < GetColourSchemeTabCount(); i++)
             {

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -677,7 +677,7 @@ static Widget _trackListWidgets[] = {
         void OnScrollDraw(const int32_t scrollIndex, DrawPixelInfo& dpi) override
         {
             uint8_t paletteIndex = ColourMapA[colours[0]].mid_light;
-            GfxClear(&dpi, paletteIndex);
+            GfxClear(dpi, paletteIndex);
 
             auto screenCoords = ScreenCoordsXY{ 0, 0 };
             size_t listIndex = 0;

--- a/src/openrct2/Intro.cpp
+++ b/src/openrct2/Intro.cpp
@@ -178,10 +178,10 @@ void IntroDraw(DrawPixelInfo& dpi)
         case IntroState::Disclaimer2:
             break;
         case IntroState::PublisherBegin:
-            GfxClear(&dpi, kBackgroundColourDark);
+            GfxClear(dpi, kBackgroundColourDark);
             break;
         case IntroState::PublisherScroll:
-            GfxClear(&dpi, kBackgroundColourDark);
+            GfxClear(dpi, kBackgroundColourDark);
 
             // Draw a white rectangle for the logo background (gives a bit of white margin)
             GfxFillRect(
@@ -197,11 +197,11 @@ void IntroDraw(DrawPixelInfo& dpi)
             GfxDrawSprite(dpi, ImageId(SPR_INTRO_INFOGRAMES_11), { (screenWidth / 2) - 320 + 319, _introStateCounter + 319 });
             break;
         case IntroState::DeveloperBegin:
-            GfxClear(&dpi, kBackgroundColourDark);
+            GfxClear(dpi, kBackgroundColourDark);
             GfxTransposePalette(PALETTE_G1_IDX_DEVELOPER, 255);
             break;
         case IntroState::DeveloperScroll:
-            GfxClear(&dpi, kBackgroundColourDark);
+            GfxClear(dpi, kBackgroundColourDark);
 
             // Draw Chris Sawyer logo
             GfxDrawSprite(dpi, ImageId(SPR_INTRO_CHRIS_SAWYER_00), { (screenWidth / 2) - 320 + 70, _introStateCounter });
@@ -233,7 +233,7 @@ void IntroDraw(DrawPixelInfo& dpi)
             ScreenIntroDrawLogo(dpi);
             break;
         case IntroState::Clear:
-            GfxClear(&dpi, kBackgroundColourDark);
+            GfxClear(dpi, kBackgroundColourDark);
             break;
         default:
             break;
@@ -293,7 +293,7 @@ static void ScreenIntroDrawLogo(DrawPixelInfo& dpi)
     DrawingEngineInvalidateImage(SPR_INTRO_LOGO_11);
     DrawingEngineInvalidateImage(SPR_INTRO_LOGO_21);
 
-    GfxClear(&dpi, kBackgroundColourLogo);
+    GfxClear(dpi, kBackgroundColourLogo);
     GfxDrawSprite(dpi, ImageId(SPR_INTRO_LOGO_00), { imageX + 0, 0 });
     GfxDrawSprite(dpi, ImageId(SPR_INTRO_LOGO_10), { imageX + 220, 0 });
     GfxDrawSprite(dpi, ImageId(SPR_INTRO_LOGO_20), { imageX + 440, 0 });

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -492,7 +492,7 @@ static void TTFDrawCharacterSprite(DrawPixelInfo& dpi, int32_t codepoint, TextDr
         }
 
         PaletteMap paletteMap(info->palette);
-        GfxDrawGlyph(&dpi, sprite, screenCoords, paletteMap);
+        GfxDrawGlyph(dpi, sprite, screenCoords, paletteMap);
     }
 
     info->x += characterWidth;
@@ -548,7 +548,7 @@ static void TTFDrawStringRawTTF(DrawPixelInfo& dpi, std::string_view text, TextD
         uint8_t hint_thresh = use_hinting ? fontDesc->hinting_threshold : 0;
         drawingEngine->InvalidateImage(imageId);
         drawingContext->DrawTTFBitmap(
-            &dpi, info, imageId, surface->pixels, surface->pitch, surface->h, drawX, drawY, hint_thresh);
+            dpi, info, imageId, surface->pixels, surface->pitch, surface->h, drawX, drawY, hint_thresh);
 
         _ttfGlId++;
         if (_ttfGlId >= 1023)

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -537,7 +537,7 @@ void GfxTransposePalette(int32_t pal, uint8_t product);
 void LoadPalette();
 
 // other
-void GfxClear(DrawPixelInfo* dpi, uint8_t paletteIndex);
+void GfxClear(DrawPixelInfo& dpi, uint8_t paletteIndex);
 void GfxFilterPixel(DrawPixelInfo& dpi, const ScreenCoordsXY& coords, FilterPaletteID palette);
 void GfxInvalidatePickedUpPeep();
 void GfxDrawPickedUpPeep(DrawPixelInfo& dpi);
@@ -569,10 +569,10 @@ void FASTCALL GfxSpriteToBuffer(DrawPixelInfo& dpi, const DrawSpriteArgs& args);
 void FASTCALL GfxBmpSpriteToBuffer(DrawPixelInfo& dpi, const DrawSpriteArgs& args);
 void FASTCALL GfxRleSpriteToBuffer(DrawPixelInfo& dpi, const DrawSpriteArgs& args);
 void FASTCALL GfxDrawSprite(DrawPixelInfo& dpi, const ImageId image_id, const ScreenCoordsXY& coords);
-void FASTCALL GfxDrawGlyph(DrawPixelInfo* dpi, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
-void FASTCALL GfxDrawSpriteSolid(DrawPixelInfo* dpi, const ImageId image, const ScreenCoordsXY& coords, uint8_t colour);
+void FASTCALL GfxDrawGlyph(DrawPixelInfo& dpi, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
+void FASTCALL GfxDrawSpriteSolid(DrawPixelInfo& dpi, const ImageId image, const ScreenCoordsXY& coords, uint8_t colour);
 void FASTCALL GfxDrawSpriteRawMasked(
-    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage);
+    DrawPixelInfo& dpi, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage);
 void FASTCALL GfxDrawSpriteSoftware(DrawPixelInfo& dpi, const ImageId imageId, const ScreenCoordsXY& spriteCoords);
 void FASTCALL GfxDrawSpritePaletteSetSoftware(
     DrawPixelInfo& dpi, const ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);

--- a/src/openrct2/drawing/IDrawingContext.h
+++ b/src/openrct2/drawing/IDrawingContext.h
@@ -20,20 +20,20 @@ namespace OpenRCT2::Drawing
     {
         virtual ~IDrawingContext() = default;
 
-        virtual void Clear(DrawPixelInfo* dpi, uint8_t paletteIndex) abstract;
+        virtual void Clear(DrawPixelInfo& dpi, uint8_t paletteIndex) abstract;
         virtual void FillRect(
-            DrawPixelInfo* dpi, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom) abstract;
+            DrawPixelInfo& dpi, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom) abstract;
         virtual void FilterRect(
-            DrawPixelInfo* dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) abstract;
-        virtual void DrawLine(DrawPixelInfo* dpi, uint32_t colour, const ScreenLine& line) abstract;
-        virtual void DrawSprite(DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y) abstract;
+            DrawPixelInfo& dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) abstract;
+        virtual void DrawLine(DrawPixelInfo& dpi, uint32_t colour, const ScreenLine& line) abstract;
+        virtual void DrawSprite(DrawPixelInfo& dpi, const ImageId image, int32_t x, int32_t y) abstract;
         virtual void DrawSpriteRawMasked(
-            DrawPixelInfo* dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) abstract;
-        virtual void DrawSpriteSolid(DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) abstract;
+            DrawPixelInfo& dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) abstract;
+        virtual void DrawSpriteSolid(DrawPixelInfo& dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) abstract;
         virtual void DrawGlyph(
-            DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette) abstract;
+            DrawPixelInfo& dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette) abstract;
         virtual void DrawTTFBitmap(
-            DrawPixelInfo* dpi, TextDrawInfo* info, ImageIndex image, const void* pixels, int32_t width, int32_t height,
+            DrawPixelInfo& dpi, TextDrawInfo* info, ImageIndex image, const void* pixels, int32_t width, int32_t height,
             int32_t x, int32_t y, uint8_t hinting_threshold) abstract;
     };
 

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -160,9 +160,9 @@ void GfxSetDirtyBlocks(const ScreenRect& rect)
     }
 }
 
-void GfxClear(DrawPixelInfo* dpi, uint8_t paletteIndex)
+void GfxClear(DrawPixelInfo& dpi, uint8_t paletteIndex)
 {
-    auto drawingEngine = dpi->DrawingEngine;
+    auto drawingEngine = dpi.DrawingEngine;
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext();
@@ -176,7 +176,7 @@ void GfxFillRect(DrawPixelInfo& dpi, const ScreenRect& rect, int32_t colour)
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext();
-        dc->FillRect(&dpi, colour, rect.GetLeft(), rect.GetTop(), rect.GetRight(), rect.GetBottom());
+        dc->FillRect(dpi, colour, rect.GetLeft(), rect.GetTop(), rect.GetRight(), rect.GetBottom());
     }
 }
 
@@ -186,7 +186,7 @@ void GfxFilterRect(DrawPixelInfo& dpi, const ScreenRect& rect, FilterPaletteID p
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext();
-        dc->FilterRect(&dpi, palette, rect.GetLeft(), rect.GetTop(), rect.GetRight(), rect.GetBottom());
+        dc->FilterRect(dpi, palette, rect.GetLeft(), rect.GetTop(), rect.GetRight(), rect.GetBottom());
     }
 }
 
@@ -196,7 +196,7 @@ void GfxDrawLine(DrawPixelInfo& dpi, const ScreenLine& line, int32_t colour)
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext();
-        dc->DrawLine(&dpi, colour, line);
+        dc->DrawLine(dpi, colour, line);
     }
 }
 
@@ -228,7 +228,7 @@ void GfxDrawDashedLine(
         {
             x = screenLine.GetX1() + dxPrecise * i * 2 / precisionFactor;
             y = screenLine.GetY1() + dyPrecise * i * 2 / precisionFactor;
-            dc->DrawLine(&dpi, color, { { x, y }, { x + dxPrecise / precisionFactor, y + dyPrecise / precisionFactor } });
+            dc->DrawLine(dpi, color, { { x, y }, { x + dxPrecise / precisionFactor, y + dyPrecise / precisionFactor } });
         }
     }
 }
@@ -239,13 +239,13 @@ void FASTCALL GfxDrawSprite(DrawPixelInfo& dpi, const ImageId imageId, const Scr
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext();
-        dc->DrawSprite(&dpi, imageId, coords.x, coords.y);
+        dc->DrawSprite(dpi, imageId, coords.x, coords.y);
     }
 }
 
-void FASTCALL GfxDrawGlyph(DrawPixelInfo* dpi, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
+void FASTCALL GfxDrawGlyph(DrawPixelInfo& dpi, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
 {
-    auto drawingEngine = dpi->DrawingEngine;
+    auto drawingEngine = dpi.DrawingEngine;
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext();
@@ -254,9 +254,9 @@ void FASTCALL GfxDrawGlyph(DrawPixelInfo* dpi, const ImageId image, const Screen
 }
 
 void FASTCALL
-    GfxDrawSpriteRawMasked(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage)
+    GfxDrawSpriteRawMasked(DrawPixelInfo& dpi, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage)
 {
-    auto drawingEngine = dpi->DrawingEngine;
+    auto drawingEngine = dpi.DrawingEngine;
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext();
@@ -264,9 +264,9 @@ void FASTCALL
     }
 }
 
-void FASTCALL GfxDrawSpriteSolid(DrawPixelInfo* dpi, const ImageId image, const ScreenCoordsXY& coords, uint8_t colour)
+void FASTCALL GfxDrawSpriteSolid(DrawPixelInfo& dpi, const ImageId image, const ScreenCoordsXY& coords, uint8_t colour)
 {
-    auto drawingEngine = dpi->DrawingEngine;
+    auto drawingEngine = dpi.DrawingEngine;
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext();

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -58,7 +58,7 @@ namespace OpenRCT2
             void Draw(
                 DrawPixelInfo& dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
                 const uint8_t* weatherpattern) override;
-            void Restore(DrawPixelInfo* dpi);
+            void Restore(DrawPixelInfo& dpi);
         };
 
 #ifdef __WARN_SUGGEST_FINAL_TYPES__
@@ -136,19 +136,19 @@ namespace OpenRCT2
         public:
             explicit X8DrawingContext(X8DrawingEngine* engine);
 
-            void Clear(DrawPixelInfo* dpi, uint8_t paletteIndex) override;
-            void FillRect(DrawPixelInfo* dpi, uint32_t colour, int32_t x, int32_t y, int32_t w, int32_t h) override;
+            void Clear(DrawPixelInfo& dpi, uint8_t paletteIndex) override;
+            void FillRect(DrawPixelInfo& dpi, uint32_t colour, int32_t x, int32_t y, int32_t w, int32_t h) override;
             void FilterRect(
-                DrawPixelInfo* dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) override;
-            void DrawLine(DrawPixelInfo* dpi, uint32_t colour, const ScreenLine& line) override;
-            void DrawSprite(DrawPixelInfo* dpi, const ImageId imageId, int32_t x, int32_t y) override;
+                DrawPixelInfo& dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) override;
+            void DrawLine(DrawPixelInfo& dpi, uint32_t colour, const ScreenLine& line) override;
+            void DrawSprite(DrawPixelInfo& dpi, const ImageId imageId, int32_t x, int32_t y) override;
             void DrawSpriteRawMasked(
-                DrawPixelInfo* dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) override;
-            void DrawSpriteSolid(DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) override;
+                DrawPixelInfo& dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) override;
+            void DrawSpriteSolid(DrawPixelInfo& dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) override;
             void DrawGlyph(
-                DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap) override;
+                DrawPixelInfo& dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap) override;
             void DrawTTFBitmap(
-                DrawPixelInfo* dpi, TextDrawInfo* info, uint32_t image, const void* pixels, int32_t width, int32_t height,
+                DrawPixelInfo& dpi, TextDrawInfo* info, uint32_t image, const void* pixels, int32_t width, int32_t height,
                 int32_t x, int32_t y, uint8_t hinting_threshold) override
             {
             }

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -987,7 +987,7 @@ static void ViewportPaintColumn(PaintSession& session)
         {
             colour = COLOUR_BLACK;
         }
-        GfxClear(&session.DPI, colour);
+        GfxClear(session.DPI, colour);
     }
 
     PaintDrawStructs(session);

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -578,7 +578,7 @@ static void PaintAttachedPS(DrawPixelInfo& dpi, PaintStruct* ps, uint32_t viewFl
         auto imageId = PaintPSColourifyImage(ps, attached_ps->image_id, viewFlags);
         if (attached_ps->IsMasked)
         {
-            GfxDrawSpriteRawMasked(&dpi, screenCoords, imageId, attached_ps->ColourImageId);
+            GfxDrawSpriteRawMasked(dpi, screenCoords, imageId, attached_ps->ColourImageId);
         }
         else
         {


### PR DESCRIPTION
Pass DrawPixelInfo by reference instead of a pointer.

Closes #19523.