### PR TITLE
Feature #21426: Save currently following entity into save file.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -45,6 +45,7 @@
 ------------------------------------------------------------------------
 - Feature: [#622] Add option to align the top toolbar buttons horizontally centred (off by default).
 - Feature: [#20263] Ability to increase the size of the map in the (0, 0) direction.
+- Feature: [#21656] Save the currently following entity into the save file.
 - Feature: [#21714] [Plugin] Costume assignment is now tailored to each staff type.
 - Feature: [#21853] Enlarged UI mode.
 - Feature: [#21893, #22065] On launch, the game now indicates what system is being initialised.
@@ -103,7 +104,6 @@
 0.4.11 (2024-05-05)
 ------------------------------------------------------------------------
 - Feature: [#11512] Coloured usernames by group on multiplayer servers.
-- Feature: [#21656] Save the currently following entity into the save file.
 - Feature: [#21734] Park admittance price can now be set via text input.
 - Feature: [#21957] [Plugin] Expose whether the game is paused to the plugin API.
 - Improved: [#21728] “Fix all rides” cheat now also works if a mechanic is already fixing the ride.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -103,6 +103,7 @@
 0.4.11 (2024-05-05)
 ------------------------------------------------------------------------
 - Feature: [#11512] Coloured usernames by group on multiplayer servers.
+- Feature: [#21656] Save the currently following entity into the save file.
 - Feature: [#21734] Park admittance price can now be set via text input.
 - Feature: [#21957] [Plugin] Expose whether the game is paused to the plugin API.
 - Improved: [#21728] “Fix all rides” cheat now also works if a mechanic is already fixing the ride.

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -363,6 +363,12 @@ void GameLoadInit()
     auto& gameState = GetGameState();
     windowManager->SetMainView(gameState.SavedView, gameState.SavedViewZoom, gameState.SavedViewRotation);
 
+    if (gameState.CurrentlyFollowingEntity != EntityId::GetNull())
+    {
+        auto* mainWindow = WindowGetMain();
+        WindowFollowSprite(*mainWindow, gameState.CurrentlyFollowingEntity);
+    }
+
     if (NetworkGetMode() != NETWORK_MODE_CLIENT)
     {
         GameActions::ClearQueue();

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -127,6 +127,7 @@ namespace OpenRCT2
         ScreenCoordsXY SavedView;
         uint8_t SavedViewRotation;
         ZoomLevel SavedViewZoom;
+        EntityId CurrentlyFollowingEntity{ EntityId::GetNull() };
 
         ObjectEntryIndex LastEntranceStyle;
 

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -1412,6 +1412,7 @@ void WindowFollowSprite(WindowBase& w, EntityId spriteIndex)
     if (spriteIndex.ToUnderlying() < MAX_ENTITIES || spriteIndex.IsNull())
     {
         w.viewport_smart_follow_sprite = spriteIndex;
+        GetGameState().CurrentlyFollowingEntity = spriteIndex;
     }
 }
 
@@ -1419,6 +1420,7 @@ void WindowUnfollowSprite(WindowBase& w)
 {
     w.viewport_smart_follow_sprite = EntityId::GetNull();
     w.viewport_target_sprite = EntityId::GetNull();
+    GetGameState().CurrentlyFollowingEntity = EntityId::GetNull();
 }
 
 Viewport* WindowGetViewport(WindowBase* w)

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -600,7 +600,7 @@ namespace OpenRCT2
 
         void ReadWriteInterfaceChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.ReadWriteChunk(ParkFileChunkType::INTERFACE, [&gameState](OrcaStream::ChunkStream& cs) {
+            os.ReadWriteChunk(ParkFileChunkType::INTERFACE, [&gameState, &os](OrcaStream::ChunkStream& cs) {
                 cs.ReadWrite(gameState.SavedView.x);
                 cs.ReadWrite(gameState.SavedView.y);
                 if (cs.GetMode() == OrcaStream::Mode::READING)
@@ -613,6 +613,12 @@ namespace OpenRCT2
                     cs.Write(static_cast<int8_t>(gameState.SavedViewZoom));
                 }
                 cs.ReadWrite(gameState.SavedViewRotation);
+
+                if (os.GetHeader().TargetVersion >= PARK_FILE_CURRENT_VERSION)
+                    cs.ReadWrite(gameState.CurrentlyFollowingEntity);
+                else
+                    gameState.CurrentlyFollowingEntity = EntityId::GetNull();
+
                 cs.ReadWrite(gameState.LastEntranceStyle);
                 cs.ReadWrite(gameState.EditorStep);
             });

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -614,7 +614,7 @@ namespace OpenRCT2
                 }
                 cs.ReadWrite(gameState.SavedViewRotation);
 
-                if (os.GetHeader().TargetVersion >= PARK_FILE_CURRENT_VERSION)
+                if (os.GetHeader().TargetVersion >= 34)
                     cs.ReadWrite(gameState.CurrentlyFollowingEntity);
                 else
                     gameState.CurrentlyFollowingEntity = EntityId::GetNull();

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -14,7 +14,7 @@ namespace OpenRCT2
     constexpr uint32_t PARK_FILE_CURRENT_VERSION = 34;
 
     // The minimum version that is forwards compatible with the current version.
-    constexpr uint32_t PARK_FILE_MIN_VERSION = 33;
+    constexpr uint32_t PARK_FILE_MIN_VERSION = 34;
 
     // The minimum version that is backwards compatible with the current version.
     // If this is increased beyond 0, uncomment the checks in ParkFile.cpp and Context.cpp!


### PR DESCRIPTION
Implements feature requested in #21426 and saves the currently following entity into the save file. Works with all entities (rollercoasters, peeps etc).