### PR TITLE
Use non-breaking spaces around currency units

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.10 (in development)
 ------------------------------------------------------------------------
 - Improved: [#21424] Extra viewports can now rotate independently from the main viewport.
+- Improved: [#21599] Currency signs now use non-breaking spaces.
 - Change: [#21529] Classify “Southern Sands”, “Tiny Towers”, “Nevermore Park”, “Pacifica” as expert scenarios.
 - Fix: [#910] Extra viewport does not preserve the location when rotating.
 - Fix: [#21434] Number of guests overflows in objective text.

--- a/src/openrct2/localisation/Currency.cpp
+++ b/src/openrct2/localisation/Currency.cpp
@@ -15,24 +15,24 @@
 
 // clang-format off
 CurrencyDescriptor CurrencyDescriptors[EnumValue(CurrencyType::Count)] = {
-    {   "GBP",  10,     CurrencyAffix::Prefix,    "\xC2\xA3",     CurrencyAffix::Suffix,    "GBP",  STR_POUNDS          },  // British Pound
-    {   "USD",  10,     CurrencyAffix::Prefix,    "$",            CurrencyAffix::Prefix,    "$",    STR_DOLLARS         },  // US Dollar
-    {   "FRF",  10,     CurrencyAffix::Suffix,    "F",            CurrencyAffix::Suffix,    "F",    STR_FRANC           },  // French Franc
-    {   "DEM",  10,     CurrencyAffix::Prefix,    "DM",           CurrencyAffix::Prefix,    "DM",   STR_DEUTSCHE_MARK   },  // Deutsche Mark
-    {   "JPY",  1000,   CurrencyAffix::Prefix,    "\xC2\xA5",     CurrencyAffix::Suffix,    "YEN",  STR_YEN             },  // Japanese Yen
-    {   "ESP",  10,     CurrencyAffix::Suffix,    "Pts",          CurrencyAffix::Suffix,    "Pts",  STR_PESETA          },  // Spanish Peseta
-    {   "ITL",  1000,   CurrencyAffix::Prefix,    "L",            CurrencyAffix::Prefix,    "L",    STR_LIRA            },  // Italian Lira
-    {   "NLG",  10,     CurrencyAffix::Prefix,    "\xC6\x92 ",    CurrencyAffix::Prefix,    "fl.",  STR_GUILDERS        },  // Dutch Guilder
-    {   "SEK",  100,    CurrencyAffix::Suffix,    " kr",          CurrencyAffix::Suffix,    " kr",  STR_KRONA           },  // Swedish Krona
-    {   "EUR",  10,     CurrencyAffix::Prefix,    "\xE2\x82\xAC", CurrencyAffix::Suffix,    "EUR",  STR_EUROS           },  // Euro
-    {   "KRW",  10000,  CurrencyAffix::Prefix,    "\xE2\x82\xA9", CurrencyAffix::Prefix,    "W",    STR_WON             },  // South Korean Won
-    {   "RUB",  1000,   CurrencyAffix::Suffix,    "\xE2\x82\xBD", CurrencyAffix::Prefix,    "R ",   STR_ROUBLE          },  // Russian Rouble
-    {   "CZK",  100,    CurrencyAffix::Suffix,    " K\xC4\x8D",   CurrencyAffix::Suffix,    " Kc",  STR_CZECH_KORUNA    },  // Czech koruna
-    {   "HKD",  100,    CurrencyAffix::Prefix,    "$",            CurrencyAffix::Prefix,    "HKD",  STR_HONG_KONG_DOLLAR},  // Hong Kong Dollar
-    {   "TWD",  1000,   CurrencyAffix::Prefix,    "NT$",          CurrencyAffix::Prefix,    "NT$",  STR_NEW_TAIWAN_DOLLAR}, // New Taiwan Dollar
-    {   "CNY",  100,    CurrencyAffix::Prefix,    "CN\xC2\xA5",   CurrencyAffix::Prefix,    "CNY",  STR_CHINESE_YUAN    },  // Chinese Yuan
-    {   "HUF",  1000,   CurrencyAffix::Suffix,    " Ft",          CurrencyAffix::Suffix,    " Ft",  STR_HUNGARIAN_FORINT},  // Hungarian Forint
-    {   "CTM",  10,     CurrencyAffix::Prefix,    "Ctm",          CurrencyAffix::Prefix,    "Ctm",  STR_CUSTOM_CURRENCY },  // Customizable currency
+    {   "GBP",  10,     CurrencyAffix::Prefix,    u8"£",      CurrencyAffix::Suffix,    "GBP",  STR_POUNDS          },  // British Pound
+    {   "USD",  10,     CurrencyAffix::Prefix,    u8"$",      CurrencyAffix::Prefix,    "$",    STR_DOLLARS         },  // US Dollar
+    {   "FRF",  10,     CurrencyAffix::Suffix,    u8"F",      CurrencyAffix::Suffix,    "F",    STR_FRANC           },  // French Franc
+    {   "DEM",  10,     CurrencyAffix::Prefix,    u8"DM",     CurrencyAffix::Prefix,    "DM",   STR_DEUTSCHE_MARK   },  // Deutsche Mark
+    {   "JPY",  1000,   CurrencyAffix::Prefix,    u8"¥",      CurrencyAffix::Suffix,    "YEN",  STR_YEN             },  // Japanese Yen
+    {   "ESP",  10,     CurrencyAffix::Suffix,    u8"Pts",    CurrencyAffix::Suffix,    "Pts",  STR_PESETA          },  // Spanish Peseta
+    {   "ITL",  1000,   CurrencyAffix::Prefix,    u8"L",      CurrencyAffix::Prefix,    "L",    STR_LIRA            },  // Italian Lira
+    {   "NLG",  10,     CurrencyAffix::Prefix,    u8"ƒ ",     CurrencyAffix::Prefix,    "fl.",  STR_GUILDERS        },  // Dutch Guilder
+    {   "SEK",  100,    CurrencyAffix::Suffix,    u8" kr",    CurrencyAffix::Suffix,    " kr",  STR_KRONA           },  // Swedish Krona
+    {   "EUR",  10,     CurrencyAffix::Prefix,    u8"€",      CurrencyAffix::Suffix,    "EUR",  STR_EUROS           },  // Euro
+    {   "KRW",  10000,  CurrencyAffix::Prefix,    u8"₩",      CurrencyAffix::Prefix,    "W",    STR_WON             },  // South Korean Won
+    {   "RUB",  1000,   CurrencyAffix::Suffix,    u8"₽",      CurrencyAffix::Prefix,    "R ",   STR_ROUBLE          },  // Russian Rouble
+    {   "CZK",  100,    CurrencyAffix::Suffix,    u8" Kč",    CurrencyAffix::Suffix,   " Kc",  STR_CZECH_KORUNA    },  // Czech koruna
+    {   "HKD",  100,    CurrencyAffix::Prefix,    u8"$",      CurrencyAffix::Prefix,    "HKD",  STR_HONG_KONG_DOLLAR},  // Hong Kong Dollar
+    {   "TWD",  1000,   CurrencyAffix::Prefix,    u8"NT$",    CurrencyAffix::Prefix,    "NT$",  STR_NEW_TAIWAN_DOLLAR}, // New Taiwan Dollar
+    {   "CNY",  100,    CurrencyAffix::Prefix,    u8"CN¥",    CurrencyAffix::Prefix,    "CNY",  STR_CHINESE_YUAN    },  // Chinese Yuan
+    {   "HUF",  1000,   CurrencyAffix::Suffix,    u8" Ft",    CurrencyAffix::Suffix,    " Ft",  STR_HUNGARIAN_FORINT},  // Hungarian Forint
+    {   "CTM",  10,     CurrencyAffix::Prefix,    u8"Ctm",    CurrencyAffix::Prefix,    "Ctm",  STR_CUSTOM_CURRENCY },  // Customizable currency
 };
 // clang-format on
 


### PR DESCRIPTION
Some currencies use spaces to set them apart from the value. These should use non-breaking spaces to keep them together, but lacked them.

For good measure, I updated the currencies table to just encode the signs as-is, like we already do for the languages.

Before:
![Schermafdruk van 2024-03-14 19-13-14](https://github.com/OpenRCT2/OpenRCT2/assets/1478678/6998f4d2-8a95-4aae-899b-a7e7d17c248a)

After:
![Schermafdruk van 2024-03-14 18-59-44](https://github.com/OpenRCT2/OpenRCT2/assets/1478678/00dc326d-4428-4ed8-b4d2-36a8dbfe7310)
