### PR TITLE
Use same parameter names in g2/sprites.json and object json

### DIFF
--- a/resources/g2/sprites.json
+++ b/resources/g2/sprites.json
@@ -136,13 +136,13 @@
     },
     {
         "path": "icons/eyedropper.png",
-        "x_offset": 5,
-        "y_offset": 5
+        "x": 5,
+        "y": 5
     },
     {
         "path": "icons/chat.png",
-        "x_offset": 2,
-        "y_offset": 1
+        "x": 2,
+        "y": 1
     },
     {
         "path": "icons/map_north.png"
@@ -182,8 +182,8 @@
     },
     {
         "path": "icons/simulate.png",
-        "x_offset": 2,
-        "y_offset": 2
+        "x": 2,
+        "y": 2
     },
     {
         "path": "icons/rct1_simulate_off.png"
@@ -203,18 +203,18 @@
     },
     {
         "path": "tool/normal_selection_6x6.png",
-        "x_offset": 1,
-        "y_offset": 4
+        "x": 1,
+        "y": 4
     },
     {
         "path": "tool/mountain_tool_even.png",
-        "x_offset": 1,
-        "y_offset": 4
+        "x": 1,
+        "y": 4
     },
     {
         "path": "tool/mountain_tool_odd.png",
-        "x_offset": 1,
-        "y_offset": 5
+        "x": 1,
+        "y": 5
     },
     {
         "path": "tool/scenery_scatter_low.png"
@@ -230,38 +230,38 @@
     },
     {
         "path": "icons/path_railings.png",
-        "x_offset": 1,
-        "y_offset": 1
+        "x": 1,
+        "y": 1
     },
     {
         "path": "icons/legacy_paths.png",
-        "x_offset": 1,
-        "y_offset": 1
+        "x": 1,
+        "y": 1
     },
     {
         "path": "icons/path_surfaces.png",
-        "x_offset": 1,
-        "y_offset": 1
+        "x": 1,
+        "y": 1
     },
     {
         "path": "icons/ride_stations.png",
-        "x_offset": 5,
-        "y_offset": 1
+        "x": 5,
+        "y": 1
     },
     {
         "path": "icons/terrain_edges.png",
-        "x_offset": 1,
-        "y_offset": 1
+        "x": 1,
+        "y": 1
     },
     {
         "path": "icons/hide_vegetation.png",
-        "x_offset": 1,
-        "y_offset": 1
+        "x": 1,
+        "y": 1
     },
     {
         "path": "icons/hide_scenery.png",
-        "x_offset": 1,
-        "y_offset": 1
+        "x": 1,
+        "y": 1
     },
     {
         "path": "icons/hide_vehicles.png"
@@ -271,18 +271,18 @@
     },
     {
         "path": "icons/hide_partial.png",
-        "x_offset": 4,
-        "y_offset": 2
+        "x": 4,
+        "y": 2
     },
     {
         "path": "icons/hide_full.png",
-        "x_offset": 4,
-        "y_offset": 2
+        "x": 4,
+        "y": 2
     },
     {
         "path": "icons/link_chain.png",
-        "x_offset": 2,
-        "y_offset": 2
+        "x": 2,
+        "y": 2
     },
     {
         "path": "sideways-tab.png"
@@ -292,18 +292,18 @@
     },
     {
         "path": "icons/arrow_up.png",
-        "x_offset": 5,
-        "y_offset": 5
+        "x": 5,
+        "y": 5
     },
     {
         "path": "icons/arrow_down.png",
-        "x_offset": 5,
-        "y_offset": 5
+        "x": 5,
+        "y": 5
     },
     {
         "path": "icons/reload.png",
-        "x_offset": 2,
-        "y_offset": 2
+        "x": 2,
+        "y": 2
     },
     {
         "path": "icons/colour_invisible.png"
@@ -553,52 +553,52 @@
     },
     {
         "path": "surface/glassy_recolourable.png",
-        "x_offset": -32,
-        "y_offset": -1,
+        "x": -32,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "surface/selection_edge_nw.png",
-        "x_offset": -32,
-        "y_offset": -1
+        "x": -32,
+        "y": -1
     },
     {
         "path": "surface/selection_edge_ne.png",
-        "x_offset": 0,
-        "y_offset": -1
+        "x": 0,
+        "y": -1
     },
     {
         "path": "surface/selection_edge_sw.png",
-        "x_offset": -32,
-        "y_offset": 15
+        "x": -32,
+        "y": 15
     },
     {
         "path": "surface/selection_edge_se.png",
-        "x_offset": 0,
-        "y_offset": 15
+        "x": 0,
+        "y": 15
     },
     {
         "path": "font/latin/ae-uc-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/ae-small.png",
-        "y_offset": 2,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/o-stroke-uc-small.png",
-        "x_offset": -1,
-        "y_offset": 0,
+        "x": -1,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/o-stroke-small.png",
-        "y_offset": 2,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
@@ -734,13 +734,13 @@
     },
     {
         "path": "font/cyrillic/U1078-small.png",
-        "y_offset": 2,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/cyrillic/U1079-small.png",
-        "y_offset": 2,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
@@ -836,7 +836,7 @@
     },
     {
         "path": "font/cyrillic/U1108-small.png",
-        "y_offset": 2,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
@@ -847,277 +847,277 @@
     },
     {
         "path": "font/cyrillic/U1169-small.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/german-openquotes-small.png",
-        "y_offset": 6,
+        "y": 6,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/guilder-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/g-breve-uc-small.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/i-with-dot-uc-small.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/s-cedilla-uc-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/g-breve-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/i-without-dot-small.png",
-        "y_offset": 2,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/s-cedilla-small.png",
-        "y_offset": 2,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/interpunct-small.png",
-        "y_offset": 3,
+        "y": 3,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/a-breve-uc-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/t-comma-uc-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/t-comma-small.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/ellipsis-small.png",
-        "y_offset": 6,
+        "y": 6,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/c-caron-uc-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/c-caron-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/y-acute-uc-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/y-acute-small.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/o-double-acute-uc-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/o-double-acute-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/oe-uc-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/oe-small.png",
-        "y_offset": 2,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/u-double-acute-uc-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/u-double-acute-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/d-caron-uc-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/d-caron-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/e-caron-uc-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/e-caron-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/n-caron-uc-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/n-caron-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/r-caron-uc-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/r-caron-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/s-caron-uc-small.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/s-caron-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/t-caron-uc-small.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/t-caron-small.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/u-ring-uc-small.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/u-ring-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/w-circumflex-uc-small.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/w-circumflex-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/y-circumflex-uc-small.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/y-circumflex-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/z-caron-uc-small.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/z-caron-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/rouble-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/j-small.png",
-        "x_offset": -1,
+        "x": -1,
         "palette": "keep",
         "forceBmp": true
     },
@@ -1128,74 +1128,74 @@
     },
     {
         "path": "font/latin/c-circumflex-uc-small.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/c-circumflex-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/g-circumflex-uc-small.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/g-circumflex-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/h-circumflex-uc-small.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/h-circumflex-small.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/j-circumflex-uc-small.png",
-        "x_offset": -1,
-        "y_offset": -1,
+        "x": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/j-circumflex-small.png",
-        "x_offset": -1,
+        "x": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/s-circumflex-uc-small.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/s-circumflex-small.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/u-breve-uc-small.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/u-breve-small.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
@@ -1206,7 +1206,7 @@
     },
     {
         "path": "font/vertical-bar-small.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
@@ -1217,39 +1217,39 @@
     },
     {
         "path": "font/tilde-small.png",
-        "y_offset": 3,
+        "y": 3,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/eye.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/ae-uc-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/ae-bold.png",
-        "y_offset": 2,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/o-stroke-uc-bold.png",
-        "x_offset": -1,
-        "y_offset": -1,
+        "x": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/o-stroke-bold.png",
-        "x_offset": 0,
-        "y_offset": 2,
+        "x": 0,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
@@ -1385,13 +1385,13 @@
     },
     {
         "path": "font/cyrillic/U1078-bold.png",
-        "y_offset": 2,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/cyrillic/U1079-bold.png",
-        "y_offset": 2,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
@@ -1487,7 +1487,7 @@
     },
     {
         "path": "font/cyrillic/U1108-bold.png",
-        "y_offset": 2,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
@@ -1498,277 +1498,277 @@
     },
     {
         "path": "font/cyrillic/U1169-bold.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/german-openquotes-bold.png",
-        "y_offset": 5,
+        "y": 5,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/guilder-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/g-breve-uc-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/i-with-dot-uc-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/s-cedilla-uc-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/g-breve-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/i-without-dot-bold.png",
-        "y_offset": 2,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/s-cedilla-bold.png",
-        "y_offset": 2,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/interpunct-bold.png",
-        "y_offset": 3,
+        "y": 3,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/a-breve-uc-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/t-comma-uc-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/t-comma-bold.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/ellipsis-bold.png",
-        "y_offset": 6,
+        "y": 6,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/c-caron-uc-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/c-caron-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/y-acute-uc-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/y-acute-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/o-double-acute-uc-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/o-double-acute-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/oe-uc-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/oe-bold.png",
-        "y_offset": 2,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/u-double-acute-uc-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/u-double-acute-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/d-caron-uc-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/d-caron-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/e-caron-uc-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/e-caron-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/n-caron-uc-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/n-caron-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/r-caron-uc-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/r-caron-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/s-caron-uc-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/s-caron-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/t-caron-uc-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/t-caron-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/u-ring-uc-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/u-ring-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/w-circumflex-uc-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/w-circumflex-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/y-circumflex-uc-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/y-circumflex-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/z-caron-uc-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/z-caron-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/rouble-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/j-bold.png",
-        "x_offset": -1,
+        "x": -1,
         "palette": "keep",
         "forceBmp": true
     },
@@ -1779,74 +1779,74 @@
     },
     {
         "path": "font/latin/c-circumflex-uc-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/c-circumflex-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/g-circumflex-uc-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/g-circumflex-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/h-circumflex-uc-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/h-circumflex-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/j-circumflex-uc-bold.png",
-        "x_offset": -1,
-        "y_offset": -1,
+        "x": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/j-circumflex-bold.png",
-        "x_offset": -1,
+        "x": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/s-circumflex-uc-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/s-circumflex-bold.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/u-breve-uc-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/u-breve-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
@@ -1857,7 +1857,7 @@
     },
     {
         "path": "font/vertical-bar-bold.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
@@ -1868,37 +1868,37 @@
     },
     {
         "path": "font/tilde-bold.png",
-        "y_offset": 2,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/eye.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/ae-uc-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/ae-tiny.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/o-stroke-uc-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/o-stroke-tiny.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
@@ -2024,7 +2024,7 @@
     },
     {
         "path": "font/cyrillic/U1075-tiny.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
@@ -2045,7 +2045,7 @@
     },
     {
         "path": "font/cyrillic/U1080-tiny.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
@@ -2056,25 +2056,25 @@
     },
     {
         "path": "font/cyrillic/U1082-tiny.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/cyrillic/U1083-tiny.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/cyrillic/U1084-tiny.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/cyrillic/U1085-tiny.png",
-        "y_offset": 2,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
@@ -2085,7 +2085,7 @@
     },
     {
         "path": "font/cyrillic/U1090-tiny.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
@@ -2106,25 +2106,25 @@
     },
     {
         "path": "font/cyrillic/U1096-tiny.png",
-        "y_offset": 2,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/cyrillic/U1097-tiny.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/cyrillic/U1099-tiny.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/cyrillic/U1100-tiny.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
@@ -2135,19 +2135,19 @@
     },
     {
         "path": "font/cyrillic/U1102-tiny.png",
-        "y_offset": 2,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/cyrillic/U1103-tiny.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/cyrillic/U1108-tiny.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
@@ -2158,277 +2158,277 @@
     },
     {
         "path": "font/cyrillic/U1169-tiny.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/german-openquotes-tiny.png",
-        "y_offset": 4,
+        "y": 4,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/guilder-tiny.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/g-breve-uc-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/i-with-dot-uc-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/s-cedilla-uc-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/g-breve-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/i-without-dot-tiny.png",
-        "y_offset": 2,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/s-cedilla-tiny.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/interpunct-tiny.png",
-        "y_offset": 2,
+        "y": 2,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/a-breve-uc-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/t-comma-uc-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/t-comma-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/ellipsis-tiny.png",
-        "y_offset": 4,
+        "y": 4,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/c-caron-uc-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/c-caron-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/y-acute-uc-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/y-acute-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/o-double-acute-uc-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/o-double-acute-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/oe-uc-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/oe-tiny.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/u-double-acute-uc-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/u-double-acute-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/d-caron-uc-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/d-caron-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/e-caron-uc-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/e-caron-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/n-caron-uc-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/n-caron-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/r-caron-uc-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/r-caron-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/s-caron-uc-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/s-caron-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/t-caron-uc-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/t-caron-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/u-ring-uc-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/u-ring-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/w-circumflex-uc-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/w-circumflex-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/y-circumflex-uc-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/y-circumflex-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/z-caron-uc-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/z-caron-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/rouble-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/j-tiny.png",
-        "x_offset": 0,
+        "x": 0,
         "palette": "keep",
         "forceBmp": true
     },
@@ -2439,73 +2439,73 @@
     },
     {
         "path": "font/latin/c-circumflex-uc-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/c-circumflex-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/g-circumflex-uc-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/g-circumflex-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/h-circumflex-uc-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/h-circumflex-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/j-circumflex-uc-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/j-circumflex-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/s-circumflex-uc-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/s-circumflex-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/u-breve-uc-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/latin/u-breve-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
@@ -2516,7 +2516,7 @@
     },
     {
         "path": "font/vertical-bar-tiny.png",
-        "y_offset": -1,
+        "y": -1,
         "palette": "keep",
         "forceBmp": true
     },
@@ -2527,13 +2527,13 @@
     },
     {
         "path": "font/tilde-tiny.png",
-        "y_offset": 1,
+        "y": 1,
         "palette": "keep",
         "forceBmp": true
     },
     {
         "path": "font/eye-tiny.png",
-        "y_offset": 0,
+        "y": 0,
         "palette": "keep",
         "forceBmp": true
     },
@@ -2611,22314 +2611,22314 @@
     },
     {
         "path": "track/junior/booster_1.png",
-        "x_offset": -21,
-        "y_offset": 0
+        "x": -21,
+        "y": 0
     },
     {
         "path": "track/junior/booster_2.png",
-        "x_offset": -22,
-        "y_offset": 1
+        "x": -22,
+        "y": 1
     },
     {
         "path": "track/junior/brake_horizontal.png",
-        "x_offset": -32,
-        "y_offset": 7,
+        "x": -32,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/junior/brake_vertical.png",
-        "x_offset": -9,
-        "y_offset": -4,
+        "x": -9,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/junior/blockbrake_horizontal_closed.png",
-        "x_offset": -32,
-        "y_offset": 7,
+        "x": -32,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/junior/blockbrake_horizontal_open.png",
-        "x_offset": -32,
-        "y_offset": 7,
+        "x": -32,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/junior/blockbrake_vertical_closed.png",
-        "x_offset": -9,
-        "y_offset": -4,
+        "x": -9,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/junior/blockbrake_vertical_open.png",
-        "x_offset": -9,
-        "y_offset": -4,
+        "x": -9,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/booster_1.png",
-        "x_offset": -22,
-        "y_offset": -4
+        "x": -22,
+        "y": -4
     },
     {
         "path": "track/intamin/booster_2.png",
-        "x_offset": -22,
-        "y_offset": -4
+        "x": -22,
+        "y": -4
     },
     {
         "path": "track/intamin/brake_horizontal_background_open.png",
-        "x_offset": -32,
-        "y_offset": -5,
+        "x": -32,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/intamin/brake_horizontal_background_closed.png",
-        "x_offset": -32,
-        "y_offset": -5,
+        "x": -32,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/intamin/brake_horizontal_foreground.png",
-        "x_offset": -30,
-        "y_offset": 8,
+        "x": -30,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/intamin/brake_vertical_background.png",
-        "x_offset": -14,
-        "y_offset": -10,
+        "x": -14,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/intamin/brake_vertical_foreground_open.png",
-        "x_offset": -13,
-        "y_offset": -9,
+        "x": -13,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/brake_vertical_foreground_closed.png",
-        "x_offset": -13,
-        "y_offset": -9,
+        "x": -13,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/liftbooster_0.png",
-        "x_offset": -21,
-        "y_offset": -20,
+        "x": -21,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/intamin/liftbooster_1.png",
-        "x_offset": -21,
-        "y_offset": -4,
+        "x": -21,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/liftbooster_2.png",
-        "x_offset": -22,
-        "y_offset": -4,
+        "x": -22,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/liftbooster_3.png",
-        "x_offset": -22,
-        "y_offset": -20,
+        "x": -22,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/intamin/steep_to_vertical_up_1.png",
-        "x_offset": -21,
-        "y_offset": -54,
+        "x": -21,
+        "y": -54,
         "palette": "keep"
     },
     {
         "path": "track/intamin/steep_to_vertical_up_2.png",
-        "x_offset": -21,
-        "y_offset": -53,
+        "x": -21,
+        "y": -53,
         "palette": "keep"
     },
     {
         "path": "track/intamin/steep_to_vertical_up_3.png",
-        "x_offset": -10,
-        "y_offset": -53,
+        "x": -10,
+        "y": -53,
         "palette": "keep"
     },
     {
         "path": "track/intamin/steep_to_vertical_up_4.png",
-        "x_offset": -10,
-        "y_offset": -54,
+        "x": -10,
+        "y": -54,
         "palette": "keep"
     },
     {
         "path": "track/intamin/vertical_to_steep_up_1.png",
-        "x_offset": -6,
-        "y_offset": -60,
+        "x": -6,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/intamin/vertical_to_steep_up_2.png",
-        "x_offset": -6,
-        "y_offset": -44,
+        "x": -6,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/intamin/vertical_to_steep_up_3.png",
-        "x_offset": -25,
-        "y_offset": -44,
+        "x": -25,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/intamin/vertical_to_steep_up_4.png",
-        "x_offset": -25,
-        "y_offset": -61,
+        "x": -25,
+        "y": -61,
         "palette": "keep"
     },
     {
         "path": "track/intamin/vertical_1.png",
-        "x_offset": -6,
-        "y_offset": -30,
+        "x": -6,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/intamin/vertical_2.png",
-        "x_offset": -6,
-        "y_offset": -29,
+        "x": -6,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/intamin/vertical_3.png",
-        "x_offset": -10,
-        "y_offset": -29,
+        "x": -10,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/intamin/vertical_4.png",
-        "x_offset": -10,
-        "y_offset": -30,
+        "x": -10,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/intamin/vertical_twist_left_up_1.png",
-        "x_offset": -10,
-        "y_offset": -95,
+        "x": -10,
+        "y": -95,
         "palette": "keep"
     },
     {
         "path": "track/intamin/vertical_twist_left_up_2_1.png",
-        "x_offset": -6,
-        "y_offset": -94,
+        "x": -6,
+        "y": -94,
         "palette": "keep"
     },
     {
         "path": "track/intamin/vertical_twist_left_up_2_2.png",
-        "x_offset": -6,
-        "y_offset": -45,
+        "x": -6,
+        "y": -45,
         "palette": "keep"
     },
     {
         "path": "track/intamin/vertical_twist_left_up_3.png",
-        "x_offset": -10,
-        "y_offset": -93,
+        "x": -10,
+        "y": -93,
         "palette": "keep"
     },
     {
         "path": "track/intamin/vertical_twist_left_up_4_1.png",
-        "x_offset": -13,
-        "y_offset": -44,
+        "x": -13,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/intamin/vertical_twist_left_up_4_2.png",
-        "x_offset": -13,
-        "y_offset": -93,
+        "x": -13,
+        "y": -93,
         "palette": "keep"
     },
     {
         "path": "track/intamin/vertical_twist_right_up_1_1.png",
-        "x_offset": -6,
-        "y_offset": -45,
+        "x": -6,
+        "y": -45,
         "palette": "keep"
     },
     {
         "path": "track/intamin/vertical_twist_right_up_1_2.png",
-        "x_offset": -6,
-        "y_offset": -93,
+        "x": -6,
+        "y": -93,
         "palette": "keep"
     },
     {
         "path": "track/intamin/vertical_twist_right_up_2.png",
-        "x_offset": -10,
-        "y_offset": -93,
+        "x": -10,
+        "y": -93,
         "palette": "keep"
     },
     {
         "path": "track/intamin/vertical_twist_right_up_3_1.png",
-        "x_offset": -13,
-        "y_offset": -94,
+        "x": -13,
+        "y": -94,
         "palette": "keep"
     },
     {
         "path": "track/intamin/vertical_twist_right_up_3_2.png",
-        "x_offset": -13,
-        "y_offset": -45,
+        "x": -13,
+        "y": -45,
         "palette": "keep"
     },
     {
         "path": "track/intamin/vertical_twist_right_up_4.png",
-        "x_offset": -10,
-        "y_offset": -94,
+        "x": -10,
+        "y": -94,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_1_1.png",
-        "x_offset": -22,
-        "y_offset": 4,
+        "x": -22,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_1_2.png",
-        "x_offset": -17,
-        "y_offset": 4,
+        "x": -17,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_1_3.png",
-        "x_offset": -22,
-        "y_offset": 3,
+        "x": -22,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_1_4.png",
-        "x_offset": -20,
-        "y_offset": -21,
+        "x": -20,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_1_5.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_1_6.png",
-        "x_offset": -11,
-        "y_offset": -31,
+        "x": -11,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_2_1.png",
-        "x_offset": -22,
-        "y_offset": -4,
+        "x": -22,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_2_2.png",
-        "x_offset": -20,
-        "y_offset": 4,
+        "x": -20,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_2_3.png",
-        "x_offset": -28,
-        "y_offset": -5,
+        "x": -28,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_2_4.png",
-        "x_offset": -28,
-        "y_offset": -8,
+        "x": -28,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_2_5.png",
-        "x_offset": 10,
-        "y_offset": -1,
+        "x": 10,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_2_6.png",
-        "x_offset": -32,
-        "y_offset": -21,
+        "x": -32,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_3_1.png",
-        "x_offset": -29,
-        "y_offset": -4,
+        "x": -29,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_3_2.png",
-        "x_offset": 10,
-        "y_offset": 8,
+        "x": 10,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_3_3.png",
-        "x_offset": -26,
-        "y_offset": -16,
+        "x": -26,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_3_4.png",
-        "x_offset": -28,
-        "y_offset": -13,
+        "x": -28,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_3_5.png",
-        "x_offset": -1,
-        "y_offset": -16,
+        "x": -1,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_3_6.png",
-        "x_offset": -22,
-        "y_offset": -29,
+        "x": -22,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_4_1.png",
-        "x_offset": -15,
-        "y_offset": -15,
+        "x": -15,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_4_2.png",
-        "x_offset": 13,
-        "y_offset": 23,
+        "x": 13,
+        "y": 23,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_4_3.png",
-        "x_offset": -12,
-        "y_offset": -23,
+        "x": -12,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_4_4.png",
-        "x_offset": -10,
-        "y_offset": -31,
+        "x": -10,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_4_5.png",
-        "x_offset": -12,
-        "y_offset": -16,
+        "x": -12,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_left_4_6.png",
-        "x_offset": -22,
-        "y_offset": -31,
+        "x": -22,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_1_1.png",
-        "x_offset": -22,
-        "y_offset": -15,
+        "x": -22,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_1_2.png",
-        "x_offset": -17,
-        "y_offset": 22,
+        "x": -17,
+        "y": 22,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_1_3.png",
-        "x_offset": -26,
-        "y_offset": -23,
+        "x": -26,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_1_4.png",
-        "x_offset": -15,
-        "y_offset": -31,
+        "x": -15,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_1_5.png",
-        "x_offset": -22,
-        "y_offset": -12,
+        "x": -22,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_1_6.png",
-        "x_offset": -26,
-        "y_offset": -31,
+        "x": -26,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_2_1.png",
-        "x_offset": -22,
-        "y_offset": -4,
+        "x": -22,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_2_2.png",
-        "x_offset": -17,
-        "y_offset": 9,
+        "x": -17,
+        "y": 9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_2_3.png",
-        "x_offset": -7,
-        "y_offset": -15,
+        "x": -7,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_2_4.png",
-        "x_offset": 14,
-        "y_offset": -12,
+        "x": 14,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_2_5.png",
-        "x_offset": -7,
-        "y_offset": -16,
+        "x": -7,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_2_6.png",
-        "x_offset": -6,
-        "y_offset": -28,
+        "x": -6,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_3_1.png",
-        "x_offset": -2,
-        "y_offset": -4,
+        "x": -2,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_3_2.png",
-        "x_offset": -4,
-        "y_offset": 4,
+        "x": -4,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_3_3.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_3_4.png",
-        "x_offset": 0,
-        "y_offset": -8,
+        "x": 0,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_3_5.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_3_6.png",
-        "x_offset": -22,
-        "y_offset": -21,
+        "x": -22,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_4_1.png",
-        "x_offset": -12,
-        "y_offset": 4,
+        "x": -12,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_4_2.png",
-        "x_offset": -25,
-        "y_offset": 5,
+        "x": -25,
+        "y": 5,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_4_3.png",
-        "x_offset": 8,
-        "y_offset": 14,
+        "x": 8,
+        "y": 14,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_4_4.png",
-        "x_offset": -28,
-        "y_offset": -21,
+        "x": -28,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_4_5.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/intamin/barrel_roll_right_4_6.png",
-        "x_offset": -22,
-        "y_offset": -31,
+        "x": -22,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/half_loop_1_1.png",
-        "x_offset": -28,
-        "y_offset": -22,
+        "x": -28,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/intamin/half_loop_1_2.png",
-        "x_offset": -23,
-        "y_offset": -40,
+        "x": -23,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/intamin/half_loop_1_3.png",
-        "x_offset": -13,
-        "y_offset": -92,
+        "x": -13,
+        "y": -92,
         "palette": "keep"
     },
     {
         "path": "track/intamin/half_loop_1_4.png",
-        "x_offset": -22,
-        "y_offset": 13,
+        "x": -22,
+        "y": 13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/half_loop_2_1.png",
-        "x_offset": -16,
-        "y_offset": -18,
+        "x": -16,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/intamin/half_loop_2_2.png",
-        "x_offset": 1,
-        "y_offset": -37,
+        "x": 1,
+        "y": -37,
         "palette": "keep"
     },
     {
         "path": "track/intamin/half_loop_2_3.png",
-        "x_offset": -38,
-        "y_offset": -114,
+        "x": -38,
+        "y": -114,
         "palette": "keep"
     },
     {
         "path": "track/intamin/half_loop_2_4.png",
-        "x_offset": -22,
-        "y_offset": 1,
+        "x": -22,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/intamin/half_loop_3_1.png",
-        "x_offset": -29,
-        "y_offset": -9,
+        "x": -29,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/half_loop_3_2.png",
-        "x_offset": -30,
-        "y_offset": -33,
+        "x": -30,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/intamin/half_loop_3_3.png",
-        "x_offset": -2,
-        "y_offset": -121,
+        "x": -2,
+        "y": -121,
         "palette": "keep"
     },
     {
         "path": "track/intamin/half_loop_3_4.png",
-        "x_offset": -29,
-        "y_offset": -7,
+        "x": -29,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/intamin/half_loop_4_1.png",
-        "x_offset": -13,
-        "y_offset": -22,
+        "x": -13,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/intamin/half_loop_4_2.png",
-        "x_offset": -14,
-        "y_offset": -44,
+        "x": -14,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/intamin/half_loop_4_3.png",
-        "x_offset": 4,
-        "y_offset": -101,
+        "x": 4,
+        "y": -101,
         "palette": "keep"
     },
     {
         "path": "track/intamin/half_loop_4_4.png",
-        "x_offset": 1,
-        "y_offset": 4,
+        "x": 1,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/left_vertical_loop_1_1.png",
-        "x_offset": -28,
-        "y_offset": -25,
+        "x": -28,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/intamin/left_vertical_loop_1_2.png",
-        "x_offset": -26,
-        "y_offset": -111,
+        "x": -26,
+        "y": -111,
         "palette": "keep"
     },
     {
         "path": "track/intamin/left_vertical_loop_1_3.png",
-        "x_offset": -22,
-        "y_offset": -84,
+        "x": -22,
+        "y": -84,
         "palette": "keep"
     },
     {
         "path": "track/intamin/left_vertical_loop_1_4.png",
-        "x_offset": -32,
-        "y_offset": 9,
+        "x": -32,
+        "y": 9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/left_vertical_loop_2_1.png",
-        "x_offset": -15,
-        "y_offset": -26,
+        "x": -15,
+        "y": -26,
         "palette": "keep"
     },
     {
         "path": "track/intamin/left_vertical_loop_2_2.png",
-        "x_offset": 1,
-        "y_offset": -32,
+        "x": 1,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/intamin/left_vertical_loop_2_3.png",
-        "x_offset": -34,
-        "y_offset": -114,
+        "x": -34,
+        "y": -114,
         "palette": "keep"
     },
     {
         "path": "track/intamin/left_vertical_loop_2_4.png",
-        "x_offset": -6,
-        "y_offset": -3,
+        "x": -6,
+        "y": -3,
         "palette": "keep"
     },
     {
         "path": "track/intamin/left_vertical_loop_3_1.png",
-        "x_offset": -25,
-        "y_offset": -110,
+        "x": -25,
+        "y": -110,
         "palette": "keep"
     },
     {
         "path": "track/intamin/left_vertical_loop_3_2.png",
-        "x_offset": -19,
-        "y_offset": -51,
+        "x": -19,
+        "y": -51,
         "palette": "keep"
     },
     {
         "path": "track/intamin/left_vertical_loop_3_3.png",
-        "x_offset": 11,
-        "y_offset": -94,
+        "x": 11,
+        "y": -94,
         "palette": "keep"
     },
     {
         "path": "track/intamin/left_vertical_loop_3_4.png",
-        "x_offset": -22,
-        "y_offset": 3,
+        "x": -22,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/intamin/left_vertical_loop_4_1.png",
-        "x_offset": -15,
-        "y_offset": -20,
+        "x": -15,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/intamin/left_vertical_loop_4_2.png",
-        "x_offset": -20,
-        "y_offset": -41,
+        "x": -20,
+        "y": -41,
         "palette": "keep"
     },
     {
         "path": "track/intamin/left_vertical_loop_4_3.png",
-        "x_offset": -4,
-        "y_offset": -87,
+        "x": -4,
+        "y": -87,
         "palette": "keep"
     },
     {
         "path": "track/intamin/left_vertical_loop_4_4.png",
-        "x_offset": -13,
-        "y_offset": 17,
+        "x": -13,
+        "y": 17,
         "palette": "keep"
     },
     {
         "path": "track/intamin/right_vertical_loop_1_1.png",
-        "x_offset": -27,
-        "y_offset": -20,
+        "x": -27,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/intamin/right_vertical_loop_1_2.png",
-        "x_offset": -27,
-        "y_offset": -41,
+        "x": -27,
+        "y": -41,
         "palette": "keep"
     },
     {
         "path": "track/intamin/right_vertical_loop_1_3.png",
-        "x_offset": -20,
-        "y_offset": -86,
+        "x": -20,
+        "y": -86,
         "palette": "keep"
     },
     {
         "path": "track/intamin/right_vertical_loop_1_4.png",
-        "x_offset": -21,
-        "y_offset": 16,
+        "x": -21,
+        "y": 16,
         "palette": "keep"
     },
     {
         "path": "track/intamin/right_vertical_loop_2_1.png",
-        "x_offset": -16,
-        "y_offset": -9,
+        "x": -16,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/right_vertical_loop_2_2.png",
-        "x_offset": -7,
-        "y_offset": -51,
+        "x": -7,
+        "y": -51,
         "palette": "keep"
     },
     {
         "path": "track/intamin/right_vertical_loop_2_3.png",
-        "x_offset": -23,
-        "y_offset": -100,
+        "x": -23,
+        "y": -100,
         "palette": "keep"
     },
     {
         "path": "track/intamin/right_vertical_loop_2_4.png",
-        "x_offset": -16,
-        "y_offset": 5,
+        "x": -16,
+        "y": 5,
         "palette": "keep"
     },
     {
         "path": "track/intamin/right_vertical_loop_3_1.png",
-        "x_offset": -46,
-        "y_offset": -26,
+        "x": -46,
+        "y": -26,
         "palette": "keep"
     },
     {
         "path": "track/intamin/right_vertical_loop_3_2.png",
-        "x_offset": -41,
-        "y_offset": -32,
+        "x": -41,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/intamin/right_vertical_loop_3_3.png",
-        "x_offset": 8,
-        "y_offset": -114,
+        "x": 8,
+        "y": -114,
         "palette": "keep"
     },
     {
         "path": "track/intamin/right_vertical_loop_3_4.png",
-        "x_offset": -27,
-        "y_offset": 0,
+        "x": -27,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/intamin/right_vertical_loop_4_1.png",
-        "x_offset": -10,
-        "y_offset": -25,
+        "x": -10,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/intamin/right_vertical_loop_4_2.png",
-        "x_offset": -11,
-        "y_offset": -111,
+        "x": -11,
+        "y": -111,
         "palette": "keep"
     },
     {
         "path": "track/intamin/right_vertical_loop_4_3.png",
-        "x_offset": 1,
-        "y_offset": -83,
+        "x": 1,
+        "y": -83,
         "palette": "keep"
     },
     {
         "path": "track/intamin/right_vertical_loop_4_4.png",
-        "x_offset": -9,
-        "y_offset": 9,
+        "x": -9,
+        "y": 9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/quarter_loop_up_1_1.png",
-        "x_offset": -18,
-        "y_offset": -55,
+        "x": -18,
+        "y": -55,
         "palette": "keep"
     },
     {
         "path": "track/intamin/quarter_loop_up_1_2.png",
-        "x_offset": 0,
-        "y_offset": -43,
+        "x": 0,
+        "y": -43,
         "palette": "keep"
     },
     {
         "path": "track/intamin/quarter_loop_up_1_3.png",
-        "x_offset": -22,
-        "y_offset": -23,
+        "x": -22,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/intamin/quarter_loop_up_2_1.png",
-        "x_offset": -24,
-        "y_offset": -79,
+        "x": -24,
+        "y": -79,
         "palette": "keep"
     },
     {
         "path": "track/intamin/quarter_loop_up_2_2.png",
-        "x_offset": -32,
-        "y_offset": -66,
+        "x": -32,
+        "y": -66,
         "palette": "keep"
     },
     {
         "path": "track/intamin/quarter_loop_up_2_3.png",
-        "x_offset": -22,
-        "y_offset": -31,
+        "x": -22,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/quarter_loop_up_3_1.png",
-        "x_offset": -10,
-        "y_offset": -78,
+        "x": -10,
+        "y": -78,
         "palette": "keep"
     },
     {
         "path": "track/intamin/quarter_loop_up_3_2.png",
-        "x_offset": -21,
-        "y_offset": -68,
+        "x": -21,
+        "y": -68,
         "palette": "keep"
     },
     {
         "path": "track/intamin/quarter_loop_up_3_3.png",
-        "x_offset": -11,
-        "y_offset": -31,
+        "x": -11,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/quarter_loop_up_4_1.png",
-        "x_offset": -10,
-        "y_offset": -56,
+        "x": -10,
+        "y": -56,
         "palette": "keep"
     },
     {
         "path": "track/intamin/quarter_loop_up_4_2.png",
-        "x_offset": -28,
-        "y_offset": -43,
+        "x": -28,
+        "y": -43,
         "palette": "keep"
     },
     {
         "path": "track/intamin/quarter_loop_up_4_3.png",
-        "x_offset": -32,
-        "y_offset": -23,
+        "x": -32,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_left_1_1.png",
-        "x_offset": -22,
-        "y_offset": -71,
+        "x": -22,
+        "y": -71,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_left_1_2.png",
-        "x_offset": -20,
-        "y_offset": -36,
+        "x": -20,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_left_1_3.png",
-        "x_offset": -22,
-        "y_offset": -31,
+        "x": -22,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_left_2_1.png",
-        "x_offset": -22,
-        "y_offset": -4,
+        "x": -22,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_left_2_2.png",
-        "x_offset": -32,
-        "y_offset": -36,
+        "x": -32,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_left_2_3.png",
-        "x_offset": -21,
-        "y_offset": -31,
+        "x": -21,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_left_3_1.png",
-        "x_offset": -31,
-        "y_offset": -9,
+        "x": -31,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_left_3_2.png",
-        "x_offset": -3,
-        "y_offset": -24,
+        "x": -3,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_left_3_3.png",
-        "x_offset": -19,
-        "y_offset": -19,
+        "x": -19,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_left_4_1.png",
-        "x_offset": -32,
-        "y_offset": -39,
+        "x": -32,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_left_4_2.png",
-        "x_offset": -34,
-        "y_offset": -21,
+        "x": -34,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_left_4_3.png",
-        "x_offset": -22,
-        "y_offset": -22,
+        "x": -22,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_right_1_1.png",
-        "x_offset": -22,
-        "y_offset": -39,
+        "x": -22,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_right_1_2.png",
-        "x_offset": -8,
-        "y_offset": -22,
+        "x": -8,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_right_1_3.png",
-        "x_offset": -20,
-        "y_offset": -22,
+        "x": -20,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_right_2_1.png",
-        "x_offset": -22,
-        "y_offset": -9,
+        "x": -22,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_right_2_2.png",
-        "x_offset": -13,
-        "y_offset": -24,
+        "x": -13,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_right_2_3.png",
-        "x_offset": -22,
-        "y_offset": -19,
+        "x": -22,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_right_3_1.png",
-        "x_offset": -7,
-        "y_offset": -4,
+        "x": -7,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_right_3_2.png",
-        "x_offset": -22,
-        "y_offset": -36,
+        "x": -22,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_right_3_3.png",
-        "x_offset": -22,
-        "y_offset": -31,
+        "x": -22,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_right_4_1.png",
-        "x_offset": -27,
-        "y_offset": -65,
+        "x": -27,
+        "y": -65,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_right_4_2.png",
-        "x_offset": -3,
-        "y_offset": -36,
+        "x": -3,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/intamin/corkscrew_right_4_3.png",
-        "x_offset": -26,
-        "y_offset": -31,
+        "x": -26,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_left_1_1.png",
-        "x_offset": -22,
-        "y_offset": -12,
+        "x": -22,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_left_1_2.png",
-        "x_offset": -21,
-        "y_offset": -72,
+        "x": -21,
+        "y": -72,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_left_1_3.png",
-        "x_offset": -28,
-        "y_offset": -40,
+        "x": -28,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_left_1_4.png",
-        "x_offset": -23,
-        "y_offset": -52,
+        "x": -23,
+        "y": -52,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_left_1_5.png",
-        "x_offset": -22,
-        "y_offset": -39,
+        "x": -22,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_left_2_1.png",
-        "x_offset": -22,
-        "y_offset": -4,
+        "x": -22,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_left_2_2.png",
-        "x_offset": -32,
-        "y_offset": -15,
+        "x": -32,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_left_2_3.png",
-        "x_offset": -23,
-        "y_offset": -50,
+        "x": -23,
+        "y": -50,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_left_2_4.png",
-        "x_offset": -18,
-        "y_offset": -56,
+        "x": -18,
+        "y": -56,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_left_2_5.png",
-        "x_offset": -14,
-        "y_offset": -39,
+        "x": -14,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_left_3_1.png",
-        "x_offset": -16,
-        "y_offset": -4,
+        "x": -16,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_left_3_2.png",
-        "x_offset": -19,
-        "y_offset": -17,
+        "x": -19,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_left_3_3.png",
-        "x_offset": 10,
-        "y_offset": -33,
+        "x": 10,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_left_3_4.png",
-        "x_offset": -8,
-        "y_offset": -38,
+        "x": -8,
+        "y": -38,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_left_3_5.png",
-        "x_offset": -16,
-        "y_offset": -30,
+        "x": -16,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_left_4_1.png",
-        "x_offset": -24,
-        "y_offset": -11,
+        "x": -24,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_left_4_2.png",
-        "x_offset": -23,
-        "y_offset": -27,
+        "x": -23,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_left_4_3.png",
-        "x_offset": -14,
-        "y_offset": -13,
+        "x": -14,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_left_4_4.png",
-        "x_offset": -29,
-        "y_offset": -36,
+        "x": -29,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_left_4_5.png",
-        "x_offset": -22,
-        "y_offset": -33,
+        "x": -22,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_right_1_1.png",
-        "x_offset": -22,
-        "y_offset": -11,
+        "x": -22,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_right_1_2.png",
-        "x_offset": -22,
-        "y_offset": -27,
+        "x": -22,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_right_1_3.png",
-        "x_offset": -20,
-        "y_offset": -13,
+        "x": -20,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_right_1_4.png",
-        "x_offset": -28,
-        "y_offset": -37,
+        "x": -28,
+        "y": -37,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_right_1_5.png",
-        "x_offset": -32,
-        "y_offset": -33,
+        "x": -32,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_right_2_1.png",
-        "x_offset": -22,
-        "y_offset": -4,
+        "x": -22,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_right_2_2.png",
-        "x_offset": -16,
-        "y_offset": -17,
+        "x": -16,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_right_2_3.png",
-        "x_offset": -24,
-        "y_offset": -32,
+        "x": -24,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_right_2_4.png",
-        "x_offset": -16,
-        "y_offset": -38,
+        "x": -16,
+        "y": -38,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_right_2_5.png",
-        "x_offset": -22,
-        "y_offset": -30,
+        "x": -22,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_right_3_1.png",
-        "x_offset": -29,
-        "y_offset": -4,
+        "x": -29,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_right_3_2.png",
-        "x_offset": -16,
-        "y_offset": -15,
+        "x": -16,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_right_3_3.png",
-        "x_offset": -25,
-        "y_offset": -50,
+        "x": -25,
+        "y": -50,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_right_3_4.png",
-        "x_offset": -28,
-        "y_offset": -56,
+        "x": -28,
+        "y": -56,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_right_3_5.png",
-        "x_offset": -22,
-        "y_offset": -39,
+        "x": -22,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_right_4_1.png",
-        "x_offset": -26,
-        "y_offset": -12,
+        "x": -26,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_right_4_2.png",
-        "x_offset": -11,
-        "y_offset": -68,
+        "x": -11,
+        "y": -68,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_right_4_3.png",
-        "x_offset": 10,
-        "y_offset": -40,
+        "x": 10,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_right_4_4.png",
-        "x_offset": -17,
-        "y_offset": -52,
+        "x": -17,
+        "y": -52,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_corkscrew_right_4_5.png",
-        "x_offset": -24,
-        "y_offset": -39,
+        "x": -24,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_turn_left_bank_to_gentle_up_1_1.png",
-        "x_offset": -26,
-        "y_offset": -20,
+        "x": -26,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_turn_left_bank_to_gentle_up_1_2.png",
-        "x_offset": -16,
-        "y_offset": -15,
+        "x": -16,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_turn_left_bank_to_gentle_up_2_1.png",
-        "x_offset": 3,
-        "y_offset": -5,
+        "x": 3,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_turn_left_bank_to_gentle_up_2_2.png",
-        "x_offset": -17,
-        "y_offset": -7,
+        "x": -17,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_turn_left_bank_to_gentle_up_2_3.png",
-        "x_offset": -38,
-        "y_offset": -15,
+        "x": -38,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_turn_left_bank_to_gentle_up_3_1.png",
-        "x_offset": -18,
-        "y_offset": -11,
+        "x": -18,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_turn_left_bank_to_gentle_up_3_2.png",
-        "x_offset": -5,
-        "y_offset": -4,
+        "x": -5,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_turn_left_bank_to_gentle_up_4_1.png",
-        "x_offset": -26,
-        "y_offset": -12,
+        "x": -26,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_turn_left_bank_to_gentle_up_4_2.png",
-        "x_offset": -28,
-        "y_offset": 1,
+        "x": -28,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_turn_right_bank_to_gentle_up_1_1.png",
-        "x_offset": -29,
-        "y_offset": -12,
+        "x": -29,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_turn_right_bank_to_gentle_up_1_2.png",
-        "x_offset": -26,
-        "y_offset": 1,
+        "x": -26,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_turn_right_bank_to_gentle_up_2_1.png",
-        "x_offset": -13,
-        "y_offset": -11,
+        "x": -13,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_turn_right_bank_to_gentle_up_2_2.png",
-        "x_offset": -28,
-        "y_offset": -4,
+        "x": -28,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_turn_right_bank_to_gentle_up_3_1.png",
-        "x_offset": -38,
-        "y_offset": -6,
+        "x": -38,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_turn_right_bank_to_gentle_up_3_2.png",
-        "x_offset": -38,
-        "y_offset": -6,
+        "x": -38,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_turn_right_bank_to_gentle_up_3_3.png",
-        "x_offset": -16,
-        "y_offset": -15,
+        "x": -16,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_turn_right_bank_to_gentle_up_4_1.png",
-        "x_offset": -6,
-        "y_offset": -20,
+        "x": -6,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_turn_right_bank_to_gentle_up_4_2.png",
-        "x_offset": -18,
-        "y_offset": -15,
+        "x": -18,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_left_1_1.png",
-        "x_offset": -22,
-        "y_offset": -34,
+        "x": -22,
+        "y": -34,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_left_1_2.png",
-        "x_offset": -21,
-        "y_offset": -51,
+        "x": -21,
+        "y": -51,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_left_1_3.png",
-        "x_offset": -29,
-        "y_offset": -100,
+        "x": -29,
+        "y": -100,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_left_1_4.png",
-        "x_offset": -44,
-        "y_offset": -128,
+        "x": -44,
+        "y": -128,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_left_1_5.png",
-        "x_offset": -21,
-        "y_offset": -37,
+        "x": -21,
+        "y": -37,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_left_2_1.png",
-        "x_offset": -22,
-        "y_offset": -12,
+        "x": -22,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_left_2_2.png",
-        "x_offset": 0,
-        "y_offset": -34,
+        "x": 0,
+        "y": -34,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_left_2_3.png",
-        "x_offset": 0,
-        "y_offset": -87,
+        "x": 0,
+        "y": -87,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_left_2_4.png",
-        "x_offset": -30,
-        "y_offset": -148,
+        "x": -30,
+        "y": -148,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_left_2_5.png",
-        "x_offset": -22,
-        "y_offset": -47,
+        "x": -22,
+        "y": -47,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_left_3_1.png",
-        "x_offset": -23,
-        "y_offset": -7,
+        "x": -23,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_left_3_2.png",
-        "x_offset": 0,
-        "y_offset": -13,
+        "x": 0,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_left_3_3.png",
-        "x_offset": -3,
-        "y_offset": -59,
+        "x": -3,
+        "y": -59,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_left_3_4.png",
-        "x_offset": -32,
-        "y_offset": -154,
+        "x": -32,
+        "y": -154,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_left_3_5.png",
-        "x_offset": -17,
-        "y_offset": -47,
+        "x": -17,
+        "y": -47,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_left_4_1.png",
-        "x_offset": -23,
-        "y_offset": -19,
+        "x": -23,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_left_4_2.png",
-        "x_offset": -25,
-        "y_offset": -26,
+        "x": -25,
+        "y": -26,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_left_4_3.png",
-        "x_offset": -30,
-        "y_offset": -31,
+        "x": -30,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_left_4_4.png",
-        "x_offset": -10,
-        "y_offset": -129,
+        "x": -10,
+        "y": -129,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_left_4_5.png",
-        "x_offset": -28,
-        "y_offset": -40,
+        "x": -28,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_right_1_1.png",
-        "x_offset": -22,
-        "y_offset": -19,
+        "x": -22,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_right_1_2.png",
-        "x_offset": -19,
-        "y_offset": -26,
+        "x": -19,
+        "y": -26,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_right_1_3.png",
-        "x_offset": -17,
-        "y_offset": -31,
+        "x": -17,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_right_1_4.png",
-        "x_offset": -26,
-        "y_offset": -129,
+        "x": -26,
+        "y": -129,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_right_1_5.png",
-        "x_offset": -22,
-        "y_offset": -40,
+        "x": -22,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_right_2_1.png",
-        "x_offset": -22,
-        "y_offset": -7,
+        "x": -22,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_right_2_2.png",
-        "x_offset": -32,
-        "y_offset": -13,
+        "x": -32,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_right_2_3.png",
-        "x_offset": -32,
-        "y_offset": -59,
+        "x": -32,
+        "y": -59,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_right_2_4.png",
-        "x_offset": -25,
-        "y_offset": -154,
+        "x": -25,
+        "y": -154,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_right_2_5.png",
-        "x_offset": -21,
-        "y_offset": -47,
+        "x": -21,
+        "y": -47,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_right_3_1.png",
-        "x_offset": -32,
-        "y_offset": -12,
+        "x": -32,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_right_3_2.png",
-        "x_offset": -32,
-        "y_offset": -34,
+        "x": -32,
+        "y": -34,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_right_3_3.png",
-        "x_offset": -32,
-        "y_offset": -87,
+        "x": -32,
+        "y": -87,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_right_3_4.png",
-        "x_offset": -10,
-        "y_offset": -148,
+        "x": -10,
+        "y": -148,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_right_3_5.png",
-        "x_offset": -12,
-        "y_offset": -47,
+        "x": -12,
+        "y": -47,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_right_4_1.png",
-        "x_offset": -23,
-        "y_offset": -34,
+        "x": -23,
+        "y": -34,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_right_4_2.png",
-        "x_offset": -16,
-        "y_offset": -51,
+        "x": -16,
+        "y": -51,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_right_4_3.png",
-        "x_offset": -3,
-        "y_offset": -100,
+        "x": -3,
+        "y": -100,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_right_4_4.png",
-        "x_offset": -32,
-        "y_offset": -128,
+        "x": -32,
+        "y": -128,
         "palette": "keep"
     },
     {
         "path": "track/intamin/medium_half_loop_right_4_5.png",
-        "x_offset": -32,
-        "y_offset": -37,
+        "x": -32,
+        "y": -37,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_1_1.png",
-        "x_offset": -22,
-        "y_offset": -29,
+        "x": -22,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_1_2.png",
-        "x_offset": -18,
-        "y_offset": -42,
+        "x": -18,
+        "y": -42,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_1_3.png",
-        "x_offset": -19,
-        "y_offset": -70,
+        "x": -19,
+        "y": -70,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_1_4.png",
-        "x_offset": -24,
-        "y_offset": -85,
+        "x": -24,
+        "y": -85,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_1_5.png",
-        "x_offset": -16,
-        "y_offset": -70,
+        "x": -16,
+        "y": -70,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_1_6.png",
-        "x_offset": -9,
-        "y_offset": -183,
+        "x": -9,
+        "y": -183,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_1_7.png",
-        "x_offset": -21,
-        "y_offset": -20,
+        "x": -21,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_2_1.png",
-        "x_offset": -22,
-        "y_offset": -5,
+        "x": -22,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_2_2.png",
-        "x_offset": -6,
-        "y_offset": -9,
+        "x": -6,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_2_3.png",
-        "x_offset": -9,
-        "y_offset": -27,
+        "x": -9,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_2_4.png",
-        "x_offset": -8,
-        "y_offset": -94,
+        "x": -8,
+        "y": -94,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_2_5.png",
-        "x_offset": -32,
-        "y_offset": -130,
+        "x": -32,
+        "y": -130,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_2_6.png",
-        "x_offset": -25,
-        "y_offset": -197,
+        "x": -25,
+        "y": -197,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_2_7.png",
-        "x_offset": -22,
-        "y_offset": -31,
+        "x": -22,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_3_1.png",
-        "x_offset": -24,
-        "y_offset": -3,
+        "x": -24,
+        "y": -3,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_3_2.png",
-        "x_offset": -32,
-        "y_offset": -9,
+        "x": -32,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_3_3.png",
-        "x_offset": -29,
-        "y_offset": -38,
+        "x": -29,
+        "y": -38,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_3_4.png",
-        "x_offset": -7,
-        "y_offset": -61,
+        "x": -7,
+        "y": -61,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_3_5.png",
-        "x_offset": -7,
-        "y_offset": -117,
+        "x": -7,
+        "y": -117,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_3_6.png",
-        "x_offset": -22,
-        "y_offset": -197,
+        "x": -22,
+        "y": -197,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_3_7.png",
-        "x_offset": -28,
-        "y_offset": -32,
+        "x": -28,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_4_1.png",
-        "x_offset": -24,
-        "y_offset": -18,
+        "x": -24,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_4_2.png",
-        "x_offset": -30,
-        "y_offset": -21,
+        "x": -30,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_4_3.png",
-        "x_offset": -32,
-        "y_offset": -52,
+        "x": -32,
+        "y": -52,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_4_4.png",
-        "x_offset": -32,
-        "y_offset": -84,
+        "x": -32,
+        "y": -84,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_4_5.png",
-        "x_offset": 16,
-        "y_offset": -62,
+        "x": 16,
+        "y": -62,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_4_6.png",
-        "x_offset": -16,
-        "y_offset": -186,
+        "x": -16,
+        "y": -186,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_left_4_7.png",
-        "x_offset": -24,
-        "y_offset": -22,
+        "x": -24,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_1_1.png",
-        "x_offset": -22,
-        "y_offset": -18,
+        "x": -22,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_1_2.png",
-        "x_offset": -18,
-        "y_offset": -21,
+        "x": -18,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_1_3.png",
-        "x_offset": -13,
-        "y_offset": -52,
+        "x": -13,
+        "y": -52,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_1_4.png",
-        "x_offset": 0,
-        "y_offset": -84,
+        "x": 0,
+        "y": -84,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_1_5.png",
-        "x_offset": -32,
-        "y_offset": -62,
+        "x": -32,
+        "y": -62,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_1_6.png",
-        "x_offset": -19,
-        "y_offset": -186,
+        "x": -19,
+        "y": -186,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_1_7.png",
-        "x_offset": -22,
-        "y_offset": -22,
+        "x": -22,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_2_1.png",
-        "x_offset": -22,
-        "y_offset": -3,
+        "x": -22,
+        "y": -3,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_2_2.png",
-        "x_offset": -13,
-        "y_offset": -9,
+        "x": -13,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_2_3.png",
-        "x_offset": -6,
-        "y_offset": -38,
+        "x": -6,
+        "y": -38,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_2_4.png",
-        "x_offset": -16,
-        "y_offset": -61,
+        "x": -16,
+        "y": -61,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_2_5.png",
-        "x_offset": -23,
-        "y_offset": -117,
+        "x": -23,
+        "y": -117,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_2_6.png",
-        "x_offset": -17,
-        "y_offset": -197,
+        "x": -17,
+        "y": -197,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_2_7.png",
-        "x_offset": -21,
-        "y_offset": -32,
+        "x": -21,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_3_1.png",
-        "x_offset": -26,
-        "y_offset": -5,
+        "x": -26,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_3_2.png",
-        "x_offset": -30,
-        "y_offset": -9,
+        "x": -30,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_3_3.png",
-        "x_offset": -29,
-        "y_offset": -27,
+        "x": -29,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_3_4.png",
-        "x_offset": -32,
-        "y_offset": -94,
+        "x": -32,
+        "y": -94,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_3_5.png",
-        "x_offset": 16,
-        "y_offset": -130,
+        "x": 16,
+        "y": -130,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_3_6.png",
-        "x_offset": 0,
-        "y_offset": -197,
+        "x": 0,
+        "y": -197,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_3_7.png",
-        "x_offset": -17,
-        "y_offset": -31,
+        "x": -17,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_4_1.png",
-        "x_offset": -24,
-        "y_offset": -29,
+        "x": -24,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_4_2.png",
-        "x_offset": -25,
-        "y_offset": -42,
+        "x": -25,
+        "y": -42,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_4_3.png",
-        "x_offset": -21,
-        "y_offset": -70,
+        "x": -21,
+        "y": -70,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_4_4.png",
-        "x_offset": -5,
-        "y_offset": -85,
+        "x": -5,
+        "y": -85,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_4_5.png",
-        "x_offset": -7,
-        "y_offset": -70,
+        "x": -7,
+        "y": -70,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_4_6.png",
-        "x_offset": -32,
-        "y_offset": -183,
+        "x": -32,
+        "y": -183,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_half_loop_right_4_7.png",
-        "x_offset": -31,
-        "y_offset": -20,
+        "x": -31,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_left_1_1.png",
-        "x_offset": -22,
-        "y_offset": -15,
+        "x": -22,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_left_1_2.png",
-        "x_offset": -10,
-        "y_offset": -16,
+        "x": -10,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_left_1_3.png",
-        "x_offset": -11,
-        "y_offset": -26,
+        "x": -11,
+        "y": -26,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_left_1_4.png",
-        "x_offset": -19,
-        "y_offset": -31,
+        "x": -19,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_left_2_1.png",
-        "x_offset": -22,
-        "y_offset": -3,
+        "x": -22,
+        "y": -3,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_left_2_2.png",
-        "x_offset": -22,
-        "y_offset": -4,
+        "x": -22,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_left_2_3.png",
-        "x_offset": -23,
-        "y_offset": -18,
+        "x": -23,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_left_2_4.png",
-        "x_offset": -21,
-        "y_offset": -18,
+        "x": -21,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_left_3_1.png",
-        "x_offset": -20,
-        "y_offset": -11,
+        "x": -20,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_left_3_2.png",
-        "x_offset": -22,
-        "y_offset": -25,
+        "x": -22,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_left_3_3.png",
-        "x_offset": -11,
-        "y_offset": -18,
+        "x": -11,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_left_3_4.png",
-        "x_offset": -23,
-        "y_offset": -27,
+        "x": -23,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_left_4_1.png",
-        "x_offset": -15,
-        "y_offset": -27,
+        "x": -15,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_left_4_2.png",
-        "x_offset": -11,
-        "y_offset": -45,
+        "x": -11,
+        "y": -45,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_left_4_3.png",
-        "x_offset": -3,
-        "y_offset": -12,
+        "x": -3,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_left_4_4.png",
-        "x_offset": -21,
-        "y_offset": -31,
+        "x": -21,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_right_1_1.png",
-        "x_offset": -22,
-        "y_offset": -27,
+        "x": -22,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_right_1_2.png",
-        "x_offset": -27,
-        "y_offset": -45,
+        "x": -27,
+        "y": -45,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_right_1_3.png",
-        "x_offset": -22,
-        "y_offset": -16,
+        "x": -22,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_right_1_4.png",
-        "x_offset": -27,
-        "y_offset": -31,
+        "x": -27,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_right_2_1.png",
-        "x_offset": -22,
-        "y_offset": -11,
+        "x": -22,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_right_2_2.png",
-        "x_offset": -17,
-        "y_offset": -25,
+        "x": -17,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_right_2_3.png",
-        "x_offset": -13,
-        "y_offset": -18,
+        "x": -13,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_right_2_4.png",
-        "x_offset": -11,
-        "y_offset": -27,
+        "x": -11,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_right_3_1.png",
-        "x_offset": 3,
-        "y_offset": -3,
+        "x": 3,
+        "y": -3,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_right_3_2.png",
-        "x_offset": -9,
-        "y_offset": -4,
+        "x": -9,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_right_3_3.png",
-        "x_offset": -11,
-        "y_offset": -18,
+        "x": -11,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_right_3_4.png",
-        "x_offset": -21,
-        "y_offset": -18,
+        "x": -21,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_right_4_1.png",
-        "x_offset": -20,
-        "y_offset": -15,
+        "x": -20,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_right_4_2.png",
-        "x_offset": -35,
-        "y_offset": -16,
+        "x": -35,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_right_4_3.png",
-        "x_offset": -24,
-        "y_offset": -26,
+        "x": -24,
+        "y": -26,
         "palette": "keep"
     },
     {
         "path": "track/intamin/zero_g_roll_right_4_4.png",
-        "x_offset": -22,
-        "y_offset": -31,
+        "x": -22,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_left_1_1.png",
-        "x_offset": -21,
-        "y_offset": -47,
+        "x": -21,
+        "y": -47,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_left_1_2.png",
-        "x_offset": -23,
-        "y_offset": -36,
+        "x": -23,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_left_1_3.png",
-        "x_offset": -15,
-        "y_offset": -52,
+        "x": -15,
+        "y": -52,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_left_1_4.png",
-        "x_offset": -13,
-        "y_offset": -40,
+        "x": -13,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_left_1_5.png",
-        "x_offset": -17,
-        "y_offset": -31,
+        "x": -17,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_left_2_1.png",
-        "x_offset": -21,
-        "y_offset": -42,
+        "x": -21,
+        "y": -42,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_left_2_2.png",
-        "x_offset": -25,
-        "y_offset": -30,
+        "x": -25,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_left_2_3.png",
-        "x_offset": -32,
-        "y_offset": -24,
+        "x": -32,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_left_2_4.png",
-        "x_offset": -29,
-        "y_offset": -19,
+        "x": -29,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_left_3_1.png",
-        "x_offset": -10,
-        "y_offset": -33,
+        "x": -10,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_left_3_2.png",
-        "x_offset": -18,
-        "y_offset": -31,
+        "x": -18,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_left_3_3.png",
-        "x_offset": -27,
-        "y_offset": -40,
+        "x": -27,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_left_3_4.png",
-        "x_offset": -24,
-        "y_offset": -33,
+        "x": -24,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_left_3_5.png",
-        "x_offset": 1,
-        "y_offset": -12,
+        "x": 1,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_left_3_6.png",
-        "x_offset": -22,
-        "y_offset": -25,
+        "x": -22,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_left_4_1.png",
-        "x_offset": -15,
-        "y_offset": -48,
+        "x": -15,
+        "y": -48,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_left_4_2.png",
-        "x_offset": -14,
-        "y_offset": -48,
+        "x": -14,
+        "y": -48,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_left_4_3.png",
-        "x_offset": -10,
-        "y_offset": -33,
+        "x": -10,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_left_4_4.png",
-        "x_offset": -9,
-        "y_offset": -42,
+        "x": -9,
+        "y": -42,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_left_4_5.png",
-        "x_offset": -21,
-        "y_offset": -31,
+        "x": -21,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_right_1_1.png",
-        "x_offset": -21,
-        "y_offset": -48,
+        "x": -21,
+        "y": -48,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_right_1_2.png",
-        "x_offset": -31,
-        "y_offset": -48,
+        "x": -31,
+        "y": -48,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_right_1_3.png",
-        "x_offset": -31,
-        "y_offset": -33,
+        "x": -31,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_right_1_4.png",
-        "x_offset": -30,
-        "y_offset": -42,
+        "x": -30,
+        "y": -42,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_right_1_5.png",
-        "x_offset": -32,
-        "y_offset": -31,
+        "x": -32,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_right_2_1.png",
-        "x_offset": -21,
-        "y_offset": -33,
+        "x": -21,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_right_2_2.png",
-        "x_offset": -21,
-        "y_offset": -31,
+        "x": -21,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_right_2_3.png",
-        "x_offset": -24,
-        "y_offset": -40,
+        "x": -24,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_right_2_4.png",
-        "x_offset": -15,
-        "y_offset": -33,
+        "x": -15,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_right_2_5.png",
-        "x_offset": -8,
-        "y_offset": -11,
+        "x": -8,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_right_2_6.png",
-        "x_offset": -8,
-        "y_offset": -25,
+        "x": -8,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_right_3_1.png",
-        "x_offset": -17,
-        "y_offset": -42,
+        "x": -17,
+        "y": -42,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_right_3_2.png",
-        "x_offset": -11,
-        "y_offset": -30,
+        "x": -11,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_right_3_3.png",
-        "x_offset": -5,
-        "y_offset": -24,
+        "x": -5,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_right_3_4.png",
-        "x_offset": -21,
-        "y_offset": -19,
+        "x": -21,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_right_4_1.png",
-        "x_offset": -23,
-        "y_offset": -47,
+        "x": -23,
+        "y": -47,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_right_4_2.png",
-        "x_offset": -6,
-        "y_offset": -26,
+        "x": -6,
+        "y": -26,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_right_4_3.png",
-        "x_offset": -32,
-        "y_offset": -52,
+        "x": -32,
+        "y": -52,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_right_4_4.png",
-        "x_offset": -26,
-        "y_offset": -40,
+        "x": -26,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_zero_g_roll_right_4_5.png",
-        "x_offset": -22,
-        "y_offset": -31,
+        "x": -22,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_flat_to_steep_up_1.png",
-        "x_offset": -22,
-        "y_offset": -28,
+        "x": -22,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_flat_to_steep_up_2_1.png",
-        "x_offset": -22,
-        "y_offset": -10,
+        "x": -22,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_flat_to_steep_up_2_2.png",
-        "x_offset": -18,
-        "y_offset": -12,
+        "x": -18,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_flat_to_steep_up_3_1.png",
-        "x_offset": -6,
-        "y_offset": -4,
+        "x": -6,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_flat_to_steep_up_3_2.png",
-        "x_offset": -25,
-        "y_offset": -12,
+        "x": -25,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_flat_to_steep_up_4.png",
-        "x_offset": -25,
-        "y_offset": -29,
+        "x": -25,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_steep_to_flat_up_1.png",
-        "x_offset": -21,
-        "y_offset": -28,
+        "x": -21,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_steep_to_flat_up_2_1.png",
-        "x_offset": -12,
-        "y_offset": -15,
+        "x": -12,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_steep_to_flat_up_2_2.png",
-        "x_offset": -21,
-        "y_offset": -7,
+        "x": -21,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_steep_to_flat_up_3_1.png",
-        "x_offset": -22,
-        "y_offset": -15,
+        "x": -22,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_steep_to_flat_up_3_2.png",
-        "x_offset": -17,
-        "y_offset": -8,
+        "x": -17,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_steep_to_flat_up_4.png",
-        "x_offset": -22,
-        "y_offset": -28,
+        "x": -22,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_flat_to_steep_up_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -22,
+        "x": -32,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_flat_to_steep_up_diag_2.png",
-        "x_offset": -8,
-        "y_offset": -10,
+        "x": -8,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_flat_to_steep_up_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -22,
+        "x": -32,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_flat_to_steep_up_diag_4.png",
-        "x_offset": -8,
-        "y_offset": -34,
+        "x": -8,
+        "y": -34,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_steep_to_flat_up_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -21,
+        "x": -32,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_steep_to_flat_up_diag_2.png",
-        "x_offset": -8,
-        "y_offset": -15,
+        "x": -8,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_steep_to_flat_up_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -21,
+        "x": -32,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/intamin/small_steep_to_flat_up_diag_4.png",
-        "x_offset": -8,
-        "y_offset": -34,
+        "x": -8,
+        "y": -34,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_diag_gentle_up_1_1.png",
-        "x_offset": -22,
-        "y_offset": -16,
+        "x": -22,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_diag_gentle_up_1_2.png",
-        "x_offset": -31,
-        "y_offset": -24,
+        "x": -31,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_diag_gentle_up_1_3.png",
-        "x_offset": 13,
-        "y_offset": 8,
+        "x": 13,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_diag_gentle_up_1_4.png",
-        "x_offset": -13,
-        "y_offset": -9,
+        "x": -13,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_diag_gentle_up_2_1.png",
-        "x_offset": -22,
-        "y_offset": -5,
+        "x": -22,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_diag_gentle_up_2_2.png",
-        "x_offset": -32,
-        "y_offset": -11,
+        "x": -32,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_diag_gentle_up_2_3.png",
-        "x_offset": -24,
-        "y_offset": 14,
+        "x": -24,
+        "y": 14,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_diag_gentle_up_2_4.png",
-        "x_offset": -32,
-        "y_offset": -13,
+        "x": -32,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_diag_gentle_up_3_1.png",
-        "x_offset": -5,
-        "y_offset": -3,
+        "x": -5,
+        "y": -3,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_diag_gentle_up_3_2.png",
-        "x_offset": 8,
-        "y_offset": -3,
+        "x": 8,
+        "y": -3,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_diag_gentle_up_3_3.png",
-        "x_offset": -31,
-        "y_offset": -1,
+        "x": -31,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_diag_gentle_up_3_4.png",
-        "x_offset": -8,
-        "y_offset": -15,
+        "x": -8,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_diag_gentle_up_4_1.png",
-        "x_offset": -25,
-        "y_offset": -17,
+        "x": -25,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_diag_gentle_up_4_2.png",
-        "x_offset": -26,
-        "y_offset": -9,
+        "x": -26,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_diag_gentle_up_4_3.png",
-        "x_offset": 0,
-        "y_offset": -15,
+        "x": 0,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_diag_gentle_up_4_4.png",
-        "x_offset": 0,
-        "y_offset": -13,
+        "x": 0,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_diag_gentle_up_1_1.png",
-        "x_offset": -22,
-        "y_offset": -17,
+        "x": -22,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_diag_gentle_up_1_2.png",
-        "x_offset": -18,
-        "y_offset": -9,
+        "x": -18,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_diag_gentle_up_1_3.png",
-        "x_offset": -12,
-        "y_offset": -15,
+        "x": -12,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_diag_gentle_up_1_4.png",
-        "x_offset": -32,
-        "y_offset": -13,
+        "x": -32,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_diag_gentle_up_2_1.png",
-        "x_offset": -22,
-        "y_offset": -3,
+        "x": -22,
+        "y": -3,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_diag_gentle_up_2_2.png",
-        "x_offset": -34,
-        "y_offset": -3,
+        "x": -34,
+        "y": -3,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_diag_gentle_up_2_3.png",
-        "x_offset": -2,
-        "y_offset": -1,
+        "x": -2,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_diag_gentle_up_2_4.png",
-        "x_offset": -13,
-        "y_offset": -15,
+        "x": -13,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_diag_gentle_up_3_1.png",
-        "x_offset": -6,
-        "y_offset": -5,
+        "x": -6,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_diag_gentle_up_3_2.png",
-        "x_offset": -8,
-        "y_offset": -11,
+        "x": -8,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_diag_gentle_up_3_3.png",
-        "x_offset": 0,
-        "y_offset": 14,
+        "x": 0,
+        "y": 14,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_diag_gentle_up_3_4.png",
-        "x_offset": 0,
-        "y_offset": -13,
+        "x": 0,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_diag_gentle_up_4_1.png",
-        "x_offset": -13,
-        "y_offset": -16,
+        "x": -13,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_diag_gentle_up_4_2.png",
-        "x_offset": -3,
-        "y_offset": -24,
+        "x": -3,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_diag_gentle_up_4_3.png",
-        "x_offset": -32,
-        "y_offset": 8,
+        "x": -32,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_diag_gentle_up_4_4.png",
-        "x_offset": -8,
-        "y_offset": -9,
+        "x": -8,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_orthogonal_gentle_up_1_1.png",
-        "x_offset": 0,
-        "y_offset": -12,
+        "x": 0,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_orthogonal_gentle_up_1_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_orthogonal_gentle_up_1_3.png",
-        "x_offset": -32,
-        "y_offset": -16,
+        "x": -32,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_orthogonal_gentle_up_1_4.png",
-        "x_offset": -31,
-        "y_offset": -20,
+        "x": -31,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_orthogonal_gentle_up_2_1.png",
-        "x_offset": -8,
-        "y_offset": 6,
+        "x": -8,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_orthogonal_gentle_up_2_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_orthogonal_gentle_up_2_3.png",
-        "x_offset": -7,
-        "y_offset": -10,
+        "x": -7,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_orthogonal_gentle_up_2_4.png",
-        "x_offset": -19,
-        "y_offset": -5,
+        "x": -19,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_orthogonal_gentle_up_3_1.png",
-        "x_offset": -32,
-        "y_offset": -6,
+        "x": -32,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_orthogonal_gentle_up_3_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_orthogonal_gentle_up_3_3.png",
-        "x_offset": -17,
-        "y_offset": -1,
+        "x": -17,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_orthogonal_gentle_up_3_4.png",
-        "x_offset": -22,
-        "y_offset": -3,
+        "x": -22,
+        "y": -3,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_orthogonal_gentle_up_4_1.png",
-        "x_offset": -9,
-        "y_offset": -8,
+        "x": -9,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_orthogonal_gentle_up_4_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_orthogonal_gentle_up_4_3.png",
-        "x_offset": -21,
-        "y_offset": -4,
+        "x": -21,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_to_orthogonal_gentle_up_4_4.png",
-        "x_offset": -22,
-        "y_offset": -20,
+        "x": -22,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_orthogonal_gentle_up_1_1.png",
-        "x_offset": 0,
-        "y_offset": -6,
+        "x": 0,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_orthogonal_gentle_up_1_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_orthogonal_gentle_up_1_3.png",
-        "x_offset": -32,
-        "y_offset": -1,
+        "x": -32,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_orthogonal_gentle_up_1_4.png",
-        "x_offset": -32,
-        "y_offset": -3,
+        "x": -32,
+        "y": -3,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_orthogonal_gentle_up_2_1.png",
-        "x_offset": 0,
-        "y_offset": 6,
+        "x": 0,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_orthogonal_gentle_up_2_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_orthogonal_gentle_up_2_3.png",
-        "x_offset": -16,
-        "y_offset": -10,
+        "x": -16,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_orthogonal_gentle_up_2_4.png",
-        "x_offset": -22,
-        "y_offset": -5,
+        "x": -22,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_orthogonal_gentle_up_3_1.png",
-        "x_offset": -32,
-        "y_offset": -12,
+        "x": -32,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_orthogonal_gentle_up_3_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_orthogonal_gentle_up_3_3.png",
-        "x_offset": -11,
-        "y_offset": -16,
+        "x": -11,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_orthogonal_gentle_up_3_4.png",
-        "x_offset": -22,
-        "y_offset": -20,
+        "x": -22,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_orthogonal_gentle_up_4_1.png",
-        "x_offset": -8,
-        "y_offset": -8,
+        "x": -8,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_orthogonal_gentle_up_4_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_orthogonal_gentle_up_4_3.png",
-        "x_offset": -6,
-        "y_offset": -4,
+        "x": -6,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_to_orthogonal_gentle_up_4_4.png",
-        "x_offset": -24,
-        "y_offset": -20,
+        "x": -24,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_to_gentle_up_left_bank_diag_1_1.png",
-        "x_offset": -32,
-        "y_offset": -13,
+        "x": -32,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_to_gentle_up_left_bank_diag_1_2.png",
-        "x_offset": -32,
-        "y_offset": -13,
+        "x": -32,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_to_gentle_up_left_bank_diag_2.png",
-        "x_offset": -10,
-        "y_offset": -10,
+        "x": -10,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_to_gentle_up_left_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -17,
+        "x": -32,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_to_gentle_up_left_bank_diag_4.png",
-        "x_offset": -8,
-        "y_offset": -30,
+        "x": -8,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_to_gentle_up_right_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -17,
+        "x": -32,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_to_gentle_up_right_bank_diag_2.png",
-        "x_offset": -8,
-        "y_offset": -10,
+        "x": -8,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_to_gentle_up_right_bank_diag_3_1.png",
-        "x_offset": -31,
-        "y_offset": -13,
+        "x": -31,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_to_gentle_up_right_bank_diag_3_2.png",
-        "x_offset": -32,
-        "y_offset": -13,
+        "x": -32,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_to_gentle_up_right_bank_diag_4.png",
-        "x_offset": -10,
-        "y_offset": -30,
+        "x": -10,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_left_bank_to_gentle_up_diag_1_1.png",
-        "x_offset": -21,
-        "y_offset": -13,
+        "x": -21,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_left_bank_to_gentle_up_diag_1_2.png",
-        "x_offset": -32,
-        "y_offset": -2,
+        "x": -32,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_left_bank_to_gentle_up_diag_2.png",
-        "x_offset": -10,
-        "y_offset": -15,
+        "x": -10,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_left_bank_to_gentle_up_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -13,
+        "x": -32,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_left_bank_to_gentle_up_diag_4.png",
-        "x_offset": -8,
-        "y_offset": -25,
+        "x": -8,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_right_bank_to_gentle_up_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -13,
+        "x": -32,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_right_bank_to_gentle_up_diag_2.png",
-        "x_offset": -8,
-        "y_offset": -15,
+        "x": -8,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_right_bank_to_gentle_up_diag_3_1.png",
-        "x_offset": -32,
-        "y_offset": -13,
+        "x": -32,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_right_bank_to_gentle_up_diag_3_2.png",
-        "x_offset": -32,
-        "y_offset": -2,
+        "x": -32,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_right_bank_to_gentle_up_diag_4.png",
-        "x_offset": -10,
-        "y_offset": -25,
+        "x": -10,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/intamin/left_bank_to_gentle_up_left_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -5,
+        "x": -32,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/intamin/left_bank_to_gentle_up_left_bank_diag_2.png",
-        "x_offset": -11,
-        "y_offset": -14,
+        "x": -11,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/intamin/left_bank_to_gentle_up_left_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -9,
+        "x": -32,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/left_bank_to_gentle_up_left_bank_diag_4.png",
-        "x_offset": -6,
-        "y_offset": -22,
+        "x": -6,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/intamin/right_bank_to_gentle_up_right_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -9,
+        "x": -32,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/right_bank_to_gentle_up_right_bank_diag_2.png",
-        "x_offset": -6,
-        "y_offset": -13,
+        "x": -6,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/right_bank_to_gentle_up_right_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -5,
+        "x": -32,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/intamin/right_bank_to_gentle_up_right_bank_diag_4.png",
-        "x_offset": -11,
-        "y_offset": -22,
+        "x": -11,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_left_bank_to_left_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -3,
+        "x": -32,
+        "y": -3,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_left_bank_to_left_bank_diag_2.png",
-        "x_offset": -11,
-        "y_offset": -15,
+        "x": -11,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_left_bank_to_left_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -9,
+        "x": -32,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_left_bank_to_left_bank_diag_4.png",
-        "x_offset": -6,
-        "y_offset": -21,
+        "x": -6,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_right_bank_to_right_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -9,
+        "x": -32,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_right_bank_to_right_bank_diag_2.png",
-        "x_offset": -6,
-        "y_offset": -15,
+        "x": -6,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_right_bank_to_right_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -3,
+        "x": -32,
+        "y": -3,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_right_bank_to_right_bank_diag_4.png",
-        "x_offset": -11,
-        "y_offset": -22,
+        "x": -11,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_left_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -13,
+        "x": -32,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_left_bank_diag_2.png",
-        "x_offset": -10,
-        "y_offset": -15,
+        "x": -10,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_left_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -17,
+        "x": -32,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_left_bank_diag_4.png",
-        "x_offset": -6,
-        "y_offset": -30,
+        "x": -6,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_right_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -17,
+        "x": -32,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_right_bank_diag_2.png",
-        "x_offset": -6,
-        "y_offset": -15,
+        "x": -6,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_right_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -13,
+        "x": -32,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_right_bank_diag_4.png",
-        "x_offset": -10,
-        "y_offset": -30,
+        "x": -10,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/intamin/flat_to_gentle_up_left_bank_diag_1_1.png",
-        "x_offset": -32,
-        "y_offset": -5,
+        "x": -32,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/intamin/flat_to_gentle_up_left_bank_diag_1_2.png",
-        "x_offset": -32,
-        "y_offset": -5,
+        "x": -32,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/intamin/flat_to_gentle_up_left_bank_diag_2.png",
-        "x_offset": -10,
-        "y_offset": -10,
+        "x": -10,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/intamin/flat_to_gentle_up_left_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -9,
+        "x": -32,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/flat_to_gentle_up_left_bank_diag_4.png",
-        "x_offset": -8,
-        "y_offset": -22,
+        "x": -8,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/intamin/flat_to_gentle_up_right_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -9,
+        "x": -32,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/intamin/flat_to_gentle_up_right_bank_diag_2.png",
-        "x_offset": -8,
-        "y_offset": -10,
+        "x": -8,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/intamin/flat_to_gentle_up_right_bank_diag_3_1.png",
-        "x_offset": -31,
-        "y_offset": -5,
+        "x": -31,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/intamin/flat_to_gentle_up_right_bank_diag_3_2.png",
-        "x_offset": -32,
-        "y_offset": -5,
+        "x": -32,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/intamin/flat_to_gentle_up_right_bank_diag_4.png",
-        "x_offset": -10,
-        "y_offset": -22,
+        "x": -10,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_left_bank_to_flat_diag_1_1.png",
-        "x_offset": -19,
-        "y_offset": -5,
+        "x": -19,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_left_bank_to_flat_diag_1_2.png",
-        "x_offset": -32,
-        "y_offset": 1,
+        "x": -32,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_left_bank_to_flat_diag_2.png",
-        "x_offset": -10,
-        "y_offset": -15,
+        "x": -10,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_left_bank_to_flat_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -6,
+        "x": -32,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_left_bank_to_flat_diag_4.png",
-        "x_offset": -8,
-        "y_offset": -18,
+        "x": -8,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_right_bank_to_flat_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -6,
+        "x": -32,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_right_bank_to_flat_diag_2.png",
-        "x_offset": -8,
-        "y_offset": -15,
+        "x": -8,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_right_bank_to_flat_diag_3_1.png",
-        "x_offset": -32,
-        "y_offset": -5,
+        "x": -32,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_right_bank_to_flat_diag_3_2.png",
-        "x_offset": -32,
-        "y_offset": 1,
+        "x": -32,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/intamin/gentle_up_right_bank_to_flat_diag_4.png",
-        "x_offset": -9,
-        "y_offset": -18,
+        "x": -9,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_diag_gentle_up_1_1.png",
-        "x_offset": -18,
-        "y_offset": -14,
+        "x": -18,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_diag_gentle_up_1_2.png",
-        "x_offset": -27,
-        "y_offset": -24,
+        "x": -27,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_diag_gentle_up_1_3.png",
-        "x_offset": 17,
-        "y_offset": 8,
+        "x": 17,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_diag_gentle_up_1_4.png",
-        "x_offset": -10,
-        "y_offset": -14,
+        "x": -10,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_diag_gentle_up_2_1.png",
-        "x_offset": -22,
-        "y_offset": -6,
+        "x": -22,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_diag_gentle_up_2_2.png",
-        "x_offset": -32,
-        "y_offset": -13,
+        "x": -32,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_diag_gentle_up_2_3.png",
-        "x_offset": -24,
-        "y_offset": 13,
+        "x": -24,
+        "y": 13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_diag_gentle_up_2_4.png",
-        "x_offset": -32,
-        "y_offset": -13,
+        "x": -32,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_diag_gentle_up_3_1.png",
-        "x_offset": -7,
-        "y_offset": -8,
+        "x": -7,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_diag_gentle_up_3_2.png",
-        "x_offset": 1,
-        "y_offset": -7,
+        "x": 1,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_diag_gentle_up_3_3.png",
-        "x_offset": -32,
-        "y_offset": -4,
+        "x": -32,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_diag_gentle_up_3_4.png",
-        "x_offset": -10,
-        "y_offset": -20,
+        "x": -10,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_diag_gentle_up_4_1.png",
-        "x_offset": -23,
-        "y_offset": -19,
+        "x": -23,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_diag_gentle_up_4_2.png",
-        "x_offset": -24,
-        "y_offset": -12,
+        "x": -24,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_diag_gentle_up_4_3.png",
-        "x_offset": 0,
-        "y_offset": -20,
+        "x": 0,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_diag_gentle_up_4_4.png",
-        "x_offset": 0,
-        "y_offset": -17,
+        "x": 0,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_diag_gentle_up_1_1.png",
-        "x_offset": -23,
-        "y_offset": -19,
+        "x": -23,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_diag_gentle_up_1_2.png",
-        "x_offset": -20,
-        "y_offset": -12,
+        "x": -20,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_diag_gentle_up_1_3.png",
-        "x_offset": -14,
-        "y_offset": -20,
+        "x": -14,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_diag_gentle_up_1_4.png",
-        "x_offset": -32,
-        "y_offset": -17,
+        "x": -32,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_diag_gentle_up_2_1.png",
-        "x_offset": -19,
-        "y_offset": -8,
+        "x": -19,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_diag_gentle_up_2_2.png",
-        "x_offset": -31,
-        "y_offset": -8,
+        "x": -31,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_diag_gentle_up_2_3.png",
-        "x_offset": 10,
-        "y_offset": -4,
+        "x": 10,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_diag_gentle_up_2_4.png",
-        "x_offset": -8,
-        "y_offset": -20,
+        "x": -8,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_diag_gentle_up_3_1.png",
-        "x_offset": -7,
-        "y_offset": -6,
+        "x": -7,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_diag_gentle_up_3_2.png",
-        "x_offset": -8,
-        "y_offset": -13,
+        "x": -8,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_diag_gentle_up_3_3.png",
-        "x_offset": 0,
-        "y_offset": 13,
+        "x": 0,
+        "y": 13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_diag_gentle_up_3_4.png",
-        "x_offset": 0,
-        "y_offset": -13,
+        "x": 0,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_diag_gentle_up_4_1.png",
-        "x_offset": -18,
-        "y_offset": -14,
+        "x": -18,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_diag_gentle_up_4_2.png",
-        "x_offset": -6,
-        "y_offset": -24,
+        "x": -6,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_diag_gentle_up_4_3.png",
-        "x_offset": -32,
-        "y_offset": 8,
+        "x": -32,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_diag_gentle_up_4_4.png",
-        "x_offset": -10,
-        "y_offset": -14,
+        "x": -10,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_orthogonal_gentle_up_1_1.png",
-        "x_offset": 0,
-        "y_offset": -10,
+        "x": 0,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_orthogonal_gentle_up_1_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_orthogonal_gentle_up_1_3.png",
-        "x_offset": -32,
-        "y_offset": -14,
+        "x": -32,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_orthogonal_gentle_up_1_4.png",
-        "x_offset": -29,
-        "y_offset": -18,
+        "x": -29,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_orthogonal_gentle_up_2_1.png",
-        "x_offset": -8,
-        "y_offset": 1,
+        "x": -8,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_orthogonal_gentle_up_2_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_orthogonal_gentle_up_2_3.png",
-        "x_offset": -10,
-        "y_offset": -10,
+        "x": -10,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_orthogonal_gentle_up_2_4.png",
-        "x_offset": -17,
-        "y_offset": -6,
+        "x": -17,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_orthogonal_gentle_up_3_1.png",
-        "x_offset": -32,
-        "y_offset": -11,
+        "x": -32,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_orthogonal_gentle_up_3_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_orthogonal_gentle_up_3_3.png",
-        "x_offset": -22,
-        "y_offset": -6,
+        "x": -22,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_orthogonal_gentle_up_3_4.png",
-        "x_offset": -26,
-        "y_offset": -8,
+        "x": -26,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_orthogonal_gentle_up_4_1.png",
-        "x_offset": -8,
-        "y_offset": -8,
+        "x": -8,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_orthogonal_gentle_up_4_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_orthogonal_gentle_up_4_3.png",
-        "x_offset": -21,
-        "y_offset": -4,
+        "x": -21,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_left_bank_to_orthogonal_gentle_up_4_4.png",
-        "x_offset": -22,
-        "y_offset": -23,
+        "x": -22,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_orthogonal_gentle_up_1_1.png",
-        "x_offset": 0,
-        "y_offset": -11,
+        "x": 0,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_orthogonal_gentle_up_1_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_orthogonal_gentle_up_1_3.png",
-        "x_offset": -32,
-        "y_offset": -6,
+        "x": -32,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_orthogonal_gentle_up_1_4.png",
-        "x_offset": -26,
-        "y_offset": -8,
+        "x": -26,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_orthogonal_gentle_up_2_1.png",
-        "x_offset": 0,
-        "y_offset": 1,
+        "x": 0,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_orthogonal_gentle_up_2_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_orthogonal_gentle_up_2_3.png",
-        "x_offset": -16,
-        "y_offset": -10,
+        "x": -16,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_orthogonal_gentle_up_2_4.png",
-        "x_offset": -21,
-        "y_offset": -6,
+        "x": -21,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_orthogonal_gentle_up_3_1.png",
-        "x_offset": -32,
-        "y_offset": -10,
+        "x": -32,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_orthogonal_gentle_up_3_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_orthogonal_gentle_up_3_3.png",
-        "x_offset": -13,
-        "y_offset": -14,
+        "x": -13,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_orthogonal_gentle_up_3_4.png",
-        "x_offset": -26,
-        "y_offset": -18,
+        "x": -26,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_orthogonal_gentle_up_4_1.png",
-        "x_offset": -10,
-        "y_offset": -8,
+        "x": -10,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_orthogonal_gentle_up_4_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_orthogonal_gentle_up_4_3.png",
-        "x_offset": -7,
-        "y_offset": -5,
+        "x": -7,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/intamin/large_turn_right_bank_to_orthogonal_gentle_up_4_4.png",
-        "x_offset": -24,
-        "y_offset": -22,
+        "x": -24,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/mini/booster_1.png",
-        "x_offset": -22,
-        "y_offset": -4
+        "x": -22,
+        "y": -4
     },
     {
         "path": "track/mini/booster_2.png",
-        "x_offset": -22,
-        "y_offset": -4
+        "x": -22,
+        "y": -4
     },
     {
         "path": "track/bm/brake_horizontal.png",
-        "x_offset": -32,
-        "y_offset": 1,
+        "x": -32,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/bm/brake_vertical.png",
-        "x_offset": -13,
-        "y_offset": -9,
+        "x": -13,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/bm/blockbrake_horizontal_closed.png",
-        "x_offset": -32,
-        "y_offset": 1,
+        "x": -32,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/bm/blockbrake_horizontal_open.png",
-        "x_offset": -32,
-        "y_offset": 1,
+        "x": -32,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/bm/blockbrake_vertical_closed.png",
-        "x_offset": -13,
-        "y_offset": -9,
+        "x": -13,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/bm/blockbrake_vertical_open.png",
-        "x_offset": -13,
-        "y_offset": -9,
+        "x": -13,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/bm/booster_1.png",
-        "x_offset": -25,
-        "y_offset": -5
+        "x": -25,
+        "y": -5
     },
     {
         "path": "track/bm/booster_2.png",
-        "x_offset": -25,
-        "y_offset": -5
+        "x": -25,
+        "y": -5
     },
     {
         "path": "track/railway/quarter_turn_3_tiles_sw_se_part_3.png",
-        "x_offset": -8,
-        "y_offset": 1
+        "x": -8,
+        "y": 1
     },
     {
         "path": "track/railway/gravel_sw_ne.png",
-        "x_offset": -33,
-        "y_offset": -2
+        "x": -33,
+        "y": -2
     },
     {
         "path": "track/railway/gravel_nw_se.png",
-        "x_offset": -21,
-        "y_offset": -2
+        "x": -21,
+        "y": -2
     },
     {
         "path": "track/railway/grooved_sw_ne.png",
-        "x_offset": -28,
-        "y_offset": -1
+        "x": -28,
+        "y": -1
     },
     {
         "path": "track/railway/grooved_nw_se.png",
-        "x_offset": -14,
-        "y_offset": -2
+        "x": -14,
+        "y": -2
     },
     {
         "path": "track/railway/grooved_sw_ne_trans.png",
-        "x_offset": -28,
-        "y_offset": -1,
+        "x": -28,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/railway/grooved_nw_se_trans.png",
-        "x_offset": -14,
-        "y_offset": -2,
+        "x": -14,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/railway/grooved_end_ne_trans.png",
-        "x_offset": -28,
-        "y_offset": -1,
+        "x": -28,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/railway/grooved_end_se_trans.png",
-        "x_offset": -14,
-        "y_offset": -2,
+        "x": -14,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/railway/grooved_end_nw_trans.png",
-        "x_offset": -14,
-        "y_offset": -2,
+        "x": -14,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/railway/grooved_end_sw_trans.png",
-        "x_offset": -26,
-        "y_offset": -2,
+        "x": -26,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/railway/grooved_end_sw_ne_trans.png",
-        "x_offset": -28,
-        "y_offset": -1,
+        "x": -28,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/railway/grooved_end_nw_se_trans.png",
-        "x_offset": -14,
-        "y_offset": -2,
+        "x": -14,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/wooden/booster_1.png",
-        "x_offset": -34,
-        "y_offset": -15
+        "x": -34,
+        "y": -15
     },
     {
         "path": "track/wooden/booster_2.png",
-        "x_offset": -30,
-        "y_offset": -15
+        "x": -30,
+        "y": -15
     },
     {
         "path": "track/wooden/brake_horizontal.png",
-        "x_offset": -32,
-        "y_offset": -10,
+        "x": -32,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/wooden/brake_vertical.png",
-        "x_offset": -25,
-        "y_offset": -14,
+        "x": -25,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/wooden/blockbrake_horizontal_closed.png",
-        "x_offset": -32,
-        "y_offset": -10,
+        "x": -32,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/wooden/blockbrake_horizontal_open.png",
-        "x_offset": -32,
-        "y_offset": -10,
+        "x": -32,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/wooden/blockbrake_vertical_closed.png",
-        "x_offset": -25,
-        "y_offset": -14,
+        "x": -25,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/wooden/blockbrake_vertical_open.png",
-        "x_offset": -25,
-        "y_offset": -14,
+        "x": -25,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/wooden/station_block_brake_open_sw_ne.png",
-        "x_offset": -34,
-        "y_offset": -8
+        "x": -34,
+        "y": -8
     },
     {
         "path": "track/wooden/station_block_brake_open_nw_se.png",
-        "x_offset": -30,
-        "y_offset": -8
+        "x": -30,
+        "y": -8
     },
     {
         "path": "track/wooden/station_block_brake_closed_sw_ne.png",
-        "x_offset": -34,
-        "y_offset": -8
+        "x": -34,
+        "y": -8
     },
     {
         "path": "track/wooden/station_block_brake_closed_nw_se.png",
-        "x_offset": -30,
-        "y_offset": -8
+        "x": -30,
+        "y": -8
     },
     {
         "path": "track/wooden/classic_wooden_preview_track.png",
-        "x_offset": 1,
-        "y_offset": 1
+        "x": 1,
+        "y": 1
     },
     {
         "path": "track/wooden/classic_wooden_preview_supports.png",
-        "x_offset": 2,
-        "y_offset": 1
+        "x": 2,
+        "y": 1
     },
     {
         "path": "track/wooden/25_60_swne_chained.png",
-        "x_offset": -32,
-        "y_offset": -49,
+        "x": -32,
+        "y": -49,
         "palette": "keep"
     },
     {
         "path": "track/wooden/25_60_senw_chained.png",
-        "x_offset": -32,
-        "y_offset": -49,
+        "x": -32,
+        "y": -49,
         "palette": "keep"
     },
     {
         "path": "track/wooden/25_60_swne_chained_back.png",
-        "x_offset": -32,
-        "y_offset": -24,
+        "x": -32,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/wooden/25_60_senw_chained_back.png",
-        "x_offset": -32,
-        "y_offset": -24,
+        "x": -32,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/wooden/60_swne_chained.png",
-        "x_offset": -32,
-        "y_offset": -80,
+        "x": -32,
+        "y": -80,
         "palette": "keep"
     },
     {
         "path": "track/wooden/60_senw_chained.png",
-        "x_offset": -32,
-        "y_offset": -80,
+        "x": -32,
+        "y": -80,
         "palette": "keep"
     },
     {
         "path": "track/wooden/60_swne_chained_back.png",
-        "x_offset": -32,
-        "y_offset": -60,
+        "x": -32,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/wooden/60_senw_chained_back.png",
-        "x_offset": -32,
-        "y_offset": -59,
+        "x": -32,
+        "y": -59,
         "palette": "keep"
     },
     {
         "path": "track/wooden/60_25_swne_chained.png",
-        "x_offset": -32,
-        "y_offset": -47,
+        "x": -32,
+        "y": -47,
         "palette": "keep"
     },
     {
         "path": "track/wooden/60_25_senw_chained.png",
-        "x_offset": -32,
-        "y_offset": -47,
+        "x": -32,
+        "y": -47,
         "palette": "keep"
     },
     {
         "path": "track/wooden/60_25_swne_chained_back.png",
-        "x_offset": 0,
-        "y_offset": -30,
+        "x": 0,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/wooden/60_25_senw_chained_back.png",
-        "x_offset": -32,
-        "y_offset": -30,
+        "x": -32,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/bm_invert/booster_1.png",
-        "x_offset": -25,
-        "y_offset": -5
+        "x": -25,
+        "y": -5
     },
     {
         "path": "track/bm_invert/booster_2.png",
-        "x_offset": -25,
-        "y_offset": -5
+        "x": -25,
+        "y": -5
     },
     {
         "path": "track/bm_invert/brake_horizontal.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/bm_invert/brake_vertical.png",
-        "x_offset": -13,
-        "y_offset": -13,
+        "x": -13,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/looping/brake_horizontal_1.png",
-        "x_offset": -32,
-        "y_offset": 0,
+        "x": -32,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/looping/brake_horizontal_2.png",
-        "x_offset": -32,
-        "y_offset": 0,
+        "x": -32,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/looping/brake_vertical_1.png",
-        "x_offset": -15,
-        "y_offset": -8,
+        "x": -15,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/looping/brake_vertical_2.png",
-        "x_offset": -15,
-        "y_offset": -8,
+        "x": -15,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/minetrain/brake_horizontal.png",
-        "x_offset": -32,
-        "y_offset": 6,
+        "x": -32,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/minetrain/brake_vertical.png",
-        "x_offset": -17,
-        "y_offset": -3,
+        "x": -17,
+        "y": -3,
         "palette": "keep"
     },
     {
         "path": "track/minetrain/blockbrake_horizontal_closed.png",
-        "x_offset": -32,
-        "y_offset": 6,
+        "x": -32,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/minetrain/blockbrake_horizontal_open.png",
-        "x_offset": -32,
-        "y_offset": 6,
+        "x": -32,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/minetrain/blockbrake_vertical_closed.png",
-        "x_offset": -17,
-        "y_offset": -3,
+        "x": -17,
+        "y": -3,
         "palette": "keep"
     },
     {
         "path": "track/minetrain/blockbrake_vertical_open.png",
-        "x_offset": -17,
-        "y_offset": -3,
+        "x": -17,
+        "y": -3,
         "palette": "keep"
     },
     {
         "path": "track/standup/brake_horizontal.png",
-        "x_offset": -32,
-        "y_offset": 1,
+        "x": -32,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/standup/brake_vertical.png",
-        "x_offset": -13,
-        "y_offset": -9,
+        "x": -13,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/standup/blockbrake_horizontal_closed.png",
-        "x_offset": -32,
-        "y_offset": 1,
+        "x": -32,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/standup/blockbrake_horizontal_open.png",
-        "x_offset": -32,
-        "y_offset": 1,
+        "x": -32,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/standup/blockbrake_vertical_closed.png",
-        "x_offset": -13,
-        "y_offset": -9,
+        "x": -13,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/standup/blockbrake_vertical_open.png",
-        "x_offset": -13,
-        "y_offset": -9,
+        "x": -13,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/steeplechase/brake_horizontal.png",
-        "x_offset": -32,
-        "y_offset": 9,
+        "x": -32,
+        "y": 9,
         "palette": "keep"
     },
     {
         "path": "track/steeplechase/brake_vertical.png",
-        "x_offset": -4,
-        "y_offset": -6,
+        "x": -4,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/multidim/upright_brake_horizontal.png",
-        "x_offset": -32,
-        "y_offset": 3,
+        "x": -32,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/multidim/upright_brake_vertical.png",
-        "x_offset": -11,
-        "y_offset": -8,
+        "x": -11,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/multidim/upright_blockbrake_horizontal_closed.png",
-        "x_offset": -32,
-        "y_offset": 3,
+        "x": -32,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/multidim/upright_blockbrake_horizontal_open.png",
-        "x_offset": -32,
-        "y_offset": 3,
+        "x": -32,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/multidim/upright_blockbrake_vertical_closed.png",
-        "x_offset": -11,
-        "y_offset": -8,
+        "x": -11,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/multidim/upright_blockbrake_vertical_open.png",
-        "x_offset": -11,
-        "y_offset": -8,
+        "x": -11,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/multidim/inverted_brake_horizontal.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/multidim/inverted_brake_vertical.png",
-        "x_offset": -11,
-        "y_offset": -12,
+        "x": -11,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/multidim/inverted_blockbrake_horizontal.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/multidim/inverted_blockbrake_vertical_open.png",
-        "x_offset": -11,
-        "y_offset": -12,
+        "x": -11,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/multidim/inverted_blockbrake_vertical_closed.png",
-        "x_offset": -11,
-        "y_offset": -12,
+        "x": -11,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/slc/brake_horizontal.png",
-        "x_offset": -32,
-        "y_offset": 4,
+        "x": -32,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/slc/brake_vertical.png",
-        "x_offset": -13,
-        "y_offset": -9,
+        "x": -13,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/slc/blockbrake_vertical_open.png",
-        "x_offset": -13,
-        "y_offset": -9,
+        "x": -13,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/corkscrew/brake_horizontal.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/corkscrew/brake_vertical.png",
-        "x_offset": -13,
-        "y_offset": -8,
+        "x": -13,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/corkscrew/blockbrake_horizontal_closed.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/corkscrew/blockbrake_horizontal_open.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/corkscrew/blockbrake_vertical_closed.png",
-        "x_offset": -13,
-        "y_offset": -8,
+        "x": -13,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/corkscrew/blockbrake_vertical_open.png",
-        "x_offset": -13,
-        "y_offset": -8,
+        "x": -13,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_1_1.png",
-        "x_offset": -22,
-        "y_offset": 9,
+        "x": -22,
+        "y": 9,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_1_2.png",
-        "x_offset": -11,
-        "y_offset": 7,
+        "x": -11,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_1_3.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_1_4.png",
-        "x_offset": -22,
-        "y_offset": -16,
+        "x": -22,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_1_5.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_1_6.png",
-        "x_offset": -12,
-        "y_offset": -20,
+        "x": -12,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_2_1.png",
-        "x_offset": -19,
-        "y_offset": 1,
+        "x": -19,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_2_2.png",
-        "x_offset": -22,
-        "y_offset": 6,
+        "x": -22,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_2_3.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_2_4.png",
-        "x_offset": -28,
-        "y_offset": -4,
+        "x": -28,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_2_5.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_2_6.png",
-        "x_offset": -32,
-        "y_offset": -18,
+        "x": -32,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_3_1.png",
-        "x_offset": -29,
-        "y_offset": -1,
+        "x": -29,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_3_2.png",
-        "x_offset": -2,
-        "y_offset": 6,
+        "x": -2,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_3_3.png",
-        "x_offset": -25,
-        "y_offset": -13,
+        "x": -25,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_3_4.png",
-        "x_offset": -27,
-        "y_offset": -12,
+        "x": -27,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_3_5.png",
-        "x_offset": 2,
-        "y_offset": -11,
+        "x": 2,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_3_6.png",
-        "x_offset": -22,
-        "y_offset": -17,
+        "x": -22,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_4_1.png",
-        "x_offset": -15,
-        "y_offset": -12,
+        "x": -15,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_4_2.png",
-        "x_offset": 1,
-        "y_offset": 18,
+        "x": 1,
+        "y": 18,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_4_3.png",
-        "x_offset": -12,
-        "y_offset": -17,
+        "x": -12,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_4_4.png",
-        "x_offset": -10,
-        "y_offset": -20,
+        "x": -10,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_4_5.png",
-        "x_offset": 11,
-        "y_offset": -4,
+        "x": 11,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_left_4_6.png",
-        "x_offset": -22,
-        "y_offset": -20,
+        "x": -22,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_1_1.png",
-        "x_offset": -23,
-        "y_offset": -12,
+        "x": -23,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_1_2.png",
-        "x_offset": -11,
-        "y_offset": 16,
+        "x": -11,
+        "y": 16,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_1_3.png",
-        "x_offset": -28,
-        "y_offset": -17,
+        "x": -28,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_1_4.png",
-        "x_offset": -23,
-        "y_offset": -19,
+        "x": -23,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_1_5.png",
-        "x_offset": -21,
-        "y_offset": -4,
+        "x": -21,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_1_6.png",
-        "x_offset": -23,
-        "y_offset": -20,
+        "x": -23,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_2_1.png",
-        "x_offset": -22,
-        "y_offset": 0,
+        "x": -22,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_2_2.png",
-        "x_offset": -22,
-        "y_offset": 7,
+        "x": -22,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_2_3.png",
-        "x_offset": -10,
-        "y_offset": -13,
+        "x": -10,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_2_4.png",
-        "x_offset": 3,
-        "y_offset": -12,
+        "x": 3,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_2_5.png",
-        "x_offset": -7,
-        "y_offset": -11,
+        "x": -7,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_2_6.png",
-        "x_offset": -6,
-        "y_offset": -18,
+        "x": -6,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_3_1.png",
-        "x_offset": -1,
-        "y_offset": 0,
+        "x": -1,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_3_2.png",
-        "x_offset": -4,
-        "y_offset": 6,
+        "x": -4,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_3_3.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_3_4.png",
-        "x_offset": 0,
-        "y_offset": -4,
+        "x": 0,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_3_5.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_3_6.png",
-        "x_offset": -22,
-        "y_offset": -18,
+        "x": -22,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_4_1.png",
-        "x_offset": -9,
-        "y_offset": 9,
+        "x": -9,
+        "y": 9,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_4_2.png",
-        "x_offset": -20,
-        "y_offset": 7,
+        "x": -20,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_4_3.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_4_4.png",
-        "x_offset": -28,
-        "y_offset": -16,
+        "x": -28,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_4_5.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/lim/barrel_roll_right_4_6.png",
-        "x_offset": -23,
-        "y_offset": -20,
+        "x": -23,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/lim/half_loop_1_1.png",
-        "x_offset": -28,
-        "y_offset": -21,
+        "x": -28,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/lim/half_loop_1_2.png",
-        "x_offset": -22,
-        "y_offset": -40,
+        "x": -22,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/lim/half_loop_1_3.png",
-        "x_offset": -15,
-        "y_offset": -82,
+        "x": -15,
+        "y": -82,
         "palette": "keep"
     },
     {
         "path": "track/lim/half_loop_1_4.png",
-        "x_offset": -22,
-        "y_offset": 24,
+        "x": -22,
+        "y": 24,
         "palette": "keep"
     },
     {
         "path": "track/lim/half_loop_2_1.png",
-        "x_offset": -16,
-        "y_offset": -4,
+        "x": -16,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/lim/half_loop_2_2.png",
-        "x_offset": 1,
-        "y_offset": -32,
+        "x": 1,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/lim/half_loop_2_3.png",
-        "x_offset": -38,
-        "y_offset": -114,
+        "x": -38,
+        "y": -114,
         "palette": "keep"
     },
     {
         "path": "track/lim/half_loop_2_4.png",
-        "x_offset": -22,
-        "y_offset": 12,
+        "x": -22,
+        "y": 12,
         "palette": "keep"
     },
     {
         "path": "track/lim/half_loop_3_1.png",
-        "x_offset": -25,
-        "y_offset": -4,
+        "x": -25,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/lim/half_loop_3_2.png",
-        "x_offset": -27,
-        "y_offset": -28,
+        "x": -27,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/lim/half_loop_3_3.png",
-        "x_offset": -1,
-        "y_offset": -121,
+        "x": -1,
+        "y": -121,
         "palette": "keep"
     },
     {
         "path": "track/lim/half_loop_3_4.png",
-        "x_offset": -24,
-        "y_offset": 4,
+        "x": -24,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/lim/half_loop_4_1.png",
-        "x_offset": -14,
-        "y_offset": -20,
+        "x": -14,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/lim/half_loop_4_2.png",
-        "x_offset": -16,
-        "y_offset": -43,
+        "x": -16,
+        "y": -43,
         "palette": "keep"
     },
     {
         "path": "track/lim/half_loop_4_3.png",
-        "x_offset": 5,
-        "y_offset": -91,
+        "x": 5,
+        "y": -91,
         "palette": "keep"
     },
     {
         "path": "track/lim/half_loop_4_4.png",
-        "x_offset": 6,
-        "y_offset": 16,
+        "x": 6,
+        "y": 16,
         "palette": "keep"
     },
     {
         "path": "track/lim/flat_to_steep_up_1_1.png",
-        "x_offset": -22,
-        "y_offset": -4,
+        "x": -22,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/lim/flat_to_steep_up_1_2.png",
-        "x_offset": -22,
-        "y_offset": -19,
+        "x": -22,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/lim/flat_to_steep_up_1_3.png",
-        "x_offset": -21,
-        "y_offset": -27,
+        "x": -21,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/lim/flat_to_steep_up_1_4.png",
-        "x_offset": -23,
-        "y_offset": -46,
+        "x": -23,
+        "y": -46,
         "palette": "keep"
     },
     {
         "path": "track/lim/flat_to_steep_up_2_1.png",
-        "x_offset": -22,
-        "y_offset": 1,
+        "x": -22,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/lim/flat_to_steep_up_2_2.png",
-        "x_offset": -25,
-        "y_offset": -5,
+        "x": -25,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/lim/flat_to_steep_up_2_3.png",
-        "x_offset": -25,
-        "y_offset": -7,
+        "x": -25,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/lim/flat_to_steep_up_2_4.png",
-        "x_offset": -20,
-        "y_offset": -32,
+        "x": -20,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/lim/flat_to_steep_up_3_1.png",
-        "x_offset": -23,
-        "y_offset": 0,
+        "x": -23,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/lim/flat_to_steep_up_3_2.png",
-        "x_offset": -24,
-        "y_offset": -4,
+        "x": -24,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/lim/flat_to_steep_up_3_3.png",
-        "x_offset": -23,
-        "y_offset": -13,
+        "x": -23,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/lim/flat_to_steep_up_3_4.png",
-        "x_offset": -23,
-        "y_offset": -32,
+        "x": -23,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/lim/flat_to_steep_up_4_1.png",
-        "x_offset": -21,
-        "y_offset": -4,
+        "x": -21,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/lim/flat_to_steep_up_4_2.png",
-        "x_offset": -23,
-        "y_offset": -19,
+        "x": -23,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/lim/flat_to_steep_up_4_3.png",
-        "x_offset": -23,
-        "y_offset": -27,
+        "x": -23,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/lim/flat_to_steep_up_4_4.png",
-        "x_offset": -22,
-        "y_offset": -46,
+        "x": -22,
+        "y": -46,
         "palette": "keep"
     },
     {
         "path": "track/lim/steep_to_flat_up_1_1.png",
-        "x_offset": -24,
-        "y_offset": -43,
+        "x": -24,
+        "y": -43,
         "palette": "keep"
     },
     {
         "path": "track/lim/steep_to_flat_up_1_2.png",
-        "x_offset": -24,
-        "y_offset": -28,
+        "x": -24,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/lim/steep_to_flat_up_1_3.png",
-        "x_offset": -24,
-        "y_offset": -19,
+        "x": -24,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/lim/steep_to_flat_up_1_4.png",
-        "x_offset": -23,
-        "y_offset": -8,
+        "x": -23,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/lim/steep_to_flat_up_2_1.png",
-        "x_offset": -24,
-        "y_offset": -26,
+        "x": -24,
+        "y": -26,
         "palette": "keep"
     },
     {
         "path": "track/lim/steep_to_flat_up_2_2.png",
-        "x_offset": -19,
-        "y_offset": -14,
+        "x": -19,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/lim/steep_to_flat_up_2_3.png",
-        "x_offset": -12,
-        "y_offset": -7,
+        "x": -12,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/lim/steep_to_flat_up_2_4.png",
-        "x_offset": -15,
-        "y_offset": -2,
+        "x": -15,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/lim/steep_to_flat_up_3_1.png",
-        "x_offset": -14,
-        "y_offset": -25,
+        "x": -14,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/lim/steep_to_flat_up_3_2.png",
-        "x_offset": -13,
-        "y_offset": -13,
+        "x": -13,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/lim/steep_to_flat_up_3_3.png",
-        "x_offset": -18,
-        "y_offset": -7,
+        "x": -18,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/lim/steep_to_flat_up_3_4.png",
-        "x_offset": -22,
-        "y_offset": -5,
+        "x": -22,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/lim/steep_to_flat_up_4_1.png",
-        "x_offset": -21,
-        "y_offset": -41,
+        "x": -21,
+        "y": -41,
         "palette": "keep"
     },
     {
         "path": "track/lim/steep_to_flat_up_4_2.png",
-        "x_offset": -20,
-        "y_offset": -28,
+        "x": -20,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/lim/steep_to_flat_up_4_3.png",
-        "x_offset": -19,
-        "y_offset": -18,
+        "x": -19,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/lim/steep_to_flat_up_4_4.png",
-        "x_offset": -22,
-        "y_offset": -7,
+        "x": -22,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_left_1_1.png",
-        "x_offset": -22,
-        "y_offset": -7,
+        "x": -22,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_left_1_2.png",
-        "x_offset": -21,
-        "y_offset": -43,
+        "x": -21,
+        "y": -43,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_left_1_3.png",
-        "x_offset": -29,
-        "y_offset": -32,
+        "x": -29,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_left_1_4.png",
-        "x_offset": -22,
-        "y_offset": -44,
+        "x": -22,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_left_1_5.png",
-        "x_offset": -22,
-        "y_offset": -28,
+        "x": -22,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_left_2_1.png",
-        "x_offset": -22,
-        "y_offset": 1,
+        "x": -22,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_left_2_2.png",
-        "x_offset": -32,
-        "y_offset": -10,
+        "x": -32,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_left_2_3.png",
-        "x_offset": -23,
-        "y_offset": -46,
+        "x": -23,
+        "y": -46,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_left_2_4.png",
-        "x_offset": -19,
-        "y_offset": -52,
+        "x": -19,
+        "y": -52,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_left_2_5.png",
-        "x_offset": -15,
-        "y_offset": -28,
+        "x": -15,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_left_3_1.png",
-        "x_offset": -16,
-        "y_offset": 0,
+        "x": -16,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_left_3_2.png",
-        "x_offset": -13,
-        "y_offset": -11,
+        "x": -13,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_left_3_3.png",
-        "x_offset": 17,
-        "y_offset": -21,
+        "x": 17,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_left_3_4.png",
-        "x_offset": -8,
-        "y_offset": -32,
+        "x": -8,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_left_3_5.png",
-        "x_offset": -16,
-        "y_offset": -24,
+        "x": -16,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_left_4_1.png",
-        "x_offset": -24,
-        "y_offset": -7,
+        "x": -24,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_left_4_2.png",
-        "x_offset": -24,
-        "y_offset": -23,
+        "x": -24,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_left_4_3.png",
-        "x_offset": -14,
-        "y_offset": -9,
+        "x": -14,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_left_4_4.png",
-        "x_offset": -14,
-        "y_offset": -25,
+        "x": -14,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_left_4_5.png",
-        "x_offset": -22,
-        "y_offset": -20,
+        "x": -22,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_right_1_1.png",
-        "x_offset": -22,
-        "y_offset": -7,
+        "x": -22,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_right_1_2.png",
-        "x_offset": -23,
-        "y_offset": -24,
+        "x": -23,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_right_1_3.png",
-        "x_offset": -21,
-        "y_offset": -9,
+        "x": -21,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_right_1_4.png",
-        "x_offset": -30,
-        "y_offset": -25,
+        "x": -30,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_right_1_5.png",
-        "x_offset": -32,
-        "y_offset": -21,
+        "x": -32,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_right_2_1.png",
-        "x_offset": -22,
-        "y_offset": 1,
+        "x": -22,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_right_2_2.png",
-        "x_offset": -16,
-        "y_offset": -11,
+        "x": -16,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_right_2_3.png",
-        "x_offset": -24,
-        "y_offset": -21,
+        "x": -24,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_right_2_4.png",
-        "x_offset": -16,
-        "y_offset": -31,
+        "x": -16,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_right_2_5.png",
-        "x_offset": -22,
-        "y_offset": -23,
+        "x": -22,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_right_3_1.png",
-        "x_offset": -18,
-        "y_offset": 0,
+        "x": -18,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_right_3_2.png",
-        "x_offset": -16,
-        "y_offset": -11,
+        "x": -16,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_right_3_3.png",
-        "x_offset": -26,
-        "y_offset": -47,
+        "x": -26,
+        "y": -47,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_right_3_4.png",
-        "x_offset": -29,
-        "y_offset": -53,
+        "x": -29,
+        "y": -53,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_right_3_5.png",
-        "x_offset": -23,
-        "y_offset": -28,
+        "x": -23,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_right_4_1.png",
-        "x_offset": -22,
-        "y_offset": -7,
+        "x": -22,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_right_4_2.png",
-        "x_offset": -10,
-        "y_offset": -43,
+        "x": -10,
+        "y": -43,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_right_4_3.png",
-        "x_offset": 17,
-        "y_offset": -32,
+        "x": 17,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_right_4_4.png",
-        "x_offset": -11,
-        "y_offset": -44,
+        "x": -11,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_corkscrew_right_4_5.png",
-        "x_offset": -18,
-        "y_offset": -28,
+        "x": -18,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_turn_left_bank_to_gentle_up_1_1.png",
-        "x_offset": -26,
-        "y_offset": -15,
+        "x": -26,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_turn_left_bank_to_gentle_up_1_2.png",
-        "x_offset": -18,
-        "y_offset": -10,
+        "x": -18,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_turn_left_bank_to_gentle_up_2_1.png",
-        "x_offset": 37,
-        "y_offset": 0,
+        "x": 37,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_turn_left_bank_to_gentle_up_2_2.png",
-        "x_offset": -16,
-        "y_offset": -4,
+        "x": -16,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_turn_left_bank_to_gentle_up_2_3.png",
-        "x_offset": -38,
-        "y_offset": -11,
+        "x": -38,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_turn_left_bank_to_gentle_up_3_1.png",
-        "x_offset": -19,
-        "y_offset": -8,
+        "x": -19,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_turn_left_bank_to_gentle_up_3_2.png",
-        "x_offset": -6,
-        "y_offset": 1,
+        "x": -6,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_turn_left_bank_to_gentle_up_4_1.png",
-        "x_offset": -26,
-        "y_offset": -9,
+        "x": -26,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_turn_left_bank_to_gentle_up_4_2.png",
-        "x_offset": -29,
-        "y_offset": 4,
+        "x": -29,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_turn_right_bank_to_gentle_up_1_1.png",
-        "x_offset": -28,
-        "y_offset": -10,
+        "x": -28,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_turn_right_bank_to_gentle_up_1_2.png",
-        "x_offset": -26,
-        "y_offset": 4,
+        "x": -26,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_turn_right_bank_to_gentle_up_2_1.png",
-        "x_offset": -14,
-        "y_offset": -8,
+        "x": -14,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_turn_right_bank_to_gentle_up_2_2.png",
-        "x_offset": -29,
-        "y_offset": 1,
+        "x": -29,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_turn_right_bank_to_gentle_up_3_1.png",
-        "x_offset": -38,
-        "y_offset": 0,
+        "x": -38,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_turn_right_bank_to_gentle_up_3_2.png",
-        "x_offset": -38,
-        "y_offset": -4,
+        "x": -38,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_turn_right_bank_to_gentle_up_3_3.png",
-        "x_offset": -17,
-        "y_offset": -10,
+        "x": -17,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_turn_right_bank_to_gentle_up_4_1.png",
-        "x_offset": -7,
-        "y_offset": -15,
+        "x": -7,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_turn_right_bank_to_gentle_up_4_2.png",
-        "x_offset": -19,
-        "y_offset": -11,
+        "x": -19,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_left_1_1.png",
-        "x_offset": -23,
-        "y_offset": -29,
+        "x": -23,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_left_1_2.png",
-        "x_offset": -23,
-        "y_offset": -46,
+        "x": -23,
+        "y": -46,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_left_1_3.png",
-        "x_offset": -30,
-        "y_offset": -80,
+        "x": -30,
+        "y": -80,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_left_1_4.png",
-        "x_offset": 0,
-        "y_offset": -114,
+        "x": 0,
+        "y": -114,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_left_1_5.png",
-        "x_offset": -22,
-        "y_offset": -25,
+        "x": -22,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_left_2_1.png",
-        "x_offset": -22,
-        "y_offset": -7,
+        "x": -22,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_left_2_2.png",
-        "x_offset": 0,
-        "y_offset": -28,
+        "x": 0,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_left_2_3.png",
-        "x_offset": 0,
-        "y_offset": -82,
+        "x": 0,
+        "y": -82,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_left_2_4.png",
-        "x_offset": -31,
-        "y_offset": -143,
+        "x": -31,
+        "y": -143,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_left_2_5.png",
-        "x_offset": -23,
-        "y_offset": -36,
+        "x": -23,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_left_3_1.png",
-        "x_offset": -17,
-        "y_offset": -1,
+        "x": -17,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_left_3_2.png",
-        "x_offset": 0,
-        "y_offset": -8,
+        "x": 0,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_left_3_3.png",
-        "x_offset": -2,
-        "y_offset": -52,
+        "x": -2,
+        "y": -52,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_left_3_4.png",
-        "x_offset": -32,
-        "y_offset": -148,
+        "x": -32,
+        "y": -148,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_left_3_5.png",
-        "x_offset": -16,
-        "y_offset": -36,
+        "x": -16,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_left_4_1.png",
-        "x_offset": -22,
-        "y_offset": -14,
+        "x": -22,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_left_4_2.png",
-        "x_offset": -24,
-        "y_offset": -21,
+        "x": -24,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_left_4_3.png",
-        "x_offset": -30,
-        "y_offset": -26,
+        "x": -30,
+        "y": -26,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_left_4_4.png",
-        "x_offset": -9,
-        "y_offset": -118,
+        "x": -9,
+        "y": -118,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_left_4_5.png",
-        "x_offset": -23,
-        "y_offset": -28,
+        "x": -23,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_right_1_1.png",
-        "x_offset": -22,
-        "y_offset": -15,
+        "x": -22,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_right_1_2.png",
-        "x_offset": -20,
-        "y_offset": -22,
+        "x": -20,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_right_1_3.png",
-        "x_offset": -18,
-        "y_offset": -27,
+        "x": -18,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_right_1_4.png",
-        "x_offset": -15,
-        "y_offset": -118,
+        "x": -15,
+        "y": -118,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_right_1_5.png",
-        "x_offset": -23,
-        "y_offset": -28,
+        "x": -23,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_right_2_1.png",
-        "x_offset": -22,
-        "y_offset": -1,
+        "x": -22,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_right_2_2.png",
-        "x_offset": -32,
-        "y_offset": -8,
+        "x": -32,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_right_2_3.png",
-        "x_offset": -32,
-        "y_offset": -52,
+        "x": -32,
+        "y": -52,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_right_2_4.png",
-        "x_offset": -25,
-        "y_offset": -148,
+        "x": -25,
+        "y": -148,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_right_2_5.png",
-        "x_offset": -22,
-        "y_offset": -36,
+        "x": -22,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_right_3_1.png",
-        "x_offset": -32,
-        "y_offset": -7,
+        "x": -32,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_right_3_2.png",
-        "x_offset": -32,
-        "y_offset": -28,
+        "x": -32,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_right_3_3.png",
-        "x_offset": -32,
-        "y_offset": -82,
+        "x": -32,
+        "y": -82,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_right_3_4.png",
-        "x_offset": -9,
-        "y_offset": -143,
+        "x": -9,
+        "y": -143,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_right_3_5.png",
-        "x_offset": -12,
-        "y_offset": -35,
+        "x": -12,
+        "y": -35,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_right_4_1.png",
-        "x_offset": -22,
-        "y_offset": -29,
+        "x": -22,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_right_4_2.png",
-        "x_offset": -16,
-        "y_offset": -46,
+        "x": -16,
+        "y": -46,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_right_4_3.png",
-        "x_offset": -2,
-        "y_offset": -80,
+        "x": -2,
+        "y": -80,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_right_4_4.png",
-        "x_offset": -32,
-        "y_offset": -115,
+        "x": -32,
+        "y": -115,
         "palette": "keep"
     },
     {
         "path": "track/lim/medium_half_loop_right_4_5.png",
-        "x_offset": -32,
-        "y_offset": -25,
+        "x": -32,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_1_1.png",
-        "x_offset": -23,
-        "y_offset": -25,
+        "x": -23,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_1_2.png",
-        "x_offset": -20,
-        "y_offset": -38,
+        "x": -20,
+        "y": -38,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_1_3.png",
-        "x_offset": -20,
-        "y_offset": -65,
+        "x": -20,
+        "y": -65,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_1_4.png",
-        "x_offset": -24,
-        "y_offset": -80,
+        "x": -24,
+        "y": -80,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_1_5.png",
-        "x_offset": -15,
-        "y_offset": -64,
+        "x": -15,
+        "y": -64,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_1_6.png",
-        "x_offset": -9,
-        "y_offset": -171,
+        "x": -9,
+        "y": -171,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_1_7.png",
-        "x_offset": -21,
-        "y_offset": -8,
+        "x": -21,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_2_1.png",
-        "x_offset": -22,
-        "y_offset": -1,
+        "x": -22,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_2_2.png",
-        "x_offset": -6,
-        "y_offset": -4,
+        "x": -6,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_2_3.png",
-        "x_offset": -9,
-        "y_offset": -22,
+        "x": -9,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_2_4.png",
-        "x_offset": -8,
-        "y_offset": -90,
+        "x": -8,
+        "y": -90,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_2_5.png",
-        "x_offset": -32,
-        "y_offset": -126,
+        "x": -32,
+        "y": -126,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_2_6.png",
-        "x_offset": -26,
-        "y_offset": -192,
+        "x": -26,
+        "y": -192,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_2_7.png",
-        "x_offset": -23,
-        "y_offset": -20,
+        "x": -23,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_3_1.png",
-        "x_offset": -24,
-        "y_offset": 0,
+        "x": -24,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_3_2.png",
-        "x_offset": -29,
-        "y_offset": -4,
+        "x": -29,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_3_3.png",
-        "x_offset": -24,
-        "y_offset": -33,
+        "x": -24,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_3_4.png",
-        "x_offset": -5,
-        "y_offset": -56,
+        "x": -5,
+        "y": -56,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_3_5.png",
-        "x_offset": -6,
-        "y_offset": -112,
+        "x": -6,
+        "y": -112,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_3_6.png",
-        "x_offset": -21,
-        "y_offset": -192,
+        "x": -21,
+        "y": -192,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_3_7.png",
-        "x_offset": -26,
-        "y_offset": -20,
+        "x": -26,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_4_1.png",
-        "x_offset": -23,
-        "y_offset": -13,
+        "x": -23,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_4_2.png",
-        "x_offset": -29,
-        "y_offset": -17,
+        "x": -29,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_4_3.png",
-        "x_offset": -32,
-        "y_offset": -48,
+        "x": -32,
+        "y": -48,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_4_4.png",
-        "x_offset": -32,
-        "y_offset": -79,
+        "x": -32,
+        "y": -79,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_4_5.png",
-        "x_offset": 17,
-        "y_offset": -57,
+        "x": 17,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_4_6.png",
-        "x_offset": -14,
-        "y_offset": -176,
+        "x": -14,
+        "y": -176,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_left_4_7.png",
-        "x_offset": -19,
-        "y_offset": -10,
+        "x": -19,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_1_1.png",
-        "x_offset": -22,
-        "y_offset": -14,
+        "x": -22,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_1_2.png",
-        "x_offset": -19,
-        "y_offset": -17,
+        "x": -19,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_1_3.png",
-        "x_offset": -14,
-        "y_offset": -49,
+        "x": -14,
+        "y": -49,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_1_4.png",
-        "x_offset": 0,
-        "y_offset": -79,
+        "x": 0,
+        "y": -79,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_1_5.png",
-        "x_offset": -32,
-        "y_offset": -57,
+        "x": -32,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_1_6.png",
-        "x_offset": -19,
-        "y_offset": -175,
+        "x": -19,
+        "y": -175,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_1_7.png",
-        "x_offset": -23,
-        "y_offset": -10,
+        "x": -23,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_2_1.png",
-        "x_offset": -22,
-        "y_offset": 0,
+        "x": -22,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_2_2.png",
-        "x_offset": -10,
-        "y_offset": -4,
+        "x": -10,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_2_3.png",
-        "x_offset": -6,
-        "y_offset": -33,
+        "x": -6,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_2_4.png",
-        "x_offset": -16,
-        "y_offset": -56,
+        "x": -16,
+        "y": -56,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_2_5.png",
-        "x_offset": -24,
-        "y_offset": -112,
+        "x": -24,
+        "y": -112,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_2_6.png",
-        "x_offset": -17,
-        "y_offset": -192,
+        "x": -17,
+        "y": -192,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_2_7.png",
-        "x_offset": -22,
-        "y_offset": -20,
+        "x": -22,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_3_1.png",
-        "x_offset": -26,
-        "y_offset": -1,
+        "x": -26,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_3_2.png",
-        "x_offset": -26,
-        "y_offset": -4,
+        "x": -26,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_3_3.png",
-        "x_offset": -28,
-        "y_offset": -22,
+        "x": -28,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_3_4.png",
-        "x_offset": -32,
-        "y_offset": -89,
+        "x": -32,
+        "y": -89,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_3_5.png",
-        "x_offset": 17,
-        "y_offset": -125,
+        "x": 17,
+        "y": -125,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_3_6.png",
-        "x_offset": 0,
-        "y_offset": -192,
+        "x": 0,
+        "y": -192,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_3_7.png",
-        "x_offset": -17,
-        "y_offset": -19,
+        "x": -17,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_4_1.png",
-        "x_offset": -23,
-        "y_offset": -25,
+        "x": -23,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_4_2.png",
-        "x_offset": -24,
-        "y_offset": -38,
+        "x": -24,
+        "y": -38,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_4_3.png",
-        "x_offset": -21,
-        "y_offset": -65,
+        "x": -21,
+        "y": -65,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_4_4.png",
-        "x_offset": -4,
-        "y_offset": -80,
+        "x": -4,
+        "y": -80,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_4_5.png",
-        "x_offset": -6,
-        "y_offset": -64,
+        "x": -6,
+        "y": -64,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_4_6.png",
-        "x_offset": -28,
-        "y_offset": -172,
+        "x": -28,
+        "y": -172,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_half_loop_right_4_7.png",
-        "x_offset": -27,
-        "y_offset": -8,
+        "x": -27,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_left_1_1.png",
-        "x_offset": -22,
-        "y_offset": -6,
+        "x": -22,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_left_1_2.png",
-        "x_offset": -12,
-        "y_offset": -11,
+        "x": -12,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_left_1_3.png",
-        "x_offset": -11,
-        "y_offset": -21,
+        "x": -11,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_left_1_4.png",
-        "x_offset": -20,
-        "y_offset": -19,
+        "x": -20,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_left_2_1.png",
-        "x_offset": -16,
-        "y_offset": 1,
+        "x": -16,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_left_2_2.png",
-        "x_offset": -22,
-        "y_offset": -1,
+        "x": -22,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_left_2_3.png",
-        "x_offset": -23,
-        "y_offset": -15,
+        "x": -23,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_left_2_4.png",
-        "x_offset": -21,
-        "y_offset": -15,
+        "x": -21,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_left_3_1.png",
-        "x_offset": -20,
-        "y_offset": -8,
+        "x": -20,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_left_3_2.png",
-        "x_offset": -21,
-        "y_offset": -21,
+        "x": -21,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_left_3_3.png",
-        "x_offset": -1,
-        "y_offset": -13,
+        "x": -1,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_left_3_4.png",
-        "x_offset": -23,
-        "y_offset": -17,
+        "x": -23,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_left_4_1.png",
-        "x_offset": -16,
-        "y_offset": -24,
+        "x": -16,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_left_4_2.png",
-        "x_offset": -11,
-        "y_offset": -33,
+        "x": -11,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_left_4_3.png",
-        "x_offset": 16,
-        "y_offset": 0,
+        "x": 16,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_left_4_4.png",
-        "x_offset": -21,
-        "y_offset": -20,
+        "x": -21,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_right_1_1.png",
-        "x_offset": -22,
-        "y_offset": -24,
+        "x": -22,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_right_1_2.png",
-        "x_offset": -28,
-        "y_offset": -33,
+        "x": -28,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_right_1_3.png",
-        "x_offset": -21,
-        "y_offset": 1,
+        "x": -21,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_right_1_4.png",
-        "x_offset": -24,
-        "y_offset": -20,
+        "x": -24,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_right_2_1.png",
-        "x_offset": -22,
-        "y_offset": -8,
+        "x": -22,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_right_2_2.png",
-        "x_offset": -16,
-        "y_offset": -21,
+        "x": -16,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_right_2_3.png",
-        "x_offset": -13,
-        "y_offset": -13,
+        "x": -13,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_right_2_4.png",
-        "x_offset": -11,
-        "y_offset": -17,
+        "x": -11,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_right_3_1.png",
-        "x_offset": 3,
-        "y_offset": 1,
+        "x": 3,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_right_3_2.png",
-        "x_offset": -9,
-        "y_offset": -1,
+        "x": -9,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_right_3_3.png",
-        "x_offset": -11,
-        "y_offset": -15,
+        "x": -11,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_right_3_4.png",
-        "x_offset": -21,
-        "y_offset": -15,
+        "x": -21,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_right_4_1.png",
-        "x_offset": -16,
-        "y_offset": -6,
+        "x": -16,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_right_4_2.png",
-        "x_offset": -27,
-        "y_offset": -11,
+        "x": -27,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_right_4_3.png",
-        "x_offset": -24,
-        "y_offset": -21,
+        "x": -24,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/lim/zero_g_roll_right_4_4.png",
-        "x_offset": -23,
-        "y_offset": -20,
+        "x": -23,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_left_1_1.png",
-        "x_offset": -24,
-        "y_offset": -43,
+        "x": -24,
+        "y": -43,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_left_1_2.png",
-        "x_offset": -24,
-        "y_offset": 2,
+        "x": -24,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_left_1_3.png",
-        "x_offset": -18,
-        "y_offset": -47,
+        "x": -18,
+        "y": -47,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_left_1_4.png",
-        "x_offset": -14,
-        "y_offset": -36,
+        "x": -14,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_left_1_5.png",
-        "x_offset": -18,
-        "y_offset": -19,
+        "x": -18,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_left_2_1.png",
-        "x_offset": -24,
-        "y_offset": -39,
+        "x": -24,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_left_2_2.png",
-        "x_offset": -27,
-        "y_offset": -28,
+        "x": -27,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_left_2_3.png",
-        "x_offset": -32,
-        "y_offset": -21,
+        "x": -32,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_left_2_4.png",
-        "x_offset": -29,
-        "y_offset": -14,
+        "x": -29,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_left_3_1.png",
-        "x_offset": -8,
-        "y_offset": -29,
+        "x": -8,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_left_3_2.png",
-        "x_offset": -11,
-        "y_offset": -28,
+        "x": -11,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_left_3_3.png",
-        "x_offset": -28,
-        "y_offset": -36,
+        "x": -28,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_left_3_4.png",
-        "x_offset": -24,
-        "y_offset": -22,
+        "x": -24,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_left_3_5.png",
-        "x_offset": 3,
-        "y_offset": -6,
+        "x": 3,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_left_3_6.png",
-        "x_offset": -23,
-        "y_offset": -13,
+        "x": -23,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_left_4_1.png",
-        "x_offset": -15,
-        "y_offset": -46,
+        "x": -15,
+        "y": -46,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_left_4_2.png",
-        "x_offset": -14,
-        "y_offset": -43,
+        "x": -14,
+        "y": -43,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_left_4_3.png",
-        "x_offset": -6,
-        "y_offset": -25,
+        "x": -6,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_left_4_4.png",
-        "x_offset": -9,
-        "y_offset": -32,
+        "x": -9,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_left_4_5.png",
-        "x_offset": -22,
-        "y_offset": -20,
+        "x": -22,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_right_1_1.png",
-        "x_offset": -24,
-        "y_offset": -48,
+        "x": -24,
+        "y": -48,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_right_1_2.png",
-        "x_offset": -32,
-        "y_offset": -43,
+        "x": -32,
+        "y": -43,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_right_1_3.png",
-        "x_offset": -30,
-        "y_offset": -24,
+        "x": -30,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_right_1_4.png",
-        "x_offset": -31,
-        "y_offset": -32,
+        "x": -31,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_right_1_5.png",
-        "x_offset": -26,
-        "y_offset": -20,
+        "x": -26,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_right_2_1.png",
-        "x_offset": 5,
-        "y_offset": -30,
+        "x": 5,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_right_2_2.png",
-        "x_offset": -24,
-        "y_offset": -29,
+        "x": -24,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_right_2_3.png",
-        "x_offset": -25,
-        "y_offset": -37,
+        "x": -25,
+        "y": -37,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_right_2_4.png",
-        "x_offset": -17,
-        "y_offset": -22,
+        "x": -17,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_right_2_5.png",
-        "x_offset": -8,
-        "y_offset": -7,
+        "x": -8,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_right_2_6.png",
-        "x_offset": -8,
-        "y_offset": -13,
+        "x": -8,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_right_3_1.png",
-        "x_offset": -16,
-        "y_offset": -39,
+        "x": -16,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_right_3_2.png",
-        "x_offset": -12,
-        "y_offset": -28,
+        "x": -12,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_right_3_3.png",
-        "x_offset": -5,
-        "y_offset": -21,
+        "x": -5,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_right_3_4.png",
-        "x_offset": -22,
-        "y_offset": -14,
+        "x": -22,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_right_4_1.png",
-        "x_offset": -16,
-        "y_offset": -42,
+        "x": -16,
+        "y": -42,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_right_4_2.png",
-        "x_offset": 5,
-        "y_offset": 1,
+        "x": 5,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_right_4_3.png",
-        "x_offset": -29,
-        "y_offset": -47,
+        "x": -29,
+        "y": -47,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_right_4_4.png",
-        "x_offset": -27,
-        "y_offset": -36,
+        "x": -27,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/lim/large_zero_g_roll_right_4_5.png",
-        "x_offset": -23,
-        "y_offset": -20,
+        "x": -23,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_flat_to_steep_up_1.png",
-        "x_offset": -22,
-        "y_offset": -22,
+        "x": -22,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_flat_to_steep_up_2_1.png",
-        "x_offset": -19,
-        "y_offset": 1,
+        "x": -19,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_flat_to_steep_up_2_2.png",
-        "x_offset": -22,
-        "y_offset": -8,
+        "x": -22,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_flat_to_steep_up_3_1.png",
-        "x_offset": -3,
-        "y_offset": 0,
+        "x": -3,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_flat_to_steep_up_3_2.png",
-        "x_offset": -23,
-        "y_offset": -8,
+        "x": -23,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_flat_to_steep_up_4.png",
-        "x_offset": -22,
-        "y_offset": -22,
+        "x": -22,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_steep_to_flat_up_1.png",
-        "x_offset": -24,
-        "y_offset": -24,
+        "x": -24,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_steep_to_flat_up_2_1.png",
-        "x_offset": -10,
-        "y_offset": -11,
+        "x": -10,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_steep_to_flat_up_2_2.png",
-        "x_offset": -24,
-        "y_offset": -6,
+        "x": -24,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_steep_to_flat_up_3_1.png",
-        "x_offset": -22,
-        "y_offset": -11,
+        "x": -22,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_steep_to_flat_up_3_2.png",
-        "x_offset": -11,
-        "y_offset": -6,
+        "x": -11,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_steep_to_flat_up_4.png",
-        "x_offset": -22,
-        "y_offset": -23,
+        "x": -22,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_flat_to_steep_up_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -18,
+        "x": -32,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_flat_to_steep_up_diag_2.png",
-        "x_offset": -10,
-        "y_offset": -5,
+        "x": -10,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_flat_to_steep_up_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -17,
+        "x": -32,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_flat_to_steep_up_diag_4.png",
-        "x_offset": -10,
-        "y_offset": -29,
+        "x": -10,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_steep_to_flat_up_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -17,
+        "x": -32,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_steep_to_flat_up_diag_2.png",
-        "x_offset": -10,
-        "y_offset": -9,
+        "x": -10,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_steep_to_flat_up_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -17,
+        "x": -32,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/lim/small_steep_to_flat_up_diag_4.png",
-        "x_offset": -10,
-        "y_offset": -29,
+        "x": -10,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/flume/25-60-down-nesw.png",
-        "x_offset": -26,
-        "y_offset": -39,
+        "x": -26,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/flume/25-60-down-nwse.png",
-        "x_offset": -28,
-        "y_offset": -39,
+        "x": -28,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/flume/25-60-down-nesw-back-water.png",
-        "y_offset": -23,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/flume/25-60-down-nesw-back.png",
-        "x_offset": -26,
-        "y_offset": -12,
+        "x": -26,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/flume/25-60-down-nwse-back-water.png",
-        "x_offset": -25,
-        "y_offset": -22,
+        "x": -25,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/flume/25-60-down-nwse-back.png",
-        "x_offset": -10,
-        "y_offset": -12,
+        "x": -10,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/flume/60-down-nesw.png",
-        "x_offset": -27,
-        "y_offset": -71,
+        "x": -27,
+        "y": -71,
         "palette": "keep"
     },
     {
         "path": "track/flume/60-down-nwse.png",
-        "x_offset": -28,
-        "y_offset": -70,
+        "x": -28,
+        "y": -70,
         "palette": "keep"
     },
     {
         "path": "track/flume/60-down-nesw-back.png",
-        "x_offset": -26,
-        "y_offset": -53,
+        "x": -26,
+        "y": -53,
         "palette": "keep"
     },
     {
         "path": "track/flume/60-down-nwse-back.png",
-        "x_offset": -27,
-        "y_offset": -55,
+        "x": -27,
+        "y": -55,
         "palette": "keep"
     },
     {
         "path": "track/flume/60-25-down-nesw.png",
-        "x_offset": -27,
-        "y_offset": -39,
+        "x": -27,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/flume/60-25-down-nwse.png",
-        "x_offset": -28,
-        "y_offset": -39,
+        "x": -28,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/flume/60-25-down-nesw-back-water.png",
-        "x_offset": -20,
-        "y_offset": -6,
+        "x": -20,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/flume/60-25-down-nesw-back.png",
-        "x_offset": -27,
-        "y_offset": -22,
+        "x": -27,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/flume/60-25-down-nwse-back-water.png",
-        "x_offset": 2,
-        "y_offset": -6,
+        "x": 2,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/flume/60-25-down-nwse-back.png",
-        "x_offset": -26,
-        "y_offset": -22,
+        "x": -26,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "support/flat_to_steep_1_1.png",
-        "x_offset": -32,
-        "y_offset": -5
+        "x": -32,
+        "y": -5
     },
     {
         "path": "support/flat_to_steep_1_2.png",
-        "x_offset": -32,
-        "y_offset": -1
+        "x": -32,
+        "y": -1
     },
     {
         "path": "support/flat_to_steep_1_3.png",
-        "x_offset": -32,
-        "y_offset": -1
+        "x": -32,
+        "y": -1
     },
     {
         "path": "support/flat_to_steep_1_4.png",
-        "x_offset": -32,
-        "y_offset": -5
+        "x": -32,
+        "y": -5
     },
     {
         "path": "support/flat_to_steep_2_1.png",
-        "x_offset": -32,
-        "y_offset": -18
+        "x": -32,
+        "y": -18
     },
     {
         "path": "support/flat_to_steep_2_2.png",
-        "x_offset": -32,
-        "y_offset": -5
+        "x": -32,
+        "y": -5
     },
     {
         "path": "support/flat_to_steep_2_3.png",
-        "x_offset": -32,
-        "y_offset": -5
+        "x": -32,
+        "y": -5
     },
     {
         "path": "support/flat_to_steep_2_4.png",
-        "x_offset": -32,
-        "y_offset": -18
+        "x": -32,
+        "y": -18
     },
     {
         "path": "support/flat_to_steep_3_1.png",
-        "x_offset": -32,
-        "y_offset": -27
+        "x": -32,
+        "y": -27
     },
     {
         "path": "support/flat_to_steep_3_2.png",
-        "x_offset": -32,
-        "y_offset": -11
+        "x": -32,
+        "y": -11
     },
     {
         "path": "support/flat_to_steep_3_3.png",
-        "x_offset": -32,
-        "y_offset": -11
+        "x": -32,
+        "y": -11
     },
     {
         "path": "support/flat_to_steep_3_4.png",
-        "x_offset": -32,
-        "y_offset": -27
+        "x": -32,
+        "y": -27
     },
     {
         "path": "support/flat_to_steep_4_1.png",
-        "x_offset": -32,
-        "y_offset": -57
+        "x": -32,
+        "y": -57
     },
     {
         "path": "support/flat_to_steep_4_2.png",
-        "x_offset": -32,
-        "y_offset": -41
+        "x": -32,
+        "y": -41
     },
     {
         "path": "support/flat_to_steep_4_3.png",
-        "x_offset": -32,
-        "y_offset": -41
+        "x": -32,
+        "y": -41
     },
     {
         "path": "support/flat_to_steep_4_4.png",
-        "x_offset": -32,
-        "y_offset": -57
+        "x": -32,
+        "y": -57
     },
     {
         "path": "support/steep_to_flat_1_1.png",
-        "x_offset": -32,
-        "y_offset": -54
+        "x": -32,
+        "y": -54
     },
     {
         "path": "support/steep_to_flat_1_2.png",
-        "x_offset": -32,
-        "y_offset": -38
+        "x": -32,
+        "y": -38
     },
     {
         "path": "support/steep_to_flat_1_3.png",
-        "x_offset": -32,
-        "y_offset": -38
+        "x": -32,
+        "y": -38
     },
     {
         "path": "support/steep_to_flat_1_4.png",
-        "x_offset": -32,
-        "y_offset": -54
+        "x": -32,
+        "y": -54
     },
     {
         "path": "support/steep_to_flat_2_1.png",
-        "x_offset": -32,
-        "y_offset": -31
+        "x": -32,
+        "y": -31
     },
     {
         "path": "support/steep_to_flat_2_2.png",
-        "x_offset": -32,
-        "y_offset": -15
+        "x": -32,
+        "y": -15
     },
     {
         "path": "support/steep_to_flat_2_3.png",
-        "x_offset": -32,
-        "y_offset": -15
+        "x": -32,
+        "y": -15
     },
     {
         "path": "support/steep_to_flat_2_4.png",
-        "x_offset": -32,
-        "y_offset": -31
+        "x": -32,
+        "y": -31
     },
     {
         "path": "support/steep_to_flat_3_1.png",
-        "x_offset": -32,
-        "y_offset": -28
+        "x": -32,
+        "y": -28
     },
     {
         "path": "support/steep_to_flat_3_2.png",
-        "x_offset": -32,
-        "y_offset": -16
+        "x": -32,
+        "y": -16
     },
     {
         "path": "support/steep_to_flat_3_3.png",
-        "x_offset": -32,
-        "y_offset": -16
+        "x": -32,
+        "y": -16
     },
     {
         "path": "support/steep_to_flat_3_4.png",
-        "x_offset": -32,
-        "y_offset": -28
+        "x": -32,
+        "y": -28
     },
     {
         "path": "support/steep_to_flat_4_1.png",
-        "x_offset": -32,
-        "y_offset": -17
+        "x": -32,
+        "y": -17
     },
     {
         "path": "support/steep_to_flat_4_2.png",
-        "x_offset": -32,
-        "y_offset": -12
+        "x": -32,
+        "y": -12
     },
     {
         "path": "support/steep_to_flat_4_3.png",
-        "x_offset": -32,
-        "y_offset": -12
+        "x": -32,
+        "y": -12
     },
     {
         "path": "support/steep_to_flat_4_4.png",
-        "x_offset": -32,
-        "y_offset": -17
+        "x": -32,
+        "y": -17
     },
     {
         "path": "track/rmc/preview_track.png",
-        "x_offset": 1,
-        "y_offset": 1,
+        "x": 1,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/rmc/preview_support.png",
-        "x_offset": 1,
-        "y_offset": 1,
+        "x": 1,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/brake_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/brake_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/block_brake_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/block_brake_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/booster_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/booster_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_1.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_3.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_4.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_flat_1.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_flat_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_flat_3.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_flat_4.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_1.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_3.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_4.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_steep_up_1.png",
-        "x_offset": -34,
-        "y_offset": -41,
+        "x": -34,
+        "y": -41,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_steep_up_2_1.png",
-        "x_offset": -34,
-        "y_offset": -25,
+        "x": -34,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_steep_up_2_2.png",
-        "x_offset": -34,
-        "y_offset": -25,
+        "x": -34,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_steep_up_3_1.png",
-        "x_offset": -34,
-        "y_offset": -25,
+        "x": -34,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_steep_up_3_2.png",
-        "x_offset": -34,
-        "y_offset": -25,
+        "x": -34,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_steep_up_4.png",
-        "x_offset": -34,
-        "y_offset": -41,
+        "x": -34,
+        "y": -41,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_gentle_up_1.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_gentle_up_2_1.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_gentle_up_2_2.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_gentle_up_3_1.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_gentle_up_3_2.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_gentle_up_4.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_1.png",
-        "x_offset": -34,
-        "y_offset": -73,
+        "x": -34,
+        "y": -73,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_2.png",
-        "x_offset": -34,
-        "y_offset": -57,
+        "x": -34,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_3.png",
-        "x_offset": -34,
-        "y_offset": -57,
+        "x": -34,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_4.png",
-        "x_offset": -34,
-        "y_offset": -73,
+        "x": -34,
+        "y": -73,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_vertical_up_1.png",
-        "x_offset": -34,
-        "y_offset": -70,
+        "x": -34,
+        "y": -70,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_vertical_up_2.png",
-        "x_offset": -34,
-        "y_offset": -59,
+        "x": -34,
+        "y": -59,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_vertical_up_3.png",
-        "x_offset": -32,
-        "y_offset": -59,
+        "x": -32,
+        "y": -59,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_vertical_up_4.png",
-        "x_offset": -32,
-        "y_offset": -70,
+        "x": -32,
+        "y": -70,
         "palette": "keep"
     },
     {
         "path": "track/rmc/vertical_to_steep_up_1.png",
-        "x_offset": -15,
-        "y_offset": -65,
+        "x": -15,
+        "y": -65,
         "palette": "keep"
     },
     {
         "path": "track/rmc/vertical_to_steep_up_2.png",
-        "x_offset": -14,
-        "y_offset": -49,
+        "x": -14,
+        "y": -49,
         "palette": "keep"
     },
     {
         "path": "track/rmc/vertical_to_steep_up_3.png",
-        "x_offset": -34,
-        "y_offset": -49,
+        "x": -34,
+        "y": -49,
         "palette": "keep"
     },
     {
         "path": "track/rmc/vertical_to_steep_up_4.png",
-        "x_offset": -34,
-        "y_offset": -65,
+        "x": -34,
+        "y": -65,
         "palette": "keep"
     },
     {
         "path": "track/rmc/vertical_1.png",
-        "x_offset": -15,
-        "y_offset": -46,
+        "x": -15,
+        "y": -46,
         "palette": "keep"
     },
     {
         "path": "track/rmc/vertical_2.png",
-        "x_offset": -15,
-        "y_offset": -35,
+        "x": -15,
+        "y": -35,
         "palette": "keep"
     },
     {
         "path": "track/rmc/vertical_3.png",
-        "x_offset": -32,
-        "y_offset": -35,
+        "x": -32,
+        "y": -35,
         "palette": "keep"
     },
     {
         "path": "track/rmc/vertical_4.png",
-        "x_offset": -32,
-        "y_offset": -46,
+        "x": -32,
+        "y": -46,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_1_1.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_1_2.png",
-        "x_offset": -66,
-        "y_offset": -28,
+        "x": -66,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_1_3.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_2_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_2_2.png",
-        "x_offset": -66,
-        "y_offset": -28,
+        "x": -66,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_2_3.png",
-        "x_offset": -98,
-        "y_offset": -12,
+        "x": -98,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_3_1.png",
-        "x_offset": -27,
-        "y_offset": -12,
+        "x": -27,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_3_2.png",
-        "x_offset": 5,
-        "y_offset": -28,
+        "x": 5,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_3_3.png",
-        "x_offset": -27,
-        "y_offset": -44,
+        "x": -27,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_4_1.png",
-        "x_offset": -98,
-        "y_offset": -8,
+        "x": -98,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_4_2.png",
-        "x_offset": -66,
-        "y_offset": 8,
+        "x": -66,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_4_3.png",
-        "x_offset": -34,
-        "y_offset": -8,
+        "x": -34,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_1_1.png",
-        "x_offset": -34,
-        "y_offset": -76,
+        "x": -34,
+        "y": -76,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_1_2.png",
-        "x_offset": -66,
-        "y_offset": -60,
+        "x": -66,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_1_3.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_1_4.png",
-        "x_offset": -66,
-        "y_offset": -28,
+        "x": -66,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_1_5.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_2_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_2_2.png",
-        "x_offset": -66,
-        "y_offset": -28,
+        "x": -66,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_2_3.png",
-        "x_offset": -98,
-        "y_offset": -12,
+        "x": -98,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_2_4.png",
-        "x_offset": -130,
-        "y_offset": -28,
+        "x": -130,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_2_5.png",
-        "x_offset": -162,
-        "y_offset": -12,
+        "x": -162,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_3_1.png",
-        "x_offset": -40,
-        "y_offset": -12,
+        "x": -40,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_3_2.png",
-        "x_offset": -8,
-        "y_offset": -28,
+        "x": -8,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_3_3.png",
-        "x_offset": -40,
-        "y_offset": -44,
+        "x": -40,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_3_4.png",
-        "x_offset": -8,
-        "y_offset": -60,
+        "x": -8,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_3_5.png",
-        "x_offset": -40,
-        "y_offset": -76,
+        "x": -40,
+        "y": -76,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_4_1.png",
-        "x_offset": -162,
-        "y_offset": -15,
+        "x": -162,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_4_2.png",
-        "x_offset": -130,
-        "y_offset": 1,
+        "x": -130,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_4_3.png",
-        "x_offset": -98,
-        "y_offset": -15,
+        "x": -98,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_4_4.png",
-        "x_offset": -66,
-        "y_offset": 1,
+        "x": -66,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_4_5.png",
-        "x_offset": -34,
-        "y_offset": -15,
+        "x": -34,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_1_1.png",
-        "x_offset": -34,
-        "y_offset": -46,
+        "x": -34,
+        "y": -46,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_1_2.png",
-        "x_offset": -66,
-        "y_offset": -30,
+        "x": -66,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_1_3.png",
-        "x_offset": -34,
-        "y_offset": -14,
+        "x": -34,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_1_4.png",
-        "x_offset": -66,
-        "y_offset": 2,
+        "x": -66,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_2_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_2_2.png",
-        "x_offset": -66,
-        "y_offset": -28,
+        "x": -66,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_2_3.png",
-        "x_offset": -98,
-        "y_offset": -12,
+        "x": -98,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_2_4.png",
-        "x_offset": -130,
-        "y_offset": -28,
+        "x": -130,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_3_1.png",
-        "x_offset": -56,
-        "y_offset": -12,
+        "x": -56,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_3_2.png",
-        "x_offset": -24,
-        "y_offset": -28,
+        "x": -24,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_3_3.png",
-        "x_offset": -56,
-        "y_offset": -44,
+        "x": -56,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_3_4.png",
-        "x_offset": -24,
-        "y_offset": -60,
+        "x": -24,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_4_1.png",
-        "x_offset": -98,
-        "y_offset": -24,
+        "x": -98,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_4_2.png",
-        "x_offset": -66,
-        "y_offset": -8,
+        "x": -66,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_4_3.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_4_4.png",
-        "x_offset": -2,
-        "y_offset": -8,
+        "x": -2,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_1_1.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_1_2.png",
-        "x_offset": -66,
-        "y_offset": -8,
+        "x": -66,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_1_3.png",
-        "x_offset": -98,
-        "y_offset": -24,
+        "x": -98,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_1_4.png",
-        "x_offset": -130,
-        "y_offset": -8,
+        "x": -130,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_2_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_2_2.png",
-        "x_offset": -66,
-        "y_offset": -28,
+        "x": -66,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_2_3.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_2_4.png",
-        "x_offset": -66,
-        "y_offset": -60,
+        "x": -66,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_3_1.png",
-        "x_offset": -98,
-        "y_offset": -12,
+        "x": -98,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_3_2.png",
-        "x_offset": -66,
-        "y_offset": -28,
+        "x": -66,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_3_3.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_3_4.png",
-        "x_offset": -2,
-        "y_offset": -28,
+        "x": -2,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_4_1.png",
-        "x_offset": -56,
-        "y_offset": -46,
+        "x": -56,
+        "y": -46,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_4_2.png",
-        "x_offset": -24,
-        "y_offset": -30,
+        "x": -24,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_4_3.png",
-        "x_offset": -56,
-        "y_offset": -14,
+        "x": -56,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_4_4.png",
-        "x_offset": -24,
-        "y_offset": 2,
+        "x": -24,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_diag_1.png",
-        "x_offset": -34,
-        "y_offset": -8,
+        "x": -34,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -14,
+        "x": -24,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/brake_diag_1.png",
-        "x_offset": -34,
-        "y_offset": -8,
+        "x": -34,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/brake_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -14,
+        "x": -24,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/block_brake_diag_1.png",
-        "x_offset": -34,
-        "y_offset": -8,
+        "x": -34,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/block_brake_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -14,
+        "x": -24,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_diag_1.png",
-        "x_offset": -34,
-        "y_offset": -15,
+        "x": -34,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -14,
+        "x": -24,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_diag_3.png",
-        "x_offset": -34,
-        "y_offset": -15,
+        "x": -34,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_diag_4.png",
-        "x_offset": -24,
-        "y_offset": -22,
+        "x": -24,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_flat_up_diag_1.png",
-        "x_offset": -53,
-        "y_offset": -16,
+        "x": -53,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_flat_up_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -14,
+        "x": -24,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_flat_up_diag_3.png",
-        "x_offset": -34,
-        "y_offset": -16,
+        "x": -34,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_flat_up_diag_4.png",
-        "x_offset": -24,
-        "y_offset": -22,
+        "x": -24,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_diag_1.png",
-        "x_offset": -54,
-        "y_offset": -23,
+        "x": -54,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -14,
+        "x": -24,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_diag_3.png",
-        "x_offset": -34,
-        "y_offset": -23,
+        "x": -34,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_diag_4.png",
-        "x_offset": -24,
-        "y_offset": -30,
+        "x": -24,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_steep_up_diag_1.png",
-        "x_offset": -56,
-        "y_offset": -37,
+        "x": -56,
+        "y": -37,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_steep_up_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -14,
+        "x": -24,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_steep_up_diag_3.png",
-        "x_offset": -35,
-        "y_offset": -37,
+        "x": -35,
+        "y": -37,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_steep_up_diag_4.png",
-        "x_offset": -24,
-        "y_offset": -46,
+        "x": -24,
+        "y": -46,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_gentle_up_diag_1.png",
-        "x_offset": -49,
-        "y_offset": -39,
+        "x": -49,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_gentle_up_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -19,
+        "x": -24,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_gentle_up_diag_3.png",
-        "x_offset": -34,
-        "y_offset": -39,
+        "x": -34,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_gentle_up_diag_4.png",
-        "x_offset": -24,
-        "y_offset": -46,
+        "x": -24,
+        "y": -46,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_diag_1.png",
-        "x_offset": -48,
-        "y_offset": -69,
+        "x": -48,
+        "y": -69,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -46,
+        "x": -24,
+        "y": -46,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_diag_3.png",
-        "x_offset": -35,
-        "y_offset": -69,
+        "x": -35,
+        "y": -69,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_diag_4.png",
-        "x_offset": -24,
-        "y_offset": -78,
+        "x": -24,
+        "y": -78,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_left_bank_1_1.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_left_bank_1_2.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_left_bank_2_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_left_bank_2_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_left_bank_3.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_left_bank_4.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_right_bank_1.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_right_bank_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_right_bank_3_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_right_bank_3_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_right_bank_4_1.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_right_bank_4_2.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_1_1.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_1_2.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_2_1.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_2_2.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_3.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_4.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_1.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_2.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_3_1.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_3_2.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_4_1.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_4_2.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_left_bank_1_1.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_left_bank_1_2.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_left_bank_2_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_left_bank_2_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_left_bank_3.png",
-        "x_offset": -34,
-        "y_offset": -16,
+        "x": -34,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_left_bank_4.png",
-        "x_offset": -34,
-        "y_offset": -32,
+        "x": -34,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_right_bank_1.png",
-        "x_offset": -34,
-        "y_offset": -32,
+        "x": -34,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_right_bank_2.png",
-        "x_offset": -34,
-        "y_offset": -16,
+        "x": -34,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_right_bank_3_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_right_bank_3_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_right_bank_4_1.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_right_bank_4_2.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_1_1.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_1_2.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_2_1.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_2_2.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_3.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_4.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_left_bank_diag_1_1.png",
-        "x_offset": -34,
-        "y_offset": -8,
+        "x": -34,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_left_bank_diag_1_2.png",
-        "x_offset": -34,
-        "y_offset": -8,
+        "x": -34,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_left_bank_diag_2.png",
-        "x_offset": -26,
-        "y_offset": -14,
+        "x": -26,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_left_bank_diag_3.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_left_bank_diag_4.png",
-        "x_offset": -24,
-        "y_offset": -25,
+        "x": -24,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_right_bank_diag_1.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_right_bank_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -14,
+        "x": -24,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_right_bank_diag_3_1.png",
-        "x_offset": -34,
-        "y_offset": -8,
+        "x": -34,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_right_bank_diag_3_2.png",
-        "x_offset": -34,
-        "y_offset": -8,
+        "x": -34,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_right_bank_diag_4.png",
-        "x_offset": -26,
-        "y_offset": -25,
+        "x": -26,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_diag_1_1.png",
-        "x_offset": -34,
-        "y_offset": -15,
+        "x": -34,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_diag_1_2.png",
-        "x_offset": -34,
-        "y_offset": -15,
+        "x": -34,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_diag_2.png",
-        "x_offset": -26,
-        "y_offset": -25,
+        "x": -26,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_diag_3.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_diag_4.png",
-        "x_offset": -24,
-        "y_offset": -22,
+        "x": -24,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_diag_1.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -25,
+        "x": -24,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_diag_3_1.png",
-        "x_offset": -34,
-        "y_offset": -15,
+        "x": -34,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_diag_3_2.png",
-        "x_offset": -34,
-        "y_offset": -15,
+        "x": -34,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_diag_4.png",
-        "x_offset": -26,
-        "y_offset": -22,
+        "x": -26,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_left_bank_diag_1_1.png",
-        "x_offset": -53,
-        "y_offset": -12,
+        "x": -53,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_left_bank_diag_1_2.png",
-        "x_offset": -53,
-        "y_offset": -12,
+        "x": -53,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_left_bank_diag_2.png",
-        "x_offset": -26,
-        "y_offset": -14,
+        "x": -26,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_left_bank_diag_3.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_left_bank_diag_4.png",
-        "x_offset": -24,
-        "y_offset": -33,
+        "x": -24,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_right_bank_diag_1.png",
-        "x_offset": -53,
-        "y_offset": -28,
+        "x": -53,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_right_bank_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -14,
+        "x": -24,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_right_bank_diag_3_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_right_bank_diag_3_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_right_bank_diag_4.png",
-        "x_offset": -25,
-        "y_offset": -33,
+        "x": -25,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_diag_1_1.png",
-        "x_offset": -34,
-        "y_offset": -4,
+        "x": -34,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_diag_1_2.png",
-        "x_offset": -34,
-        "y_offset": -4,
+        "x": -34,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -25,
+        "x": -24,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_diag_3.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_diag_4.png",
-        "x_offset": -24,
-        "y_offset": -25,
+        "x": -24,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_1_1.png",
-        "x_offset": -34,
-        "y_offset": -56,
+        "x": -34,
+        "y": -56,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_1_2.png",
-        "x_offset": -34,
-        "y_offset": -56,
+        "x": -34,
+        "y": -56,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_1_3.png",
-        "x_offset": -66,
-        "y_offset": -40,
+        "x": -66,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_1_4.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_2_1.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_2_2.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_2_3.png",
-        "x_offset": -66,
-        "y_offset": -25,
+        "x": -66,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_2_4.png",
-        "x_offset": -98,
-        "y_offset": -9,
+        "x": -98,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_2_5.png",
-        "x_offset": -98,
-        "y_offset": -9,
+        "x": -98,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_3_1.png",
-        "x_offset": -27,
-        "y_offset": -24,
+        "x": -27,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_3_2.png",
-        "x_offset": 5,
-        "y_offset": -40,
+        "x": 5,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_3_3.png",
-        "x_offset": -27,
-        "y_offset": -56,
+        "x": -27,
+        "y": -56,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_3_4.png",
-        "x_offset": -27,
-        "y_offset": -56,
+        "x": -27,
+        "y": -56,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_4_1.png",
-        "x_offset": -98,
-        "y_offset": -20,
+        "x": -98,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_4_2.png",
-        "x_offset": -66,
-        "y_offset": -4,
+        "x": -66,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_4_3.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_1_1.png",
-        "x_offset": -34,
-        "y_offset": -88,
+        "x": -34,
+        "y": -88,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_1_2.png",
-        "x_offset": -34,
-        "y_offset": -88,
+        "x": -34,
+        "y": -88,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_1_3.png",
-        "x_offset": -66,
-        "y_offset": -72,
+        "x": -66,
+        "y": -72,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_1_4.png",
-        "x_offset": -34,
-        "y_offset": -56,
+        "x": -34,
+        "y": -56,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_1_5.png",
-        "x_offset": -66,
-        "y_offset": -40,
+        "x": -66,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_1_6.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_2_1.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_2_2.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_2_3.png",
-        "x_offset": -66,
-        "y_offset": -25,
+        "x": -66,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_2_4.png",
-        "x_offset": -98,
-        "y_offset": -9,
+        "x": -98,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_2_5.png",
-        "x_offset": -98,
-        "y_offset": -9,
+        "x": -98,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_2_6.png",
-        "x_offset": -130,
-        "y_offset": -25,
+        "x": -130,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_2_7.png",
-        "x_offset": -162,
-        "y_offset": -9,
+        "x": -162,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_2_8.png",
-        "x_offset": -162,
-        "y_offset": -9,
+        "x": -162,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_3_1.png",
-        "x_offset": -40,
-        "y_offset": -24,
+        "x": -40,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_3_2.png",
-        "x_offset": -8,
-        "y_offset": -40,
+        "x": -8,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_3_3.png",
-        "x_offset": -40,
-        "y_offset": -56,
+        "x": -40,
+        "y": -56,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_3_4.png",
-        "x_offset": -8,
-        "y_offset": -72,
+        "x": -8,
+        "y": -72,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_3_5.png",
-        "x_offset": -40,
-        "y_offset": -88,
+        "x": -40,
+        "y": -88,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_3_6.png",
-        "x_offset": -40,
-        "y_offset": -88,
+        "x": -40,
+        "y": -88,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_4_1.png",
-        "x_offset": -162,
-        "y_offset": -27,
+        "x": -162,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_4_2.png",
-        "x_offset": -130,
-        "y_offset": -11,
+        "x": -130,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_4_3.png",
-        "x_offset": -98,
-        "y_offset": -27,
+        "x": -98,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_4_4.png",
-        "x_offset": -66,
-        "y_offset": -11,
+        "x": -66,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_4_5.png",
-        "x_offset": -34,
-        "y_offset": -27,
+        "x": -34,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_bank_1_1.png",
-        "x_offset": -34,
-        "y_offset": -57,
+        "x": -34,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_bank_1_2.png",
-        "x_offset": -34,
-        "y_offset": -57,
+        "x": -34,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_bank_1_3.png",
-        "x_offset": -66,
-        "y_offset": -41,
+        "x": -66,
+        "y": -41,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_bank_1_4.png",
-        "x_offset": -34,
-        "y_offset": -25,
+        "x": -34,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_bank_1_5.png",
-        "x_offset": -66,
-        "y_offset": -9,
+        "x": -66,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_bank_2_1.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_bank_2_2.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_bank_2_3.png",
-        "x_offset": -66,
-        "y_offset": -25,
+        "x": -66,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_bank_2_4.png",
-        "x_offset": -66,
-        "y_offset": -25,
+        "x": -66,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_bank_2_5.png",
-        "x_offset": -98,
-        "y_offset": -9,
+        "x": -98,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_bank_2_6.png",
-        "x_offset": -130,
-        "y_offset": -25,
+        "x": -130,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_bank_2_7.png",
-        "x_offset": -130,
-        "y_offset": -25,
+        "x": -130,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_bank_3_1.png",
-        "x_offset": -56,
-        "y_offset": -24,
+        "x": -56,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_bank_3_2.png",
-        "x_offset": -24,
-        "y_offset": -40,
+        "x": -24,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_bank_3_3.png",
-        "x_offset": -56,
-        "y_offset": -56,
+        "x": -56,
+        "y": -56,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_bank_3_4.png",
-        "x_offset": -24,
-        "y_offset": -72,
+        "x": -24,
+        "y": -72,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_bank_4_1.png",
-        "x_offset": -98,
-        "y_offset": -36,
+        "x": -98,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_bank_4_2.png",
-        "x_offset": -66,
-        "y_offset": -20,
+        "x": -66,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_bank_4_3.png",
-        "x_offset": -34,
-        "y_offset": -36,
+        "x": -34,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_bank_4_4.png",
-        "x_offset": -2,
-        "y_offset": -20,
+        "x": -2,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_bank_1_1.png",
-        "x_offset": -34,
-        "y_offset": -36,
+        "x": -34,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_bank_1_2.png",
-        "x_offset": -66,
-        "y_offset": -20,
+        "x": -66,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_bank_1_3.png",
-        "x_offset": -98,
-        "y_offset": -36,
+        "x": -98,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_bank_1_4.png",
-        "x_offset": -130,
-        "y_offset": -20,
+        "x": -130,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_bank_2_1.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_bank_2_2.png",
-        "x_offset": -66,
-        "y_offset": -40,
+        "x": -66,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_bank_2_3.png",
-        "x_offset": -34,
-        "y_offset": -56,
+        "x": -34,
+        "y": -56,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_bank_2_4.png",
-        "x_offset": -66,
-        "y_offset": -72,
+        "x": -66,
+        "y": -72,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_bank_3_1.png",
-        "x_offset": -97,
-        "y_offset": -9,
+        "x": -97,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_bank_3_2.png",
-        "x_offset": -97,
-        "y_offset": -9,
+        "x": -97,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_bank_3_3.png",
-        "x_offset": -65,
-        "y_offset": -25,
+        "x": -65,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_bank_3_4.png",
-        "x_offset": -65,
-        "y_offset": -25,
+        "x": -65,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_bank_3_5.png",
-        "x_offset": -33,
-        "y_offset": -9,
+        "x": -33,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_bank_3_6.png",
-        "x_offset": -1,
-        "y_offset": -25,
+        "x": -1,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_bank_3_7.png",
-        "x_offset": -1,
-        "y_offset": -25,
+        "x": -1,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_bank_4_1.png",
-        "x_offset": -56,
-        "y_offset": -57,
+        "x": -56,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_bank_4_2.png",
-        "x_offset": -56,
-        "y_offset": -57,
+        "x": -56,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_bank_4_3.png",
-        "x_offset": -24,
-        "y_offset": -41,
+        "x": -24,
+        "y": -41,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_bank_4_4.png",
-        "x_offset": -56,
-        "y_offset": -25,
+        "x": -56,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_bank_4_5.png",
-        "x_offset": -24,
-        "y_offset": -9,
+        "x": -24,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_gentle_up_1_1.png",
-        "x_offset": -40,
-        "y_offset": -79,
+        "x": -40,
+        "y": -79,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_gentle_up_1_2.png",
-        "x_offset": -28,
-        "y_offset": -31,
+        "x": -28,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_gentle_up_2_1.png",
-        "x_offset": -28,
-        "y_offset": -47,
+        "x": -28,
+        "y": -47,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_gentle_up_2_2.png",
-        "x_offset": -104,
-        "y_offset": -31,
+        "x": -104,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_gentle_up_3_1.png",
-        "x_offset": -33,
-        "y_offset": -15,
+        "x": -33,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_gentle_up_3_2.png",
-        "x_offset": -21,
-        "y_offset": -31,
+        "x": -21,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_gentle_up_4_1.png",
-        "x_offset": -92,
-        "y_offset": -32,
+        "x": -92,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_gentle_up_4_2.png",
-        "x_offset": -40,
-        "y_offset": -16,
+        "x": -40,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_gentle_up_1_1.png",
-        "x_offset": -40,
-        "y_offset": -32,
+        "x": -40,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_gentle_up_1_2.png",
-        "x_offset": -92,
-        "y_offset": -16,
+        "x": -92,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_gentle_up_2_1.png",
-        "x_offset": -28,
-        "y_offset": -15,
+        "x": -28,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_gentle_up_2_2.png",
-        "x_offset": -40,
-        "y_offset": -31,
+        "x": -40,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_gentle_up_3_1.png",
-        "x_offset": -104,
-        "y_offset": -47,
+        "x": -104,
+        "y": -47,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_gentle_up_3_2.png",
-        "x_offset": -28,
-        "y_offset": -31,
+        "x": -28,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_gentle_up_4_1.png",
-        "x_offset": -21,
-        "y_offset": -79,
+        "x": -21,
+        "y": -79,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_gentle_up_4_2.png",
-        "x_offset": -33,
-        "y_offset": -31,
+        "x": -33,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_gentle_up_1_1.png",
-        "x_offset": -34,
-        "y_offset": -140,
+        "x": -34,
+        "y": -140,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_gentle_up_1_2.png",
-        "x_offset": -66,
-        "y_offset": -108,
+        "x": -66,
+        "y": -108,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_gentle_up_1_3.png",
-        "x_offset": -34,
-        "y_offset": -140,
+        "x": -34,
+        "y": -140,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_gentle_up_1_4.png",
-        "x_offset": -66,
-        "y_offset": -60,
+        "x": -66,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_gentle_up_1_5.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_gentle_up_2_1.png",
-        "x_offset": -34,
-        "y_offset": -76,
+        "x": -34,
+        "y": -76,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_gentle_up_2_2.png",
-        "x_offset": -66,
-        "y_offset": -76,
+        "x": -66,
+        "y": -76,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_gentle_up_2_3.png",
-        "x_offset": -98,
-        "y_offset": -52,
+        "x": -98,
+        "y": -52,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_gentle_up_2_4.png",
-        "x_offset": -130,
-        "y_offset": -60,
+        "x": -130,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_gentle_up_2_5.png",
-        "x_offset": -162,
-        "y_offset": -28,
+        "x": -162,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_gentle_up_3_1.png",
-        "x_offset": -40,
-        "y_offset": -12,
+        "x": -40,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_gentle_up_3_2.png",
-        "x_offset": -40,
-        "y_offset": -12,
+        "x": -40,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_gentle_up_3_3.png",
-        "x_offset": -40,
-        "y_offset": -20,
+        "x": -40,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_gentle_up_3_4.png",
-        "x_offset": -40,
-        "y_offset": -12,
+        "x": -40,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_gentle_up_3_5.png",
-        "x_offset": -40,
-        "y_offset": -28,
+        "x": -40,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_gentle_up_4_1.png",
-        "x_offset": -162,
-        "y_offset": -60,
+        "x": -162,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_gentle_up_4_2.png",
-        "x_offset": -130,
-        "y_offset": -28,
+        "x": -130,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_gentle_up_4_3.png",
-        "x_offset": -98,
-        "y_offset": -36,
+        "x": -98,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_gentle_up_4_4.png",
-        "x_offset": -66,
-        "y_offset": -12,
+        "x": -66,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_gentle_up_4_5.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_gentle_up_1_1.png",
-        "x_offset": -34,
-        "y_offset": -60,
+        "x": -34,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_gentle_up_1_2.png",
-        "x_offset": -66,
-        "y_offset": -28,
+        "x": -66,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_gentle_up_1_3.png",
-        "x_offset": -98,
-        "y_offset": -36,
+        "x": -98,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_gentle_up_1_4.png",
-        "x_offset": -130,
-        "y_offset": -12,
+        "x": -130,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_gentle_up_1_5.png",
-        "x_offset": -162,
-        "y_offset": -12,
+        "x": -162,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_gentle_up_2_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_gentle_up_2_2.png",
-        "x_offset": -66,
-        "y_offset": -12,
+        "x": -66,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_gentle_up_2_3.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_gentle_up_2_4.png",
-        "x_offset": -66,
-        "y_offset": -20,
+        "x": -66,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_gentle_up_2_5.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_gentle_up_3_1.png",
-        "x_offset": -162,
-        "y_offset": -76,
+        "x": -162,
+        "y": -76,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_gentle_up_3_2.png",
-        "x_offset": -130,
-        "y_offset": -76,
+        "x": -130,
+        "y": -76,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_gentle_up_3_3.png",
-        "x_offset": -98,
-        "y_offset": -52,
+        "x": -98,
+        "y": -52,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_gentle_up_3_4.png",
-        "x_offset": -66,
-        "y_offset": -60,
+        "x": -66,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_gentle_up_3_5.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_gentle_up_4_1.png",
-        "x_offset": -40,
-        "y_offset": -140,
+        "x": -40,
+        "y": -140,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_gentle_up_4_2.png",
-        "x_offset": -8,
-        "y_offset": -108,
+        "x": -8,
+        "y": -108,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_gentle_up_4_3.png",
-        "x_offset": -40,
-        "y_offset": -84,
+        "x": -40,
+        "y": -84,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_gentle_up_4_4.png",
-        "x_offset": -8,
-        "y_offset": -60,
+        "x": -8,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_gentle_up_4_5.png",
-        "x_offset": -40,
-        "y_offset": -28,
+        "x": -40,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/very_small_turn_left_steep_up_1_1.png",
-        "x_offset": -34,
-        "y_offset": -73,
+        "x": -34,
+        "y": -73,
         "palette": "keep"
     },
     {
         "path": "track/rmc/very_small_turn_left_steep_up_1_2.png",
-        "x_offset": -34,
-        "y_offset": -73,
+        "x": -34,
+        "y": -73,
         "palette": "keep"
     },
     {
         "path": "track/rmc/very_small_turn_left_steep_up_2_1.png",
-        "x_offset": -34,
-        "y_offset": -73,
+        "x": -34,
+        "y": -73,
         "palette": "keep"
     },
     {
         "path": "track/rmc/very_small_turn_left_steep_up_2_2.png",
-        "x_offset": -34,
-        "y_offset": -73,
+        "x": -34,
+        "y": -73,
         "palette": "keep"
     },
     {
         "path": "track/rmc/very_small_turn_left_steep_up_3_1.png",
-        "x_offset": -15,
-        "y_offset": -57,
+        "x": -15,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/very_small_turn_left_steep_up_3_2.png",
-        "x_offset": -15,
-        "y_offset": -57,
+        "x": -15,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/very_small_turn_left_steep_up_4_1.png",
-        "x_offset": -34,
-        "y_offset": -57,
+        "x": -34,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/very_small_turn_left_steep_up_4_2.png",
-        "x_offset": -34,
-        "y_offset": -57,
+        "x": -34,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/very_small_turn_right_steep_up_1_1.png",
-        "x_offset": -34,
-        "y_offset": -57,
+        "x": -34,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/very_small_turn_right_steep_up_1_2.png",
-        "x_offset": -34,
-        "y_offset": -57,
+        "x": -34,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/very_small_turn_right_steep_up_2_1.png",
-        "x_offset": -34,
-        "y_offset": -57,
+        "x": -34,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/very_small_turn_right_steep_up_2_2.png",
-        "x_offset": -34,
-        "y_offset": -57,
+        "x": -34,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/very_small_turn_right_steep_up_3_1.png",
-        "x_offset": -34,
-        "y_offset": -73,
+        "x": -34,
+        "y": -73,
         "palette": "keep"
     },
     {
         "path": "track/rmc/very_small_turn_right_steep_up_3_2.png",
-        "x_offset": -34,
-        "y_offset": -73,
+        "x": -34,
+        "y": -73,
         "palette": "keep"
     },
     {
         "path": "track/rmc/very_small_turn_right_steep_up_4_1.png",
-        "x_offset": -15,
-        "y_offset": -73,
+        "x": -15,
+        "y": -73,
         "palette": "keep"
     },
     {
         "path": "track/rmc/very_small_turn_right_steep_up_4_2.png",
-        "x_offset": -15,
-        "y_offset": -73,
+        "x": -15,
+        "y": -73,
         "palette": "keep"
     },
     {
         "path": "track/rmc/vertical_twist_left_up_1.png",
-        "x_offset": -32,
-        "y_offset": -110,
+        "x": -32,
+        "y": -110,
         "palette": "keep"
     },
     {
         "path": "track/rmc/vertical_twist_left_up_2_1.png",
-        "x_offset": -15,
-        "y_offset": -110,
+        "x": -15,
+        "y": -110,
         "palette": "keep"
     },
     {
         "path": "track/rmc/vertical_twist_left_up_2_2.png",
-        "x_offset": -15,
-        "y_offset": -110,
+        "x": -15,
+        "y": -110,
         "palette": "keep"
     },
     {
         "path": "track/rmc/vertical_twist_left_up_3.png",
-        "x_offset": -32,
-        "y_offset": -99,
+        "x": -32,
+        "y": -99,
         "palette": "keep"
     },
     {
         "path": "track/rmc/vertical_twist_left_up_4_1.png",
-        "x_offset": -32,
-        "y_offset": -99,
+        "x": -32,
+        "y": -99,
         "palette": "keep"
     },
     {
         "path": "track/rmc/vertical_twist_left_up_4_2.png",
-        "x_offset": -32,
-        "y_offset": -99,
+        "x": -32,
+        "y": -99,
         "palette": "keep"
     },
     {
         "path": "track/rmc/vertical_twist_right_up_1_1.png",
-        "x_offset": -15,
-        "y_offset": -99,
+        "x": -15,
+        "y": -99,
         "palette": "keep"
     },
     {
         "path": "track/rmc/vertical_twist_right_up_1_2.png",
-        "x_offset": -15,
-        "y_offset": -99,
+        "x": -15,
+        "y": -99,
         "palette": "keep"
     },
     {
         "path": "track/rmc/vertical_twist_right_up_2.png",
-        "x_offset": -32,
-        "y_offset": -99,
+        "x": -32,
+        "y": -99,
         "palette": "keep"
     },
     {
         "path": "track/rmc/vertical_twist_right_up_3_1.png",
-        "x_offset": -32,
-        "y_offset": -110,
+        "x": -32,
+        "y": -110,
         "palette": "keep"
     },
     {
         "path": "track/rmc/vertical_twist_right_up_3_2.png",
-        "x_offset": -32,
-        "y_offset": -110,
+        "x": -32,
+        "y": -110,
         "palette": "keep"
     },
     {
         "path": "track/rmc/vertical_twist_right_up_4.png",
-        "x_offset": -32,
-        "y_offset": -110,
+        "x": -32,
+        "y": -110,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_gentle_up_left_bank_1.png",
-        "x_offset": -34,
-        "y_offset": -25,
+        "x": -34,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_gentle_up_left_bank_2_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_gentle_up_left_bank_2_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_gentle_up_left_bank_3.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_gentle_up_left_bank_4.png",
-        "x_offset": -34,
-        "y_offset": -40,
+        "x": -34,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_gentle_up_right_bank_1.png",
-        "x_offset": -34,
-        "y_offset": -40,
+        "x": -34,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_gentle_up_right_bank_2.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_gentle_up_right_bank_3_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_gentle_up_right_bank_3_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_gentle_up_right_bank_4.png",
-        "x_offset": -34,
-        "y_offset": -25,
+        "x": -34,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_gentle_up_1.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_gentle_up_2_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_gentle_up_2_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_gentle_up_3.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_gentle_up_4.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_gentle_up_1.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_gentle_up_2.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_gentle_up_3_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_gentle_up_3_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_gentle_up_4.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_left_bank_1_1.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_left_bank_1_2.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_left_bank_2_1.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_left_bank_2_2.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_left_bank_3.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_left_bank_4.png",
-        "x_offset": -34,
-        "y_offset": -32,
+        "x": -34,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_right_bank_1.png",
-        "x_offset": -34,
-        "y_offset": -32,
+        "x": -34,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_right_bank_2.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_right_bank_3_1.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_right_bank_3_2.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_right_bank_4_1.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_right_bank_4_2.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_left_bank_1_1.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_left_bank_1_2.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_left_bank_2_1.png",
-        "x_offset": -34,
-        "y_offset": -10,
+        "x": -34,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_left_bank_2_2.png",
-        "x_offset": -34,
-        "y_offset": -10,
+        "x": -34,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_left_bank_3.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_left_bank_4.png",
-        "x_offset": -34,
-        "y_offset": -32,
+        "x": -34,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_right_bank_1.png",
-        "x_offset": -34,
-        "y_offset": -32,
+        "x": -34,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_right_bank_2.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_right_bank_3_1.png",
-        "x_offset": -34,
-        "y_offset": -10,
+        "x": -34,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_right_bank_3_2.png",
-        "x_offset": -34,
-        "y_offset": -10,
+        "x": -34,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_right_bank_4_1.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_right_bank_4_2.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_1.png",
-        "x_offset": -34,
-        "y_offset": -25,
+        "x": -34,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_2.png",
-        "x_offset": -34,
-        "y_offset": -10,
+        "x": -34,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_3.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_4.png",
-        "x_offset": -34,
-        "y_offset": -40,
+        "x": -34,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_1.png",
-        "x_offset": -34,
-        "y_offset": -40,
+        "x": -34,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_2.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_3.png",
-        "x_offset": -34,
-        "y_offset": -10,
+        "x": -34,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_4.png",
-        "x_offset": -34,
-        "y_offset": -25,
+        "x": -34,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_left_bank_1.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_left_bank_2_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_left_bank_2_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_left_bank_3.png",
-        "x_offset": -34,
-        "y_offset": -16,
+        "x": -34,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_left_bank_4.png",
-        "x_offset": -34,
-        "y_offset": -32,
+        "x": -34,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_right_bank_1.png",
-        "x_offset": -34,
-        "y_offset": -32,
+        "x": -34,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_right_bank_2.png",
-        "x_offset": -34,
-        "y_offset": -16,
+        "x": -34,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_right_bank_3_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_right_bank_3_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_right_bank_4.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_flat_1.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_flat_2_1.png",
-        "x_offset": -34,
-        "y_offset": -10,
+        "x": -34,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_flat_2_2.png",
-        "x_offset": -34,
-        "y_offset": -10,
+        "x": -34,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_flat_3.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_flat_4.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_flat_1.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_flat_2.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_flat_3_1.png",
-        "x_offset": -34,
-        "y_offset": -10,
+        "x": -34,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_flat_3_2.png",
-        "x_offset": -34,
-        "y_offset": -10,
+        "x": -34,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_flat_4.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_gentle_up_1_1.png",
-        "x_offset": -40,
-        "y_offset": -91,
+        "x": -40,
+        "y": -91,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_gentle_up_1_2.png",
-        "x_offset": -28,
-        "y_offset": -43,
+        "x": -28,
+        "y": -43,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_gentle_up_2_1.png",
-        "x_offset": -28,
-        "y_offset": -44,
+        "x": -28,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_gentle_up_2_2.png",
-        "x_offset": -28,
-        "y_offset": -44,
+        "x": -28,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_gentle_up_2_3.png",
-        "x_offset": -104,
-        "y_offset": -28,
+        "x": -104,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_gentle_up_2_4.png",
-        "x_offset": -104,
-        "y_offset": -28,
+        "x": -104,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_gentle_up_3_1.png",
-        "x_offset": -33,
-        "y_offset": -27,
+        "x": -33,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_gentle_up_3_2.png",
-        "x_offset": -21,
-        "y_offset": -43,
+        "x": -21,
+        "y": -43,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_gentle_up_3_3.png",
-        "x_offset": -21,
-        "y_offset": -43,
+        "x": -21,
+        "y": -43,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_gentle_up_4_1.png",
-        "x_offset": -92,
-        "y_offset": -44,
+        "x": -92,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_gentle_up_4_2.png",
-        "x_offset": -40,
-        "y_offset": -28,
+        "x": -40,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_bank_gentle_up_1_1.png",
-        "x_offset": -40,
-        "y_offset": -44,
+        "x": -40,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_bank_gentle_up_1_2.png",
-        "x_offset": -92,
-        "y_offset": -28,
+        "x": -92,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_bank_gentle_up_2_1.png",
-        "x_offset": -28,
-        "y_offset": -27,
+        "x": -28,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_bank_gentle_up_2_2.png",
-        "x_offset": -40,
-        "y_offset": -43,
+        "x": -40,
+        "y": -43,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_bank_gentle_up_2_3.png",
-        "x_offset": -40,
-        "y_offset": -43,
+        "x": -40,
+        "y": -43,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_bank_gentle_up_3_1.png",
-        "x_offset": -104,
-        "y_offset": -44,
+        "x": -104,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_bank_gentle_up_3_2.png",
-        "x_offset": -104,
-        "y_offset": -44,
+        "x": -104,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_bank_gentle_up_3_3.png",
-        "x_offset": -28,
-        "y_offset": -28,
+        "x": -28,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_bank_gentle_up_3_4.png",
-        "x_offset": -28,
-        "y_offset": -28,
+        "x": -28,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_bank_gentle_up_4_1.png",
-        "x_offset": -21,
-        "y_offset": -91,
+        "x": -21,
+        "y": -91,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_bank_gentle_up_4_2.png",
-        "x_offset": -33,
-        "y_offset": -43,
+        "x": -33,
+        "y": -43,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_1_1.png",
-        "x_offset": -34,
-        "y_offset": -152,
+        "x": -34,
+        "y": -152,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_1_2.png",
-        "x_offset": -66,
-        "y_offset": -120,
+        "x": -66,
+        "y": -120,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_1_3.png",
-        "x_offset": -34,
-        "y_offset": -152,
+        "x": -34,
+        "y": -152,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_1_4.png",
-        "x_offset": -66,
-        "y_offset": -72,
+        "x": -66,
+        "y": -72,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_1_5.png",
-        "x_offset": -34,
-        "y_offset": -40,
+        "x": -34,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_2_1.png",
-        "x_offset": -34,
-        "y_offset": -73,
+        "x": -34,
+        "y": -73,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_2_2.png",
-        "x_offset": -34,
-        "y_offset": -73,
+        "x": -34,
+        "y": -73,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_2_3.png",
-        "x_offset": -66,
-        "y_offset": -73,
+        "x": -66,
+        "y": -73,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_2_4.png",
-        "x_offset": -66,
-        "y_offset": -73,
+        "x": -66,
+        "y": -73,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_2_5.png",
-        "x_offset": -98,
-        "y_offset": -49,
+        "x": -98,
+        "y": -49,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_2_6.png",
-        "x_offset": -98,
-        "y_offset": -49,
+        "x": -98,
+        "y": -49,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_2_7.png",
-        "x_offset": -130,
-        "y_offset": -57,
+        "x": -130,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_2_8.png",
-        "x_offset": -130,
-        "y_offset": -57,
+        "x": -130,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_2_9.png",
-        "x_offset": -162,
-        "y_offset": -25,
+        "x": -162,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_2_10.png",
-        "x_offset": -162,
-        "y_offset": -25,
+        "x": -162,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_3_1.png",
-        "x_offset": -40,
-        "y_offset": -24,
+        "x": -40,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_3_2.png",
-        "x_offset": -40,
-        "y_offset": -24,
+        "x": -40,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_3_3.png",
-        "x_offset": -40,
-        "y_offset": -32,
+        "x": -40,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_3_4.png",
-        "x_offset": -40,
-        "y_offset": -24,
+        "x": -40,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_3_5.png",
-        "x_offset": -40,
-        "y_offset": -40,
+        "x": -40,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_3_6.png",
-        "x_offset": -40,
-        "y_offset": -40,
+        "x": -40,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_4_1.png",
-        "x_offset": -162,
-        "y_offset": -72,
+        "x": -162,
+        "y": -72,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_4_2.png",
-        "x_offset": -130,
-        "y_offset": -40,
+        "x": -130,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_4_3.png",
-        "x_offset": -98,
-        "y_offset": -48,
+        "x": -98,
+        "y": -48,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_4_4.png",
-        "x_offset": -66,
-        "y_offset": -24,
+        "x": -66,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_left_bank_gentle_up_4_5.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_1_1.png",
-        "x_offset": -34,
-        "y_offset": -72,
+        "x": -34,
+        "y": -72,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_1_2.png",
-        "x_offset": -66,
-        "y_offset": -40,
+        "x": -66,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_1_3.png",
-        "x_offset": -98,
-        "y_offset": -48,
+        "x": -98,
+        "y": -48,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_1_4.png",
-        "x_offset": -130,
-        "y_offset": -24,
+        "x": -130,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_1_5.png",
-        "x_offset": -162,
-        "y_offset": -24,
+        "x": -162,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_2_1.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_2_2.png",
-        "x_offset": -66,
-        "y_offset": -24,
+        "x": -66,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_2_3.png",
-        "x_offset": -34,
-        "y_offset": -32,
+        "x": -34,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_2_4.png",
-        "x_offset": -66,
-        "y_offset": -32,
+        "x": -66,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_2_5.png",
-        "x_offset": -34,
-        "y_offset": -40,
+        "x": -34,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_2_6.png",
-        "x_offset": -34,
-        "y_offset": -40,
+        "x": -34,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_3_1.png",
-        "x_offset": -162,
-        "y_offset": -73,
+        "x": -162,
+        "y": -73,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_3_2.png",
-        "x_offset": -162,
-        "y_offset": -73,
+        "x": -162,
+        "y": -73,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_3_3.png",
-        "x_offset": -130,
-        "y_offset": -73,
+        "x": -130,
+        "y": -73,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_3_4.png",
-        "x_offset": -130,
-        "y_offset": -73,
+        "x": -130,
+        "y": -73,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_3_5.png",
-        "x_offset": -98,
-        "y_offset": -49,
+        "x": -98,
+        "y": -49,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_3_6.png",
-        "x_offset": -98,
-        "y_offset": -49,
+        "x": -98,
+        "y": -49,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_3_7.png",
-        "x_offset": -66,
-        "y_offset": -57,
+        "x": -66,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_3_8.png",
-        "x_offset": -66,
-        "y_offset": -57,
+        "x": -66,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_3_9.png",
-        "x_offset": -34,
-        "y_offset": -25,
+        "x": -34,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_3_10.png",
-        "x_offset": -34,
-        "y_offset": -25,
+        "x": -34,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_4_1.png",
-        "x_offset": -40,
-        "y_offset": -152,
+        "x": -40,
+        "y": -152,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_4_2.png",
-        "x_offset": -8,
-        "y_offset": -120,
+        "x": -8,
+        "y": -120,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_4_3.png",
-        "x_offset": -40,
-        "y_offset": -96,
+        "x": -40,
+        "y": -96,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_4_4.png",
-        "x_offset": -8,
-        "y_offset": -72,
+        "x": -8,
+        "y": -72,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_turn_right_bank_gentle_up_4_5.png",
-        "x_offset": -40,
-        "y_offset": -40,
+        "x": -40,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/s_bend_left_1_1.png",
-        "x_offset": -34,
-        "y_offset": -60,
+        "x": -34,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/rmc/s_bend_left_1_2.png",
-        "x_offset": -66,
-        "y_offset": -44,
+        "x": -66,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/s_bend_left_1_3.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/s_bend_left_1_4.png",
-        "x_offset": -66,
-        "y_offset": -12,
+        "x": -66,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/s_bend_left_2_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/s_bend_left_2_2.png",
-        "x_offset": -66,
-        "y_offset": -28,
+        "x": -66,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/s_bend_left_2_3.png",
-        "x_offset": -98,
-        "y_offset": -12,
+        "x": -98,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/s_bend_left_2_4.png",
-        "x_offset": -130,
-        "y_offset": -28,
+        "x": -130,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/s_bend_right_1_1.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/s_bend_right_1_2.png",
-        "x_offset": -66,
-        "y_offset": -12,
+        "x": -66,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/s_bend_right_1_3.png",
-        "x_offset": -98,
-        "y_offset": -28,
+        "x": -98,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/s_bend_right_1_4.png",
-        "x_offset": -130,
-        "y_offset": -12,
+        "x": -130,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/s_bend_right_2_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/s_bend_right_2_2.png",
-        "x_offset": -66,
-        "y_offset": -28,
+        "x": -66,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/s_bend_right_2_3.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/s_bend_right_2_4.png",
-        "x_offset": -66,
-        "y_offset": -60,
+        "x": -66,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_left_up_1_1.png",
-        "x_offset": -34,
-        "y_offset": -64,
+        "x": -34,
+        "y": -64,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_left_up_1_2.png",
-        "x_offset": -34,
-        "y_offset": -64,
+        "x": -34,
+        "y": -64,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_left_up_1_3.png",
-        "x_offset": -66,
-        "y_offset": -48,
+        "x": -66,
+        "y": -48,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_left_up_1_4.png",
-        "x_offset": -34,
-        "y_offset": -32,
+        "x": -34,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_left_up_2_1.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_left_up_2_2.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_left_up_2_3.png",
-        "x_offset": -66,
-        "y_offset": -33,
+        "x": -66,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_left_up_2_4.png",
-        "x_offset": -98,
-        "y_offset": -17,
+        "x": -98,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_left_up_2_5.png",
-        "x_offset": -98,
-        "y_offset": -17,
+        "x": -98,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_left_up_3_1.png",
-        "x_offset": -27,
-        "y_offset": -24,
+        "x": -27,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_left_up_3_2.png",
-        "x_offset": 5,
-        "y_offset": -40,
+        "x": 5,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_left_up_3_3.png",
-        "x_offset": -27,
-        "y_offset": -56,
+        "x": -27,
+        "y": -56,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_left_up_3_4.png",
-        "x_offset": -27,
-        "y_offset": -56,
+        "x": -27,
+        "y": -56,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_left_up_4_1.png",
-        "x_offset": -98,
-        "y_offset": -25,
+        "x": -98,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_left_up_4_2.png",
-        "x_offset": -66,
-        "y_offset": -9,
+        "x": -66,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_left_up_4_3.png",
-        "x_offset": -34,
-        "y_offset": -25,
+        "x": -34,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_right_up_1_1.png",
-        "x_offset": -34,
-        "y_offset": -25,
+        "x": -34,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_right_up_1_2.png",
-        "x_offset": -66,
-        "y_offset": -9,
+        "x": -66,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_right_up_1_3.png",
-        "x_offset": -98,
-        "y_offset": -25,
+        "x": -98,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_right_up_2_1.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_right_up_2_2.png",
-        "x_offset": -66,
-        "y_offset": -40,
+        "x": -66,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_right_up_2_3.png",
-        "x_offset": -34,
-        "y_offset": -56,
+        "x": -34,
+        "y": -56,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_right_up_2_4.png",
-        "x_offset": -34,
-        "y_offset": -56,
+        "x": -34,
+        "y": -56,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_right_up_3_1.png",
-        "x_offset": -98,
-        "y_offset": -17,
+        "x": -98,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_right_up_3_2.png",
-        "x_offset": -98,
-        "y_offset": -17,
+        "x": -98,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_right_up_3_3.png",
-        "x_offset": -66,
-        "y_offset": -33,
+        "x": -66,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_right_up_3_4.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_right_up_3_5.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_right_up_4_1.png",
-        "x_offset": -27,
-        "y_offset": -64,
+        "x": -27,
+        "y": -64,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_right_up_4_2.png",
-        "x_offset": -27,
-        "y_offset": -64,
+        "x": -27,
+        "y": -64,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_right_up_4_3.png",
-        "x_offset": 5,
-        "y_offset": -48,
+        "x": 5,
+        "y": -48,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_helix_right_up_4_4.png",
-        "x_offset": -27,
-        "y_offset": -32,
+        "x": -27,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_1_1.png",
-        "x_offset": -34,
-        "y_offset": -96,
+        "x": -34,
+        "y": -96,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_1_2.png",
-        "x_offset": -34,
-        "y_offset": -96,
+        "x": -34,
+        "y": -96,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_1_3.png",
-        "x_offset": -66,
-        "y_offset": -80,
+        "x": -66,
+        "y": -80,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_1_4.png",
-        "x_offset": -34,
-        "y_offset": -64,
+        "x": -34,
+        "y": -64,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_1_5.png",
-        "x_offset": -66,
-        "y_offset": -48,
+        "x": -66,
+        "y": -48,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_1_6.png",
-        "x_offset": -34,
-        "y_offset": -32,
+        "x": -34,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_2_1.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_2_2.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_2_3.png",
-        "x_offset": -66,
-        "y_offset": -33,
+        "x": -66,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_2_4.png",
-        "x_offset": -98,
-        "y_offset": -17,
+        "x": -98,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_2_5.png",
-        "x_offset": -98,
-        "y_offset": -17,
+        "x": -98,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_2_6.png",
-        "x_offset": -130,
-        "y_offset": -33,
+        "x": -130,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_2_7.png",
-        "x_offset": -162,
-        "y_offset": -17,
+        "x": -162,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_2_8.png",
-        "x_offset": -162,
-        "y_offset": -17,
+        "x": -162,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_3_1.png",
-        "x_offset": -40,
-        "y_offset": -24,
+        "x": -40,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_3_2.png",
-        "x_offset": -8,
-        "y_offset": -40,
+        "x": -8,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_3_3.png",
-        "x_offset": -40,
-        "y_offset": -56,
+        "x": -40,
+        "y": -56,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_3_4.png",
-        "x_offset": -8,
-        "y_offset": -72,
+        "x": -8,
+        "y": -72,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_3_5.png",
-        "x_offset": -40,
-        "y_offset": -88,
+        "x": -40,
+        "y": -88,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_3_6.png",
-        "x_offset": -40,
-        "y_offset": -88,
+        "x": -40,
+        "y": -88,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_4_1.png",
-        "x_offset": -162,
-        "y_offset": -32,
+        "x": -162,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_4_2.png",
-        "x_offset": -130,
-        "y_offset": -16,
+        "x": -130,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_4_3.png",
-        "x_offset": -98,
-        "y_offset": -32,
+        "x": -98,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_4_4.png",
-        "x_offset": -66,
-        "y_offset": -16,
+        "x": -66,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_left_up_4_5.png",
-        "x_offset": -34,
-        "y_offset": -32,
+        "x": -34,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_1_1.png",
-        "x_offset": -34,
-        "y_offset": -32,
+        "x": -34,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_1_2.png",
-        "x_offset": -66,
-        "y_offset": -16,
+        "x": -66,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_1_3.png",
-        "x_offset": -98,
-        "y_offset": -32,
+        "x": -98,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_1_4.png",
-        "x_offset": -130,
-        "y_offset": -16,
+        "x": -130,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_1_5.png",
-        "x_offset": -162,
-        "y_offset": -32,
+        "x": -162,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_2_1.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_2_2.png",
-        "x_offset": -66,
-        "y_offset": -40,
+        "x": -66,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_2_3.png",
-        "x_offset": -34,
-        "y_offset": -56,
+        "x": -34,
+        "y": -56,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_2_4.png",
-        "x_offset": -66,
-        "y_offset": -72,
+        "x": -66,
+        "y": -72,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_2_5.png",
-        "x_offset": -34,
-        "y_offset": -88,
+        "x": -34,
+        "y": -88,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_2_6.png",
-        "x_offset": -34,
-        "y_offset": -88,
+        "x": -34,
+        "y": -88,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_3_1.png",
-        "x_offset": -162,
-        "y_offset": -17,
+        "x": -162,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_3_2.png",
-        "x_offset": -162,
-        "y_offset": -17,
+        "x": -162,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_3_3.png",
-        "x_offset": -130,
-        "y_offset": -33,
+        "x": -130,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_3_4.png",
-        "x_offset": -98,
-        "y_offset": -17,
+        "x": -98,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_3_5.png",
-        "x_offset": -98,
-        "y_offset": -17,
+        "x": -98,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_3_6.png",
-        "x_offset": -66,
-        "y_offset": -33,
+        "x": -66,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_3_7.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_3_8.png",
-        "x_offset": -34,
-        "y_offset": -17,
+        "x": -34,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_4_1.png",
-        "x_offset": -40,
-        "y_offset": -96,
+        "x": -40,
+        "y": -96,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_4_2.png",
-        "x_offset": -40,
-        "y_offset": -96,
+        "x": -40,
+        "y": -96,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_4_3.png",
-        "x_offset": -8,
-        "y_offset": -80,
+        "x": -8,
+        "y": -80,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_4_4.png",
-        "x_offset": -40,
-        "y_offset": -64,
+        "x": -40,
+        "y": -64,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_4_5.png",
-        "x_offset": -8,
-        "y_offset": -48,
+        "x": -8,
+        "y": -48,
         "palette": "keep"
     },
     {
         "path": "track/rmc/medium_helix_right_up_4_6.png",
-        "x_offset": -40,
-        "y_offset": -32,
+        "x": -40,
+        "y": -32,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_1_1.png",
-        "x_offset": -34,
-        "y_offset": -76,
+        "x": -34,
+        "y": -76,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_1_2.png",
-        "x_offset": -34,
-        "y_offset": -76,
+        "x": -34,
+        "y": -76,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_1_3.png",
-        "x_offset": -66,
-        "y_offset": -60,
+        "x": -66,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_1_4.png",
-        "x_offset": -66,
-        "y_offset": -60,
+        "x": -66,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_1_5.png",
-        "x_offset": -98,
-        "y_offset": -44,
+        "x": -98,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_1_6.png",
-        "x_offset": -98,
-        "y_offset": -44,
+        "x": -98,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_2_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_2_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_2_3.png",
-        "x_offset": -66,
-        "y_offset": -28,
+        "x": -66,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_2_4.png",
-        "x_offset": -66,
-        "y_offset": -28,
+        "x": -66,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_2_5.png",
-        "x_offset": -98,
-        "y_offset": -44,
+        "x": -98,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_2_6.png",
-        "x_offset": -98,
-        "y_offset": -44,
+        "x": -98,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_3_1.png",
-        "x_offset": -98,
-        "y_offset": -15,
+        "x": -98,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_3_2.png",
-        "x_offset": -98,
-        "y_offset": -15,
+        "x": -98,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_3_3.png",
-        "x_offset": -66,
-        "y_offset": -31,
+        "x": -66,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_3_4.png",
-        "x_offset": -66,
-        "y_offset": -31,
+        "x": -66,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_3_5.png",
-        "x_offset": -34,
-        "y_offset": -47,
+        "x": -34,
+        "y": -47,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_3_6.png",
-        "x_offset": -34,
-        "y_offset": -47,
+        "x": -34,
+        "y": -47,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_4_1.png",
-        "x_offset": -98,
-        "y_offset": -76,
+        "x": -98,
+        "y": -76,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_4_2.png",
-        "x_offset": -98,
-        "y_offset": -76,
+        "x": -98,
+        "y": -76,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_4_3.png",
-        "x_offset": -66,
-        "y_offset": -60,
+        "x": -66,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_4_4.png",
-        "x_offset": -66,
-        "y_offset": -60,
+        "x": -66,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_4_5.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_left_4_6.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_1_1.png",
-        "x_offset": -34,
-        "y_offset": -76,
+        "x": -34,
+        "y": -76,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_1_2.png",
-        "x_offset": -34,
-        "y_offset": -76,
+        "x": -34,
+        "y": -76,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_1_3.png",
-        "x_offset": -66,
-        "y_offset": -60,
+        "x": -66,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_1_4.png",
-        "x_offset": -66,
-        "y_offset": -60,
+        "x": -66,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_1_5.png",
-        "x_offset": -98,
-        "y_offset": -44,
+        "x": -98,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_1_6.png",
-        "x_offset": -98,
-        "y_offset": -44,
+        "x": -98,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_2_1.png",
-        "x_offset": -34,
-        "y_offset": -15,
+        "x": -34,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_2_2.png",
-        "x_offset": -34,
-        "y_offset": -15,
+        "x": -34,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_2_3.png",
-        "x_offset": -66,
-        "y_offset": -31,
+        "x": -66,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_2_4.png",
-        "x_offset": -66,
-        "y_offset": -31,
+        "x": -66,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_2_5.png",
-        "x_offset": -98,
-        "y_offset": -47,
+        "x": -98,
+        "y": -47,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_2_6.png",
-        "x_offset": -98,
-        "y_offset": -47,
+        "x": -98,
+        "y": -47,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_3_1.png",
-        "x_offset": -98,
-        "y_offset": -12,
+        "x": -98,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_3_2.png",
-        "x_offset": -98,
-        "y_offset": -12,
+        "x": -98,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_3_3.png",
-        "x_offset": -66,
-        "y_offset": -28,
+        "x": -66,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_3_4.png",
-        "x_offset": -66,
-        "y_offset": -28,
+        "x": -66,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_3_5.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_3_6.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_4_1.png",
-        "x_offset": -98,
-        "y_offset": -76,
+        "x": -98,
+        "y": -76,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_4_2.png",
-        "x_offset": -98,
-        "y_offset": -76,
+        "x": -98,
+        "y": -76,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_4_3.png",
-        "x_offset": -66,
-        "y_offset": -60,
+        "x": -66,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_4_4.png",
-        "x_offset": -66,
-        "y_offset": -60,
+        "x": -66,
+        "y": -60,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_4_5.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/barrel_roll_right_4_6.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_steep_up_1_1.png",
-        "x_offset": -34,
-        "y_offset": -145,
+        "x": -34,
+        "y": -145,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_steep_up_1_2.png",
-        "x_offset": -66,
-        "y_offset": -129,
+        "x": -66,
+        "y": -129,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_steep_up_1_3.png",
-        "x_offset": -98,
-        "y_offset": -97,
+        "x": -98,
+        "y": -97,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_steep_up_1_4.png",
-        "x_offset": -130,
-        "y_offset": -57,
+        "x": -130,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_steep_up_2_1.png",
-        "x_offset": -34,
-        "y_offset": -33,
+        "x": -34,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_steep_up_2_2.png",
-        "x_offset": -66,
-        "y_offset": -49,
+        "x": -66,
+        "y": -49,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_steep_up_2_3.png",
-        "x_offset": -98,
-        "y_offset": -49,
+        "x": -98,
+        "y": -49,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_steep_up_2_4.png",
-        "x_offset": -130,
-        "y_offset": -41,
+        "x": -130,
+        "y": -41,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_steep_up_3_1.png",
-        "x_offset": -130,
-        "y_offset": -33,
+        "x": -130,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_steep_up_3_2.png",
-        "x_offset": -98,
-        "y_offset": -49,
+        "x": -98,
+        "y": -49,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_steep_up_3_3.png",
-        "x_offset": -66,
-        "y_offset": -49,
+        "x": -66,
+        "y": -49,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_steep_up_3_4.png",
-        "x_offset": -34,
-        "y_offset": -41,
+        "x": -34,
+        "y": -41,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_steep_up_4_1.png",
-        "x_offset": -130,
-        "y_offset": -145,
+        "x": -130,
+        "y": -145,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_steep_up_4_2.png",
-        "x_offset": -98,
-        "y_offset": -129,
+        "x": -98,
+        "y": -129,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_steep_up_4_3.png",
-        "x_offset": -66,
-        "y_offset": -97,
+        "x": -66,
+        "y": -97,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_steep_up_4_4.png",
-        "x_offset": -34,
-        "y_offset": -57,
+        "x": -34,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_flat_up_1_1.png",
-        "x_offset": -34,
-        "y_offset": -148,
+        "x": -34,
+        "y": -148,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_flat_up_1_2.png",
-        "x_offset": -66,
-        "y_offset": -92,
+        "x": -66,
+        "y": -92,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_flat_up_1_3.png",
-        "x_offset": -98,
-        "y_offset": -52,
+        "x": -98,
+        "y": -52,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_flat_up_1_4.png",
-        "x_offset": -130,
-        "y_offset": -20,
+        "x": -130,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_flat_up_2_1.png",
-        "x_offset": -34,
-        "y_offset": -51,
+        "x": -34,
+        "y": -51,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_flat_up_2_2.png",
-        "x_offset": -66,
-        "y_offset": -27,
+        "x": -66,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_flat_up_2_3.png",
-        "x_offset": -98,
-        "y_offset": -19,
+        "x": -98,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_flat_up_2_4.png",
-        "x_offset": -130,
-        "y_offset": -19,
+        "x": -130,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_flat_up_3_1.png",
-        "x_offset": -130,
-        "y_offset": -51,
+        "x": -130,
+        "y": -51,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_flat_up_3_2.png",
-        "x_offset": -98,
-        "y_offset": -27,
+        "x": -98,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_flat_up_3_3.png",
-        "x_offset": -66,
-        "y_offset": -19,
+        "x": -66,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_flat_up_3_4.png",
-        "x_offset": -34,
-        "y_offset": -19,
+        "x": -34,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_flat_up_4_1.png",
-        "x_offset": -130,
-        "y_offset": -148,
+        "x": -130,
+        "y": -148,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_flat_up_4_2.png",
-        "x_offset": -98,
-        "y_offset": -92,
+        "x": -98,
+        "y": -92,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_flat_up_4_3.png",
-        "x_offset": -66,
-        "y_offset": -52,
+        "x": -66,
+        "y": -52,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_flat_up_4_4.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_1_1.png",
-        "x_offset": -98,
-        "y_offset": -99,
+        "x": -98,
+        "y": -99,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_1_2.png",
-        "x_offset": -98,
-        "y_offset": -99,
+        "x": -98,
+        "y": -99,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_1_3.png",
-        "x_offset": -66,
-        "y_offset": -59,
+        "x": -66,
+        "y": -59,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_1_4.png",
-        "x_offset": -66,
-        "y_offset": -59,
+        "x": -66,
+        "y": -59,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_1_5.png",
-        "x_offset": -34,
-        "y_offset": -35,
+        "x": -34,
+        "y": -35,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_1_6.png",
-        "x_offset": -34,
-        "y_offset": -35,
+        "x": -34,
+        "y": -35,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_2_1.png",
-        "x_offset": -98,
-        "y_offset": -172,
+        "x": -98,
+        "y": -172,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_2_2.png",
-        "x_offset": -98,
-        "y_offset": -172,
+        "x": -98,
+        "y": -172,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_2_3.png",
-        "x_offset": -66,
-        "y_offset": -100,
+        "x": -66,
+        "y": -100,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_2_4.png",
-        "x_offset": -66,
-        "y_offset": -100,
+        "x": -66,
+        "y": -100,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_2_5.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_2_6.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_3_1.png",
-        "x_offset": -32,
-        "y_offset": -172,
+        "x": -32,
+        "y": -172,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_3_2.png",
-        "x_offset": -32,
-        "y_offset": -172,
+        "x": -32,
+        "y": -172,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_3_3.png",
-        "x_offset": -64,
-        "y_offset": -100,
+        "x": -64,
+        "y": -100,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_3_4.png",
-        "x_offset": -64,
-        "y_offset": -100,
+        "x": -64,
+        "y": -100,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_3_5.png",
-        "x_offset": -96,
-        "y_offset": -44,
+        "x": -96,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_3_6.png",
-        "x_offset": -96,
-        "y_offset": -44,
+        "x": -96,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_4_1.png",
-        "x_offset": -32,
-        "y_offset": -99,
+        "x": -32,
+        "y": -99,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_4_2.png",
-        "x_offset": -32,
-        "y_offset": -99,
+        "x": -32,
+        "y": -99,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_4_3.png",
-        "x_offset": -64,
-        "y_offset": -59,
+        "x": -64,
+        "y": -59,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_4_4.png",
-        "x_offset": -64,
-        "y_offset": -59,
+        "x": -64,
+        "y": -59,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_4_5.png",
-        "x_offset": -96,
-        "y_offset": -35,
+        "x": -96,
+        "y": -35,
         "palette": "keep"
     },
     {
         "path": "track/rmc/quarter_loop_up_4_6.png",
-        "x_offset": -96,
-        "y_offset": -35,
+        "x": -96,
+        "y": -35,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_to_gentle_up_1_1.png",
-        "x_offset": -40,
-        "y_offset": -71,
+        "x": -40,
+        "y": -71,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_to_gentle_up_1_2.png",
-        "x_offset": -28,
-        "y_offset": -23,
+        "x": -28,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_to_gentle_up_2_1.png",
-        "x_offset": -28,
-        "y_offset": -39,
+        "x": -28,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_to_gentle_up_2_2.png",
-        "x_offset": -28,
-        "y_offset": -39,
+        "x": -28,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_to_gentle_up_2_3.png",
-        "x_offset": -104,
-        "y_offset": -23,
+        "x": -104,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_to_gentle_up_3_1.png",
-        "x_offset": -33,
-        "y_offset": -27,
+        "x": -33,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_to_gentle_up_3_2.png",
-        "x_offset": -21,
-        "y_offset": -43,
+        "x": -21,
+        "y": -43,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_to_gentle_up_4_1.png",
-        "x_offset": -92,
-        "y_offset": -29,
+        "x": -92,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_left_bank_to_gentle_up_4_2.png",
-        "x_offset": -40,
-        "y_offset": -13,
+        "x": -40,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_bank_to_gentle_up_1_1.png",
-        "x_offset": -40,
-        "y_offset": -29,
+        "x": -40,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_bank_to_gentle_up_1_2.png",
-        "x_offset": -92,
-        "y_offset": -13,
+        "x": -92,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_bank_to_gentle_up_2_1.png",
-        "x_offset": -28,
-        "y_offset": -27,
+        "x": -28,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_bank_to_gentle_up_2_2.png",
-        "x_offset": -40,
-        "y_offset": -43,
+        "x": -40,
+        "y": -43,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_bank_to_gentle_up_3_1.png",
-        "x_offset": -104,
-        "y_offset": -39,
+        "x": -104,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_bank_to_gentle_up_3_2.png",
-        "x_offset": -104,
-        "y_offset": -39,
+        "x": -104,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_bank_to_gentle_up_3_3.png",
-        "x_offset": -28,
-        "y_offset": -23,
+        "x": -28,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_bank_to_gentle_up_4_1.png",
-        "x_offset": -21,
-        "y_offset": -71,
+        "x": -21,
+        "y": -71,
         "palette": "keep"
     },
     {
         "path": "track/rmc/small_turn_right_bank_to_gentle_up_4_2.png",
-        "x_offset": -33,
-        "y_offset": -23,
+        "x": -33,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/rmc/powered_lift_1.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/powered_lift_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/powered_lift_3.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/powered_lift_4.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_left_1_1.png",
-        "x_offset": -34,
-        "y_offset": -100,
+        "x": -34,
+        "y": -100,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_left_1_2.png",
-        "x_offset": -34,
-        "y_offset": -100,
+        "x": -34,
+        "y": -100,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_left_1_3.png",
-        "x_offset": -66,
-        "y_offset": -76,
+        "x": -66,
+        "y": -76,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_left_1_4.png",
-        "x_offset": -66,
-        "y_offset": -76,
+        "x": -66,
+        "y": -76,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_left_1_5.png",
-        "x_offset": -98,
-        "y_offset": -44,
+        "x": -98,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_left_1_6.png",
-        "x_offset": -98,
-        "y_offset": -44,
+        "x": -98,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_left_2_1.png",
-        "x_offset": -34,
-        "y_offset": -36,
+        "x": -34,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_left_2_2.png",
-        "x_offset": -34,
-        "y_offset": -36,
+        "x": -34,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_left_2_3.png",
-        "x_offset": -66,
-        "y_offset": -44,
+        "x": -66,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_left_2_4.png",
-        "x_offset": -66,
-        "y_offset": -44,
+        "x": -66,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_left_2_5.png",
-        "x_offset": -98,
-        "y_offset": -44,
+        "x": -98,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_left_2_6.png",
-        "x_offset": -98,
-        "y_offset": -44,
+        "x": -98,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_left_3_1.png",
-        "x_offset": -98,
-        "y_offset": -36,
+        "x": -98,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_left_3_2.png",
-        "x_offset": -66,
-        "y_offset": -44,
+        "x": -66,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_left_3_3.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_left_3_4.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_left_4_1.png",
-        "x_offset": -98,
-        "y_offset": -100,
+        "x": -98,
+        "y": -100,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_left_4_2.png",
-        "x_offset": -66,
-        "y_offset": -76,
+        "x": -66,
+        "y": -76,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_left_4_3.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_left_4_4.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_right_1_1.png",
-        "x_offset": -34,
-        "y_offset": -100,
+        "x": -34,
+        "y": -100,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_right_1_2.png",
-        "x_offset": -66,
-        "y_offset": -76,
+        "x": -66,
+        "y": -76,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_right_1_3.png",
-        "x_offset": -98,
-        "y_offset": -44,
+        "x": -98,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_right_1_4.png",
-        "x_offset": -98,
-        "y_offset": -44,
+        "x": -98,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_right_2_1.png",
-        "x_offset": -34,
-        "y_offset": -36,
+        "x": -34,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_right_2_2.png",
-        "x_offset": -66,
-        "y_offset": -44,
+        "x": -66,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_right_2_3.png",
-        "x_offset": -98,
-        "y_offset": -44,
+        "x": -98,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_right_2_4.png",
-        "x_offset": -98,
-        "y_offset": -44,
+        "x": -98,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_right_3_1.png",
-        "x_offset": -98,
-        "y_offset": -36,
+        "x": -98,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_right_3_2.png",
-        "x_offset": -98,
-        "y_offset": -36,
+        "x": -98,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_right_3_3.png",
-        "x_offset": -66,
-        "y_offset": -44,
+        "x": -66,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_right_3_4.png",
-        "x_offset": -66,
-        "y_offset": -44,
+        "x": -66,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_right_3_5.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_right_3_6.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_right_4_1.png",
-        "x_offset": -98,
-        "y_offset": -100,
+        "x": -98,
+        "y": -100,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_right_4_2.png",
-        "x_offset": -98,
-        "y_offset": -100,
+        "x": -98,
+        "y": -100,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_right_4_3.png",
-        "x_offset": -66,
-        "y_offset": -76,
+        "x": -66,
+        "y": -76,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_right_4_4.png",
-        "x_offset": -66,
-        "y_offset": -76,
+        "x": -66,
+        "y": -76,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_right_4_5.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/zero_g_roll_right_4_6.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_1_1.png",
-        "x_offset": -34,
-        "y_offset": -212,
+        "x": -34,
+        "y": -212,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_1_2.png",
-        "x_offset": -66,
-        "y_offset": -140,
+        "x": -66,
+        "y": -140,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_1_3.png",
-        "x_offset": -66,
-        "y_offset": -140,
+        "x": -66,
+        "y": -140,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_1_4.png",
-        "x_offset": -98,
-        "y_offset": -84,
+        "x": -98,
+        "y": -84,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_1_5.png",
-        "x_offset": -98,
-        "y_offset": -84,
+        "x": -98,
+        "y": -84,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_1_6.png",
-        "x_offset": -130,
-        "y_offset": -44,
+        "x": -130,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_1_7.png",
-        "x_offset": -130,
-        "y_offset": -44,
+        "x": -130,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_2_1.png",
-        "x_offset": -34,
-        "y_offset": -117,
+        "x": -34,
+        "y": -117,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_2_2.png",
-        "x_offset": -34,
-        "y_offset": -117,
+        "x": -34,
+        "y": -117,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_2_3.png",
-        "x_offset": -66,
-        "y_offset": -77,
+        "x": -66,
+        "y": -77,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_2_4.png",
-        "x_offset": -66,
-        "y_offset": -77,
+        "x": -66,
+        "y": -77,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_2_5.png",
-        "x_offset": -98,
-        "y_offset": -53,
+        "x": -98,
+        "y": -53,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_2_6.png",
-        "x_offset": -98,
-        "y_offset": -53,
+        "x": -98,
+        "y": -53,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_2_7.png",
-        "x_offset": -130,
-        "y_offset": -45,
+        "x": -130,
+        "y": -45,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_2_8.png",
-        "x_offset": -130,
-        "y_offset": -45,
+        "x": -130,
+        "y": -45,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_3_1.png",
-        "x_offset": -130,
-        "y_offset": -117,
+        "x": -130,
+        "y": -117,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_3_2.png",
-        "x_offset": -130,
-        "y_offset": -117,
+        "x": -130,
+        "y": -117,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_3_3.png",
-        "x_offset": -98,
-        "y_offset": -77,
+        "x": -98,
+        "y": -77,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_3_4.png",
-        "x_offset": -98,
-        "y_offset": -77,
+        "x": -98,
+        "y": -77,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_3_5.png",
-        "x_offset": -66,
-        "y_offset": -53,
+        "x": -66,
+        "y": -53,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_3_6.png",
-        "x_offset": -66,
-        "y_offset": -53,
+        "x": -66,
+        "y": -53,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_3_7.png",
-        "x_offset": -34,
-        "y_offset": -45,
+        "x": -34,
+        "y": -45,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_3_8.png",
-        "x_offset": -34,
-        "y_offset": -45,
+        "x": -34,
+        "y": -45,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_4_1.png",
-        "x_offset": -130,
-        "y_offset": -212,
+        "x": -130,
+        "y": -212,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_4_2.png",
-        "x_offset": -98,
-        "y_offset": -140,
+        "x": -98,
+        "y": -140,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_4_3.png",
-        "x_offset": -66,
-        "y_offset": -84,
+        "x": -66,
+        "y": -84,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_4_4.png",
-        "x_offset": -66,
-        "y_offset": -84,
+        "x": -66,
+        "y": -84,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_4_5.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_left_4_6.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_1_1.png",
-        "x_offset": -34,
-        "y_offset": -212,
+        "x": -34,
+        "y": -212,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_1_2.png",
-        "x_offset": -66,
-        "y_offset": -140,
+        "x": -66,
+        "y": -140,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_1_3.png",
-        "x_offset": -98,
-        "y_offset": -84,
+        "x": -98,
+        "y": -84,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_1_4.png",
-        "x_offset": -98,
-        "y_offset": -84,
+        "x": -98,
+        "y": -84,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_1_5.png",
-        "x_offset": -130,
-        "y_offset": -44,
+        "x": -130,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_1_6.png",
-        "x_offset": -130,
-        "y_offset": -44,
+        "x": -130,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_2_1.png",
-        "x_offset": -34,
-        "y_offset": -117,
+        "x": -34,
+        "y": -117,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_2_2.png",
-        "x_offset": -34,
-        "y_offset": -117,
+        "x": -34,
+        "y": -117,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_2_3.png",
-        "x_offset": -66,
-        "y_offset": -77,
+        "x": -66,
+        "y": -77,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_2_4.png",
-        "x_offset": -66,
-        "y_offset": -77,
+        "x": -66,
+        "y": -77,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_2_5.png",
-        "x_offset": -98,
-        "y_offset": -53,
+        "x": -98,
+        "y": -53,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_2_6.png",
-        "x_offset": -98,
-        "y_offset": -53,
+        "x": -98,
+        "y": -53,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_2_7.png",
-        "x_offset": -130,
-        "y_offset": -45,
+        "x": -130,
+        "y": -45,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_2_8.png",
-        "x_offset": -130,
-        "y_offset": -45,
+        "x": -130,
+        "y": -45,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_3_1.png",
-        "x_offset": -130,
-        "y_offset": -117,
+        "x": -130,
+        "y": -117,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_3_2.png",
-        "x_offset": -130,
-        "y_offset": -117,
+        "x": -130,
+        "y": -117,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_3_3.png",
-        "x_offset": -98,
-        "y_offset": -77,
+        "x": -98,
+        "y": -77,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_3_4.png",
-        "x_offset": -98,
-        "y_offset": -77,
+        "x": -98,
+        "y": -77,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_3_5.png",
-        "x_offset": -66,
-        "y_offset": -53,
+        "x": -66,
+        "y": -53,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_3_6.png",
-        "x_offset": -66,
-        "y_offset": -53,
+        "x": -66,
+        "y": -53,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_3_7.png",
-        "x_offset": -34,
-        "y_offset": -45,
+        "x": -34,
+        "y": -45,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_3_8.png",
-        "x_offset": -34,
-        "y_offset": -45,
+        "x": -34,
+        "y": -45,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_4_1.png",
-        "x_offset": -130,
-        "y_offset": -212,
+        "x": -130,
+        "y": -212,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_4_2.png",
-        "x_offset": -98,
-        "y_offset": -140,
+        "x": -98,
+        "y": -140,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_4_3.png",
-        "x_offset": -98,
-        "y_offset": -140,
+        "x": -98,
+        "y": -140,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_4_4.png",
-        "x_offset": -66,
-        "y_offset": -84,
+        "x": -66,
+        "y": -84,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_4_5.png",
-        "x_offset": -66,
-        "y_offset": -84,
+        "x": -66,
+        "y": -84,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_4_6.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_zero_g_roll_right_4_7.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_gentle_up_1_1.png",
-        "x_offset": -34,
-        "y_offset": -40,
+        "x": -34,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_gentle_up_1_2.png",
-        "x_offset": -32,
-        "y_offset": -24,
+        "x": -32,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_gentle_up_1_3.png",
-        "x_offset": -3,
-        "y_offset": 8,
+        "x": -3,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_gentle_up_1_4.png",
-        "x_offset": -28,
-        "y_offset": -14,
+        "x": -28,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_gentle_up_2_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_gentle_up_2_2.png",
-        "x_offset": -32,
-        "y_offset": -17,
+        "x": -32,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_gentle_up_2_3.png",
-        "x_offset": -24,
-        "y_offset": 8,
+        "x": -24,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_gentle_up_2_4.png",
-        "x_offset": -32,
-        "y_offset": -23,
+        "x": -32,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_gentle_up_3_1.png",
-        "x_offset": -8,
-        "y_offset": -12,
+        "x": -8,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_gentle_up_3_2.png",
-        "x_offset": 0,
-        "y_offset": -10,
+        "x": 0,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_gentle_up_3_3.png",
-        "x_offset": -32,
-        "y_offset": -4,
+        "x": -32,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_gentle_up_3_4.png",
-        "x_offset": -24,
-        "y_offset": -23,
+        "x": -24,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_gentle_up_4_1.png",
-        "x_offset": -32,
-        "y_offset": -21,
+        "x": -32,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_gentle_up_4_2.png",
-        "x_offset": -31,
-        "y_offset": -14,
+        "x": -31,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_gentle_up_4_3.png",
-        "x_offset": 0,
-        "y_offset": -25,
+        "x": 0,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_diag_gentle_up_4_4.png",
-        "x_offset": 0,
-        "y_offset": -23,
+        "x": 0,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_gentle_up_1_1.png",
-        "x_offset": -34,
-        "y_offset": -21,
+        "x": -34,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_gentle_up_1_2.png",
-        "x_offset": -21,
-        "y_offset": -14,
+        "x": -21,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_gentle_up_1_3.png",
-        "x_offset": -15,
-        "y_offset": -25,
+        "x": -15,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_gentle_up_1_4.png",
-        "x_offset": -32,
-        "y_offset": -23,
+        "x": -32,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_gentle_up_2_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_gentle_up_2_2.png",
-        "x_offset": -34,
-        "y_offset": -10,
+        "x": -34,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_gentle_up_2_3.png",
-        "x_offset": -2,
-        "y_offset": -4,
+        "x": -2,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_gentle_up_2_4.png",
-        "x_offset": -11,
-        "y_offset": -23,
+        "x": -11,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_gentle_up_3_1.png",
-        "x_offset": -13,
-        "y_offset": -12,
+        "x": -13,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_gentle_up_3_2.png",
-        "x_offset": -8,
-        "y_offset": -17,
+        "x": -8,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_gentle_up_3_3.png",
-        "x_offset": 0,
-        "y_offset": 8,
+        "x": 0,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_gentle_up_3_4.png",
-        "x_offset": 0,
-        "y_offset": -23,
+        "x": 0,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_gentle_up_4_1.png",
-        "x_offset": -30,
-        "y_offset": -40,
+        "x": -30,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_gentle_up_4_2.png",
-        "x_offset": -20,
-        "y_offset": -24,
+        "x": -20,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_gentle_up_4_3.png",
-        "x_offset": -32,
-        "y_offset": 8,
+        "x": -32,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_diag_gentle_up_4_4.png",
-        "x_offset": -24,
-        "y_offset": -13,
+        "x": -24,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_orthogonal_gentle_up_1_1.png",
-        "x_offset": 0,
-        "y_offset": -18,
+        "x": 0,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_orthogonal_gentle_up_1_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_orthogonal_gentle_up_1_3.png",
-        "x_offset": -32,
-        "y_offset": -22,
+        "x": -32,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_orthogonal_gentle_up_1_4.png",
-        "x_offset": -32,
-        "y_offset": -28,
+        "x": -32,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_orthogonal_gentle_up_2_1.png",
-        "x_offset": -24,
-        "y_offset": -2,
+        "x": -24,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_orthogonal_gentle_up_2_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_orthogonal_gentle_up_2_3.png",
-        "x_offset": -23,
-        "y_offset": -18,
+        "x": -23,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_orthogonal_gentle_up_2_4.png",
-        "x_offset": -27,
-        "y_offset": -13,
+        "x": -27,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_orthogonal_gentle_up_3_1.png",
-        "x_offset": -32,
-        "y_offset": -15,
+        "x": -32,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_orthogonal_gentle_up_3_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_orthogonal_gentle_up_3_3.png",
-        "x_offset": -23,
-        "y_offset": -7,
+        "x": -23,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_orthogonal_gentle_up_3_4.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_orthogonal_gentle_up_4_1.png",
-        "x_offset": -26,
-        "y_offset": -8,
+        "x": -26,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_orthogonal_gentle_up_4_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_orthogonal_gentle_up_4_3.png",
-        "x_offset": -31,
-        "y_offset": -8,
+        "x": -31,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_to_orthogonal_gentle_up_4_4.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_orthogonal_gentle_up_1_1.png",
-        "x_offset": 0,
-        "y_offset": -15,
+        "x": 0,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_orthogonal_gentle_up_1_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_orthogonal_gentle_up_1_3.png",
-        "x_offset": -32,
-        "y_offset": -7,
+        "x": -32,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_orthogonal_gentle_up_1_4.png",
-        "x_offset": -32,
-        "y_offset": -12,
+        "x": -32,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_orthogonal_gentle_up_2_1.png",
-        "x_offset": 0,
-        "y_offset": -2,
+        "x": 0,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_orthogonal_gentle_up_2_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_orthogonal_gentle_up_2_3.png",
-        "x_offset": -16,
-        "y_offset": -18,
+        "x": -16,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_orthogonal_gentle_up_2_4.png",
-        "x_offset": -34,
-        "y_offset": -13,
+        "x": -34,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_orthogonal_gentle_up_3_1.png",
-        "x_offset": -32,
-        "y_offset": -18,
+        "x": -32,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_orthogonal_gentle_up_3_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_orthogonal_gentle_up_3_3.png",
-        "x_offset": -16,
-        "y_offset": -22,
+        "x": -16,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_orthogonal_gentle_up_3_4.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_orthogonal_gentle_up_4_1.png",
-        "x_offset": -24,
-        "y_offset": -8,
+        "x": -24,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_orthogonal_gentle_up_4_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_orthogonal_gentle_up_4_3.png",
-        "x_offset": -22,
-        "y_offset": -8,
+        "x": -22,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_to_orthogonal_gentle_up_4_4.png",
-        "x_offset": -32,
-        "y_offset": -28,
+        "x": -32,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_gentle_up_left_bank_diag_1_1.png",
-        "x_offset": -32,
-        "y_offset": -20,
+        "x": -32,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_gentle_up_left_bank_diag_1_2.png",
-        "x_offset": -32,
-        "y_offset": -16,
+        "x": -32,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_gentle_up_left_bank_diag_2.png",
-        "x_offset": -26,
-        "y_offset": -19,
+        "x": -26,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_gentle_up_left_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -35,
+        "x": -32,
+        "y": -35,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_gentle_up_left_bank_diag_4.png",
-        "x_offset": -24,
-        "y_offset": -41,
+        "x": -24,
+        "y": -41,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_gentle_up_right_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -35,
+        "x": -32,
+        "y": -35,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_gentle_up_right_bank_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -19,
+        "x": -24,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_gentle_up_right_bank_diag_3_1.png",
-        "x_offset": -32,
-        "y_offset": -20,
+        "x": -32,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_gentle_up_right_bank_diag_3_2.png",
-        "x_offset": -32,
-        "y_offset": -16,
+        "x": -32,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_gentle_up_right_bank_diag_4.png",
-        "x_offset": -26,
-        "y_offset": -41,
+        "x": -26,
+        "y": -41,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_gentle_up_diag_1_1.png",
-        "x_offset": -32,
-        "y_offset": -23,
+        "x": -32,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_gentle_up_diag_1_2.png",
-        "x_offset": -32,
-        "y_offset": -8,
+        "x": -32,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_gentle_up_diag_2.png",
-        "x_offset": -26,
-        "y_offset": -25,
+        "x": -26,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_gentle_up_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -23,
+        "x": -32,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_gentle_up_diag_4.png",
-        "x_offset": -24,
-        "y_offset": -30,
+        "x": -24,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_gentle_up_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -23,
+        "x": -32,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_gentle_up_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -25,
+        "x": -24,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_gentle_up_diag_3_1.png",
-        "x_offset": -32,
-        "y_offset": -23,
+        "x": -32,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_gentle_up_diag_3_2.png",
-        "x_offset": -32,
-        "y_offset": -8,
+        "x": -32,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_gentle_up_diag_4.png",
-        "x_offset": -26,
-        "y_offset": -30,
+        "x": -26,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_left_bank_diag_1_1.png",
-        "x_offset": -32,
-        "y_offset": -12,
+        "x": -32,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_left_bank_diag_1_2.png",
-        "x_offset": -32,
-        "y_offset": -8,
+        "x": -32,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_left_bank_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -25,
+        "x": -24,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_left_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -27,
+        "x": -32,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/rmc/left_bank_to_gentle_up_left_bank_diag_4.png",
-        "x_offset": -24,
-        "y_offset": -33,
+        "x": -24,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_right_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -27,
+        "x": -32,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_right_bank_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -25,
+        "x": -24,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_right_bank_diag_3_1.png",
-        "x_offset": -32,
-        "y_offset": -12,
+        "x": -32,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_right_bank_diag_3_2.png",
-        "x_offset": -32,
-        "y_offset": -8,
+        "x": -32,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/right_bank_to_gentle_up_right_bank_diag_4.png",
-        "x_offset": -24,
-        "y_offset": -33,
+        "x": -24,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_left_bank_diag_1_1.png",
-        "x_offset": -32,
-        "y_offset": -12,
+        "x": -32,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_left_bank_diag_1_2.png",
-        "x_offset": -32,
-        "y_offset": -8,
+        "x": -32,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_left_bank_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -25,
+        "x": -24,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_left_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -28,
+        "x": -32,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_left_bank_diag_4.png",
-        "x_offset": -24,
-        "y_offset": -33,
+        "x": -24,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_right_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -28,
+        "x": -32,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_right_bank_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -25,
+        "x": -24,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_right_bank_diag_3_1.png",
-        "x_offset": -32,
-        "y_offset": -12,
+        "x": -32,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_right_bank_diag_3_2.png",
-        "x_offset": -32,
-        "y_offset": -8,
+        "x": -32,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_right_bank_diag_4.png",
-        "x_offset": -24,
-        "y_offset": -33,
+        "x": -24,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_diag_1_1.png",
-        "x_offset": -32,
-        "y_offset": -20,
+        "x": -32,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_diag_1_2.png",
-        "x_offset": -32,
-        "y_offset": -16,
+        "x": -32,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -25,
+        "x": -24,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -35,
+        "x": -32,
+        "y": -35,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_diag_4.png",
-        "x_offset": -24,
-        "y_offset": -41,
+        "x": -24,
+        "y": -41,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -35,
+        "x": -32,
+        "y": -35,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -25,
+        "x": -24,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_diag_3_1.png",
-        "x_offset": -32,
-        "y_offset": -20,
+        "x": -32,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_diag_3_2.png",
-        "x_offset": -32,
-        "y_offset": -16,
+        "x": -32,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_diag_4.png",
-        "x_offset": -24,
-        "y_offset": -41,
+        "x": -24,
+        "y": -41,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_left_bank_diag_1_1.png",
-        "x_offset": -32,
-        "y_offset": -12,
+        "x": -32,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_left_bank_diag_1_2.png",
-        "x_offset": -32,
-        "y_offset": -8,
+        "x": -32,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_left_bank_diag_2.png",
-        "x_offset": -26,
-        "y_offset": -14,
+        "x": -26,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_left_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -27,
+        "x": -32,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_left_bank_diag_4.png",
-        "x_offset": -24,
-        "y_offset": -33,
+        "x": -24,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_right_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -27,
+        "x": -32,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_right_bank_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -14,
+        "x": -24,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_right_bank_diag_3_1.png",
-        "x_offset": -32,
-        "y_offset": -12,
+        "x": -32,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_right_bank_diag_3_2.png",
-        "x_offset": -32,
-        "y_offset": -8,
+        "x": -32,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_right_bank_diag_4.png",
-        "x_offset": -26,
-        "y_offset": -33,
+        "x": -26,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_flat_diag_1_1.png",
-        "x_offset": -32,
-        "y_offset": -16,
+        "x": -32,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_flat_diag_1_2.png",
-        "x_offset": -32,
-        "y_offset": -3,
+        "x": -32,
+        "y": -3,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_flat_diag_2.png",
-        "x_offset": -26,
-        "y_offset": -25,
+        "x": -26,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_flat_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -21,
+        "x": -32,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_left_bank_to_flat_diag_4.png",
-        "x_offset": -24,
-        "y_offset": -21,
+        "x": -24,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_flat_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -21,
+        "x": -32,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_flat_diag_2.png",
-        "x_offset": -24,
-        "y_offset": -25,
+        "x": -24,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_flat_diag_3_1.png",
-        "x_offset": -32,
-        "y_offset": -16,
+        "x": -32,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_flat_diag_3_2.png",
-        "x_offset": -32,
-        "y_offset": -3,
+        "x": -32,
+        "y": -3,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_right_bank_to_flat_diag_4.png",
-        "x_offset": -25,
-        "y_offset": -21,
+        "x": -25,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_diag_gentle_up_1_1.png",
-        "x_offset": -34,
-        "y_offset": -39,
+        "x": -34,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_diag_gentle_up_1_2.png",
-        "x_offset": -32,
-        "y_offset": -24,
+        "x": -32,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_diag_gentle_up_1_3.png",
-        "x_offset": 1,
-        "y_offset": 8,
+        "x": 1,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_diag_gentle_up_1_4.png",
-        "x_offset": -28,
-        "y_offset": -25,
+        "x": -28,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_diag_gentle_up_2_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_diag_gentle_up_2_2.png",
-        "x_offset": -32,
-        "y_offset": -17,
+        "x": -32,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_diag_gentle_up_2_3.png",
-        "x_offset": -24,
-        "y_offset": 9,
+        "x": -24,
+        "y": 9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_diag_gentle_up_2_4.png",
-        "x_offset": -32,
-        "y_offset": -20,
+        "x": -32,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_diag_gentle_up_3_1.png",
-        "x_offset": -11,
-        "y_offset": -24,
+        "x": -11,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_diag_gentle_up_3_2.png",
-        "x_offset": 0,
-        "y_offset": -22,
+        "x": 0,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_diag_gentle_up_3_3.png",
-        "x_offset": -31,
-        "y_offset": -4,
+        "x": -31,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_diag_gentle_up_3_4.png",
-        "x_offset": -24,
-        "y_offset": -35,
+        "x": -24,
+        "y": -35,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_diag_gentle_up_4_1.png",
-        "x_offset": -32,
-        "y_offset": -31,
+        "x": -32,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_diag_gentle_up_4_2.png",
-        "x_offset": -31,
-        "y_offset": -20,
+        "x": -31,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_diag_gentle_up_4_3.png",
-        "x_offset": 0,
-        "y_offset": -37,
+        "x": 0,
+        "y": -37,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_diag_gentle_up_4_4.png",
-        "x_offset": 0,
-        "y_offset": -35,
+        "x": 0,
+        "y": -35,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_diag_gentle_up_1_1.png",
-        "x_offset": -34,
-        "y_offset": -31,
+        "x": -34,
+        "y": -31,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_diag_gentle_up_1_2.png",
-        "x_offset": -24,
-        "y_offset": -20,
+        "x": -24,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_diag_gentle_up_1_3.png",
-        "x_offset": -16,
-        "y_offset": -37,
+        "x": -16,
+        "y": -37,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_diag_gentle_up_1_4.png",
-        "x_offset": -32,
-        "y_offset": -35,
+        "x": -32,
+        "y": -35,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_diag_gentle_up_2_1.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_diag_gentle_up_2_2.png",
-        "x_offset": -34,
-        "y_offset": -22,
+        "x": -34,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_diag_gentle_up_2_3.png",
-        "x_offset": -2,
-        "y_offset": -4,
+        "x": -2,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_diag_gentle_up_2_4.png",
-        "x_offset": -15,
-        "y_offset": -35,
+        "x": -15,
+        "y": -35,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_diag_gentle_up_3_1.png",
-        "x_offset": -13,
-        "y_offset": -12,
+        "x": -13,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_diag_gentle_up_3_2.png",
-        "x_offset": -8,
-        "y_offset": -17,
+        "x": -8,
+        "y": -17,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_diag_gentle_up_3_3.png",
-        "x_offset": 0,
-        "y_offset": 9,
+        "x": 0,
+        "y": 9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_diag_gentle_up_3_4.png",
-        "x_offset": 0,
-        "y_offset": -20,
+        "x": 0,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_diag_gentle_up_4_1.png",
-        "x_offset": -30,
-        "y_offset": -39,
+        "x": -30,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_diag_gentle_up_4_2.png",
-        "x_offset": -20,
-        "y_offset": -24,
+        "x": -20,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_diag_gentle_up_4_3.png",
-        "x_offset": -32,
-        "y_offset": 8,
+        "x": -32,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_diag_gentle_up_4_4.png",
-        "x_offset": -24,
-        "y_offset": -25,
+        "x": -24,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_orthogonal_gentle_up_1_1.png",
-        "x_offset": 0,
-        "y_offset": -14,
+        "x": 0,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_orthogonal_gentle_up_1_2.png",
-        "x_offset": 0,
-        "y_offset": -14,
+        "x": 0,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_orthogonal_gentle_up_1_3.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_orthogonal_gentle_up_1_4.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_orthogonal_gentle_up_1_5.png",
-        "x_offset": -20,
-        "y_offset": -19,
+        "x": -20,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_orthogonal_gentle_up_1_6.png",
-        "x_offset": -32,
-        "y_offset": -16,
+        "x": -32,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_orthogonal_gentle_up_1_7.png",
-        "x_offset": -32,
-        "y_offset": -24,
+        "x": -32,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_orthogonal_gentle_up_1_8.png",
-        "x_offset": -32,
-        "y_offset": -25,
+        "x": -32,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_orthogonal_gentle_up_2_1.png",
-        "x_offset": -24,
-        "y_offset": -9,
+        "x": -24,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_orthogonal_gentle_up_2_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_orthogonal_gentle_up_2_3.png",
-        "x_offset": -23,
-        "y_offset": -14,
+        "x": -23,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_orthogonal_gentle_up_2_4.png",
-        "x_offset": -27,
-        "y_offset": -11,
+        "x": -27,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_orthogonal_gentle_up_3_1.png",
-        "x_offset": -32,
-        "y_offset": -27,
+        "x": -32,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_orthogonal_gentle_up_3_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_orthogonal_gentle_up_3_3.png",
-        "x_offset": -32,
-        "y_offset": -23,
+        "x": -32,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_orthogonal_gentle_up_3_4.png",
-        "x_offset": -34,
-        "y_offset": -24,
+        "x": -34,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_orthogonal_gentle_up_4_1.png",
-        "x_offset": -27,
-        "y_offset": -8,
+        "x": -27,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_orthogonal_gentle_up_4_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_orthogonal_gentle_up_4_3.png",
-        "x_offset": -31,
-        "y_offset": -12,
+        "x": -31,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_left_bank_to_orthogonal_gentle_up_4_4.png",
-        "x_offset": -34,
-        "y_offset": -40,
+        "x": -34,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_orthogonal_gentle_up_1_1.png",
-        "x_offset": 0,
-        "y_offset": -27,
+        "x": 0,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_orthogonal_gentle_up_1_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_orthogonal_gentle_up_1_3.png",
-        "x_offset": -32,
-        "y_offset": -23,
+        "x": -32,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_orthogonal_gentle_up_1_4.png",
-        "x_offset": -32,
-        "y_offset": -24,
+        "x": -32,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_orthogonal_gentle_up_2_1.png",
-        "x_offset": 0,
-        "y_offset": -9,
+        "x": 0,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_orthogonal_gentle_up_2_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_orthogonal_gentle_up_2_3.png",
-        "x_offset": -16,
-        "y_offset": -14,
+        "x": -16,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_orthogonal_gentle_up_2_4.png",
-        "x_offset": -34,
-        "y_offset": -11,
+        "x": -34,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_orthogonal_gentle_up_3_1.png",
-        "x_offset": -24,
-        "y_offset": -14,
+        "x": -24,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_orthogonal_gentle_up_3_2.png",
-        "x_offset": -32,
-        "y_offset": -14,
+        "x": -32,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_orthogonal_gentle_up_3_3.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_orthogonal_gentle_up_3_4.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_orthogonal_gentle_up_3_5.png",
-        "x_offset": 0,
-        "y_offset": -19,
+        "x": 0,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_orthogonal_gentle_up_3_6.png",
-        "x_offset": -16,
-        "y_offset": -16,
+        "x": -16,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_orthogonal_gentle_up_3_7.png",
-        "x_offset": -9,
-        "y_offset": -24,
+        "x": -9,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_orthogonal_gentle_up_3_8.png",
-        "x_offset": -34,
-        "y_offset": -25,
+        "x": -34,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_orthogonal_gentle_up_4_1.png",
-        "x_offset": -24,
-        "y_offset": -8,
+        "x": -24,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_orthogonal_gentle_up_4_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_orthogonal_gentle_up_4_3.png",
-        "x_offset": -22,
-        "y_offset": -12,
+        "x": -22,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/large_turn_right_bank_to_orthogonal_gentle_up_4_4.png",
-        "x_offset": -32,
-        "y_offset": -40,
+        "x": -32,
+        "y": -40,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_lift_1.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_lift_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_lift_3.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_lift_4.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_lift_1.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_lift_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_lift_3.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_lift_4.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_flat_lift_1.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_flat_lift_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_flat_lift_3.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_up_to_flat_lift_4.png",
-        "x_offset": -34,
-        "y_offset": -20,
+        "x": -34,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_lift_1.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_lift_2.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_lift_3.png",
-        "x_offset": -34,
-        "y_offset": -12,
+        "x": -34,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_lift_4.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_steep_up_lift_1.png",
-        "x_offset": -34,
-        "y_offset": -41,
+        "x": -34,
+        "y": -41,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_steep_up_lift_2_1.png",
-        "x_offset": -34,
-        "y_offset": -25,
+        "x": -34,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_steep_up_lift_2_2.png",
-        "x_offset": -34,
-        "y_offset": -25,
+        "x": -34,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_steep_up_lift_3_1.png",
-        "x_offset": -34,
-        "y_offset": -25,
+        "x": -34,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_steep_up_lift_3_2.png",
-        "x_offset": -34,
-        "y_offset": -25,
+        "x": -34,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_steep_up_lift_4.png",
-        "x_offset": -34,
-        "y_offset": -41,
+        "x": -34,
+        "y": -41,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_gentle_up_lift_1.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_gentle_up_lift_2_1.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_gentle_up_lift_2_2.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_gentle_up_lift_3_1.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_gentle_up_lift_3_2.png",
-        "x_offset": -34,
-        "y_offset": -28,
+        "x": -34,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_gentle_up_lift_4.png",
-        "x_offset": -34,
-        "y_offset": -44,
+        "x": -34,
+        "y": -44,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_lift_1.png",
-        "x_offset": -34,
-        "y_offset": -73,
+        "x": -34,
+        "y": -73,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_lift_2.png",
-        "x_offset": -34,
-        "y_offset": -57,
+        "x": -34,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_lift_3.png",
-        "x_offset": -34,
-        "y_offset": -57,
+        "x": -34,
+        "y": -57,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_lift_4.png",
-        "x_offset": -34,
-        "y_offset": -73,
+        "x": -34,
+        "y": -73,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_diag_lift_1.png",
-        "x_offset": -34,
-        "y_offset": -8,
+        "x": -34,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_diag_lift_2.png",
-        "x_offset": -24,
-        "y_offset": -14,
+        "x": -24,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_diag_lift_3.png",
-        "x_offset": -34,
-        "y_offset": -8,
+        "x": -34,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_diag_lift_4.png",
-        "x_offset": -24,
-        "y_offset": -14,
+        "x": -24,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_diag_lift_1.png",
-        "x_offset": -34,
-        "y_offset": -15,
+        "x": -34,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_diag_lift_2.png",
-        "x_offset": -24,
-        "y_offset": -14,
+        "x": -24,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_diag_lift_3.png",
-        "x_offset": -34,
-        "y_offset": -15,
+        "x": -34,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/rmc/flat_to_gentle_up_diag_lift_4.png",
-        "x_offset": -24,
-        "y_offset": -22,
+        "x": -24,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_flat_up_diag_lift_1.png",
-        "x_offset": -53,
-        "y_offset": -16,
+        "x": -53,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_flat_up_diag_lift_2.png",
-        "x_offset": -24,
-        "y_offset": -14,
+        "x": -24,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_flat_up_diag_lift_3.png",
-        "x_offset": -34,
-        "y_offset": -16,
+        "x": -34,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_flat_up_diag_lift_4.png",
-        "x_offset": -24,
-        "y_offset": -22,
+        "x": -24,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_diag_lift_1.png",
-        "x_offset": -54,
-        "y_offset": -23,
+        "x": -54,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_diag_lift_2.png",
-        "x_offset": -24,
-        "y_offset": -14,
+        "x": -24,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_diag_lift_3.png",
-        "x_offset": -34,
-        "y_offset": -23,
+        "x": -34,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_diag_lift_4.png",
-        "x_offset": -24,
-        "y_offset": -30,
+        "x": -24,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_steep_up_diag_lift_1.png",
-        "x_offset": -56,
-        "y_offset": -37,
+        "x": -56,
+        "y": -37,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_steep_up_diag_lift_2.png",
-        "x_offset": -24,
-        "y_offset": -14,
+        "x": -24,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_steep_up_diag_lift_3.png",
-        "x_offset": -35,
-        "y_offset": -37,
+        "x": -35,
+        "y": -37,
         "palette": "keep"
     },
     {
         "path": "track/rmc/gentle_to_steep_up_diag_lift_4.png",
-        "x_offset": -24,
-        "y_offset": -46,
+        "x": -24,
+        "y": -46,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_gentle_up_diag_lift_1.png",
-        "x_offset": -49,
-        "y_offset": -39,
+        "x": -49,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_gentle_up_diag_lift_2.png",
-        "x_offset": -24,
-        "y_offset": -19,
+        "x": -24,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_gentle_up_diag_lift_3.png",
-        "x_offset": -34,
-        "y_offset": -39,
+        "x": -34,
+        "y": -39,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_to_gentle_up_diag_lift_4.png",
-        "x_offset": -24,
-        "y_offset": -46,
+        "x": -24,
+        "y": -46,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_diag_lift_1.png",
-        "x_offset": -48,
-        "y_offset": -69,
+        "x": -48,
+        "y": -69,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_diag_lift_2.png",
-        "x_offset": -24,
-        "y_offset": -46,
+        "x": -24,
+        "y": -46,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_diag_lift_3.png",
-        "x_offset": -35,
-        "y_offset": -69,
+        "x": -35,
+        "y": -69,
         "palette": "keep"
     },
     {
         "path": "track/rmc/steep_diag_lift_4.png",
-        "x_offset": -24,
-        "y_offset": -78,
+        "x": -24,
+        "y": -78,
         "palette": "keep"
     },
     {
         "path": "track/raptor/preview_track.png",
-        "x_offset": 9,
-        "y_offset": 3
+        "x": 9,
+        "y": 3
     },
     {
         "path": "track/raptor/preview_support.png",
-        "x_offset": 24,
-        "y_offset": 13
+        "x": 24,
+        "y": 13
     },
     {
         "path": "track/raptor/flat_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_2.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/brake_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/brake_2.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/block_brake_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/block_brake_2.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_to_gentle_up_1.png",
-        "x_offset": -18,
-        "y_offset": -6
+        "x": -18,
+        "y": -6
     },
     {
         "path": "track/raptor/flat_to_gentle_up_2.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_to_gentle_up_3.png",
-        "x_offset": -19,
-        "y_offset": 2
+        "x": -19,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_to_gentle_up_4.png",
-        "x_offset": -19,
-        "y_offset": -6
+        "x": -19,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_up_to_flat_1.png",
-        "x_offset": -18,
-        "y_offset": -6
+        "x": -18,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_up_to_flat_2.png",
-        "x_offset": -18,
-        "y_offset": 1
+        "x": -18,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_to_flat_3.png",
-        "x_offset": -18,
-        "y_offset": 1
+        "x": -18,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_to_flat_4.png",
-        "x_offset": -18,
-        "y_offset": -6
+        "x": -18,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_1.png",
-        "x_offset": -18,
-        "y_offset": -14
+        "x": -18,
+        "y": -14
     },
     {
         "path": "track/raptor/gentle_2.png",
-        "x_offset": -18,
-        "y_offset": 1
+        "x": -18,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_3.png",
-        "x_offset": -19,
-        "y_offset": 1
+        "x": -19,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_4.png",
-        "x_offset": -19,
-        "y_offset": -14
+        "x": -19,
+        "y": -14
     },
     {
         "path": "track/raptor/gentle_to_steep_up_1.png",
-        "x_offset": -18,
-        "y_offset": -30
+        "x": -18,
+        "y": -30
     },
     {
         "path": "track/raptor/gentle_to_steep_up_2_1.png",
-        "x_offset": -18,
-        "y_offset": 0
+        "x": -18,
+        "y": 0
     },
     {
         "path": "track/raptor/gentle_to_steep_up_2_2.png",
-        "x_offset": -17,
-        "y_offset": -14
+        "x": -17,
+        "y": -14
     },
     {
         "path": "track/raptor/gentle_to_steep_up_3_1.png",
-        "x_offset": 2,
-        "y_offset": 0
+        "x": 2,
+        "y": 0
     },
     {
         "path": "track/raptor/gentle_to_steep_up_3_2.png",
-        "x_offset": -21,
-        "y_offset": -14
+        "x": -21,
+        "y": -14
     },
     {
         "path": "track/raptor/gentle_to_steep_up_4.png",
-        "x_offset": -21,
-        "y_offset": -30
+        "x": -21,
+        "y": -30
     },
     {
         "path": "track/raptor/steep_to_gentle_up_1.png",
-        "x_offset": -18,
-        "y_offset": -30
+        "x": -18,
+        "y": -30
     },
     {
         "path": "track/raptor/steep_to_gentle_up_2_1.png",
-        "x_offset": -5,
-        "y_offset": -15
+        "x": -5,
+        "y": -15
     },
     {
         "path": "track/raptor/steep_to_gentle_up_2_2.png",
-        "x_offset": -18,
-        "y_offset": -10
+        "x": -18,
+        "y": -10
     },
     {
         "path": "track/raptor/steep_to_gentle_up_3_1.png",
-        "x_offset": -19,
-        "y_offset": -15
+        "x": -19,
+        "y": -15
     },
     {
         "path": "track/raptor/steep_to_gentle_up_3_2.png",
-        "x_offset": -12,
-        "y_offset": -10
+        "x": -12,
+        "y": -10
     },
     {
         "path": "track/raptor/steep_to_gentle_up_4.png",
-        "x_offset": -19,
-        "y_offset": -30
+        "x": -19,
+        "y": -30
     },
     {
         "path": "track/raptor/steep_1.png",
-        "x_offset": -18,
-        "y_offset": -62
+        "x": -18,
+        "y": -62
     },
     {
         "path": "track/raptor/steep_2.png",
-        "x_offset": -18,
-        "y_offset": -46
+        "x": -18,
+        "y": -46
     },
     {
         "path": "track/raptor/steep_3.png",
-        "x_offset": -21,
-        "y_offset": -46
+        "x": -21,
+        "y": -46
     },
     {
         "path": "track/raptor/steep_4.png",
-        "x_offset": -21,
-        "y_offset": -62
+        "x": -21,
+        "y": -62
     },
     {
         "path": "track/raptor/steep_to_vertical_up_1.png",
-        "x_offset": -18,
-        "y_offset": -48
+        "x": -18,
+        "y": -48
     },
     {
         "path": "track/raptor/steep_to_vertical_up_2.png",
-        "x_offset": -18,
-        "y_offset": -46
+        "x": -18,
+        "y": -46
     },
     {
         "path": "track/raptor/steep_to_vertical_up_3.png",
-        "x_offset": -6,
-        "y_offset": -46
+        "x": -6,
+        "y": -46
     },
     {
         "path": "track/raptor/steep_to_vertical_up_4.png",
-        "x_offset": -6,
-        "y_offset": -48
+        "x": -6,
+        "y": -48
     },
     {
         "path": "track/raptor/vertical_to_steep_up_1.png",
-        "x_offset": -2,
-        "y_offset": -54
+        "x": -2,
+        "y": -54
     },
     {
         "path": "track/raptor/vertical_to_steep_up_2.png",
-        "x_offset": -2,
-        "y_offset": -38
+        "x": -2,
+        "y": -38
     },
     {
         "path": "track/raptor/vertical_to_steep_up_3.png",
-        "x_offset": -21,
-        "y_offset": -38
+        "x": -21,
+        "y": -38
     },
     {
         "path": "track/raptor/vertical_to_steep_up_4.png",
-        "x_offset": -21,
-        "y_offset": -54
+        "x": -21,
+        "y": -54
     },
     {
         "path": "track/raptor/vertical_1.png",
-        "x_offset": -2,
-        "y_offset": -24
+        "x": -2,
+        "y": -24
     },
     {
         "path": "track/raptor/vertical_2.png",
-        "x_offset": -2,
-        "y_offset": -22
+        "x": -2,
+        "y": -22
     },
     {
         "path": "track/raptor/vertical_3.png",
-        "x_offset": -6,
-        "y_offset": -22
+        "x": -6,
+        "y": -22
     },
     {
         "path": "track/raptor/vertical_4.png",
-        "x_offset": -6,
-        "y_offset": -24
+        "x": -6,
+        "y": -24
     },
     {
         "path": "track/raptor/small_turn_left_1_1.png",
-        "x_offset": -18,
-        "y_offset": -1
+        "x": -18,
+        "y": -1
     },
     {
         "path": "track/raptor/small_turn_left_1_2.png",
-        "x_offset": -32,
-        "y_offset": 2
+        "x": -32,
+        "y": 2
     },
     {
         "path": "track/raptor/small_turn_left_1_3.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/small_turn_left_2_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/small_turn_left_2_2.png",
-        "x_offset": -4,
-        "y_offset": 0
+        "x": -4,
+        "y": 0
     },
     {
         "path": "track/raptor/small_turn_left_2_3.png",
-        "x_offset": -32,
-        "y_offset": 2
+        "x": -32,
+        "y": 2
     },
     {
         "path": "track/raptor/small_turn_left_3_1.png",
-        "x_offset": -4,
-        "y_offset": 2
+        "x": -4,
+        "y": 2
     },
     {
         "path": "track/raptor/small_turn_left_3_2.png",
-        "x_offset": 25,
-        "y_offset": 1
+        "x": 25,
+        "y": 1
     },
     {
         "path": "track/raptor/small_turn_left_3_3.png",
-        "x_offset": -7,
-        "y_offset": -1
+        "x": -7,
+        "y": -1
     },
     {
         "path": "track/raptor/small_turn_left_4_1.png",
-        "x_offset": -28,
-        "y_offset": 7
+        "x": -28,
+        "y": 7
     },
     {
         "path": "track/raptor/small_turn_left_4_2.png",
-        "x_offset": -8,
-        "y_offset": 23
+        "x": -8,
+        "y": 23
     },
     {
         "path": "track/raptor/small_turn_left_4_3.png",
-        "x_offset": -18,
-        "y_offset": 7
+        "x": -18,
+        "y": 7
     },
     {
         "path": "track/raptor/medium_turn_left_1_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/medium_turn_left_1_2.png",
-        "x_offset": -28,
-        "y_offset": 6
+        "x": -28,
+        "y": 6
     },
     {
         "path": "track/raptor/medium_turn_left_1_3.png",
-        "x_offset": 9,
-        "y_offset": 6
+        "x": 9,
+        "y": 6
     },
     {
         "path": "track/raptor/medium_turn_left_1_4.png",
-        "x_offset": -24,
-        "y_offset": 9
+        "x": -24,
+        "y": 9
     },
     {
         "path": "track/raptor/medium_turn_left_1_5.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/medium_turn_left_2_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/medium_turn_left_2_2.png",
-        "x_offset": -10,
-        "y_offset": 0
+        "x": -10,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_left_2_3.png",
-        "x_offset": -32,
-        "y_offset": 15
+        "x": -32,
+        "y": 15
     },
     {
         "path": "track/raptor/medium_turn_left_2_4.png",
-        "x_offset": -16,
-        "y_offset": 0
+        "x": -16,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_left_2_5.png",
-        "x_offset": -32,
-        "y_offset": 2
+        "x": -32,
+        "y": 2
     },
     {
         "path": "track/raptor/medium_turn_left_3_1.png",
-        "x_offset": -14,
-        "y_offset": 2
+        "x": -14,
+        "y": 2
     },
     {
         "path": "track/raptor/medium_turn_left_3_2.png",
-        "x_offset": 12,
-        "y_offset": 9
+        "x": 12,
+        "y": 9
     },
     {
         "path": "track/raptor/medium_turn_left_3_3.png",
-        "x_offset": -20,
-        "y_offset": 6
+        "x": -20,
+        "y": 6
     },
     {
         "path": "track/raptor/medium_turn_left_3_4.png",
-        "x_offset": 13,
-        "y_offset": 6
+        "x": 13,
+        "y": 6
     },
     {
         "path": "track/raptor/medium_turn_left_3_5.png",
-        "x_offset": -11,
-        "y_offset": 2
+        "x": -11,
+        "y": 2
     },
     {
         "path": "track/raptor/medium_turn_left_4_1.png",
-        "x_offset": -23,
-        "y_offset": 6
+        "x": -23,
+        "y": 6
     },
     {
         "path": "track/raptor/medium_turn_left_4_2.png",
-        "x_offset": -30,
-        "y_offset": 16
+        "x": -30,
+        "y": 16
     },
     {
         "path": "track/raptor/medium_turn_left_4_3.png",
-        "x_offset": -16,
-        "y_offset": 0
+        "x": -16,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_left_4_4.png",
-        "x_offset": -18,
-        "y_offset": 16
+        "x": -18,
+        "y": 16
     },
     {
         "path": "track/raptor/medium_turn_left_4_5.png",
-        "x_offset": -18,
-        "y_offset": 6
+        "x": -18,
+        "y": 6
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_1_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_1_2.png",
-        "x_offset": -26,
-        "y_offset": 1
+        "x": -26,
+        "y": 1
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_1_3.png",
-        "x_offset": 17,
-        "y_offset": 12
+        "x": 17,
+        "y": 12
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_1_4.png",
-        "x_offset": -8,
-        "y_offset": 10
+        "x": -8,
+        "y": 10
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_2_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_2_2.png",
-        "x_offset": -12,
-        "y_offset": 1
+        "x": -12,
+        "y": 1
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_2_3.png",
-        "x_offset": -24,
-        "y_offset": 19
+        "x": -24,
+        "y": 19
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_2_4.png",
-        "x_offset": -30,
-        "y_offset": 8
+        "x": -30,
+        "y": 8
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_3_1.png",
-        "x_offset": -16,
-        "y_offset": 2
+        "x": -16,
+        "y": 2
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_3_2.png",
-        "x_offset": -1,
-        "y_offset": 7
+        "x": -1,
+        "y": 7
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_3_3.png",
-        "x_offset": -32,
-        "y_offset": 11
+        "x": -32,
+        "y": 11
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_3_4.png",
-        "x_offset": -3,
-        "y_offset": -1
+        "x": -3,
+        "y": -1
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_4_1.png",
-        "x_offset": -21,
-        "y_offset": 6
+        "x": -21,
+        "y": 6
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_4_2.png",
-        "x_offset": -32,
-        "y_offset": 11
+        "x": -32,
+        "y": 11
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_4_3.png",
-        "x_offset": -4,
-        "y_offset": 0
+        "x": -4,
+        "y": 0
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_4_4.png",
-        "x_offset": 0,
-        "y_offset": 9
+        "x": 0,
+        "y": 9
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_1_1.png",
-        "x_offset": -18,
-        "y_offset": 6
+        "x": -18,
+        "y": 6
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_1_2.png",
-        "x_offset": -20,
-        "y_offset": 11
+        "x": -20,
+        "y": 11
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_1_3.png",
-        "x_offset": -6,
-        "y_offset": 0
+        "x": -6,
+        "y": 0
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_1_4.png",
-        "x_offset": -32,
-        "y_offset": 9
+        "x": -32,
+        "y": 9
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_2_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_2_2.png",
-        "x_offset": -22,
-        "y_offset": 7
+        "x": -22,
+        "y": 7
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_2_3.png",
-        "x_offset": 23,
-        "y_offset": 11
+        "x": 23,
+        "y": 11
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_2_4.png",
-        "x_offset": -5,
-        "y_offset": -1
+        "x": -5,
+        "y": -1
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_3_1.png",
-        "x_offset": -29,
-        "y_offset": 2
+        "x": -29,
+        "y": 2
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_3_2.png",
-        "x_offset": -28,
-        "y_offset": 1
+        "x": -28,
+        "y": 1
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_3_3.png",
-        "x_offset": -14,
-        "y_offset": 19
+        "x": -14,
+        "y": 19
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_3_4.png",
-        "x_offset": 0,
-        "y_offset": 8
+        "x": 0,
+        "y": 8
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_4_1.png",
-        "x_offset": -12,
-        "y_offset": 2
+        "x": -12,
+        "y": 2
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_4_2.png",
-        "x_offset": 2,
-        "y_offset": 1
+        "x": 2,
+        "y": 1
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_4_3.png",
-        "x_offset": -31,
-        "y_offset": 12
+        "x": -31,
+        "y": 12
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_4_4.png",
-        "x_offset": -3,
-        "y_offset": 10
+        "x": -3,
+        "y": 10
     },
     {
         "path": "track/raptor/flat_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 9
+        "x": -32,
+        "y": 9
     },
     {
         "path": "track/raptor/flat_diag_2.png",
-        "x_offset": -3,
-        "y_offset": -6
+        "x": -3,
+        "y": -6
     },
     {
         "path": "track/raptor/brake_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 9,
+        "x": -32,
+        "y": 9,
         "palette": "keep"
     },
     {
         "path": "track/raptor/brake_diag_2.png",
-        "x_offset": -3,
-        "y_offset": -6,
+        "x": -3,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/block_brake_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 9,
+        "x": -32,
+        "y": 9,
         "palette": "keep"
     },
     {
         "path": "track/raptor/block_brake_diag_2.png",
-        "x_offset": -3,
-        "y_offset": -6,
+        "x": -3,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/flat_to_gentle_up_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 1
+        "x": -32,
+        "y": 1
     },
     {
         "path": "track/raptor/flat_to_gentle_up_diag_2.png",
-        "x_offset": -3,
-        "y_offset": -6
+        "x": -3,
+        "y": -6
     },
     {
         "path": "track/raptor/flat_to_gentle_up_diag_3.png",
-        "x_offset": -33,
-        "y_offset": 1
+        "x": -33,
+        "y": 1
     },
     {
         "path": "track/raptor/flat_to_gentle_up_diag_4.png",
-        "x_offset": -3,
-        "y_offset": -14
+        "x": -3,
+        "y": -14
     },
     {
         "path": "track/raptor/gentle_to_flat_up_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 1
+        "x": -32,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_to_flat_up_diag_2.png",
-        "x_offset": -3,
-        "y_offset": -6
+        "x": -3,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_to_flat_up_diag_3.png",
-        "x_offset": -32,
-        "y_offset": 1
+        "x": -32,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_to_flat_up_diag_4.png",
-        "x_offset": -3,
-        "y_offset": -14
+        "x": -3,
+        "y": -14
     },
     {
         "path": "track/raptor/gentle_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -7
+        "x": -32,
+        "y": -7
     },
     {
         "path": "track/raptor/gentle_diag_2.png",
-        "x_offset": -3,
-        "y_offset": -6
+        "x": -3,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -7
+        "x": -32,
+        "y": -7
     },
     {
         "path": "track/raptor/gentle_diag_4.png",
-        "x_offset": -3,
-        "y_offset": -22
+        "x": -3,
+        "y": -22
     },
     {
         "path": "track/raptor/gentle_to_steep_up_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -23
+        "x": -32,
+        "y": -23
     },
     {
         "path": "track/raptor/gentle_to_steep_up_diag_2.png",
-        "x_offset": -3,
-        "y_offset": -6
+        "x": -3,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_to_steep_up_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -23
+        "x": -32,
+        "y": -23
     },
     {
         "path": "track/raptor/gentle_to_steep_up_diag_4.png",
-        "x_offset": -3,
-        "y_offset": -38
+        "x": -3,
+        "y": -38
     },
     {
         "path": "track/raptor/steep_to_gentle_up_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -23
+        "x": -32,
+        "y": -23
     },
     {
         "path": "track/raptor/steep_to_gentle_up_diag_2.png",
-        "x_offset": -3,
-        "y_offset": -11
+        "x": -3,
+        "y": -11
     },
     {
         "path": "track/raptor/steep_to_gentle_up_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -23
+        "x": -32,
+        "y": -23
     },
     {
         "path": "track/raptor/steep_to_gentle_up_diag_4.png",
-        "x_offset": -3,
-        "y_offset": -38
+        "x": -3,
+        "y": -38
     },
     {
         "path": "track/raptor/steep_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -55
+        "x": -32,
+        "y": -55
     },
     {
         "path": "track/raptor/steep_diag_2.png",
-        "x_offset": -3,
-        "y_offset": -38
+        "x": -3,
+        "y": -38
     },
     {
         "path": "track/raptor/steep_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -55
+        "x": -32,
+        "y": -55
     },
     {
         "path": "track/raptor/steep_diag_4.png",
-        "x_offset": -3,
-        "y_offset": -70
+        "x": -3,
+        "y": -70
     },
     {
         "path": "track/raptor/flat_to_left_bank_1_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_to_left_bank_1_2.png",
-        "x_offset": 1,
-        "y_offset": 2
+        "x": 1,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_to_left_bank_2_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_to_left_bank_2_2.png",
-        "x_offset": -17,
-        "y_offset": 8
+        "x": -17,
+        "y": 8
     },
     {
         "path": "track/raptor/flat_to_left_bank_3.png",
-        "x_offset": -19,
-        "y_offset": 2
+        "x": -19,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_to_left_bank_4.png",
-        "x_offset": -17,
-        "y_offset": 0
+        "x": -17,
+        "y": 0
     },
     {
         "path": "track/raptor/flat_to_right_bank_1.png",
-        "x_offset": -18,
-        "y_offset": 0
+        "x": -18,
+        "y": 0
     },
     {
         "path": "track/raptor/flat_to_right_bank_2.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_to_right_bank_3_1.png",
-        "x_offset": -13,
-        "y_offset": 2
+        "x": -13,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_to_right_bank_3_2.png",
-        "x_offset": -17,
-        "y_offset": 8
+        "x": -17,
+        "y": 8
     },
     {
         "path": "track/raptor/flat_to_right_bank_4_1.png",
-        "x_offset": -16,
-        "y_offset": 2
+        "x": -16,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_to_right_bank_4_2.png",
-        "x_offset": -20,
-        "y_offset": 2
+        "x": -20,
+        "y": 2
     },
     {
         "path": "track/raptor/left_bank_to_gentle_up_1_1.png",
-        "x_offset": -13,
-        "y_offset": -6
+        "x": -13,
+        "y": -6
     },
     {
         "path": "track/raptor/left_bank_to_gentle_up_1_2.png",
-        "x_offset": -17,
-        "y_offset": 7
+        "x": -17,
+        "y": 7
     },
     {
         "path": "track/raptor/left_bank_to_gentle_up_2_1.png",
-        "x_offset": -16,
-        "y_offset": 2
+        "x": -16,
+        "y": 2
     },
     {
         "path": "track/raptor/left_bank_to_gentle_up_2_2.png",
-        "x_offset": -20,
-        "y_offset": 2
+        "x": -20,
+        "y": 2
     },
     {
         "path": "track/raptor/left_bank_to_gentle_up_3.png",
-        "x_offset": -19,
-        "y_offset": 0
+        "x": -19,
+        "y": 0
     },
     {
         "path": "track/raptor/left_bank_to_gentle_up_4.png",
-        "x_offset": -19,
-        "y_offset": -6
+        "x": -19,
+        "y": -6
     },
     {
         "path": "track/raptor/right_bank_to_gentle_up_1.png",
-        "x_offset": -19,
-        "y_offset": -6
+        "x": -19,
+        "y": -6
     },
     {
         "path": "track/raptor/right_bank_to_gentle_up_2.png",
-        "x_offset": -17,
-        "y_offset": 0
+        "x": -17,
+        "y": 0
     },
     {
         "path": "track/raptor/right_bank_to_gentle_up_3_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/right_bank_to_gentle_up_3_2.png",
-        "x_offset": -5,
-        "y_offset": 2
+        "x": -5,
+        "y": 2
     },
     {
         "path": "track/raptor/right_bank_to_gentle_up_4_1.png",
-        "x_offset": -19,
-        "y_offset": -6
+        "x": -19,
+        "y": -6
     },
     {
         "path": "track/raptor/right_bank_to_gentle_up_4_2.png",
-        "x_offset": -10,
-        "y_offset": 7
+        "x": -10,
+        "y": 7
     },
     {
         "path": "track/raptor/gentle_up_to_left_bank_1_1.png",
-        "x_offset": -18,
-        "y_offset": -6
+        "x": -18,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_up_to_left_bank_1_2.png",
-        "x_offset": 3,
-        "y_offset": -6
+        "x": 3,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_up_to_left_bank_2_1.png",
-        "x_offset": -18,
-        "y_offset": 1
+        "x": -18,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_to_left_bank_2_2.png",
-        "x_offset": -16,
-        "y_offset": 4
+        "x": -16,
+        "y": 4
     },
     {
         "path": "track/raptor/gentle_up_to_left_bank_3.png",
-        "x_offset": -19,
-        "y_offset": 1
+        "x": -19,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_to_left_bank_4.png",
-        "x_offset": -17,
-        "y_offset": -8
+        "x": -17,
+        "y": -8
     },
     {
         "path": "track/raptor/gentle_up_to_right_bank_1.png",
-        "x_offset": -18,
-        "y_offset": -8
+        "x": -18,
+        "y": -8
     },
     {
         "path": "track/raptor/gentle_up_to_right_bank_2.png",
-        "x_offset": -18,
-        "y_offset": 1
+        "x": -18,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_to_right_bank_3_1.png",
-        "x_offset": -13,
-        "y_offset": 1
+        "x": -13,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_to_right_bank_3_2.png",
-        "x_offset": -17,
-        "y_offset": 4
+        "x": -17,
+        "y": 4
     },
     {
         "path": "track/raptor/gentle_up_to_right_bank_4_1.png",
-        "x_offset": -17,
-        "y_offset": -6
+        "x": -17,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_up_to_right_bank_4_2.png",
-        "x_offset": -20,
-        "y_offset": -6
+        "x": -20,
+        "y": -6
     },
     {
         "path": "track/raptor/left_bank_1.png",
-        "x_offset": -17,
-        "y_offset": 2
+        "x": -17,
+        "y": 2
     },
     {
         "path": "track/raptor/left_bank_2.png",
-        "x_offset": -20,
-        "y_offset": 2
+        "x": -20,
+        "y": 2
     },
     {
         "path": "track/raptor/left_bank_3.png",
-        "x_offset": -19,
-        "y_offset": 0
+        "x": -19,
+        "y": 0
     },
     {
         "path": "track/raptor/left_bank_4.png",
-        "x_offset": -17,
-        "y_offset": 0
+        "x": -17,
+        "y": 0
     },
     {
         "path": "track/raptor/flat_to_left_bank_diag_1_1.png",
-        "x_offset": -32,
-        "y_offset": 9
+        "x": -32,
+        "y": 9
     },
     {
         "path": "track/raptor/flat_to_left_bank_diag_1_2.png",
-        "x_offset": -30,
-        "y_offset": 9
+        "x": -30,
+        "y": 9
     },
     {
         "path": "track/raptor/flat_to_left_bank_diag_2.png",
-        "x_offset": -5,
-        "y_offset": -6
+        "x": -5,
+        "y": -6
     },
     {
         "path": "track/raptor/flat_to_left_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": 8
+        "x": -32,
+        "y": 8
     },
     {
         "path": "track/raptor/flat_to_left_bank_diag_4.png",
-        "x_offset": -3,
-        "y_offset": -7
+        "x": -3,
+        "y": -7
     },
     {
         "path": "track/raptor/flat_to_right_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 8
+        "x": -32,
+        "y": 8
     },
     {
         "path": "track/raptor/flat_to_right_bank_diag_2.png",
-        "x_offset": -3,
-        "y_offset": -6
+        "x": -3,
+        "y": -6
     },
     {
         "path": "track/raptor/flat_to_right_bank_diag_3_1.png",
-        "x_offset": -31,
-        "y_offset": 9
+        "x": -31,
+        "y": 9
     },
     {
         "path": "track/raptor/flat_to_right_bank_diag_3_2.png",
-        "x_offset": -32,
-        "y_offset": 9
+        "x": -32,
+        "y": 9
     },
     {
         "path": "track/raptor/flat_to_right_bank_diag_4.png",
-        "x_offset": -6,
-        "y_offset": -7
+        "x": -6,
+        "y": -7
     },
     {
         "path": "track/raptor/left_bank_to_gentle_up_diag_1_1.png",
-        "x_offset": -31,
-        "y_offset": 1
+        "x": -31,
+        "y": 1
     },
     {
         "path": "track/raptor/left_bank_to_gentle_up_diag_1_2.png",
-        "x_offset": -32,
-        "y_offset": 8
+        "x": -32,
+        "y": 8
     },
     {
         "path": "track/raptor/left_bank_to_gentle_up_diag_2.png",
-        "x_offset": -6,
-        "y_offset": -7
+        "x": -6,
+        "y": -7
     },
     {
         "path": "track/raptor/left_bank_to_gentle_up_diag_3.png",
-        "x_offset": -33,
-        "y_offset": 1
+        "x": -33,
+        "y": 1
     },
     {
         "path": "track/raptor/left_bank_to_gentle_up_diag_4.png",
-        "x_offset": -3,
-        "y_offset": -14
+        "x": -3,
+        "y": -14
     },
     {
         "path": "track/raptor/right_bank_to_gentle_up_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 1
+        "x": -32,
+        "y": 1
     },
     {
         "path": "track/raptor/right_bank_to_gentle_up_diag_2.png",
-        "x_offset": -3,
-        "y_offset": -7
+        "x": -3,
+        "y": -7
     },
     {
         "path": "track/raptor/right_bank_to_gentle_up_diag_3_1.png",
-        "x_offset": -32,
-        "y_offset": 1
+        "x": -32,
+        "y": 1
     },
     {
         "path": "track/raptor/right_bank_to_gentle_up_diag_3_2.png",
-        "x_offset": -31,
-        "y_offset": 8
+        "x": -31,
+        "y": 8
     },
     {
         "path": "track/raptor/right_bank_to_gentle_up_diag_4.png",
-        "x_offset": -5,
-        "y_offset": -14
+        "x": -5,
+        "y": -14
     },
     {
         "path": "track/raptor/gentle_up_to_left_bank_diag_1_1.png",
-        "x_offset": -32,
-        "y_offset": 3
+        "x": -32,
+        "y": 3
     },
     {
         "path": "track/raptor/gentle_up_to_left_bank_diag_1_2.png",
-        "x_offset": -31,
-        "y_offset": 1
+        "x": -31,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_to_left_bank_diag_2.png",
-        "x_offset": -5,
-        "y_offset": -6
+        "x": -5,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_up_to_left_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": 0
+        "x": -32,
+        "y": 0
     },
     {
         "path": "track/raptor/gentle_up_to_left_bank_diag_4.png",
-        "x_offset": -3,
-        "y_offset": -15
+        "x": -3,
+        "y": -15
     },
     {
         "path": "track/raptor/gentle_up_to_right_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 0
+        "x": -32,
+        "y": 0
     },
     {
         "path": "track/raptor/gentle_up_to_right_bank_diag_2.png",
-        "x_offset": -3,
-        "y_offset": -6
+        "x": -3,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_up_to_right_bank_diag_3_1.png",
-        "x_offset": -31,
-        "y_offset": 1
+        "x": -31,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_to_right_bank_diag_3_2.png",
-        "x_offset": -32,
-        "y_offset": 1
+        "x": -32,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_to_right_bank_diag_4.png",
-        "x_offset": -6,
-        "y_offset": -15
+        "x": -6,
+        "y": -15
     },
     {
         "path": "track/raptor/left_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 9
+        "x": -32,
+        "y": 9
     },
     {
         "path": "track/raptor/left_bank_diag_2.png",
-        "x_offset": -6,
-        "y_offset": -7
+        "x": -6,
+        "y": -7
     },
     {
         "path": "track/raptor/left_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": 8
+        "x": -32,
+        "y": 8
     },
     {
         "path": "track/raptor/left_bank_diag_4.png",
-        "x_offset": -2,
-        "y_offset": -7
+        "x": -2,
+        "y": -7
     },
     {
         "path": "track/raptor/small_turn_left_bank_1_1.png",
-        "x_offset": -5,
-        "y_offset": -1
+        "x": -5,
+        "y": -1
     },
     {
         "path": "track/raptor/small_turn_left_bank_1_2.png",
-        "x_offset": -17,
-        "y_offset": -1
+        "x": -17,
+        "y": -1
     },
     {
         "path": "track/raptor/small_turn_left_bank_1_3.png",
-        "x_offset": -32,
-        "y_offset": 2
+        "x": -32,
+        "y": 2
     },
     {
         "path": "track/raptor/small_turn_left_bank_1_4.png",
-        "x_offset": -17,
-        "y_offset": 0
+        "x": -17,
+        "y": 0
     },
     {
         "path": "track/raptor/small_turn_left_bank_2_1.png",
-        "x_offset": -20,
-        "y_offset": 2
+        "x": -20,
+        "y": 2
     },
     {
         "path": "track/raptor/small_turn_left_bank_2_2.png",
-        "x_offset": -4,
-        "y_offset": 0
+        "x": -4,
+        "y": 0
     },
     {
         "path": "track/raptor/small_turn_left_bank_2_3.png",
-        "x_offset": -32,
-        "y_offset": 2
+        "x": -32,
+        "y": 2
     },
     {
         "path": "track/raptor/small_turn_left_bank_3_1.png",
-        "x_offset": -6,
-        "y_offset": 0
+        "x": -6,
+        "y": 0
     },
     {
         "path": "track/raptor/small_turn_left_bank_3_2.png",
-        "x_offset": 23,
-        "y_offset": 1
+        "x": 23,
+        "y": 1
     },
     {
         "path": "track/raptor/small_turn_left_bank_3_3.png",
-        "x_offset": -8,
-        "y_offset": -1
+        "x": -8,
+        "y": -1
     },
     {
         "path": "track/raptor/small_turn_left_bank_3_4.png",
-        "x_offset": -9,
-        "y_offset": -1
+        "x": -9,
+        "y": -1
     },
     {
         "path": "track/raptor/small_turn_left_bank_4_1.png",
-        "x_offset": -26,
-        "y_offset": 6
+        "x": -26,
+        "y": 6
     },
     {
         "path": "track/raptor/small_turn_left_bank_4_2.png",
-        "x_offset": -8,
-        "y_offset": 22
+        "x": -8,
+        "y": 22
     },
     {
         "path": "track/raptor/small_turn_left_bank_4_3.png",
-        "x_offset": -19,
-        "y_offset": 6
+        "x": -19,
+        "y": 6
     },
     {
         "path": "track/raptor/medium_turn_left_bank_1_1.png",
-        "x_offset": 3,
-        "y_offset": 3
+        "x": 3,
+        "y": 3
     },
     {
         "path": "track/raptor/medium_turn_left_bank_1_2.png",
-        "x_offset": -17,
-        "y_offset": 3
+        "x": -17,
+        "y": 3
     },
     {
         "path": "track/raptor/medium_turn_left_bank_1_3.png",
-        "x_offset": -26,
-        "y_offset": 5
+        "x": -26,
+        "y": 5
     },
     {
         "path": "track/raptor/medium_turn_left_bank_1_4.png",
-        "x_offset": 12,
-        "y_offset": 7
+        "x": 12,
+        "y": 7
     },
     {
         "path": "track/raptor/medium_turn_left_bank_1_5.png",
-        "x_offset": -22,
-        "y_offset": 8
+        "x": -22,
+        "y": 8
     },
     {
         "path": "track/raptor/medium_turn_left_bank_1_6.png",
-        "x_offset": -17,
-        "y_offset": 0
+        "x": -17,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_left_bank_2_1.png",
-        "x_offset": -20,
-        "y_offset": 2
+        "x": -20,
+        "y": 2
     },
     {
         "path": "track/raptor/medium_turn_left_bank_2_2.png",
-        "x_offset": -10,
-        "y_offset": 0
+        "x": -10,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_left_bank_2_3.png",
-        "x_offset": -30,
-        "y_offset": 16
+        "x": -30,
+        "y": 16
     },
     {
         "path": "track/raptor/medium_turn_left_bank_2_4.png",
-        "x_offset": -16,
-        "y_offset": 0
+        "x": -16,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_left_bank_2_5.png",
-        "x_offset": -30,
-        "y_offset": 2
+        "x": -30,
+        "y": 2
     },
     {
         "path": "track/raptor/medium_turn_left_bank_3_1.png",
-        "x_offset": -15,
-        "y_offset": 0
+        "x": -15,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_left_bank_3_2.png",
-        "x_offset": 9,
-        "y_offset": 8
+        "x": 9,
+        "y": 8
     },
     {
         "path": "track/raptor/medium_turn_left_bank_3_3.png",
-        "x_offset": -23,
-        "y_offset": 7
+        "x": -23,
+        "y": 7
     },
     {
         "path": "track/raptor/medium_turn_left_bank_3_4.png",
-        "x_offset": 11,
-        "y_offset": 5
+        "x": 11,
+        "y": 5
     },
     {
         "path": "track/raptor/medium_turn_left_bank_3_5.png",
-        "x_offset": -6,
-        "y_offset": 3
+        "x": -6,
+        "y": 3
     },
     {
         "path": "track/raptor/medium_turn_left_bank_3_6.png",
-        "x_offset": -11,
-        "y_offset": 3
+        "x": -11,
+        "y": 3
     },
     {
         "path": "track/raptor/medium_turn_left_bank_4_1.png",
-        "x_offset": -20,
-        "y_offset": 5
+        "x": -20,
+        "y": 5
     },
     {
         "path": "track/raptor/medium_turn_left_bank_4_2.png",
-        "x_offset": -32,
-        "y_offset": 15
+        "x": -32,
+        "y": 15
     },
     {
         "path": "track/raptor/medium_turn_left_bank_4_3.png",
-        "x_offset": -12,
-        "y_offset": 0
+        "x": -12,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_left_bank_4_4.png",
-        "x_offset": -20,
-        "y_offset": 15
+        "x": -20,
+        "y": 15
     },
     {
         "path": "track/raptor/medium_turn_left_bank_4_5.png",
-        "x_offset": -19,
-        "y_offset": 5
+        "x": -19,
+        "y": 5
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_bank_1_1.png",
-        "x_offset": -17,
-        "y_offset": 3
+        "x": -17,
+        "y": 3
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_bank_1_2.png",
-        "x_offset": -24,
-        "y_offset": 0
+        "x": -24,
+        "y": 0
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_bank_1_3.png",
-        "x_offset": 21,
-        "y_offset": 13
+        "x": 21,
+        "y": 13
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_bank_1_4.png",
-        "x_offset": -11,
-        "y_offset": 9
+        "x": -11,
+        "y": 9
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_bank_2_1.png",
-        "x_offset": -20,
-        "y_offset": 2
+        "x": -20,
+        "y": 2
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_bank_2_2.png",
-        "x_offset": -32,
-        "y_offset": -7
+        "x": -32,
+        "y": -7
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_bank_2_3.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_bank_2_4.png",
-        "x_offset": -32,
-        "y_offset": 8
+        "x": -32,
+        "y": 8
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_bank_3_1.png",
-        "x_offset": -18,
-        "y_offset": 0
+        "x": -18,
+        "y": 0
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_bank_3_2.png",
-        "x_offset": -2,
-        "y_offset": 7
+        "x": -2,
+        "y": 7
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_bank_3_3.png",
-        "x_offset": -32,
-        "y_offset": 13
+        "x": -32,
+        "y": 13
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_bank_3_4.png",
-        "x_offset": -5,
-        "y_offset": -2
+        "x": -5,
+        "y": -2
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_bank_4_1.png",
-        "x_offset": -18,
-        "y_offset": 5
+        "x": -18,
+        "y": 5
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_bank_4_2.png",
-        "x_offset": -32,
-        "y_offset": 10
+        "x": -32,
+        "y": 10
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_bank_4_3.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_bank_4_4.png",
-        "x_offset": 0,
-        "y_offset": 8
+        "x": 0,
+        "y": 8
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_bank_1_1.png",
-        "x_offset": -19,
-        "y_offset": 5
+        "x": -19,
+        "y": 5
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_bank_1_2.png",
-        "x_offset": -20,
-        "y_offset": 10
+        "x": -20,
+        "y": 10
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_bank_1_3.png",
-        "x_offset": -2,
-        "y_offset": 0
+        "x": -2,
+        "y": 0
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_bank_1_4.png",
-        "x_offset": -32,
-        "y_offset": 8
+        "x": -32,
+        "y": 8
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_bank_2_1.png",
-        "x_offset": -17,
-        "y_offset": 0
+        "x": -17,
+        "y": 0
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_bank_2_2.png",
-        "x_offset": -20,
-        "y_offset": 7
+        "x": -20,
+        "y": 7
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_bank_2_3.png",
-        "x_offset": 26,
-        "y_offset": 13
+        "x": 26,
+        "y": 13
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_bank_2_4.png",
-        "x_offset": -4,
-        "y_offset": -2
+        "x": -4,
+        "y": -2
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_bank_3_1.png",
-        "x_offset": -28,
-        "y_offset": 2
+        "x": -28,
+        "y": 2
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_bank_3_2.png",
-        "x_offset": -32,
-        "y_offset": -7
+        "x": -32,
+        "y": -7
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_bank_3_3.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_bank_3_4.png",
-        "x_offset": 0,
-        "y_offset": 8
+        "x": 0,
+        "y": 8
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_bank_4_1.png",
-        "x_offset": -27,
-        "y_offset": -10
+        "x": -27,
+        "y": -10
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_bank_4_2.png",
-        "x_offset": 1,
-        "y_offset": 0
+        "x": 1,
+        "y": 0
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_bank_4_3.png",
-        "x_offset": -32,
-        "y_offset": 13
+        "x": -32,
+        "y": 13
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_bank_4_4.png",
-        "x_offset": -6,
-        "y_offset": 9
+        "x": -6,
+        "y": 9
     },
     {
         "path": "track/raptor/small_turn_left_gentle_up_1_1.png",
-        "x_offset": -24,
-        "y_offset": -32
+        "x": -24,
+        "y": -32
     },
     {
         "path": "track/raptor/small_turn_left_gentle_up_1_2.png",
-        "x_offset": -13,
-        "y_offset": -17
+        "x": -13,
+        "y": -17
     },
     {
         "path": "track/raptor/small_turn_left_gentle_up_2_1.png",
-        "x_offset": -12,
-        "y_offset": -8
+        "x": -12,
+        "y": -8
     },
     {
         "path": "track/raptor/small_turn_left_gentle_up_2_2.png",
-        "x_offset": -38,
-        "y_offset": -17
+        "x": -38,
+        "y": -17
     },
     {
         "path": "track/raptor/small_turn_left_gentle_up_3_1.png",
-        "x_offset": -13,
-        "y_offset": -2
+        "x": -13,
+        "y": -2
     },
     {
         "path": "track/raptor/small_turn_left_gentle_up_3_2.png",
-        "x_offset": -1,
-        "y_offset": -7
+        "x": -1,
+        "y": -7
     },
     {
         "path": "track/raptor/small_turn_left_gentle_up_4_1.png",
-        "x_offset": -26,
-        "y_offset": -12
+        "x": -26,
+        "y": -12
     },
     {
         "path": "track/raptor/small_turn_left_gentle_up_4_2.png",
-        "x_offset": -25,
-        "y_offset": -2
+        "x": -25,
+        "y": -2
     },
     {
         "path": "track/raptor/small_turn_right_gentle_up_1_1.png",
-        "x_offset": -24,
-        "y_offset": -12
+        "x": -24,
+        "y": -12
     },
     {
         "path": "track/raptor/small_turn_right_gentle_up_1_2.png",
-        "x_offset": -26,
-        "y_offset": -2
+        "x": -26,
+        "y": -2
     },
     {
         "path": "track/raptor/small_turn_right_gentle_up_2_1.png",
-        "x_offset": -12,
-        "y_offset": -2
+        "x": -12,
+        "y": -2
     },
     {
         "path": "track/raptor/small_turn_right_gentle_up_2_2.png",
-        "x_offset": -25,
-        "y_offset": -7
+        "x": -25,
+        "y": -7
     },
     {
         "path": "track/raptor/small_turn_right_gentle_up_3_1.png",
-        "x_offset": -38,
-        "y_offset": -8
+        "x": -38,
+        "y": -8
     },
     {
         "path": "track/raptor/small_turn_right_gentle_up_3_2.png",
-        "x_offset": -13,
-        "y_offset": -17
+        "x": -13,
+        "y": -17
     },
     {
         "path": "track/raptor/small_turn_right_gentle_up_4_1.png",
-        "x_offset": -1,
-        "y_offset": -25
+        "x": -1,
+        "y": -25
     },
     {
         "path": "track/raptor/small_turn_right_gentle_up_4_2.png",
-        "x_offset": -13,
-        "y_offset": -17
+        "x": -13,
+        "y": -17
     },
     {
         "path": "track/raptor/medium_turn_left_gentle_up_1_1.png",
-        "x_offset": -18,
-        "y_offset": -15
+        "x": -18,
+        "y": -15
     },
     {
         "path": "track/raptor/medium_turn_left_gentle_up_1_2.png",
-        "x_offset": -27,
-        "y_offset": -11
+        "x": -27,
+        "y": -11
     },
     {
         "path": "track/raptor/medium_turn_left_gentle_up_1_3.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_left_gentle_up_1_4.png",
-        "x_offset": -27,
-        "y_offset": -8
+        "x": -27,
+        "y": -8
     },
     {
         "path": "track/raptor/medium_turn_left_gentle_up_1_5.png",
-        "x_offset": -19,
-        "y_offset": -14
+        "x": -19,
+        "y": -14
     },
     {
         "path": "track/raptor/medium_turn_left_gentle_up_2_1.png",
-        "x_offset": -18,
-        "y_offset": -5
+        "x": -18,
+        "y": -5
     },
     {
         "path": "track/raptor/medium_turn_left_gentle_up_2_2.png",
-        "x_offset": 0,
-        "y_offset": -14
+        "x": 0,
+        "y": -14
     },
     {
         "path": "track/raptor/medium_turn_left_gentle_up_2_3.png",
-        "x_offset": 0,
-        "y_offset": 1
+        "x": 0,
+        "y": 1
     },
     {
         "path": "track/raptor/medium_turn_left_gentle_up_2_4.png",
-        "x_offset": -12,
-        "y_offset": -21
+        "x": -12,
+        "y": -21
     },
     {
         "path": "track/raptor/medium_turn_left_gentle_up_2_5.png",
-        "x_offset": -17,
-        "y_offset": -14
+        "x": -17,
+        "y": -14
     },
     {
         "path": "track/raptor/medium_turn_left_gentle_up_3_1.png",
-        "x_offset": -20,
-        "y_offset": 1
+        "x": -20,
+        "y": 1
     },
     {
         "path": "track/raptor/medium_turn_left_gentle_up_3_2.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_left_gentle_up_3_3.png",
-        "x_offset": -20,
-        "y_offset": 6
+        "x": -20,
+        "y": 6
     },
     {
         "path": "track/raptor/medium_turn_left_gentle_up_3_4.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_left_gentle_up_3_5.png",
-        "x_offset": -16,
-        "y_offset": 0
+        "x": -16,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_left_gentle_up_4_1.png",
-        "x_offset": -26,
-        "y_offset": -12
+        "x": -26,
+        "y": -12
     },
     {
         "path": "track/raptor/medium_turn_left_gentle_up_4_2.png",
-        "x_offset": -32,
-        "y_offset": 1
+        "x": -32,
+        "y": 1
     },
     {
         "path": "track/raptor/medium_turn_left_gentle_up_4_3.png",
-        "x_offset": -18,
-        "y_offset": -13
+        "x": -18,
+        "y": -13
     },
     {
         "path": "track/raptor/medium_turn_left_gentle_up_4_4.png",
-        "x_offset": -16,
-        "y_offset": 4
+        "x": -16,
+        "y": 4
     },
     {
         "path": "track/raptor/medium_turn_left_gentle_up_4_5.png",
-        "x_offset": -19,
-        "y_offset": 1
+        "x": -19,
+        "y": 1
     },
     {
         "path": "track/raptor/medium_turn_right_gentle_up_1_1.png",
-        "x_offset": -18,
-        "y_offset": -12
+        "x": -18,
+        "y": -12
     },
     {
         "path": "track/raptor/medium_turn_right_gentle_up_1_2.png",
-        "x_offset": -10,
-        "y_offset": 1
+        "x": -10,
+        "y": 1
     },
     {
         "path": "track/raptor/medium_turn_right_gentle_up_1_3.png",
-        "x_offset": 0,
-        "y_offset": -13
+        "x": 0,
+        "y": -13
     },
     {
         "path": "track/raptor/medium_turn_right_gentle_up_1_4.png",
-        "x_offset": -16,
-        "y_offset": 4
+        "x": -16,
+        "y": 4
     },
     {
         "path": "track/raptor/medium_turn_right_gentle_up_1_5.png",
-        "x_offset": -21,
-        "y_offset": 1
+        "x": -21,
+        "y": 1
     },
     {
         "path": "track/raptor/medium_turn_right_gentle_up_2_1.png",
-        "x_offset": -18,
-        "y_offset": 1
+        "x": -18,
+        "y": 1
     },
     {
         "path": "track/raptor/medium_turn_right_gentle_up_2_2.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_right_gentle_up_2_3.png",
-        "x_offset": 0,
-        "y_offset": 6
+        "x": 0,
+        "y": 6
     },
     {
         "path": "track/raptor/medium_turn_right_gentle_up_2_4.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_right_gentle_up_2_5.png",
-        "x_offset": -19,
-        "y_offset": 0
+        "x": -19,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_right_gentle_up_3_1.png",
-        "x_offset": -32,
-        "y_offset": -5
+        "x": -32,
+        "y": -5
     },
     {
         "path": "track/raptor/medium_turn_right_gentle_up_3_2.png",
-        "x_offset": -32,
-        "y_offset": -14
+        "x": -32,
+        "y": -14
     },
     {
         "path": "track/raptor/medium_turn_right_gentle_up_3_3.png",
-        "x_offset": -26,
-        "y_offset": -1
+        "x": -26,
+        "y": -1
     },
     {
         "path": "track/raptor/medium_turn_right_gentle_up_3_4.png",
-        "x_offset": -22,
-        "y_offset": -24
+        "x": -22,
+        "y": -24
     },
     {
         "path": "track/raptor/medium_turn_right_gentle_up_3_5.png",
-        "x_offset": -19,
-        "y_offset": -14
+        "x": -19,
+        "y": -14
     },
     {
         "path": "track/raptor/medium_turn_right_gentle_up_4_1.png",
-        "x_offset": -12,
-        "y_offset": -13
+        "x": -12,
+        "y": -13
     },
     {
         "path": "track/raptor/medium_turn_right_gentle_up_4_2.png",
-        "x_offset": 12,
-        "y_offset": -11
+        "x": 12,
+        "y": -11
     },
     {
         "path": "track/raptor/medium_turn_right_gentle_up_4_3.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_right_gentle_up_4_4.png",
-        "x_offset": 12,
-        "y_offset": -7
+        "x": 12,
+        "y": -7
     },
     {
         "path": "track/raptor/medium_turn_right_gentle_up_4_5.png",
-        "x_offset": -13,
-        "y_offset": -14
+        "x": -13,
+        "y": -14
     },
     {
         "path": "track/raptor/very_small_turn_left_steep_up_1_1.png",
-        "x_offset": -21,
-        "y_offset": -62
+        "x": -21,
+        "y": -62
     },
     {
         "path": "track/raptor/very_small_turn_left_steep_up_1_2.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/very_small_turn_left_steep_up_2_1.png",
-        "x_offset": -10,
-        "y_offset": -62
+        "x": -10,
+        "y": -62
     },
     {
         "path": "track/raptor/very_small_turn_left_steep_up_2_2.png",
-        "x_offset": -18,
-        "y_offset": -31
+        "x": -18,
+        "y": -31
     },
     {
         "path": "track/raptor/very_small_turn_left_steep_up_3_1.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/very_small_turn_left_steep_up_3_2.png",
-        "x_offset": 6,
-        "y_offset": -46
+        "x": 6,
+        "y": -46
     },
     {
         "path": "track/raptor/very_small_turn_left_steep_up_4_1.png",
-        "x_offset": -9,
-        "y_offset": -33
+        "x": -9,
+        "y": -33
     },
     {
         "path": "track/raptor/very_small_turn_left_steep_up_4_2.png",
-        "x_offset": -21,
-        "y_offset": -46
+        "x": -21,
+        "y": -46
     },
     {
         "path": "track/raptor/very_small_turn_right_steep_up_1_1.png",
-        "x_offset": -18,
-        "y_offset": -24
+        "x": -18,
+        "y": -24
     },
     {
         "path": "track/raptor/very_small_turn_right_steep_up_1_2.png",
-        "x_offset": 0,
-        "y_offset": -46
+        "x": 0,
+        "y": -46
     },
     {
         "path": "track/raptor/very_small_turn_right_steep_up_2_1.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/very_small_turn_right_steep_up_2_2.png",
-        "x_offset": -21,
-        "y_offset": -46
+        "x": -21,
+        "y": -46
     },
     {
         "path": "track/raptor/very_small_turn_right_steep_up_3_1.png",
-        "x_offset": -21,
-        "y_offset": -62
+        "x": -21,
+        "y": -62
     },
     {
         "path": "track/raptor/very_small_turn_right_steep_up_3_2.png",
-        "x_offset": -10,
-        "y_offset": -33
+        "x": -10,
+        "y": -33
     },
     {
         "path": "track/raptor/very_small_turn_right_steep_up_4_1.png",
-        "x_offset": 6,
-        "y_offset": -62
+        "x": 6,
+        "y": -62
     },
     {
         "path": "track/raptor/very_small_turn_right_steep_up_4_2.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/vertical_twist_left_up_1.png",
-        "x_offset": -6,
-        "y_offset": -88
+        "x": -6,
+        "y": -88
     },
     {
         "path": "track/raptor/vertical_twist_left_up_2_1.png",
-        "x_offset": -2,
-        "y_offset": -88
+        "x": -2,
+        "y": -88
     },
     {
         "path": "track/raptor/vertical_twist_left_up_2_2.png",
-        "x_offset": -2,
-        "y_offset": -41
+        "x": -2,
+        "y": -41
     },
     {
         "path": "track/raptor/vertical_twist_left_up_3.png",
-        "x_offset": -6,
-        "y_offset": -86
+        "x": -6,
+        "y": -86
     },
     {
         "path": "track/raptor/vertical_twist_left_up_4_1.png",
-        "x_offset": -6,
-        "y_offset": -40
+        "x": -6,
+        "y": -40
     },
     {
         "path": "track/raptor/vertical_twist_left_up_4_2.png",
-        "x_offset": -6,
-        "y_offset": -86
+        "x": -6,
+        "y": -86
     },
     {
         "path": "track/raptor/vertical_twist_right_up_1_1.png",
-        "x_offset": -2,
-        "y_offset": -41
+        "x": -2,
+        "y": -41
     },
     {
         "path": "track/raptor/vertical_twist_right_up_1_2.png",
-        "x_offset": -2,
-        "y_offset": -86
+        "x": -2,
+        "y": -86
     },
     {
         "path": "track/raptor/vertical_twist_right_up_2.png",
-        "x_offset": -6,
-        "y_offset": -86
+        "x": -6,
+        "y": -86
     },
     {
         "path": "track/raptor/vertical_twist_right_up_3_1.png",
-        "x_offset": -6,
-        "y_offset": -88
+        "x": -6,
+        "y": -88
     },
     {
         "path": "track/raptor/vertical_twist_right_up_3_2.png",
-        "x_offset": -6,
-        "y_offset": -41
+        "x": -6,
+        "y": -41
     },
     {
         "path": "track/raptor/vertical_twist_right_up_4.png",
-        "x_offset": -6,
-        "y_offset": -88
+        "x": -6,
+        "y": -88
     },
     {
         "path": "track/raptor/gentle_up_to_gentle_up_left_bank_1.png",
-        "x_offset": -18,
-        "y_offset": -14
+        "x": -18,
+        "y": -14
     },
     {
         "path": "track/raptor/gentle_up_to_gentle_up_left_bank_2_1.png",
-        "x_offset": -18,
-        "y_offset": 1
+        "x": -18,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_to_gentle_up_left_bank_2_2.png",
-        "x_offset": -17,
-        "y_offset": 1
+        "x": -17,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_to_gentle_up_left_bank_3.png",
-        "x_offset": -20,
-        "y_offset": 0
+        "x": -20,
+        "y": 0
     },
     {
         "path": "track/raptor/gentle_up_to_gentle_up_left_bank_4.png",
-        "x_offset": -18,
-        "y_offset": -15
+        "x": -18,
+        "y": -15
     },
     {
         "path": "track/raptor/gentle_up_to_gentle_up_right_bank_1.png",
-        "x_offset": -18,
-        "y_offset": -15
+        "x": -18,
+        "y": -15
     },
     {
         "path": "track/raptor/gentle_up_to_gentle_up_right_bank_2.png",
-        "x_offset": -18,
-        "y_offset": 0
+        "x": -18,
+        "y": 0
     },
     {
         "path": "track/raptor/gentle_up_to_gentle_up_right_bank_3_1.png",
-        "x_offset": -9,
-        "y_offset": 1
+        "x": -9,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_to_gentle_up_right_bank_3_2.png",
-        "x_offset": -18,
-        "y_offset": 1
+        "x": -18,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_to_gentle_up_right_bank_4.png",
-        "x_offset": -20,
-        "y_offset": -14
+        "x": -20,
+        "y": -14
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_gentle_up_1.png",
-        "x_offset": -17,
-        "y_offset": -14
+        "x": -17,
+        "y": -14
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_gentle_up_2_1.png",
-        "x_offset": -16,
-        "y_offset": 1
+        "x": -16,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_gentle_up_2_2.png",
-        "x_offset": -19,
-        "y_offset": 1
+        "x": -19,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_gentle_up_3.png",
-        "x_offset": -19,
-        "y_offset": 0
+        "x": -19,
+        "y": 0
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_gentle_up_4.png",
-        "x_offset": -19,
-        "y_offset": -14
+        "x": -19,
+        "y": -14
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_gentle_up_1.png",
-        "x_offset": -19,
-        "y_offset": -14
+        "x": -19,
+        "y": -14
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_gentle_up_2.png",
-        "x_offset": -17,
-        "y_offset": 0
+        "x": -17,
+        "y": 0
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_gentle_up_3_1.png",
-        "x_offset": -18,
-        "y_offset": 1
+        "x": -18,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_gentle_up_3_2.png",
-        "x_offset": 0,
-        "y_offset": 1
+        "x": 0,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_gentle_up_4.png",
-        "x_offset": -19,
-        "y_offset": -14
+        "x": -19,
+        "y": -14
     },
     {
         "path": "track/raptor/left_bank_to_gentle_up_left_bank_1.png",
-        "x_offset": -17,
-        "y_offset": -6
+        "x": -17,
+        "y": -6
     },
     {
         "path": "track/raptor/left_bank_to_gentle_up_left_bank_2.png",
-        "x_offset": -20,
-        "y_offset": 2
+        "x": -20,
+        "y": 2
     },
     {
         "path": "track/raptor/left_bank_to_gentle_up_left_bank_3.png",
-        "x_offset": -20,
-        "y_offset": 0
+        "x": -20,
+        "y": 0
     },
     {
         "path": "track/raptor/left_bank_to_gentle_up_left_bank_4.png",
-        "x_offset": -18,
-        "y_offset": -7
+        "x": -18,
+        "y": -7
     },
     {
         "path": "track/raptor/right_bank_to_gentle_up_right_bank_1.png",
-        "x_offset": -19,
-        "y_offset": -7
+        "x": -19,
+        "y": -7
     },
     {
         "path": "track/raptor/right_bank_to_gentle_up_right_bank_2.png",
-        "x_offset": -17,
-        "y_offset": 0
+        "x": -17,
+        "y": 0
     },
     {
         "path": "track/raptor/right_bank_to_gentle_up_right_bank_3.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/right_bank_to_gentle_up_right_bank_4.png",
-        "x_offset": -20,
-        "y_offset": -6
+        "x": -20,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_left_bank_1.png",
-        "x_offset": -16,
-        "y_offset": -6
+        "x": -16,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_left_bank_2.png",
-        "x_offset": -19,
-        "y_offset": 1
+        "x": -19,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_left_bank_3.png",
-        "x_offset": -19,
-        "y_offset": 0
+        "x": -19,
+        "y": 0
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_left_bank_4.png",
-        "x_offset": -17,
-        "y_offset": -8
+        "x": -17,
+        "y": -8
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_right_bank_1.png",
-        "x_offset": -19,
-        "y_offset": -8
+        "x": -19,
+        "y": -8
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_right_bank_2.png",
-        "x_offset": -17,
-        "y_offset": 0
+        "x": -17,
+        "y": 0
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_right_bank_3.png",
-        "x_offset": -17,
-        "y_offset": 1
+        "x": -17,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_right_bank_4.png",
-        "x_offset": -20,
-        "y_offset": -6
+        "x": -20,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_up_left_bank_1.png",
-        "x_offset": -16,
-        "y_offset": -14
+        "x": -16,
+        "y": -14
     },
     {
         "path": "track/raptor/gentle_up_left_bank_2.png",
-        "x_offset": -19,
-        "y_offset": 1
+        "x": -19,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_left_bank_3.png",
-        "x_offset": -20,
-        "y_offset": 0
+        "x": -20,
+        "y": 0
     },
     {
         "path": "track/raptor/gentle_up_left_bank_4.png",
-        "x_offset": -18,
-        "y_offset": -15
+        "x": -18,
+        "y": -15
     },
     {
         "path": "track/raptor/gentle_up_right_bank_1.png",
-        "x_offset": -19,
-        "y_offset": -15
+        "x": -19,
+        "y": -15
     },
     {
         "path": "track/raptor/gentle_up_right_bank_2.png",
-        "x_offset": -17,
-        "y_offset": 0
+        "x": -17,
+        "y": 0
     },
     {
         "path": "track/raptor/gentle_up_right_bank_3.png",
-        "x_offset": -18,
-        "y_offset": 1
+        "x": -18,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_right_bank_4.png",
-        "x_offset": -20,
-        "y_offset": -14
+        "x": -20,
+        "y": -14
     },
     {
         "path": "track/raptor/flat_to_gentle_up_left_bank_1.png",
-        "x_offset": -18,
-        "y_offset": -6
+        "x": -18,
+        "y": -6
     },
     {
         "path": "track/raptor/flat_to_gentle_up_left_bank_2_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_to_gentle_up_left_bank_2_2.png",
-        "x_offset": -17,
-        "y_offset": 7
+        "x": -17,
+        "y": 7
     },
     {
         "path": "track/raptor/flat_to_gentle_up_left_bank_3.png",
-        "x_offset": -20,
-        "y_offset": 2
+        "x": -20,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_to_gentle_up_left_bank_4.png",
-        "x_offset": -18,
-        "y_offset": -7
+        "x": -18,
+        "y": -7
     },
     {
         "path": "track/raptor/flat_to_gentle_up_right_bank_1.png",
-        "x_offset": -18,
-        "y_offset": -7
+        "x": -18,
+        "y": -7
     },
     {
         "path": "track/raptor/flat_to_gentle_up_right_bank_2.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_to_gentle_up_right_bank_3_1.png",
-        "x_offset": -3,
-        "y_offset": 2
+        "x": -3,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_to_gentle_up_right_bank_3_2.png",
-        "x_offset": -18,
-        "y_offset": 7
+        "x": -18,
+        "y": 7
     },
     {
         "path": "track/raptor/flat_to_gentle_up_right_bank_4.png",
-        "x_offset": -20,
-        "y_offset": -6
+        "x": -20,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_flat_1.png",
-        "x_offset": -17,
-        "y_offset": -6
+        "x": -17,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_flat_2_1.png",
-        "x_offset": -16,
-        "y_offset": 1
+        "x": -16,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_flat_2_2.png",
-        "x_offset": -19,
-        "y_offset": 1
+        "x": -19,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_flat_3.png",
-        "x_offset": -18,
-        "y_offset": 0
+        "x": -18,
+        "y": 0
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_flat_4.png",
-        "x_offset": -18,
-        "y_offset": -6
+        "x": -18,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_flat_1.png",
-        "x_offset": -19,
-        "y_offset": -6
+        "x": -19,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_flat_2.png",
-        "x_offset": -17,
-        "y_offset": 0
+        "x": -17,
+        "y": 0
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_flat_3_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_flat_3_2.png",
-        "x_offset": -3,
-        "y_offset": 1
+        "x": -3,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_flat_4.png",
-        "x_offset": -18,
-        "y_offset": -6
+        "x": -18,
+        "y": -6
     },
     {
         "path": "track/raptor/small_turn_left_bank_gentle_up_1_1.png",
-        "x_offset": -23,
-        "y_offset": -32
+        "x": -23,
+        "y": -32
     },
     {
         "path": "track/raptor/small_turn_left_bank_gentle_up_1_2.png",
-        "x_offset": -12,
-        "y_offset": -18
+        "x": -12,
+        "y": -18
     },
     {
         "path": "track/raptor/small_turn_left_bank_gentle_up_2_1.png",
-        "x_offset": -13,
-        "y_offset": -7
+        "x": -13,
+        "y": -7
     },
     {
         "path": "track/raptor/small_turn_left_bank_gentle_up_2_2.png",
-        "x_offset": -38,
-        "y_offset": -17
+        "x": -38,
+        "y": -17
     },
     {
         "path": "track/raptor/small_turn_left_bank_gentle_up_3_1.png",
-        "x_offset": -15,
-        "y_offset": -3
+        "x": -15,
+        "y": -3
     },
     {
         "path": "track/raptor/small_turn_left_bank_gentle_up_3_2.png",
-        "x_offset": -3,
-        "y_offset": -7
+        "x": -3,
+        "y": -7
     },
     {
         "path": "track/raptor/small_turn_left_bank_gentle_up_4_1.png",
-        "x_offset": -26,
-        "y_offset": -13
+        "x": -26,
+        "y": -13
     },
     {
         "path": "track/raptor/small_turn_left_bank_gentle_up_4_2.png",
-        "x_offset": -26,
-        "y_offset": -4
+        "x": -26,
+        "y": -4
     },
     {
         "path": "track/raptor/small_turn_right_bank_gentle_up_1_1.png",
-        "x_offset": -25,
-        "y_offset": -13
+        "x": -25,
+        "y": -13
     },
     {
         "path": "track/raptor/small_turn_right_bank_gentle_up_1_2.png",
-        "x_offset": -26,
-        "y_offset": -4
+        "x": -26,
+        "y": -4
     },
     {
         "path": "track/raptor/small_turn_right_bank_gentle_up_2_1.png",
-        "x_offset": -11,
-        "y_offset": -3
+        "x": -11,
+        "y": -3
     },
     {
         "path": "track/raptor/small_turn_right_bank_gentle_up_2_2.png",
-        "x_offset": -24,
-        "y_offset": -7
+        "x": -24,
+        "y": -7
     },
     {
         "path": "track/raptor/small_turn_right_bank_gentle_up_3_1.png",
-        "x_offset": -38,
-        "y_offset": -7
+        "x": -38,
+        "y": -7
     },
     {
         "path": "track/raptor/small_turn_right_bank_gentle_up_3_2.png",
-        "x_offset": -14,
-        "y_offset": -17
+        "x": -14,
+        "y": -17
     },
     {
         "path": "track/raptor/small_turn_right_bank_gentle_up_4_1.png",
-        "x_offset": -3,
-        "y_offset": -25
+        "x": -3,
+        "y": -25
     },
     {
         "path": "track/raptor/small_turn_right_bank_gentle_up_4_2.png",
-        "x_offset": -15,
-        "y_offset": -18
+        "x": -15,
+        "y": -18
     },
     {
         "path": "track/raptor/medium_turn_left_bank_gentle_up_1_1.png",
-        "x_offset": -17,
-        "y_offset": -15
+        "x": -17,
+        "y": -15
     },
     {
         "path": "track/raptor/medium_turn_left_bank_gentle_up_1_2.png",
-        "x_offset": -25,
-        "y_offset": -11
+        "x": -25,
+        "y": -11
     },
     {
         "path": "track/raptor/medium_turn_left_bank_gentle_up_1_3.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_left_bank_gentle_up_1_4.png",
-        "x_offset": -25,
-        "y_offset": -8
+        "x": -25,
+        "y": -8
     },
     {
         "path": "track/raptor/medium_turn_left_bank_gentle_up_1_5.png",
-        "x_offset": -18,
-        "y_offset": -15
+        "x": -18,
+        "y": -15
     },
     {
         "path": "track/raptor/medium_turn_left_bank_gentle_up_2_1.png",
-        "x_offset": -19,
-        "y_offset": -5
+        "x": -19,
+        "y": -5
     },
     {
         "path": "track/raptor/medium_turn_left_bank_gentle_up_2_2.png",
-        "x_offset": 0,
-        "y_offset": -14
+        "x": 0,
+        "y": -14
     },
     {
         "path": "track/raptor/medium_turn_left_bank_gentle_up_2_3.png",
-        "x_offset": 0,
-        "y_offset": 2
+        "x": 0,
+        "y": 2
     },
     {
         "path": "track/raptor/medium_turn_left_bank_gentle_up_2_4.png",
-        "x_offset": -11,
-        "y_offset": -21
+        "x": -11,
+        "y": -21
     },
     {
         "path": "track/raptor/medium_turn_left_bank_gentle_up_2_5.png",
-        "x_offset": -16,
-        "y_offset": -14
+        "x": -16,
+        "y": -14
     },
     {
         "path": "track/raptor/medium_turn_left_bank_gentle_up_3_1.png",
-        "x_offset": -22,
-        "y_offset": 0
+        "x": -22,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_left_bank_gentle_up_3_2.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_left_bank_gentle_up_3_3.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_left_bank_gentle_up_3_4.png",
-        "x_offset": 11,
-        "y_offset": -2
+        "x": 11,
+        "y": -2
     },
     {
         "path": "track/raptor/medium_turn_left_bank_gentle_up_3_5.png",
-        "x_offset": -15,
-        "y_offset": 0
+        "x": -15,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_left_bank_gentle_up_4_1.png",
-        "x_offset": -24,
-        "y_offset": -13
+        "x": -24,
+        "y": -13
     },
     {
         "path": "track/raptor/medium_turn_left_bank_gentle_up_4_2.png",
-        "x_offset": -32,
-        "y_offset": -1
+        "x": -32,
+        "y": -1
     },
     {
         "path": "track/raptor/medium_turn_left_bank_gentle_up_4_3.png",
-        "x_offset": -18,
-        "y_offset": -14
+        "x": -18,
+        "y": -14
     },
     {
         "path": "track/raptor/medium_turn_left_bank_gentle_up_4_4.png",
-        "x_offset": -16,
-        "y_offset": 3
+        "x": -16,
+        "y": 3
     },
     {
         "path": "track/raptor/medium_turn_left_bank_gentle_up_4_5.png",
-        "x_offset": -20,
-        "y_offset": 0
+        "x": -20,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_right_bank_gentle_up_1_1.png",
-        "x_offset": -19,
-        "y_offset": -13
+        "x": -19,
+        "y": -13
     },
     {
         "path": "track/raptor/medium_turn_right_bank_gentle_up_1_2.png",
-        "x_offset": -11,
-        "y_offset": -1
+        "x": -11,
+        "y": -1
     },
     {
         "path": "track/raptor/medium_turn_right_bank_gentle_up_1_3.png",
-        "x_offset": 0,
-        "y_offset": -14
+        "x": 0,
+        "y": -14
     },
     {
         "path": "track/raptor/medium_turn_right_bank_gentle_up_1_4.png",
-        "x_offset": -16,
-        "y_offset": 3
+        "x": -16,
+        "y": 3
     },
     {
         "path": "track/raptor/medium_turn_right_bank_gentle_up_1_5.png",
-        "x_offset": -20,
-        "y_offset": 0
+        "x": -20,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_right_bank_gentle_up_2_1.png",
-        "x_offset": -17,
-        "y_offset": 0
+        "x": -17,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_right_bank_gentle_up_2_2.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_right_bank_gentle_up_2_3.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_right_bank_gentle_up_2_4.png",
-        "x_offset": -32,
-        "y_offset": -2
+        "x": -32,
+        "y": -2
     },
     {
         "path": "track/raptor/medium_turn_right_bank_gentle_up_2_5.png",
-        "x_offset": -18,
-        "y_offset": 0
+        "x": -18,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_right_bank_gentle_up_3_1.png",
-        "x_offset": -32,
-        "y_offset": -5
+        "x": -32,
+        "y": -5
     },
     {
         "path": "track/raptor/medium_turn_right_bank_gentle_up_3_2.png",
-        "x_offset": -32,
-        "y_offset": -14
+        "x": -32,
+        "y": -14
     },
     {
         "path": "track/raptor/medium_turn_right_bank_gentle_up_3_3.png",
-        "x_offset": -26,
-        "y_offset": 0
+        "x": -26,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_right_bank_gentle_up_3_4.png",
-        "x_offset": -22,
-        "y_offset": -22
+        "x": -22,
+        "y": -22
     },
     {
         "path": "track/raptor/medium_turn_right_bank_gentle_up_3_5.png",
-        "x_offset": -20,
-        "y_offset": -14
+        "x": -20,
+        "y": -14
     },
     {
         "path": "track/raptor/medium_turn_right_bank_gentle_up_4_1.png",
-        "x_offset": -13,
-        "y_offset": -13
+        "x": -13,
+        "y": -13
     },
     {
         "path": "track/raptor/medium_turn_right_bank_gentle_up_4_2.png",
-        "x_offset": 10,
-        "y_offset": -11
+        "x": 10,
+        "y": -11
     },
     {
         "path": "track/raptor/medium_turn_right_bank_gentle_up_4_3.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_turn_right_bank_gentle_up_4_4.png",
-        "x_offset": 9,
-        "y_offset": -7
+        "x": 9,
+        "y": -7
     },
     {
         "path": "track/raptor/medium_turn_right_bank_gentle_up_4_5.png",
-        "x_offset": -15,
-        "y_offset": -15
+        "x": -15,
+        "y": -15
     },
     {
         "path": "track/raptor/s_bend_left_1_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/s_bend_left_1_2.png",
-        "x_offset": -26,
-        "y_offset": 6
+        "x": -26,
+        "y": 6
     },
     {
         "path": "track/raptor/s_bend_left_1_3.png",
-        "x_offset": 11,
-        "y_offset": 8
+        "x": 11,
+        "y": 8
     },
     {
         "path": "track/raptor/s_bend_left_1_4.png",
-        "x_offset": -15,
-        "y_offset": 2
+        "x": -15,
+        "y": 2
     },
     {
         "path": "track/raptor/s_bend_left_2_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/s_bend_left_2_2.png",
-        "x_offset": -10,
-        "y_offset": 0
+        "x": -10,
+        "y": 0
     },
     {
         "path": "track/raptor/s_bend_left_2_3.png",
-        "x_offset": -30,
-        "y_offset": 16
+        "x": -30,
+        "y": 16
     },
     {
         "path": "track/raptor/s_bend_left_2_4.png",
-        "x_offset": -22,
-        "y_offset": 6
+        "x": -22,
+        "y": 6
     },
     {
         "path": "track/raptor/s_bend_right_1_1.png",
-        "x_offset": -18,
-        "y_offset": 6
+        "x": -18,
+        "y": 6
     },
     {
         "path": "track/raptor/s_bend_right_1_2.png",
-        "x_offset": -19,
-        "y_offset": 16
+        "x": -19,
+        "y": 16
     },
     {
         "path": "track/raptor/s_bend_right_1_3.png",
-        "x_offset": -16,
-        "y_offset": 0
+        "x": -16,
+        "y": 0
     },
     {
         "path": "track/raptor/s_bend_right_1_4.png",
-        "x_offset": -32,
-        "y_offset": 2
+        "x": -32,
+        "y": 2
     },
     {
         "path": "track/raptor/s_bend_right_2_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/s_bend_right_2_2.png",
-        "x_offset": -23,
-        "y_offset": 8
+        "x": -23,
+        "y": 8
     },
     {
         "path": "track/raptor/s_bend_right_2_3.png",
-        "x_offset": 13,
-        "y_offset": 6
+        "x": 13,
+        "y": 6
     },
     {
         "path": "track/raptor/s_bend_right_2_4.png",
-        "x_offset": -12,
-        "y_offset": 2
+        "x": -12,
+        "y": 2
     },
     {
         "path": "track/raptor/small_helix_left_up_1_1.png",
-        "x_offset": -6,
-        "y_offset": -1
+        "x": -6,
+        "y": -1
     },
     {
         "path": "track/raptor/small_helix_left_up_1_2.png",
-        "x_offset": -17,
-        "y_offset": -1
+        "x": -17,
+        "y": -1
     },
     {
         "path": "track/raptor/small_helix_left_up_1_3.png",
-        "x_offset": -32,
-        "y_offset": 1
+        "x": -32,
+        "y": 1
     },
     {
         "path": "track/raptor/small_helix_left_up_1_4.png",
-        "x_offset": -17,
-        "y_offset": -8
+        "x": -17,
+        "y": -8
     },
     {
         "path": "track/raptor/small_helix_left_up_2_1.png",
-        "x_offset": -19,
-        "y_offset": 2
+        "x": -19,
+        "y": 2
     },
     {
         "path": "track/raptor/small_helix_left_up_2_2.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/small_helix_left_up_2_3.png",
-        "x_offset": -32,
-        "y_offset": -6
+        "x": -32,
+        "y": -6
     },
     {
         "path": "track/raptor/small_helix_left_up_3_1.png",
-        "x_offset": -7,
-        "y_offset": 0
+        "x": -7,
+        "y": 0
     },
     {
         "path": "track/raptor/small_helix_left_up_3_2.png",
-        "x_offset": 23,
-        "y_offset": 0
+        "x": 23,
+        "y": 0
     },
     {
         "path": "track/raptor/small_helix_left_up_3_3.png",
-        "x_offset": -2,
-        "y_offset": -1
+        "x": -2,
+        "y": -1
     },
     {
         "path": "track/raptor/small_helix_left_up_3_4.png",
-        "x_offset": -7,
-        "y_offset": -1
+        "x": -7,
+        "y": -1
     },
     {
         "path": "track/raptor/small_helix_left_up_4_1.png",
-        "x_offset": -26,
-        "y_offset": 2
+        "x": -26,
+        "y": 2
     },
     {
         "path": "track/raptor/small_helix_left_up_4_2.png",
-        "x_offset": -8,
-        "y_offset": 17
+        "x": -8,
+        "y": 17
     },
     {
         "path": "track/raptor/small_helix_left_up_4_3.png",
-        "x_offset": -19,
-        "y_offset": 1
+        "x": -19,
+        "y": 1
     },
     {
         "path": "track/raptor/small_helix_right_up_1_1.png",
-        "x_offset": -19,
-        "y_offset": 2
+        "x": -19,
+        "y": 2
     },
     {
         "path": "track/raptor/small_helix_right_up_1_2.png",
-        "x_offset": -6,
-        "y_offset": 17
+        "x": -6,
+        "y": 17
     },
     {
         "path": "track/raptor/small_helix_right_up_1_3.png",
-        "x_offset": -26,
-        "y_offset": 1
+        "x": -26,
+        "y": 1
     },
     {
         "path": "track/raptor/small_helix_right_up_2_1.png",
-        "x_offset": -17,
-        "y_offset": 0
+        "x": -17,
+        "y": 0
     },
     {
         "path": "track/raptor/small_helix_right_up_2_2.png",
-        "x_offset": -32,
-        "y_offset": 1
+        "x": -32,
+        "y": 1
     },
     {
         "path": "track/raptor/small_helix_right_up_2_3.png",
-        "x_offset": -2,
-        "y_offset": -1
+        "x": -2,
+        "y": -1
     },
     {
         "path": "track/raptor/small_helix_right_up_2_4.png",
-        "x_offset": -17,
-        "y_offset": -1
+        "x": -17,
+        "y": -1
     },
     {
         "path": "track/raptor/small_helix_right_up_3_1.png",
-        "x_offset": -32,
-        "y_offset": 2
+        "x": -32,
+        "y": 2
     },
     {
         "path": "track/raptor/small_helix_right_up_3_2.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/small_helix_right_up_3_3.png",
-        "x_offset": -20,
-        "y_offset": -6
+        "x": -20,
+        "y": -6
     },
     {
         "path": "track/raptor/small_helix_right_up_4_1.png",
-        "x_offset": -6,
-        "y_offset": -1
+        "x": -6,
+        "y": -1
     },
     {
         "path": "track/raptor/small_helix_right_up_4_2.png",
-        "x_offset": -8,
-        "y_offset": -1
+        "x": -8,
+        "y": -1
     },
     {
         "path": "track/raptor/small_helix_right_up_4_3.png",
-        "x_offset": 23,
-        "y_offset": 0
+        "x": 23,
+        "y": 0
     },
     {
         "path": "track/raptor/small_helix_right_up_4_4.png",
-        "x_offset": -8,
-        "y_offset": -8
+        "x": -8,
+        "y": -8
     },
     {
         "path": "track/raptor/medium_helix_left_up_1_1.png",
-        "x_offset": -1,
-        "y_offset": 2
+        "x": -1,
+        "y": 2
     },
     {
         "path": "track/raptor/medium_helix_left_up_1_2.png",
-        "x_offset": -17,
-        "y_offset": 3
+        "x": -17,
+        "y": 3
     },
     {
         "path": "track/raptor/medium_helix_left_up_1_3.png",
-        "x_offset": -27,
-        "y_offset": 6
+        "x": -27,
+        "y": 6
     },
     {
         "path": "track/raptor/medium_helix_left_up_1_4.png",
-        "x_offset": 10,
-        "y_offset": 7
+        "x": 10,
+        "y": 7
     },
     {
         "path": "track/raptor/medium_helix_left_up_1_5.png",
-        "x_offset": -20,
-        "y_offset": 7
+        "x": -20,
+        "y": 7
     },
     {
         "path": "track/raptor/medium_helix_left_up_1_6.png",
-        "x_offset": -17,
-        "y_offset": -8
+        "x": -17,
+        "y": -8
     },
     {
         "path": "track/raptor/medium_helix_left_up_2_1.png",
-        "x_offset": -20,
-        "y_offset": 2
+        "x": -20,
+        "y": 2
     },
     {
         "path": "track/raptor/medium_helix_left_up_2_2.png",
-        "x_offset": -6,
-        "y_offset": 0
+        "x": -6,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_helix_left_up_2_3.png",
-        "x_offset": -32,
-        "y_offset": 10
+        "x": -32,
+        "y": 10
     },
     {
         "path": "track/raptor/medium_helix_left_up_2_4.png",
-        "x_offset": -4,
-        "y_offset": 0
+        "x": -4,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_helix_left_up_2_5.png",
-        "x_offset": -32,
-        "y_offset": -6
+        "x": -32,
+        "y": -6
     },
     {
         "path": "track/raptor/medium_helix_left_up_3_1.png",
-        "x_offset": -16,
-        "y_offset": 0
+        "x": -16,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_helix_left_up_3_2.png",
-        "x_offset": 9,
-        "y_offset": 7
+        "x": 9,
+        "y": 7
     },
     {
         "path": "track/raptor/medium_helix_left_up_3_3.png",
-        "x_offset": -22,
-        "y_offset": 7
+        "x": -22,
+        "y": 7
     },
     {
         "path": "track/raptor/medium_helix_left_up_3_4.png",
-        "x_offset": 15,
-        "y_offset": 7
+        "x": 15,
+        "y": 7
     },
     {
         "path": "track/raptor/medium_helix_left_up_3_5.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_helix_left_up_3_6.png",
-        "x_offset": -6,
-        "y_offset": 0
+        "x": -6,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_helix_left_up_4_1.png",
-        "x_offset": -18,
-        "y_offset": 4
+        "x": -18,
+        "y": 4
     },
     {
         "path": "track/raptor/medium_helix_left_up_4_2.png",
-        "x_offset": -32,
-        "y_offset": 12
+        "x": -32,
+        "y": 12
     },
     {
         "path": "track/raptor/medium_helix_left_up_4_3.png",
-        "x_offset": -8,
-        "y_offset": -5
+        "x": -8,
+        "y": -5
     },
     {
         "path": "track/raptor/medium_helix_left_up_4_4.png",
-        "x_offset": -28,
-        "y_offset": 11
+        "x": -28,
+        "y": 11
     },
     {
         "path": "track/raptor/medium_helix_left_up_4_5.png",
-        "x_offset": -19,
-        "y_offset": 1
+        "x": -19,
+        "y": 1
     },
     {
         "path": "track/raptor/medium_helix_right_up_1_1.png",
-        "x_offset": -19,
-        "y_offset": 4
+        "x": -19,
+        "y": 4
     },
     {
         "path": "track/raptor/medium_helix_right_up_1_2.png",
-        "x_offset": -22,
-        "y_offset": 12
+        "x": -22,
+        "y": 12
     },
     {
         "path": "track/raptor/medium_helix_right_up_1_3.png",
-        "x_offset": -8,
-        "y_offset": -5
+        "x": -8,
+        "y": -5
     },
     {
         "path": "track/raptor/medium_helix_right_up_1_4.png",
-        "x_offset": -32,
-        "y_offset": 11
+        "x": -32,
+        "y": 11
     },
     {
         "path": "track/raptor/medium_helix_right_up_1_5.png",
-        "x_offset": -12,
-        "y_offset": 1
+        "x": -12,
+        "y": 1
     },
     {
         "path": "track/raptor/medium_helix_right_up_2_1.png",
-        "x_offset": -17,
-        "y_offset": 0
+        "x": -17,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_helix_right_up_2_2.png",
-        "x_offset": -21,
-        "y_offset": 7
+        "x": -21,
+        "y": 7
     },
     {
         "path": "track/raptor/medium_helix_right_up_2_3.png",
-        "x_offset": 7,
-        "y_offset": 7
+        "x": 7,
+        "y": 7
     },
     {
         "path": "track/raptor/medium_helix_right_up_2_4.png",
-        "x_offset": -30,
-        "y_offset": 7
+        "x": -30,
+        "y": 7
     },
     {
         "path": "track/raptor/medium_helix_right_up_2_5.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_helix_right_up_2_6.png",
-        "x_offset": -17,
-        "y_offset": 0
+        "x": -17,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_helix_right_up_3_1.png",
-        "x_offset": -32,
-        "y_offset": 2
+        "x": -32,
+        "y": 2
     },
     {
         "path": "track/raptor/medium_helix_right_up_3_2.png",
-        "x_offset": -10,
-        "y_offset": 0
+        "x": -10,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_helix_right_up_3_3.png",
-        "x_offset": -32,
-        "y_offset": 10
+        "x": -32,
+        "y": 10
     },
     {
         "path": "track/raptor/medium_helix_right_up_3_4.png",
-        "x_offset": -2,
-        "y_offset": 0
+        "x": -2,
+        "y": 0
     },
     {
         "path": "track/raptor/medium_helix_right_up_3_5.png",
-        "x_offset": -20,
-        "y_offset": -6
+        "x": -20,
+        "y": -6
     },
     {
         "path": "track/raptor/medium_helix_right_up_4_1.png",
-        "x_offset": -6,
-        "y_offset": 2
+        "x": -6,
+        "y": 2
     },
     {
         "path": "track/raptor/medium_helix_right_up_4_2.png",
-        "x_offset": -10,
-        "y_offset": 3
+        "x": -10,
+        "y": 3
     },
     {
         "path": "track/raptor/medium_helix_right_up_4_3.png",
-        "x_offset": 13,
-        "y_offset": 6
+        "x": 13,
+        "y": 6
     },
     {
         "path": "track/raptor/medium_helix_right_up_4_4.png",
-        "x_offset": -22,
-        "y_offset": 7
+        "x": -22,
+        "y": 7
     },
     {
         "path": "track/raptor/medium_helix_right_up_4_5.png",
-        "x_offset": 9,
-        "y_offset": 7
+        "x": 9,
+        "y": 7
     },
     {
         "path": "track/raptor/medium_helix_right_up_4_6.png",
-        "x_offset": -18,
-        "y_offset": -8
+        "x": -18,
+        "y": -8
     },
     {
         "path": "track/raptor/barrel_roll_left_1_1.png",
-        "x_offset": -18,
-        "y_offset": 8
+        "x": -18,
+        "y": 8
     },
     {
         "path": "track/raptor/barrel_roll_left_1_2.png",
-        "x_offset": -5,
-        "y_offset": 6
+        "x": -5,
+        "y": 6
     },
     {
         "path": "track/raptor/barrel_roll_left_1_3.png",
-        "x_offset": -21,
-        "y_offset": 22
+        "x": -21,
+        "y": 22
     },
     {
         "path": "track/raptor/barrel_roll_left_1_4.png",
-        "x_offset": -20,
-        "y_offset": -12
+        "x": -20,
+        "y": -12
     },
     {
         "path": "track/raptor/barrel_roll_left_1_5.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/barrel_roll_left_1_6.png",
-        "x_offset": -9,
-        "y_offset": -21
+        "x": -9,
+        "y": -21
     },
     {
         "path": "track/raptor/barrel_roll_left_2_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/barrel_roll_left_2_2.png",
-        "x_offset": -17,
-        "y_offset": 8
+        "x": -17,
+        "y": 8
     },
     {
         "path": "track/raptor/barrel_roll_left_2_3.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/barrel_roll_left_2_4.png",
-        "x_offset": -28,
-        "y_offset": -2
+        "x": -28,
+        "y": -2
     },
     {
         "path": "track/raptor/barrel_roll_left_2_5.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/barrel_roll_left_2_6.png",
-        "x_offset": -32,
-        "y_offset": -13
+        "x": -32,
+        "y": -13
     },
     {
         "path": "track/raptor/barrel_roll_left_3_1.png",
-        "x_offset": -28,
-        "y_offset": 1
+        "x": -28,
+        "y": 1
     },
     {
         "path": "track/raptor/barrel_roll_left_3_2.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/barrel_roll_left_3_3.png",
-        "x_offset": -26,
-        "y_offset": -8
+        "x": -26,
+        "y": -8
     },
     {
         "path": "track/raptor/barrel_roll_left_3_4.png",
-        "x_offset": -27,
-        "y_offset": -6
+        "x": -27,
+        "y": -6
     },
     {
         "path": "track/raptor/barrel_roll_left_3_5.png",
-        "x_offset": 2,
-        "y_offset": -14
+        "x": 2,
+        "y": -14
     },
     {
         "path": "track/raptor/barrel_roll_left_3_6.png",
-        "x_offset": -18,
-        "y_offset": -19
+        "x": -18,
+        "y": -19
     },
     {
         "path": "track/raptor/barrel_roll_left_4_1.png",
-        "x_offset": -11,
-        "y_offset": -9
+        "x": -11,
+        "y": -9
     },
     {
         "path": "track/raptor/barrel_roll_left_4_2.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/barrel_roll_left_4_3.png",
-        "x_offset": -11,
-        "y_offset": -19
+        "x": -11,
+        "y": -19
     },
     {
         "path": "track/raptor/barrel_roll_left_4_4.png",
-        "x_offset": -10,
-        "y_offset": -21
+        "x": -10,
+        "y": -21
     },
     {
         "path": "track/raptor/barrel_roll_left_4_5.png",
-        "x_offset": 8,
-        "y_offset": -7
+        "x": 8,
+        "y": -7
     },
     {
         "path": "track/raptor/barrel_roll_left_4_6.png",
-        "x_offset": -18,
-        "y_offset": -21
+        "x": -18,
+        "y": -21
     },
     {
         "path": "track/raptor/barrel_roll_right_1_1.png",
-        "x_offset": -18,
-        "y_offset": -9
+        "x": -18,
+        "y": -9
     },
     {
         "path": "track/raptor/barrel_roll_right_1_2.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/barrel_roll_right_1_3.png",
-        "x_offset": -25,
-        "y_offset": -19
+        "x": -25,
+        "y": -19
     },
     {
         "path": "track/raptor/barrel_roll_right_1_4.png",
-        "x_offset": 3,
-        "y_offset": -21
+        "x": 3,
+        "y": -21
     },
     {
         "path": "track/raptor/barrel_roll_right_1_5.png",
-        "x_offset": -22,
-        "y_offset": -14
+        "x": -22,
+        "y": -14
     },
     {
         "path": "track/raptor/barrel_roll_right_1_6.png",
-        "x_offset": -23,
-        "y_offset": -21
+        "x": -23,
+        "y": -21
     },
     {
         "path": "track/raptor/barrel_roll_right_2_1.png",
-        "x_offset": -18,
-        "y_offset": 1
+        "x": -18,
+        "y": 1
     },
     {
         "path": "track/raptor/barrel_roll_right_2_2.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/barrel_roll_right_2_3.png",
-        "x_offset": -6,
-        "y_offset": -8
+        "x": -6,
+        "y": -8
     },
     {
         "path": "track/raptor/barrel_roll_right_2_4.png",
-        "x_offset": 17,
-        "y_offset": -6
+        "x": 17,
+        "y": -6
     },
     {
         "path": "track/raptor/barrel_roll_right_2_5.png",
-        "x_offset": -6,
-        "y_offset": -14
+        "x": -6,
+        "y": -14
     },
     {
         "path": "track/raptor/barrel_roll_right_2_6.png",
-        "x_offset": -6,
-        "y_offset": -19
+        "x": -6,
+        "y": -19
     },
     {
         "path": "track/raptor/barrel_roll_right_3_1.png",
-        "x_offset": -2,
-        "y_offset": 2
+        "x": -2,
+        "y": 2
     },
     {
         "path": "track/raptor/barrel_roll_right_3_2.png",
-        "x_offset": -4,
-        "y_offset": 8
+        "x": -4,
+        "y": 8
     },
     {
         "path": "track/raptor/barrel_roll_right_3_3.png",
-        "x_offset": 6,
-        "y_offset": -2
+        "x": 6,
+        "y": -2
     },
     {
         "path": "track/raptor/barrel_roll_right_3_4.png",
-        "x_offset": 0,
-        "y_offset": -2
+        "x": 0,
+        "y": -2
     },
     {
         "path": "track/raptor/barrel_roll_right_3_5.png",
-        "x_offset": -12,
-        "y_offset": -2
+        "x": -12,
+        "y": -2
     },
     {
         "path": "track/raptor/barrel_roll_right_3_6.png",
-        "x_offset": -18,
-        "y_offset": -13
+        "x": -18,
+        "y": -13
     },
     {
         "path": "track/raptor/barrel_roll_right_4_1.png",
-        "x_offset": -11,
-        "y_offset": 8
+        "x": -11,
+        "y": 8
     },
     {
         "path": "track/raptor/barrel_roll_right_4_2.png",
-        "x_offset": -19,
-        "y_offset": 6
+        "x": -19,
+        "y": 6
     },
     {
         "path": "track/raptor/barrel_roll_right_4_3.png",
-        "x_offset": -9,
-        "y_offset": 1
+        "x": -9,
+        "y": 1
     },
     {
         "path": "track/raptor/barrel_roll_right_4_4.png",
-        "x_offset": -26,
-        "y_offset": -12
+        "x": -26,
+        "y": -12
     },
     {
         "path": "track/raptor/barrel_roll_right_4_5.png",
-        "x_offset": 0,
-        "y_offset": 0
+        "x": 0,
+        "y": 0
     },
     {
         "path": "track/raptor/barrel_roll_right_4_6.png",
-        "x_offset": -18,
-        "y_offset": -21
+        "x": -18,
+        "y": -21
     },
     {
         "path": "track/raptor/half_loop_1_1.png",
-        "x_offset": -24,
-        "y_offset": -18
+        "x": -24,
+        "y": -18
     },
     {
         "path": "track/raptor/half_loop_1_2.png",
-        "x_offset": -19,
-        "y_offset": -38
+        "x": -19,
+        "y": -38
     },
     {
         "path": "track/raptor/half_loop_1_3.png",
-        "x_offset": -12,
-        "y_offset": -82
+        "x": -12,
+        "y": -82
     },
     {
         "path": "track/raptor/half_loop_1_4.png",
-        "x_offset": -18,
-        "y_offset": 23
+        "x": -18,
+        "y": 23
     },
     {
         "path": "track/raptor/half_loop_2_1.png",
-        "x_offset": -12,
-        "y_offset": -4
+        "x": -12,
+        "y": -4
     },
     {
         "path": "track/raptor/half_loop_2_2.png",
-        "x_offset": 1,
-        "y_offset": -31
+        "x": 1,
+        "y": -31
     },
     {
         "path": "track/raptor/half_loop_2_3.png",
-        "x_offset": -38,
-        "y_offset": -113
+        "x": -38,
+        "y": -113
     },
     {
         "path": "track/raptor/half_loop_2_4.png",
-        "x_offset": -18,
-        "y_offset": 11
+        "x": -18,
+        "y": 11
     },
     {
         "path": "track/raptor/half_loop_3_1.png",
-        "x_offset": -26,
-        "y_offset": -4
+        "x": -26,
+        "y": -4
     },
     {
         "path": "track/raptor/half_loop_3_2.png",
-        "x_offset": -25,
-        "y_offset": -27
+        "x": -25,
+        "y": -27
     },
     {
         "path": "track/raptor/half_loop_3_3.png",
-        "x_offset": 2,
-        "y_offset": -120
+        "x": 2,
+        "y": -120
     },
     {
         "path": "track/raptor/half_loop_3_4.png",
-        "x_offset": -22,
-        "y_offset": 3
+        "x": -22,
+        "y": 3
     },
     {
         "path": "track/raptor/half_loop_4_1.png",
-        "x_offset": -12,
-        "y_offset": -18
+        "x": -12,
+        "y": -18
     },
     {
         "path": "track/raptor/half_loop_4_2.png",
-        "x_offset": -12,
-        "y_offset": -42
+        "x": -12,
+        "y": -42
     },
     {
         "path": "track/raptor/half_loop_4_3.png",
-        "x_offset": 8,
-        "y_offset": -91
+        "x": 8,
+        "y": -91
     },
     {
         "path": "track/raptor/half_loop_4_4.png",
-        "x_offset": 5,
-        "y_offset": 15
+        "x": 5,
+        "y": 15
     },
     {
         "path": "track/raptor/flat_to_steep_up_1_1.png",
-        "x_offset": -18,
-        "y_offset": -2
+        "x": -18,
+        "y": -2
     },
     {
         "path": "track/raptor/flat_to_steep_up_1_2.png",
-        "x_offset": -19,
-        "y_offset": -17
+        "x": -19,
+        "y": -17
     },
     {
         "path": "track/raptor/flat_to_steep_up_1_3.png",
-        "x_offset": -17,
-        "y_offset": -25
+        "x": -17,
+        "y": -25
     },
     {
         "path": "track/raptor/flat_to_steep_up_1_4.png",
-        "x_offset": -18,
-        "y_offset": -46
+        "x": -18,
+        "y": -46
     },
     {
         "path": "track/raptor/flat_to_steep_up_2_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_to_steep_up_2_2.png",
-        "x_offset": -24,
-        "y_offset": -4
+        "x": -24,
+        "y": -4
     },
     {
         "path": "track/raptor/flat_to_steep_up_2_3.png",
-        "x_offset": -25,
-        "y_offset": -6
+        "x": -25,
+        "y": -6
     },
     {
         "path": "track/raptor/flat_to_steep_up_2_4.png",
-        "x_offset": -20,
-        "y_offset": -30
+        "x": -20,
+        "y": -30
     },
     {
         "path": "track/raptor/flat_to_steep_up_3_1.png",
-        "x_offset": -20,
-        "y_offset": 2
+        "x": -20,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_to_steep_up_3_2.png",
-        "x_offset": -22,
-        "y_offset": -2
+        "x": -22,
+        "y": -2
     },
     {
         "path": "track/raptor/flat_to_steep_up_3_3.png",
-        "x_offset": -23,
-        "y_offset": -13
+        "x": -23,
+        "y": -13
     },
     {
         "path": "track/raptor/flat_to_steep_up_3_4.png",
-        "x_offset": -21,
-        "y_offset": -30
+        "x": -21,
+        "y": -30
     },
     {
         "path": "track/raptor/flat_to_steep_up_4_1.png",
-        "x_offset": -19,
-        "y_offset": -2
+        "x": -19,
+        "y": -2
     },
     {
         "path": "track/raptor/flat_to_steep_up_4_2.png",
-        "x_offset": -21,
-        "y_offset": -17
+        "x": -21,
+        "y": -17
     },
     {
         "path": "track/raptor/flat_to_steep_up_4_3.png",
-        "x_offset": -20,
-        "y_offset": -25
+        "x": -20,
+        "y": -25
     },
     {
         "path": "track/raptor/flat_to_steep_up_4_4.png",
-        "x_offset": -21,
-        "y_offset": -46
+        "x": -21,
+        "y": -46
     },
     {
         "path": "track/raptor/steep_to_flat_up_1_1.png",
-        "x_offset": -18,
-        "y_offset": -41
+        "x": -18,
+        "y": -41
     },
     {
         "path": "track/raptor/steep_to_flat_up_1_2.png",
-        "x_offset": -20,
-        "y_offset": -26
+        "x": -20,
+        "y": -26
     },
     {
         "path": "track/raptor/steep_to_flat_up_1_3.png",
-        "x_offset": -20,
-        "y_offset": -18
+        "x": -20,
+        "y": -18
     },
     {
         "path": "track/raptor/steep_to_flat_up_1_4.png",
-        "x_offset": -18,
-        "y_offset": -6
+        "x": -18,
+        "y": -6
     },
     {
         "path": "track/raptor/steep_to_flat_up_2_1.png",
-        "x_offset": -18,
-        "y_offset": -26
+        "x": -18,
+        "y": -26
     },
     {
         "path": "track/raptor/steep_to_flat_up_2_2.png",
-        "x_offset": -18,
-        "y_offset": -13
+        "x": -18,
+        "y": -13
     },
     {
         "path": "track/raptor/steep_to_flat_up_2_3.png",
-        "x_offset": -13,
-        "y_offset": -5
+        "x": -13,
+        "y": -5
     },
     {
         "path": "track/raptor/steep_to_flat_up_2_4.png",
-        "x_offset": -14,
-        "y_offset": -1
+        "x": -14,
+        "y": -1
     },
     {
         "path": "track/raptor/steep_to_flat_up_3_1.png",
-        "x_offset": -14,
-        "y_offset": -25
+        "x": -14,
+        "y": -25
     },
     {
         "path": "track/raptor/steep_to_flat_up_3_2.png",
-        "x_offset": -13,
-        "y_offset": -13
+        "x": -13,
+        "y": -13
     },
     {
         "path": "track/raptor/steep_to_flat_up_3_3.png",
-        "x_offset": -16,
-        "y_offset": -5
+        "x": -16,
+        "y": -5
     },
     {
         "path": "track/raptor/steep_to_flat_up_3_4.png",
-        "x_offset": -18,
-        "y_offset": -3
+        "x": -18,
+        "y": -3
     },
     {
         "path": "track/raptor/steep_to_flat_up_4_1.png",
-        "x_offset": -18,
-        "y_offset": -40
+        "x": -18,
+        "y": -40
     },
     {
         "path": "track/raptor/steep_to_flat_up_4_2.png",
-        "x_offset": -18,
-        "y_offset": -26
+        "x": -18,
+        "y": -26
     },
     {
         "path": "track/raptor/steep_to_flat_up_4_3.png",
-        "x_offset": -17,
-        "y_offset": -16
+        "x": -17,
+        "y": -16
     },
     {
         "path": "track/raptor/steep_to_flat_up_4_4.png",
-        "x_offset": -18,
-        "y_offset": -6
+        "x": -18,
+        "y": -6
     },
     {
         "path": "track/raptor/quarter_loop_up_1_1.png",
-        "x_offset": -17,
-        "y_offset": -52
+        "x": -17,
+        "y": -52
     },
     {
         "path": "track/raptor/quarter_loop_up_1_2.png",
-        "x_offset": 0,
-        "y_offset": -30
+        "x": 0,
+        "y": -30
     },
     {
         "path": "track/raptor/quarter_loop_up_1_3.png",
-        "x_offset": -18,
-        "y_offset": -12
+        "x": -18,
+        "y": -12
     },
     {
         "path": "track/raptor/quarter_loop_up_2_1.png",
-        "x_offset": -22,
-        "y_offset": -77
+        "x": -22,
+        "y": -77
     },
     {
         "path": "track/raptor/quarter_loop_up_2_2.png",
-        "x_offset": -32,
-        "y_offset": -66
+        "x": -32,
+        "y": -66
     },
     {
         "path": "track/raptor/quarter_loop_up_2_3.png",
-        "x_offset": -18,
-        "y_offset": -21
+        "x": -18,
+        "y": -21
     },
     {
         "path": "track/raptor/quarter_loop_up_3_1.png",
-        "x_offset": -6,
-        "y_offset": -76
+        "x": -6,
+        "y": -76
     },
     {
         "path": "track/raptor/quarter_loop_up_3_2.png",
-        "x_offset": -17,
-        "y_offset": -68
+        "x": -17,
+        "y": -68
     },
     {
         "path": "track/raptor/quarter_loop_up_3_3.png",
-        "x_offset": 0,
-        "y_offset": -21
+        "x": 0,
+        "y": -21
     },
     {
         "path": "track/raptor/quarter_loop_up_4_1.png",
-        "x_offset": -6,
-        "y_offset": -52
+        "x": -6,
+        "y": -52
     },
     {
         "path": "track/raptor/quarter_loop_up_4_2.png",
-        "x_offset": -20,
-        "y_offset": -30
+        "x": -20,
+        "y": -30
     },
     {
         "path": "track/raptor/quarter_loop_up_4_3.png",
-        "x_offset": -32,
-        "y_offset": -12
+        "x": -32,
+        "y": -12
     },
     {
         "path": "track/raptor/corkscrew_left_1_1.png",
-        "x_offset": -18,
-        "y_offset": -32
+        "x": -18,
+        "y": -32
     },
     {
         "path": "track/raptor/corkscrew_left_1_2.png",
-        "x_offset": -17,
-        "y_offset": -29
+        "x": -17,
+        "y": -29
     },
     {
         "path": "track/raptor/corkscrew_left_1_3.png",
-        "x_offset": -18,
-        "y_offset": -21
+        "x": -18,
+        "y": -21
     },
     {
         "path": "track/raptor/corkscrew_left_2_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/corkscrew_left_2_2.png",
-        "x_offset": -32,
-        "y_offset": -28
+        "x": -32,
+        "y": -28
     },
     {
         "path": "track/raptor/corkscrew_left_2_3.png",
-        "x_offset": -18,
-        "y_offset": -21
+        "x": -18,
+        "y": -21
     },
     {
         "path": "track/raptor/corkscrew_left_3_1.png",
-        "x_offset": -26,
-        "y_offset": -4
+        "x": -26,
+        "y": -4
     },
     {
         "path": "track/raptor/corkscrew_left_3_2.png",
-        "x_offset": 5,
-        "y_offset": -14
+        "x": 5,
+        "y": -14
     },
     {
         "path": "track/raptor/corkscrew_left_3_3.png",
-        "x_offset": -19,
-        "y_offset": -11
+        "x": -19,
+        "y": -11
     },
     {
         "path": "track/raptor/corkscrew_left_4_1.png",
-        "x_offset": -29,
-        "y_offset": -32
+        "x": -29,
+        "y": -32
     },
     {
         "path": "track/raptor/corkscrew_left_4_2.png",
-        "x_offset": -27,
-        "y_offset": -14
+        "x": -27,
+        "y": -14
     },
     {
         "path": "track/raptor/corkscrew_left_4_3.png",
-        "x_offset": -18,
-        "y_offset": -11
+        "x": -18,
+        "y": -11
     },
     {
         "path": "track/raptor/corkscrew_right_1_1.png",
-        "x_offset": -18,
-        "y_offset": -32
+        "x": -18,
+        "y": -32
     },
     {
         "path": "track/raptor/corkscrew_right_1_2.png",
-        "x_offset": -6,
-        "y_offset": -14
+        "x": -6,
+        "y": -14
     },
     {
         "path": "track/raptor/corkscrew_right_1_3.png",
-        "x_offset": -19,
-        "y_offset": -11
+        "x": -19,
+        "y": -11
     },
     {
         "path": "track/raptor/corkscrew_right_2_1.png",
-        "x_offset": -18,
-        "y_offset": -4
+        "x": -18,
+        "y": -4
     },
     {
         "path": "track/raptor/corkscrew_right_2_2.png",
-        "x_offset": -13,
-        "y_offset": -14
+        "x": -13,
+        "y": -14
     },
     {
         "path": "track/raptor/corkscrew_right_2_3.png",
-        "x_offset": -18,
-        "y_offset": -11
+        "x": -18,
+        "y": -11
     },
     {
         "path": "track/raptor/corkscrew_right_3_1.png",
-        "x_offset": -20,
-        "y_offset": -2
+        "x": -20,
+        "y": -2
     },
     {
         "path": "track/raptor/corkscrew_right_3_2.png",
-        "x_offset": -18,
-        "y_offset": -28
+        "x": -18,
+        "y": -28
     },
     {
         "path": "track/raptor/corkscrew_right_3_3.png",
-        "x_offset": -18,
-        "y_offset": -21
+        "x": -18,
+        "y": -21
     },
     {
         "path": "track/raptor/corkscrew_right_4_1.png",
-        "x_offset": -22,
-        "y_offset": -32
+        "x": -22,
+        "y": -32
     },
     {
         "path": "track/raptor/corkscrew_right_4_2.png",
-        "x_offset": 5,
-        "y_offset": -29
+        "x": 5,
+        "y": -29
     },
     {
         "path": "track/raptor/corkscrew_right_4_3.png",
-        "x_offset": -20,
-        "y_offset": -21
+        "x": -20,
+        "y": -21
     },
     {
         "path": "track/raptor/large_corkscrew_left_1_1.png",
-        "x_offset": -18,
-        "y_offset": -6,
+        "x": -18,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_left_1_2.png",
-        "x_offset": -18,
-        "y_offset": -52,
+        "x": -18,
+        "y": -52,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_left_1_3.png",
-        "x_offset": -26,
-        "y_offset": -33,
+        "x": -26,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_left_1_4.png",
-        "x_offset": -20,
-        "y_offset": -45,
+        "x": -20,
+        "y": -45,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_left_1_5.png",
-        "x_offset": -18,
-        "y_offset": -29,
+        "x": -18,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_left_2_1.png",
-        "x_offset": -18,
-        "y_offset": 2,
+        "x": -18,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_left_2_2.png",
-        "x_offset": -32,
-        "y_offset": -9,
+        "x": -32,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_left_2_3.png",
-        "x_offset": -20,
-        "y_offset": -43,
+        "x": -20,
+        "y": -43,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_left_2_4.png",
-        "x_offset": -15,
-        "y_offset": -50,
+        "x": -15,
+        "y": -50,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_left_2_5.png",
-        "x_offset": -12,
-        "y_offset": -29,
+        "x": -12,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_left_3_1.png",
-        "x_offset": -16,
-        "y_offset": 2,
+        "x": -16,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_left_3_2.png",
-        "x_offset": -13,
-        "y_offset": -12,
+        "x": -13,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_left_3_3.png",
-        "x_offset": 17,
-        "y_offset": -21,
+        "x": 17,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_left_3_4.png",
-        "x_offset": -8,
-        "y_offset": -30,
+        "x": -8,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_left_3_5.png",
-        "x_offset": -16,
-        "y_offset": -22,
+        "x": -16,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_left_4_1.png",
-        "x_offset": -20,
-        "y_offset": -5,
+        "x": -20,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_left_4_2.png",
-        "x_offset": -19,
-        "y_offset": -20,
+        "x": -19,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_left_4_3.png",
-        "x_offset": -10,
-        "y_offset": -7,
+        "x": -10,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_left_4_4.png",
-        "x_offset": -16,
-        "y_offset": -27,
+        "x": -16,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_left_4_5.png",
-        "x_offset": -18,
-        "y_offset": -21,
+        "x": -18,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_right_1_1.png",
-        "x_offset": -18,
-        "y_offset": -5,
+        "x": -18,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_right_1_2.png",
-        "x_offset": -18,
-        "y_offset": -20,
+        "x": -18,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_right_1_3.png",
-        "x_offset": -16,
-        "y_offset": -7,
+        "x": -16,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_right_1_4.png",
-        "x_offset": -27,
-        "y_offset": -27,
+        "x": -27,
+        "y": -27,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_right_1_5.png",
-        "x_offset": -32,
-        "y_offset": -21,
+        "x": -32,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_right_2_1.png",
-        "x_offset": -18,
-        "y_offset": 2,
+        "x": -18,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_right_2_2.png",
-        "x_offset": -16,
-        "y_offset": -18,
+        "x": -16,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_right_2_3.png",
-        "x_offset": -24,
-        "y_offset": -21,
+        "x": -24,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_right_2_4.png",
-        "x_offset": -16,
-        "y_offset": -30,
+        "x": -16,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_right_2_5.png",
-        "x_offset": -18,
-        "y_offset": -22,
+        "x": -18,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_right_3_1.png",
-        "x_offset": -40,
-        "y_offset": 1,
+        "x": -40,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_right_3_2.png",
-        "x_offset": -16,
-        "y_offset": -9,
+        "x": -16,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_right_3_3.png",
-        "x_offset": -21,
-        "y_offset": -43,
+        "x": -21,
+        "y": -43,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_right_3_4.png",
-        "x_offset": -25,
-        "y_offset": -50,
+        "x": -25,
+        "y": -50,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_right_3_5.png",
-        "x_offset": -18,
-        "y_offset": -29,
+        "x": -18,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_right_4_1.png",
-        "x_offset": -20,
-        "y_offset": -6,
+        "x": -20,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_right_4_2.png",
-        "x_offset": -11,
-        "y_offset": -52,
+        "x": -11,
+        "y": -52,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_right_4_3.png",
-        "x_offset": 17,
-        "y_offset": -33,
+        "x": 17,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_right_4_4.png",
-        "x_offset": -11,
-        "y_offset": -45,
+        "x": -11,
+        "y": -45,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_corkscrew_right_4_5.png",
-        "x_offset": -18,
-        "y_offset": -29,
+        "x": -18,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/raptor/small_turn_left_bank_to_gentle_up_1_1.png",
-        "x_offset": -23,
-        "y_offset": -16
+        "x": -23,
+        "y": -16
     },
     {
         "path": "track/raptor/small_turn_left_bank_to_gentle_up_1_2.png",
-        "x_offset": -13,
-        "y_offset": -9
+        "x": -13,
+        "y": -9
     },
     {
         "path": "track/raptor/small_turn_left_bank_to_gentle_up_2_1.png",
-        "x_offset": 26,
-        "y_offset": 0
+        "x": 26,
+        "y": 0
     },
     {
         "path": "track/raptor/small_turn_left_bank_to_gentle_up_2_2.png",
-        "x_offset": -13,
-        "y_offset": -2
+        "x": -13,
+        "y": -2
     },
     {
         "path": "track/raptor/small_turn_left_bank_to_gentle_up_2_3.png",
-        "x_offset": -38,
-        "y_offset": -9
+        "x": -38,
+        "y": -9
     },
     {
         "path": "track/raptor/small_turn_left_bank_to_gentle_up_3_1.png",
-        "x_offset": -14,
-        "y_offset": -3
+        "x": -14,
+        "y": -3
     },
     {
         "path": "track/raptor/small_turn_left_bank_to_gentle_up_3_2.png",
-        "x_offset": -2,
-        "y_offset": 0
+        "x": -2,
+        "y": 0
     },
     {
         "path": "track/raptor/small_turn_left_bank_to_gentle_up_4_1.png",
-        "x_offset": -26,
-        "y_offset": -5
+        "x": -26,
+        "y": -5
     },
     {
         "path": "track/raptor/small_turn_left_bank_to_gentle_up_4_2.png",
-        "x_offset": -25,
-        "y_offset": 6
+        "x": -25,
+        "y": 6
     },
     {
         "path": "track/raptor/small_turn_right_bank_to_gentle_up_1_1.png",
-        "x_offset": -25,
-        "y_offset": -5
+        "x": -25,
+        "y": -5
     },
     {
         "path": "track/raptor/small_turn_right_bank_to_gentle_up_1_2.png",
-        "x_offset": -26,
-        "y_offset": 6
+        "x": -26,
+        "y": 6
     },
     {
         "path": "track/raptor/small_turn_right_bank_to_gentle_up_2_1.png",
-        "x_offset": -11,
-        "y_offset": -3
+        "x": -11,
+        "y": -3
     },
     {
         "path": "track/raptor/small_turn_right_bank_to_gentle_up_2_2.png",
-        "x_offset": -24,
-        "y_offset": 0
+        "x": -24,
+        "y": 0
     },
     {
         "path": "track/raptor/small_turn_right_bank_to_gentle_up_3_1.png",
-        "x_offset": -38,
-        "y_offset": 0
+        "x": -38,
+        "y": 0
     },
     {
         "path": "track/raptor/small_turn_right_bank_to_gentle_up_3_2.png",
-        "x_offset": -38,
-        "y_offset": -2
+        "x": -38,
+        "y": -2
     },
     {
         "path": "track/raptor/small_turn_right_bank_to_gentle_up_3_3.png",
-        "x_offset": -13,
-        "y_offset": -9
+        "x": -13,
+        "y": -9
     },
     {
         "path": "track/raptor/small_turn_right_bank_to_gentle_up_4_1.png",
-        "x_offset": -2,
-        "y_offset": -16
+        "x": -2,
+        "y": -16
     },
     {
         "path": "track/raptor/small_turn_right_bank_to_gentle_up_4_2.png",
-        "x_offset": -14,
-        "y_offset": -9
+        "x": -14,
+        "y": -9
     },
     {
         "path": "track/raptor/medium_half_loop_left_1_1.png",
-        "x_offset": -18,
-        "y_offset": -28,
+        "x": -18,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_left_1_2.png",
-        "x_offset": -18,
-        "y_offset": -45,
+        "x": -18,
+        "y": -45,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_left_1_3.png",
-        "x_offset": -26,
-        "y_offset": -70,
+        "x": -26,
+        "y": -70,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_left_1_4.png",
-        "x_offset": -1,
-        "y_offset": -115,
+        "x": -1,
+        "y": -115,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_left_1_5.png",
-        "x_offset": -18,
-        "y_offset": -26,
+        "x": -18,
+        "y": -26,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_left_2_1.png",
-        "x_offset": -18,
-        "y_offset": -9,
+        "x": -18,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_left_2_2.png",
-        "x_offset": -32,
-        "y_offset": -28,
+        "x": -32,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_left_2_3.png",
-        "x_offset": 0,
-        "y_offset": -83,
+        "x": 0,
+        "y": -83,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_left_2_4.png",
-        "x_offset": -27,
-        "y_offset": -142,
+        "x": -27,
+        "y": -142,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_left_2_5.png",
-        "x_offset": -18,
-        "y_offset": -37,
+        "x": -18,
+        "y": -37,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_left_3_1.png",
-        "x_offset": -20,
-        "y_offset": -2,
+        "x": -20,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_left_3_2.png",
-        "x_offset": 0,
-        "y_offset": -8,
+        "x": 0,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_left_3_3.png",
-        "x_offset": 1,
-        "y_offset": -52,
+        "x": 1,
+        "y": -52,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_left_3_4.png",
-        "x_offset": -30,
-        "y_offset": -147,
+        "x": -30,
+        "y": -147,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_left_3_5.png",
-        "x_offset": -15,
-        "y_offset": -37,
+        "x": -15,
+        "y": -37,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_left_4_1.png",
-        "x_offset": -20,
-        "y_offset": -12,
+        "x": -20,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_left_4_2.png",
-        "x_offset": -22,
-        "y_offset": -19,
+        "x": -22,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_left_4_3.png",
-        "x_offset": -28,
-        "y_offset": -25,
+        "x": -28,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_left_4_4.png",
-        "x_offset": -6,
-        "y_offset": -119,
+        "x": -6,
+        "y": -119,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_left_4_5.png",
-        "x_offset": -23,
-        "y_offset": -29,
+        "x": -23,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_right_1_1.png",
-        "x_offset": -18,
-        "y_offset": -12,
+        "x": -18,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_right_1_2.png",
-        "x_offset": -17,
-        "y_offset": -19,
+        "x": -17,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_right_1_3.png",
-        "x_offset": -15,
-        "y_offset": -25,
+        "x": -15,
+        "y": -25,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_right_1_4.png",
-        "x_offset": -13,
-        "y_offset": -119,
+        "x": -13,
+        "y": -119,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_right_1_5.png",
-        "x_offset": -18,
-        "y_offset": -29,
+        "x": -18,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_right_2_1.png",
-        "x_offset": -18,
-        "y_offset": -2,
+        "x": -18,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_right_2_2.png",
-        "x_offset": -32,
-        "y_offset": -8,
+        "x": -32,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_right_2_3.png",
-        "x_offset": -32,
-        "y_offset": -52,
+        "x": -32,
+        "y": -52,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_right_2_4.png",
-        "x_offset": -22,
-        "y_offset": -147,
+        "x": -22,
+        "y": -147,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_right_2_5.png",
-        "x_offset": -18,
-        "y_offset": -37,
+        "x": -18,
+        "y": -37,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_right_3_1.png",
-        "x_offset": -34,
-        "y_offset": -9,
+        "x": -34,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_right_3_2.png",
-        "x_offset": -32,
-        "y_offset": -28,
+        "x": -32,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_right_3_3.png",
-        "x_offset": -32,
-        "y_offset": -83,
+        "x": -32,
+        "y": -83,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_right_3_4.png",
-        "x_offset": -6,
-        "y_offset": -142,
+        "x": -6,
+        "y": -142,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_right_3_5.png",
-        "x_offset": -10,
-        "y_offset": -37,
+        "x": -10,
+        "y": -37,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_right_4_1.png",
-        "x_offset": -20,
-        "y_offset": -28,
+        "x": -20,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_right_4_2.png",
-        "x_offset": -13,
-        "y_offset": -45,
+        "x": -13,
+        "y": -45,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_right_4_3.png",
-        "x_offset": 1,
-        "y_offset": -70,
+        "x": 1,
+        "y": -70,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_right_4_4.png",
-        "x_offset": -31,
-        "y_offset": -115,
+        "x": -31,
+        "y": -115,
         "palette": "keep"
     },
     {
         "path": "track/raptor/medium_half_loop_right_4_5.png",
-        "x_offset": -32,
-        "y_offset": -26,
+        "x": -32,
+        "y": -26,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_half_loop_left_1_1.png",
-        "x_offset": -18,
-        "y_offset": -22
+        "x": -18,
+        "y": -22
     },
     {
         "path": "track/raptor/large_half_loop_left_1_2.png",
-        "x_offset": -16,
-        "y_offset": -36
+        "x": -16,
+        "y": -36
     },
     {
         "path": "track/raptor/large_half_loop_left_1_3.png",
-        "x_offset": -16,
-        "y_offset": -64
+        "x": -16,
+        "y": -64
     },
     {
         "path": "track/raptor/large_half_loop_left_1_4.png",
-        "x_offset": -20,
-        "y_offset": -80
+        "x": -20,
+        "y": -80
     },
     {
         "path": "track/raptor/large_half_loop_left_1_5.png",
-        "x_offset": -12,
-        "y_offset": -65
+        "x": -12,
+        "y": -65
     },
     {
         "path": "track/raptor/large_half_loop_left_1_6.png",
-        "x_offset": -8,
-        "y_offset": -172
+        "x": -8,
+        "y": -172
     },
     {
         "path": "track/raptor/large_half_loop_left_1_7.png",
-        "x_offset": -18,
-        "y_offset": -9
+        "x": -18,
+        "y": -9
     },
     {
         "path": "track/raptor/large_half_loop_left_2_1.png",
-        "x_offset": -18,
-        "y_offset": -1
+        "x": -18,
+        "y": -1
     },
     {
         "path": "track/raptor/large_half_loop_left_2_2.png",
-        "x_offset": -6,
-        "y_offset": -4
+        "x": -6,
+        "y": -4
     },
     {
         "path": "track/raptor/large_half_loop_left_2_3.png",
-        "x_offset": -9,
-        "y_offset": -22
+        "x": -9,
+        "y": -22
     },
     {
         "path": "track/raptor/large_half_loop_left_2_4.png",
-        "x_offset": -8,
-        "y_offset": -69
+        "x": -8,
+        "y": -69
     },
     {
         "path": "track/raptor/large_half_loop_left_2_5.png",
-        "x_offset": -32,
-        "y_offset": -118
+        "x": -32,
+        "y": -118
     },
     {
         "path": "track/raptor/large_half_loop_left_2_6.png",
-        "x_offset": -22,
-        "y_offset": -191
+        "x": -22,
+        "y": -191
     },
     {
         "path": "track/raptor/large_half_loop_left_2_7.png",
-        "x_offset": -18,
-        "y_offset": -21
+        "x": -18,
+        "y": -21
     },
     {
         "path": "track/raptor/large_half_loop_left_3_1.png",
-        "x_offset": -24,
-        "y_offset": 1
+        "x": -24,
+        "y": 1
     },
     {
         "path": "track/raptor/large_half_loop_left_3_2.png",
-        "x_offset": -29,
-        "y_offset": -5
+        "x": -29,
+        "y": -5
     },
     {
         "path": "track/raptor/large_half_loop_left_3_3.png",
-        "x_offset": -24,
-        "y_offset": -32
+        "x": -24,
+        "y": -32
     },
     {
         "path": "track/raptor/large_half_loop_left_3_4.png",
-        "x_offset": -3,
-        "y_offset": -56
+        "x": -3,
+        "y": -56
     },
     {
         "path": "track/raptor/large_half_loop_left_3_5.png",
-        "x_offset": -3,
-        "y_offset": -111
+        "x": -3,
+        "y": -111
     },
     {
         "path": "track/raptor/large_half_loop_left_3_6.png",
-        "x_offset": -19,
-        "y_offset": -191
+        "x": -19,
+        "y": -191
     },
     {
         "path": "track/raptor/large_half_loop_left_3_7.png",
-        "x_offset": -25,
-        "y_offset": -21
+        "x": -25,
+        "y": -21
     },
     {
         "path": "track/raptor/large_half_loop_left_4_1.png",
-        "x_offset": -21,
-        "y_offset": -11
+        "x": -21,
+        "y": -11
     },
     {
         "path": "track/raptor/large_half_loop_left_4_2.png",
-        "x_offset": -27,
-        "y_offset": -15
+        "x": -27,
+        "y": -15
     },
     {
         "path": "track/raptor/large_half_loop_left_4_3.png",
-        "x_offset": -32,
-        "y_offset": -40
+        "x": -32,
+        "y": -40
     },
     {
         "path": "track/raptor/large_half_loop_left_4_4.png",
-        "x_offset": -32,
-        "y_offset": -69
+        "x": -32,
+        "y": -69
     },
     {
         "path": "track/raptor/large_half_loop_left_4_5.png",
-        "x_offset": 20,
-        "y_offset": -58
+        "x": 20,
+        "y": -58
     },
     {
         "path": "track/raptor/large_half_loop_left_4_6.png",
-        "x_offset": -12,
-        "y_offset": -176
+        "x": -12,
+        "y": -176
     },
     {
         "path": "track/raptor/large_half_loop_left_4_7.png",
-        "x_offset": -18,
-        "y_offset": -12
+        "x": -18,
+        "y": -12
     },
     {
         "path": "track/raptor/large_half_loop_right_1_1.png",
-        "x_offset": -18,
-        "y_offset": -11
+        "x": -18,
+        "y": -11
     },
     {
         "path": "track/raptor/large_half_loop_right_1_2.png",
-        "x_offset": -16,
-        "y_offset": -15
+        "x": -16,
+        "y": -15
     },
     {
         "path": "track/raptor/large_half_loop_right_1_3.png",
-        "x_offset": -10,
-        "y_offset": -40
+        "x": -10,
+        "y": -40
     },
     {
         "path": "track/raptor/large_half_loop_right_1_4.png",
-        "x_offset": 0,
-        "y_offset": -69
+        "x": 0,
+        "y": -69
     },
     {
         "path": "track/raptor/large_half_loop_right_1_5.png",
-        "x_offset": -32,
-        "y_offset": -58
+        "x": -32,
+        "y": -58
     },
     {
         "path": "track/raptor/large_half_loop_right_1_6.png",
-        "x_offset": -17,
-        "y_offset": -176
+        "x": -17,
+        "y": -176
     },
     {
         "path": "track/raptor/large_half_loop_right_1_7.png",
-        "x_offset": -18,
-        "y_offset": -12
+        "x": -18,
+        "y": -12
     },
     {
         "path": "track/raptor/large_half_loop_right_2_1.png",
-        "x_offset": -18,
-        "y_offset": 1
+        "x": -18,
+        "y": 1
     },
     {
         "path": "track/raptor/large_half_loop_right_2_2.png",
-        "x_offset": -10,
-        "y_offset": -5
+        "x": -10,
+        "y": -5
     },
     {
         "path": "track/raptor/large_half_loop_right_2_3.png",
-        "x_offset": -5,
-        "y_offset": -32
+        "x": -5,
+        "y": -32
     },
     {
         "path": "track/raptor/large_half_loop_right_2_4.png",
-        "x_offset": -14,
-        "y_offset": -56
+        "x": -14,
+        "y": -56
     },
     {
         "path": "track/raptor/large_half_loop_right_2_5.png",
-        "x_offset": -19,
-        "y_offset": -111
+        "x": -19,
+        "y": -111
     },
     {
         "path": "track/raptor/large_half_loop_right_2_6.png",
-        "x_offset": -13,
-        "y_offset": -191
+        "x": -13,
+        "y": -191
     },
     {
         "path": "track/raptor/large_half_loop_right_2_7.png",
-        "x_offset": -18,
-        "y_offset": -21
+        "x": -18,
+        "y": -21
     },
     {
         "path": "track/raptor/large_half_loop_right_3_1.png",
-        "x_offset": -26,
-        "y_offset": -1
+        "x": -26,
+        "y": -1
     },
     {
         "path": "track/raptor/large_half_loop_right_3_2.png",
-        "x_offset": -26,
-        "y_offset": -4
+        "x": -26,
+        "y": -4
     },
     {
         "path": "track/raptor/large_half_loop_right_3_3.png",
-        "x_offset": -28,
-        "y_offset": -22
+        "x": -28,
+        "y": -22
     },
     {
         "path": "track/raptor/large_half_loop_right_3_4.png",
-        "x_offset": -32,
-        "y_offset": -69
+        "x": -32,
+        "y": -69
     },
     {
         "path": "track/raptor/large_half_loop_right_3_5.png",
-        "x_offset": 20,
-        "y_offset": -118
+        "x": 20,
+        "y": -118
     },
     {
         "path": "track/raptor/large_half_loop_right_3_6.png",
-        "x_offset": 0,
-        "y_offset": -191
+        "x": 0,
+        "y": -191
     },
     {
         "path": "track/raptor/large_half_loop_right_3_7.png",
-        "x_offset": -15,
-        "y_offset": -21
+        "x": -15,
+        "y": -21
     },
     {
         "path": "track/raptor/large_half_loop_right_4_1.png",
-        "x_offset": -21,
-        "y_offset": -22
+        "x": -21,
+        "y": -22
     },
     {
         "path": "track/raptor/large_half_loop_right_4_2.png",
-        "x_offset": -22,
-        "y_offset": -36
+        "x": -22,
+        "y": -36
     },
     {
         "path": "track/raptor/large_half_loop_right_4_3.png",
-        "x_offset": -18,
-        "y_offset": -64
+        "x": -18,
+        "y": -64
     },
     {
         "path": "track/raptor/large_half_loop_right_4_4.png",
-        "x_offset": -2,
-        "y_offset": -80
+        "x": -2,
+        "y": -80
     },
     {
         "path": "track/raptor/large_half_loop_right_4_5.png",
-        "x_offset": -3,
-        "y_offset": -65
+        "x": -3,
+        "y": -65
     },
     {
         "path": "track/raptor/large_half_loop_right_4_6.png",
-        "x_offset": -27,
-        "y_offset": -172
+        "x": -27,
+        "y": -172
     },
     {
         "path": "track/raptor/large_half_loop_right_4_7.png",
-        "x_offset": -27,
-        "y_offset": -9
+        "x": -27,
+        "y": -9
     },
     {
         "path": "track/raptor/zero_g_roll_left_1_1.png",
-        "x_offset": -18,
-        "y_offset": -9,
+        "x": -18,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_left_1_2.png",
-        "x_offset": 4,
-        "y_offset": -12,
+        "x": 4,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_left_1_3.png",
-        "x_offset": -10,
-        "y_offset": -19,
+        "x": -10,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_left_1_4.png",
-        "x_offset": -16,
-        "y_offset": -21,
+        "x": -16,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_left_2_1.png",
-        "x_offset": -18,
-        "y_offset": 1,
+        "x": -18,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_left_2_2.png",
-        "x_offset": -17,
-        "y_offset": 2,
+        "x": -17,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_left_2_3.png",
-        "x_offset": -23,
-        "y_offset": -11,
+        "x": -23,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_left_2_4.png",
-        "x_offset": -21,
-        "y_offset": -11,
+        "x": -21,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_left_3_1.png",
-        "x_offset": -19,
-        "y_offset": -4,
+        "x": -19,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_left_3_2.png",
-        "x_offset": -21,
-        "y_offset": -19,
+        "x": -21,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_left_3_3.png",
-        "x_offset": 4,
-        "y_offset": -15,
+        "x": 4,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_left_3_4.png",
-        "x_offset": -18,
-        "y_offset": -19,
+        "x": -18,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_left_4_1.png",
-        "x_offset": -12,
-        "y_offset": -21,
+        "x": -12,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_left_4_2.png",
-        "x_offset": -11,
-        "y_offset": -34,
+        "x": -11,
+        "y": -34,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_left_4_3.png",
-        "x_offset": 12,
-        "y_offset": -4,
+        "x": 12,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_left_4_4.png",
-        "x_offset": -18,
-        "y_offset": -21,
+        "x": -18,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_right_1_1.png",
-        "x_offset": -18,
-        "y_offset": -21,
+        "x": -18,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_right_1_2.png",
-        "x_offset": -25,
-        "y_offset": -34,
+        "x": -25,
+        "y": -34,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_right_1_3.png",
-        "x_offset": -22,
-        "y_offset": -13,
+        "x": -22,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_right_1_4.png",
-        "x_offset": -24,
-        "y_offset": -21,
+        "x": -24,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_right_2_1.png",
-        "x_offset": -18,
-        "y_offset": -4,
+        "x": -18,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_right_2_2.png",
-        "x_offset": -15,
-        "y_offset": -19,
+        "x": -15,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_right_2_3.png",
-        "x_offset": -12,
-        "y_offset": -15,
+        "x": -12,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_right_2_4.png",
-        "x_offset": -11,
-        "y_offset": -19,
+        "x": -11,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_right_3_1.png",
-        "x_offset": -9,
-        "y_offset": 1,
+        "x": -9,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_right_3_2.png",
-        "x_offset": -9,
-        "y_offset": 3,
+        "x": -9,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_right_3_3.png",
-        "x_offset": -11,
-        "y_offset": -11,
+        "x": -11,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_right_3_4.png",
-        "x_offset": -18,
-        "y_offset": -11,
+        "x": -18,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_right_4_1.png",
-        "x_offset": -20,
-        "y_offset": -10,
+        "x": -20,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_right_4_2.png",
-        "x_offset": -27,
-        "y_offset": -12,
+        "x": -27,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_right_4_3.png",
-        "x_offset": -22,
-        "y_offset": -19,
+        "x": -22,
+        "y": -19,
         "palette": "keep"
     },
     {
         "path": "track/raptor/zero_g_roll_right_4_4.png",
-        "x_offset": -18,
-        "y_offset": -21,
+        "x": -18,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_left_1_1.png",
-        "x_offset": -18,
-        "y_offset": -42,
+        "x": -18,
+        "y": -42,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_left_1_2.png",
-        "x_offset": -21,
-        "y_offset": 0,
+        "x": -21,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_left_1_3.png",
-        "x_offset": -16,
-        "y_offset": -47,
+        "x": -16,
+        "y": -47,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_left_1_4.png",
-        "x_offset": -11,
-        "y_offset": -33,
+        "x": -11,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_left_1_5.png",
-        "x_offset": -14,
-        "y_offset": -21,
+        "x": -14,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_left_2_1.png",
-        "x_offset": -18,
-        "y_offset": -36,
+        "x": -18,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_left_2_2.png",
-        "x_offset": -23,
-        "y_offset": -24,
+        "x": -23,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_left_2_3.png",
-        "x_offset": -29,
-        "y_offset": -18,
+        "x": -29,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_left_2_4.png",
-        "x_offset": -28,
-        "y_offset": -12,
+        "x": -28,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_left_3_1.png",
-        "x_offset": -9,
-        "y_offset": -29,
+        "x": -9,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_left_3_2.png",
-        "x_offset": -12,
-        "y_offset": -28,
+        "x": -12,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_left_3_3.png",
-        "x_offset": -23,
-        "y_offset": -33,
+        "x": -23,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_left_3_4.png",
-        "x_offset": -24,
-        "y_offset": -23,
+        "x": -24,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_left_3_5.png",
-        "x_offset": 7,
-        "y_offset": -9,
+        "x": 7,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_left_3_6.png",
-        "x_offset": -18,
-        "y_offset": -14,
+        "x": -18,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_left_4_1.png",
-        "x_offset": -10,
-        "y_offset": -42,
+        "x": -10,
+        "y": -42,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_left_4_2.png",
-        "x_offset": -10,
-        "y_offset": -43,
+        "x": -10,
+        "y": -43,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_left_4_3.png",
-        "x_offset": -8,
-        "y_offset": -28,
+        "x": -8,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_left_4_4.png",
-        "x_offset": -9,
-        "y_offset": -33,
+        "x": -9,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_left_4_5.png",
-        "x_offset": -18,
-        "y_offset": -21,
+        "x": -18,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_right_1_1.png",
-        "x_offset": -18,
-        "y_offset": -42,
+        "x": -18,
+        "y": -42,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_right_1_2.png",
-        "x_offset": -28,
-        "y_offset": -43,
+        "x": -28,
+        "y": -43,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_right_1_3.png",
-        "x_offset": -29,
-        "y_offset": -28,
+        "x": -29,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_right_1_4.png",
-        "x_offset": -18,
-        "y_offset": -33,
+        "x": -18,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_right_1_5.png",
-        "x_offset": -26,
-        "y_offset": -21,
+        "x": -26,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_right_2_1.png",
-        "x_offset": 2,
-        "y_offset": -29,
+        "x": 2,
+        "y": -29,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_right_2_2.png",
-        "x_offset": -18,
-        "y_offset": -28,
+        "x": -18,
+        "y": -28,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_right_2_3.png",
-        "x_offset": -24,
-        "y_offset": -33,
+        "x": -24,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_right_2_4.png",
-        "x_offset": -13,
-        "y_offset": -23,
+        "x": -13,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_right_2_5.png",
-        "x_offset": -8,
-        "y_offset": -9,
+        "x": -8,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_right_2_6.png",
-        "x_offset": -8,
-        "y_offset": -14,
+        "x": -8,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_right_3_1.png",
-        "x_offset": -14,
-        "y_offset": -36,
+        "x": -14,
+        "y": -36,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_right_3_2.png",
-        "x_offset": -6,
-        "y_offset": -24,
+        "x": -6,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_right_3_3.png",
-        "x_offset": -4,
-        "y_offset": -18,
+        "x": -4,
+        "y": -18,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_right_3_4.png",
-        "x_offset": -18,
-        "y_offset": -12,
+        "x": -18,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_right_4_1.png",
-        "x_offset": -17,
-        "y_offset": -42,
+        "x": -17,
+        "y": -42,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_right_4_2.png",
-        "x_offset": -21,
-        "y_offset": -47,
+        "x": -21,
+        "y": -47,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_right_4_3.png",
-        "x_offset": -27,
-        "y_offset": -47,
+        "x": -27,
+        "y": -47,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_right_4_4.png",
-        "x_offset": -22,
-        "y_offset": -33,
+        "x": -22,
+        "y": -33,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_zero_g_roll_right_4_5.png",
-        "x_offset": -18,
-        "y_offset": -21,
+        "x": -18,
+        "y": -21,
         "palette": "keep"
     },
     {
         "path": "track/raptor/small_flat_to_steep_up_1.png",
-        "x_offset": -18,
-        "y_offset": -22
+        "x": -18,
+        "y": -22
     },
     {
         "path": "track/raptor/small_flat_to_steep_up_2_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/small_flat_to_steep_up_2_2.png",
-        "x_offset": -13,
-        "y_offset": -6
+        "x": -13,
+        "y": -6
     },
     {
         "path": "track/raptor/small_flat_to_steep_up_3_1.png",
-        "x_offset": -3,
-        "y_offset": 2
+        "x": -3,
+        "y": 2
     },
     {
         "path": "track/raptor/small_flat_to_steep_up_3_2.png",
-        "x_offset": -21,
-        "y_offset": -6
+        "x": -21,
+        "y": -6
     },
     {
         "path": "track/raptor/small_flat_to_steep_up_4.png",
-        "x_offset": -21,
-        "y_offset": -22
+        "x": -21,
+        "y": -22
     },
     {
         "path": "track/raptor/small_steep_to_flat_up_1.png",
-        "x_offset": -18,
-        "y_offset": -22
+        "x": -18,
+        "y": -22
     },
     {
         "path": "track/raptor/small_steep_to_flat_up_2_1.png",
-        "x_offset": -10,
-        "y_offset": -10
+        "x": -10,
+        "y": -10
     },
     {
         "path": "track/raptor/small_steep_to_flat_up_2_2.png",
-        "x_offset": -18,
-        "y_offset": -5
+        "x": -18,
+        "y": -5
     },
     {
         "path": "track/raptor/small_steep_to_flat_up_3_1.png",
-        "x_offset": -18,
-        "y_offset": -10
+        "x": -18,
+        "y": -10
     },
     {
         "path": "track/raptor/small_steep_to_flat_up_3_2.png",
-        "x_offset": -4,
-        "y_offset": -5
+        "x": -4,
+        "y": -5
     },
     {
         "path": "track/raptor/small_steep_to_flat_up_4.png",
-        "x_offset": -18,
-        "y_offset": -22
+        "x": -18,
+        "y": -22
     },
     {
         "path": "track/raptor/small_flat_to_steep_up_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -15
+        "x": -32,
+        "y": -15
     },
     {
         "path": "track/raptor/small_flat_to_steep_up_diag_2.png",
-        "x_offset": -3,
-        "y_offset": -6
+        "x": -3,
+        "y": -6
     },
     {
         "path": "track/raptor/small_flat_to_steep_up_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -15
+        "x": -32,
+        "y": -15
     },
     {
         "path": "track/raptor/small_flat_to_steep_up_diag_4.png",
-        "x_offset": -3,
-        "y_offset": -30
+        "x": -3,
+        "y": -30
     },
     {
         "path": "track/raptor/small_steep_to_flat_up_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -15
+        "x": -32,
+        "y": -15
     },
     {
         "path": "track/raptor/small_steep_to_flat_up_diag_2.png",
-        "x_offset": -3,
-        "y_offset": -10
+        "x": -3,
+        "y": -10
     },
     {
         "path": "track/raptor/small_steep_to_flat_up_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -15
+        "x": -32,
+        "y": -15
     },
     {
         "path": "track/raptor/small_steep_to_flat_up_diag_4.png",
-        "x_offset": -3,
-        "y_offset": -30
+        "x": -3,
+        "y": -30
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_gentle_up_1_1.png",
-        "x_offset": -18,
-        "y_offset": -13,
+        "x": -18,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_gentle_up_1_2.png",
-        "x_offset": -26,
-        "y_offset": -8,
+        "x": -26,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_gentle_up_1_3.png",
-        "x_offset": 19,
-        "y_offset": 8,
+        "x": 19,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_gentle_up_1_4.png",
-        "x_offset": -7,
-        "y_offset": -6,
+        "x": -7,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_gentle_up_2_1.png",
-        "x_offset": -18,
-        "y_offset": -2,
+        "x": -18,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_gentle_up_2_2.png",
-        "x_offset": -16,
-        "y_offset": -6,
+        "x": -16,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_gentle_up_2_3.png",
-        "x_offset": -24,
-        "y_offset": 19,
+        "x": -24,
+        "y": 19,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_gentle_up_2_4.png",
-        "x_offset": -32,
-        "y_offset": -7,
+        "x": -32,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_gentle_up_3_1.png",
-        "x_offset": -6,
-        "y_offset": 1,
+        "x": -6,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_gentle_up_3_2.png",
-        "x_offset": 10,
-        "y_offset": 2,
+        "x": 10,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_gentle_up_3_3.png",
-        "x_offset": -27,
-        "y_offset": 4,
+        "x": -27,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_gentle_up_3_4.png",
-        "x_offset": -3,
-        "y_offset": -11,
+        "x": -3,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_gentle_up_4_1.png",
-        "x_offset": -23,
-        "y_offset": -13,
+        "x": -23,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_gentle_up_4_2.png",
-        "x_offset": -25,
-        "y_offset": -4,
+        "x": -25,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_gentle_up_4_3.png",
-        "x_offset": 0,
-        "y_offset": -9,
+        "x": 0,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_diag_gentle_up_4_4.png",
-        "x_offset": 0,
-        "y_offset": -7,
+        "x": 0,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_gentle_up_1_1.png",
-        "x_offset": -18,
-        "y_offset": -13,
+        "x": -18,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_gentle_up_1_2.png",
-        "x_offset": -13,
-        "y_offset": -4,
+        "x": -13,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_gentle_up_1_3.png",
-        "x_offset": -10,
-        "y_offset": -9,
+        "x": -10,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_gentle_up_1_4.png",
-        "x_offset": -32,
-        "y_offset": -7,
+        "x": -32,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_gentle_up_2_1.png",
-        "x_offset": -18,
-        "y_offset": 1,
+        "x": -18,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_gentle_up_2_2.png",
-        "x_offset": -29,
-        "y_offset": 2,
+        "x": -29,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_gentle_up_2_3.png",
-        "x_offset": 19,
-        "y_offset": 4,
+        "x": 19,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_gentle_up_2_4.png",
-        "x_offset": -10,
-        "y_offset": -11,
+        "x": -10,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_gentle_up_3_1.png",
-        "x_offset": -16,
-        "y_offset": -2,
+        "x": -16,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_gentle_up_3_2.png",
-        "x_offset": -8,
-        "y_offset": -6,
+        "x": -8,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_gentle_up_3_3.png",
-        "x_offset": 0,
-        "y_offset": 19,
+        "x": 0,
+        "y": 19,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_gentle_up_3_4.png",
-        "x_offset": 0,
-        "y_offset": -7,
+        "x": 0,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_gentle_up_4_1.png",
-        "x_offset": -12,
-        "y_offset": -13,
+        "x": -12,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_gentle_up_4_2.png",
-        "x_offset": 5,
-        "y_offset": -8,
+        "x": 5,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_gentle_up_4_3.png",
-        "x_offset": -32,
-        "y_offset": 8,
+        "x": -32,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_diag_gentle_up_4_4.png",
-        "x_offset": -3,
-        "y_offset": -6,
+        "x": -3,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_orthogonal_gentle_up_1_1.png",
-        "x_offset": 0,
-        "y_offset": -5,
+        "x": 0,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_orthogonal_gentle_up_1_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_orthogonal_gentle_up_1_3.png",
-        "x_offset": -32,
-        "y_offset": -12,
+        "x": -32,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_orthogonal_gentle_up_1_4.png",
-        "x_offset": -27,
-        "y_offset": -14,
+        "x": -27,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_orthogonal_gentle_up_2_1.png",
-        "x_offset": -3,
-        "y_offset": 10,
+        "x": -3,
+        "y": 10,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_orthogonal_gentle_up_2_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_orthogonal_gentle_up_2_3.png",
-        "x_offset": 0,
-        "y_offset": -4,
+        "x": 0,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_orthogonal_gentle_up_2_4.png",
-        "x_offset": -16,
-        "y_offset": 0,
+        "x": -16,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_orthogonal_gentle_up_3_1.png",
-        "x_offset": -32,
-        "y_offset": -1,
+        "x": -32,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_orthogonal_gentle_up_3_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_orthogonal_gentle_up_3_3.png",
-        "x_offset": -22,
-        "y_offset": 3,
+        "x": -22,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_orthogonal_gentle_up_3_4.png",
-        "x_offset": -19,
-        "y_offset": 1,
+        "x": -19,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_orthogonal_gentle_up_4_1.png",
-        "x_offset": -6,
-        "y_offset": -8,
+        "x": -6,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_orthogonal_gentle_up_4_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_orthogonal_gentle_up_4_3.png",
-        "x_offset": -19,
-        "y_offset": -1,
+        "x": -19,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_to_orthogonal_gentle_up_4_4.png",
-        "x_offset": -19,
-        "y_offset": -14,
+        "x": -19,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_orthogonal_gentle_up_1_1.png",
-        "x_offset": 0,
-        "y_offset": -1,
+        "x": 0,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_orthogonal_gentle_up_1_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_orthogonal_gentle_up_1_3.png",
-        "x_offset": -32,
-        "y_offset": 3,
+        "x": -32,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_orthogonal_gentle_up_1_4.png",
-        "x_offset": -14,
-        "y_offset": 1,
+        "x": -14,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_orthogonal_gentle_up_2_1.png",
-        "x_offset": -3,
-        "y_offset": 10,
+        "x": -3,
+        "y": 10,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_orthogonal_gentle_up_2_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_orthogonal_gentle_up_2_3.png",
-        "x_offset": -16,
-        "y_offset": -4,
+        "x": -16,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_orthogonal_gentle_up_2_4.png",
-        "x_offset": -19,
-        "y_offset": 0,
+        "x": -19,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_orthogonal_gentle_up_3_1.png",
-        "x_offset": -32,
-        "y_offset": -5,
+        "x": -32,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_orthogonal_gentle_up_3_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_orthogonal_gentle_up_3_3.png",
-        "x_offset": -10,
-        "y_offset": -12,
+        "x": -10,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_orthogonal_gentle_up_3_4.png",
-        "x_offset": -19,
-        "y_offset": -14,
+        "x": -19,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_orthogonal_gentle_up_4_1.png",
-        "x_offset": -3,
-        "y_offset": -8,
+        "x": -3,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_orthogonal_gentle_up_4_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_orthogonal_gentle_up_4_3.png",
-        "x_offset": -1,
-        "y_offset": -1,
+        "x": -1,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_to_orthogonal_gentle_up_4_4.png",
-        "x_offset": -19,
-        "y_offset": -14,
+        "x": -19,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_to_gentle_up_left_bank_diag_1_1.png",
-        "x_offset": -32,
-        "y_offset": 1,
+        "x": -32,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_to_gentle_up_left_bank_diag_1_2.png",
-        "x_offset": -31,
-        "y_offset": -6,
+        "x": -31,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_to_gentle_up_left_bank_diag_2.png",
-        "x_offset": -5,
-        "y_offset": -6,
+        "x": -5,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_to_gentle_up_left_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -8,
+        "x": -32,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_to_gentle_up_left_bank_diag_4.png",
-        "x_offset": -3,
-        "y_offset": -23,
+        "x": -3,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_to_gentle_up_right_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -8,
+        "x": -32,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_to_gentle_up_right_bank_diag_2.png",
-        "x_offset": -3,
-        "y_offset": -6,
+        "x": -3,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_to_gentle_up_right_bank_diag_3_1.png",
-        "x_offset": -29,
-        "y_offset": -6,
+        "x": -29,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_to_gentle_up_right_bank_diag_3_2.png",
-        "x_offset": -32,
-        "y_offset": -6,
+        "x": -32,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_to_gentle_up_right_bank_diag_4.png",
-        "x_offset": -6,
-        "y_offset": -23,
+        "x": -6,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_gentle_up_diag_1_1.png",
-        "x_offset": -14,
-        "y_offset": -7,
+        "x": -14,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_gentle_up_diag_1_2.png",
-        "x_offset": -32,
-        "y_offset": 0,
+        "x": -32,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_gentle_up_diag_2.png",
-        "x_offset": -5,
-        "y_offset": -7,
+        "x": -5,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_gentle_up_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -7,
+        "x": -32,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_gentle_up_diag_4.png",
-        "x_offset": -3,
-        "y_offset": -22,
+        "x": -3,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_gentle_up_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -7,
+        "x": -32,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_gentle_up_diag_2.png",
-        "x_offset": -3,
-        "y_offset": -7,
+        "x": -3,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_gentle_up_diag_3_1.png",
-        "x_offset": -32,
-        "y_offset": -7,
+        "x": -32,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_gentle_up_diag_3_2.png",
-        "x_offset": -31,
-        "y_offset": 0,
+        "x": -31,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_gentle_up_diag_4.png",
-        "x_offset": -6,
-        "y_offset": -22,
+        "x": -6,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/raptor/left_bank_to_gentle_up_left_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/left_bank_to_gentle_up_left_bank_diag_2.png",
-        "x_offset": -6,
-        "y_offset": -7,
+        "x": -6,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/left_bank_to_gentle_up_left_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": 0,
+        "x": -32,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/left_bank_to_gentle_up_left_bank_diag_4.png",
-        "x_offset": -2,
-        "y_offset": -15,
+        "x": -2,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/raptor/right_bank_to_gentle_up_right_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 0,
+        "x": -32,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/right_bank_to_gentle_up_right_bank_diag_2.png",
-        "x_offset": -2,
-        "y_offset": -7,
+        "x": -2,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/right_bank_to_gentle_up_right_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/right_bank_to_gentle_up_right_bank_diag_4.png",
-        "x_offset": -6,
-        "y_offset": -15,
+        "x": -6,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_left_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 1,
+        "x": -32,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_left_bank_diag_2.png",
-        "x_offset": -6,
-        "y_offset": -7,
+        "x": -6,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_left_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": 0,
+        "x": -32,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_left_bank_diag_4.png",
-        "x_offset": -2,
-        "y_offset": -15,
+        "x": -2,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_right_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 0,
+        "x": -32,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_right_bank_diag_2.png",
-        "x_offset": -2,
-        "y_offset": -7,
+        "x": -2,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_right_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": 1,
+        "x": -32,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_right_bank_diag_4.png",
-        "x_offset": -6,
-        "y_offset": -15,
+        "x": -6,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_left_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -6,
+        "x": -32,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_left_bank_diag_2.png",
-        "x_offset": -6,
-        "y_offset": -7,
+        "x": -6,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_left_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -8,
+        "x": -32,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_left_bank_diag_4.png",
-        "x_offset": -2,
-        "y_offset": -23,
+        "x": -2,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_right_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -8,
+        "x": -32,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_right_bank_diag_2.png",
-        "x_offset": -2,
-        "y_offset": -7,
+        "x": -2,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_right_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -6,
+        "x": -32,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_right_bank_diag_4.png",
-        "x_offset": -6,
-        "y_offset": -23,
+        "x": -6,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/raptor/flat_to_gentle_up_left_bank_diag_1_1.png",
-        "x_offset": -32,
-        "y_offset": 7,
+        "x": -32,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/flat_to_gentle_up_left_bank_diag_1_2.png",
-        "x_offset": -29,
-        "y_offset": 2,
+        "x": -29,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/flat_to_gentle_up_left_bank_diag_2.png",
-        "x_offset": -5,
-        "y_offset": -6,
+        "x": -5,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/flat_to_gentle_up_left_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": 0,
+        "x": -32,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/flat_to_gentle_up_left_bank_diag_4.png",
-        "x_offset": -3,
-        "y_offset": -15,
+        "x": -3,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/raptor/flat_to_gentle_up_right_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 0,
+        "x": -32,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/flat_to_gentle_up_right_bank_diag_2.png",
-        "x_offset": -3,
-        "y_offset": -6,
+        "x": -3,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/flat_to_gentle_up_right_bank_diag_3_1.png",
-        "x_offset": -29,
-        "y_offset": 2,
+        "x": -29,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/flat_to_gentle_up_right_bank_diag_3_2.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/flat_to_gentle_up_right_bank_diag_4.png",
-        "x_offset": -6,
-        "y_offset": -15,
+        "x": -6,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_flat_diag_1_1.png",
-        "x_offset": -9,
-        "y_offset": 1,
+        "x": -9,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_flat_diag_1_2.png",
-        "x_offset": -32,
-        "y_offset": 6,
+        "x": -32,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_flat_diag_2.png",
-        "x_offset": -5,
-        "y_offset": -7,
+        "x": -5,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_flat_diag_3.png",
-        "x_offset": -32,
-        "y_offset": 1,
+        "x": -32,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_left_bank_to_flat_diag_4.png",
-        "x_offset": -3,
-        "y_offset": -14,
+        "x": -3,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_flat_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 1,
+        "x": -32,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_flat_diag_2.png",
-        "x_offset": -3,
-        "y_offset": -7,
+        "x": -3,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_flat_diag_3_1.png",
-        "x_offset": -32,
-        "y_offset": 1,
+        "x": -32,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_flat_diag_3_2.png",
-        "x_offset": -30,
-        "y_offset": 6,
+        "x": -30,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/gentle_up_right_bank_to_flat_diag_4.png",
-        "x_offset": -6,
-        "y_offset": -13,
+        "x": -6,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_diag_gentle_up_1_1.png",
-        "x_offset": -17,
-        "y_offset": -13,
+        "x": -17,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_diag_gentle_up_1_2.png",
-        "x_offset": -24,
-        "y_offset": -24,
+        "x": -24,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_diag_gentle_up_1_3.png",
-        "x_offset": 21,
-        "y_offset": 8,
+        "x": 21,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_diag_gentle_up_1_4.png",
-        "x_offset": -6,
-        "y_offset": -6,
+        "x": -6,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_diag_gentle_up_2_1.png",
-        "x_offset": -19,
-        "y_offset": -2,
+        "x": -19,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_diag_gentle_up_2_2.png",
-        "x_offset": -16,
-        "y_offset": -7,
+        "x": -16,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_diag_gentle_up_2_3.png",
-        "x_offset": -24,
-        "y_offset": 19,
+        "x": -24,
+        "y": 19,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_diag_gentle_up_2_4.png",
-        "x_offset": -32,
-        "y_offset": -6,
+        "x": -32,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_diag_gentle_up_3_1.png",
-        "x_offset": -7,
-        "y_offset": 0,
+        "x": -7,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_diag_gentle_up_3_2.png",
-        "x_offset": 10,
-        "y_offset": 0,
+        "x": 10,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_diag_gentle_up_3_3.png",
-        "x_offset": -28,
-        "y_offset": 2,
+        "x": -28,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_diag_gentle_up_3_4.png",
-        "x_offset": -5,
-        "y_offset": -12,
+        "x": -5,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_diag_gentle_up_4_1.png",
-        "x_offset": -22,
-        "y_offset": -14,
+        "x": -22,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_diag_gentle_up_4_2.png",
-        "x_offset": -24,
-        "y_offset": -5,
+        "x": -24,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_diag_gentle_up_4_3.png",
-        "x_offset": 0,
-        "y_offset": -11,
+        "x": 0,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_diag_gentle_up_4_4.png",
-        "x_offset": 0,
-        "y_offset": -8,
+        "x": 0,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_diag_gentle_up_1_1.png",
-        "x_offset": -19,
-        "y_offset": -14,
+        "x": -19,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_diag_gentle_up_1_2.png",
-        "x_offset": -14,
-        "y_offset": -5,
+        "x": -14,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_diag_gentle_up_1_3.png",
-        "x_offset": -10,
-        "y_offset": -11,
+        "x": -10,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_diag_gentle_up_1_4.png",
-        "x_offset": -32,
-        "y_offset": -8,
+        "x": -32,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_diag_gentle_up_2_1.png",
-        "x_offset": -17,
-        "y_offset": 0,
+        "x": -17,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_diag_gentle_up_2_2.png",
-        "x_offset": -28,
-        "y_offset": 0,
+        "x": -28,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_diag_gentle_up_2_3.png",
-        "x_offset": 19,
-        "y_offset": 2,
+        "x": 19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_diag_gentle_up_2_4.png",
-        "x_offset": -9,
-        "y_offset": -12,
+        "x": -9,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_diag_gentle_up_3_1.png",
-        "x_offset": -16,
-        "y_offset": -2,
+        "x": -16,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_diag_gentle_up_3_2.png",
-        "x_offset": -8,
-        "y_offset": -7,
+        "x": -8,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_diag_gentle_up_3_3.png",
-        "x_offset": 0,
-        "y_offset": 19,
+        "x": 0,
+        "y": 19,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_diag_gentle_up_3_4.png",
-        "x_offset": 0,
-        "y_offset": -6,
+        "x": 0,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_diag_gentle_up_4_1.png",
-        "x_offset": -13,
-        "y_offset": -13,
+        "x": -13,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_diag_gentle_up_4_2.png",
-        "x_offset": -1,
-        "y_offset": -24,
+        "x": -1,
+        "y": -24,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_diag_gentle_up_4_3.png",
-        "x_offset": -32,
-        "y_offset": 8,
+        "x": -32,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_diag_gentle_up_4_4.png",
-        "x_offset": -6,
-        "y_offset": -6,
+        "x": -6,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_orthogonal_gentle_up_1_1.png",
-        "x_offset": 0,
-        "y_offset": -4,
+        "x": 0,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_orthogonal_gentle_up_1_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_orthogonal_gentle_up_1_3.png",
-        "x_offset": -32,
-        "y_offset": -11,
+        "x": -32,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_orthogonal_gentle_up_1_4.png",
-        "x_offset": -26,
-        "y_offset": -14,
+        "x": -26,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_orthogonal_gentle_up_2_1.png",
-        "x_offset": -5,
-        "y_offset": 9,
+        "x": -5,
+        "y": 9,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_orthogonal_gentle_up_2_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_orthogonal_gentle_up_2_3.png",
-        "x_offset": 0,
-        "y_offset": -3,
+        "x": 0,
+        "y": -3,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_orthogonal_gentle_up_2_4.png",
-        "x_offset": -16,
-        "y_offset": 0,
+        "x": -16,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_orthogonal_gentle_up_3_1.png",
-        "x_offset": -32,
-        "y_offset": -2,
+        "x": -32,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_orthogonal_gentle_up_3_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_orthogonal_gentle_up_3_3.png",
-        "x_offset": -22,
-        "y_offset": 2,
+        "x": -22,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_orthogonal_gentle_up_3_4.png",
-        "x_offset": -20,
-        "y_offset": 0,
+        "x": -20,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_orthogonal_gentle_up_4_1.png",
-        "x_offset": -4,
-        "y_offset": -8,
+        "x": -4,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_orthogonal_gentle_up_4_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_orthogonal_gentle_up_4_3.png",
-        "x_offset": -18,
-        "y_offset": -2,
+        "x": -18,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_left_bank_to_orthogonal_gentle_up_4_4.png",
-        "x_offset": -18,
-        "y_offset": -15,
+        "x": -18,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_orthogonal_gentle_up_1_1.png",
-        "x_offset": 0,
-        "y_offset": -2,
+        "x": 0,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_orthogonal_gentle_up_1_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_orthogonal_gentle_up_1_3.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_orthogonal_gentle_up_1_4.png",
-        "x_offset": -13,
-        "y_offset": 0,
+        "x": -13,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_orthogonal_gentle_up_2_1.png",
-        "x_offset": -2,
-        "y_offset": 9,
+        "x": -2,
+        "y": 9,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_orthogonal_gentle_up_2_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_orthogonal_gentle_up_2_3.png",
-        "x_offset": -16,
-        "y_offset": -3,
+        "x": -16,
+        "y": -3,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_orthogonal_gentle_up_2_4.png",
-        "x_offset": -18,
-        "y_offset": 0,
+        "x": -18,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_orthogonal_gentle_up_3_1.png",
-        "x_offset": -32,
-        "y_offset": -4,
+        "x": -32,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_orthogonal_gentle_up_3_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_orthogonal_gentle_up_3_3.png",
-        "x_offset": -9,
-        "y_offset": -11,
+        "x": -9,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_orthogonal_gentle_up_3_4.png",
-        "x_offset": -20,
-        "y_offset": -14,
+        "x": -20,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_orthogonal_gentle_up_4_1.png",
-        "x_offset": -6,
-        "y_offset": -8,
+        "x": -6,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_orthogonal_gentle_up_4_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_orthogonal_gentle_up_4_3.png",
-        "x_offset": -3,
-        "y_offset": -2,
+        "x": -3,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/raptor/large_turn_right_bank_to_orthogonal_gentle_up_4_4.png",
-        "x_offset": -20,
-        "y_offset": -15,
+        "x": -20,
+        "y": -15,
         "palette": "keep"
     },
     {
         "path": "track/raptor/flat_lift_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_lift_2.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_lift_3.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_lift_4.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_to_gentle_up_lift_1.png",
-        "x_offset": -18,
-        "y_offset": -6
+        "x": -18,
+        "y": -6
     },
     {
         "path": "track/raptor/flat_to_gentle_up_lift_2.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_to_gentle_up_lift_3.png",
-        "x_offset": -19,
-        "y_offset": 2
+        "x": -19,
+        "y": 2
     },
     {
         "path": "track/raptor/flat_to_gentle_up_lift_4.png",
-        "x_offset": -19,
-        "y_offset": -6
+        "x": -19,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_up_to_flat_lift_1.png",
-        "x_offset": -18,
-        "y_offset": -6
+        "x": -18,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_up_to_flat_lift_2.png",
-        "x_offset": -18,
-        "y_offset": 1
+        "x": -18,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_to_flat_lift_3.png",
-        "x_offset": -18,
-        "y_offset": 1
+        "x": -18,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_up_to_flat_lift_4.png",
-        "x_offset": -18,
-        "y_offset": -6
+        "x": -18,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_lift_1.png",
-        "x_offset": -18,
-        "y_offset": -14
+        "x": -18,
+        "y": -14
     },
     {
         "path": "track/raptor/gentle_lift_2.png",
-        "x_offset": -18,
-        "y_offset": 1
+        "x": -18,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_lift_3.png",
-        "x_offset": -19,
-        "y_offset": 1
+        "x": -19,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_lift_4.png",
-        "x_offset": -19,
-        "y_offset": -14
+        "x": -19,
+        "y": -14
     },
     {
         "path": "track/raptor/gentle_to_steep_up_lift_1.png",
-        "x_offset": -18,
-        "y_offset": -30
+        "x": -18,
+        "y": -30
     },
     {
         "path": "track/raptor/gentle_to_steep_up_lift_2_1.png",
-        "x_offset": -18,
-        "y_offset": -1
+        "x": -18,
+        "y": -1
     },
     {
         "path": "track/raptor/gentle_to_steep_up_lift_2_2.png",
-        "x_offset": -17,
-        "y_offset": -14
+        "x": -17,
+        "y": -14
     },
     {
         "path": "track/raptor/gentle_to_steep_up_lift_3_1.png",
-        "x_offset": 0,
-        "y_offset": -1
+        "x": 0,
+        "y": -1
     },
     {
         "path": "track/raptor/gentle_to_steep_up_lift_3_2.png",
-        "x_offset": -21,
-        "y_offset": -14
+        "x": -21,
+        "y": -14
     },
     {
         "path": "track/raptor/gentle_to_steep_up_lift_4.png",
-        "x_offset": -21,
-        "y_offset": -30
+        "x": -21,
+        "y": -30
     },
     {
         "path": "track/raptor/steep_to_gentle_up_lift_1.png",
-        "x_offset": -18,
-        "y_offset": -30
+        "x": -18,
+        "y": -30
     },
     {
         "path": "track/raptor/steep_to_gentle_up_lift_2_1.png",
-        "x_offset": -5,
-        "y_offset": -15
+        "x": -5,
+        "y": -15
     },
     {
         "path": "track/raptor/steep_to_gentle_up_lift_2_2.png",
-        "x_offset": -18,
-        "y_offset": -10
+        "x": -18,
+        "y": -10
     },
     {
         "path": "track/raptor/steep_to_gentle_up_lift_3_1.png",
-        "x_offset": -19,
-        "y_offset": -15
+        "x": -19,
+        "y": -15
     },
     {
         "path": "track/raptor/steep_to_gentle_up_lift_3_2.png",
-        "x_offset": -12,
-        "y_offset": -10
+        "x": -12,
+        "y": -10
     },
     {
         "path": "track/raptor/steep_to_gentle_up_lift_4.png",
-        "x_offset": -19,
-        "y_offset": -30
+        "x": -19,
+        "y": -30
     },
     {
         "path": "track/raptor/steep_lift_1.png",
-        "x_offset": -18,
-        "y_offset": -62
+        "x": -18,
+        "y": -62
     },
     {
         "path": "track/raptor/steep_lift_2.png",
-        "x_offset": -18,
-        "y_offset": -46
+        "x": -18,
+        "y": -46
     },
     {
         "path": "track/raptor/steep_lift_3.png",
-        "x_offset": -21,
-        "y_offset": -46
+        "x": -21,
+        "y": -46
     },
     {
         "path": "track/raptor/steep_lift_4.png",
-        "x_offset": -21,
-        "y_offset": -62
+        "x": -21,
+        "y": -62
     },
     {
         "path": "track/raptor/flat_diag_lift_1.png",
-        "x_offset": -32,
-        "y_offset": 9
+        "x": -32,
+        "y": 9
     },
     {
         "path": "track/raptor/flat_diag_lift_2.png",
-        "x_offset": -3,
-        "y_offset": -6
+        "x": -3,
+        "y": -6
     },
     {
         "path": "track/raptor/flat_diag_lift_3.png",
-        "x_offset": -32,
-        "y_offset": 9
+        "x": -32,
+        "y": 9
     },
     {
         "path": "track/raptor/flat_diag_lift_4.png",
-        "x_offset": -3,
-        "y_offset": -6
+        "x": -3,
+        "y": -6
     },
     {
         "path": "track/raptor/flat_to_gentle_up_diag_lift_1.png",
-        "x_offset": -32,
-        "y_offset": 1
+        "x": -32,
+        "y": 1
     },
     {
         "path": "track/raptor/flat_to_gentle_up_diag_lift_2.png",
-        "x_offset": -3,
-        "y_offset": -6
+        "x": -3,
+        "y": -6
     },
     {
         "path": "track/raptor/flat_to_gentle_up_diag_lift_3.png",
-        "x_offset": -33,
-        "y_offset": 1
+        "x": -33,
+        "y": 1
     },
     {
         "path": "track/raptor/flat_to_gentle_up_diag_lift_4.png",
-        "x_offset": -3,
-        "y_offset": -14
+        "x": -3,
+        "y": -14
     },
     {
         "path": "track/raptor/gentle_to_flat_up_diag_lift_1.png",
-        "x_offset": -32,
-        "y_offset": 1
+        "x": -32,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_to_flat_up_diag_lift_2.png",
-        "x_offset": -3,
-        "y_offset": -6
+        "x": -3,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_to_flat_up_diag_lift_3.png",
-        "x_offset": -32,
-        "y_offset": 1
+        "x": -32,
+        "y": 1
     },
     {
         "path": "track/raptor/gentle_to_flat_up_diag_lift_4.png",
-        "x_offset": -3,
-        "y_offset": -14
+        "x": -3,
+        "y": -14
     },
     {
         "path": "track/raptor/gentle_diag_lift_1.png",
-        "x_offset": -32,
-        "y_offset": -7
+        "x": -32,
+        "y": -7
     },
     {
         "path": "track/raptor/gentle_diag_lift_2.png",
-        "x_offset": -3,
-        "y_offset": -6
+        "x": -3,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_diag_lift_3.png",
-        "x_offset": -32,
-        "y_offset": -7
+        "x": -32,
+        "y": -7
     },
     {
         "path": "track/raptor/gentle_diag_lift_4.png",
-        "x_offset": -3,
-        "y_offset": -22
+        "x": -3,
+        "y": -22
     },
     {
         "path": "track/raptor/gentle_to_steep_up_diag_lift_1.png",
-        "x_offset": -32,
-        "y_offset": -23
+        "x": -32,
+        "y": -23
     },
     {
         "path": "track/raptor/gentle_to_steep_up_diag_lift_2.png",
-        "x_offset": -3,
-        "y_offset": -6
+        "x": -3,
+        "y": -6
     },
     {
         "path": "track/raptor/gentle_to_steep_up_diag_lift_3.png",
-        "x_offset": -32,
-        "y_offset": -23
+        "x": -32,
+        "y": -23
     },
     {
         "path": "track/raptor/gentle_to_steep_up_diag_lift_4.png",
-        "x_offset": -3,
-        "y_offset": -38
+        "x": -3,
+        "y": -38
     },
     {
         "path": "track/raptor/steep_to_gentle_up_diag_lift_1.png",
-        "x_offset": -32,
-        "y_offset": -23
+        "x": -32,
+        "y": -23
     },
     {
         "path": "track/raptor/steep_to_gentle_up_diag_lift_2.png",
-        "x_offset": -3,
-        "y_offset": -11
+        "x": -3,
+        "y": -11
     },
     {
         "path": "track/raptor/steep_to_gentle_up_diag_lift_3.png",
-        "x_offset": -32,
-        "y_offset": -23
+        "x": -32,
+        "y": -23
     },
     {
         "path": "track/raptor/steep_to_gentle_up_diag_lift_4.png",
-        "x_offset": -3,
-        "y_offset": -38
+        "x": -3,
+        "y": -38
     },
     {
         "path": "track/raptor/steep_diag_lift_1.png",
-        "x_offset": -32,
-        "y_offset": -55
+        "x": -32,
+        "y": -55
     },
     {
         "path": "track/raptor/steep_diag_lift_2.png",
-        "x_offset": -3,
-        "y_offset": -38
+        "x": -3,
+        "y": -38
     },
     {
         "path": "track/raptor/steep_diag_lift_3.png",
-        "x_offset": -32,
-        "y_offset": -55
+        "x": -32,
+        "y": -55
     },
     {
         "path": "track/raptor/steep_diag_lift_4.png",
-        "x_offset": -3,
-        "y_offset": -70
+        "x": -3,
+        "y": -70
     },
     {
         "path": "track/raptor/small_flat_to_steep_up_lift_1.png",
-        "x_offset": -18,
-        "y_offset": -22
+        "x": -18,
+        "y": -22
     },
     {
         "path": "track/raptor/small_flat_to_steep_up_lift_2_1.png",
-        "x_offset": -18,
-        "y_offset": 2
+        "x": -18,
+        "y": 2
     },
     {
         "path": "track/raptor/small_flat_to_steep_up_lift_2_2.png",
-        "x_offset": -13,
-        "y_offset": -6
+        "x": -13,
+        "y": -6
     },
     {
         "path": "track/raptor/small_flat_to_steep_up_lift_3_1.png",
-        "x_offset": -5,
-        "y_offset": 2
+        "x": -5,
+        "y": 2
     },
     {
         "path": "track/raptor/small_flat_to_steep_up_lift_3_2.png",
-        "x_offset": -21,
-        "y_offset": -6
+        "x": -21,
+        "y": -6
     },
     {
         "path": "track/raptor/small_flat_to_steep_up_lift_4.png",
-        "x_offset": -21,
-        "y_offset": -22
+        "x": -21,
+        "y": -22
     },
     {
         "path": "track/raptor/small_steep_to_flat_up_lift_1.png",
-        "x_offset": -18,
-        "y_offset": -22
+        "x": -18,
+        "y": -22
     },
     {
         "path": "track/raptor/small_steep_to_flat_up_lift_2_1.png",
-        "x_offset": -10,
-        "y_offset": -10
+        "x": -10,
+        "y": -10
     },
     {
         "path": "track/raptor/small_steep_to_flat_up_lift_2_2.png",
-        "x_offset": -18,
-        "y_offset": -5
+        "x": -18,
+        "y": -5
     },
     {
         "path": "track/raptor/small_steep_to_flat_up_lift_3_1.png",
-        "x_offset": -18,
-        "y_offset": -10
+        "x": -18,
+        "y": -10
     },
     {
         "path": "track/raptor/small_steep_to_flat_up_lift_3_2.png",
-        "x_offset": -4,
-        "y_offset": -5
+        "x": -4,
+        "y": -5
     },
     {
         "path": "track/raptor/small_steep_to_flat_up_lift_4.png",
-        "x_offset": -18,
-        "y_offset": -22
+        "x": -18,
+        "y": -22
     },
     {
         "path": "track/raptor/small_flat_to_steep_up_diag_lift_1.png",
-        "x_offset": -32,
-        "y_offset": -15
+        "x": -32,
+        "y": -15
     },
     {
         "path": "track/raptor/small_flat_to_steep_up_diag_lift_2.png",
-        "x_offset": -3,
-        "y_offset": -6
+        "x": -3,
+        "y": -6
     },
     {
         "path": "track/raptor/small_flat_to_steep_up_diag_lift_3.png",
-        "x_offset": -32,
-        "y_offset": -15
+        "x": -32,
+        "y": -15
     },
     {
         "path": "track/raptor/small_flat_to_steep_up_diag_lift_4.png",
-        "x_offset": -3,
-        "y_offset": -30
+        "x": -3,
+        "y": -30
     },
     {
         "path": "track/raptor/small_steep_to_flat_up_diag_lift_1.png",
-        "x_offset": -32,
-        "y_offset": -15
+        "x": -32,
+        "y": -15
     },
     {
         "path": "track/raptor/small_steep_to_flat_up_diag_lift_2.png",
-        "x_offset": -3,
-        "y_offset": -10
+        "x": -3,
+        "y": -10
     },
     {
         "path": "track/raptor/small_steep_to_flat_up_diag_lift_3.png",
-        "x_offset": -32,
-        "y_offset": -15
+        "x": -32,
+        "y": -15
     },
     {
         "path": "track/raptor/small_steep_to_flat_up_diag_lift_4.png",
-        "x_offset": -3,
-        "y_offset": -30
+        "x": -3,
+        "y": -30
     },
     {
         "path": "track/alpine/preview_track.png",
-        "x_offset": 8,
-        "y_offset": 1
+        "x": 8,
+        "y": 1
     },
     {
         "path": "track/alpine/preview_support.png",
-        "x_offset": 25,
-        "y_offset": 11
+        "x": 25,
+        "y": 11
     },
     {
         "path": "track/alpine/flat_1.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_2.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_gentle_up_1.png",
-        "x_offset": -19,
-        "y_offset": -5,
+        "x": -19,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_gentle_up_2.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_gentle_up_3.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_gentle_up_4.png",
-        "x_offset": -19,
-        "y_offset": -5,
+        "x": -19,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_flat_1.png",
-        "x_offset": -19,
-        "y_offset": -5,
+        "x": -19,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_flat_2.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_flat_3.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_flat_4.png",
-        "x_offset": -19,
-        "y_offset": -5,
+        "x": -19,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_1.png",
-        "x_offset": -19,
-        "y_offset": -13,
+        "x": -19,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_2.png",
-        "x_offset": -19,
-        "y_offset": 2,
+        "x": -19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_3.png",
-        "x_offset": -19,
-        "y_offset": 2,
+        "x": -19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_4.png",
-        "x_offset": -19,
-        "y_offset": -13,
+        "x": -19,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_1_1.png",
-        "x_offset": -19,
-        "y_offset": -1,
+        "x": -19,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_1_2.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_1_3.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_2_1.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_2_2.png",
-        "x_offset": -2,
-        "y_offset": 0,
+        "x": -2,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_2_3.png",
-        "x_offset": -32,
-        "y_offset": 3,
+        "x": -32,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_3_1.png",
-        "x_offset": -4,
-        "y_offset": 3,
+        "x": -4,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_3_2.png",
-        "x_offset": 24,
-        "y_offset": 1,
+        "x": 24,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_3_3.png",
-        "x_offset": -8,
-        "y_offset": -1,
+        "x": -8,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_4_1.png",
-        "x_offset": -26,
-        "y_offset": 8,
+        "x": -26,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_4_2.png",
-        "x_offset": -8,
-        "y_offset": 24,
+        "x": -8,
+        "y": 24,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_4_3.png",
-        "x_offset": -19,
-        "y_offset": 8,
+        "x": -19,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_1_1.png",
-        "x_offset": -19,
-        "y_offset": 2,
+        "x": -19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_1_2.png",
-        "x_offset": -28,
-        "y_offset": 6,
+        "x": -28,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_1_3.png",
-        "x_offset": 9,
-        "y_offset": 6,
+        "x": 9,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_1_4.png",
-        "x_offset": -24,
-        "y_offset": 9,
+        "x": -24,
+        "y": 9,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_1_5.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_2_1.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_2_2.png",
-        "x_offset": -8,
-        "y_offset": 0,
+        "x": -8,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_2_3.png",
-        "x_offset": -28,
-        "y_offset": 17,
+        "x": -28,
+        "y": 17,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_2_4.png",
-        "x_offset": -14,
-        "y_offset": 0,
+        "x": -14,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_2_5.png",
-        "x_offset": -30,
-        "y_offset": 3,
+        "x": -30,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_3_1.png",
-        "x_offset": -14,
-        "y_offset": 3,
+        "x": -14,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_3_2.png",
-        "x_offset": 11,
-        "y_offset": 9,
+        "x": 11,
+        "y": 9,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_3_3.png",
-        "x_offset": -22,
-        "y_offset": 6,
+        "x": -22,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_3_4.png",
-        "x_offset": 12,
-        "y_offset": 6,
+        "x": 12,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_3_5.png",
-        "x_offset": -10,
-        "y_offset": 2,
+        "x": -10,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_4_1.png",
-        "x_offset": -22,
-        "y_offset": 7,
+        "x": -22,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_4_2.png",
-        "x_offset": -28,
-        "y_offset": 17,
+        "x": -28,
+        "y": 17,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_4_3.png",
-        "x_offset": -14,
-        "y_offset": 1,
+        "x": -14,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_4_4.png",
-        "x_offset": -16,
-        "y_offset": 17,
+        "x": -16,
+        "y": 17,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_4_5.png",
-        "x_offset": -19,
-        "y_offset": 7,
+        "x": -19,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_1_1.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_1_2.png",
-        "x_offset": -26,
-        "y_offset": 0,
+        "x": -26,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_1_3.png",
-        "x_offset": 17,
-        "y_offset": 12,
+        "x": 17,
+        "y": 12,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_1_4.png",
-        "x_offset": -8,
-        "y_offset": 12,
+        "x": -8,
+        "y": 12,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_2_1.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_2_2.png",
-        "x_offset": -10,
-        "y_offset": 2,
+        "x": -10,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_2_3.png",
-        "x_offset": -20,
-        "y_offset": 21,
+        "x": -20,
+        "y": 21,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_2_4.png",
-        "x_offset": -28,
-        "y_offset": 9,
+        "x": -28,
+        "y": 9,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_3_1.png",
-        "x_offset": -16,
-        "y_offset": 3,
+        "x": -16,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_3_2.png",
-        "x_offset": -1,
-        "y_offset": 7,
+        "x": -1,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_3_3.png",
-        "x_offset": -32,
-        "y_offset": 11,
+        "x": -32,
+        "y": 11,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_3_4.png",
-        "x_offset": -4,
-        "y_offset": -1,
+        "x": -4,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_4_1.png",
-        "x_offset": -20,
-        "y_offset": 6,
+        "x": -20,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_4_2.png",
-        "x_offset": -32,
-        "y_offset": 12,
+        "x": -32,
+        "y": 12,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_4_3.png",
-        "x_offset": -3,
-        "y_offset": 0,
+        "x": -3,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_4_4.png",
-        "x_offset": 0,
-        "y_offset": 10,
+        "x": 0,
+        "y": 10,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_1_1.png",
-        "x_offset": -19,
-        "y_offset": 6,
+        "x": -19,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_1_2.png",
-        "x_offset": -18,
-        "y_offset": 12,
+        "x": -18,
+        "y": 12,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_1_3.png",
-        "x_offset": -4,
-        "y_offset": 0,
+        "x": -4,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_1_4.png",
-        "x_offset": -32,
-        "y_offset": 10,
+        "x": -32,
+        "y": 10,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_2_1.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_2_2.png",
-        "x_offset": -22,
-        "y_offset": 7,
+        "x": -22,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_2_3.png",
-        "x_offset": 23,
-        "y_offset": 11,
+        "x": 23,
+        "y": 11,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_2_4.png",
-        "x_offset": -6,
-        "y_offset": -1,
+        "x": -6,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_3_1.png",
-        "x_offset": -28,
-        "y_offset": 3,
+        "x": -28,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_3_2.png",
-        "x_offset": -24,
-        "y_offset": 2,
+        "x": -24,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_3_3.png",
-        "x_offset": -12,
-        "y_offset": 21,
+        "x": -12,
+        "y": 21,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_3_4.png",
-        "x_offset": 0,
-        "y_offset": 9,
+        "x": 0,
+        "y": 9,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_4_1.png",
-        "x_offset": -12,
-        "y_offset": 3,
+        "x": -12,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_4_2.png",
-        "x_offset": 1,
-        "y_offset": 0,
+        "x": 1,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_4_3.png",
-        "x_offset": -31,
-        "y_offset": 12,
+        "x": -31,
+        "y": 12,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_4_4.png",
-        "x_offset": -4,
-        "y_offset": 12,
+        "x": -4,
+        "y": 12,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 10,
+        "x": -32,
+        "y": 10,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_diag_2.png",
-        "x_offset": -5,
-        "y_offset": -4,
+        "x": -5,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_diag_3.png",
-        "x_offset": -32,
-        "y_offset": 10,
+        "x": -32,
+        "y": 10,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_diag_4.png",
-        "x_offset": -5,
-        "y_offset": -4,
+        "x": -5,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_gentle_up_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_gentle_up_diag_2.png",
-        "x_offset": -5,
-        "y_offset": -4,
+        "x": -5,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_gentle_up_diag_3.png",
-        "x_offset": -33,
-        "y_offset": 2,
+        "x": -33,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_gentle_up_diag_4.png",
-        "x_offset": -5,
-        "y_offset": -12,
+        "x": -5,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_to_flat_up_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_to_flat_up_diag_2.png",
-        "x_offset": -5,
-        "y_offset": -4,
+        "x": -5,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_to_flat_up_diag_3.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_to_flat_up_diag_4.png",
-        "x_offset": -5,
-        "y_offset": -12,
+        "x": -5,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_diag_1.png",
-        "x_offset": -32,
-        "y_offset": -6,
+        "x": -32,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_diag_2.png",
-        "x_offset": -5,
-        "y_offset": -4,
+        "x": -5,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_diag_3.png",
-        "x_offset": -32,
-        "y_offset": -6,
+        "x": -32,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_diag_4.png",
-        "x_offset": -5,
-        "y_offset": -20,
+        "x": -5,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_left_bank_1_1.png",
-        "x_offset": -19,
-        "y_offset": 4,
+        "x": -19,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_left_bank_1_2.png",
-        "x_offset": -1,
-        "y_offset": 4,
+        "x": -1,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_left_bank_2_1.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_left_bank_2_2.png",
-        "x_offset": -19,
-        "y_offset": 6,
+        "x": -19,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_left_bank_3.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_left_bank_4.png",
-        "x_offset": -19,
-        "y_offset": 2,
+        "x": -19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_right_bank_1.png",
-        "x_offset": -19,
-        "y_offset": 2,
+        "x": -19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_right_bank_2.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_right_bank_3_1.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_right_bank_3_2.png",
-        "x_offset": -15,
-        "y_offset": 6,
+        "x": -15,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_right_bank_4_1.png",
-        "x_offset": -18,
-        "y_offset": 4,
+        "x": -18,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_right_bank_4_2.png",
-        "x_offset": -19,
-        "y_offset": 4,
+        "x": -19,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/left_bank_to_gentle_up_1_1.png",
-        "x_offset": -19,
-        "y_offset": -5,
+        "x": -19,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/left_bank_to_gentle_up_1_2.png",
-        "x_offset": -15,
-        "y_offset": -1,
+        "x": -15,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/left_bank_to_gentle_up_2_1.png",
-        "x_offset": -18,
-        "y_offset": 4,
+        "x": -18,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/left_bank_to_gentle_up_2_2.png",
-        "x_offset": -19,
-        "y_offset": 4,
+        "x": -19,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/left_bank_to_gentle_up_3.png",
-        "x_offset": -19,
-        "y_offset": 2,
+        "x": -19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/left_bank_to_gentle_up_4.png",
-        "x_offset": -19,
-        "y_offset": -5,
+        "x": -19,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/right_bank_to_gentle_up_1.png",
-        "x_offset": -19,
-        "y_offset": -5,
+        "x": -19,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/right_bank_to_gentle_up_2.png",
-        "x_offset": -19,
-        "y_offset": 2,
+        "x": -19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/right_bank_to_gentle_up_3_1.png",
-        "x_offset": -19,
-        "y_offset": 4,
+        "x": -19,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/right_bank_to_gentle_up_3_2.png",
-        "x_offset": -5,
-        "y_offset": 4,
+        "x": -5,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/right_bank_to_gentle_up_4_1.png",
-        "x_offset": -19,
-        "y_offset": -5,
+        "x": -19,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/right_bank_to_gentle_up_4_2.png",
-        "x_offset": -18,
-        "y_offset": -1,
+        "x": -18,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_left_bank_1_1.png",
-        "x_offset": -19,
-        "y_offset": -4,
+        "x": -19,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_left_bank_1_2.png",
-        "x_offset": -1,
-        "y_offset": -4,
+        "x": -1,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_left_bank_2_1.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_left_bank_2_2.png",
-        "x_offset": -16,
-        "y_offset": 6,
+        "x": -16,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_left_bank_3.png",
-        "x_offset": -19,
-        "y_offset": 2,
+        "x": -19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_left_bank_4.png",
-        "x_offset": -19,
-        "y_offset": -6,
+        "x": -19,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_right_bank_1.png",
-        "x_offset": -19,
-        "y_offset": -6,
+        "x": -19,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_right_bank_2.png",
-        "x_offset": -19,
-        "y_offset": 2,
+        "x": -19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_right_bank_3_1.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_right_bank_3_2.png",
-        "x_offset": -15,
-        "y_offset": 6,
+        "x": -15,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_right_bank_4_1.png",
-        "x_offset": -18,
-        "y_offset": -4,
+        "x": -18,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_right_bank_4_2.png",
-        "x_offset": -19,
-        "y_offset": -4,
+        "x": -19,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/left_bank_1.png",
-        "x_offset": -19,
-        "y_offset": 4,
+        "x": -19,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/left_bank_2.png",
-        "x_offset": -19,
-        "y_offset": 4,
+        "x": -19,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/left_bank_3.png",
-        "x_offset": -19,
-        "y_offset": 2,
+        "x": -19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/left_bank_4.png",
-        "x_offset": -19,
-        "y_offset": 2,
+        "x": -19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_left_bank_diag_1_1.png",
-        "x_offset": -32,
-        "y_offset": 10,
+        "x": -32,
+        "y": 10,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_left_bank_diag_1_2.png",
-        "x_offset": -32,
-        "y_offset": 12,
+        "x": -32,
+        "y": 12,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_left_bank_diag_2.png",
-        "x_offset": -5,
-        "y_offset": -4,
+        "x": -5,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_left_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": 9,
+        "x": -32,
+        "y": 9,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_left_bank_diag_4.png",
-        "x_offset": -4,
-        "y_offset": -5,
+        "x": -4,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_right_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 9,
+        "x": -32,
+        "y": 9,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_right_bank_diag_2.png",
-        "x_offset": -4,
-        "y_offset": -4,
+        "x": -4,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_right_bank_diag_3_1.png",
-        "x_offset": -32,
-        "y_offset": 10,
+        "x": -32,
+        "y": 10,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_right_bank_diag_3_2.png",
-        "x_offset": -32,
-        "y_offset": 12,
+        "x": -32,
+        "y": 12,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_right_bank_diag_4.png",
-        "x_offset": -5,
-        "y_offset": -5,
+        "x": -5,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/left_bank_to_gentle_up_diag_1_1.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/left_bank_to_gentle_up_diag_1_2.png",
-        "x_offset": -32,
-        "y_offset": 7,
+        "x": -32,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/alpine/left_bank_to_gentle_up_diag_2.png",
-        "x_offset": -5,
-        "y_offset": -5,
+        "x": -5,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/left_bank_to_gentle_up_diag_3.png",
-        "x_offset": -33,
-        "y_offset": 2,
+        "x": -33,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/left_bank_to_gentle_up_diag_4.png",
-        "x_offset": -4,
-        "y_offset": -12,
+        "x": -4,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/alpine/right_bank_to_gentle_up_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/right_bank_to_gentle_up_diag_2.png",
-        "x_offset": -4,
-        "y_offset": -5,
+        "x": -4,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/right_bank_to_gentle_up_diag_3_1.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/right_bank_to_gentle_up_diag_3_2.png",
-        "x_offset": -31,
-        "y_offset": 7,
+        "x": -31,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/alpine/right_bank_to_gentle_up_diag_4.png",
-        "x_offset": -5,
-        "y_offset": -12,
+        "x": -5,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_left_bank_diag_1_1.png",
-        "x_offset": -32,
-        "y_offset": 3,
+        "x": -32,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_left_bank_diag_1_2.png",
-        "x_offset": -32,
-        "y_offset": 4,
+        "x": -32,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_left_bank_diag_2.png",
-        "x_offset": -5,
-        "y_offset": -4,
+        "x": -5,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_left_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": 1,
+        "x": -32,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_left_bank_diag_4.png",
-        "x_offset": -4,
-        "y_offset": -13,
+        "x": -4,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_right_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 1,
+        "x": -32,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_right_bank_diag_2.png",
-        "x_offset": -4,
-        "y_offset": -4,
+        "x": -4,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_right_bank_diag_3_1.png",
-        "x_offset": -32,
-        "y_offset": 3,
+        "x": -32,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_right_bank_diag_3_2.png",
-        "x_offset": -32,
-        "y_offset": 4,
+        "x": -32,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_right_bank_diag_4.png",
-        "x_offset": -5,
-        "y_offset": -13,
+        "x": -5,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/alpine/left_bank_diag_1.png",
-        "x_offset": -32,
-        "y_offset": 11,
+        "x": -32,
+        "y": 11,
         "palette": "keep"
     },
     {
         "path": "track/alpine/left_bank_diag_2.png",
-        "x_offset": -5,
-        "y_offset": -5,
+        "x": -5,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/left_bank_diag_3.png",
-        "x_offset": -32,
-        "y_offset": 9,
+        "x": -32,
+        "y": 9,
         "palette": "keep"
     },
     {
         "path": "track/alpine/left_bank_diag_4.png",
-        "x_offset": -4,
-        "y_offset": -5,
+        "x": -4,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_1_1.png",
-        "x_offset": -19,
-        "y_offset": -1,
+        "x": -19,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_1_2.png",
-        "x_offset": -15,
-        "y_offset": 4,
+        "x": -15,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_1_3.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_1_4.png",
-        "x_offset": -19,
-        "y_offset": 2,
+        "x": -19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_2_1.png",
-        "x_offset": -19,
-        "y_offset": 4,
+        "x": -19,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_2_2.png",
-        "x_offset": -2,
-        "y_offset": 0,
+        "x": -2,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_2_3.png",
-        "x_offset": -32,
-        "y_offset": 4,
+        "x": -32,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_3_1.png",
-        "x_offset": -5,
-        "y_offset": 2,
+        "x": -5,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_3_2.png",
-        "x_offset": 23,
-        "y_offset": 1,
+        "x": 23,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_3_3.png",
-        "x_offset": -7,
-        "y_offset": -1,
+        "x": -7,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_3_4.png",
-        "x_offset": -6,
-        "y_offset": 4,
+        "x": -6,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_4_1.png",
-        "x_offset": -28,
-        "y_offset": 7,
+        "x": -28,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_4_2.png",
-        "x_offset": -8,
-        "y_offset": 23,
+        "x": -8,
+        "y": 23,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_4_3.png",
-        "x_offset": -19,
-        "y_offset": 7,
+        "x": -19,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_1_1.png",
-        "x_offset": -19,
-        "y_offset": 2,
+        "x": -19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_1_2.png",
-        "x_offset": -15,
-        "y_offset": 4,
+        "x": -15,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_1_3.png",
-        "x_offset": -26,
-        "y_offset": 6,
+        "x": -26,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_1_4.png",
-        "x_offset": 11,
-        "y_offset": 6,
+        "x": 11,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_1_5.png",
-        "x_offset": -25,
-        "y_offset": 8,
+        "x": -25,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_1_6.png",
-        "x_offset": -19,
-        "y_offset": 2,
+        "x": -19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_2_1.png",
-        "x_offset": -19,
-        "y_offset": 4,
+        "x": -19,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_2_2.png",
-        "x_offset": -8,
-        "y_offset": 1,
+        "x": -8,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_2_3.png",
-        "x_offset": -24,
-        "y_offset": 19,
+        "x": -24,
+        "y": 19,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_2_4.png",
-        "x_offset": -14,
-        "y_offset": 1,
+        "x": -14,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_2_5.png",
-        "x_offset": -28,
-        "y_offset": 4,
+        "x": -28,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_3_1.png",
-        "x_offset": -14,
-        "y_offset": 2,
+        "x": -14,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_3_2.png",
-        "x_offset": 11,
-        "y_offset": 8,
+        "x": 11,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_3_3.png",
-        "x_offset": -22,
-        "y_offset": 6,
+        "x": -22,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_3_4.png",
-        "x_offset": 13,
-        "y_offset": 6,
+        "x": 13,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_3_5.png",
-        "x_offset": -9,
-        "y_offset": 2,
+        "x": -9,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_3_6.png",
-        "x_offset": -10,
-        "y_offset": 4,
+        "x": -10,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_4_1.png",
-        "x_offset": -24,
-        "y_offset": 6,
+        "x": -24,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_4_2.png",
-        "x_offset": -30,
-        "y_offset": 16,
+        "x": -30,
+        "y": 16,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_4_3.png",
-        "x_offset": -16,
-        "y_offset": 0,
+        "x": -16,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_4_4.png",
-        "x_offset": -18,
-        "y_offset": 16,
+        "x": -18,
+        "y": 16,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_bank_4_5.png",
-        "x_offset": -19,
-        "y_offset": 6,
+        "x": -19,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_bank_1_1.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_bank_1_2.png",
-        "x_offset": -24,
-        "y_offset": 0,
+        "x": -24,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_bank_1_3.png",
-        "x_offset": 19,
-        "y_offset": 12,
+        "x": 19,
+        "y": 12,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_bank_1_4.png",
-        "x_offset": -13,
-        "y_offset": 11,
+        "x": -13,
+        "y": 11,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_bank_2_1.png",
-        "x_offset": -19,
-        "y_offset": 4,
+        "x": -19,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_bank_2_2.png",
-        "x_offset": -32,
-        "y_offset": -6,
+        "x": -32,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_bank_2_3.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_bank_2_4.png",
-        "x_offset": -32,
-        "y_offset": 10,
+        "x": -32,
+        "y": 10,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_bank_3_1.png",
-        "x_offset": -17,
-        "y_offset": 2,
+        "x": -17,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_bank_3_2.png",
-        "x_offset": -2,
-        "y_offset": 7,
+        "x": -2,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_bank_3_3.png",
-        "x_offset": -32,
-        "y_offset": 11,
+        "x": -32,
+        "y": 11,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_bank_3_4.png",
-        "x_offset": -4,
-        "y_offset": -1,
+        "x": -4,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_bank_4_1.png",
-        "x_offset": -22,
-        "y_offset": 6,
+        "x": -22,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_bank_4_2.png",
-        "x_offset": -32,
-        "y_offset": 11,
+        "x": -32,
+        "y": 11,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_bank_4_3.png",
-        "x_offset": -4,
-        "y_offset": 0,
+        "x": -4,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_left_to_diag_bank_4_4.png",
-        "x_offset": 0,
-        "y_offset": 9,
+        "x": 0,
+        "y": 9,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_bank_1_1.png",
-        "x_offset": -19,
-        "y_offset": 6,
+        "x": -19,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_bank_1_2.png",
-        "x_offset": -20,
-        "y_offset": 11,
+        "x": -20,
+        "y": 11,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_bank_1_3.png",
-        "x_offset": -6,
-        "y_offset": 0,
+        "x": -6,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_bank_1_4.png",
-        "x_offset": -32,
-        "y_offset": 9,
+        "x": -32,
+        "y": 9,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_bank_2_1.png",
-        "x_offset": -19,
-        "y_offset": 2,
+        "x": -19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_bank_2_2.png",
-        "x_offset": -22,
-        "y_offset": 7,
+        "x": -22,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_bank_2_3.png",
-        "x_offset": 23,
-        "y_offset": 11,
+        "x": 23,
+        "y": 11,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_bank_2_4.png",
-        "x_offset": -6,
-        "y_offset": -1,
+        "x": -6,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_bank_3_1.png",
-        "x_offset": -26,
-        "y_offset": 4,
+        "x": -26,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_bank_3_2.png",
-        "x_offset": -32,
-        "y_offset": -6,
+        "x": -32,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_bank_3_3.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_bank_3_4.png",
-        "x_offset": 0,
-        "y_offset": 10,
+        "x": 0,
+        "y": 10,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_bank_4_1.png",
-        "x_offset": -25,
-        "y_offset": -10,
+        "x": -25,
+        "y": -10,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_bank_4_2.png",
-        "x_offset": 1,
-        "y_offset": 0,
+        "x": 1,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_bank_4_3.png",
-        "x_offset": -31,
-        "y_offset": 12,
+        "x": -31,
+        "y": 12,
         "palette": "keep"
     },
     {
         "path": "track/alpine/large_turn_right_to_diag_bank_4_4.png",
-        "x_offset": -4,
-        "y_offset": 11,
+        "x": -4,
+        "y": 11,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_gentle_up_1_1.png",
-        "x_offset": -25,
-        "y_offset": -30,
+        "x": -25,
+        "y": -30,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_gentle_up_1_2.png",
-        "x_offset": -13,
-        "y_offset": -16,
+        "x": -13,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_gentle_up_2_1.png",
-        "x_offset": -13,
-        "y_offset": -7,
+        "x": -13,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_gentle_up_2_2.png",
-        "x_offset": -38,
-        "y_offset": -16,
+        "x": -38,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_gentle_up_3_1.png",
-        "x_offset": -14,
-        "y_offset": 0,
+        "x": -14,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_gentle_up_3_2.png",
-        "x_offset": -2,
-        "y_offset": -5,
+        "x": -2,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_gentle_up_4_1.png",
-        "x_offset": -26,
-        "y_offset": -11,
+        "x": -26,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_gentle_up_4_2.png",
-        "x_offset": -25,
-        "y_offset": -1,
+        "x": -25,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_right_gentle_up_1_1.png",
-        "x_offset": -25,
-        "y_offset": -11,
+        "x": -25,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_right_gentle_up_1_2.png",
-        "x_offset": -26,
-        "y_offset": -1,
+        "x": -26,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_right_gentle_up_2_1.png",
-        "x_offset": -13,
-        "y_offset": 0,
+        "x": -13,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_right_gentle_up_2_2.png",
-        "x_offset": -25,
-        "y_offset": -5,
+        "x": -25,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_right_gentle_up_3_1.png",
-        "x_offset": -38,
-        "y_offset": -7,
+        "x": -38,
+        "y": -7,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_right_gentle_up_3_2.png",
-        "x_offset": -13,
-        "y_offset": -16,
+        "x": -13,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_right_gentle_up_4_1.png",
-        "x_offset": -2,
-        "y_offset": -23,
+        "x": -2,
+        "y": -23,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_right_gentle_up_4_2.png",
-        "x_offset": -14,
-        "y_offset": -16,
+        "x": -14,
+        "y": -16,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_gentle_up_1_1.png",
-        "x_offset": -19,
-        "y_offset": -13,
+        "x": -19,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_gentle_up_1_2.png",
-        "x_offset": -28,
-        "y_offset": -9,
+        "x": -28,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_gentle_up_1_3.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_gentle_up_1_4.png",
-        "x_offset": -26,
-        "y_offset": -6,
+        "x": -26,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_gentle_up_1_5.png",
-        "x_offset": -19,
-        "y_offset": -13,
+        "x": -19,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_gentle_up_2_1.png",
-        "x_offset": -19,
-        "y_offset": -4,
+        "x": -19,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_gentle_up_2_2.png",
-        "x_offset": 0,
-        "y_offset": -13,
+        "x": 0,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_gentle_up_2_3.png",
-        "x_offset": 0,
-        "y_offset": 2,
+        "x": 0,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_gentle_up_2_4.png",
-        "x_offset": -12,
-        "y_offset": -20,
+        "x": -12,
+        "y": -20,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_gentle_up_2_5.png",
-        "x_offset": -17,
-        "y_offset": -13,
+        "x": -17,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_gentle_up_3_1.png",
-        "x_offset": -22,
-        "y_offset": 3,
+        "x": -22,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_gentle_up_3_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_gentle_up_3_3.png",
-        "x_offset": -20,
-        "y_offset": 8,
+        "x": -20,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_gentle_up_3_4.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_gentle_up_3_5.png",
-        "x_offset": -13,
-        "y_offset": 2,
+        "x": -13,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_gentle_up_4_1.png",
-        "x_offset": -24,
-        "y_offset": -11,
+        "x": -24,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_gentle_up_4_2.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_gentle_up_4_3.png",
-        "x_offset": -17,
-        "y_offset": -11,
+        "x": -17,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_gentle_up_4_4.png",
-        "x_offset": -16,
-        "y_offset": 5,
+        "x": -16,
+        "y": 5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_left_gentle_up_4_5.png",
-        "x_offset": -19,
-        "y_offset": 2,
+        "x": -19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_right_gentle_up_1_1.png",
-        "x_offset": -19,
-        "y_offset": -11,
+        "x": -19,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_right_gentle_up_1_2.png",
-        "x_offset": -11,
-        "y_offset": 2,
+        "x": -11,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_right_gentle_up_1_3.png",
-        "x_offset": 0,
-        "y_offset": -11,
+        "x": 0,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_right_gentle_up_1_4.png",
-        "x_offset": -16,
-        "y_offset": 5,
+        "x": -16,
+        "y": 5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_right_gentle_up_1_5.png",
-        "x_offset": -18,
-        "y_offset": 2,
+        "x": -18,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_right_gentle_up_2_1.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_right_gentle_up_2_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_right_gentle_up_2_3.png",
-        "x_offset": 0,
-        "y_offset": 8,
+        "x": 0,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_right_gentle_up_2_4.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_right_gentle_up_2_5.png",
-        "x_offset": -19,
-        "y_offset": 2,
+        "x": -19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_right_gentle_up_3_1.png",
-        "x_offset": -32,
-        "y_offset": -4,
+        "x": -32,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_right_gentle_up_3_2.png",
-        "x_offset": -32,
-        "y_offset": -13,
+        "x": -32,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_right_gentle_up_3_3.png",
-        "x_offset": -25,
-        "y_offset": 1,
+        "x": -25,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_right_gentle_up_3_4.png",
-        "x_offset": -21,
-        "y_offset": -22,
+        "x": -21,
+        "y": -22,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_right_gentle_up_3_5.png",
-        "x_offset": -19,
-        "y_offset": -13,
+        "x": -19,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_right_gentle_up_4_1.png",
-        "x_offset": -11,
-        "y_offset": -11,
+        "x": -11,
+        "y": -11,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_right_gentle_up_4_2.png",
-        "x_offset": 11,
-        "y_offset": -9,
+        "x": 11,
+        "y": -9,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_right_gentle_up_4_3.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_right_gentle_up_4_4.png",
-        "x_offset": 10,
-        "y_offset": -5,
+        "x": 10,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_turn_right_gentle_up_4_5.png",
-        "x_offset": -14,
-        "y_offset": -13,
+        "x": -14,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/alpine/s_bend_left_1_1.png",
-        "x_offset": -19,
-        "y_offset": 2,
+        "x": -19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/s_bend_left_1_2.png",
-        "x_offset": -26,
-        "y_offset": 6,
+        "x": -26,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/s_bend_left_1_3.png",
-        "x_offset": 10,
-        "y_offset": 8,
+        "x": 10,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/alpine/s_bend_left_1_4.png",
-        "x_offset": -15,
-        "y_offset": 3,
+        "x": -15,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/s_bend_left_2_1.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/s_bend_left_2_2.png",
-        "x_offset": -10,
-        "y_offset": 1,
+        "x": -10,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/s_bend_left_2_3.png",
-        "x_offset": -28,
-        "y_offset": 17,
+        "x": -28,
+        "y": 17,
         "palette": "keep"
     },
     {
         "path": "track/alpine/s_bend_left_2_4.png",
-        "x_offset": -20,
-        "y_offset": 6,
+        "x": -20,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/s_bend_right_1_1.png",
-        "x_offset": -19,
-        "y_offset": 6,
+        "x": -19,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/s_bend_right_1_2.png",
-        "x_offset": -18,
-        "y_offset": 17,
+        "x": -18,
+        "y": 17,
         "palette": "keep"
     },
     {
         "path": "track/alpine/s_bend_right_1_3.png",
-        "x_offset": -14,
-        "y_offset": 1,
+        "x": -14,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/s_bend_right_1_4.png",
-        "x_offset": -30,
-        "y_offset": 3,
+        "x": -30,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/s_bend_right_2_1.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/s_bend_right_2_2.png",
-        "x_offset": -24,
-        "y_offset": 8,
+        "x": -24,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/alpine/s_bend_right_2_3.png",
-        "x_offset": 12,
-        "y_offset": 6,
+        "x": 12,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/s_bend_right_2_4.png",
-        "x_offset": -12,
-        "y_offset": 2,
+        "x": -12,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_left_up_1_1.png",
-        "x_offset": -18,
-        "y_offset": -1,
+        "x": -18,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_left_up_1_2.png",
-        "x_offset": -15,
-        "y_offset": 1,
+        "x": -15,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_left_up_1_3.png",
-        "x_offset": -32,
-        "y_offset": 1,
+        "x": -32,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_left_up_1_4.png",
-        "x_offset": -19,
-        "y_offset": -6,
+        "x": -19,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_left_up_2_1.png",
-        "x_offset": -19,
-        "y_offset": 4,
+        "x": -19,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_left_up_2_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_left_up_2_3.png",
-        "x_offset": -32,
-        "y_offset": -4,
+        "x": -32,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_left_up_3_1.png",
-        "x_offset": -6,
-        "y_offset": 1,
+        "x": -6,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_left_up_3_2.png",
-        "x_offset": 23,
-        "y_offset": 1,
+        "x": 23,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_left_up_3_3.png",
-        "x_offset": -5,
-        "y_offset": -1,
+        "x": -5,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_left_up_3_4.png",
-        "x_offset": -5,
-        "y_offset": 0,
+        "x": -5,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_left_up_4_1.png",
-        "x_offset": -26,
-        "y_offset": 4,
+        "x": -26,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_left_up_4_2.png",
-        "x_offset": -8,
-        "y_offset": 19,
+        "x": -8,
+        "y": 19,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_left_up_4_3.png",
-        "x_offset": -18,
-        "y_offset": 3,
+        "x": -18,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_right_up_1_1.png",
-        "x_offset": -19,
-        "y_offset": 4,
+        "x": -19,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_right_up_1_2.png",
-        "x_offset": -6,
-        "y_offset": 19,
+        "x": -6,
+        "y": 19,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_right_up_1_3.png",
-        "x_offset": -26,
-        "y_offset": 3,
+        "x": -26,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_right_up_2_1.png",
-        "x_offset": -19,
-        "y_offset": 1,
+        "x": -19,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_right_up_2_2.png",
-        "x_offset": -32,
-        "y_offset": 1,
+        "x": -32,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_right_up_2_3.png",
-        "x_offset": -19,
-        "y_offset": -1,
+        "x": -19,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_right_up_2_4.png",
-        "x_offset": -16,
-        "y_offset": 0,
+        "x": -16,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_right_up_3_1.png",
-        "x_offset": -32,
-        "y_offset": 4,
+        "x": -32,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_right_up_3_2.png",
-        "x_offset": 0,
-        "y_offset": 0,
+        "x": 0,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_right_up_3_3.png",
-        "x_offset": -19,
-        "y_offset": -4,
+        "x": -19,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_right_up_4_1.png",
-        "x_offset": -6,
-        "y_offset": -1,
+        "x": -6,
+        "y": -1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_right_up_4_2.png",
-        "x_offset": -6,
-        "y_offset": 1,
+        "x": -6,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_right_up_4_3.png",
-        "x_offset": 23,
-        "y_offset": 0,
+        "x": 23,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_helix_right_up_4_4.png",
-        "x_offset": -7,
-        "y_offset": -6,
+        "x": -7,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_1_1.png",
-        "x_offset": -19,
-        "y_offset": 2,
+        "x": -19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_1_2.png",
-        "x_offset": -15,
-        "y_offset": 4,
+        "x": -15,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_1_3.png",
-        "x_offset": -28,
-        "y_offset": 7,
+        "x": -28,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_1_4.png",
-        "x_offset": 9,
-        "y_offset": 6,
+        "x": 9,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_1_5.png",
-        "x_offset": -22,
-        "y_offset": 7,
+        "x": -22,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_1_6.png",
-        "x_offset": -19,
-        "y_offset": -6,
+        "x": -19,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_2_1.png",
-        "x_offset": -19,
-        "y_offset": 4,
+        "x": -19,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_2_2.png",
-        "x_offset": -4,
-        "y_offset": 0,
+        "x": -4,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_2_3.png",
-        "x_offset": -32,
-        "y_offset": 12,
+        "x": -32,
+        "y": 12,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_2_4.png",
-        "x_offset": 1,
-        "y_offset": 0,
+        "x": 1,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_2_5.png",
-        "x_offset": -32,
-        "y_offset": -4,
+        "x": -32,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_3_1.png",
-        "x_offset": -16,
-        "y_offset": 1,
+        "x": -16,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_3_2.png",
-        "x_offset": 10,
-        "y_offset": 8,
+        "x": 10,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_3_3.png",
-        "x_offset": -21,
-        "y_offset": 6,
+        "x": -21,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_3_4.png",
-        "x_offset": 15,
-        "y_offset": 7,
+        "x": 15,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_3_5.png",
-        "x_offset": -3,
-        "y_offset": 0,
+        "x": -3,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_3_6.png",
-        "x_offset": -7,
-        "y_offset": 2,
+        "x": -7,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_4_1.png",
-        "x_offset": -20,
-        "y_offset": 5,
+        "x": -20,
+        "y": 5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_4_2.png",
-        "x_offset": -30,
-        "y_offset": 13,
+        "x": -30,
+        "y": 13,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_4_3.png",
-        "x_offset": -8,
-        "y_offset": -4,
+        "x": -8,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_4_4.png",
-        "x_offset": -26,
-        "y_offset": 12,
+        "x": -26,
+        "y": 12,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_left_up_4_5.png",
-        "x_offset": -18,
-        "y_offset": 2,
+        "x": -18,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_1_1.png",
-        "x_offset": -19,
-        "y_offset": 5,
+        "x": -19,
+        "y": 5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_1_2.png",
-        "x_offset": -20,
-        "y_offset": 13,
+        "x": -20,
+        "y": 13,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_1_3.png",
-        "x_offset": -8,
-        "y_offset": -4,
+        "x": -8,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_1_4.png",
-        "x_offset": -30,
-        "y_offset": 12,
+        "x": -30,
+        "y": 12,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_1_5.png",
-        "x_offset": -14,
-        "y_offset": 2,
+        "x": -14,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_2_1.png",
-        "x_offset": -19,
-        "y_offset": 1,
+        "x": -19,
+        "y": 1,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_2_2.png",
-        "x_offset": -24,
-        "y_offset": 8,
+        "x": -24,
+        "y": 8,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_2_3.png",
-        "x_offset": 5,
-        "y_offset": 6,
+        "x": 5,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_2_4.png",
-        "x_offset": -30,
-        "y_offset": 7,
+        "x": -30,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_2_5.png",
-        "x_offset": -19,
-        "y_offset": 0,
+        "x": -19,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_2_6.png",
-        "x_offset": -15,
-        "y_offset": 2,
+        "x": -15,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_3_1.png",
-        "x_offset": -32,
-        "y_offset": 4,
+        "x": -32,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_3_2.png",
-        "x_offset": -6,
-        "y_offset": 0,
+        "x": -6,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_3_3.png",
-        "x_offset": -32,
-        "y_offset": 12,
+        "x": -32,
+        "y": 12,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_3_4.png",
-        "x_offset": -2,
-        "y_offset": 0,
+        "x": -2,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_3_5.png",
-        "x_offset": -19,
-        "y_offset": -4,
+        "x": -19,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_4_1.png",
-        "x_offset": -8,
-        "y_offset": 2,
+        "x": -8,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_4_2.png",
-        "x_offset": -8,
-        "y_offset": 4,
+        "x": -8,
+        "y": 4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_4_3.png",
-        "x_offset": 15,
-        "y_offset": 7,
+        "x": 15,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_4_4.png",
-        "x_offset": -21,
-        "y_offset": 6,
+        "x": -21,
+        "y": 6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_4_5.png",
-        "x_offset": 10,
-        "y_offset": 7,
+        "x": 10,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/alpine/medium_helix_right_up_4_6.png",
-        "x_offset": -17,
-        "y_offset": -6,
+        "x": -17,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_to_gentle_up_1_1.png",
-        "x_offset": -24,
-        "y_offset": -14,
+        "x": -24,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_to_gentle_up_1_2.png",
-        "x_offset": -13,
-        "y_offset": -8,
+        "x": -13,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_to_gentle_up_2_1.png",
-        "x_offset": -10,
-        "y_offset": 0,
+        "x": -10,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_to_gentle_up_2_2.png",
-        "x_offset": -12,
-        "y_offset": 0,
+        "x": -12,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_to_gentle_up_2_3.png",
-        "x_offset": -38,
-        "y_offset": -8,
+        "x": -38,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_to_gentle_up_3_1.png",
-        "x_offset": -15,
-        "y_offset": -2,
+        "x": -15,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_to_gentle_up_3_2.png",
-        "x_offset": -3,
-        "y_offset": 2,
+        "x": -3,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_to_gentle_up_4_1.png",
-        "x_offset": -26,
-        "y_offset": -4,
+        "x": -26,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_left_bank_to_gentle_up_4_2.png",
-        "x_offset": -25,
-        "y_offset": 7,
+        "x": -25,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_right_bank_to_gentle_up_1_1.png",
-        "x_offset": -24,
-        "y_offset": -4,
+        "x": -24,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_right_bank_to_gentle_up_1_2.png",
-        "x_offset": -26,
-        "y_offset": 7,
+        "x": -26,
+        "y": 7,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_right_bank_to_gentle_up_2_1.png",
-        "x_offset": -12,
-        "y_offset": -2,
+        "x": -12,
+        "y": -2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_right_bank_to_gentle_up_2_2.png",
-        "x_offset": -25,
-        "y_offset": 2,
+        "x": -25,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_right_bank_to_gentle_up_3_1.png",
-        "x_offset": -38,
-        "y_offset": 0,
+        "x": -38,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_right_bank_to_gentle_up_3_2.png",
-        "x_offset": -38,
-        "y_offset": 0,
+        "x": -38,
+        "y": 0,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_right_bank_to_gentle_up_3_3.png",
-        "x_offset": -13,
-        "y_offset": -8,
+        "x": -13,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_right_bank_to_gentle_up_4_1.png",
-        "x_offset": -2,
-        "y_offset": -14,
+        "x": -2,
+        "y": -14,
         "palette": "keep"
     },
     {
         "path": "track/alpine/small_turn_right_bank_to_gentle_up_4_2.png",
-        "x_offset": -15,
-        "y_offset": -8,
+        "x": -15,
+        "y": -8,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_lift_1.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_lift_2.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_lift_3.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_lift_4.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_gentle_up_lift_1.png",
-        "x_offset": -19,
-        "y_offset": -5,
+        "x": -19,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_gentle_up_lift_2.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_gentle_up_lift_3.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_gentle_up_lift_4.png",
-        "x_offset": -19,
-        "y_offset": -5,
+        "x": -19,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_flat_lift_1.png",
-        "x_offset": -19,
-        "y_offset": -5,
+        "x": -19,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_flat_lift_2.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_flat_lift_3.png",
-        "x_offset": -19,
-        "y_offset": 3,
+        "x": -19,
+        "y": 3,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_up_to_flat_lift_4.png",
-        "x_offset": -19,
-        "y_offset": -5,
+        "x": -19,
+        "y": -5,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_lift_1.png",
-        "x_offset": -19,
-        "y_offset": -13,
+        "x": -19,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_lift_2.png",
-        "x_offset": -19,
-        "y_offset": 2,
+        "x": -19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_lift_3.png",
-        "x_offset": -19,
-        "y_offset": 2,
+        "x": -19,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_lift_4.png",
-        "x_offset": -19,
-        "y_offset": -13,
+        "x": -19,
+        "y": -13,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_diag_lift_1.png",
-        "x_offset": -32,
-        "y_offset": 10,
+        "x": -32,
+        "y": 10,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_diag_lift_2.png",
-        "x_offset": -5,
-        "y_offset": -4,
+        "x": -5,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_diag_lift_3.png",
-        "x_offset": -32,
-        "y_offset": 10,
+        "x": -32,
+        "y": 10,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_diag_lift_4.png",
-        "x_offset": -5,
-        "y_offset": -4,
+        "x": -5,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_gentle_up_diag_lift_1.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_gentle_up_diag_lift_2.png",
-        "x_offset": -5,
-        "y_offset": -4,
+        "x": -5,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_gentle_up_diag_lift_3.png",
-        "x_offset": -33,
-        "y_offset": 2,
+        "x": -33,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/flat_to_gentle_up_diag_lift_4.png",
-        "x_offset": -5,
-        "y_offset": -12,
+        "x": -5,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_to_flat_up_diag_lift_1.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_to_flat_up_diag_lift_2.png",
-        "x_offset": -5,
-        "y_offset": -4,
+        "x": -5,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_to_flat_up_diag_lift_3.png",
-        "x_offset": -32,
-        "y_offset": 2,
+        "x": -32,
+        "y": 2,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_to_flat_up_diag_lift_4.png",
-        "x_offset": -5,
-        "y_offset": -12,
+        "x": -5,
+        "y": -12,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_diag_lift_1.png",
-        "x_offset": -32,
-        "y_offset": -6,
+        "x": -32,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_diag_lift_2.png",
-        "x_offset": -5,
-        "y_offset": -4,
+        "x": -5,
+        "y": -4,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_diag_lift_3.png",
-        "x_offset": -32,
-        "y_offset": -6,
+        "x": -32,
+        "y": -6,
         "palette": "keep"
     },
     {
         "path": "track/alpine/gentle_diag_lift_4.png",
-        "x_offset": -5,
-        "y_offset": -20,
+        "x": -5,
+        "y": -20,
         "palette": "keep"
     },
     {
     	"path": "icons/medium-curve-left.png",
-        "x_offset": 2,
-        "y_offset": 6
+        "x": 2,
+        "y": 6
     },
     {
     	"path": "icons/medium-curve-right.png",
-        "x_offset": 1,
-        "y_offset": 6
+        "x": 1,
+        "y": 6
     }
 ]

--- a/src/openrct2/CommandLineSprite.cpp
+++ b/src/openrct2/CommandLineSprite.cpp
@@ -579,8 +579,8 @@ int32_t CommandLineForSprite(const char** argv, int32_t argc)
             }
             std::string strPath = Json::GetString(path);
 
-            json_t x_offset = jsonSprite["x_offset"];
-            json_t y_offset = jsonSprite["y_offset"];
+            json_t x_offset = jsonSprite["x"];
+            json_t y_offset = jsonSprite["y"];
 
             auto palette = (Json::GetString(jsonSprite["palette"]) == "keep") ? ImageImporter::Palette::KeepIndices
                                                                               : ImageImporter::Palette::OpenRCT2;


### PR DESCRIPTION
I’m working on a few improvements in object image handling. Part of these is using the same code to process both g2/sprites.json and object json. This PR is preparation for that: it changes the names of the parameters used in g2/sprites.json to match those used in the objects. (Doing it the other way round is unfeasible due to the number of existing objects.)