### PR TITLE
Fix sound effects not working with RCTC base, fix audio object conflict

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,9 +64,9 @@ set(TITLE_SEQUENCE_VERSION "0.4.6")
 set(TITLE_SEQUENCE_URL  "https://github.com/OpenRCT2/title-sequences/releases/download/v${TITLE_SEQUENCE_VERSION}/title-sequences.zip")
 set(TITLE_SEQUENCE_SHA1 "80fefc6ebbabc42a6f4703412daa5c62f661420d")
 
-set(OBJECTS_VERSION "1.4.2")
+set(OBJECTS_VERSION "1.4.3")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v${OBJECTS_VERSION}/objects.zip")
-set(OBJECTS_SHA1 "2adc4cb66a6446533d67097bdf44cd9c5882fea3")
+set(OBJECTS_SHA1 "ac78210ef46465c0f51bbffd6fe21845092af48e")
 
 set(OPENSFX_VERSION "1.0.5")
 set(OPENSFX_URL  "https://github.com/OpenRCT2/OpenSoundEffects/releases/download/v${OPENSFX_VERSION}/opensound.zip")

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -27,6 +27,8 @@
 - Fix: [#21635] Tile inspector hotkey can set wall slope for non-slopeable objects.
 - Fix: [#21641] Crash when creating track iterator from an invalid tile element.
 - Fix: [#21652] Dialog window to confirm overwriting files does not apply the theme colours correctly.
+- Fix: [#21654] No sound effects when using RCT Classic as an asset base.
+- Fix: [#21654] Extraneous reports of an object conflict between `rct2.audio.base` and `rct2.audio.base.rctc`.
 - Fix: [#21668] Crash when on null ride in Guest::UpdateRideLeaveExit.
 - Fix: [objects#290] “Haunted Mansion” cars have a non-functional third remap colour.
 - Fix: [objects#296] Incorrect wall placement around large Kremlin/drab pieces.

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -45,8 +45,8 @@
     <LibsSha1 Condition="'$(Platform)'=='ARM64'">bd338aa3da9a357fb996dcaa6cea02c4f906718c</LibsSha1>
     <TitleSequencesUrl>https://github.com/OpenRCT2/title-sequences/releases/download/v0.4.6/title-sequences.zip</TitleSequencesUrl>
     <TitleSequencesSha1>80fefc6ebbabc42a6f4703412daa5c62f661420d</TitleSequencesSha1>
-    <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.4.2/objects.zip</ObjectsUrl>
-    <ObjectsSha1>2adc4cb66a6446533d67097bdf44cd9c5882fea3</ObjectsSha1>
+    <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.4.3/objects.zip</ObjectsUrl>
+    <ObjectsSha1>ac78210ef46465c0f51bbffd6fe21845092af48e</ObjectsSha1>
     <OpenSFXUrl>https://github.com/OpenRCT2/OpenSoundEffects/releases/download/v1.0.5/opensound.zip</OpenSFXUrl>
     <OpenSFXSha1>b1b1f1b241d2cbff63a1889c4dc5a09bdf769bfb</OpenSFXSha1>
     <OpenMSXUrl>https://github.com/OpenRCT2/OpenMusic/releases/download/v1.5/openmusic.zip</OpenMSXUrl>

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -101,27 +101,10 @@ namespace OpenRCT2::Audio
     {
         auto& objManager = GetContext()->GetObjectManager();
 
-        Object* baseAudio{};
-
-        // We have a different audio object for RCT Classic
-        auto env = GetContext()->GetPlatformEnvironment();
-        if (env->IsUsingClassic())
+        Object* baseAudio = objManager.LoadObject(AudioObjectIdentifiers::RCT2);
+        if (baseAudio != nullptr)
         {
-            baseAudio = objManager.LoadObject(AudioObjectIdentifiers::RCTCBase);
-            if (baseAudio != nullptr)
-            {
-                _soundsAudioObjectEntryIndex = objManager.GetLoadedObjectEntryIndex(baseAudio);
-            }
-        }
-
-        if (baseAudio == nullptr)
-        {
-            // Fallback to vanilla RCT2 audio object
-            baseAudio = objManager.LoadObject(AudioObjectIdentifiers::RCT2Base);
-            if (baseAudio != nullptr)
-            {
-                _soundsAudioObjectEntryIndex = objManager.GetLoadedObjectEntryIndex(baseAudio);
-            }
+            _soundsAudioObjectEntryIndex = objManager.GetLoadedObjectEntryIndex(baseAudio);
         }
 
         objManager.LoadObject(AudioObjectIdentifiers::OpenRCT2Additional);

--- a/src/openrct2/audio/audio.h
+++ b/src/openrct2/audio/audio.h
@@ -140,7 +140,9 @@ namespace OpenRCT2::Audio
     namespace AudioObjectIdentifiers
     {
         constexpr std::string_view RCT1Title = "rct1.audio.title";
-        constexpr std::string_view RCT2Base = "rct2.audio.base";
+        // virtual name, used by either RCT2Base or RCTCBase, depending on which one is loaded.
+        constexpr std::string_view RCT2 = "rct2.audio.base";
+        constexpr std::string_view RCT2Base = "rct2.audio.base.rct2";
         constexpr std::string_view RCTCBase = "rct2.audio.base.rctc";
         constexpr std::string_view RCT2Title = "rct2.audio.title";
         constexpr std::string_view OpenRCT2Title = "openrct2.audio.title";

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -46,7 +46,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "2"
+#define NETWORK_STREAM_VERSION "3"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 


### PR DESCRIPTION
Asset packs expect the name of the sound effects file to be `rct2.audio.base`. To allow for loading the RCTC sound effects instead and still allow asset packs to properly work, the ID was overwritten to `rct2.audio.base`.

Due to this overwriting of object IDs, loading the sound effects would not work on RCTC, as it tried using the original name. This overwriting also caused object conflicts which weren’t always won by the RCTC object. 

This PR fixes both problems by using renaming the RCT2 base object to `rct2.audio.base.rct2`, so that the names no longer clash,  and only overwriting the ID of the actually loaded one to `rct2.audio.base`, the name expected by the asset packs. Requires https://github.com/OpenRCT2/objects/pull/322 to fully work, but can be merged without it.