### PR TITLE
Refactor TTF drawing

### DIFF
--- a/src/openrct2/drawing/IDrawingContext.h
+++ b/src/openrct2/drawing/IDrawingContext.h
@@ -11,6 +11,7 @@
 
 #include "../common.h"
 #include "Drawing.h"
+#include "TTF.h"
 
 namespace OpenRCT2::Drawing
 {
@@ -33,8 +34,8 @@ namespace OpenRCT2::Drawing
         virtual void DrawGlyph(
             DrawPixelInfo& dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette) abstract;
         virtual void DrawTTFBitmap(
-            DrawPixelInfo& dpi, TextDrawInfo* info, ImageIndex image, const void* pixels, int32_t width, int32_t height,
-            int32_t x, int32_t y, uint8_t hinting_threshold) abstract;
+            DrawPixelInfo& dpi, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y,
+            uint8_t hintingThreshold) abstract;
     };
 
 } // namespace OpenRCT2::Drawing

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -1577,12 +1577,11 @@ static void ScrollingTextSetBitmapForTTF(
         return;
     }
 
-    int32_t pitch = surface->pitch;
     int32_t width = surface->w;
     auto src = static_cast<const uint8_t*>(surface->pixels);
 
     // Pitch offset
-    src += 2 * pitch;
+    src += 2 * width;
 
     // Line height offset
     int32_t min_vpos = -fontDesc->offset_y;
