### PR TITLE
Fix #21604: Scenario selector shows incorrect guest objectives

### DIFF
--- a/src/openrct2-ui/interface/Objective.cpp
+++ b/src/openrct2-ui/interface/Objective.cpp
@@ -1,0 +1,53 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2024 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "Objective.h"
+
+#include <cstdint>
+#include <openrct2/localisation/Formatter.h>
+#include <openrct2/localisation/Localisation.h>
+#include <openrct2/ride/Ride.h>
+#include <openrct2/ride/RideData.h>
+#include <openrct2/scenario/Scenario.h>
+
+void formatObjective(Formatter& ft, Objective objective)
+{
+    if (objective.Type == OBJECTIVE_BUILD_THE_BEST)
+    {
+        StringId rideTypeString = STR_NONE;
+        auto rideTypeId = objective.RideId;
+        if (rideTypeId != RIDE_TYPE_NULL && rideTypeId < RIDE_TYPE_COUNT)
+        {
+            rideTypeString = GetRideTypeDescriptor(rideTypeId).Naming.Name;
+        }
+        ft.Add<StringId>(rideTypeString);
+    }
+    else if (objective.Type == OBJECTIVE_GUESTS_BY)
+    {
+        ft.Add<int32_t>(objective.NumGuests);
+        ft.Add<int16_t>(DateGetTotalMonths(MONTH_OCTOBER, objective.Year));
+    }
+    else if (objective.Type == OBJECTIVE_GUESTS_AND_RATING)
+    {
+        ft.Add<int32_t>(objective.NumGuests);
+    }
+    else if (objective.Type == OBJECTIVE_10_ROLLERCOASTERS_LENGTH)
+    {
+        ft.Add<int16_t>(objective.MinimumLength);
+    }
+    else
+    {
+        ft.Add<int16_t>(objective.NumGuests);
+        ft.Add<int16_t>(DateGetTotalMonths(MONTH_OCTOBER, objective.Year));
+        if (objective.Type == OBJECTIVE_FINISH_5_ROLLERCOASTERS)
+            ft.Add<uint16_t>(objective.MinimumExcitement);
+        else
+            ft.Add<money64>(objective.Currency);
+    }
+}

--- a/src/openrct2-ui/interface/Objective.h
+++ b/src/openrct2-ui/interface/Objective.h
@@ -1,0 +1,17 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2024 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+class Formatter;
+struct Objective;
+
+void formatObjective(Formatter& ft, Objective objective);

--- a/src/openrct2-ui/libopenrct2ui.vcxproj
+++ b/src/openrct2-ui/libopenrct2ui.vcxproj
@@ -69,6 +69,7 @@
     <ClInclude Include="interface\Graph.h" />
     <ClInclude Include="interface\InGameConsole.h" />
     <ClInclude Include="interface\LandTool.h" />
+    <ClInclude Include="interface\Objective.h" />
     <ClInclude Include="interface\Theme.h" />
     <ClInclude Include="interface\Viewport.h" />
     <ClInclude Include="interface\Widget.h" />
@@ -129,6 +130,7 @@
     <ClCompile Include="interface\Graph.cpp" />
     <ClCompile Include="interface\InGameConsole.cpp" />
     <ClCompile Include="interface\LandTool.cpp" />
+    <ClCompile Include="interface\Objective.cpp" />
     <ClCompile Include="interface\Theme.cpp" />
     <ClCompile Include="interface\ViewportInteraction.cpp" />
     <ClCompile Include="interface\Widget.cpp" />

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -15,6 +15,7 @@
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Graph.h>
 #include <openrct2-ui/interface/LandTool.h>
+#include <openrct2-ui/interface/Objective.h>
 #include <openrct2-ui/interface/Viewport.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
