### PR TITLE
Refactor image import

### DIFF
--- a/resources/g2/sprites.json
+++ b/resources/g2/sprites.json
@@ -314,242 +314,242 @@
     {
         "path": "palette_map/palette_map_dark_olive_dark.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_dark_olive_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_saturated_brown_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_bordeaux_red_dark.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_bordeaux_red_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_grass_green_dark.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_grass_green_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_olive_dark.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_olive_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_saturated_green_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_tan_dark.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_tan_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_dull_purple_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_dull_green_dark.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_dull_green_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_saturated_purple_dark.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_saturated_purple_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_orange_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_aqua_dark.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_magenta_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_dull_brown_dark.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_dull_brown_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_invisible.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_void.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_dark_olive_dark.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_dark_olive_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_saturated_brown_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_bordeaux_red_dark.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_bordeaux_red_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_grass_green_dark.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_grass_green_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_olive_dark.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_olive_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_saturated_green_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_tan_dark.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_tan_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_dull_purple_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_dull_green_dark.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_dull_green_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_saturated_purple_dark.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_saturated_purple_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_orange_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_aqua_dark.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_magenta_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_dull_brown_dark.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_dull_brown_light.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_invisible.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "palette_map/palette_map_glass_void.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "surface/glassy_recolourable.png",
@@ -581,1961 +581,1961 @@
         "path": "font/latin/ae-uc-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/ae-small.png",
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/o-stroke-uc-small.png",
         "x": -1,
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/o-stroke-small.png",
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1028-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1041-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1043-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1044-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1046-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1047-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1048-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1049-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1051-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1055-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1059-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1060-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1062-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1063-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1064-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1065-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1066-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1067-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1068-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1069-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1070-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1071-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1073-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1074-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1075-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1076-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1078-small.png",
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1079-small.png",
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1080-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1081-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1082-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1083-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1084-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1085-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1087-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1090-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1092-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1094-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1095-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1096-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1097-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1099-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1100-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1101-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1102-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1103-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1108-small.png",
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1168-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1169-small.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/german-openquotes-small.png",
         "y": 6,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/guilder-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/g-breve-uc-small.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/i-with-dot-uc-small.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/s-cedilla-uc-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/g-breve-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/i-without-dot-small.png",
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/s-cedilla-small.png",
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/interpunct-small.png",
         "y": 3,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/a-breve-uc-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/t-comma-uc-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/t-comma-small.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/ellipsis-small.png",
         "y": 6,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/c-caron-uc-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/c-caron-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/y-acute-uc-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/y-acute-small.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/o-double-acute-uc-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/o-double-acute-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/oe-uc-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/oe-small.png",
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/u-double-acute-uc-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/u-double-acute-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/d-caron-uc-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/d-caron-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/e-caron-uc-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/e-caron-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/n-caron-uc-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/n-caron-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/r-caron-uc-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/r-caron-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/s-caron-uc-small.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/s-caron-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/t-caron-uc-small.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/t-caron-small.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/u-ring-uc-small.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/u-ring-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/w-circumflex-uc-small.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/w-circumflex-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/y-circumflex-uc-small.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/y-circumflex-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/z-caron-uc-small.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/z-caron-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/rouble-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/j-small.png",
         "x": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/l-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/c-circumflex-uc-small.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/c-circumflex-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/g-circumflex-uc-small.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/g-circumflex-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/h-circumflex-uc-small.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/h-circumflex-small.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/j-circumflex-uc-small.png",
         "x": -1,
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/j-circumflex-small.png",
         "x": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/s-circumflex-uc-small.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/s-circumflex-small.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/u-breve-uc-small.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/u-breve-small.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/left-brace-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/vertical-bar-small.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/right-brace-small.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/tilde-small.png",
         "y": 3,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/eye.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/ae-uc-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/ae-bold.png",
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/o-stroke-uc-bold.png",
         "x": -1,
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/o-stroke-bold.png",
         "x": 0,
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1028-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1041-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1043-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1044-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1046-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1047-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1048-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1049-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1051-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1055-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1059-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1060-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1062-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1063-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1064-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1065-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1066-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1067-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1068-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1069-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1070-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1071-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1073-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1074-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1075-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1076-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1078-bold.png",
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1079-bold.png",
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1080-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1081-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1082-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1083-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1084-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1085-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1087-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1090-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1092-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1094-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1095-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1096-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1097-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1099-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1100-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1101-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1102-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1103-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1108-bold.png",
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1168-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1169-bold.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/german-openquotes-bold.png",
         "y": 5,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/guilder-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/g-breve-uc-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/i-with-dot-uc-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/s-cedilla-uc-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/g-breve-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/i-without-dot-bold.png",
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/s-cedilla-bold.png",
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/interpunct-bold.png",
         "y": 3,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/a-breve-uc-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/t-comma-uc-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/t-comma-bold.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/ellipsis-bold.png",
         "y": 6,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/c-caron-uc-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/c-caron-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/y-acute-uc-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/y-acute-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/o-double-acute-uc-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/o-double-acute-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/oe-uc-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/oe-bold.png",
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/u-double-acute-uc-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/u-double-acute-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/d-caron-uc-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/d-caron-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/e-caron-uc-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/e-caron-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/n-caron-uc-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/n-caron-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/r-caron-uc-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/r-caron-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/s-caron-uc-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/s-caron-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/t-caron-uc-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/t-caron-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/u-ring-uc-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/u-ring-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/w-circumflex-uc-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/w-circumflex-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/y-circumflex-uc-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/y-circumflex-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/z-caron-uc-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/z-caron-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/rouble-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/j-bold.png",
         "x": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/l-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/c-circumflex-uc-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/c-circumflex-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/g-circumflex-uc-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/g-circumflex-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/h-circumflex-uc-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/h-circumflex-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/j-circumflex-uc-bold.png",
         "x": -1,
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/j-circumflex-bold.png",
         "x": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/s-circumflex-uc-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/s-circumflex-bold.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/u-breve-uc-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/u-breve-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/left-brace-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/vertical-bar-bold.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/right-brace-bold.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/tilde-bold.png",
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/eye.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/ae-uc-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/ae-tiny.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/o-stroke-uc-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/o-stroke-tiny.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1028-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1041-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1043-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1044-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1046-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1047-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1048-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1049-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1051-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1055-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1059-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1060-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1062-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1063-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1064-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1065-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1066-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1067-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1068-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1069-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1070-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1071-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1073-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1074-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1075-tiny.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1076-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1078-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1079-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1080-tiny.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1081-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1082-tiny.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1083-tiny.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1084-tiny.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1085-tiny.png",
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1087-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1090-tiny.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1092-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1094-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1095-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1096-tiny.png",
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1097-tiny.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1099-tiny.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1100-tiny.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1101-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1102-tiny.png",
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1103-tiny.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1108-tiny.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1168-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/cyrillic/U1169-tiny.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/german-openquotes-tiny.png",
         "y": 4,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/guilder-tiny.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/g-breve-uc-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/i-with-dot-uc-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/s-cedilla-uc-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/g-breve-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/i-without-dot-tiny.png",
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/s-cedilla-tiny.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/interpunct-tiny.png",
         "y": 2,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/a-breve-uc-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/t-comma-uc-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/t-comma-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/ellipsis-tiny.png",
         "y": 4,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/c-caron-uc-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/c-caron-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/y-acute-uc-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/y-acute-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/o-double-acute-uc-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/o-double-acute-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/oe-uc-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/oe-tiny.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/u-double-acute-uc-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/u-double-acute-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/d-caron-uc-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/d-caron-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/e-caron-uc-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/e-caron-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/n-caron-uc-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/n-caron-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/r-caron-uc-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/r-caron-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/s-caron-uc-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/s-caron-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/t-caron-uc-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/t-caron-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/u-ring-uc-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/u-ring-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/w-circumflex-uc-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/w-circumflex-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/y-circumflex-uc-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/y-circumflex-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/z-caron-uc-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/z-caron-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/rouble-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/j-tiny.png",
         "x": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/l-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/c-circumflex-uc-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/c-circumflex-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/g-circumflex-uc-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/g-circumflex-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/h-circumflex-uc-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/h-circumflex-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/j-circumflex-uc-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/j-circumflex-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/s-circumflex-uc-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/s-circumflex-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/u-breve-uc-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/latin/u-breve-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/left-brace-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/vertical-bar-tiny.png",
         "y": -1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/right-brace-tiny.png",
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/tilde-tiny.png",
         "y": 1,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "font/eye-tiny.png",
         "y": 0,
         "palette": "keep",
-        "forceBmp": true
+        "format": "raw"
     },
     {
         "path": "track/junior/flat_to_steep_1.png"

--- a/src/openrct2/CommandLineSprite.cpp
+++ b/src/openrct2/CommandLineSprite.cpp
@@ -584,7 +584,7 @@ int32_t CommandLineForSprite(const char** argv, int32_t argc)
 
             auto palette = (Json::GetString(jsonSprite["palette"]) == "keep") ? ImageImporter::Palette::KeepIndices
                                                                               : ImageImporter::Palette::OpenRCT2;
-            bool forceBmp = !jsonSprite["palette"].is_null() && Json::GetBoolean(jsonSprite["forceBmp"]);
+            bool forceBmp = !jsonSprite["palette"].is_null() && Json::GetString(jsonSprite["format"]) == "raw";
 
             auto imagePath = Path::GetAbsolute(Path::Combine(directoryPath, strPath));
 

--- a/src/openrct2/CommandLineSprite.h
+++ b/src/openrct2/CommandLineSprite.h
@@ -13,4 +13,4 @@
 #include "drawing/ImageImporter.h"
 
 int32_t CommandLineForSprite(const char** argv, int32_t argc);
-extern OpenRCT2::Drawing::ImageImporter::ImportMode gSpriteMode;
+extern OpenRCT2::Drawing::ImportMode gSpriteMode;

--- a/src/openrct2/command_line/SpriteCommands.cpp
+++ b/src/openrct2/command_line/SpriteCommands.cpp
@@ -16,7 +16,7 @@
 #define SZ_CLOSEST "closest"
 #define SZ_DITHERING "dithering"
 
-using ImportMode = OpenRCT2::Drawing::ImageImporter::ImportMode;
+using ImportMode = OpenRCT2::Drawing::ImportMode;
 
 ImportMode gSpriteMode = ImportMode::Default;
 

--- a/src/openrct2/drawing/ImageImporter.cpp
+++ b/src/openrct2/drawing/ImageImporter.cpp
@@ -16,374 +16,372 @@
 #include <stdexcept>
 #include <string>
 
-using namespace OpenRCT2::Drawing;
-using ImportResult = ImageImporter::ImportResult;
-
-constexpr int32_t PALETTE_TRANSPARENT = -1;
-
-ImportResult ImageImporter::Import(const Image& image, ImageImportMeta& meta) const
+namespace OpenRCT2::Drawing
 {
-    if (meta.srcSize.width == 0)
-        meta.srcSize.width = image.Width;
+    constexpr int32_t PALETTE_TRANSPARENT = -1;
 
-    if (meta.srcSize.height == 0)
-        meta.srcSize.height = image.Height;
-
-    if (meta.srcSize.width > 256 || meta.srcSize.height > 256)
+    ImageImporter::ImportResult ImageImporter::Import(const Image& image, ImageImportMeta& meta) const
     {
-        throw std::invalid_argument("Only images 256x256 or less are supported.");
-    }
+        if (meta.srcSize.width == 0)
+            meta.srcSize.width = image.Width;
 
-    if (meta.palette == Palette::KeepIndices && image.Depth != 8)
-    {
-        throw std::invalid_argument("Image is not paletted, it has bit depth of " + std::to_string(image.Depth));
-    }
-    const bool isRLE = meta.importFlags & ImportFlags::RLE;
+        if (meta.srcSize.height == 0)
+            meta.srcSize.height = image.Height;
 
-    auto pixels = GetPixels(image, meta);
-    auto buffer = isRLE ? EncodeRLE(pixels.data(), meta.srcSize) : EncodeRaw(pixels.data(), meta.srcSize);
-
-    G1Element outElement;
-    outElement.width = meta.srcSize.width;
-    outElement.height = meta.srcSize.height;
-    outElement.flags = isRLE ? G1_FLAG_RLE_COMPRESSION : G1_FLAG_HAS_TRANSPARENCY;
-    outElement.x_offset = meta.offset.x;
-    outElement.y_offset = meta.offset.y;
-    outElement.zoomed_offset = meta.zoomedOffset;
-
-    ImportResult result;
-    result.Element = outElement;
-    result.Buffer = std::move(buffer);
-    result.Element.offset = result.Buffer.data();
-    return result;
-}
-
-std::vector<int32_t> ImageImporter::GetPixels(const Image& image, const ImageImportMeta& meta)
-{
-    const uint8_t* pixels = image.Pixels.data();
-    std::vector<int32_t> buffer;
-    buffer.reserve(meta.srcSize.width * meta.srcSize.height);
-
-    // A larger range is needed for proper dithering
-    auto palettedSrc = pixels;
-    std::unique_ptr<int16_t[]> rgbaSrcBuffer;
-    if (meta.palette != Palette::KeepIndices)
-    {
-        rgbaSrcBuffer = std::make_unique<int16_t[]>(meta.srcSize.height * meta.srcSize.width * 4);
-    }
-
-    auto rgbaSrc = rgbaSrcBuffer.get();
-    if (meta.palette != Palette::KeepIndices)
-    {
-        auto src = pixels + (meta.srcOffset.y * image.Stride) + (meta.srcOffset.x * 4);
-        auto dst = rgbaSrc;
-        for (auto y = 0; y < meta.srcSize.height; y++)
+        if (meta.srcSize.width > 256 || meta.srcSize.height > 256)
         {
-            for (auto x = 0; x < meta.srcSize.width * 4; x++)
-            {
-                *dst = static_cast<int16_t>(*src);
-                src++;
-                dst++;
-            }
-            src += (image.Stride - (meta.srcSize.width * 4));
+            throw std::invalid_argument("Only images 256x256 or less are supported.");
         }
+
+        if (meta.palette == Palette::KeepIndices && image.Depth != 8)
+        {
+            throw std::invalid_argument("Image is not paletted, it has bit depth of " + std::to_string(image.Depth));
+        }
+        const bool isRLE = meta.importFlags & ImportFlags::RLE;
+
+        auto pixels = GetPixels(image, meta);
+        auto buffer = isRLE ? EncodeRLE(pixels.data(), meta.srcSize) : EncodeRaw(pixels.data(), meta.srcSize);
+
+        G1Element outElement;
+        outElement.width = meta.srcSize.width;
+        outElement.height = meta.srcSize.height;
+        outElement.flags = isRLE ? G1_FLAG_RLE_COMPRESSION : G1_FLAG_HAS_TRANSPARENCY;
+        outElement.x_offset = meta.offset.x;
+        outElement.y_offset = meta.offset.y;
+        outElement.zoomed_offset = meta.zoomedOffset;
+
+        ImageImporter::ImportResult result;
+        result.Element = outElement;
+        result.Buffer = std::move(buffer);
+        result.Element.offset = result.Buffer.data();
+        return result;
     }
 
-    if (meta.palette == Palette::KeepIndices)
+    std::vector<int32_t> ImageImporter::GetPixels(const Image& image, const ImageImportMeta& meta)
     {
-        palettedSrc += meta.srcOffset.x + meta.srcOffset.y * image.Stride;
-        for (auto y = 0; y < meta.srcSize.height; y++)
+        const uint8_t* pixels = image.Pixels.data();
+        std::vector<int32_t> buffer;
+        buffer.reserve(meta.srcSize.width * meta.srcSize.height);
+
+        // A larger range is needed for proper dithering
+        auto palettedSrc = pixels;
+        std::unique_ptr<int16_t[]> rgbaSrcBuffer;
+        if (meta.palette != Palette::KeepIndices)
         {
-            for (auto x = 0; x < meta.srcSize.width; x++)
+            rgbaSrcBuffer = std::make_unique<int16_t[]>(meta.srcSize.height * meta.srcSize.width * 4);
+        }
+
+        auto rgbaSrc = rgbaSrcBuffer.get();
+        if (meta.palette != Palette::KeepIndices)
+        {
+            auto src = pixels + (meta.srcOffset.y * image.Stride) + (meta.srcOffset.x * 4);
+            auto dst = rgbaSrc;
+            for (auto y = 0; y < meta.srcSize.height; y++)
             {
-                int32_t paletteIndex = *palettedSrc;
-                // The 1st index is always transparent
-                if (paletteIndex == 0)
+                for (auto x = 0; x < meta.srcSize.width * 4; x++)
                 {
-                    paletteIndex = PALETTE_TRANSPARENT;
+                    *dst = static_cast<int16_t>(*src);
+                    src++;
+                    dst++;
                 }
-                palettedSrc += 1;
-                buffer.push_back(paletteIndex);
-            }
-            palettedSrc += (image.Stride - meta.srcSize.width);
-        }
-    }
-    else
-    {
-        for (auto y = 0; y < meta.srcSize.height; y++)
-        {
-            for (auto x = 0; x < meta.srcSize.width; x++)
-            {
-                auto paletteIndex = CalculatePaletteIndex(
-                    meta.importMode, rgbaSrc, x, y, meta.srcSize.width, meta.srcSize.height);
-                rgbaSrc += 4;
-                buffer.push_back(paletteIndex);
+                src += (image.Stride - (meta.srcSize.width * 4));
             }
         }
-    }
 
-    return buffer;
-}
-
-std::vector<uint8_t> ImageImporter::EncodeRaw(const int32_t* pixels, ScreenSize size)
-{
-    auto bufferLength = size.width * size.height;
-    std::vector<uint8_t> buffer(bufferLength);
-    for (auto i = 0; i < bufferLength; i++)
-    {
-        auto p = pixels[i];
-        buffer[i] = (p == PALETTE_TRANSPARENT ? 0 : static_cast<uint8_t>(p));
-    }
-    return buffer;
-}
-
-std::vector<uint8_t> ImageImporter::EncodeRLE(const int32_t* pixels, ScreenSize size)
-{
-    struct RLECode
-    {
-        uint8_t NumPixels{};
-        uint8_t OffsetX{};
-    };
-
-    auto src = pixels;
-    std::vector<uint8_t> buffer((size.height * 2) + (size.width * size.height * 16));
-
-    std::fill_n(buffer.data(), (size.height * 2) + (size.width * size.height * 16), 0x00);
-    auto yOffsets = reinterpret_cast<uint16_t*>(buffer.data());
-    auto dst = buffer.data() + (size.height * 2);
-    for (auto y = 0; y < size.height; y++)
-    {
-        yOffsets[y] = static_cast<uint16_t>(dst - buffer.data());
-
-        auto previousCode = static_cast<RLECode*>(nullptr);
-        auto currentCode = reinterpret_cast<RLECode*>(dst);
-        dst += 2;
-
-        auto startX = 0;
-        auto npixels = 0;
-        bool pushRun = false;
-        for (auto x = 0; x < size.width; x++)
+        if (meta.palette == Palette::KeepIndices)
         {
-            int32_t paletteIndex = *src++;
-            if (paletteIndex == PALETTE_TRANSPARENT)
+            palettedSrc += meta.srcOffset.x + meta.srcOffset.y * image.Stride;
+            for (auto y = 0; y < meta.srcSize.height; y++)
             {
-                if (npixels != 0)
+                for (auto x = 0; x < meta.srcSize.width; x++)
                 {
-                    x--;
-                    src--;
-                    pushRun = true;
-                }
-            }
-            else
-            {
-                if (npixels == 0)
-                {
-                    startX = x;
-                }
-
-                npixels++;
-                *dst++ = static_cast<uint8_t>(paletteIndex);
-            }
-            if (npixels == 127 || x == size.width - 1)
-            {
-                pushRun = true;
-            }
-
-            if (pushRun)
-            {
-                if (npixels > 0)
-                {
-                    previousCode = currentCode;
-                    currentCode->NumPixels = npixels;
-                    currentCode->OffsetX = startX;
-
-                    if (x == size.width - 1)
+                    int32_t paletteIndex = *palettedSrc;
+                    // The 1st index is always transparent
+                    if (paletteIndex == 0)
                     {
-                        currentCode->NumPixels |= 0x80;
+                        paletteIndex = PALETTE_TRANSPARENT;
                     }
+                    palettedSrc += 1;
+                    buffer.push_back(paletteIndex);
+                }
+                palettedSrc += (image.Stride - meta.srcSize.width);
+            }
+        }
+        else
+        {
+            for (auto y = 0; y < meta.srcSize.height; y++)
+            {
+                for (auto x = 0; x < meta.srcSize.width; x++)
+                {
+                    auto paletteIndex = CalculatePaletteIndex(
+                        meta.importMode, rgbaSrc, x, y, meta.srcSize.width, meta.srcSize.height);
+                    rgbaSrc += 4;
+                    buffer.push_back(paletteIndex);
+                }
+            }
+        }
 
-                    currentCode = reinterpret_cast<RLECode*>(dst);
-                    dst += 2;
+        return buffer;
+    }
+
+    std::vector<uint8_t> ImageImporter::EncodeRaw(const int32_t* pixels, ScreenSize size)
+    {
+        auto bufferLength = size.width * size.height;
+        std::vector<uint8_t> buffer(bufferLength);
+        for (auto i = 0; i < bufferLength; i++)
+        {
+            auto p = pixels[i];
+            buffer[i] = (p == PALETTE_TRANSPARENT ? 0 : static_cast<uint8_t>(p));
+        }
+        return buffer;
+    }
+
+    std::vector<uint8_t> ImageImporter::EncodeRLE(const int32_t* pixels, ScreenSize size)
+    {
+        struct RLECode
+        {
+            uint8_t NumPixels{};
+            uint8_t OffsetX{};
+        };
+
+        auto src = pixels;
+        std::vector<uint8_t> buffer((size.height * 2) + (size.width * size.height * 16));
+
+        std::fill_n(buffer.data(), (size.height * 2) + (size.width * size.height * 16), 0x00);
+        auto yOffsets = reinterpret_cast<uint16_t*>(buffer.data());
+        auto dst = buffer.data() + (size.height * 2);
+        for (auto y = 0; y < size.height; y++)
+        {
+            yOffsets[y] = static_cast<uint16_t>(dst - buffer.data());
+
+            auto previousCode = static_cast<RLECode*>(nullptr);
+            auto currentCode = reinterpret_cast<RLECode*>(dst);
+            dst += 2;
+
+            auto startX = 0;
+            auto npixels = 0;
+            bool pushRun = false;
+            for (auto x = 0; x < size.width; x++)
+            {
+                int32_t paletteIndex = *src++;
+                if (paletteIndex == PALETTE_TRANSPARENT)
+                {
+                    if (npixels != 0)
+                    {
+                        x--;
+                        src--;
+                        pushRun = true;
+                    }
                 }
                 else
                 {
-                    if (previousCode == nullptr)
+                    if (npixels == 0)
                     {
-                        currentCode->NumPixels = 0x80;
-                        currentCode->OffsetX = 0;
+                        startX = x;
+                    }
+
+                    npixels++;
+                    *dst++ = static_cast<uint8_t>(paletteIndex);
+                }
+                if (npixels == 127 || x == size.width - 1)
+                {
+                    pushRun = true;
+                }
+
+                if (pushRun)
+                {
+                    if (npixels > 0)
+                    {
+                        previousCode = currentCode;
+                        currentCode->NumPixels = npixels;
+                        currentCode->OffsetX = startX;
+
+                        if (x == size.width - 1)
+                        {
+                            currentCode->NumPixels |= 0x80;
+                        }
+
+                        currentCode = reinterpret_cast<RLECode*>(dst);
+                        dst += 2;
                     }
                     else
                     {
-                        previousCode->NumPixels |= 0x80;
-                        dst -= 2;
+                        if (previousCode == nullptr)
+                        {
+                            currentCode->NumPixels = 0x80;
+                            currentCode->OffsetX = 0;
+                        }
+                        else
+                        {
+                            previousCode->NumPixels |= 0x80;
+                            dst -= 2;
+                        }
                     }
-                }
 
-                startX = 0;
-                npixels = 0;
-                pushRun = false;
+                    startX = 0;
+                    npixels = 0;
+                    pushRun = false;
+                }
             }
         }
+
+        auto bufferLength = static_cast<size_t>(dst - buffer.data());
+        buffer.resize(bufferLength);
+        return buffer;
     }
 
-    auto bufferLength = static_cast<size_t>(dst - buffer.data());
-    buffer.resize(bufferLength);
-    return buffer;
-}
-
-int32_t ImageImporter::CalculatePaletteIndex(
-    ImportMode mode, int16_t* rgbaSrc, int32_t x, int32_t y, int32_t width, int32_t height)
-{
-    auto& palette = StandardPalette;
-    auto paletteIndex = GetPaletteIndex(palette, rgbaSrc);
-    if ((mode == ImportMode::Closest || mode == ImportMode::Dithering) && !IsInPalette(palette, rgbaSrc))
+    int32_t ImageImporter::CalculatePaletteIndex(
+        ImportMode mode, int16_t* rgbaSrc, int32_t x, int32_t y, int32_t width, int32_t height)
     {
-        paletteIndex = GetClosestPaletteIndex(palette, rgbaSrc);
-        if (mode == ImportMode::Dithering)
+        auto& palette = StandardPalette;
+        auto paletteIndex = GetPaletteIndex(palette, rgbaSrc);
+        if ((mode == ImportMode::Closest || mode == ImportMode::Dithering) && !IsInPalette(palette, rgbaSrc))
         {
-            auto dr = rgbaSrc[0] - static_cast<int16_t>(palette[paletteIndex].Red);
-            auto dg = rgbaSrc[1] - static_cast<int16_t>(palette[paletteIndex].Green);
-            auto db = rgbaSrc[2] - static_cast<int16_t>(palette[paletteIndex].Blue);
-
-            // We don't want to dither remappable colours with nonremappable colours, etc
-            PaletteIndexType thisIndexType = GetPaletteIndexType(paletteIndex);
-
-            if (x + 1 < width)
+            paletteIndex = GetClosestPaletteIndex(palette, rgbaSrc);
+            if (mode == ImportMode::Dithering)
             {
-                if (!IsInPalette(palette, rgbaSrc + 4)
-                    && thisIndexType == GetPaletteIndexType(GetClosestPaletteIndex(palette, rgbaSrc + 4)))
-                {
-                    // Right
-                    rgbaSrc[4] += dr * 7 / 16;
-                    rgbaSrc[5] += dg * 7 / 16;
-                    rgbaSrc[6] += db * 7 / 16;
-                }
-            }
+                auto dr = rgbaSrc[0] - static_cast<int16_t>(palette[paletteIndex].Red);
+                auto dg = rgbaSrc[1] - static_cast<int16_t>(palette[paletteIndex].Green);
+                auto db = rgbaSrc[2] - static_cast<int16_t>(palette[paletteIndex].Blue);
 
-            if (y + 1 < height)
-            {
-                if (x > 0)
-                {
-                    if (!IsInPalette(palette, rgbaSrc + 4 * (width - 1))
-                        && thisIndexType == GetPaletteIndexType(GetClosestPaletteIndex(palette, rgbaSrc + 4 * (width - 1))))
-                    {
-                        // Bottom left
-                        rgbaSrc[4 * (width - 1)] += dr * 3 / 16;
-                        rgbaSrc[4 * (width - 1) + 1] += dg * 3 / 16;
-                        rgbaSrc[4 * (width - 1) + 2] += db * 3 / 16;
-                    }
-                }
-
-                // Bottom
-                if (!IsInPalette(palette, rgbaSrc + 4 * width)
-                    && thisIndexType == GetPaletteIndexType(GetClosestPaletteIndex(palette, rgbaSrc + 4 * width)))
-                {
-                    rgbaSrc[4 * width] += dr * 5 / 16;
-                    rgbaSrc[4 * width + 1] += dg * 5 / 16;
-                    rgbaSrc[4 * width + 2] += db * 5 / 16;
-                }
+                // We don't want to dither remappable colours with nonremappable colours, etc
+                PaletteIndexType thisIndexType = GetPaletteIndexType(paletteIndex);
 
                 if (x + 1 < width)
                 {
-                    if (!IsInPalette(palette, rgbaSrc + 4 * (width + 1))
-                        && thisIndexType == GetPaletteIndexType(GetClosestPaletteIndex(palette, rgbaSrc + 4 * (width + 1))))
+                    if (!IsInPalette(palette, rgbaSrc + 4)
+                        && thisIndexType == GetPaletteIndexType(GetClosestPaletteIndex(palette, rgbaSrc + 4)))
                     {
-                        // Bottom right
-                        rgbaSrc[4 * (width + 1)] += dr * 1 / 16;
-                        rgbaSrc[4 * (width + 1) + 1] += dg * 1 / 16;
-                        rgbaSrc[4 * (width + 1) + 2] += db * 1 / 16;
+                        // Right
+                        rgbaSrc[4] += dr * 7 / 16;
+                        rgbaSrc[5] += dg * 7 / 16;
+                        rgbaSrc[6] += db * 7 / 16;
+                    }
+                }
+
+                if (y + 1 < height)
+                {
+                    if (x > 0)
+                    {
+                        if (!IsInPalette(palette, rgbaSrc + 4 * (width - 1))
+                            && thisIndexType == GetPaletteIndexType(GetClosestPaletteIndex(palette, rgbaSrc + 4 * (width - 1))))
+                        {
+                            // Bottom left
+                            rgbaSrc[4 * (width - 1)] += dr * 3 / 16;
+                            rgbaSrc[4 * (width - 1) + 1] += dg * 3 / 16;
+                            rgbaSrc[4 * (width - 1) + 2] += db * 3 / 16;
+                        }
+                    }
+
+                    // Bottom
+                    if (!IsInPalette(palette, rgbaSrc + 4 * width)
+                        && thisIndexType == GetPaletteIndexType(GetClosestPaletteIndex(palette, rgbaSrc + 4 * width)))
+                    {
+                        rgbaSrc[4 * width] += dr * 5 / 16;
+                        rgbaSrc[4 * width + 1] += dg * 5 / 16;
+                        rgbaSrc[4 * width + 2] += db * 5 / 16;
+                    }
+
+                    if (x + 1 < width)
+                    {
+                        if (!IsInPalette(palette, rgbaSrc + 4 * (width + 1))
+                            && thisIndexType == GetPaletteIndexType(GetClosestPaletteIndex(palette, rgbaSrc + 4 * (width + 1))))
+                        {
+                            // Bottom right
+                            rgbaSrc[4 * (width + 1)] += dr * 1 / 16;
+                            rgbaSrc[4 * (width + 1) + 1] += dg * 1 / 16;
+                            rgbaSrc[4 * (width + 1) + 2] += db * 1 / 16;
+                        }
                     }
                 }
             }
         }
+
+        return paletteIndex;
     }
 
-    return paletteIndex;
-}
-
-int32_t ImageImporter::GetPaletteIndex(const GamePalette& palette, int16_t* colour)
-{
-    if (!IsTransparentPixel(colour))
+    int32_t ImageImporter::GetPaletteIndex(const GamePalette& palette, int16_t* colour)
     {
-        for (uint32_t i = 0; i < PALETTE_SIZE; i++)
+        if (!IsTransparentPixel(colour))
         {
-            if (static_cast<int16_t>(palette[i].Red) == colour[0] && static_cast<int16_t>(palette[i].Green) == colour[1]
-                && static_cast<int16_t>(palette[i].Blue) == colour[2])
+            for (uint32_t i = 0; i < PALETTE_SIZE; i++)
             {
-                return i;
+                if (static_cast<int16_t>(palette[i].Red) == colour[0] && static_cast<int16_t>(palette[i].Green) == colour[1]
+                    && static_cast<int16_t>(palette[i].Blue) == colour[2])
+                {
+                    return i;
+                }
             }
         }
+        return PALETTE_TRANSPARENT;
     }
-    return PALETTE_TRANSPARENT;
-}
 
