### PR TITLE
Fix #18413: Trying to set tooltip using null vehicle

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Improved: [#21599] Currency signs now use non-breaking spaces.
 - Change: [#21529] Classify “Southern Sands”, “Tiny Towers”, “Nevermore Park”, “Pacifica” as expert scenarios.
 - Fix: [#910] Extra viewport does not preserve the location when rotating.
+- Fix: [#18413] Crash when mouse over a hacked train.
 - Fix: [#20338] Cannot select Scenery Picker or Scatter Tool when the scenery recolouring tool is active.
 - Fix: [#21419] Cannot place walls underground beneath sloped tiles with clearance checks disabled.
 - Fix: [#21434] Number of guests overflows in objective text.

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -5055,6 +5055,8 @@ void Vehicle::SetMapToolbar() const
     if (curRide != nullptr && curRide->type < RIDE_TYPE_COUNT)
     {
         const Vehicle* vehicle = GetHead();
+        if (vehicle == nullptr)
+            return;
 
         size_t vehicleIndex;
         for (vehicleIndex = 0; vehicleIndex < std::size(curRide->vehicles); vehicleIndex++)


### PR DESCRIPTION
In some cases, the train's head can be null, such as in the attached park, resulting in nullptr access when mouse-over even tries setting tooltip.

While this fixes the symptoms, I fear more work needs to be done to figure out how is it possible to have a headless train.

To trigger this, mouse-over the area in screenshot, it might take a few tries.

![18413](https://github.com/OpenRCT2/OpenRCT2/assets/550290/3211c13b-0fd3-4253-9af1-6a8da479ec34)

[18413.park.txt](https://github.com/OpenRCT2/OpenRCT2/files/14733860/18413.park.txt)
