### PR TITLE
Fix building sloped banked 3×3 turns when coaster also has 1×1 turns

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -340,8 +340,7 @@ static Widget _rideConstructionWidgets[] = {
                 // Disable small curves if the start or end of the track is sloped.
                 if (_previousTrackPitchEnd != TrackPitch::None || _currentTrackPitchEnd != TrackPitch::None)
                 {
-                    disabledWidgets |= (1uLL << WIDX_LEFT_CURVE_VERY_SMALL) | (1uLL << WIDX_LEFT_CURVE)
-                        | (1uLL << WIDX_RIGHT_CURVE) | (1uLL << WIDX_RIGHT_CURVE_VERY_SMALL);
+                    disabledWidgets |= (1uLL << WIDX_LEFT_CURVE_VERY_SMALL) | (1uLL << WIDX_RIGHT_CURVE_VERY_SMALL);
                 }
             }
             if (!IsTrackEnabled(TRACK_SLOPE_CURVE))


### PR DESCRIPTION
This fixes a bug that would prevent the user from building 3×3 banked sloped turns, if the roller coaster also had 1×1 flat turns enabled. The Spinning Roller Coaster that @RealSteel89 is working on is the first one to do so, revealing this bug.

I am putting this in a separate PR so it can be tested more easily. I want to make sure it doesn’t accidentally break some other coasters. As far as I have been able to tell, only the Inverted Hairpin and Steel Wild Mouse enable both sloped curves _and_ the 1×1 curve, so in principle only those two should be affected. But it wouldn’t hurt to test a few more coaster/ride types.