### PR TITLE
Create or delete banners when tile elements are changed by plugins

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -66,6 +66,7 @@
 - Fix: [#21434] Number of guests overflows in objective text.
 - Fix: [#21522] Supports for 3×3 turns and 45 degree turns on the Hybrid Coaster and Wooden Roller Coaster not drawn correctly.
 - Fix: [#21543] Crash with creating a TrackIterator with invalid arguments.
+- Fix: [#21627] [Plugin] Banners are properly created or deleted when tile elements are changed by plugins.
 - Fix: [#21635] Tile inspector hotkey can set wall slope for non-slopeable objects.
 - Fix: [#21641] Crash when creating track iterator from an invalid tile element.
 - Fix: [#21652] Dialog window to confirm overwriting files does not apply the theme colours correctly.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -46,7 +46,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kNetworkStreamVersion = 0;
+constexpr uint8_t kNetworkStreamVersion = 1;
 
 const std::string kNetworkStreamID = std::string(OPENRCT2_VERSION) + "-" + std::to_string(kNetworkStreamVersion);
 

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -47,7 +47,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 87;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 88;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;

--- a/src/openrct2/scripting/bindings/world/ScTile.cpp
+++ b/src/openrct2/scripting/bindings/world/ScTile.cpp
@@ -15,6 +15,7 @@
 #    include "../../../common.h"
 #    include "../../../core/Guard.hpp"
 #    include "../../../entity/EntityRegistry.h"
+#    include "../../../object/LargeSceneryEntry.h"
 #    include "../../../ride/Track.h"
 #    include "../../../world/Footpath.h"
 #    include "../../../world/Scenery.h"
@@ -195,6 +196,13 @@ namespace OpenRCT2::Scripting
         auto first = GetFirstElement();
         if (index < GetNumElements(first))
         {
+            auto element = &first[index];
+            if (element->GetType() != TileElementType::LargeScenery
+                || element->AsLargeScenery()->GetEntry()->scrolling_mode == SCROLLING_MODE_NONE
+                || ScTileElement::GetOtherLargeSceneryElement(_coords, element->AsLargeScenery()) == nullptr)
+            {
+                element->RemoveBannerEntry();
+            }
             TileElementRemove(&first[index]);
             MapInvalidateTileFull(_coords);
         }

--- a/src/openrct2/scripting/bindings/world/ScTileElement.cpp
+++ b/src/openrct2/scripting/bindings/world/ScTileElement.cpp
@@ -15,6 +15,8 @@
 #    include "../../../common.h"
 #    include "../../../core/Guard.hpp"
 #    include "../../../entity/EntityRegistry.h"
+#    include "../../../object/LargeSceneryEntry.h"
+#    include "../../../object/WallSceneryEntry.h"
 #    include "../../../ride/Ride.h"
 #    include "../../../ride/RideData.h"
 #    include "../../../ride/Track.h"
@@ -63,6 +65,7 @@ namespace OpenRCT2::Scripting
 
     void ScTileElement::type_set(std::string value)
     {
+        RemoveBannerEntryIfNeeded();
         if (value == "surface")
             _element->SetType(TileElementType::Surface);
         else if (value == "footpath")
@@ -85,7 +88,7 @@ namespace OpenRCT2::Scripting
             scriptEngine.LogPluginInfo("Element type not recognised!");
             return;
         }
-
+        CreateBannerEntryIfNeeded();
         Invalidate();
     }
 
@@ -537,8 +540,10 @@ namespace OpenRCT2::Scripting
             {
                 case TileElementType::LargeScenery:
                 {
+                    RemoveBannerEntryIfNeeded();
                     auto* el = _element->AsLargeScenery();
                     el->SetSequenceIndex(value.as_uint());
+                    CreateBannerEntryIfNeeded();
                     Invalidate();
                     break;
                 }
@@ -1194,15 +1199,19 @@ namespace OpenRCT2::Scripting
             }
             case TileElementType::LargeScenery:
             {
+                RemoveBannerEntryIfNeeded();
                 auto* el = _element->AsLargeScenery();
                 el->SetEntryIndex(index);
+                CreateBannerEntryIfNeeded();
                 Invalidate();
                 break;
             }
             case TileElementType::Wall:
             {
+                RemoveBannerEntryIfNeeded();
                 auto* el = _element->AsWall();
                 el->SetEntryIndex(index);
+                CreateBannerEntryIfNeeded();
                 Invalidate();
                 break;
             }
@@ -2138,6 +2147,129 @@ namespace OpenRCT2::Scripting
     void ScTileElement::Invalidate()
     {
         MapInvalidateTileFull(_coords);
+    }
+
+    const LargeSceneryElement* ScTileElement::GetOtherLargeSceneryElement(
+        const CoordsXY& loc, const LargeSceneryElement* const largeScenery)
+    {
+        const auto* const largeEntry = largeScenery->GetEntry();
+        const auto direction = largeScenery->GetDirection();
+        const auto sequenceIndex = largeScenery->GetSequenceIndex();
+        const auto* tiles = largeEntry->tiles;
+        const auto& tile = tiles[sequenceIndex];
+        const auto rotatedFirstTile = CoordsXYZ{
+            CoordsXY{ tile.x_offset, tile.y_offset }.Rotate(direction),
+            tile.z_offset,
+        };
+
+        const auto firstTile = CoordsXYZ{ loc, largeScenery->GetBaseZ() } - rotatedFirstTile;
+        for (int32_t i = 0; tiles[i].x_offset != -1; i++)
+        {
+            const auto rotatedCurrentTile = CoordsXYZ{ CoordsXY{ tiles[i].x_offset, tiles[i].y_offset }.Rotate(direction),
+                                                       tiles[i].z_offset };
+
+            const auto currentTile = firstTile + rotatedCurrentTile;
+
+            const TileElement* tileElement = MapGetFirstElementAt(currentTile);
+            if (tileElement != nullptr)
+            {
+                do
+                {
+                    if (tileElement->GetType() != TileElementType::LargeScenery)
+                        continue;
+                    if (tileElement->GetDirection() != direction)
+                        continue;
+                    if (tileElement->GetBaseZ() != currentTile.z)
+                        continue;
+
+                    if (tileElement->AsLargeScenery() == largeScenery)
+                        continue;
+                    if (tileElement->AsLargeScenery()->GetEntryIndex() != largeScenery->GetEntryIndex())
+                        continue;
+                    if (tileElement->AsLargeScenery()->GetSequenceIndex() != i)
+                        continue;
+
+                    return tileElement->AsLargeScenery();
+                } while (!(tileElement++)->IsLastForTile());
+            }
+        }
+        return nullptr;
+    }
+
+    void ScTileElement::RemoveBannerEntryIfNeeded()
+    {
+        // check if other element still uses the banner entry
+        if (_element->GetType() == TileElementType::LargeScenery
+            && _element->AsLargeScenery()->GetEntry()->scrolling_mode != SCROLLING_MODE_NONE
+            && GetOtherLargeSceneryElement(_coords, _element->AsLargeScenery()) != nullptr)
+            return;
+        // remove banner entry (if one exists)
+        _element->RemoveBannerEntry();
+    }
+
+    void ScTileElement::CreateBannerEntryIfNeeded()
+    {
+        // check if creation is needed
+        switch (_element->GetType())
+        {
+            case TileElementType::Banner:
+                break;
+            case TileElementType::Wall:
+            {
+                auto wallEntry = _element->AsWall()->GetEntry();
+                if (wallEntry->scrolling_mode == SCROLLING_MODE_NONE)
+                    return;
+                break;
+            }
+            case TileElementType::LargeScenery:
+            {
+                auto largeScenery = _element->AsLargeScenery();
+                auto largeSceneryEntry = largeScenery->GetEntry();
+                if (largeSceneryEntry == nullptr || largeSceneryEntry->scrolling_mode == SCROLLING_MODE_NONE)
+                    return;
+
+                auto otherElement = GetOtherLargeSceneryElement(_coords, largeScenery);
+                if (otherElement != nullptr)
+                {
+                    largeScenery->SetBannerIndex(otherElement->GetBannerIndex());
+                    return;
+                }
+
+                break;
+            }
+            default:
+                return;
+        }
+
+        // create banner entry and initialise it
+        auto* banner = CreateBanner();
+        if (banner == nullptr)
+            GetContext()->GetScriptEngine().LogPluginInfo("No free banners available.");
+        else
+        {
+            banner->text = {};
+            banner->colour = 0;
+            banner->text_colour = 0;
+            banner->flags = 0;
+            if (_element->GetType() == TileElementType::Wall)
+                banner->flags = BANNER_FLAG_IS_WALL;
+            if (_element->GetType() == TileElementType::LargeScenery)
+                banner->flags = BANNER_FLAG_IS_LARGE_SCENERY;
+            banner->type = 0;
+            banner->position = TileCoordsXY(_coords);
+
+            if (_element->GetType() == TileElementType::Wall || _element->GetType() == TileElementType::LargeScenery)
+            {
+                RideId rideIndex = BannerGetClosestRideIndex({ _coords, _element->BaseHeight });
+                if (!rideIndex.IsNull())
+                {
+                    banner->ride_index = rideIndex;
+                    banner->flags |= BANNER_FLAG_LINKED_TO_RIDE;
+                }
+            }
+
+            _element->SetBannerIndex(banner->id);
+        }
     }
 
     void ScTileElement::Register(duk_context* ctx)

--- a/src/openrct2/scripting/bindings/world/ScTileElement.hpp
+++ b/src/openrct2/scripting/bindings/world/ScTileElement.hpp
@@ -210,7 +210,12 @@ namespace OpenRCT2::Scripting
 
         void Invalidate();
 
+        void RemoveBannerEntryIfNeeded();
+        void CreateBannerEntryIfNeeded();
+
     public:
+        static const LargeSceneryElement* GetOtherLargeSceneryElement(
+            const CoordsXY& loc, const LargeSceneryElement* const largeScenery);
         static void Register(duk_context* ctx);
     };
 


### PR DESCRIPTION
### Problem:
The plugin API can change (allmost) any property of tile elements. Usually not much sanity checks are done, which may lead to problems, e.g. with banners. The banner data of tile elements like `BannerElement`, `LargeSceneryElement` or `WallElement` are stored separately from the tile element data; the tile element only stores a reference to the banner data (the id of the banner or `bannerIndex`). When placing or removing elements via actions, this is taken care of. This is not the case for the situation described above. For example, if an element changes its type, there is no check to see if the original element was a banner (and thus the banner data needs to be deleted) or if the new element is a banner (and thus new banner data needs to be allocated and initialised).
A direct visible result of this problem is that it is impossible to insert a working `BannerElement` onto a tile.

### Proposed Solution:
Whenever a tile element is changed in a way that transforms it from / to being a banner-having element, the banner data is deleted / created. This affects `Tile.removeElement`, `TileElement.type`, `WallElement.object` and `LargeSceneryElement.object`.
Large scenery requires special care here. It is the only of the affected element types that can span multiple tiles. We need to decide what to do if only some of the parts are changed. You can observe in-game that regarding visuals, the banner rendering only depend on exactly the very first part of the large scenery (`sequence == 0`). ~~Therefore, we will delete/create banner data if and only if it affects the first part of the large scenery element. I think this is the best solution, since we cannot assume that all parts of the element are present at all times.
One consequence of this is that there will be situations where the plugin programmer needs to manually set the banner index of the non-first large scenery parts. This is unavoidable since, again, we cannot assume that all parts of the element are present at all times. Therefore, if a non-first part is changed, we simply cannot infer the correct banner index in all cases.
(Why is the banner index important for the non-first element parts? Because right-clicking on them will open the banner window associated to the part.)
A different approach is followed by the tile element inspector, which checks the location of all parts and only deletes the banner data if none of the other parts is present. While this made sense in a time where tile element changes were more limited, it certainly does not work anymore considering how many assumptions are invalidated by the power of plugins. For example, tile elements are more freely moved and copied all over the map; it takes too many ressources (iteration over the whole map) to find out if all references to a banner are gone. This is why I decided against this approach.~~
**Edit**: I changed the implementation closer to what the tile inspector does. When a large scenery element is changed, it checks for the existence of at least one other element that fits into the sequence. This should cover all cases that can occur using both plugins and the tile inspector, assuming that no plugin writes to bannerIndex, which is deprecated.

### Implementation Details:
- Bumped API version.
- New function `ScTileElement::RemoveBannerEntry`: Deletes the banner data associated to this tile element, unless it is a large scenery element and another element is still using it.
- New function `ScTileElement::CreateBannerEntry`: Checks if this tile element should have associated banner data and creates it. The banner data is initialised appropriately. If the element is large scenery, it only creates a new banner if it cannot find another element that fits into the sequence.
- `ScTileElement::type_set`, `ScTileElement::sequence_set` and `ScTileElement::object_set` now call the remove function before and the create function after the property change.
- `ScTile::removeElement` now deletes the banner data associated to the deleted tile element, unless it is a large scenery element and another element is still using it.


### Documentation Changes:
- ~~`LargeScenery.bannerIndex` is back to being writable. The reason was explained above.~~