@@ -1092,38 +1093,7 @@ static constexpr WindowParkAward _parkAwards[] = {
 
             // Objective
             ft = Formatter();
-            if (gameState.ScenarioObjective.Type == OBJECTIVE_BUILD_THE_BEST)
-            {
-                StringId rideTypeString = STR_NONE;
-                auto rideTypeId = gameState.ScenarioObjective.RideId;
-                if (rideTypeId != RIDE_TYPE_NULL && rideTypeId < RIDE_TYPE_COUNT)
-                {
-                    rideTypeString = GetRideTypeDescriptor(rideTypeId).Naming.Name;
-                }
-                ft.Add<StringId>(rideTypeString);
-            }
-            else if (gameState.ScenarioObjective.Type == OBJECTIVE_GUESTS_BY)
-            {
-                ft.Add<int32_t>(gameState.ScenarioObjective.NumGuests);
-                ft.Add<int16_t>(DateGetTotalMonths(MONTH_OCTOBER, gameState.ScenarioObjective.Year));
-            }
-            else if (gameState.ScenarioObjective.Type == OBJECTIVE_GUESTS_AND_RATING)
-            {
-                ft.Add<int32_t>(gameState.ScenarioObjective.NumGuests);
-            }
-            else if (gameState.ScenarioObjective.Type == OBJECTIVE_10_ROLLERCOASTERS_LENGTH)
-            {
-                ft.Add<int16_t>(gameState.ScenarioObjective.MinimumLength);
-            }
-            else
-            {
-                ft.Add<int16_t>(0); // Unused value by other objective messages
-                ft.Add<int16_t>(DateGetTotalMonths(MONTH_OCTOBER, gameState.ScenarioObjective.Year));
-                if (gameState.ScenarioObjective.Type == OBJECTIVE_FINISH_5_ROLLERCOASTERS)
-                    ft.Add<uint16_t>(gameState.ScenarioObjective.MinimumExcitement);
-                else
-                    ft.Add<money64>(gameState.ScenarioObjective.Currency);
-            }
+            formatObjective(ft, gameState.ScenarioObjective);
 
             screenCoords.y += DrawTextWrapped(dpi, screenCoords, 221, ObjectiveNames[gameState.ScenarioObjective.Type], ft);
             screenCoords.y += 5;

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -9,6 +9,7 @@
 
 #include "../interface/Theme.h"
 
+#include <openrct2-ui/interface/Objective.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
@@ -244,27 +245,14 @@ static Widget _scenarioSelectWidgets[] = {
             screenPos.y += DrawTextWrapped(dpi, screenPos, 170, STR_BLACK_STRING, ft) + 5;
 
             // Scenario objective
+            Objective objective = { .Type = scenario->ObjectiveType,
+                                    .Year = scenario->ObjectiveArg1,
+                                    .NumGuests = static_cast<uint16_t>(scenario->ObjectiveArg3),
+                                    .Currency = scenario->ObjectiveArg2 };
+
             ft = Formatter();
             ft.Add<StringId>(ObjectiveNames[scenario->ObjectiveType]);
-            if (scenario->ObjectiveType == OBJECTIVE_BUILD_THE_BEST)
-            {
-                StringId rideTypeString = STR_NONE;
-                auto rideTypeId = scenario->ObjectiveArg3;
-                if (rideTypeId != RIDE_TYPE_NULL && rideTypeId < RIDE_TYPE_COUNT)
-                {
-                    rideTypeString = GetRideTypeDescriptor(rideTypeId).Naming.Name;
-                }
-                ft.Add<StringId>(rideTypeString);
-            }
-            else
-            {
-                ft.Add<int16_t>(scenario->ObjectiveArg3);
-                ft.Add<int16_t>(DateGetTotalMonths(MONTH_OCTOBER, scenario->ObjectiveArg1));
-                if (scenario->ObjectiveType == OBJECTIVE_FINISH_5_ROLLERCOASTERS)
-                    ft.Add<uint16_t>(scenario->ObjectiveArg2);
-                else
-                    ft.Add<money64>(scenario->ObjectiveArg2);
-            }
+            formatObjective(ft, objective);
             screenPos.y += DrawTextWrapped(dpi, screenPos, 170, STR_OBJECTIVE, ft) + 5;
 
             // Scenario score


### PR DESCRIPTION
#21518 made some changes to objective formatting, but forgot to update the scenario selector. This PR addresses this, and also moves the code into a function of its own to reduce code duplication and prevent this problem in the future.