@@ -1608,7 +1607,7 @@ static void ScrollingTextSetBitmapForTTF(
 
                 for (int32_t y = min_vpos; y < max_vpos; y++)
                 {
-                    uint8_t src_pixel = src[y * pitch + x];
+                    uint8_t src_pixel = src[y * width + x];
                     if ((!use_hinting && src_pixel != 0) || src_pixel > 140)
                     {
                         // Centre of the glyph: use full colour.

--- a/src/openrct2/drawing/TTF.cpp
+++ b/src/openrct2/drawing/TTF.cpp
@@ -9,7 +9,6 @@
 
 #ifndef NO_TTF
 
-#    include <atomic>
 #    include <mutex>
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wdocumentation"
@@ -21,7 +20,6 @@
 #    include "../config/Config.h"
 #    include "../core/Numerics.hpp"
 #    include "../core/String.hpp"
-#    include "../localisation/Localisation.h"
 #    include "../localisation/LocalisationService.h"
 #    include "../platform/Platform.h"
 #    include "TTF.h"
@@ -372,13 +370,6 @@ void TTFFreeSurface(TTFSurface* surface)
 {
     free(const_cast<void*>(surface->pixels));
     free(surface);
-}
-
-uint8_t GetPixel(const TTFSurface& surface, int32_t x, int32_t y)
-{
-    if (x < 0 || y < 0 || x >= surface.w || y >= surface.h)
-        return 0;
-    return static_cast<const uint8_t*>(surface.pixels)[y * surface.pitch + x];
 }
 
 #else

--- a/src/openrct2/drawing/TTF.h
+++ b/src/openrct2/drawing/TTF.h
@@ -15,6 +15,7 @@
 
 bool TTFInitialise();
 void TTFDispose();
+struct TTFSurface;
 
 #ifndef NO_TTF
 
@@ -23,7 +24,6 @@ struct TTFSurface
     const void* pixels;
     int32_t w;
     int32_t h;
-    int32_t pitch;
 };
 
 TTFFontDescriptor* TTFGetFontFromSpriteBase(FontStyle fontStyle);
@@ -43,6 +43,5 @@ void TTF_CloseFont(TTF_Font* font);
 void TTF_SetFontHinting(TTF_Font* font, int hinting);
 int TTF_GetFontHinting(const TTF_Font* font);
 void TTF_Quit(void);
-uint8_t GetPixel(const TTFSurface& surface, int32_t x, int32_t y);
 
 #endif // NO_TTF

--- a/src/openrct2/drawing/TTFSDLPort.cpp
+++ b/src/openrct2/drawing/TTFSDLPort.cpp
@@ -216,7 +216,7 @@ static void TTF_initLineMectrics(const TTF_Font* font, const TTFSurface* textbuf
     dst = const_cast<uint8_t*>(static_cast<const uint8_t*>(textbuf->pixels));
     if (row > 0)
     {
-        dst += row * textbuf->pitch;
+        dst += row * textbuf->w;
     }
 
     height = font->underline_height;
@@ -236,7 +236,7 @@ outline into account.
 static void TTF_drawLine_Solid(const TTF_Font* font, const TTFSurface* textbuf, const int row)
 {
     int line;
-    uint8_t* dst_check = const_cast<uint8_t*>(static_cast<const uint8_t*>(textbuf->pixels)) + textbuf->pitch * textbuf->h;
+    uint8_t* dst_check = const_cast<uint8_t*>(static_cast<const uint8_t*>(textbuf->pixels)) + textbuf->w * textbuf->h;
     uint8_t* dst;
     int height;
 
@@ -247,7 +247,7 @@ static void TTF_drawLine_Solid(const TTF_Font* font, const TTFSurface* textbuf, 
     {
         /* 1 because 0 is the bg color */
         std::fill_n(dst, textbuf->w, 0x01);
-        dst += textbuf->pitch;
+        dst += textbuf->w;
     }
 }
 
@@ -258,7 +258,7 @@ static void TTF_drawLine_Solid(const TTF_Font* font, const TTFSurface* textbuf, 
 static void TTF_drawLine_Shaded(const TTF_Font* font, const TTFSurface* textbuf, const int row)
 {
     int line;
-    uint8_t* dst_check = const_cast<uint8_t*>(static_cast<const uint8_t*>(textbuf->pixels)) + textbuf->pitch * textbuf->h;
+    uint8_t* dst_check = const_cast<uint8_t*>(static_cast<const uint8_t*>(textbuf->pixels)) + textbuf->w * textbuf->h;
     uint8_t* dst;
     int height;
 
@@ -268,7 +268,7 @@ static void TTF_drawLine_Shaded(const TTF_Font* font, const TTFSurface* textbuf,
     for (line = height; line > 0 && dst < dst_check; --line)
     {
         std::fill_n(dst, textbuf->w, NUM_GRAYS - 1);
-        dst += textbuf->pitch;
+        dst += textbuf->w;
     }
 }
 
@@ -1299,12 +1299,11 @@ TTFSurface* TTF_RenderUTF8(TTF_Font* font, const char* text, bool shaded)
     }
     textbuf->w = width;
     textbuf->h = height;
-    textbuf->pitch = width;
     textbuf->pixels = calloc(1, width * height);
 
     /* Adding bound checking to avoid all kinds of memory corruption errors
     that may occur. */
-    dst_check = const_cast<uint8_t*>(static_cast<const uint8_t*>(textbuf->pixels)) + textbuf->pitch * textbuf->h;
+    dst_check = const_cast<uint8_t*>(static_cast<const uint8_t*>(textbuf->pixels)) + textbuf->w * textbuf->h;
 
     /* check kerning */
     use_kerning = FT_HAS_KERNING(font->face) && font->kerning;
@@ -1363,7 +1362,7 @@ TTFSurface* TTF_RenderUTF8(TTF_Font* font, const char* text, bool shaded)
             {
                 continue;
             }
-            dst = const_cast<uint8_t*>(static_cast<const uint8_t*>(textbuf->pixels)) + (row + glyph->yoffset) * textbuf->pitch
+            dst = const_cast<uint8_t*>(static_cast<const uint8_t*>(textbuf->pixels)) + (row + glyph->yoffset) * textbuf->w
                 + xstart + glyph->minx;
             src = current->buffer + row * current->pitch;
 

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include "../common.h"
 #include "IDrawingContext.h"
 #include "IDrawingEngine.h"
 
@@ -148,10 +147,8 @@ namespace OpenRCT2
             void DrawGlyph(
                 DrawPixelInfo& dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap) override;
             void DrawTTFBitmap(
-                DrawPixelInfo& dpi, TextDrawInfo* info, uint32_t image, const void* pixels, int32_t width, int32_t height,
-                int32_t x, int32_t y, uint8_t hinting_threshold) override
-            {
-            }
+                DrawPixelInfo& dpi, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y,
+                uint8_t hintingThreshold) override;
         };
     } // namespace Drawing
 } // namespace OpenRCT2


### PR DESCRIPTION
The software TTF rendering was very hacky and leaked details of the `IDrawingContext` and `IDrawingEngine` into `Drawing.String.cpp`

This PR: 

- Plugs the leaks by putting the hacky opengl texture assignment (this should also be cleaned up in the future) into the opengl rendering function, and putting the software rendering into the `X8DrawingEngine`.
- Fixes #21620 in software by simply drawing the text multiple times with offsets for these effects (same as opengl). As a consequence I got rid of the `GetPixel` in `TTF.cpp` 
- Removes `TTFSurface.pitch` since it was always the same as the width and much of the existing code relies on this assumption anyway.
- Cleans up some unused #includes
