### PR TITLE
Fix Object Load Error and Scenery Scatter windows looking weird

### DIFF
--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -325,7 +325,7 @@ static Widget window_object_load_error_widgets[] = {
         }
     }
 
-    class ObjectLoadErrorWindow final : public WindowBase
+    class ObjectLoadErrorWindow final : public Window
     {
     private:
         std::vector<ObjectEntryDescriptor> _invalidEntries;

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -53,7 +53,7 @@ static Widget _sceneryScatterWidgets[] = {
 };
     // clang-format on
 
-    class SceneryScatterWindow final : public WindowBase
+    class SceneryScatterWindow final : public Window
     {
     public:
         void OnOpen() override


### PR DESCRIPTION
These two windows (and only these two) inherited from WindowBase, rather than Window, and as such regressed because of #21572.