### PR TITLE
Prevent TI hotkey from setting wall slope for non-slopeable objects

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Fix: [#910] Extra viewport does not preserve the location when rotating.
 - Fix: [#21434] Number of guests overflows in objective text.
 - Fix: [#21543] Crash with creating a TrackIterator with invalid arguments.
+- Fix: [#21635] Tile inspector hotkey can set wall slope for non-slopeable objects.
 - Fix: [#21641] Crash when creating track iterator from an invalid tile element.
 
 0.4.9 (2024-03-02)

--- a/src/openrct2-ui/input/Shortcuts.cpp
+++ b/src/openrct2-ui/input/Shortcuts.cpp
@@ -33,6 +33,7 @@
 #include <openrct2/interface/Screenshot.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/network/network.h>
+#include <openrct2/object/WallSceneryEntry.h>
 #include <openrct2/platform/Platform.h>
 #include <openrct2/ride/Track.h>
 #include <openrct2/ride/TrackPaint.h>
@@ -523,6 +524,12 @@ static void ShortcutToggleWallSlope()
 
     // Ensure an element is selected and it's a wall
     if (tileElement == nullptr || tileElement->GetType() != TileElementType::Wall)
+    {
+        return;
+    }
+
+    // Ensure a wall can be built on a slope
+    if (tileElement->AsWall()->GetEntry()->flags & WALL_SCENERY_CANT_BUILD_ON_SLOPE)
     {
         return;
     }


### PR DESCRIPTION
If you set the Tile Inspector hotkey to set wall slopes, it doesn't check whether that wall can actually has sloped sprites. If it doesn't, the game will set the slope anyway, and it will use some other random sprite instead.

Before:
![image](https://github.com/OpenRCT2/OpenRCT2/assets/5436387/0edd316b-65bb-45c1-b1fc-1974a3f58b7f)

After pressing the slope hotkey:
![image](https://github.com/OpenRCT2/OpenRCT2/assets/5436387/ff169cd2-e270-44d0-a2bc-32d21ec7bd3c)

Related PR: #20860 