### PR TITLE
Feature: #21669 - Guests Ignore Price Limits

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -121,6 +121,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Alex Parisi (alex-parisi) - Added API for returning metadata from all registered plugins.
 * Arnold Zhou (mrmagic2020) - Various plugin additions, new game option, misc.
 * John Dolph (johnwdolph) - Ride music UI, misc.
+* Harry Hopkinson (Harry-Hopkinson) - Added Cheat for guests ignoring price of rides and stalls.
 
 ## Bug fixes & Refactors
 * Claudio Tiecher (janclod)

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3730,6 +3730,8 @@ STR_6655    :Only ‘{POP16}{STRINGID}’
 STR_6656    :Remove all fences from the park
 STR_6657    :Land Not Owned
 STR_6658    :Set land to be not owned by the park, nor available for purchase
+STR_6659    :Guests ignore prices
+STR_6660    :Guests will ignore the price of rides and stalls.
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#15750] Allow using different types of park entrance in one park.
 - Feature: [#20942] Allow removing all park fences from the Cheats window.
+- Feature: [#21675] Guests ignore price limit cheat.
 - Feature: [#22392] [Plugin] Expose ride vehicle’s spin to the plugin API.
 - Feature: [#22414] Finance graphs can be resized.
 - Change: [#21659] Increase the Hybrid Roller Coaster’s maximum lift speed to 17 km/h (11 mph).

--- a/src/openrct2-ui/UiStringIds.h
+++ b/src/openrct2-ui/UiStringIds.h
@@ -407,6 +407,7 @@ namespace OpenRCT2
         STR_THIS_FEATURE_IS_CURRENTLY_UNSTABLE = 5563,
         STR_WARNING_IN_CAPS = 5562,
         STR_YEAR = 6196,
+        STR_CHEAT_IGNORE_PRICE_TIP = 6660,
 
         // Window: Cheats -- weather
         STR_SUNNY = 5719,

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -115,6 +115,7 @@ enum WindowCheatsWidgetIdx
     WIDX_GUEST_RIDE_INTENSITY_MORE_THAN_1,
     WIDX_GUEST_RIDE_INTENSITY_LESS_THAN_15,
     WIDX_GUEST_IGNORE_RIDE_INTENSITY,
+    WIDX_GUEST_IGNORE_PRICE,
     WIDX_DISABLE_VANDALISM,
     WIDX_DISABLE_LITTERING,
     WIDX_GIVE_ALL_GUESTS_GROUP,
@@ -226,7 +227,7 @@ static Widget window_cheats_money_widgets[] =
 static Widget window_cheats_guests_widgets[] =
 {
     MAIN_CHEATS_WIDGETS,
-    MakeWidget({  5,  48}, {238, 279},    WindowWidgetType::Groupbox, WindowColour::Secondary, STR_CHEAT_SET_GUESTS_PARAMETERS                                 ), // Guests parameters group frame
+    MakeWidget({  5,  48}, {238, 290},    WindowWidgetType::Groupbox, WindowColour::Secondary, STR_CHEAT_SET_GUESTS_PARAMETERS                                 ), // Guests parameters group frame
     MakeWidget({183,  69}, MINMAX_BUTTON, WindowWidgetType::Button,   WindowColour::Secondary, STR_MAX                                                         ), // happiness max
     MakeWidget({127,  69}, MINMAX_BUTTON, WindowWidgetType::Button,   WindowColour::Secondary, STR_MIN                                                         ), // happiness min
     MakeWidget({183,  90}, MINMAX_BUTTON, WindowWidgetType::Button,   WindowColour::Secondary, STR_MAX                                                         ), // energy max
@@ -244,8 +245,9 @@ static Widget window_cheats_guests_widgets[] =
     MakeWidget({127, 237}, CHEAT_BUTTON,  WindowWidgetType::Button,   WindowColour::Secondary, STR_CHEAT_MORE_THAN_1                                           ), // ride intensity > 1
     MakeWidget({ 11, 237}, CHEAT_BUTTON,  WindowWidgetType::Button,   WindowColour::Secondary, STR_CHEAT_LESS_THAN_15                                          ), // ride intensity < 15
     MakeWidget({ 11, 258}, CHEAT_CHECK,   WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_IGNORE_INTENSITY,      STR_CHEAT_IGNORE_INTENSITY_TIP ), // guests ignore intensity
-    MakeWidget({ 11, 279}, CHEAT_CHECK,   WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_DISABLE_VANDALISM,     STR_CHEAT_DISABLE_VANDALISM_TIP), // disable vandalism
-    MakeWidget({ 11, 300}, CHEAT_CHECK,   WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_DISABLE_LITTERING,     STR_CHEAT_DISABLE_LITTERING_TIP), // disable littering
+    MakeWidget({ 11, 279}, CHEAT_CHECK,   WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_IGNORE_PRICE,          STR_CHEAT_IGNORE_PRICE_TIP     ), // guests ignore price
+    MakeWidget({ 11, 300}, CHEAT_CHECK,   WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_DISABLE_VANDALISM,     STR_CHEAT_DISABLE_VANDALISM_TIP), // disable vandalism
+    MakeWidget({ 11, 321}, CHEAT_CHECK,   WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_DISABLE_LITTERING,     STR_CHEAT_DISABLE_LITTERING_TIP), // disable littering
     MakeWidget({  5, 342}, {238,  69},    WindowWidgetType::Groupbox, WindowColour::Secondary, STR_CHEAT_GIVE_ALL_GUESTS                                       ), // Guests parameters group frame
     MakeWidget({ 11, 363}, CHEAT_BUTTON,  WindowWidgetType::Button,   WindowColour::Secondary, STR_CURRENCY_FORMAT                                             ), // give guests money
     MakeWidget({127, 363}, CHEAT_BUTTON,  WindowWidgetType::Button,   WindowColour::Secondary, STR_SHOP_ITEM_PLURAL_PARK_MAP                                   ), // give guests park maps
@@ -477,6 +479,7 @@ static StringId window_cheats_page_titles[] = {
                     auto ft = Formatter::Common();
                     ft.Add<money64>(1000.00_GBP);
                     SetCheckboxValue(WIDX_GUEST_IGNORE_RIDE_INTENSITY, gameState.Cheats.IgnoreRideIntensity);
+                    SetCheckboxValue(WIDX_GUEST_IGNORE_PRICE, gameState.Cheats.IgnorePrice);
                     SetCheckboxValue(WIDX_DISABLE_VANDALISM, gameState.Cheats.DisableVandalism);
                     SetCheckboxValue(WIDX_DISABLE_LITTERING, gameState.Cheats.DisableLittering);
                     break;
@@ -1048,6 +1051,9 @@ static StringId window_cheats_page_titles[] = {
                     break;
                 case WIDX_GUEST_IGNORE_RIDE_INTENSITY:
                     CheatsSet(CheatType::IgnoreRideIntensity, !gameState.Cheats.IgnoreRideIntensity);
+                    break;
+                case WIDX_GUEST_IGNORE_PRICE:
+                    CheatsSet(CheatType::IgnorePrice, !gameState.Cheats.IgnorePrice);
                     break;
                 case WIDX_DISABLE_VANDALISM:
                     CheatsSet(CheatType::DisableVandalism, !gameState.Cheats.DisableVandalism);

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -44,6 +44,7 @@ void CheatsReset()
     gameState.Cheats.DisableAllBreakdowns = false;
     gameState.Cheats.BuildInPauseMode = false;
     gameState.Cheats.IgnoreRideIntensity = false;
+    gameState.Cheats.IgnorePrice = false;
     gameState.Cheats.DisableVandalism = false;
     gameState.Cheats.DisableLittering = false;
     gameState.Cheats.NeverendingMarketing = false;
@@ -114,6 +115,7 @@ void CheatsSerialise(DataSerialiser& ds)
         CheatEntrySerialise(ds, CheatType::AllowSpecialColourSchemes, gameState.Cheats.AllowSpecialColourSchemes, count);
         CheatEntrySerialise(ds, CheatType::MakeDestructible, gameState.Cheats.MakeAllDestructible, count);
         CheatEntrySerialise(ds, CheatType::SetStaffSpeed, gameState.Cheats.SelectedStaffSpeed, count);
+        CheatEntrySerialise(ds, CheatType::IgnorePrice, gameState.Cheats.IgnorePrice, count);
 
         // Remember current position and update count.
         uint64_t endOffset = stream.GetPosition();
@@ -166,6 +168,9 @@ void CheatsSerialise(DataSerialiser& ds)
                     break;
                 case CheatType::IgnoreRideIntensity:
                     ds << gameState.Cheats.IgnoreRideIntensity;
+                    break;
+                case CheatType::IgnorePrice:
+                    ds << gameState.Cheats.IgnorePrice;
                     break;
                 case CheatType::DisableVandalism:
                     ds << gameState.Cheats.DisableVandalism;
@@ -253,6 +258,8 @@ const char* CheatsGetName(CheatType cheatType)
             return LanguageGetString(STR_CHEAT_BUILD_IN_PAUSE_MODE);
         case CheatType::IgnoreRideIntensity:
             return LanguageGetString(STR_CHEAT_IGNORE_INTENSITY);
+        case CheatType::IgnorePrice:
+            return LanguageGetString(STR_CHEAT_IGNORE_PRICE);
         case CheatType::DisableVandalism:
             return LanguageGetString(STR_CHEAT_DISABLE_VANDALISM);
         case CheatType::DisableLittering:

--- a/src/openrct2/Cheats.h
+++ b/src/openrct2/Cheats.h
@@ -30,6 +30,7 @@ struct CheatsState
     bool DisableAllBreakdowns;
     bool BuildInPauseMode;
     bool IgnoreRideIntensity;
+    bool IgnorePrice;
     bool DisableVandalism;
     bool DisableLittering;
     bool NeverendingMarketing;
@@ -103,6 +104,7 @@ enum class CheatType : int32_t
     AllowRegularPathAsQueue,
     AllowSpecialColourSchemes,
     RemoveParkFences,
+    IgnorePrice,
     Count,
 };
 

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -144,6 +144,9 @@ GameActions::Result CheatSetAction::Execute() const
         case CheatType::IgnoreRideIntensity:
             GetGameState().Cheats.IgnoreRideIntensity = _param1 != 0;
             break;
+        case CheatType::IgnorePrice:
+            GetGameState().Cheats.IgnorePrice = _param1 != 0;
+            break;
         case CheatType::DisableVandalism:
             GetGameState().Cheats.DisableVandalism = _param1 != 0;
             break;
@@ -308,6 +311,8 @@ ParametersRange CheatSetAction::GetParameterRange(CheatType cheatType) const
         case CheatType::BuildInPauseMode:
             [[fallthrough]];
         case CheatType::IgnoreRideIntensity:
+            [[fallthrough]];
+        case CheatType::IgnorePrice:
             [[fallthrough]];
         case CheatType::DisableVandalism:
             [[fallthrough]];

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -1584,7 +1584,7 @@ bool Guest::DecideAndBuyItem(Ride& ride, const ShopItem shopItem, money64 price)
                     if (Happiness >= 180)
                         itemValue /= 2;
                 }
-                if (itemValue > (static_cast<money64>(ScenarioRand() & 0x07)))
+                if (itemValue > (static_cast<money64>(ScenarioRand() & 0x07)) && !(GetGameState().Cheats.IgnorePrice))
                 {
                     // "I'm not paying that much for x"
                     InsertNewThought(shopItemDescriptor.TooMuchThought, ride.id);
@@ -2175,7 +2175,7 @@ bool Guest::ShouldGoOnRide(Ride& ride, StationIndex entranceNum, bool atQueue, b
 
                 // Peeps won't pay more than twice the value of the ride.
                 ridePrice = RideGetPrice(ride);
-                if (ridePrice > (value * 2))
+                if ((ridePrice > (value * 2)) && !(gameState.Cheats.IgnorePrice))
                 {
                     if (peepAtRide)
                     {
@@ -2243,7 +2243,7 @@ bool Guest::ShouldGoToShop(Ride& ride, bool peepAtShop)
 
         // The amount that peeps are willing to pay to use the Toilets scales with their toilet stat.
         // It effectively has a minimum of $0.10 (due to the check above) and a maximum of $0.60.
-        if (RideGetPrice(ride) * 40 > Toilet)
+        if ((RideGetPrice(ride) * 40 > Toilet) && !GetGameState().Cheats.IgnorePrice)
         {
             if (peepAtShop)
             {
@@ -2650,7 +2650,7 @@ static bool PeepCheckRidePriceAtEntrance(Guest* peep, const Ride& ride, money64 
     auto value = ride.value;
     if (value != RIDE_VALUE_UNDEFINED)
     {
-        if ((value * 2) < ridePrice)
+        if (((value * 2) < ridePrice) && !(GetGameState().Cheats.IgnorePrice))
         {
             peep->InsertNewThought(PeepThoughtType::BadValue, peep->CurrentRide);
             PeepUpdateRideAtEntranceTryLeave(peep);

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -1689,6 +1689,8 @@ enum : StringId
     STR_LOADING_SAVED_GAME = 6650,
     STR_STRING_M_PERCENT = 6651,
 
+    STR_CHEAT_IGNORE_PRICE = 6659,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -49,7 +49,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kNetworkStreamVersion = 3;
+constexpr uint8_t kNetworkStreamVersion = 4;
 
 const std::string kNetworkStreamID = std::string(OPENRCT2_VERSION) + "-" + std::to_string(kNetworkStreamVersion);
 

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -11,7 +11,7 @@ namespace OpenRCT2
     struct GameState_t;
 
     // Current version that is saved.
-    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 35;
+    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 36;
 
     // The minimum version that is forwards compatible with the current version.
     constexpr uint32_t PARK_FILE_MIN_VERSION = 33;


### PR DESCRIPTION
Adds a cheat that allows for guests to ignore the prices of rollercoasters, shop items, etc.