-bool ImageImporter::IsTransparentPixel(const int16_t* colour)
-{
-    return colour[3] < 128;
-}
-
-/**
- * @returns true if this colour is in the standard palette.
- */
-bool ImageImporter::IsInPalette(const GamePalette& palette, int16_t* colour)
-{
-    return !(GetPaletteIndex(palette, colour) == PALETTE_TRANSPARENT && !IsTransparentPixel(colour));
-}
-
-/**
- * @returns true if palette index is an index not used for a special purpose.
- */
-bool ImageImporter::IsChangablePixel(int32_t paletteIndex)
-{
-    PaletteIndexType entryType = GetPaletteIndexType(paletteIndex);
-    return entryType != PaletteIndexType::Special && entryType != PaletteIndexType::PrimaryRemap;
-}
-
-/**
- * @returns the type of palette entry this is.
- */
-ImageImporter::PaletteIndexType ImageImporter::GetPaletteIndexType(int32_t paletteIndex)
-{
-    if (paletteIndex <= 9)
-        return PaletteIndexType::Special;
-    if (paletteIndex >= 230 && paletteIndex <= 239)
-        return PaletteIndexType::Special;
-    if (paletteIndex == 255)
-        return PaletteIndexType::Special;
-    if (paletteIndex >= 243 && paletteIndex <= 254)
-        return PaletteIndexType::PrimaryRemap;
-    if (paletteIndex >= 202 && paletteIndex <= 213)
-        return PaletteIndexType::SecondaryRemap;
-    if (paletteIndex >= 46 && paletteIndex <= 57)
-        return PaletteIndexType::TertiaryRemap;
-    return PaletteIndexType::Normal;
-}
-
-int32_t ImageImporter::GetClosestPaletteIndex(const GamePalette& palette, const int16_t* colour)
-{
-    auto smallestError = static_cast<uint32_t>(-1);
-    auto bestMatch = PALETTE_TRANSPARENT;
-    for (uint32_t x = 0; x < PALETTE_SIZE; x++)
+    bool ImageImporter::IsTransparentPixel(const int16_t* colour)
     {
-        if (IsChangablePixel(x))
-        {
-            uint32_t error = (static_cast<int16_t>(palette[x].Red) - colour[0])
-                    * (static_cast<int16_t>(palette[x].Red) - colour[0])
-                + (static_cast<int16_t>(palette[x].Green) - colour[1]) * (static_cast<int16_t>(palette[x].Green) - colour[1])
-                + (static_cast<int16_t>(palette[x].Blue) - colour[2]) * (static_cast<int16_t>(palette[x].Blue) - colour[2]);
+        return colour[3] < 128;
+    }
 
-            if (smallestError == static_cast<uint32_t>(-1) || smallestError > error)
+    /**
+     * @returns true if this colour is in the standard palette.
+     */
+    bool ImageImporter::IsInPalette(const GamePalette& palette, int16_t* colour)
+    {
+        return !(GetPaletteIndex(palette, colour) == PALETTE_TRANSPARENT && !IsTransparentPixel(colour));
+    }
+
+    /**
+     * @returns true if palette index is an index not used for a special purpose.
+     */
+    bool ImageImporter::IsChangablePixel(int32_t paletteIndex)
+    {
+        PaletteIndexType entryType = GetPaletteIndexType(paletteIndex);
+        return entryType != PaletteIndexType::Special && entryType != PaletteIndexType::PrimaryRemap;
+    }
+
+    /**
+     * @returns the type of palette entry this is.
+     */
+    ImageImporter::PaletteIndexType ImageImporter::GetPaletteIndexType(int32_t paletteIndex)
+    {
+        if (paletteIndex <= 9)
+            return PaletteIndexType::Special;
+        if (paletteIndex >= 230 && paletteIndex <= 239)
+            return PaletteIndexType::Special;
+        if (paletteIndex == 255)
+            return PaletteIndexType::Special;
+        if (paletteIndex >= 243 && paletteIndex <= 254)
+            return PaletteIndexType::PrimaryRemap;
+        if (paletteIndex >= 202 && paletteIndex <= 213)
+            return PaletteIndexType::SecondaryRemap;
+        if (paletteIndex >= 46 && paletteIndex <= 57)
+            return PaletteIndexType::TertiaryRemap;
+        return PaletteIndexType::Normal;
+    }
+
+    int32_t ImageImporter::GetClosestPaletteIndex(const GamePalette& palette, const int16_t* colour)
+    {
+        auto smallestError = static_cast<uint32_t>(-1);
+        auto bestMatch = PALETTE_TRANSPARENT;
+        for (uint32_t x = 0; x < PALETTE_SIZE; x++)
+        {
+            if (IsChangablePixel(x))
             {
-                bestMatch = x;
-                smallestError = error;
+                uint32_t error = (static_cast<int16_t>(palette[x].Red) - colour[0])
+                        * (static_cast<int16_t>(palette[x].Red) - colour[0])
+                    + (static_cast<int16_t>(palette[x].Green) - colour[1])
+                        * (static_cast<int16_t>(palette[x].Green) - colour[1])
+                    + (static_cast<int16_t>(palette[x].Blue) - colour[2]) * (static_cast<int16_t>(palette[x].Blue) - colour[2]);
+
+                if (smallestError == static_cast<uint32_t>(-1) || smallestError > error)
+                {
+                    bestMatch = x;
+                    smallestError = error;
+                }
             }
         }
+        return bestMatch;
     }
-    return bestMatch;
-}
 
-namespace OpenRCT2::Drawing
-{
     ImageImportMeta createImageImportMetaFromJson(json_t& input)
     {
         auto xOffset = Json::GetNumber<int16_t>(input["x"]);

--- a/test/tests/ImageImporterTests.cpp
+++ b/test/tests/ImageImporterTests.cpp
@@ -41,7 +41,8 @@ TEST_F(ImageImporterTests, Import_Logo)
 
     ImageImporter importer;
     auto image = Imaging::ReadFromFile(logoPath, IMAGE_FORMAT::PNG_32);
-    auto result = importer.Import(image, 3, 5, ImageImporter::Palette::OpenRCT2, ImageImporter::ImportFlags::RLE);
+    auto meta = ImageImportMeta{ .offset = { 3, 5 } };
+    auto result = importer.Import(image, meta);
 
     ASSERT_EQ(result.Buffer.data(), result.Element.offset);
     ASSERT_EQ(128, result.Element.width);


### PR DESCRIPTION
This PR:

- Makes sprites.json and the objects use the same arguments and code to parse JSON
- Makes all features previously available to object images now available to g2 as well.
- Sets zoomed_offset in the importer if specified (rather than having to modify the result manually afterwards)
- Simplifies import handling through the addition of a meta object with sane defaults.