### PR TITLE
Part of #21193: move entities to GameState_t

### DIFF
--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -94,6 +94,7 @@ namespace OpenRCT2
         std::string ScenarioCompletedBy;
 
         std::vector<Banner> Banners;
+        Entity_t Entities[MAX_ENTITIES]{};
         // Ride storage for all the rides in the park, rides with RideId::Null are considered free.
         std::array<Ride, OpenRCT2::Limits::MaxRidesInPark> Rides{};
         ::RideRatingUpdateStates RideRatingUpdateStates;

--- a/src/openrct2/entity/EntityRegistry.h
+++ b/src/openrct2/entity/EntityRegistry.h
@@ -14,6 +14,19 @@
 
 #include <array>
 
+namespace OpenRCT2
+{
+    union Entity_t
+    {
+        uint8_t Pad00[0x200];
+        EntityBase base;
+        Entity_t()
+            : Pad00()
+        {
+        }
+    };
+} // namespace OpenRCT2
+
 constexpr uint16_t MAX_ENTITIES = 65535;
 
 EntityBase* GetEntity(EntityId sprite_idx);


### PR DESCRIPTION
I’m not sure if `Entity_t` is the correct name, but leaving off the `_t` suffix caused a conflict with the `OpenRCT2::Entity` namespace. Another option would be to move it into that namespace, which would mean a FQCN of `OpenRCT2::Entity::Entity`.