### PR TITLE
Move everything in GameState to GameState_t

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -714,9 +714,7 @@ public:
     {
         if (_titleSequencePlayer == nullptr)
         {
-            auto context = GetContext();
-            auto gameState = context->GetGameState();
-            _titleSequencePlayer = OpenRCT2::Title::CreateTitleSequencePlayer(*gameState);
+            _titleSequencePlayer = OpenRCT2::Title::CreateTitleSequencePlayer();
         }
         return _titleSequencePlayer.get();
     }

--- a/src/openrct2-ui/input/Shortcuts.cpp
+++ b/src/openrct2-ui/input/Shortcuts.cpp
@@ -278,7 +278,7 @@ static void ShortcutShowFinancialInformation()
         return;
 
     if (!(gScreenFlags & (SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER)))
-        if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+        if (!(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             ContextOpenWindow(WindowClass::Finances);
 }
 

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -134,7 +134,7 @@ static InteractionInfo ViewportInteractionGetItemLeft(const ScreenCoordsXY& scre
             break;
         case ViewportInteractionItem::ParkEntrance:
         {
-            auto& park = GetContext()->GetGameState()->GetPark();
+            auto& park = GetGameState().Park;
             auto parkName = park.Name.c_str();
 
             auto ft = Formatter();

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -134,8 +134,8 @@ static InteractionInfo ViewportInteractionGetItemLeft(const ScreenCoordsXY& scre
             break;
         case ViewportInteractionItem::ParkEntrance:
         {
-            auto& park = GetGameState().Park;
-            auto parkName = park.Name.c_str();
+            auto& gameState = GetGameState();
+            auto parkName = gameState.Park.Name.c_str();
 
             auto ft = Formatter();
             ft.Add<StringId>(STR_STRING);

--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -46,8 +46,6 @@ namespace OpenRCT2::Title
     class TitleSequencePlayer final : public ITitleSequencePlayer
     {
     private:
-        GameState& _gameState;
-
         std::unique_ptr<TitleSequence> _sequence;
         int32_t _position = 0;
         int32_t _waitCounter = 0;
@@ -57,8 +55,7 @@ namespace OpenRCT2::Title
         ScreenCoordsXY _previousViewPosition = {};
 
     public:
-        explicit TitleSequencePlayer(GameState& gameState)
-            : _gameState(gameState)
+        explicit TitleSequencePlayer()
         {
         }
 
@@ -248,7 +245,7 @@ namespace OpenRCT2::Title
             {
                 if (Update())
                 {
-                    _gameState.UpdateLogic();
+                    gameStateUpdateLogic();
                 }
                 else
                 {
@@ -431,8 +428,8 @@ namespace OpenRCT2::Title
         }
     };
 
-    std::unique_ptr<ITitleSequencePlayer> CreateTitleSequencePlayer(GameState& gameState)
+    std::unique_ptr<ITitleSequencePlayer> CreateTitleSequencePlayer()
     {
-        return std::make_unique<TitleSequencePlayer>(gameState);
+        return std::make_unique<TitleSequencePlayer>();
     }
 } // namespace OpenRCT2::Title

--- a/src/openrct2-ui/title/TitleSequencePlayer.h
+++ b/src/openrct2-ui/title/TitleSequencePlayer.h
@@ -17,10 +17,8 @@ struct IScenarioRepository;
 
 namespace OpenRCT2
 {
-    class GameState;
-
     namespace Title
     {
-        [[nodiscard]] std::unique_ptr<ITitleSequencePlayer> CreateTitleSequencePlayer(GameState& gameState);
+        [[nodiscard]] std::unique_ptr<ITitleSequencePlayer> CreateTitleSequencePlayer();
     } // namespace Title
 } // namespace OpenRCT2

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -371,7 +371,7 @@ static StringId window_cheats_page_titles[] = {
         void OnOpen() override
         {
             SetPage(WINDOW_CHEATS_PAGE_MONEY);
-            _parkRatingSpinnerValue = ParkGetForcedRating() >= 0 ? ParkGetForcedRating() : 999;
+            _parkRatingSpinnerValue = Park::GetForcedRating() >= 0 ? Park::GetForcedRating() : 999;
         }
 
         void OnUpdate() override
@@ -459,7 +459,7 @@ static StringId window_cheats_page_titles[] = {
             {
                 case WINDOW_CHEATS_PAGE_MONEY:
                 {
-                    auto moneyDisabled = (gameState.ParkFlags & PARK_FLAGS_NO_MONEY) != 0;
+                    auto moneyDisabled = (gameState.Park.Flags & PARK_FLAGS_NO_MONEY) != 0;
                     SetCheckboxValue(WIDX_NO_MONEY, moneyDisabled);
                     SetWidgetDisabled(WIDX_ADD_SET_MONEY_GROUP, moneyDisabled);
                     SetWidgetDisabled(WIDX_MONEY_SPINNER, moneyDisabled);
@@ -480,9 +480,9 @@ static StringId window_cheats_page_titles[] = {
                     break;
                 }
                 case WINDOW_CHEATS_PAGE_MISC:
-                    widgets[WIDX_OPEN_CLOSE_PARK].text = (gameState.ParkFlags & PARK_FLAGS_PARK_OPEN) ? STR_CHEAT_CLOSE_PARK
-                                                                                                      : STR_CHEAT_OPEN_PARK;
-                    SetCheckboxValue(WIDX_FORCE_PARK_RATING, ParkGetForcedRating() >= 0);
+                    widgets[WIDX_OPEN_CLOSE_PARK].text = (gameState.Park.Flags & PARK_FLAGS_PARK_OPEN) ? STR_CHEAT_CLOSE_PARK
+                                                                                                       : STR_CHEAT_OPEN_PARK;
+                    SetCheckboxValue(WIDX_FORCE_PARK_RATING, Park::GetForcedRating() >= 0);
                     SetCheckboxValue(WIDX_FREEZE_WEATHER, gameState.Cheats.FreezeWeather);
                     SetCheckboxValue(WIDX_NEVERENDING_MARKETING, gameState.Cheats.NeverendingMarketing);
                     SetCheckboxValue(WIDX_DISABLE_PLANT_AGING, gameState.Cheats.DisablePlantAging);
@@ -788,7 +788,7 @@ static StringId window_cheats_page_titles[] = {
             switch (widgetIndex)
             {
                 case WIDX_NO_MONEY:
-                    CheatsSet(CheatType::NoMoney, GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY ? 0 : 1);
+                    CheatsSet(CheatType::NoMoney, GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY ? 0 : 1);
                     break;
                 case WIDX_MONEY_SPINNER:
                     MoneyToString(_moneySpinnerValue, _moneySpinnerText, MONEY_STRING_MAXLENGTH, false);
@@ -814,7 +814,7 @@ static StringId window_cheats_page_titles[] = {
                 case WIDX_INCREASE_PARK_RATING:
                     _parkRatingSpinnerValue = std::min(999, 10 * (_parkRatingSpinnerValue / 10 + 1));
                     InvalidateWidget(WIDX_PARK_RATING_SPINNER);
-                    if (ParkGetForcedRating() >= 0)
+                    if (Park::GetForcedRating() >= 0)
                     {
                         auto cheatSetAction = CheatSetAction(CheatType::SetForcedParkRating, _parkRatingSpinnerValue);
                         GameActions::Execute(&cheatSetAction);
@@ -823,7 +823,7 @@ static StringId window_cheats_page_titles[] = {
                 case WIDX_DECREASE_PARK_RATING:
                     _parkRatingSpinnerValue = std::max(0, 10 * (_parkRatingSpinnerValue / 10 - 1));
                     InvalidateWidget(WIDX_PARK_RATING_SPINNER);
-                    if (ParkGetForcedRating() >= 0)
+                    if (Park::GetForcedRating() >= 0)
                     {
                         CheatsSet(CheatType::SetForcedParkRating, _parkRatingSpinnerValue);
                     }
@@ -913,7 +913,7 @@ static StringId window_cheats_page_titles[] = {
                     CheatsSet(CheatType::NeverEndingMarketing, !gameState.Cheats.NeverendingMarketing);
                     break;
                 case WIDX_FORCE_PARK_RATING:
-                    if (ParkGetForcedRating() >= 0)
+                    if (Park::GetForcedRating() >= 0)
                     {
                         CheatsSet(CheatType::SetForcedParkRating, -1);
                     }

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -192,7 +192,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Draw cost amount
             if (gClearSceneryCost != kMoney64Undefined && gClearSceneryCost != 0
-                && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+                && !(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
                 ft.Add<money64>(gClearSceneryCost);

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -84,8 +84,8 @@ static Widget window_ride_demolish_widgets[] =
             auto currentRide = GetRide(rideId);
             if (currentRide != nullptr)
             {
-                auto stringId = (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY) ? STR_DEMOLISH_RIDE_ID
-                                                                                 : STR_DEMOLISH_RIDE_ID_MONEY;
+                auto stringId = (GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY) ? STR_DEMOLISH_RIDE_ID
+                                                                                  : STR_DEMOLISH_RIDE_ID_MONEY;
                 auto ft = Formatter();
                 currentRide->FormatNameTo(ft);
                 ft.Add<money64>(_demolishRideCost);

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -105,7 +105,7 @@ static Widget _editorBottomToolbarWidgets[] = {
                 }
                 else if (!(gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER))
                 {
-                    if (GetNumFreeEntities() != MAX_ENTITIES || GetGameState().ParkFlags & PARK_FLAGS_SPRITES_INITIALISED)
+                    if (GetNumFreeEntities() != MAX_ENTITIES || GetGameState().Park.Flags & PARK_FLAGS_SPRITES_INITIALISED)
                     {
                         HidePreviousStepButton();
                     }
@@ -141,7 +141,7 @@ static Widget _editorBottomToolbarWidgets[] = {
             if (widgetIndex == WIDX_PREVIOUS_STEP_BUTTON)
             {
                 if ((gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER)
-                    || (GetNumFreeEntities() == MAX_ENTITIES && !(GetGameState().ParkFlags & PARK_FLAGS_SPRITES_INITIALISED)))
+                    || (GetNumFreeEntities() == MAX_ENTITIES && !(GetGameState().Park.Flags & PARK_FLAGS_SPRITES_INITIALISED)))
                 {
                     ((this)->*(_previousButtonMouseUp[EnumValue(gameState.EditorStep)]))();
                 }

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -446,10 +446,11 @@ static uint64_t window_editor_objective_options_page_hold_down_widgets[] = {
                 if (i == OBJECTIVE_NONE || i == OBJECTIVE_BUILD_THE_BEST)
                     continue;
 
-                const bool objectiveAllowedByMoneyUsage = !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
+                const bool objectiveAllowedByMoneyUsage = !(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY)
                     || !ObjectiveNeedsMoney(i);
                 // This objective can only work if the player can ask money for rides.
-                const bool objectiveAllowedByPaymentSettings = (i != OBJECTIVE_MONTHLY_RIDE_INCOME) || ParkRidePricesUnlocked();
+                const bool objectiveAllowedByPaymentSettings = (i != OBJECTIVE_MONTHLY_RIDE_INCOME)
+                    || Park::RidePricesUnlocked();
                 if (objectiveAllowedByMoneyUsage && objectiveAllowedByPaymentSettings)
                 {
                     gDropdownItems[numItems].Format = STR_DROPDOWN_MENU_LABEL;
@@ -763,11 +764,11 @@ static uint64_t window_editor_objective_options_page_hold_down_widgets[] = {
             objectiveType = GetGameState().ScenarioObjective.Type;
 
             // Check if objective is allowed by money and pay-per-ride settings.
-            const bool objectiveAllowedByMoneyUsage = !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
+            const bool objectiveAllowedByMoneyUsage = !(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY)
                 || !ObjectiveNeedsMoney(objectiveType);
             // This objective can only work if the player can ask money for rides.
             const bool objectiveAllowedByPaymentSettings = (objectiveType != OBJECTIVE_MONTHLY_RIDE_INCOME)
-                || ParkRidePricesUnlocked();
+                || Park::RidePricesUnlocked();
             if (!objectiveAllowedByMoneyUsage || !objectiveAllowedByPaymentSettings)
             {
                 // Reset objective

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -662,7 +662,7 @@ static uint64_t window_editor_objective_options_page_hold_down_widgets[] = {
             {
                 case WIDX_PARK_NAME:
                 {
-                    auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+                    auto& park = OpenRCT2::GetGameState().Park;
                     WindowTextInputRawOpen(
                         this, WIDX_PARK_NAME, STR_PARK_NAME, STR_ENTER_PARK_NAME, {}, park.Name.c_str(), ParkNameMaxLength);
                     break;
@@ -794,7 +794,7 @@ static uint64_t window_editor_objective_options_page_hold_down_widgets[] = {
 
                     if (gameState.ScenarioName.empty())
                     {
-                        auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+                        auto& park = OpenRCT2::GetGameState().Park;
                         gameState.ScenarioName = park.Name;
                     }
                     break;
@@ -972,7 +972,7 @@ static uint64_t window_editor_objective_options_page_hold_down_widgets[] = {
             widthToSet = widgets[WIDX_PARK_NAME].left - 16;
 
             {
-                auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+                auto& park = OpenRCT2::GetGameState().Park;
                 auto parkName = park.Name.c_str();
 
                 ft = Formatter();

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -662,9 +662,9 @@ static uint64_t window_editor_objective_options_page_hold_down_widgets[] = {
             {
                 case WIDX_PARK_NAME:
                 {
-                    auto& park = OpenRCT2::GetGameState().Park;
                     WindowTextInputRawOpen(
-                        this, WIDX_PARK_NAME, STR_PARK_NAME, STR_ENTER_PARK_NAME, {}, park.Name.c_str(), ParkNameMaxLength);
+                        this, WIDX_PARK_NAME, STR_PARK_NAME, STR_ENTER_PARK_NAME, {}, gameState.Park.Name.c_str(),
+                        ParkNameMaxLength);
                     break;
                 }
                 case WIDX_SCENARIO_NAME:
@@ -794,8 +794,7 @@ static uint64_t window_editor_objective_options_page_hold_down_widgets[] = {
 
                     if (gameState.ScenarioName.empty())
                     {
-                        auto& park = OpenRCT2::GetGameState().Park;
-                        gameState.ScenarioName = park.Name;
+                        gameState.ScenarioName = gameState.Park.Name;
                     }
                     break;
                 }
@@ -972,8 +971,7 @@ static uint64_t window_editor_objective_options_page_hold_down_widgets[] = {
             widthToSet = widgets[WIDX_PARK_NAME].left - 16;
 
             {
-                auto& park = OpenRCT2::GetGameState().Park;
-                auto parkName = park.Name.c_str();
+                auto parkName = OpenRCT2::GetGameState().Park.Name.c_str();
 
                 ft = Formatter();
                 ft.Add<StringId>(STR_STRING);

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -385,7 +385,7 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
                     break;
                 case WIDX_NO_MONEY:
                 {
-                    auto newMoneySetting = (gameState.ParkFlags & PARK_FLAGS_NO_MONEY) ? 0 : 1;
+                    auto newMoneySetting = (gameState.Park.Flags & PARK_FLAGS_NO_MONEY) ? 0 : 1;
                     auto scenarioSetSetting = ScenarioSetSettingAction(ScenarioSetSetting::NoMoney, newMoneySetting);
                     GameActions::Execute(&scenarioSetSetting);
                     Invalidate();
@@ -395,7 +395,7 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
                 {
                     auto scenarioSetSetting = ScenarioSetSettingAction(
                         ScenarioSetSetting::ForbidMarketingCampaigns,
-                        gameState.ParkFlags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN ? 0 : 1);
+                        gameState.Park.Flags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN ? 0 : 1);
                     GameActions::Execute(&scenarioSetSetting);
                     Invalidate();
                     break;
@@ -403,7 +403,7 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
                 case WIDX_RCT1_INTEREST:
                 {
                     auto scenarioSetSetting = ScenarioSetSettingAction(
-                        ScenarioSetSetting::UseRCT1Interest, gameState.ParkFlags & PARK_FLAGS_RCT1_INTEREST ? 0 : 1);
+                        ScenarioSetSetting::UseRCT1Interest, gameState.Park.Flags & PARK_FLAGS_RCT1_INTEREST ? 0 : 1);
                     GameActions::Execute(&scenarioSetSetting);
                     Invalidate();
                     break;
@@ -570,7 +570,7 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
             SetPressedTab();
 
             auto& gameState = GetGameState();
-            if (gameState.ParkFlags & PARK_FLAGS_NO_MONEY)
+            if (gameState.Park.Flags & PARK_FLAGS_NO_MONEY)
             {
                 SetWidgetPressed(WIDX_NO_MONEY, true);
                 for (int32_t i = WIDX_INITIAL_CASH; i <= WIDX_RCT1_INTEREST; i++)
@@ -590,7 +590,7 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
                 widgets[WIDX_MAXIMUM_LOAN_DECREASE].type = WindowWidgetType::Button;
                 widgets[WIDX_FORBID_MARKETING].type = WindowWidgetType::Checkbox;
 
-                if (gameState.ParkFlags & PARK_FLAGS_RCT1_INTEREST)
+                if (gameState.Park.Flags & PARK_FLAGS_RCT1_INTEREST)
                 {
                     widgets[WIDX_INTEREST_RATE].type = WindowWidgetType::Empty;
                     widgets[WIDX_INTEREST_RATE_INCREASE].type = WindowWidgetType::Empty;
@@ -607,7 +607,7 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
                 }
             }
 
-            SetWidgetPressed(WIDX_FORBID_MARKETING, gameState.ParkFlags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN);
+            SetWidgetPressed(WIDX_FORBID_MARKETING, gameState.Park.Flags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN);
 
             widgets[WIDX_CLOSE].type = (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) ? WindowWidgetType::Empty
                                                                                      : WindowWidgetType::CloseBox;
@@ -696,7 +696,7 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
                 {
                     auto scenarioSetSetting = ScenarioSetSettingAction(
                         ScenarioSetSetting::GuestsPreferLessIntenseRides,
-                        gameState.ParkFlags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES ? 0 : 1);
+                        gameState.Park.Flags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES ? 0 : 1);
                     GameActions::Execute(&scenarioSetSetting);
                     Invalidate();
                     break;
@@ -705,7 +705,7 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
                 {
                     auto scenarioSetSetting = ScenarioSetSettingAction(
                         ScenarioSetSetting::GuestsPreferMoreIntenseRides,
-                        gameState.ParkFlags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES ? 0 : 1);
+                        gameState.Park.Flags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES ? 0 : 1);
                     GameActions::Execute(&scenarioSetSetting);
                     Invalidate();
                     break;
@@ -850,7 +850,7 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
             SetPressedTab();
 
             auto& gameState = GetGameState();
-            if (gameState.ParkFlags & PARK_FLAGS_NO_MONEY)
+            if (gameState.Park.Flags & PARK_FLAGS_NO_MONEY)
             {
                 widgets[WIDX_CASH_PER_GUEST].type = WindowWidgetType::Empty;
                 widgets[WIDX_CASH_PER_GUEST_INCREASE].type = WindowWidgetType::Empty;
@@ -863,8 +863,8 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
                 widgets[WIDX_CASH_PER_GUEST_DECREASE].type = WindowWidgetType::Button;
             }
 
-            SetWidgetPressed(WIDX_GUEST_PREFER_LESS_INTENSE_RIDES, gameState.ParkFlags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES);
-            SetWidgetPressed(WIDX_GUEST_PREFER_MORE_INTENSE_RIDES, gameState.ParkFlags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES);
+            SetWidgetPressed(WIDX_GUEST_PREFER_LESS_INTENSE_RIDES, gameState.Park.Flags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES);
+            SetWidgetPressed(WIDX_GUEST_PREFER_MORE_INTENSE_RIDES, gameState.Park.Flags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES);
 
             widgets[WIDX_CLOSE].type = (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) ? WindowWidgetType::Empty
                                                                                      : WindowWidgetType::CloseBox;
@@ -948,7 +948,7 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
                 case WIDX_FORBID_TREE_REMOVAL:
                 {
                     auto scenarioSetSetting = ScenarioSetSettingAction(
-                        ScenarioSetSetting::ForbidTreeRemoval, gameState.ParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL ? 0 : 1);
+                        ScenarioSetSetting::ForbidTreeRemoval, gameState.Park.Flags & PARK_FLAGS_FORBID_TREE_REMOVAL ? 0 : 1);
                     GameActions::Execute(&scenarioSetSetting);
                     Invalidate();
                     break;
@@ -957,7 +957,7 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
                 {
                     auto scenarioSetSetting = ScenarioSetSettingAction(
                         ScenarioSetSetting::ForbidLandscapeChanges,
-                        gameState.ParkFlags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES ? 0 : 1);
+                        gameState.Park.Flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES ? 0 : 1);
                     GameActions::Execute(&scenarioSetSetting);
                     Invalidate();
                     break;
@@ -966,7 +966,7 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
                 {
                     auto scenarioSetSetting = ScenarioSetSettingAction(
                         ScenarioSetSetting::ForbidHighConstruction,
-                        gameState.ParkFlags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION ? 0 : 1);
+                        gameState.Park.Flags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION ? 0 : 1);
                     GameActions::Execute(&scenarioSetSetting);
                     Invalidate();
                     break;
@@ -975,7 +975,7 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
                 {
                     auto scenarioSetSetting = ScenarioSetSettingAction(
                         ScenarioSetSetting::ParkRatingHigherDifficultyLevel,
-                        gameState.ParkFlags & PARK_FLAGS_DIFFICULT_PARK_RATING ? 0 : 1);
+                        gameState.Park.Flags & PARK_FLAGS_DIFFICULT_PARK_RATING ? 0 : 1);
                     GameActions::Execute(&scenarioSetSetting);
                     Invalidate();
                     break;
@@ -984,7 +984,7 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
                 {
                     auto scenarioSetSetting = ScenarioSetSettingAction(
                         ScenarioSetSetting::GuestGenerationHigherDifficultyLevel,
-                        gameState.ParkFlags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION ? 0 : 1);
+                        gameState.Park.Flags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION ? 0 : 1);
                     GameActions::Execute(&scenarioSetSetting);
                     Invalidate();
                     break;
@@ -1058,10 +1058,10 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
                     Invalidate();
                     break;
                 case WIDX_ENTRY_PRICE_INCREASE:
-                    if (gameState.ParkEntranceFee < MAX_ENTRANCE_FEE)
+                    if (gameState.Park.EntranceFee < MAX_ENTRANCE_FEE)
                     {
                         auto scenarioSetSetting = ScenarioSetSettingAction(
-                            ScenarioSetSetting::ParkChargeEntryFee, gameState.ParkEntranceFee + 1.00_GBP);
+                            ScenarioSetSetting::ParkChargeEntryFee, gameState.Park.EntranceFee + 1.00_GBP);
                         GameActions::Execute(&scenarioSetSetting);
                     }
                     else
@@ -1071,10 +1071,10 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
                     Invalidate();
                     break;
                 case WIDX_ENTRY_PRICE_DECREASE:
-                    if (gameState.ParkEntranceFee > 0.00_GBP)
+                    if (gameState.Park.EntranceFee > 0.00_GBP)
                     {
                         auto scenarioSetSetting = ScenarioSetSettingAction(
-                            ScenarioSetSetting::ParkChargeEntryFee, gameState.ParkEntranceFee - 1.00_GBP);
+                            ScenarioSetSetting::ParkChargeEntryFee, gameState.Park.EntranceFee - 1.00_GBP);
                         GameActions::Execute(&scenarioSetSetting);
                     }
                     else
@@ -1097,9 +1097,9 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
                         { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height() - 1,
                         colours[1], 0, Dropdown::Flag::StayOpen, 3, dropdownWidget->width() - 3);
 
-                    if (gameState.ParkFlags & PARK_FLAGS_UNLOCK_ALL_PRICES)
+                    if (gameState.Park.Flags & PARK_FLAGS_UNLOCK_ALL_PRICES)
                         Dropdown::SetChecked(2, true);
-                    else if (gameState.ParkFlags & PARK_FLAGS_PARK_FREE_ENTRY)
+                    else if (gameState.Park.Flags & PARK_FLAGS_PARK_FREE_ENTRY)
                         Dropdown::SetChecked(0, true);
                     else
                         Dropdown::SetChecked(1, true);
@@ -1156,7 +1156,7 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
             SetPressedTab();
 
             auto& gameState = GetGameState();
-            if (gameState.ParkFlags & PARK_FLAGS_NO_MONEY)
+            if (gameState.Park.Flags & PARK_FLAGS_NO_MONEY)
             {
                 for (int32_t i = WIDX_LAND_COST; i <= WIDX_ENTRY_PRICE_DECREASE; i++)
                     widgets[i].type = WindowWidgetType::Empty;
@@ -1172,7 +1172,7 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
                 widgets[WIDX_PAY_FOR_PARK_OR_RIDES].type = WindowWidgetType::DropdownMenu;
                 widgets[WIDX_PAY_FOR_PARK_OR_RIDES_DROPDOWN].type = WindowWidgetType::Button;
 
-                if (!ParkEntranceFeeUnlocked())
+                if (!Park::EntranceFeeUnlocked())
                 {
                     widgets[WIDX_ENTRY_PRICE].type = WindowWidgetType::Empty;
                     widgets[WIDX_ENTRY_PRICE_INCREASE].type = WindowWidgetType::Empty;
@@ -1186,11 +1186,11 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
                 }
             }
 
-            SetWidgetPressed(WIDX_FORBID_TREE_REMOVAL, gameState.ParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL);
-            SetWidgetPressed(WIDX_FORBID_LANDSCAPE_CHANGES, gameState.ParkFlags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES);
-            SetWidgetPressed(WIDX_FORBID_HIGH_CONSTRUCTION, gameState.ParkFlags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION);
-            SetWidgetPressed(WIDX_HARD_PARK_RATING, gameState.ParkFlags & PARK_FLAGS_DIFFICULT_PARK_RATING);
-            SetWidgetPressed(WIDX_HARD_GUEST_GENERATION, gameState.ParkFlags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION);
+            SetWidgetPressed(WIDX_FORBID_TREE_REMOVAL, gameState.Park.Flags & PARK_FLAGS_FORBID_TREE_REMOVAL);
+            SetWidgetPressed(WIDX_FORBID_LANDSCAPE_CHANGES, gameState.Park.Flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES);
+            SetWidgetPressed(WIDX_FORBID_HIGH_CONSTRUCTION, gameState.Park.Flags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION);
+            SetWidgetPressed(WIDX_HARD_PARK_RATING, gameState.Park.Flags & PARK_FLAGS_DIFFICULT_PARK_RATING);
+            SetWidgetPressed(WIDX_HARD_GUEST_GENERATION, gameState.Park.Flags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION);
 
             widgets[WIDX_CLOSE].type = (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) ? WindowWidgetType::Empty
                                                                                      : WindowWidgetType::CloseBox;
@@ -1243,9 +1243,9 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
 
                 auto ft = Formatter();
                 // Pay for park and/or rides value
-                if (gameState.ParkFlags & PARK_FLAGS_UNLOCK_ALL_PRICES)
+                if (gameState.Park.Flags & PARK_FLAGS_UNLOCK_ALL_PRICES)
                     ft.Add<StringId>(STR_PAID_ENTRY_PAID_RIDES);
-                else if (gameState.ParkFlags & PARK_FLAGS_PARK_FREE_ENTRY)
+                else if (gameState.Park.Flags & PARK_FLAGS_PARK_FREE_ENTRY)
                     ft.Add<StringId>(STR_FREE_PARK_ENTER);
                 else
                     ft.Add<StringId>(STR_PAY_PARK_ENTER);
@@ -1263,7 +1263,7 @@ static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
                 // Entry price value
                 screenCoords = windowPos + ScreenCoordsXY{ entryPriceWidget.left + 1, entryPriceWidget.top };
                 auto ft = Formatter();
-                ft.Add<money64>(gameState.ParkEntranceFee);
+                ft.Add<money64>(gameState.Park.EntranceFee);
                 DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
             }
 

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -230,7 +230,7 @@ static Widget _windowFinancesResearchWidgets[] =
 
         void SetDisabledTabs()
         {
-            disabled_widgets = (GetGameState().ParkFlags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN) ? (1uLL << WIDX_TAB_5) : 0;
+            disabled_widgets = (GetGameState().Park.Flags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN) ? (1uLL << WIDX_TAB_5) : 0;
         }
 
     public:
@@ -569,7 +569,7 @@ static Widget _windowFinancesResearchWidgets[] =
 
             // Loan and interest rate
             DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ 8, 279 }, STR_FINANCES_SUMMARY_LOAN);
-            if (!(gameState.ParkFlags & PARK_FLAGS_RCT1_INTEREST))
+            if (!(gameState.Park.Flags & PARK_FLAGS_RCT1_INTEREST))
             {
                 auto ft = Formatter();
                 ft.Add<uint16_t>(gameState.BankLoanInterestRate);
@@ -596,7 +596,7 @@ static Widget _windowFinancesResearchWidgets[] =
             {
                 // Park value and company value
                 ft = Formatter();
-                ft.Add<money64>(gameState.ParkValue);
+                ft.Add<money64>(gameState.Park.Value);
                 DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ 280, 279 }, STR_PARK_VALUE_LABEL, ft);
                 ft = Formatter();
                 ft.Add<money64>(gameState.CompanyValue);
@@ -688,7 +688,7 @@ static Widget _windowFinancesResearchWidgets[] =
 
             // Park value
             auto ft = Formatter();
-            ft.Add<money64>(gameState.ParkValue);
+            ft.Add<money64>(gameState.Park.Value);
             DrawTextBasic(dpi, graphTopLeft - ScreenCoordsXY{ 0, 11 }, STR_FINANCES_PARK_VALUE, ft);
 
             // Graph
@@ -698,7 +698,7 @@ static Widget _windowFinancesResearchWidgets[] =
             int32_t yAxisScale = 0;
             for (int32_t i = 0; i < 64; i++)
             {
-                auto balance = gameState.ParkValueHistory[i];
+                auto balance = gameState.Park.ValueHistory[i];
                 if (balance == kMoney64Undefined)
                     continue;
 
@@ -730,7 +730,7 @@ static Widget _windowFinancesResearchWidgets[] =
 
             // X axis labels and values
             coords = graphTopLeft + ScreenCoordsXY{ 98, 17 };
-            Graph::Draw(dpi, gameState.ParkValueHistory, 64, coords, yAxisScale, 0);
+            Graph::Draw(dpi, gameState.Park.ValueHistory, 64, coords, yAxisScale, 0);
         }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -870,7 +870,7 @@ static Widget _windowFinancesResearchWidgets[] =
                         break;
                     default:
                     {
-                        auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+                        auto& park = OpenRCT2::GetGameState().Park;
                         auto parkName = park.Name.c_str();
                         ft.Add<StringId>(STR_STRING);
                         ft.Add<const char*>(parkName);

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -870,8 +870,7 @@ static Widget _windowFinancesResearchWidgets[] =
                         break;
                     default:
                     {
-                        auto& park = OpenRCT2::GetGameState().Park;
-                        auto parkName = park.Name.c_str();
+                        auto parkName = OpenRCT2::GetGameState().Park.Name.c_str();
                         ft.Add<StringId>(STR_STRING);
                         ft.Add<const char*>(parkName);
                     }

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -500,7 +500,7 @@ static constexpr uint8_t ConstructionPreviewImages[][4] = {
                                   window_footpath_widgets[WIDX_CONSTRUCT].bottom - 12 };
             if (_windowFootpathCost != kMoney64Undefined)
             {
-                if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+                if (!(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
                 {
                     auto ft = Formatter();
                     ft.Add<money64>(_windowFootpathCost);

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -92,7 +92,7 @@ static Widget window_game_bottom_toolbar_widgets[] =
             auto& gameState = GetGameState();
 
             // Draw money
-            if (!(gameState.ParkFlags & PARK_FLAGS_NO_MONEY))
+            if (!(gameState.Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 Widget widget = window_game_bottom_toolbar_widgets[WIDX_MONEY];
                 auto screenCoords = ScreenCoordsXY{ windowPos.x + widget.midX(),
@@ -143,7 +143,7 @@ static Widget window_game_bottom_toolbar_widgets[] =
                 Widget widget = window_game_bottom_toolbar_widgets[WIDX_PARK_RATING];
                 auto screenCoords = windowPos + ScreenCoordsXY{ widget.left + 11, widget.midY() - 5 };
 
-                DrawParkRating(dpi, colours[3], screenCoords, std::max(10, ((gameState.ParkRating / 4) * 263) / 256));
+                DrawParkRating(dpi, colours[3], screenCoords, std::max(10, ((gameState.Park.Rating / 4) * 263) / 256));
             }
         }
 
@@ -422,7 +422,7 @@ static Widget window_game_bottom_toolbar_widgets[] =
             {
                 case WIDX_LEFT_OUTSET:
                 case WIDX_MONEY:
-                    if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+                    if (!(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
                         ContextOpenWindow(WindowClass::Finances);
                     break;
                 case WIDX_GUESTS:
@@ -478,10 +478,10 @@ static Widget window_game_bottom_toolbar_widgets[] =
             {
                 case WIDX_MONEY:
                     ft.Add<money64>(gameState.CurrentProfit);
-                    ft.Add<money64>(gameState.ParkValue);
+                    ft.Add<money64>(gameState.Park.Value);
                     break;
                 case WIDX_PARK_RATING:
-                    ft.Add<int16_t>(gameState.ParkRating);
+                    ft.Add<int16_t>(gameState.Park.Rating);
                     break;
             }
             return { fallback, ft };
@@ -504,7 +504,7 @@ static Widget window_game_bottom_toolbar_widgets[] =
                 + 1;
 
             // Reposition left widgets in accordance with line height... depending on whether there is money in play.
-            if (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
+            if (GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY)
             {
                 widgets[WIDX_MONEY].type = WindowWidgetType::Empty;
                 widgets[WIDX_GUESTS].top = 1;

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -468,7 +468,7 @@ static_assert(_guestWindowPageWidgets.size() == WINDOW_GUEST_PAGE_COUNT);
                 if (!WidgetIsDisabled(*this, WIDX_PICKUP))
                     Invalidate();
             }
-            if (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
+            if (GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY)
             {
                 newDisabledWidgets |= (1uLL << WIDX_TAB_4); // Disable finance tab if no money
             }

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1629,8 +1629,7 @@ static_assert(_guestWindowPageWidgets.size() == WINDOW_GUEST_PAGE_COUNT);
 
         std::pair<StringId, Formatter> InventoryFormatItem(Guest& guest, ShopItem item) const
         {
-            auto& park = OpenRCT2::GetGameState().Park;
-            auto parkName = park.Name.c_str();
+            auto parkName = OpenRCT2::GetGameState().Park.Name.c_str();
 
             // Default arguments
             auto ft = Formatter();

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1629,7 +1629,7 @@ static_assert(_guestWindowPageWidgets.size() == WINDOW_GUEST_PAGE_COUNT);
 
         std::pair<StringId, Formatter> InventoryFormatItem(Guest& guest, ShopItem item) const
         {
-            auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+            auto& park = OpenRCT2::GetGameState().Park;
             auto parkName = park.Name.c_str();
 
             // Default arguments

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -960,8 +960,8 @@ static Widget window_guest_list_widgets[] = {
 
         static GuestItem::CompareFunc GetGuestCompareFunc()
         {
-            return GetGameState().ParkFlags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES ? CompareGuestItem<true>
-                                                                               : CompareGuestItem<false>;
+            return GetGameState().Park.Flags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES ? CompareGuestItem<true>
+                                                                                : CompareGuestItem<false>;
         }
     };
 

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -264,7 +264,7 @@ static Widget window_land_widgets[] = {
 
             screenCoords = { windowPos.x + previewWidget->midX(), windowPos.y + previewWidget->bottom + 5 };
 
-            if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+            if (!(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 // Draw raise cost amount
                 if (gLandToolRaiseCost != kMoney64Undefined && gLandToolRaiseCost != 0)

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -230,7 +230,7 @@ static Widget window_land_rights_widgets[] = {
 
             // Draw cost amount
             if (_landRightsCost != kMoney64Undefined && _landRightsCost != 0
-                && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+                && !(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
                 ft.Add<money64>(_landRightsCost);

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -343,12 +343,12 @@ static Widget window_loadsave_widgets[] =
             case (LOADSAVETYPE_SAVE | LOADSAVETYPE_SCENARIO):
             {
                 SetAndSaveConfigPath(gConfigGeneral.LastSaveScenarioDirectory, pathBuffer);
-                int32_t parkFlagsBackup = gameState.ParkFlags;
-                gameState.ParkFlags &= ~PARK_FLAGS_SPRITES_INITIALISED;
+                int32_t parkFlagsBackup = gameState.Park.Flags;
+                gameState.Park.Flags &= ~PARK_FLAGS_SPRITES_INITIALISED;
                 gameState.EditorStep = EditorStep::Invalid;
                 gScenarioFileName = std::string(String::ToStringView(pathBuffer, std::size(pathBuffer)));
                 int32_t success = ScenarioSave(gameState, pathBuffer, gConfigGeneral.SavePluginData ? 3 : 2);
-                gameState.ParkFlags = parkFlagsBackup;
+                gameState.Park.Flags = parkFlagsBackup;
 
                 if (success)
                 {

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -458,7 +458,7 @@ static Widget window_loadsave_widgets[] =
             }
             else
             {
-                auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+                auto& park = OpenRCT2::GetGameState().Park;
                 auto buffer = park.Name;
                 if (buffer.empty())
                 {

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -458,8 +458,7 @@ static Widget window_loadsave_widgets[] =
             }
             else
             {
-                auto& park = OpenRCT2::GetGameState().Park;
-                auto buffer = park.Name;
+                auto buffer = OpenRCT2::GetGameState().Park.Name;
                 if (buffer.empty())
                 {
                     buffer = LanguageGetString(STR_UNNAMED_PARK);

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -846,7 +846,7 @@ static Widget window_new_ride_widgets[] = {
                 widgets[WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP].type = WindowWidgetType::Groupbox;
                 widgets[WIDX_LAST_DEVELOPMENT_GROUP].type = WindowWidgetType::Groupbox;
                 widgets[WIDX_LAST_DEVELOPMENT_BUTTON].type = WindowWidgetType::FlatBtn;
-                if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+                if (!(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
                     widgets[WIDX_RESEARCH_FUNDING_BUTTON].type = WindowWidgetType::FlatBtn;
 
                 newWidth = 300;
@@ -954,7 +954,7 @@ static Widget window_new_ride_widgets[] = {
             DrawTextBasic(dpi, screenPos + ScreenCoordsXY{ 0, 51 }, designCountStringId, ft);
 
             // Price
-            if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+            if (!(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 // Get price of ride
                 int32_t startPieceId = GetRideTypeDescriptor(item.Type).StartTrackPiece;

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -402,7 +402,7 @@ static constexpr WindowParkAward _parkAwards[] = {
 
         void PrepareWindowTitleText()
         {
-            auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+            auto& park = OpenRCT2::GetGameState().Park;
             auto parkName = park.Name.c_str();
 
             auto ft = Formatter::Common();
@@ -423,7 +423,7 @@ static constexpr WindowParkAward _parkAwards[] = {
                     break;
                 case WIDX_RENAME:
                 {
-                    auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+                    auto& park = OpenRCT2::GetGameState().Park;
                     WindowTextInputRawOpen(
                         this, WIDX_RENAME, STR_PARK_NAME, STR_ENTER_PARK_NAME, {}, park.Name.c_str(), USER_STRING_MAX_LENGTH);
                     break;
@@ -512,7 +512,7 @@ static constexpr WindowParkAward _parkAwards[] = {
 
             // Set open / close park button state
             {
-                auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+                auto& park = OpenRCT2::GetGameState().Park;
                 auto parkName = park.Name.c_str();
 
                 auto ft = Formatter::Common();

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -402,8 +402,7 @@ static constexpr WindowParkAward _parkAwards[] = {
 
         void PrepareWindowTitleText()
         {
-            auto& park = OpenRCT2::GetGameState().Park;
-            auto parkName = park.Name.c_str();
+            auto parkName = OpenRCT2::GetGameState().Park.Name.c_str();
 
             auto ft = Formatter::Common();
             ft.Add<StringId>(STR_STRING);
@@ -456,7 +455,7 @@ static constexpr WindowParkAward _parkAwards[] = {
                 WindowDropdownShowText(
                     { windowPos.x + widget.left, windowPos.y + widget.top }, widget.height() + 1, colours[1], 0, 2);
 
-                if (ParkIsOpen())
+                if (GetGameState().Park.IsOpen())
                 {
                     gDropdownDefaultIndex = 0;
                     Dropdown::SetChecked(1, true);
@@ -512,18 +511,18 @@ static constexpr WindowParkAward _parkAwards[] = {
 
             // Set open / close park button state
             {
-                auto& park = OpenRCT2::GetGameState().Park;
-                auto parkName = park.Name.c_str();
+                auto parkName = OpenRCT2::GetGameState().Park.Name.c_str();
 
                 auto ft = Formatter::Common();
                 ft.Add<StringId>(STR_STRING);
                 ft.Add<const char*>(parkName);
             }
-            widgets[WIDX_OPEN_OR_CLOSE].image = ImageId(ParkIsOpen() ? SPR_OPEN : SPR_CLOSED);
-            const auto closeLightImage = SPR_G2_RCT1_CLOSE_BUTTON_0 + !ParkIsOpen() * 2
+            const bool parkIsOpen = gameState.Park.IsOpen();
+            widgets[WIDX_OPEN_OR_CLOSE].image = ImageId(parkIsOpen ? SPR_OPEN : SPR_CLOSED);
+            const auto closeLightImage = SPR_G2_RCT1_CLOSE_BUTTON_0 + !parkIsOpen * 2
                 + WidgetIsPressed(*this, WIDX_CLOSE_LIGHT);
             widgets[WIDX_CLOSE_LIGHT].image = ImageId(closeLightImage);
-            const auto openLightImage = SPR_G2_RCT1_OPEN_BUTTON_0 + ParkIsOpen() * 2 + WidgetIsPressed(*this, WIDX_OPEN_LIGHT);
+            const auto openLightImage = SPR_G2_RCT1_OPEN_BUTTON_0 + parkIsOpen * 2 + WidgetIsPressed(*this, WIDX_OPEN_LIGHT);
             widgets[WIDX_OPEN_LIGHT].image = ImageId(openLightImage);
 
             // Only allow closing of park for guest / rating objective
@@ -605,7 +604,7 @@ static constexpr WindowParkAward _parkAwards[] = {
 
             // Draw park closed / open label
             auto ft = Formatter();
-            ft.Add<StringId>(ParkIsOpen() ? STR_PARK_OPEN : STR_PARK_CLOSED);
+            ft.Add<StringId>(GetGameState().Park.IsOpen() ? STR_PARK_OPEN : STR_PARK_CLOSED);
 
             auto* labelWidget = &widgets[WIDX_STATUS];
             DrawTextEllipsised(

--- a/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
@@ -83,8 +83,8 @@ static Widget window_ride_refurbish_widgets[] =
             auto currentRide = GetRide(rideId);
             if (currentRide != nullptr)
             {
-                auto stringId = (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY) ? STR_REFURBISH_RIDE_ID_NO_MONEY
-                                                                                 : STR_REFURBISH_RIDE_ID_MONEY;
+                auto stringId = (GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY) ? STR_REFURBISH_RIDE_ID_NO_MONEY
+                                                                                  : STR_REFURBISH_RIDE_ID_MONEY;
                 auto ft = Formatter();
                 currentRide->FormatNameTo(ft);
                 ft.Add<money64>(_demolishRideCost / 2);

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -547,7 +547,7 @@ static Widget *window_research_page_widgets[] = {
         const auto& gameState = GetGameState();
         auto widgetOffset = GetWidgetIndexOffset(baseWidgetIndex, WIDX_RESEARCH_FUNDING);
 
-        if ((GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY) || gameState.ResearchProgressStage == RESEARCH_STAGE_FINISHED_ALL)
+        if ((GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY) || gameState.ResearchProgressStage == RESEARCH_STAGE_FINISHED_ALL)
         {
             w->widgets[WIDX_RESEARCH_FUNDING + widgetOffset].type = WindowWidgetType::Empty;
             w->widgets[WIDX_RESEARCH_FUNDING_DROPDOWN_BUTTON + widgetOffset].type = WindowWidgetType::Empty;
@@ -591,7 +591,7 @@ static Widget *window_research_page_widgets[] = {
 
     void WindowResearchFundingDraw(WindowBase* w, DrawPixelInfo& dpi)
     {
-        if (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
+        if (GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY)
             return;
 
         const auto& gameState = GetGameState();

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1281,7 +1281,7 @@ static_assert(std::size(RatingNames) == 6);
             }
 
             if (rtd.HasFlag(RIDE_TYPE_FLAG_IS_CASH_MACHINE) || rtd.HasFlag(RIDE_TYPE_FLAG_IS_FIRST_AID)
-                || (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY) != 0)
+                || (GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY) != 0)
                 disabledTabs |= (1uLL << WIDX_TAB_9); // 0x1000
 
             if ((gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER) != 0)
@@ -6070,7 +6070,7 @@ static_assert(std::size(RatingNames) == 6);
 
             auto rideEntry = ride->GetRideEntry();
             const auto& rtd = ride->GetRideTypeDescriptor();
-            return ParkRidePricesUnlocked() || rtd.HasFlag(RIDE_TYPE_FLAG_IS_TOILET)
+            return Park::RidePricesUnlocked() || rtd.HasFlag(RIDE_TYPE_FLAG_IS_TOILET)
                 || (rideEntry != nullptr && rideEntry->shop_item[0] != ShopItem::None);
         }
 
@@ -6245,7 +6245,7 @@ static_assert(std::size(RatingNames) == 6);
 
             // If ride prices are locked, do not allow setting the price, unless we're dealing with a shop or toilet.
             const auto& rtd = ride->GetRideTypeDescriptor();
-            if (!ParkRidePricesUnlocked() && rideEntry->shop_item[0] == ShopItem::None
+            if (!Park::RidePricesUnlocked() && rideEntry->shop_item[0] == ShopItem::None
                 && !rtd.HasFlag(RIDE_TYPE_FLAG_IS_TOILET))
             {
                 disabled_widgets |= (1uLL << WIDX_PRIMARY_PRICE);

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1575,7 +1575,7 @@ static Widget _rideConstructionWidgets[] = {
                 DrawTextBasic(dpi, screenCoords, STR_BUILD_THIS, {}, { TextAlignment::CENTRE });
 
             screenCoords.y += 11;
-            if (_currentTrackPrice != kMoney64Undefined && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+            if (_currentTrackPrice != kMoney64Undefined && !(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
                 ft.Add<money64>(_currentTrackPrice);

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -301,7 +301,7 @@ static Widget _rideListWidgets[] = {
                 int32_t selectedIndex = -1;
                 for (int32_t type = INFORMATION_TYPE_STATUS; type <= lastType; type++)
                 {
-                    if ((GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+                    if ((GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
                     {
                         if (ride_info_type_money_mapping[type])
                         {

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -803,7 +803,7 @@ static Widget WindowSceneryBaseWidgets[] = {
             }
 
             auto [name, price] = GetNameAndPrice(selectedSceneryEntry);
-            if (price != kMoney64Undefined && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+            if (price != kMoney64Undefined && !(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
                 ft.Add<money64>(price);

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -931,7 +931,7 @@ static Widget _staffOptionsWidgets[] = {
 
             auto screenCoords = windowPos + ScreenCoordsXY{ widgets[WIDX_RESIZE].left + 4, widgets[WIDX_RESIZE].top + 4 };
 
-            if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+            if (!(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
                 ft.Add<money64>(GetStaffWage(staff->AssignedStaffType));

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -290,7 +290,7 @@ static Widget _staffListWidgets[] = {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
 
-            if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+            if (!(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
                 ft.Add<money64>(GetStaffWage(GetSelectedStaffType()));

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -35,6 +35,7 @@
 #include <openrct2/sprites.h>
 #include <openrct2/windows/TileInspectorGlobals.h>
 #include <openrct2/world/Banner.h>
+#include <openrct2/world/Entrance.h>
 #include <openrct2/world/Footpath.h>
 #include <openrct2/world/Park.h>
 #include <openrct2/world/Scenery.h>

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -3036,7 +3036,7 @@ static Widget _topToolbarWidgets[] = {
                 widgets[WIDX_PAUSE].type = WindowWidgetType::Empty;
             }
 
-            if ((GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY) || !gConfigInterface.ToolbarShowFinances)
+            if ((GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY) || !gConfigInterface.ToolbarShowFinances)
                 widgets[WIDX_FINANCES].type = WindowWidgetType::Empty;
 
             if (gScreenFlags & SCREEN_FLAGS_EDITOR)

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -306,7 +306,7 @@ static Widget _trackPlaceWidgets[] = {
             }
 
             // Price
-            if (_placementCost != kMoney64Undefined && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+            if (_placementCost != kMoney64Undefined && !(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 ft = Formatter();
                 ft.Add<money64>(_placementCost);

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -156,7 +156,7 @@ static Widget _waterWidgets[] = {
                     dpi, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, ft, { TextAlignment::CENTRE });
             }
 
-            if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+            if (!(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 // Draw raise cost amount
                 screenCoords = { widgets[WIDX_PREVIEW].midX() + windowPos.x, widgets[WIDX_PREVIEW].bottom + windowPos.y + 5 };

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -123,7 +123,6 @@ namespace OpenRCT2
 
         // Game states
         std::unique_ptr<TitleScreen> _titleScreen;
-        std::unique_ptr<GameState> _gameState;
 
         DrawingEngine _drawingEngineType = DrawingEngine::Software;
         std::unique_ptr<IDrawingEngine> _drawingEngine;
@@ -220,11 +219,6 @@ namespace OpenRCT2
             return _scriptEngine;
         }
 #endif
-
-        GameState* GetGameState() override
-        {
-            return _gameState.get();
-        }
 
         std::shared_ptr<IPlatformEnvironment> GetPlatformEnvironment() override
         {
@@ -477,14 +471,13 @@ namespace OpenRCT2
             InputResetPlaceObjModifier();
             ViewportInitAll();
 
-            _gameState = std::make_unique<GameState>();
-            _gameState->InitAll(DEFAULT_MAP_SIZE);
+            gameStateInitAll(GetGameState(), DEFAULT_MAP_SIZE);
 
 #ifdef ENABLE_SCRIPTING
             _scriptEngine.Initialise();
 #endif
 
-            _titleScreen = std::make_unique<TitleScreen>(*_gameState);
+            _titleScreen = std::make_unique<TitleScreen>();
             _uiContext->Initialise();
 
             return true;
@@ -1199,7 +1192,7 @@ namespace OpenRCT2
             }
             else
             {
-                _gameState->Tick();
+                gameStateTick();
             }
 
 #ifdef __ENABLE_DISCORD__

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -81,7 +81,6 @@ class NetworkBase;
 namespace OpenRCT2
 {
     class AssetPackManager;
-    class GameState;
 
     struct IPlatformEnvironment;
     struct IReplayManager;
@@ -125,7 +124,6 @@ namespace OpenRCT2
 
         [[nodiscard]] virtual std::shared_ptr<Audio::IAudioContext> GetAudioContext() abstract;
         [[nodiscard]] virtual std::shared_ptr<Ui::IUiContext> GetUiContext() abstract;
-        virtual GameState* GetGameState() abstract;
         [[nodiscard]] virtual std::shared_ptr<IPlatformEnvironment> GetPlatformEnvironment() abstract;
         virtual Localisation::LocalisationService& GetLocalisationService() abstract;
         virtual IObjectManager& GetObjectManager() abstract;

--- a/src/openrct2/Date.cpp
+++ b/src/openrct2/Date.cpp
@@ -31,12 +31,6 @@ static const int16_t days_in_month[MONTH_COUNT] = {
 
 RealWorldTime gRealTimeOfDay;
 
-Date::Date(uint32_t monthsElapsed, uint16_t monthTicks)
-    : _monthTicks(monthTicks)
-    , _monthsElapsed(monthsElapsed)
-{
-}
-
 Date Date::FromYMD(int32_t year, int32_t month, int32_t day)
 {
     year = std::clamp(year, 0, kMaxYear - 1);
@@ -44,83 +38,69 @@ Date Date::FromYMD(int32_t year, int32_t month, int32_t day)
     auto daysInMonth = days_in_month[month];
     day = std::clamp(day, 0, daysInMonth - 1);
 
-    int32_t monthsElapsed = (year * MONTH_COUNT) + month;
+    uint32_t paramMonthsElapsed = (year * MONTH_COUNT) + month;
     // Day
-    int32_t monthTicks = 0;
+    uint16_t paramMonthTicks = 0;
     if (day != 0)
     {
-        monthTicks = ((day << 16) / daysInMonth) + kMonthTicksIncrement;
+        paramMonthTicks = ((day << 16) / daysInMonth) + kMonthTicksIncrement;
     }
 
-    return Date(monthsElapsed, monthTicks);
-}
-
-void Date::Update()
-{
-    int32_t monthTicks = _monthTicks + kMonthTicksIncrement;
-    if (monthTicks > kMaskMonthTicks)
-    {
-        _monthTicks = 0;
-        _monthsElapsed++;
-    }
-    else
-    {
-        _monthTicks = static_cast<uint16_t>(monthTicks);
-    }
+    return Date{ paramMonthsElapsed, paramMonthTicks };
 }
 
 uint16_t Date::GetMonthTicks() const
 {
-    return _monthTicks;
+    return monthTicks;
 }
 
 uint32_t Date::GetMonthsElapsed() const
 {
-    return _monthsElapsed;
+    return monthsElapsed;
 }
 
 int32_t Date::GetDay() const
 {
     auto month = GetMonth();
     auto daysInMonth = GetDaysInMonth(month);
-    return ((_monthTicks * daysInMonth) >> 16) & 0xFF;
+    return ((monthTicks * daysInMonth) >> 16) & 0xFF;
 }
 
 int32_t Date::GetMonth() const
 {
-    return _monthsElapsed % MONTH_COUNT;
+    return monthsElapsed % MONTH_COUNT;
 }
 
 int32_t Date::GetYear() const
 {
-    return _monthsElapsed / MONTH_COUNT;
+    return monthsElapsed / MONTH_COUNT;
 }
 
 bool Date::IsDayStart() const
 {
-    if (_monthTicks < 4)
+    if (monthTicks < 4)
     {
         return false;
     }
-    int32_t prevMonthTick = _monthTicks - 4;
+    int32_t prevMonthTick = monthTicks - 4;
     int32_t currentMonth = GetMonth();
     int32_t currentDaysInMonth = GetDaysInMonth(currentMonth);
-    return ((currentDaysInMonth * _monthTicks) >> 16 != (currentDaysInMonth * prevMonthTick) >> 16);
+    return ((currentDaysInMonth * monthTicks) >> 16 != (currentDaysInMonth * prevMonthTick) >> 16);
 }
 
 bool Date::IsWeekStart() const
 {
-    return (_monthTicks & kMaskWeekTicks) == 0;
+    return (monthTicks & kMaskWeekTicks) == 0;
 }
 
 bool Date::IsFortnightStart() const
 {
-    return (_monthTicks & kMaskFortnightTicks) == 0;
+    return (monthTicks & kMaskFortnightTicks) == 0;
 }
 
 bool Date::IsMonthStart() const
 {
-    return (_monthTicks == 0);
+    return (monthTicks == 0);
 }
 
 int32_t Date::GetDaysInMonth(int32_t month)
@@ -128,6 +108,20 @@ int32_t Date::GetDaysInMonth(int32_t month)
     Guard::ArgumentInRange(month, 0, MONTH_COUNT - 1);
 
     return days_in_month[month];
+}
+
+void OpenRCT2::DateUpdate(GameState_t& gameState)
+{
+    int32_t monthTicks = gameState.Date.monthTicks + kMonthTicksIncrement;
+    if (monthTicks > kMaskMonthTicks)
+    {
+        gameState.Date.monthTicks = 0;
+        gameState.Date.monthsElapsed++;
+    }
+    else
+    {
+        gameState.Date.monthTicks = static_cast<uint16_t>(monthTicks);
+    }
 }
 
 int32_t DateGetMonth(int32_t months)
@@ -167,6 +161,6 @@ Date& GetDate()
 void ResetDate()
 {
     auto& gameState = GetGameState();
-    gameState.Date = OpenRCT2::Date();
+    gameState.Date = {};
     gCurrentRealTimeTicks = 0;
 }

--- a/src/openrct2/Date.cpp
+++ b/src/openrct2/Date.cpp
@@ -157,5 +157,16 @@ void DateUpdateRealTimeOfDay()
 
 Date& GetDate()
 {
-    return OpenRCT2::GetContext()->GetGameState()->GetDate();
+    return GetGameState().Date;
+}
+
+/**
+ *
+ *  rct2: 0x006C4494
+ */
+void ResetDate()
+{
+    auto& gameState = GetGameState();
+    gameState.Date = OpenRCT2::Date();
+    gCurrentRealTimeTicks = 0;
 }

--- a/src/openrct2/Date.h
+++ b/src/openrct2/Date.h
@@ -38,22 +38,17 @@ enum
 
 namespace OpenRCT2
 {
+    struct GameState_t;
+
     /**
      * Represents the current day, month and year in OpenRCT2.
      */
-    class Date final
+    struct Date final
     {
-    private:
-        uint16_t _monthTicks = 0;
-        uint32_t _monthsElapsed = 0;
-
-    public:
-        Date() = default;
-        Date(uint32_t monthsElapsed, uint16_t monthTicks);
+        uint32_t monthsElapsed = 0;
+        uint16_t monthTicks = 0;
 
         static Date FromYMD(int32_t year, int32_t month = 0, int32_t day = 0);
-
-        void Update();
 
         uint16_t GetMonthTicks() const;
         uint32_t GetMonthsElapsed() const;
@@ -68,6 +63,8 @@ namespace OpenRCT2
 
         static int32_t GetDaysInMonth(int32_t month);
     };
+
+    void DateUpdate(GameState_t& gameState);
 } // namespace OpenRCT2
 
 struct RealWorldDate

--- a/src/openrct2/Date.h
+++ b/src/openrct2/Date.h
@@ -86,6 +86,8 @@ struct RealWorldTime
 };
 
 OpenRCT2::Date& GetDate();
+void ResetDate();
+
 extern RealWorldTime gRealTimeOfDay;
 
 int32_t DateGetMonth(int32_t months);

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -108,7 +108,7 @@ namespace Editor
         gameStateInitAll(gameState, DEFAULT_MAP_SIZE);
         gScreenFlags = SCREEN_FLAGS_SCENARIO_EDITOR;
         gameState.EditorStep = EditorStep::ObjectSelection;
-        gameState.ParkFlags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
+        gameState.Park.Flags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
         gameState.ScenarioCategory = SCENARIO_CATEGORY_OTHER;
         ViewportInitAll();
         WindowBase* mainWindow = OpenEditorWindows();
@@ -324,18 +324,18 @@ namespace Editor
         gameState.GuestChangeModifier = 0;
         if (fromSave)
         {
-            gameState.ParkFlags |= PARK_FLAGS_NO_MONEY;
+            gameState.Park.Flags |= PARK_FLAGS_NO_MONEY;
 
-            if (gameState.ParkEntranceFee == 0)
+            if (gameState.Park.EntranceFee == 0)
             {
-                gameState.ParkFlags |= PARK_FLAGS_PARK_FREE_ENTRY;
+                gameState.Park.Flags |= PARK_FLAGS_PARK_FREE_ENTRY;
             }
             else
             {
-                gameState.ParkFlags &= ~PARK_FLAGS_PARK_FREE_ENTRY;
+                gameState.Park.Flags &= ~PARK_FLAGS_PARK_FREE_ENTRY;
             }
 
-            gameState.ParkFlags &= ~PARK_FLAGS_SPRITES_INITIALISED;
+            gameState.Park.Flags &= ~PARK_FLAGS_SPRITES_INITIALISED;
 
             gameState.GuestInitialCash = std::clamp(gameState.GuestInitialCash, 10.00_GBP, MAX_ENTRANCE_FEE);
 
@@ -500,18 +500,18 @@ namespace Editor
     ResultWithMessage CheckPark()
     {
         auto& gameState = GetGameState();
-        int32_t parkSize = ParkUpdateSize(gameState);
+        int32_t parkSize = Park::UpdateSize(gameState);
         if (parkSize == 0)
         {
             return { false, STR_PARK_MUST_OWN_SOME_LAND };
         }
 
-        if (gameState.ParkEntrances.empty())
+        if (gameState.Park.Entrances.empty())
         {
             return { false, STR_NO_PARK_ENTRANCES };
         }
 
-        for (const auto& parkEntrance : gameState.ParkEntrances)
+        for (const auto& parkEntrance : gameState.Park.Entrances)
         {
             int32_t direction = DirectionReverse(parkEntrance.direction);
 

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -105,7 +105,7 @@ namespace Editor
         auto& gameState = GetGameState();
         Audio::StopAll();
         ObjectListLoad();
-        GetContext()->GetGameState()->InitAll(DEFAULT_MAP_SIZE);
+        gameStateInitAll(gameState, DEFAULT_MAP_SIZE);
         gScreenFlags = SCREEN_FLAGS_SCENARIO_EDITOR;
         gameState.EditorStep = EditorStep::ObjectSelection;
         gameState.ParkFlags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
@@ -167,7 +167,7 @@ namespace Editor
 
         ObjectManagerUnloadAllObjects();
         ObjectListLoad();
-        GetContext()->GetGameState()->InitAll(DEFAULT_MAP_SIZE);
+        gameStateInitAll(GetGameState(), DEFAULT_MAP_SIZE);
         SetAllLandOwned();
         GetGameState().EditorStep = EditorStep::ObjectSelection;
         ViewportInitAll();
@@ -188,7 +188,7 @@ namespace Editor
 
         ObjectManagerUnloadAllObjects();
         ObjectListLoad();
-        GetContext()->GetGameState()->InitAll(DEFAULT_MAP_SIZE);
+        gameStateInitAll(GetGameState(), DEFAULT_MAP_SIZE);
         SetAllLandOwned();
         GetGameState().EditorStep = EditorStep::ObjectSelection;
         ViewportInitAll();

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -499,13 +499,13 @@ namespace Editor
      */
     ResultWithMessage CheckPark()
     {
-        int32_t parkSize = ParkCalculateSize();
+        auto& gameState = GetGameState();
+        int32_t parkSize = ParkUpdateSize(gameState);
         if (parkSize == 0)
         {
             return { false, STR_PARK_MUST_OWN_SOME_LAND };
         }
 
-        const auto& gameState = GetGameState();
         if (gameState.ParkEntrances.empty())
         {
             return { false, STR_NO_PARK_ENTRANCES };

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -62,7 +62,6 @@ namespace OpenRCT2
 
 GameState::GameState()
 {
-    _park = std::make_unique<Park>();
 }
 
 /**
@@ -77,7 +76,7 @@ void GameState::InitAll(const TileCoordsXY& mapSize)
     gameState.CurrentTicks = 0;
 
     MapInit(mapSize);
-    _park->Initialise();
+    gameState.Park.Initialise();
     FinanceInit();
     BannerInit(gameState);
     RideInitAll();
@@ -340,7 +339,7 @@ void GameState::UpdateLogic()
 
     if (!(gScreenFlags & SCREEN_FLAGS_EDITOR))
     {
-        _park->Update(gameState.Date);
+        gameState.Park.Update(gameState.Date);
     }
 
     ResearchUpdate();

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -58,338 +58,332 @@ namespace OpenRCT2
     {
         return _gameState;
     }
-} // namespace OpenRCT2
 
-GameState::GameState()
-{
-}
+    /**
+     * Initialises the map, park etc. basically all S6 data.
+     */
+    void gameStateInitAll(GameState_t& gameState, const TileCoordsXY& mapSize)
+    {
+        PROFILED_FUNCTION();
 
-/**
- * Initialises the map, park etc. basically all S6 data.
- */
-void GameState::InitAll(const TileCoordsXY& mapSize)
-{
-    PROFILED_FUNCTION();
+        gInMapInitCode = true;
+        gameState.CurrentTicks = 0;
 
-    auto& gameState = GetGameState();
-    gInMapInitCode = true;
-    gameState.CurrentTicks = 0;
+        MapInit(mapSize);
+        gameState.Park.Initialise();
+        FinanceInit();
+        BannerInit(gameState);
+        RideInitAll();
+        ResetAllEntities();
+        UpdateConsolidatedPatrolAreas();
+        ResetDate();
+        ClimateReset(ClimateType::CoolAndWet);
+        News::InitQueue();
 
-    MapInit(mapSize);
-    gameState.Park.Initialise();
-    FinanceInit();
-    BannerInit(gameState);
-    RideInitAll();
-    ResetAllEntities();
-    UpdateConsolidatedPatrolAreas();
-    ResetDate();
-    ClimateReset(ClimateType::CoolAndWet);
-    News::InitQueue();
+        gInMapInitCode = false;
 
-    gInMapInitCode = false;
+        GetGameState().NextGuestNumber = 1;
 
-    GetGameState().NextGuestNumber = 1;
+        ContextInit();
+        ScenerySetDefaultPlacementConfiguration();
 
-    ContextInit();
-    ScenerySetDefaultPlacementConfiguration();
+        auto intent = Intent(INTENT_ACTION_CLEAR_TILE_INSPECTOR_CLIPBOARD);
+        ContextBroadcastIntent(&intent);
 
-    auto intent = Intent(INTENT_ACTION_CLEAR_TILE_INSPECTOR_CLIPBOARD);
-    ContextBroadcastIntent(&intent);
+        LoadPalette();
 
-    LoadPalette();
-
-    CheatsReset();
-    ClearRestrictedScenery();
+        CheatsReset();
+        ClearRestrictedScenery();
 
 #ifdef ENABLE_SCRIPTING
-    auto& scriptEngine = GetContext()->GetScriptEngine();
-    scriptEngine.ClearParkStorage();
+        auto& scriptEngine = GetContext()->GetScriptEngine();
+        scriptEngine.ClearParkStorage();
 #endif
 
-    EntityTweener::Get().Reset();
-}
+        EntityTweener::Get().Reset();
+    }
 
-/**
- * Function will be called every kGameUpdateTimeMS.
- * It has its own loop which might run multiple updates per call such as
- * when operating as a client it may run multiple updates to catch up with the server tick,
- * another influence can be the game speed setting.
- */
-void GameState::Tick()
-{
-    PROFILED_FUNCTION();
-
-    // Normal game play will update only once every kGameUpdateTimeMS
-    uint32_t numUpdates = 1;
-
-    // 0x006E3AEC // screen_game_process_mouse_input();
-    ScreenshotCheck();
-    GameHandleKeyboardInput();
-
-    if (GameIsNotPaused() && gPreviewingTitleSequenceInGame)
+    /**
+     * Function will be called every kGameUpdateTimeMS.
+     * It has its own loop which might run multiple updates per call such as
+     * when operating as a client it may run multiple updates to catch up with the server tick,
+     * another influence can be the game speed setting.
+     */
+    void gameStateTick()
     {
-        auto player = GetContext()->GetUiContext()->GetTitleSequencePlayer();
-        if (player != nullptr)
+        PROFILED_FUNCTION();
+
+        // Normal game play will update only once every kGameUpdateTimeMS
+        uint32_t numUpdates = 1;
+
+        // 0x006E3AEC // screen_game_process_mouse_input();
+        ScreenshotCheck();
+        GameHandleKeyboardInput();
+
+        if (GameIsNotPaused() && gPreviewingTitleSequenceInGame)
         {
-            player->Update();
+            auto player = GetContext()->GetUiContext()->GetTitleSequencePlayer();
+            if (player != nullptr)
+            {
+                player->Update();
+            }
         }
-    }
 
-    NetworkUpdate();
+        NetworkUpdate();
 
-    if (NetworkGetMode() == NETWORK_MODE_CLIENT && NetworkGetStatus() == NETWORK_STATUS_CONNECTED
-        && NetworkGetAuthstatus() == NetworkAuth::Ok)
-    {
-        numUpdates = std::clamp<uint32_t>(NetworkGetServerTick() - GetGameState().CurrentTicks, 0, 10);
-    }
-    else
-    {
-        // Determine how many times we need to update the game
-        if (gGameSpeed > 1)
+        if (NetworkGetMode() == NETWORK_MODE_CLIENT && NetworkGetStatus() == NETWORK_STATUS_CONNECTED
+            && NetworkGetAuthstatus() == NetworkAuth::Ok)
         {
-            // Update more often if game speed is above normal.
-            numUpdates = 1 << (gGameSpeed - 1);
-        }
-    }
-
-    bool isPaused = GameIsPaused();
-    if (NetworkGetMode() == NETWORK_MODE_SERVER && gConfigNetwork.PauseServerIfNoClients)
-    {
-        // If we are headless we always have 1 player (host), pause if no one else is around.
-        if (gOpenRCT2Headless && NetworkGetNumPlayers() == 1)
-        {
-            isPaused |= true;
-        }
-    }
-
-    bool didRunSingleFrame = false;
-    if (isPaused)
-    {
-        if (gDoSingleUpdate && NetworkGetMode() == NETWORK_MODE_NONE)
-        {
-            didRunSingleFrame = true;
-            PauseToggle();
-            numUpdates = 1;
+            numUpdates = std::clamp<uint32_t>(NetworkGetServerTick() - GetGameState().CurrentTicks, 0, 10);
         }
         else
         {
-            // NOTE: Here are a few special cases that would be normally handled in UpdateLogic.
-            // If the game is paused it will not call UpdateLogic at all.
-            numUpdates = 0;
-
-            if (NetworkGetMode() == NETWORK_MODE_SERVER)
+            // Determine how many times we need to update the game
+            if (gGameSpeed > 1)
             {
-                // Make sure the client always knows about what tick the host is on.
-                NetworkSendTick();
+                // Update more often if game speed is above normal.
+                numUpdates = 1 << (gGameSpeed - 1);
             }
-
-            // Keep updating the money effect even when paused.
-            UpdateMoneyEffect();
-
-            // Update the animation list. Note this does not
-            // increment the map animation.
-            MapAnimationInvalidateAll();
-
-            // Post-tick network update
-            NetworkProcessPending();
-
-            // Post-tick game actions.
-            GameActions::ProcessQueue();
         }
-    }
 
-    // Update the game one or more times
-    for (uint32_t i = 0; i < numUpdates; i++)
-    {
-        UpdateLogic();
-        if (gGameSpeed == 1)
+        bool isPaused = GameIsPaused();
+        if (NetworkGetMode() == NETWORK_MODE_SERVER && gConfigNetwork.PauseServerIfNoClients)
         {
-            if (InputGetState() == InputState::Reset || InputGetState() == InputState::Normal)
+            // If we are headless we always have 1 player (host), pause if no one else is around.
+            if (gOpenRCT2Headless && NetworkGetNumPlayers() == 1)
             {
-                if (InputTestFlag(INPUT_FLAG_VIEWPORT_SCROLLING))
-                {
-                    InputSetFlag(INPUT_FLAG_VIEWPORT_SCROLLING, false);
-                    break;
-                }
+                isPaused |= true;
+            }
+        }
+
+        bool didRunSingleFrame = false;
+        if (isPaused)
+        {
+            if (gDoSingleUpdate && NetworkGetMode() == NETWORK_MODE_NONE)
+            {
+                didRunSingleFrame = true;
+                PauseToggle();
+                numUpdates = 1;
             }
             else
             {
-                break;
+                // NOTE: Here are a few special cases that would be normally handled in UpdateLogic.
+                // If the game is paused it will not call UpdateLogic at all.
+                numUpdates = 0;
+
+                if (NetworkGetMode() == NETWORK_MODE_SERVER)
+                {
+                    // Make sure the client always knows about what tick the host is on.
+                    NetworkSendTick();
+                }
+
+                // Keep updating the money effect even when paused.
+                UpdateMoneyEffect();
+
+                // Update the animation list. Note this does not
+                // increment the map animation.
+                MapAnimationInvalidateAll();
+
+                // Post-tick network update
+                NetworkProcessPending();
+
+                // Post-tick game actions.
+                GameActions::ProcessQueue();
             }
         }
-        // Don't call UpdateLogic again if the game was just paused.
-        isPaused |= GameIsPaused();
-        if (isPaused)
-            break;
-    }
 
-    NetworkFlush();
-
-    if (!gOpenRCT2Headless)
-    {
-        InputSetFlag(INPUT_FLAG_VIEWPORT_SCROLLING, false);
-
-        // the flickering frequency is reduced by 4, compared to the original
-        // it was done due to inability to reproduce original frequency
-        // and decision that the original one looks too fast
-        if (gCurrentRealTimeTicks % 4 == 0)
-            gWindowMapFlashingFlags ^= MapFlashingFlags::SwitchColour;
-
-        // Handle guest map flashing
-        gWindowMapFlashingFlags &= ~MapFlashingFlags::FlashGuests;
-        if (gWindowMapFlashingFlags & MapFlashingFlags::GuestListOpen)
-            gWindowMapFlashingFlags |= MapFlashingFlags::FlashGuests;
-        gWindowMapFlashingFlags &= ~MapFlashingFlags::GuestListOpen;
-
-        // Handle staff map flashing
-        gWindowMapFlashingFlags &= ~MapFlashingFlags::FlashStaff;
-        if (gWindowMapFlashingFlags & MapFlashingFlags::StaffListOpen)
-            gWindowMapFlashingFlags |= MapFlashingFlags::FlashStaff;
-        gWindowMapFlashingFlags &= ~MapFlashingFlags::StaffListOpen;
-
-        ContextUpdateMapTooltip();
-    }
-
-    // Always perform autosave check, even when paused
-    if (!(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) && !(gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER)
-        && !(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER))
-    {
-        ScenarioAutosaveCheck();
-    }
-
-    WindowDispatchUpdateAll();
-
-    if (didRunSingleFrame && GameIsNotPaused() && !(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO))
-    {
-        PauseToggle();
-    }
-
-    gDoSingleUpdate = false;
-}
-
-void GameState::UpdateLogic()
-{
-    PROFILED_FUNCTION();
-
-    gInUpdateCode = true;
-
-    gScreenAge++;
-    if (gScreenAge == 0)
-        gScreenAge--;
-
-    GetContext()->GetReplayManager()->Update();
-
-    NetworkUpdate();
-
-    if (NetworkGetMode() == NETWORK_MODE_SERVER)
-    {
-        if (NetworkGamestateSnapshotsEnabled())
+        // Update the game one or more times
+        for (uint32_t i = 0; i < numUpdates; i++)
         {
-            CreateStateSnapshot();
-        }
-
-        // Send current tick out.
-        NetworkSendTick();
-    }
-    else if (NetworkGetMode() == NETWORK_MODE_CLIENT)
-    {
-        // Don't run past the server, this condition can happen during map changes.
-        if (NetworkGetServerTick() == GetGameState().CurrentTicks)
-        {
-            gInUpdateCode = false;
-            return;
-        }
-
-        // Check desync.
-        bool desynced = NetworkCheckDesynchronisation();
-        if (desynced)
-        {
-            // If desync debugging is enabled and we are still connected request the specific game state from server.
-            if (NetworkGamestateSnapshotsEnabled() && NetworkGetStatus() == NETWORK_STATUS_CONNECTED)
+            gameStateUpdateLogic();
+            if (gGameSpeed == 1)
             {
-                // Create snapshot from this tick so we can compare it later
-                // as we won't pause the game on this event.
-                CreateStateSnapshot();
+                if (InputGetState() == InputState::Reset || InputGetState() == InputState::Normal)
+                {
+                    if (InputTestFlag(INPUT_FLAG_VIEWPORT_SCROLLING))
+                    {
+                        InputSetFlag(INPUT_FLAG_VIEWPORT_SCROLLING, false);
+                        break;
+                    }
+                }
+                else
+                {
+                    break;
+                }
+            }
+            // Don't call UpdateLogic again if the game was just paused.
+            isPaused |= GameIsPaused();
+            if (isPaused)
+                break;
+        }
 
-                NetworkRequestGamestateSnapshot();
+        NetworkFlush();
+
+        if (!gOpenRCT2Headless)
+        {
+            InputSetFlag(INPUT_FLAG_VIEWPORT_SCROLLING, false);
+
+            // the flickering frequency is reduced by 4, compared to the original
+            // it was done due to inability to reproduce original frequency
+            // and decision that the original one looks too fast
+            if (gCurrentRealTimeTicks % 4 == 0)
+                gWindowMapFlashingFlags ^= MapFlashingFlags::SwitchColour;
+
+            // Handle guest map flashing
+            gWindowMapFlashingFlags &= ~MapFlashingFlags::FlashGuests;
+            if (gWindowMapFlashingFlags & MapFlashingFlags::GuestListOpen)
+                gWindowMapFlashingFlags |= MapFlashingFlags::FlashGuests;
+            gWindowMapFlashingFlags &= ~MapFlashingFlags::GuestListOpen;
+
+            // Handle staff map flashing
+            gWindowMapFlashingFlags &= ~MapFlashingFlags::FlashStaff;
+            if (gWindowMapFlashingFlags & MapFlashingFlags::StaffListOpen)
+                gWindowMapFlashingFlags |= MapFlashingFlags::FlashStaff;
+            gWindowMapFlashingFlags &= ~MapFlashingFlags::StaffListOpen;
+
+            ContextUpdateMapTooltip();
+        }
+
+        // Always perform autosave check, even when paused
+        if (!(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) && !(gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER)
+            && !(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER))
+        {
+            ScenarioAutosaveCheck();
+        }
+
+        WindowDispatchUpdateAll();
+
+        if (didRunSingleFrame && GameIsNotPaused() && !(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO))
+        {
+            PauseToggle();
+        }
+
+        gDoSingleUpdate = false;
+    }
+
+    static void gameStateCreateStateSnapshot()
+    {
+        PROFILED_FUNCTION();
+
+        IGameStateSnapshots* snapshots = GetContext()->GetGameStateSnapshots();
+
+        auto& snapshot = snapshots->CreateSnapshot();
+        snapshots->Capture(snapshot);
+        snapshots->LinkSnapshot(snapshot, GetGameState().CurrentTicks, ScenarioRandState().s0);
+    }
+
+    void gameStateUpdateLogic()
+    {
+        PROFILED_FUNCTION();
+
+        gInUpdateCode = true;
+
+        gScreenAge++;
+        if (gScreenAge == 0)
+            gScreenAge--;
+
+        GetContext()->GetReplayManager()->Update();
+
+        NetworkUpdate();
+
+        if (NetworkGetMode() == NETWORK_MODE_SERVER)
+        {
+            if (NetworkGamestateSnapshotsEnabled())
+            {
+                gameStateCreateStateSnapshot();
+            }
+
+            // Send current tick out.
+            NetworkSendTick();
+        }
+        else if (NetworkGetMode() == NETWORK_MODE_CLIENT)
+        {
+            // Don't run past the server, this condition can happen during map changes.
+            if (NetworkGetServerTick() == GetGameState().CurrentTicks)
+            {
+                gInUpdateCode = false;
+                return;
+            }
+
+            // Check desync.
+            bool desynced = NetworkCheckDesynchronisation();
+            if (desynced)
+            {
+                // If desync debugging is enabled and we are still connected request the specific game state from server.
+                if (NetworkGamestateSnapshotsEnabled() && NetworkGetStatus() == NETWORK_STATUS_CONNECTED)
+                {
+                    // Create snapshot from this tick so we can compare it later
+                    // as we won't pause the game on this event.
+                    gameStateCreateStateSnapshot();
+
+                    NetworkRequestGamestateSnapshot();
+                }
             }
         }
-    }
 
-    auto& gameState = GetGameState();
+        auto& gameState = GetGameState();
 #ifdef ENABLE_SCRIPTING
-    // Stash the current day number before updating the date so that we
-    // know if the day number changes on this tick.
-    auto day = gameState.Date.GetDay();
+        // Stash the current day number before updating the date so that we
+        // know if the day number changes on this tick.
+        auto day = gameState.Date.GetDay();
 #endif
 
-    gameState.Date.Update();
+        gameState.Date.Update();
 
-    ScenarioUpdate(gameState);
-    ClimateUpdate();
-    MapUpdateTiles();
-    // Temporarily remove provisional paths to prevent peep from interacting with them
-    MapRemoveProvisionalElements();
-    MapUpdatePathWideFlags();
-    PeepUpdateAll();
-    MapRestoreProvisionalElements();
-    VehicleUpdateAll();
-    UpdateAllMiscEntities();
-    Ride::UpdateAll();
+        ScenarioUpdate(gameState);
+        ClimateUpdate();
+        MapUpdateTiles();
+        // Temporarily remove provisional paths to prevent peep from interacting with them
+        MapRemoveProvisionalElements();
+        MapUpdatePathWideFlags();
+        PeepUpdateAll();
+        MapRestoreProvisionalElements();
+        VehicleUpdateAll();
+        UpdateAllMiscEntities();
+        Ride::UpdateAll();
 
-    if (!(gScreenFlags & SCREEN_FLAGS_EDITOR))
-    {
-        gameState.Park.Update(gameState.Date);
-    }
+        if (!(gScreenFlags & SCREEN_FLAGS_EDITOR))
+        {
+            gameState.Park.Update(gameState.Date);
+        }
 
-    ResearchUpdate();
-    RideRatingsUpdateAll();
-    RideMeasurementsUpdate();
-    News::UpdateCurrentItem();
+        ResearchUpdate();
+        RideRatingsUpdateAll();
+        RideMeasurementsUpdate();
+        News::UpdateCurrentItem();
 
-    MapAnimationInvalidateAll();
-    VehicleSoundsUpdate();
-    PeepUpdateCrowdNoise();
-    ClimateUpdateSound();
-    EditorOpenWindowsForCurrentStep();
+        MapAnimationInvalidateAll();
+        VehicleSoundsUpdate();
+        PeepUpdateCrowdNoise();
+        ClimateUpdateSound();
+        EditorOpenWindowsForCurrentStep();
 
-    // Update windows
-    // WindowDispatchUpdateAll();
+        // Update windows
+        // WindowDispatchUpdateAll();
 
-    // Start autosave timer after update
+        // Start autosave timer after update
     if (gLastAutoSaveUpdate == kAutosavePause)
-    {
-        gLastAutoSaveUpdate = Platform::GetTicks();
-    }
+        {
+            gLastAutoSaveUpdate = Platform::GetTicks();
+        }
 
-    GameActions::ProcessQueue();
+        GameActions::ProcessQueue();
 
-    NetworkProcessPending();
-    NetworkFlush();
+        NetworkProcessPending();
+        NetworkFlush();
 
-    gameState.CurrentTicks++;
+        gameState.CurrentTicks++;
 
 #ifdef ENABLE_SCRIPTING
-    auto& hookEngine = GetContext()->GetScriptEngine().GetHookEngine();
-    hookEngine.Call(HOOK_TYPE::INTERVAL_TICK, true);
+        auto& hookEngine = GetContext()->GetScriptEngine().GetHookEngine();
+        hookEngine.Call(HOOK_TYPE::INTERVAL_TICK, true);
 
-    if (day != gameState.Date.GetDay())
-    {
-        hookEngine.Call(HOOK_TYPE::INTERVAL_DAY, true);
-    }
+        if (day != gameState.Date.GetDay())
+        {
+            hookEngine.Call(HOOK_TYPE::INTERVAL_DAY, true);
+        }
 #endif
 
-    gInUpdateCode = false;
-}
-
-void GameState::CreateStateSnapshot()
-{
-    PROFILED_FUNCTION();
-
-    IGameStateSnapshots* snapshots = GetContext()->GetGameStateSnapshots();
-
-    auto& snapshot = snapshots->CreateSnapshot();
-    snapshots->Capture(snapshot);
-    snapshots->LinkSnapshot(snapshot, GetGameState().CurrentTicks, ScenarioRandState().s0);
-}
-
+        gInUpdateCode = false;
+    }
+} // namespace OpenRCT2

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -70,7 +70,7 @@ namespace OpenRCT2
         gameState.CurrentTicks = 0;
 
         MapInit(mapSize);
-        gameState.Park.Initialise();
+        ParkInitialise(gameState);
         FinanceInit();
         BannerInit(gameState);
         RideInitAll();
@@ -344,7 +344,7 @@ namespace OpenRCT2
 
         if (!(gScreenFlags & SCREEN_FLAGS_EDITOR))
         {
-            gameState.Park.Update(gameState.Date);
+            ParkUpdate(gameState, gameState.Date);
         }
 
         ResearchUpdate();

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -328,7 +328,7 @@ namespace OpenRCT2
         auto day = gameState.Date.GetDay();
 #endif
 
-        gameState.Date.Update();
+        DateUpdate(gameState);
 
         ScenarioUpdate(gameState);
         ClimateUpdate();

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -362,7 +362,7 @@ namespace OpenRCT2
         // WindowDispatchUpdateAll();
 
         // Start autosave timer after update
-    if (gLastAutoSaveUpdate == kAutosavePause)
+        if (gLastAutoSaveUpdate == kAutosavePause)
         {
             gLastAutoSaveUpdate = Platform::GetTicks();
         }

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -70,7 +70,7 @@ namespace OpenRCT2
         gameState.CurrentTicks = 0;
 
         MapInit(mapSize);
-        ParkInitialise(gameState);
+        Park::Initialise(gameState);
         FinanceInit();
         BannerInit(gameState);
         RideInitAll();
@@ -344,7 +344,7 @@ namespace OpenRCT2
 
         if (!(gScreenFlags & SCREEN_FLAGS_EDITOR))
         {
-            ParkUpdate(gameState, gameState.Date);
+            Park::Update(gameState, gameState.Date);
         }
 
         ResearchUpdate();

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -317,15 +317,15 @@ void GameState::UpdateLogic()
         }
     }
 
+    auto& gameState = GetGameState();
 #ifdef ENABLE_SCRIPTING
     // Stash the current day number before updating the date so that we
     // know if the day number changes on this tick.
-    auto day = _date.GetDay();
+    auto day = gameState.Date.GetDay();
 #endif
 
-    _date.Update();
+    gameState.Date.Update();
 
-    auto& gameState = GetGameState();
     ScenarioUpdate(gameState);
     ClimateUpdate();
     MapUpdateTiles();
@@ -340,7 +340,7 @@ void GameState::UpdateLogic()
 
     if (!(gScreenFlags & SCREEN_FLAGS_EDITOR))
     {
-        _park->Update(_date);
+        _park->Update(gameState.Date);
     }
 
     ResearchUpdate();
@@ -374,7 +374,7 @@ void GameState::UpdateLogic()
     auto& hookEngine = GetContext()->GetScriptEngine().GetHookEngine();
     hookEngine.Call(HOOK_TYPE::INTERVAL_TICK, true);
 
-    if (day != _date.GetDay())
+    if (day != gameState.Date.GetDay())
     {
         hookEngine.Call(HOOK_TYPE::INTERVAL_DAY, true);
     }
@@ -394,17 +394,3 @@ void GameState::CreateStateSnapshot()
     snapshots->LinkSnapshot(snapshot, GetGameState().CurrentTicks, ScenarioRandState().s0);
 }
 
-void GameState::SetDate(Date newDate)
-{
-    _date = newDate;
-}
-
-/**
- *
- *  rct2: 0x006C4494
- */
-void GameState::ResetDate()
-{
-    _date = OpenRCT2::Date();
-    gCurrentRealTimeTicks = 0;
-}

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -34,11 +34,12 @@
 
 namespace OpenRCT2
 {
-    class Park;
+    struct Park;
 
     struct GameState_t
     {
         ::OpenRCT2::Park Park{};
+        std::string PluginStorage;
         uint32_t CurrentTicks{};
         ::OpenRCT2::Date Date;
         uint64_t ParkFlags;

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -38,6 +38,7 @@ namespace OpenRCT2
 
     struct GameState_t
     {
+        ::OpenRCT2::Park Park{};
         uint32_t CurrentTicks{};
         ::OpenRCT2::Date Date;
         uint64_t ParkFlags;
@@ -162,17 +163,9 @@ namespace OpenRCT2
      */
     class GameState final
     {
-    private:
-        std::unique_ptr<Park> _park;
-
     public:
         GameState();
         GameState(const GameState&) = delete;
-
-        Park& GetPark()
-        {
-            return *_park;
-        }
 
         void InitAll(const TileCoordsXY& mapSize);
         void Tick();

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -39,6 +39,7 @@ namespace OpenRCT2
     struct GameState_t
     {
         uint32_t CurrentTicks{};
+        ::OpenRCT2::Date Date;
         uint64_t ParkFlags;
         uint16_t ParkRating;
         money64 ParkEntranceFee;
@@ -163,16 +164,11 @@ namespace OpenRCT2
     {
     private:
         std::unique_ptr<Park> _park;
-        Date _date;
 
     public:
         GameState();
         GameState(const GameState&) = delete;
 
-        Date& GetDate()
-        {
-            return _date;
-        }
         Park& GetPark()
         {
             return *_park;
@@ -181,8 +177,6 @@ namespace OpenRCT2
         void InitAll(const TileCoordsXY& mapSize);
         void Tick();
         void UpdateLogic();
-        void SetDate(Date newDate);
-        void ResetDate();
 
     private:
         void CreateStateSnapshot();

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -158,20 +158,8 @@ namespace OpenRCT2
 
     GameState_t& GetGameState();
 
-    /**
-     * Class to update the state of the map and park.
-     */
-    class GameState final
-    {
-    public:
-        GameState();
-        GameState(const GameState&) = delete;
+    void gameStateInitAll(GameState_t& gameState, const TileCoordsXY& mapSize);
+    void gameStateTick();
+    void gameStateUpdateLogic();
 
-        void InitAll(const TileCoordsXY& mapSize);
-        void Tick();
-        void UpdateLogic();
-
-    private:
-        void CreateStateSnapshot();
-    };
 } // namespace OpenRCT2

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -34,29 +34,18 @@
 
 namespace OpenRCT2
 {
-    struct Park;
-
     struct GameState_t
     {
-        ::OpenRCT2::Park Park{};
+        ::OpenRCT2::Park::ParkData Park{};
         std::string PluginStorage;
         uint32_t CurrentTicks{};
         ::OpenRCT2::Date Date;
-        uint64_t ParkFlags;
-        uint16_t ParkRating;
-        money64 ParkEntranceFee;
-        std::vector<CoordsXYZD> ParkEntrances;
-        uint32_t ParkSize;
-        int16_t ParkRatingCasualtyPenalty;
-        money64 ParkValue;
-        money64 ParkValueHistory[FINANCE_GRAPH_SIZE];
         money64 CompanyValue;
         // The total profit for the entire scenario that precedes the current financial table.
         money64 HistoricalProfit;
         money64 ConstructionRightsPrice;
         money64 CurrentExpenditure;
         money64 CurrentProfit;
-        uint8_t ParkRatingHistory[kParkRatingHistorySize];
         uint32_t GuestsInParkHistory[32];
         ClimateType Climate;
         ClimateState ClimateCurrent;

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -228,7 +228,7 @@ GameActions::Result CheatSetAction::Execute() const
             gameState.ScenarioObjective.Type = OBJECTIVE_HAVE_FUN;
             break;
         case CheatType::SetForcedParkRating:
-            ParkSetForcedRating(_param1);
+            Park::SetForcedRating(_param1);
             break;
         case CheatType::AllowArbitraryRideTypeChanges:
             GetGameState().Cheats.AllowArbitraryRideTypeChanges = _param1 != 0;
@@ -562,11 +562,11 @@ void CheatSetAction::SetScenarioNoMoney(bool enabled) const
     auto& gameState = GetGameState();
     if (enabled)
     {
-        gameState.ParkFlags |= PARK_FLAGS_NO_MONEY;
+        gameState.Park.Flags |= PARK_FLAGS_NO_MONEY;
     }
     else
     {
-        gameState.ParkFlags &= ~PARK_FLAGS_NO_MONEY;
+        gameState.Park.Flags &= ~PARK_FLAGS_NO_MONEY;
     }
 
     // Invalidate all windows that have anything to do with finance
@@ -609,7 +609,7 @@ void CheatSetAction::GenerateGuests(int32_t count) const
 {
     for (int32_t i = 0; i < count; i++)
     {
-        GenerateGuest();
+        Park::GenerateGuest();
     }
     WindowInvalidateByClass(WindowClass::BottomToolbar);
 }
@@ -766,7 +766,7 @@ void CheatSetAction::OwnAllLand() const
             if (destOwnership != OWNERSHIP_UNOWNED)
             {
                 surfaceElement->SetOwnership(destOwnership);
-                ParkUpdateFencesAroundTile(coords);
+                Park::UpdateFencesAroundTile(coords);
                 MapInvalidateTile({ coords, baseZ, baseZ + 16 });
             }
         }
@@ -779,7 +779,7 @@ void CheatSetAction::OwnAllLand() const
         if (surfaceElement != nullptr)
         {
             surfaceElement->SetOwnership(OWNERSHIP_UNOWNED);
-            ParkUpdateFencesAroundTile(spawn);
+            Park::UpdateFencesAroundTile(spawn);
             uint16_t baseZ = surfaceElement->GetBaseZ();
             MapInvalidateTile({ spawn, baseZ, baseZ + 16 });
         }

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -222,7 +222,7 @@ GameActions::Result CheatSetAction::Execute() const
             GetGameState().Cheats.NeverendingMarketing = _param1 != 0;
             break;
         case CheatType::OpenClosePark:
-            ParkSetOpen(!ParkIsOpen());
+            ParkSetOpen(!GetGameState().Park.IsOpen());
             break;
         case CheatType::HaveFun:
             gameState.ScenarioObjective.Type = OBJECTIVE_HAVE_FUN;
@@ -607,10 +607,9 @@ void CheatSetAction::ClearLoan() const
 
 void CheatSetAction::GenerateGuests(int32_t count) const
 {
-    auto& park = OpenRCT2::GetGameState().Park;
     for (int32_t i = 0; i < count; i++)
     {
-        park.GenerateGuest();
+        GenerateGuest();
     }
     WindowInvalidateByClass(WindowClass::BottomToolbar);
 }

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -607,7 +607,7 @@ void CheatSetAction::ClearLoan() const
 
 void CheatSetAction::GenerateGuests(int32_t count) const
 {
-    auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+    auto& park = OpenRCT2::GetGameState().Park;
     for (int32_t i = 0; i < count; i++)
     {
         park.GenerateGuest();

--- a/src/openrct2/actions/LandBuyRightsAction.cpp
+++ b/src/openrct2/actions/LandBuyRightsAction.cpp
@@ -143,7 +143,7 @@ GameActions::Result LandBuyRightsAction::MapBuyLandRightsForTile(const CoordsXY&
             if (isExecuting)
             {
                 surfaceElement->SetOwnership(OWNERSHIP_OWNED);
-                ParkUpdateFencesAroundTile(loc);
+                Park::UpdateFencesAroundTile(loc);
             }
             res.Cost = GetGameState().LandPrice;
             return res;

--- a/src/openrct2/actions/LandSetHeightAction.cpp
+++ b/src/openrct2/actions/LandSetHeightAction.cpp
@@ -56,7 +56,7 @@ void LandSetHeightAction::Serialise(DataSerialiser& stream)
 GameActions::Result LandSetHeightAction::Query() const
 {
     auto& gameState = GetGameState();
-    if (gameState.ParkFlags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES)
+    if (gameState.Park.Flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES)
     {
         return GameActions::Result(GameActions::Status::Disallowed, STR_FORBIDDEN_BY_THE_LOCAL_AUTHORITY, STR_NONE);
     }
@@ -78,7 +78,7 @@ GameActions::Result LandSetHeightAction::Query() const
     money64 sceneryRemovalCost = 0;
     if (!GetGameState().Cheats.DisableClearanceChecks)
     {
-        if (gameState.ParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL)
+        if (gameState.Park.Flags & PARK_FLAGS_FORBID_TREE_REMOVAL)
         {
             // Check for obstructing large trees
             TileElement* tileElement = CheckTreeObstructions();

--- a/src/openrct2/actions/LandSetRightsAction.cpp
+++ b/src/openrct2/actions/LandSetRightsAction.cpp
@@ -129,7 +129,7 @@ GameActions::Result LandSetRightsAction::MapBuyLandRightsForTile(const CoordsXY&
             {
                 surfaceElement->SetOwnership(
                     surfaceElement->GetOwnership() & ~(OWNERSHIP_OWNED | OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED));
-                ParkUpdateFencesAroundTile(loc);
+                Park::UpdateFencesAroundTile(loc);
             }
             return res;
         case LandSetRightSetting::UnownConstructionRights:
@@ -199,7 +199,7 @@ GameActions::Result LandSetRightsAction::MapBuyLandRightsForTile(const CoordsXY&
                         gameState.PeepSpawns.end());
                 }
                 surfaceElement->SetOwnership(_ownership);
-                ParkUpdateFencesAroundTile(loc);
+                Park::UpdateFencesAroundTile(loc);
                 gMapLandRightsUpdateSuccess = true;
             }
             return res;

--- a/src/openrct2/actions/LargeSceneryRemoveAction.cpp
+++ b/src/openrct2/actions/LargeSceneryRemoveAction.cpp
@@ -97,7 +97,7 @@ GameActions::Result LargeSceneryRemoveAction::Query() const
 
         if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && !GetGameState().Cheats.SandboxMode)
         {
-            if (GetGameState().ParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL)
+            if (GetGameState().Park.Flags & PARK_FLAGS_FORBID_TREE_REMOVAL)
             {
                 if (sceneryEntry->HasFlag(LARGE_SCENERY_FLAG_IS_TREE))
                 {

--- a/src/openrct2/actions/MapChangeSizeAction.cpp
+++ b/src/openrct2/actions/MapChangeSizeAction.cpp
@@ -73,7 +73,7 @@ GameActions::Result MapChangeSizeAction::Execute() const
     auto* ctx = OpenRCT2::GetContext();
     auto uiContext = ctx->GetUiContext();
     auto* windowManager = uiContext->GetWindowManager();
-    ParkUpdateSize(gameState);
+    OpenRCT2::Park::UpdateSize(gameState);
 
     windowManager->BroadcastIntent(Intent(INTENT_ACTION_MAP));
     GfxInvalidateScreen();

--- a/src/openrct2/actions/MapChangeSizeAction.cpp
+++ b/src/openrct2/actions/MapChangeSizeAction.cpp
@@ -73,7 +73,7 @@ GameActions::Result MapChangeSizeAction::Execute() const
     auto* ctx = OpenRCT2::GetContext();
     auto uiContext = ctx->GetUiContext();
     auto* windowManager = uiContext->GetWindowManager();
-    ParkCalculateSize();
+    ParkUpdateSize(gameState);
 
     windowManager->BroadcastIntent(Intent(INTENT_ACTION_MAP));
     GfxInvalidateScreen();

--- a/src/openrct2/actions/ParkEntrancePlaceAction.cpp
+++ b/src/openrct2/actions/ParkEntrancePlaceAction.cpp
@@ -75,7 +75,7 @@ GameActions::Result ParkEntrancePlaceAction::Query() const
     }
 
     const auto& gameState = GetGameState();
-    if (gameState.ParkEntrances.size() >= OpenRCT2::Limits::MaxParkEntrances)
+    if (gameState.Park.Entrances.size() >= OpenRCT2::Limits::MaxParkEntrances)
     {
         return GameActions::Result(
             GameActions::Status::InvalidParameters, STR_CANT_BUILD_THIS_HERE, STR_ERR_TOO_MANY_PARK_ENTRANCES);
@@ -121,7 +121,7 @@ GameActions::Result ParkEntrancePlaceAction::Execute() const
 
     uint32_t flags = GetFlags();
 
-    GetGameState().ParkEntrances.push_back(_loc);
+    GetGameState().Park.Entrances.push_back(_loc);
 
     auto zLow = _loc.z;
     auto zHigh = zLow + ParkEntranceHeight;
@@ -170,11 +170,11 @@ GameActions::Result ParkEntrancePlaceAction::Execute() const
             FootpathConnectEdges(entranceLoc, entranceElement->as<TileElement>(), GAME_COMMAND_FLAG_APPLY);
         }
 
-        ParkUpdateFences(entranceLoc);
-        ParkUpdateFences({ entranceLoc.x - COORDS_XY_STEP, entranceLoc.y });
-        ParkUpdateFences({ entranceLoc.x + COORDS_XY_STEP, entranceLoc.y });
-        ParkUpdateFences({ entranceLoc.x, entranceLoc.y - COORDS_XY_STEP });
-        ParkUpdateFences({ entranceLoc.x, entranceLoc.y + COORDS_XY_STEP });
+        Park::UpdateFences(entranceLoc);
+        Park::UpdateFences({ entranceLoc.x - COORDS_XY_STEP, entranceLoc.y });
+        Park::UpdateFences({ entranceLoc.x + COORDS_XY_STEP, entranceLoc.y });
+        Park::UpdateFences({ entranceLoc.x, entranceLoc.y - COORDS_XY_STEP });
+        Park::UpdateFences({ entranceLoc.x, entranceLoc.y + COORDS_XY_STEP });
 
         MapInvalidateTile({ entranceLoc, entranceElement->GetBaseZ(), entranceElement->GetClearanceZ() });
 

--- a/src/openrct2/actions/ParkEntranceRemoveAction.cpp
+++ b/src/openrct2/actions/ParkEntranceRemoveAction.cpp
@@ -78,7 +78,7 @@ GameActions::Result ParkEntranceRemoveAction::Execute() const
     }
 
     auto& gameState = GetGameState();
-    auto direction = (gameState.ParkEntrances[entranceIndex].direction - 1) & 3;
+    auto direction = (gameState.Park.Entrances[entranceIndex].direction - 1) & 3;
 
     // Centre (sign)
     ParkEntranceRemoveSegment(_loc);
@@ -91,7 +91,7 @@ GameActions::Result ParkEntranceRemoveAction::Execute() const
     ParkEntranceRemoveSegment(
         { _loc.x - CoordsDirectionDelta[direction].x, _loc.y - CoordsDirectionDelta[direction].y, _loc.z });
 
-    gameState.ParkEntrances.erase(gameState.ParkEntrances.begin() + entranceIndex);
+    gameState.Park.Entrances.erase(gameState.Park.Entrances.begin() + entranceIndex);
     return res;
 }
 
@@ -105,5 +105,5 @@ void ParkEntranceRemoveAction::ParkEntranceRemoveSegment(const CoordsXYZ& loc) c
 
     MapInvalidateTile({ loc, entranceElement->GetBaseZ(), entranceElement->GetClearanceZ() });
     entranceElement->Remove();
-    ParkUpdateFences({ loc.x, loc.y });
+    Park::UpdateFences({ loc.x, loc.y });
 }

--- a/src/openrct2/actions/ParkMarketingAction.cpp
+++ b/src/openrct2/actions/ParkMarketingAction.cpp
@@ -56,7 +56,7 @@ GameActions::Result ParkMarketingAction::Query() const
         return GameActions::Result(
             GameActions::Status::InvalidParameters, STR_CANT_START_MARKETING_CAMPAIGN, STR_ERR_VALUE_OUT_OF_RANGE);
     }
-    if (GetGameState().ParkFlags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN)
+    if (GetGameState().Park.Flags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN)
     {
         return GameActions::Result(
             GameActions::Status::Disallowed, STR_CANT_START_MARKETING_CAMPAIGN,

--- a/src/openrct2/actions/ParkSetDateAction.cpp
+++ b/src/openrct2/actions/ParkSetDateAction.cpp
@@ -18,6 +18,8 @@
 #include "../ui/WindowManager.h"
 #include "../windows/Intent.h"
 
+using namespace OpenRCT2;
+
 ParkSetDateAction::ParkSetDateAction(int32_t year, int32_t month, int32_t day)
     : _year(year)
     , _month(month)
@@ -69,6 +71,7 @@ GameActions::Result ParkSetDateAction::Query() const
 
 GameActions::Result ParkSetDateAction::Execute() const
 {
-    OpenRCT2::GetContext()->GetGameState()->SetDate(OpenRCT2::Date::FromYMD(_year, _month, _day));
+    auto& gameState = GetGameState();
+    gameState.Date = OpenRCT2::Date::FromYMD(_year, _month, _day);
     return GameActions::Result();
 }

--- a/src/openrct2/actions/ParkSetEntranceFeeAction.cpp
+++ b/src/openrct2/actions/ParkSetEntranceFeeAction.cpp
@@ -42,12 +42,12 @@ void ParkSetEntranceFeeAction::Serialise(DataSerialiser& stream)
 
 GameActions::Result ParkSetEntranceFeeAction::Query() const
 {
-    if ((GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY) != 0)
+    if ((GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY) != 0)
     {
         LOG_ERROR("Can't set park entrance fee because the park has no money");
         return GameActions::Result(GameActions::Status::Disallowed, STR_ERR_CANT_CHANGE_PARK_ENTRANCE_FEE, STR_NONE);
     }
-    else if (!ParkEntranceFeeUnlocked())
+    else if (!Park::EntranceFeeUnlocked())
     {
         LOG_ERROR("Park entrance fee is locked");
         return GameActions::Result(GameActions::Status::Disallowed, STR_ERR_CANT_CHANGE_PARK_ENTRANCE_FEE, STR_NONE);
@@ -64,7 +64,7 @@ GameActions::Result ParkSetEntranceFeeAction::Query() const
 
 GameActions::Result ParkSetEntranceFeeAction::Execute() const
 {
-    GetGameState().ParkEntranceFee = _fee;
+    GetGameState().Park.EntranceFee = _fee;
     WindowInvalidateByClass(WindowClass::ParkInformation);
     return GameActions::Result();
 }

--- a/src/openrct2/actions/ParkSetNameAction.cpp
+++ b/src/openrct2/actions/ParkSetNameAction.cpp
@@ -56,7 +56,7 @@ GameActions::Result ParkSetNameAction::Query() const
 GameActions::Result ParkSetNameAction::Execute() const
 {
     // Do a no-op if new name is the same as the current name is the same
-    auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+    auto& park = OpenRCT2::GetGameState().Park;
     if (_name != park.Name)
     {
         park.Name = _name;

--- a/src/openrct2/actions/ParkSetParameterAction.cpp
+++ b/src/openrct2/actions/ParkSetParameterAction.cpp
@@ -60,16 +60,16 @@ GameActions::Result ParkSetParameterAction::Execute() const
     switch (_parameter)
     {
         case ParkParameter::Close:
-            if (gameState.ParkFlags & PARK_FLAGS_PARK_OPEN)
+            if (gameState.Park.Flags & PARK_FLAGS_PARK_OPEN)
             {
-                gameState.ParkFlags &= ~PARK_FLAGS_PARK_OPEN;
+                gameState.Park.Flags &= ~PARK_FLAGS_PARK_OPEN;
                 WindowInvalidateByClass(WindowClass::ParkInformation);
             }
             break;
         case ParkParameter::Open:
-            if (!(gameState.ParkFlags & PARK_FLAGS_PARK_OPEN))
+            if (!(gameState.Park.Flags & PARK_FLAGS_PARK_OPEN))
             {
-                gameState.ParkFlags |= PARK_FLAGS_PARK_OPEN;
+                gameState.Park.Flags |= PARK_FLAGS_PARK_OPEN;
                 WindowInvalidateByClass(WindowClass::ParkInformation);
             }
             break;

--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -207,7 +207,7 @@ GameActions::Result RideCreateAction::Execute() const
     ride->excitement = kRideRatingUndefined;
 
     auto& gameState = GetGameState();
-    if (!(gameState.ParkFlags & PARK_FLAGS_NO_MONEY))
+    if (!(gameState.Park.Flags & PARK_FLAGS_NO_MONEY))
     {
         for (auto i = 0; i < RCT2::ObjectLimits::MaxShopItemsPerRideEntry; i++)
         {
@@ -216,7 +216,7 @@ GameActions::Result RideCreateAction::Execute() const
 
         if (rideEntry->shop_item[0] == ShopItem::None)
         {
-            if (!ParkRidePricesUnlocked() || gameState.ParkEntranceFee > 0)
+            if (!Park::RidePricesUnlocked() || gameState.Park.EntranceFee > 0)
             {
                 ride->price[0] = 0;
             }

--- a/src/openrct2/actions/RideDemolishAction.cpp
+++ b/src/openrct2/actions/RideDemolishAction.cpp
@@ -156,7 +156,7 @@ GameActions::Result RideDemolishAction::DemolishRide(Ride& ride) const
     }
 
     ride.Delete();
-    GetGameState().ParkValue = CalculateParkValue();
+    GetGameState().Park.Value = Park::CalculateParkValue();
 
     // Close windows related to the demolished ride
     WindowCloseByNumber(WindowClass::RideConstruction, rideId.ToUnderlying());

--- a/src/openrct2/actions/RideDemolishAction.cpp
+++ b/src/openrct2/actions/RideDemolishAction.cpp
@@ -156,7 +156,7 @@ GameActions::Result RideDemolishAction::DemolishRide(Ride& ride) const
     }
 
     ride.Delete();
-    GetGameState().ParkValue = GetGameState().Park.CalculateParkValue();
+    GetGameState().ParkValue = CalculateParkValue();
 
     // Close windows related to the demolished ride
     WindowCloseByNumber(WindowClass::RideConstruction, rideId.ToUnderlying());

--- a/src/openrct2/actions/RideDemolishAction.cpp
+++ b/src/openrct2/actions/RideDemolishAction.cpp
@@ -156,7 +156,7 @@ GameActions::Result RideDemolishAction::DemolishRide(Ride& ride) const
     }
 
     ride.Delete();
-    GetGameState().ParkValue = GetContext()->GetGameState()->GetPark().CalculateParkValue();
+    GetGameState().ParkValue = GetGameState().Park.CalculateParkValue();
 
     // Close windows related to the demolished ride
     WindowCloseByNumber(WindowClass::RideConstruction, rideId.ToUnderlying());

--- a/src/openrct2/actions/ScenarioSetSettingAction.cpp
+++ b/src/openrct2/actions/ScenarioSetSettingAction.cpp
@@ -57,22 +57,22 @@ GameActions::Result ScenarioSetSettingAction::Execute() const
             {
                 if (_value != 0)
                 {
-                    gameState.ParkFlags |= PARK_FLAGS_NO_MONEY;
+                    gameState.Park.Flags |= PARK_FLAGS_NO_MONEY;
                 }
                 else
                 {
-                    gameState.ParkFlags &= ~PARK_FLAGS_NO_MONEY;
+                    gameState.Park.Flags &= ~PARK_FLAGS_NO_MONEY;
                 }
             }
             else
             {
                 if (_value != 0)
                 {
-                    gameState.ParkFlags |= PARK_FLAGS_NO_MONEY;
+                    gameState.Park.Flags |= PARK_FLAGS_NO_MONEY;
                 }
                 else
                 {
-                    gameState.ParkFlags &= ~PARK_FLAGS_NO_MONEY;
+                    gameState.Park.Flags &= ~PARK_FLAGS_NO_MONEY;
                 }
                 // Invalidate all windows that have anything to do with finance
                 WindowInvalidateByClass(WindowClass::Ride);
@@ -106,11 +106,11 @@ GameActions::Result ScenarioSetSettingAction::Execute() const
         case ScenarioSetSetting::ForbidMarketingCampaigns:
             if (_value != 0)
             {
-                gameState.ParkFlags |= PARK_FLAGS_FORBID_MARKETING_CAMPAIGN;
+                gameState.Park.Flags |= PARK_FLAGS_FORBID_MARKETING_CAMPAIGN;
             }
             else
             {
-                gameState.ParkFlags &= ~PARK_FLAGS_FORBID_MARKETING_CAMPAIGN;
+                gameState.Park.Flags &= ~PARK_FLAGS_FORBID_MARKETING_CAMPAIGN;
             }
             break;
         case ScenarioSetSetting::AverageCashPerGuest:
@@ -128,21 +128,21 @@ GameActions::Result ScenarioSetSettingAction::Execute() const
         case ScenarioSetSetting::GuestsPreferLessIntenseRides:
             if (_value != 0)
             {
-                gameState.ParkFlags |= PARK_FLAGS_PREF_LESS_INTENSE_RIDES;
+                gameState.Park.Flags |= PARK_FLAGS_PREF_LESS_INTENSE_RIDES;
             }
             else
             {
-                gameState.ParkFlags &= ~PARK_FLAGS_PREF_LESS_INTENSE_RIDES;
+                gameState.Park.Flags &= ~PARK_FLAGS_PREF_LESS_INTENSE_RIDES;
             }
             break;
         case ScenarioSetSetting::GuestsPreferMoreIntenseRides:
             if (_value != 0)
             {
-                gameState.ParkFlags |= PARK_FLAGS_PREF_MORE_INTENSE_RIDES;
+                gameState.Park.Flags |= PARK_FLAGS_PREF_MORE_INTENSE_RIDES;
             }
             else
             {
-                gameState.ParkFlags &= ~PARK_FLAGS_PREF_MORE_INTENSE_RIDES;
+                gameState.Park.Flags &= ~PARK_FLAGS_PREF_MORE_INTENSE_RIDES;
             }
             break;
         case ScenarioSetSetting::CostToBuyLand:
@@ -156,96 +156,96 @@ GameActions::Result ScenarioSetSettingAction::Execute() const
             {
                 if (_value == 0)
                 {
-                    gameState.ParkFlags |= PARK_FLAGS_PARK_FREE_ENTRY;
-                    gameState.ParkFlags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
-                    gameState.ParkEntranceFee = 0.00_GBP;
+                    gameState.Park.Flags |= PARK_FLAGS_PARK_FREE_ENTRY;
+                    gameState.Park.Flags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
+                    gameState.Park.EntranceFee = 0.00_GBP;
                 }
                 else if (_value == 1)
                 {
-                    gameState.ParkFlags &= ~PARK_FLAGS_PARK_FREE_ENTRY;
-                    gameState.ParkFlags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
-                    gameState.ParkEntranceFee = 10.00_GBP;
+                    gameState.Park.Flags &= ~PARK_FLAGS_PARK_FREE_ENTRY;
+                    gameState.Park.Flags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
+                    gameState.Park.EntranceFee = 10.00_GBP;
                 }
                 else
                 {
-                    gameState.ParkFlags |= PARK_FLAGS_PARK_FREE_ENTRY;
-                    gameState.ParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
-                    gameState.ParkEntranceFee = 10.00_GBP;
+                    gameState.Park.Flags |= PARK_FLAGS_PARK_FREE_ENTRY;
+                    gameState.Park.Flags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
+                    gameState.Park.EntranceFee = 10.00_GBP;
                 }
             }
             else
             {
                 if (_value == 0)
                 {
-                    gameState.ParkFlags |= PARK_FLAGS_PARK_FREE_ENTRY;
-                    gameState.ParkFlags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
+                    gameState.Park.Flags |= PARK_FLAGS_PARK_FREE_ENTRY;
+                    gameState.Park.Flags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
                 }
                 else if (_value == 1)
                 {
-                    gameState.ParkFlags &= ~PARK_FLAGS_PARK_FREE_ENTRY;
-                    gameState.ParkFlags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
+                    gameState.Park.Flags &= ~PARK_FLAGS_PARK_FREE_ENTRY;
+                    gameState.Park.Flags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
                 }
                 else
                 {
-                    gameState.ParkFlags |= PARK_FLAGS_PARK_FREE_ENTRY;
-                    gameState.ParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
+                    gameState.Park.Flags |= PARK_FLAGS_PARK_FREE_ENTRY;
+                    gameState.Park.Flags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
                 }
                 WindowInvalidateByClass(WindowClass::ParkInformation);
                 WindowInvalidateByClass(WindowClass::Ride);
             }
             break;
         case ScenarioSetSetting::ParkChargeEntryFee:
-            gameState.ParkEntranceFee = std::clamp<money64>(_value, 0.00_GBP, MAX_ENTRANCE_FEE);
+            gameState.Park.EntranceFee = std::clamp<money64>(_value, 0.00_GBP, MAX_ENTRANCE_FEE);
             WindowInvalidateByClass(WindowClass::ParkInformation);
             break;
         case ScenarioSetSetting::ForbidTreeRemoval:
             if (_value != 0)
             {
-                gameState.ParkFlags |= PARK_FLAGS_FORBID_TREE_REMOVAL;
+                gameState.Park.Flags |= PARK_FLAGS_FORBID_TREE_REMOVAL;
             }
             else
             {
-                gameState.ParkFlags &= ~PARK_FLAGS_FORBID_TREE_REMOVAL;
+                gameState.Park.Flags &= ~PARK_FLAGS_FORBID_TREE_REMOVAL;
             }
             break;
         case ScenarioSetSetting::ForbidLandscapeChanges:
             if (_value != 0)
             {
-                gameState.ParkFlags |= PARK_FLAGS_FORBID_LANDSCAPE_CHANGES;
+                gameState.Park.Flags |= PARK_FLAGS_FORBID_LANDSCAPE_CHANGES;
             }
             else
             {
-                gameState.ParkFlags &= ~PARK_FLAGS_FORBID_LANDSCAPE_CHANGES;
+                gameState.Park.Flags &= ~PARK_FLAGS_FORBID_LANDSCAPE_CHANGES;
             }
             break;
         case ScenarioSetSetting::ForbidHighConstruction:
             if (_value != 0)
             {
-                gameState.ParkFlags |= PARK_FLAGS_FORBID_HIGH_CONSTRUCTION;
+                gameState.Park.Flags |= PARK_FLAGS_FORBID_HIGH_CONSTRUCTION;
             }
             else
             {
-                gameState.ParkFlags &= ~PARK_FLAGS_FORBID_HIGH_CONSTRUCTION;
+                gameState.Park.Flags &= ~PARK_FLAGS_FORBID_HIGH_CONSTRUCTION;
             }
             break;
         case ScenarioSetSetting::ParkRatingHigherDifficultyLevel:
             if (_value != 0)
             {
-                gameState.ParkFlags |= PARK_FLAGS_DIFFICULT_PARK_RATING;
+                gameState.Park.Flags |= PARK_FLAGS_DIFFICULT_PARK_RATING;
             }
             else
             {
-                gameState.ParkFlags &= ~PARK_FLAGS_DIFFICULT_PARK_RATING;
+                gameState.Park.Flags &= ~PARK_FLAGS_DIFFICULT_PARK_RATING;
             }
             break;
         case ScenarioSetSetting::GuestGenerationHigherDifficultyLevel:
             if (_value != 0)
             {
-                gameState.ParkFlags |= PARK_FLAGS_DIFFICULT_GUEST_GENERATION;
+                gameState.Park.Flags |= PARK_FLAGS_DIFFICULT_GUEST_GENERATION;
             }
             else
             {
-                gameState.ParkFlags &= ~PARK_FLAGS_DIFFICULT_GUEST_GENERATION;
+                gameState.Park.Flags &= ~PARK_FLAGS_DIFFICULT_GUEST_GENERATION;
             }
             break;
         case ScenarioSetSetting::AllowEarlyCompletion:
@@ -255,11 +255,11 @@ GameActions::Result ScenarioSetSettingAction::Execute() const
         {
             if (_value != 0)
             {
-                gameState.ParkFlags |= PARK_FLAGS_RCT1_INTEREST;
+                gameState.Park.Flags |= PARK_FLAGS_RCT1_INTEREST;
             }
             else
             {
-                gameState.ParkFlags &= ~PARK_FLAGS_RCT1_INTEREST;
+                gameState.Park.Flags &= ~PARK_FLAGS_RCT1_INTEREST;
             }
             break;
         }

--- a/src/openrct2/actions/SmallSceneryRemoveAction.cpp
+++ b/src/openrct2/actions/SmallSceneryRemoveAction.cpp
@@ -79,7 +79,7 @@ GameActions::Result SmallSceneryRemoveAction::Query() const
         && !GetGameState().Cheats.SandboxMode)
     {
         // Check if allowed to remove item
-        if (GetGameState().ParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL)
+        if (GetGameState().Park.Flags & PARK_FLAGS_FORBID_TREE_REMOVAL)
         {
             if (entry->HasFlag(SMALL_SCENERY_FLAG_IS_TREE))
             {

--- a/src/openrct2/actions/StaffHireNewAction.cpp
+++ b/src/openrct2/actions/StaffHireNewAction.cpp
@@ -288,10 +288,10 @@ void StaffHireNewAction::AutoPositionNewStaff(Peep* newPeep) const
     {
         // No walking guests; pick random park entrance
         const auto& gameState = GetGameState();
-        if (!gameState.ParkEntrances.empty())
+        if (!gameState.Park.Entrances.empty())
         {
-            auto rand = ScenarioRandMax(static_cast<uint32_t>(gameState.ParkEntrances.size()));
-            const auto& entrance = gameState.ParkEntrances[rand];
+            auto rand = ScenarioRandMax(static_cast<uint32_t>(gameState.Park.Entrances.size()));
+            const auto& entrance = gameState.Park.Entrances[rand];
             auto dir = entrance.direction;
             newLocation = entrance;
             // TODO: Replace with CoordsDirectionDelta

--- a/src/openrct2/actions/SurfaceSetStyleAction.cpp
+++ b/src/openrct2/actions/SurfaceSetStyleAction.cpp
@@ -86,7 +86,7 @@ GameActions::Result SurfaceSetStyleAction::Query() const
 
     // Do nothing if not in editor, sandbox mode or landscaping is forbidden
     if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && !GetGameState().Cheats.SandboxMode
-        && (GetGameState().ParkFlags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES))
+        && (GetGameState().Park.Flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES))
     {
         return GameActions::Result(
             GameActions::Status::Disallowed, STR_CANT_CHANGE_LAND_TYPE, STR_FORBIDDEN_BY_THE_LOCAL_AUTHORITY);

--- a/src/openrct2/actions/WaterSetHeightAction.cpp
+++ b/src/openrct2/actions/WaterSetHeightAction.cpp
@@ -49,7 +49,7 @@ GameActions::Result WaterSetHeightAction::Query() const
     res.Position = { _coords, _height * COORDS_Z_STEP };
 
     if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && !GetGameState().Cheats.SandboxMode
-        && GetGameState().ParkFlags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES)
+        && GetGameState().Park.Flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES)
     {
         return GameActions::Result(GameActions::Status::Disallowed, STR_NONE, STR_FORBIDDEN_BY_THE_LOCAL_AUTHORITY);
     }

--- a/src/openrct2/command_line/SimulateCommands.cpp
+++ b/src/openrct2/command_line/SimulateCommands.cpp
@@ -59,7 +59,7 @@ static exitcode_t HandleSimulate(CommandLineArgEnumerator* argEnumerator)
         Console::WriteLine("Running %d ticks...", ticks);
         for (uint32_t i = 0; i < ticks; i++)
         {
-            context->GetGameState()->UpdateLogic();
+            gameStateUpdateLogic();
         }
         Console::WriteLine("Completed: %s", GetAllEntitiesChecksum().ToString().c_str());
     }

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -1075,7 +1075,7 @@ void Guest::Tick128UpdateGuest(uint32_t index)
                         possible_thoughts[num_thoughts++] = PeepThoughtType::Toilet;
                     }
 
-                    if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY) && CashInPocket <= 9.00_GBP && Happiness >= 105
+                    if (!(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY) && CashInPocket <= 9.00_GBP && Happiness >= 105
                         && Energy >= 70)
                     {
                         /* The energy check was originally a second check on happiness.
@@ -1539,7 +1539,7 @@ bool Guest::DecideAndBuyItem(Ride& ride, const ShopItem shopItem, money64 price)
 
     if (!hasVoucher)
     {
-        if (price != 0 && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+        if (price != 0 && !(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
         {
             if (CashInPocket == 0)
             {
@@ -1586,7 +1586,7 @@ bool Guest::DecideAndBuyItem(Ride& ride, const ShopItem shopItem, money64 price)
             itemValue -= price;
             itemValue = std::max(0.80_GBP, itemValue);
 
-            if (!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+            if (!(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 if (itemValue >= static_cast<money64>(ScenarioRand() & 0x07))
                 {
@@ -1694,7 +1694,7 @@ bool Guest::DecideAndBuyItem(Ride& ride, const ShopItem shopItem, money64 price)
         expenditure = ExpenditureType::FoodDrinkStock;
     }
 
-    if (!(gameState.ParkFlags & PARK_FLAGS_NO_MONEY))
+    if (!(gameState.Park.Flags & PARK_FLAGS_NO_MONEY))
         FinancePayment(shopItemDescriptor.Cost, expenditure);
 
     // Sets the expenditure type to *_FOODDRINK_SALES or *_SHOP_SALES appropriately.
@@ -1704,7 +1704,7 @@ bool Guest::DecideAndBuyItem(Ride& ride, const ShopItem shopItem, money64 price)
         RemoveItem(ShopItem::Voucher);
         WindowInvalidateFlags |= PEEP_INVALIDATE_PEEP_INVENTORY;
     }
-    else if (!(gameState.ParkFlags & PARK_FLAGS_NO_MONEY))
+    else if (!(gameState.Park.Flags & PARK_FLAGS_NO_MONEY))
     {
         SpendMoney(*expend_type, price, expenditure);
     }
@@ -2006,7 +2006,7 @@ bool Guest::ShouldGoOnRide(Ride& ride, StationIndex entranceNum, bool atQueue, b
 
             auto& gameState = GetGameState();
             // Basic price checks
-            if (ridePrice != 0 && !PeepHasVoucherForFreeRide(this, ride) && !(gameState.ParkFlags & PARK_FLAGS_NO_MONEY))
+            if (ridePrice != 0 && !PeepHasVoucherForFreeRide(this, ride) && !(gameState.Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 if (ridePrice > CashInPocket)
                 {
@@ -2155,7 +2155,7 @@ bool Guest::ShouldGoOnRide(Ride& ride, StationIndex entranceNum, bool atQueue, b
 
             // If the value of the ride hasn't yet been calculated, peeps will be willing to pay any amount for the ride.
             if (value != RIDE_VALUE_UNDEFINED && !PeepHasVoucherForFreeRide(this, ride)
-                && !(gameState.ParkFlags & PARK_FLAGS_NO_MONEY))
+                && !(gameState.Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 // The amount peeps are willing to pay is decreased by 75% if they had to pay to enter the park.
                 if (PeepFlags & PEEP_FLAGS_HAS_PAID_FOR_PARK_ENTRY)
@@ -2181,7 +2181,7 @@ bool Guest::ShouldGoOnRide(Ride& ride, StationIndex entranceNum, bool atQueue, b
                 // A ride is good value if the price is 50% or less of the ride value and the peep didn't pay to enter the park.
                 if (ridePrice <= (value / 2) && peepAtRide)
                 {
-                    if (!(gameState.ParkFlags & PARK_FLAGS_NO_MONEY))
+                    if (!(gameState.Park.Flags & PARK_FLAGS_NO_MONEY))
                     {
                         if (!(PeepFlags & PEEP_FLAGS_HAS_PAID_FOR_PARK_ENTRY))
                         {
@@ -2300,7 +2300,7 @@ void Guest::SpendMoney(money64 amount, ExpenditureType expenditure)
  */
 void Guest::SpendMoney(money64& peep_expend_type, money64 amount, ExpenditureType expenditure)
 {
-    assert(!(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY));
+    assert(!(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY));
 
     CashInPocket = std::max(0.00_GBP, static_cast<money64>(CashInPocket) - amount);
     CashSpent += amount;
@@ -2615,7 +2615,7 @@ static bool PeepCheckRidePriceAtEntrance(Guest* peep, const Ride& ride, money64 
         && peep->VoucherRideId == peep->CurrentRide)
         return true;
 
-    if (peep->CashInPocket <= 0 && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+    if (peep->CashInPocket <= 0 && !(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
     {
         peep->InsertNewThought(PeepThoughtType::SpentMoney);
         PeepUpdateRideAtEntranceTryLeave(peep);
@@ -2709,7 +2709,7 @@ static void PeepUpdateFavouriteRide(Guest* peep, const Ride& ride)
 /* rct2: 0x00695555 */
 static int16_t PeepCalculateRideValueSatisfaction(Guest* peep, const Ride& ride)
 {
-    if (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
+    if (GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY)
     {
         return -30;
     }
@@ -2883,7 +2883,7 @@ static bool PeepShouldGoOnRideAgain(Guest* peep, const Ride& ride)
 
 static bool PeepShouldPreferredIntensityIncrease(Guest* peep)
 {
-    if (GetGameState().ParkFlags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES)
+    if (GetGameState().Park.Flags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES)
         return false;
     if (peep->Happiness < 200)
         return false;
@@ -3068,7 +3068,7 @@ static void PeepDecideWhetherToLeavePark(Guest* peep)
      * in the park. */
     if (!(peep->PeepFlags & PEEP_FLAGS_LEAVING_PARK))
     {
-        if (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
+        if (GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY)
         {
             if (peep->Energy >= 70 && peep->Happiness >= 60)
             {
@@ -3298,7 +3298,7 @@ void Guest::StopPurchaseThought(ride_type_t rideType)
  */
 static bool PeepShouldUseCashMachine(Guest* peep, RideId rideIndex)
 {
-    if (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
+    if (GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY)
         return false;
     if (peep->PeepFlags & PEEP_FLAGS_LEAVING_PARK)
         return false;
@@ -7141,9 +7141,9 @@ Guest* Guest::Generate(const CoordsXYZ& coords)
 
     /* Check which intensity boxes are enabled
      * and apply the appropriate intensity settings. */
-    if (gameState.ParkFlags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES)
+    if (gameState.Park.Flags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES)
     {
-        if (gameState.ParkFlags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES)
+        if (gameState.Park.Flags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES)
         {
             intensityLowest = 0;
             intensityHighest = 15;
@@ -7154,7 +7154,7 @@ Guest* Guest::Generate(const CoordsXYZ& coords)
             intensityHighest = 4;
         }
     }
-    else if (gameState.ParkFlags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES)
+    else if (gameState.Park.Flags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES)
     {
         intensityLowest = 9;
         intensityHighest = 15;
@@ -7163,7 +7163,7 @@ Guest* Guest::Generate(const CoordsXYZ& coords)
     peep->Intensity = IntensityRange(intensityLowest, intensityHighest);
 
     uint8_t nauseaTolerance = ScenarioRand() & 0x7;
-    if (gameState.ParkFlags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES)
+    if (gameState.Park.Flags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES)
     {
         nauseaTolerance += 4;
     }
@@ -7220,7 +7220,7 @@ Guest* Guest::Generate(const CoordsXYZ& coords)
         cash = 500;
     }
 
-    if (gameState.ParkFlags & PARK_FLAGS_NO_MONEY)
+    if (gameState.Park.Flags & PARK_FLAGS_NO_MONEY)
     {
         cash = 0;
     }

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -718,7 +718,7 @@ void Peep::UpdateFalling()
         }
 
         auto& gameState = GetGameState();
-        gameState.ParkRatingCasualtyPenalty = std::min(gameState.ParkRatingCasualtyPenalty + 25, 1000);
+        gameState.Park.RatingCasualtyPenalty = std::min(gameState.Park.RatingCasualtyPenalty + 25, 1000);
         Remove();
         return;
     }
@@ -1538,7 +1538,7 @@ void Peep::FormatNameTo(Formatter& ft) const
             ft.Add<StringId>(_staffNames[staffNameIndex]);
             ft.Add<uint32_t>(PeepId);
         }
-        else if (GetGameState().ParkFlags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES)
+        else if (GetGameState().Park.Flags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES)
         {
             auto realNameStringId = GetRealNameStringIDFromPeepID(PeepId);
             ft.Add<StringId>(realNameStringId);
@@ -1805,7 +1805,7 @@ static bool PeepInteractWithEntrance(Peep* peep, const CoordsXYE& coords, uint8_
             if (!(guest->PeepFlags & PEEP_FLAGS_LEAVING_PARK))
             {
                 // If the park is open and leaving flag isn't set return to centre
-                if (gameState.ParkFlags & PARK_FLAGS_PARK_OPEN)
+                if (gameState.Park.Flags & PARK_FLAGS_PARK_OPEN)
                 {
                     PeepReturnToCentreOfTile(guest);
                     return true;
@@ -1838,7 +1838,7 @@ static bool PeepInteractWithEntrance(Peep* peep, const CoordsXYE& coords, uint8_
             return true;
         }
 
-        if (!(gameState.ParkFlags & PARK_FLAGS_PARK_OPEN))
+        if (!(gameState.Park.Flags & PARK_FLAGS_PARK_OPEN))
         {
             guest->State = PeepState::LeavingPark;
             guest->Var37 = 1;
@@ -1849,10 +1849,10 @@ static bool PeepInteractWithEntrance(Peep* peep, const CoordsXYE& coords, uint8_
         }
 
         bool found = false;
-        auto entrance = std::find_if(gameState.ParkEntrances.begin(), gameState.ParkEntrances.end(), [coords](const auto& e) {
+        auto entrance = std::find_if(gameState.Park.Entrances.begin(), gameState.Park.Entrances.end(), [coords](const auto& e) {
             return coords.ToTileStart() == e;
         });
-        if (entrance != gameState.ParkEntrances.end())
+        if (entrance != gameState.Park.Entrances.end())
         {
             int16_t z = entrance->z / 8;
             entranceDirection = entrance->direction;
@@ -1911,7 +1911,7 @@ static bool PeepInteractWithEntrance(Peep* peep, const CoordsXYE& coords, uint8_
             return true;
         }
 
-        auto entranceFee = ParkGetEntranceFee();
+        auto entranceFee = Park::GetEntranceFee();
         if (entranceFee != 0)
         {
             if (guest->HasItem(ShopItem::Voucher))
@@ -2287,7 +2287,7 @@ static bool PeepInteractWithShop(Peep* peep, const CoordsXYE& coords)
         }
 
         auto cost = ride->price[0];
-        if (cost != 0 && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+        if (cost != 0 && !(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
         {
             ride->total_profit += cost;
             ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_INCOME;
@@ -2552,7 +2552,7 @@ int32_t PeepCompare(const EntityId sprite_index_a, const EntityId sprite_index_b
 
     if (peep_a->Name == nullptr && peep_b->Name == nullptr)
     {
-        if (GetGameState().ParkFlags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES)
+        if (GetGameState().Park.Flags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES)
         {
             // Potentially could find a more optional way of sorting dynamic real names
         }
@@ -2585,12 +2585,12 @@ void PeepUpdateNames(bool realNames)
     auto& gameState = GetGameState();
     if (realNames)
     {
-        gameState.ParkFlags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
+        gameState.Park.Flags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
         // Peep names are now dynamic
     }
     else
     {
-        gameState.ParkFlags &= ~PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
+        gameState.Park.Flags &= ~PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
         // Peep names are now dynamic
     }
 

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -557,11 +557,11 @@ static int32_t ConsoleCommandGet(InteractiveConsole& console, const arguments_t&
     {
         if (argv[0] == "park_rating")
         {
-            console.WriteFormatLine("park_rating %d", gameState.ParkRating);
+            console.WriteFormatLine("park_rating %d", gameState.Park.Rating);
         }
         else if (argv[0] == "park_value")
         {
-            console.WriteFormatLine("park_value %d", gameState.ParkValue / 10);
+            console.WriteFormatLine("park_value %d", gameState.Park.Value / 10);
         }
         else if (argv[0] == "company_value")
         {
@@ -597,7 +597,7 @@ static int32_t ConsoleCommandGet(InteractiveConsole& console, const arguments_t&
                 {
                     console.WriteFormatLine("guest_initial_happiness %d%%  (%d)", 15, gameState.GuestInitialHappiness);
                 }
-                else if (current_happiness == CalculateGuestInitialHappiness(i))
+                else if (current_happiness == Park::CalculateGuestInitialHappiness(i))
                 {
                     console.WriteFormatLine("guest_initial_happiness %d%%  (%d)", i, gameState.GuestInitialHappiness);
                     break;
@@ -619,52 +619,52 @@ static int32_t ConsoleCommandGet(InteractiveConsole& console, const arguments_t&
         else if (argv[0] == "guest_prefer_less_intense_rides")
         {
             console.WriteFormatLine(
-                "guest_prefer_less_intense_rides %d", (gameState.ParkFlags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES) != 0);
+                "guest_prefer_less_intense_rides %d", (gameState.Park.Flags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES) != 0);
         }
         else if (argv[0] == "guest_prefer_more_intense_rides")
         {
             console.WriteFormatLine(
-                "guest_prefer_more_intense_rides %d", (gameState.ParkFlags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES) != 0);
+                "guest_prefer_more_intense_rides %d", (gameState.Park.Flags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES) != 0);
         }
         else if (argv[0] == "forbid_marketing_campaigns")
         {
             console.WriteFormatLine(
-                "forbid_marketing_campaigns %d", (gameState.ParkFlags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN) != 0);
+                "forbid_marketing_campaigns %d", (gameState.Park.Flags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN) != 0);
         }
         else if (argv[0] == "forbid_landscape_changes")
         {
             console.WriteFormatLine(
-                "forbid_landscape_changes %d", (gameState.ParkFlags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES) != 0);
+                "forbid_landscape_changes %d", (gameState.Park.Flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES) != 0);
         }
         else if (argv[0] == "forbid_tree_removal")
         {
-            console.WriteFormatLine("forbid_tree_removal %d", (gameState.ParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL) != 0);
+            console.WriteFormatLine("forbid_tree_removal %d", (gameState.Park.Flags & PARK_FLAGS_FORBID_TREE_REMOVAL) != 0);
         }
         else if (argv[0] == "forbid_high_construction")
         {
             console.WriteFormatLine(
-                "forbid_high_construction %d", (gameState.ParkFlags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION) != 0);
+                "forbid_high_construction %d", (gameState.Park.Flags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION) != 0);
         }
         else if (argv[0] == "pay_for_rides")
         {
-            console.WriteFormatLine("pay_for_rides %d", (gameState.ParkFlags & PARK_FLAGS_PARK_FREE_ENTRY) != 0);
+            console.WriteFormatLine("pay_for_rides %d", (gameState.Park.Flags & PARK_FLAGS_PARK_FREE_ENTRY) != 0);
         }
         else if (argv[0] == "no_money")
         {
-            console.WriteFormatLine("no_money %d", (gameState.ParkFlags & PARK_FLAGS_NO_MONEY) != 0);
+            console.WriteFormatLine("no_money %d", (gameState.Park.Flags & PARK_FLAGS_NO_MONEY) != 0);
         }
         else if (argv[0] == "difficult_park_rating")
         {
-            console.WriteFormatLine("difficult_park_rating %d", (gameState.ParkFlags & PARK_FLAGS_DIFFICULT_PARK_RATING) != 0);
+            console.WriteFormatLine("difficult_park_rating %d", (gameState.Park.Flags & PARK_FLAGS_DIFFICULT_PARK_RATING) != 0);
         }
         else if (argv[0] == "difficult_guest_generation")
         {
             console.WriteFormatLine(
-                "difficult_guest_generation %d", (gameState.ParkFlags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION) != 0);
+                "difficult_guest_generation %d", (gameState.Park.Flags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION) != 0);
         }
         else if (argv[0] == "park_open")
         {
-            console.WriteFormatLine("park_open %d", (gameState.ParkFlags & PARK_FLAGS_PARK_OPEN) != 0);
+            console.WriteFormatLine("park_open %d", (gameState.Park.Flags & PARK_FLAGS_PARK_OPEN) != 0);
         }
         else if (argv[0] == "land_rights_cost")
         {
@@ -850,7 +850,8 @@ static int32_t ConsoleCommandSet(InteractiveConsole& console, const arguments_t&
         else if (argv[0] == "guest_initial_happiness" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
             auto scenarioSetSetting = ScenarioSetSettingAction(
-                ScenarioSetSetting::GuestInitialHappiness, CalculateGuestInitialHappiness(static_cast<uint8_t>(int_val[0])));
+                ScenarioSetSetting::GuestInitialHappiness,
+                Park::CalculateGuestInitialHappiness(static_cast<uint8_t>(int_val[0])));
             scenarioSetSetting.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
                 if (res->Error != GameActions::Status::Ok)
                     console.WriteLineError("set guest_initial_happiness command failed, likely due to permissions.");
@@ -951,7 +952,7 @@ static int32_t ConsoleCommandSet(InteractiveConsole& console, const arguments_t&
         }
         else if (argv[0] == "pay_for_rides" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
-            SET_FLAG(gameState.ParkFlags, PARK_FLAGS_PARK_FREE_ENTRY, int_val[0]);
+            SET_FLAG(gameState.Park.Flags, PARK_FLAGS_PARK_FREE_ENTRY, int_val[0]);
             console.Execute("get pay_for_rides");
         }
         else if (argv[0] == "no_money" && InvalidArguments(&invalidArgs, int_valid[0]))

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -105,7 +105,7 @@ void ScreenshotCheck()
 
 static std::string ScreenshotGetParkName()
 {
-    return GetContext()->GetGameState()->GetPark().Name;
+    return GetGameState().Park.Name;
 }
 
 static std::string ScreenshotGetDirectory()

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -176,13 +176,13 @@ static bool AwardIsDeservedBestValue(int32_t activeAwardTypes)
     if (activeAwardTypes & EnumToFlag(AwardType::MostDisappointing))
         return false;
 
-    if ((gameState.ParkFlags & PARK_FLAGS_NO_MONEY) || !ParkEntranceFeeUnlocked())
+    if ((gameState.Park.Flags & PARK_FLAGS_NO_MONEY) || !Park::EntranceFeeUnlocked())
         return false;
 
     if (gameState.TotalRideValueForMoney < 10.00_GBP)
         return false;
 
-    if (ParkGetEntranceFee() + 0.10_GBP >= gameState.TotalRideValueForMoney / 2)
+    if (Park::GetEntranceFee() + 0.10_GBP >= gameState.TotalRideValueForMoney / 2)
         return false;
 
     return true;
@@ -228,10 +228,10 @@ static bool AwardIsDeservedWorstValue(int32_t activeAwardTypes)
 
     if (activeAwardTypes & EnumToFlag(AwardType::BestValue))
         return false;
-    if (gameState.ParkFlags & PARK_FLAGS_NO_MONEY)
+    if (gameState.Park.Flags & PARK_FLAGS_NO_MONEY)
         return false;
 
-    const auto parkEntranceFee = ParkGetEntranceFee();
+    const auto parkEntranceFee = Park::GetEntranceFee();
     if (parkEntranceFee == 0.00_GBP)
         return false;
     if (parkEntranceFee <= gameState.TotalRideValueForMoney)
@@ -407,7 +407,7 @@ static bool AwardIsDeservedMostDisappointing(int32_t activeAwardTypes)
 {
     if (activeAwardTypes & EnumToFlag(AwardType::BestValue))
         return false;
-    if (GetGameState().ParkRating > 650)
+    if (GetGameState().Park.Rating > 650)
         return false;
 
     // Count the number of disappointing rides
@@ -622,7 +622,7 @@ void AwardUpdateAll()
     }
 
     // Only add new awards if park is open
-    if (GetGameState().ParkFlags & PARK_FLAGS_PARK_OPEN)
+    if (GetGameState().Park.Flags & PARK_FLAGS_PARK_OPEN)
     {
         // Set active award types as flags
         int32_t activeAwardTypes = 0;

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -47,7 +47,7 @@ static constexpr int32_t dword_988E60[EnumValue(ExpenditureType::Count)] = {
  */
 bool FinanceCheckMoneyRequired(uint32_t flags)
 {
-    if (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
+    if (GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY)
         return false;
     if (gScreenFlags & SCREEN_FLAGS_EDITOR)
         return false;
@@ -99,7 +99,7 @@ void FinancePayWages()
 {
     PROFILED_FUNCTION();
 
-    if (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
+    if (GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY)
     {
         return;
     }
@@ -117,7 +117,7 @@ void FinancePayWages()
 void FinancePayResearch()
 {
     const auto& gameState = GetGameState();
-    if (gameState.ParkFlags & PARK_FLAGS_NO_MONEY)
+    if (gameState.Park.Flags & PARK_FLAGS_NO_MONEY)
     {
         return;
     }
@@ -134,7 +134,7 @@ void FinancePayInterest()
 {
     const auto& gameState = GetGameState();
 
-    if (gameState.ParkFlags & PARK_FLAGS_NO_MONEY)
+    if (gameState.Park.Flags & PARK_FLAGS_NO_MONEY)
     {
         return;
     }
@@ -143,7 +143,7 @@ void FinancePayInterest()
     // that will overflow money64 if the loan is greater than (1 << 31) / (5 * current_interest_rate)
     const money64 current_loan = gameState.BankLoan;
     const auto current_interest_rate = gameState.BankLoanInterestRate;
-    const money64 interest_to_pay = (gameState.ParkFlags & PARK_FLAGS_RCT1_INTEREST)
+    const money64 interest_to_pay = (gameState.Park.Flags & PARK_FLAGS_RCT1_INTEREST)
         ? (current_loan / 2400)
         : (current_loan * 5 * current_interest_rate) >> 14;
 
@@ -165,7 +165,7 @@ void FinancePayRideUpkeep()
             ride.Renew();
         }
 
-        if (ride.status != RideStatus::Closed && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY))
+        if (ride.status != RideStatus::Closed && !(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
         {
             auto upkeep = ride.upkeep_cost;
             if (upkeep != kMoney64Undefined)
@@ -190,7 +190,7 @@ void FinanceResetHistory()
     {
         gameState.CashHistory[i] = kMoney64Undefined;
         gameState.WeeklyProfitHistory[i] = kMoney64Undefined;
-        gameState.ParkValueHistory[i] = kMoney64Undefined;
+        gameState.Park.ValueHistory[i] = kMoney64Undefined;
     }
 
     for (uint32_t i = 0; i < EXPENDITURE_TABLE_MONTH_COUNT; ++i)
@@ -229,7 +229,7 @@ void FinanceInit()
     gameState.MaxBankLoan = 20000.00_GBP;
 
     gameState.BankLoanInterestRate = 10;
-    gameState.ParkValue = 0;
+    gameState.Park.Value = 0;
     gameState.CompanyValue = 0;
     gameState.HistoricalProfit = 0;
     gameState.ScenarioCompletedCompanyValue = kMoney64Undefined;
@@ -252,7 +252,7 @@ void FinanceUpdateDailyProfit()
 
     money64 current_profit = 0;
 
-    if (!(gameState.ParkFlags & PARK_FLAGS_NO_MONEY))
+    if (!(gameState.Park.Flags & PARK_FLAGS_NO_MONEY))
     {
         // Staff costs
         for (auto peep : EntityList<Staff>())

--- a/src/openrct2/management/Marketing.cpp
+++ b/src/openrct2/management/Marketing.cpp
@@ -53,11 +53,11 @@ uint16_t MarketingGetCampaignGuestGenerationProbability(int32_t campaignType)
     switch (campaign->Type)
     {
         case ADVERTISING_CAMPAIGN_PARK_ENTRY_FREE:
-            if (ParkGetEntranceFee() < 4.00_GBP)
+            if (Park::GetEntranceFee() < 4.00_GBP)
                 probability /= 8;
             break;
         case ADVERTISING_CAMPAIGN_PARK_ENTRY_HALF_PRICE:
-            if (ParkGetEntranceFee() < 6.00_GBP)
+            if (Park::GetEntranceFee() < 6.00_GBP)
                 probability /= 8;
             break;
         case ADVERTISING_CAMPAIGN_RIDE_FREE:
@@ -177,12 +177,12 @@ bool MarketingIsCampaignTypeApplicable(int32_t campaignType)
     {
         case ADVERTISING_CAMPAIGN_PARK_ENTRY_FREE:
         case ADVERTISING_CAMPAIGN_PARK_ENTRY_HALF_PRICE:
-            if (!ParkEntranceFeeUnlocked())
+            if (!Park::EntranceFeeUnlocked())
                 return false;
             return true;
 
         case ADVERTISING_CAMPAIGN_RIDE_FREE:
-            if (!ParkRidePricesUnlocked())
+            if (!Park::RidePricesUnlocked())
                 return false;
 
             // fall-through

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -315,7 +315,7 @@ void ResearchUpdate()
         return;
     }
 
-    if ((gameState.ParkFlags & PARK_FLAGS_NO_MONEY) && gameState.ResearchFundingLevel == RESEARCH_FUNDING_NONE)
+    if ((gameState.Park.Flags & PARK_FLAGS_NO_MONEY) && gameState.ResearchFundingLevel == RESEARCH_FUNDING_NONE)
     {
         researchLevel = RESEARCH_FUNDING_NORMAL;
     }

--- a/src/openrct2/network/DiscordService.cpp
+++ b/src/openrct2/network/DiscordService.cpp
@@ -63,12 +63,8 @@ DiscordService::~DiscordService()
 
 static std::string GetParkName()
 {
-    auto gameState = OpenRCT2::GetContext()->GetGameState();
-    if (gameState != nullptr)
-    {
-        return gameState->GetPark().Name;
-    }
-    return {};
+    auto& gameState = OpenRCT2::GetGameState();
+    return gameState.Park.Name;
 }
 
 void DiscordService::Tick()

--- a/src/openrct2/network/NetworkServerAdvertiser.cpp
+++ b/src/openrct2/network/NetworkServerAdvertiser.cpp
@@ -309,10 +309,10 @@ private:
             { "day", date.GetMonthTicks() },
             { "month", date.GetMonthsElapsed() },
             { "guests", gameState.NumGuestsInPark },
-            { "parkValue", gameState.ParkValue },
+            { "parkValue", gameState.Park.Value },
         };
 
-        if (!(gameState.ParkFlags & PARK_FLAGS_NO_MONEY))
+        if (!(gameState.Park.Flags & PARK_FLAGS_NO_MONEY))
         {
             gameInfo["cash"] = gameState.Cash;
         }

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -220,7 +220,7 @@ static void PaintParkEntranceScrollingText(
         return;
 
     auto ft = Formatter();
-    if (GetGameState().ParkFlags & PARK_FLAGS_PARK_OPEN)
+    if (GetGameState().Park.Flags & PARK_FLAGS_PARK_OPEN)
     {
         const auto& park = OpenRCT2::GetGameState().Park;
         auto name = park.Name.c_str();

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -222,7 +222,7 @@ static void PaintParkEntranceScrollingText(
     auto ft = Formatter();
     if (GetGameState().ParkFlags & PARK_FLAGS_PARK_OPEN)
     {
-        const auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+        const auto& park = OpenRCT2::GetGameState().Park;
         auto name = park.Name.c_str();
         ft.Add<StringId>(STR_STRING);
         ft.Add<const char*>(name);

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -484,7 +484,7 @@ namespace OpenRCT2
                     uint32_t monthsElapsed;
                     cs.ReadWrite(monthTicks);
                     cs.ReadWrite(monthsElapsed);
-                    gameState.Date = Date(monthsElapsed, monthTicks);
+                    gameState.Date = Date{ monthsElapsed, monthTicks };
                 }
                 else
                 {

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -420,11 +420,7 @@ namespace OpenRCT2
             os.ReadWriteChunk(ParkFileChunkType::SCENARIO, [&gameState, &os](OrcaStream::ChunkStream& cs) {
                 cs.ReadWrite(gameState.ScenarioCategory);
                 ReadWriteStringTable(cs, gameState.ScenarioName, "en-GB");
-
-                // TODO: Use the passed gameState instead of the global one.
-                auto& park = GetContext()->GetGameState()->GetPark();
-                ReadWriteStringTable(cs, park.Name, "en-GB");
-
+                ReadWriteStringTable(cs, gameState.Park.Name, "en-GB");
                 ReadWriteStringTable(cs, gameState.ScenarioDetails, "en-GB");
 
                 cs.ReadWrite(gameState.ScenarioObjective.Type);
@@ -653,8 +649,7 @@ namespace OpenRCT2
 
         void ReadWritePluginStorageChunk(GameState_t& gameState, OrcaStream& os)
         {
-            // TODO: Use the passed gameState instead of the global one.
-            auto& park = GetContext()->GetGameState()->GetPark();
+            auto& park = gameState.Park;
             if (os.GetMode() == OrcaStream::Mode::WRITING)
             {
 #ifdef ENABLE_SCRIPTING
@@ -798,9 +793,7 @@ namespace OpenRCT2
         {
             os.ReadWriteChunk(
                 ParkFileChunkType::PARK, [version = os.GetHeader().TargetVersion, &gameState](OrcaStream::ChunkStream& cs) {
-                    // TODO: Use the passed gameState instead of the global one.
-                    auto& park = GetContext()->GetGameState()->GetPark();
-                    cs.ReadWrite(park.Name);
+                    cs.ReadWrite(gameState.Park.Name);
                     cs.ReadWrite(gameState.Cash);
                     cs.ReadWrite(gameState.BankLoan);
                     cs.ReadWrite(gameState.MaxBankLoan);

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -649,29 +649,29 @@ namespace OpenRCT2
 
         void ReadWritePluginStorageChunk(GameState_t& gameState, OrcaStream& os)
         {
-            auto& park = gameState.Park;
             if (os.GetMode() == OrcaStream::Mode::WRITING)
             {
 #ifdef ENABLE_SCRIPTING
                 // Dump the plugin storage to JSON (stored in park)
                 auto& scriptEngine = GetContext()->GetScriptEngine();
-                park.PluginStorage = scriptEngine.GetParkStorageAsJSON();
+                gameState.PluginStorage = scriptEngine.GetParkStorageAsJSON();
 #endif
-                if (park.PluginStorage.empty() || park.PluginStorage == "{}")
+                if (gameState.PluginStorage.empty() || gameState.PluginStorage == "{}")
                 {
                     // Don't write the chunk if there is no plugin storage
                     return;
                 }
             }
 
-            os.ReadWriteChunk(
-                ParkFileChunkType::PLUGIN_STORAGE, [&park](OrcaStream::ChunkStream& cs) { cs.ReadWrite(park.PluginStorage); });
+            os.ReadWriteChunk(ParkFileChunkType::PLUGIN_STORAGE, [&gameState](OrcaStream::ChunkStream& cs) {
+                cs.ReadWrite(gameState.PluginStorage);
+            });
 
             if (os.GetMode() == OrcaStream::Mode::READING)
             {
 #ifdef ENABLE_SCRIPTING
                 auto& scriptEngine = GetContext()->GetScriptEngine();
-                scriptEngine.SetParkStorageFromJSON(park.PluginStorage);
+                scriptEngine.SetParkStorageFromJSON(gameState.PluginStorage);
 #endif
             }
         }

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -798,16 +798,16 @@ namespace OpenRCT2
                     cs.ReadWrite(gameState.BankLoan);
                     cs.ReadWrite(gameState.MaxBankLoan);
                     cs.ReadWrite(gameState.BankLoanInterestRate);
-                    cs.ReadWrite(gameState.ParkFlags);
+                    cs.ReadWrite(gameState.Park.Flags);
                     if (version <= 18)
                     {
                         money16 tempParkEntranceFee{};
                         cs.ReadWrite(tempParkEntranceFee);
-                        gameState.ParkEntranceFee = ToMoney64(tempParkEntranceFee);
+                        gameState.Park.EntranceFee = ToMoney64(tempParkEntranceFee);
                     }
                     else
                     {
-                        cs.ReadWrite(gameState.ParkEntranceFee);
+                        cs.ReadWrite(gameState.Park.EntranceFee);
                     }
 
                     cs.ReadWrite(gameState.StaffHandymanColour);
@@ -877,13 +877,13 @@ namespace OpenRCT2
                             cs.ReadWrite(award.Type);
                         });
                     }
-                    cs.ReadWrite(gameState.ParkValue);
+                    cs.ReadWrite(gameState.Park.Value);
                     cs.ReadWrite(gameState.CompanyValue);
-                    cs.ReadWrite(gameState.ParkSize);
+                    cs.ReadWrite(gameState.Park.Size);
                     cs.ReadWrite(gameState.NumGuestsInPark);
                     cs.ReadWrite(gameState.NumGuestsHeadingForPark);
-                    cs.ReadWrite(gameState.ParkRating);
-                    cs.ReadWrite(gameState.ParkRatingCasualtyPenalty);
+                    cs.ReadWrite(gameState.Park.Rating);
+                    cs.ReadWrite(gameState.Park.RatingCasualtyPenalty);
                     cs.ReadWrite(gameState.CurrentExpenditure);
                     cs.ReadWrite(gameState.CurrentProfit);
                     cs.ReadWrite(gameState.WeeklyProfitAverageDividend);
@@ -910,7 +910,7 @@ namespace OpenRCT2
                         return true;
                     });
 
-                    cs.ReadWriteArray(gameState.ParkRatingHistory, [&cs](uint8_t& value) {
+                    cs.ReadWriteArray(gameState.Park.RatingHistory, [&cs](uint8_t& value) {
                         cs.ReadWrite(value);
                         return true;
                     });
@@ -928,7 +928,7 @@ namespace OpenRCT2
                         cs.ReadWrite(value);
                         return true;
                     });
-                    cs.ReadWriteArray(gameState.ParkValueHistory, [&cs](money64& value) {
+                    cs.ReadWriteArray(gameState.Park.ValueHistory, [&cs](money64& value) {
                         cs.ReadWrite(value);
                         return true;
                     });

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -488,8 +488,7 @@ namespace OpenRCT2
                     uint32_t monthsElapsed;
                     cs.ReadWrite(monthTicks);
                     cs.ReadWrite(monthsElapsed);
-                    // TODO: Use the passed gameState instead of the global one.
-                    GetContext()->GetGameState()->SetDate(Date(monthsElapsed, monthTicks));
+                    gameState.Date = Date(monthsElapsed, monthTicks);
                 }
                 else
                 {

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1063,8 +1063,7 @@ namespace OpenRCT2
 
                     if (cs.GetMode() == OrcaStream::Mode::READING)
                     {
-                        // TODO: Use the passed gameState instead of the global one.
-                        OpenRCT2::GetContext()->GetGameState()->InitAll(gameState.MapSize);
+                        gameStateInitAll(gameState, gameState.MapSize);
 
                         auto numElements = cs.Read<uint32_t>();
 

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -1548,7 +1548,7 @@ namespace OpenRCT2::PathFinding
     {
         std::optional<CoordsXYZ> chosenEntrance = std::nullopt;
         uint16_t nearestDist = 0xFFFF;
-        for (const auto& parkEntrance : GetGameState().ParkEntrances)
+        for (const auto& parkEntrance : GetGameState().Park.Entrances)
         {
             auto dist = abs(parkEntrance.x - loc.x) + abs(parkEntrance.y - loc.y);
             if (dist < nearestDist)

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -326,8 +326,7 @@ namespace RCT1
             gScenarioFileName = GetRCT1ScenarioName();
 
             // Do map initialisation, same kind of stuff done when loading scenario editor
-            auto context = OpenRCT2::GetContext();
-            context->GetGameState()->InitAll({ mapSize, mapSize });
+            gameStateInitAll(gameState, { mapSize, mapSize });
             gameState.EditorStep = EditorStep::ObjectSelection;
             gameState.ParkFlags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
             gameState.ScenarioCategory = SCENARIO_CATEGORY_OTHER;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -275,7 +275,7 @@ namespace RCT1
                 {
                     // Use the ratio between the old and new park value to calcute the ratio to
                     // use for the park value history and the goal.
-                    auto& park = GetContext()->GetGameState()->GetPark();
+                    auto& park = GetGameState().Park;
                     _parkValueConversionFactor = (park.CalculateParkValue() * 10) / _s4.ParkValue;
                 }
                 else
@@ -2136,7 +2136,7 @@ namespace RCT1
                 }
             }
 
-            auto& park = GetContext()->GetGameState()->GetPark();
+            auto& park = GetGameState().Park;
             park.Name = std::move(parkName);
         }
 
@@ -2150,7 +2150,7 @@ namespace RCT1
             // Park rating
             gameState.ParkRating = _s4.ParkRating;
 
-            auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+            auto& park = OpenRCT2::GetGameState().Park;
             park.ResetHistories();
             std::copy(std::begin(_s4.ParkRatingHistory), std::end(_s4.ParkRatingHistory), gameState.ParkRatingHistory);
             for (size_t i = 0; i < std::size(_s4.GuestsInParkHistory); i++)
@@ -2351,7 +2351,7 @@ namespace RCT1
             gameState.ScenarioDetails = std::move(details);
             if (_isScenario && !parkName.empty())
             {
-                auto& park = GetContext()->GetGameState()->GetPark();
+                auto& park = GetGameState().Park;
                 park.Name = std::move(parkName);
             }
         }

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2145,7 +2145,7 @@ namespace RCT1
             // Date and srand
             gameState.CurrentTicks = _s4.Ticks;
             ScenarioRandSeed(_s4.RandomA, _s4.RandomB);
-            GetContext()->GetGameState()->SetDate(Date(_s4.Month, _s4.Day));
+            gameState.Date = Date(_s4.Month, _s4.Day);
 
             // Park rating
             gameState.ParkRating = _s4.ParkRating;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -275,8 +275,7 @@ namespace RCT1
                 {
                     // Use the ratio between the old and new park value to calcute the ratio to
                     // use for the park value history and the goal.
-                    auto& park = GetGameState().Park;
-                    _parkValueConversionFactor = (park.CalculateParkValue() * 10) / _s4.ParkValue;
+                    _parkValueConversionFactor = (CalculateParkValue() * 10) / _s4.ParkValue;
                 }
                 else
                 {
@@ -2149,8 +2148,7 @@ namespace RCT1
             // Park rating
             gameState.ParkRating = _s4.ParkRating;
 
-            auto& park = OpenRCT2::GetGameState().Park;
-            park.ResetHistories();
+            ResetParkHistories(gameState);
             std::copy(std::begin(_s4.ParkRatingHistory), std::end(_s4.ParkRatingHistory), gameState.ParkRatingHistory);
             for (size_t i = 0; i < std::size(_s4.GuestsInParkHistory); i++)
             {

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2144,7 +2144,7 @@ namespace RCT1
             // Date and srand
             gameState.CurrentTicks = _s4.Ticks;
             ScenarioRandSeed(_s4.RandomA, _s4.RandomB);
-            gameState.Date = Date(_s4.Month, _s4.Day);
+            gameState.Date = Date{ _s4.Month, _s4.Day };
 
             // Park rating
             gameState.ParkRating = _s4.ParkRating;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -275,7 +275,7 @@ namespace RCT1
                 {
                     // Use the ratio between the old and new park value to calcute the ratio to
                     // use for the park value history and the goal.
-                    _parkValueConversionFactor = (CalculateParkValue() * 10) / _s4.ParkValue;
+                    _parkValueConversionFactor = (Park::CalculateParkValue() * 10) / _s4.ParkValue;
                 }
                 else
                 {
@@ -327,7 +327,7 @@ namespace RCT1
             // Do map initialisation, same kind of stuff done when loading scenario editor
             gameStateInitAll(gameState, { mapSize, mapSize });
             gameState.EditorStep = EditorStep::ObjectSelection;
-            gameState.ParkFlags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
+            gameState.Park.Flags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
             gameState.ScenarioCategory = SCENARIO_CATEGORY_OTHER;
         }
 
@@ -1423,7 +1423,7 @@ namespace RCT1
 
         void ImportFinance(GameState_t& gameState)
         {
-            gameState.ParkEntranceFee = _s4.ParkEntranceFee;
+            gameState.Park.EntranceFee = _s4.ParkEntranceFee;
             gameState.LandPrice = ToMoney64(_s4.LandPrice);
             gameState.ConstructionRightsPrice = ToMoney64(_s4.ConstructionRightsPrice);
 
@@ -1435,13 +1435,13 @@ namespace RCT1
             gameState.InitialCash = ToMoney64(_s4.Cash);
 
             gameState.CompanyValue = ToMoney64(_s4.CompanyValue);
-            gameState.ParkValue = CorrectRCT1ParkValue(_s4.ParkValue);
+            gameState.Park.Value = CorrectRCT1ParkValue(_s4.ParkValue);
             gameState.CurrentProfit = ToMoney64(_s4.Profit);
 
             for (size_t i = 0; i < Limits::FinanceGraphSize; i++)
             {
                 gameState.CashHistory[i] = ToMoney64(_s4.CashHistory[i]);
-                gameState.ParkValueHistory[i] = CorrectRCT1ParkValue(_s4.ParkValueHistory[i]);
+                gameState.Park.ValueHistory[i] = CorrectRCT1ParkValue(_s4.ParkValueHistory[i]);
                 gameState.WeeklyProfitHistory[i] = ToMoney64(_s4.WeeklyProfitHistory[i]);
             }
 
@@ -2146,10 +2146,10 @@ namespace RCT1
             gameState.Date = Date{ _s4.Month, _s4.Day };
 
             // Park rating
-            gameState.ParkRating = _s4.ParkRating;
+            gameState.Park.Rating = _s4.ParkRating;
 
-            ResetParkHistories(gameState);
-            std::copy(std::begin(_s4.ParkRatingHistory), std::end(_s4.ParkRatingHistory), gameState.ParkRatingHistory);
+            Park::ResetHistories(gameState);
+            std::copy(std::begin(_s4.ParkRatingHistory), std::end(_s4.ParkRatingHistory), gameState.Park.RatingHistory);
             for (size_t i = 0; i < std::size(_s4.GuestsInParkHistory); i++)
             {
                 if (_s4.GuestsInParkHistory[i] != RCT12ParkHistoryUndefined)
@@ -2222,17 +2222,17 @@ namespace RCT1
             gameState.StaffSecurityColour = RCT1::GetColour(_s4.SecurityGuardColour);
 
             // Flags
-            gameState.ParkFlags = _s4.ParkFlags;
-            gameState.ParkFlags &= ~PARK_FLAGS_ANTI_CHEAT_DEPRECATED;
-            gameState.ParkFlags |= PARK_FLAGS_RCT1_INTEREST;
+            gameState.Park.Flags = _s4.ParkFlags;
+            gameState.Park.Flags &= ~PARK_FLAGS_ANTI_CHEAT_DEPRECATED;
+            gameState.Park.Flags |= PARK_FLAGS_RCT1_INTEREST;
             // Loopy Landscape parks can set a flag to lock the entry price to free.
             // If this flag is not set, the player can ask money for both rides and entry.
             if (!(_s4.ParkFlags & RCT1_PARK_FLAGS_PARK_ENTRY_LOCKED_AT_FREE))
             {
-                gameState.ParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
+                gameState.Park.Flags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
             }
 
-            gameState.ParkSize = _s4.ParkSize;
+            gameState.Park.Size = _s4.ParkSize;
             gameState.TotalRideValueForMoney = _s4.TotalRideValueForMoney;
             gameState.SamePriceThroughoutPark = 0;
             if (_gameVersion == FILE_VERSION_RCT1_LL)
@@ -2444,10 +2444,10 @@ namespace RCT1
         void FixEntrancePositions()
         {
             auto& gameState = GetGameState();
-            gameState.ParkEntrances.clear();
+            gameState.Park.Entrances.clear();
             TileElementIterator it;
             TileElementIteratorBegin(&it);
-            while (TileElementIteratorNext(&it) && gameState.ParkEntrances.size() < Limits::MaxParkEntrances)
+            while (TileElementIteratorNext(&it) && gameState.Park.Entrances.size() < Limits::MaxParkEntrances)
             {
                 TileElement* element = it.element;
 
@@ -2459,7 +2459,7 @@ namespace RCT1
                     continue;
 
                 CoordsXYZD entrance = { TileCoordsXY(it.x, it.y).ToCoordsXY(), element->GetBaseZ(), element->GetDirection() };
-                gameState.ParkEntrances.push_back(entrance);
+                gameState.Park.Entrances.push_back(entrance);
             }
         }
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -307,8 +307,7 @@ namespace RCT2
 
             gameState.ParkRating = _s6.ParkRating;
 
-            auto& park = OpenRCT2::GetGameState().Park;
-            park.ResetHistories();
+            ResetParkHistories(gameState);
             std::copy(std::begin(_s6.ParkRatingHistory), std::end(_s6.ParkRatingHistory), gameState.ParkRatingHistory);
             for (size_t i = 0; i < std::size(_s6.GuestsInParkHistory); i++)
             {
@@ -504,7 +503,7 @@ namespace RCT2
             ConvertScenarioStringsToUTF8(gameState);
             DetermineRideEntranceAndExitLocations();
 
-            park.Name = GetUserString(_s6.ParkName);
+            gameState.Park.Name = GetUserString(_s6.ParkName);
 
             FixLandOwnership();
             FixWater();

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -263,18 +263,18 @@ namespace RCT2
             gameState.InitialCash = ToMoney64(_s6.InitialCash);
             gameState.BankLoan = ToMoney64(_s6.CurrentLoan);
 
-            gameState.ParkFlags = _s6.ParkFlags & ~PARK_FLAGS_NO_MONEY_SCENARIO;
+            gameState.Park.Flags = _s6.ParkFlags & ~PARK_FLAGS_NO_MONEY_SCENARIO;
 
             // RCT2 used a different flag for `no money` when the park is a scenario
             if (_s6.Header.Type == S6_TYPE_SCENARIO)
             {
                 if (_s6.ParkFlags & PARK_FLAGS_NO_MONEY_SCENARIO)
-                    gameState.ParkFlags |= PARK_FLAGS_NO_MONEY;
+                    gameState.Park.Flags |= PARK_FLAGS_NO_MONEY;
                 else
-                    gameState.ParkFlags &= ~PARK_FLAGS_NO_MONEY;
+                    gameState.Park.Flags &= ~PARK_FLAGS_NO_MONEY;
             }
 
-            gameState.ParkEntranceFee = _s6.ParkEntranceFee;
+            gameState.Park.EntranceFee = _s6.ParkEntranceFee;
             // rct1_park_entranceX
             // rct1_park_entrance_y
             // Pad013573EE
@@ -305,10 +305,10 @@ namespace RCT2
             gameState.StaffMechanicColour = _s6.MechanicColour;
             gameState.StaffSecurityColour = _s6.SecurityColour;
 
-            gameState.ParkRating = _s6.ParkRating;
+            gameState.Park.Rating = _s6.ParkRating;
 
-            ResetParkHistories(gameState);
-            std::copy(std::begin(_s6.ParkRatingHistory), std::end(_s6.ParkRatingHistory), gameState.ParkRatingHistory);
+            Park::ResetHistories(gameState);
+            std::copy(std::begin(_s6.ParkRatingHistory), std::end(_s6.ParkRatingHistory), gameState.Park.RatingHistory);
             for (size_t i = 0; i < std::size(_s6.GuestsInParkHistory); i++)
             {
                 if (_s6.GuestsInParkHistory[i] != RCT12ParkHistoryUndefined)
@@ -336,7 +336,7 @@ namespace RCT2
             gameState.ResearchExpectedDay = _s6.NextResearchExpectedDay;
             gameState.ResearchExpectedMonth = _s6.NextResearchExpectedMonth;
             gameState.GuestInitialHappiness = _s6.GuestInitialHappiness;
-            gameState.ParkSize = _s6.ParkSize;
+            gameState.Park.Size = _s6.ParkSize;
             gameState.GuestGenerationProbability = _s6.GuestGenerationProbability;
             gameState.TotalRideValueForMoney = _s6.TotalRideValueForMoney;
             gameState.MaxBankLoan = ToMoney64(_s6.MaximumLoan);
@@ -361,13 +361,13 @@ namespace RCT2
             gameState.WeeklyProfitAverageDivisor = _s6.WeeklyProfitAverageDivisor;
             // Pad0135833A
 
-            gameState.ParkValue = ToMoney64(_s6.ParkValue);
+            gameState.Park.Value = ToMoney64(_s6.ParkValue);
 
             for (size_t i = 0; i < Limits::FinanceGraphSize; i++)
             {
                 gameState.CashHistory[i] = ToMoney64(_s6.BalanceHistory[i]);
                 gameState.WeeklyProfitHistory[i] = ToMoney64(_s6.WeeklyProfitHistory[i]);
-                gameState.ParkValueHistory[i] = ToMoney64(_s6.ParkValueHistory[i]);
+                gameState.Park.ValueHistory[i] = ToMoney64(_s6.ParkValueHistory[i]);
             }
 
             gameState.ScenarioCompletedCompanyValue = RCT12CompletedCompanyValueToOpenRCT2(_s6.CompletedCompanyValue);
@@ -400,7 +400,7 @@ namespace RCT2
             gameState.ScenarioCompletedBy = std::string_view(_s6.ScenarioCompletedName, sizeof(_s6.ScenarioCompletedName));
             gameState.Cash = ToMoney64(DECRYPT_MONEY(_s6.Cash));
             // Pad013587FC
-            gameState.ParkRatingCasualtyPenalty = _s6.ParkRatingCasualtyPenalty;
+            gameState.Park.RatingCasualtyPenalty = _s6.ParkRatingCasualtyPenalty;
             gameState.MapSize = { _s6.MapSize, _s6.MapSize };
             gameState.SamePriceThroughoutPark = _s6.SamePriceThroughout
                 | (static_cast<uint64_t>(_s6.SamePriceThroughoutExtended) << 32);
@@ -413,7 +413,7 @@ namespace RCT2
             gameState.BankLoanInterestRate = _s6.CurrentInterestRate;
             // Pad0135934B
             // Preserve compatibility with vanilla RCT2's save format.
-            gameState.ParkEntrances.clear();
+            gameState.Park.Entrances.clear();
             for (uint8_t i = 0; i < Limits::MaxParkEntrances; i++)
             {
                 if (_s6.ParkEntranceX[i] != LOCATION_NULL)
@@ -423,7 +423,7 @@ namespace RCT2
                     entrance.y = _s6.ParkEntranceY[i];
                     entrance.z = _s6.ParkEntranceZ[i];
                     entrance.direction = _s6.ParkEntranceDirection[i];
-                    gameState.ParkEntrances.push_back(entrance);
+                    gameState.Park.Entrances.push_back(entrance);
                 }
             }
             if (_s6.Header.Type == S6_TYPE_SCENARIO)

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -251,7 +251,7 @@ namespace RCT2
                 gameState.ScenarioDetails = loadMaybeUTF8(_s6.ScenarioDescription);
             }
 
-            OpenRCT2::GetContext()->GetGameState()->SetDate(OpenRCT2::Date(_s6.ElapsedMonths, _s6.CurrentDay));
+            gameState.Date = OpenRCT2::Date(_s6.ElapsedMonths, _s6.CurrentDay);
             gameState.CurrentTicks = _s6.GameTicks1;
 
             ScenarioRandSeed(_s6.ScenarioSrand0, _s6.ScenarioSrand1);

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -229,7 +229,7 @@ namespace RCT2
 
         void Import(GameState_t& gameState) override
         {
-            Initialise();
+            Initialise(gameState);
 
             gameState.EditorStep = _s6.Info.EditorStep;
             gameState.ScenarioCategory = static_cast<SCENARIO_CATEGORY>(_s6.Info.Category);
@@ -1719,9 +1719,9 @@ namespace RCT2
             dst->position.y = src->y;
         }
 
-        void Initialise()
+        void Initialise(GameState_t& gameState)
         {
-            OpenRCT2::GetContext()->GetGameState()->InitAll({ _s6.MapSize, _s6.MapSize });
+            gameStateInitAll(gameState, { _s6.MapSize, _s6.MapSize });
         }
 
         /**

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -307,7 +307,7 @@ namespace RCT2
 
             gameState.ParkRating = _s6.ParkRating;
 
-            auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+            auto& park = OpenRCT2::GetGameState().Park;
             park.ResetHistories();
             std::copy(std::begin(_s6.ParkRatingHistory), std::end(_s6.ParkRatingHistory), gameState.ParkRatingHistory);
             for (size_t i = 0; i < std::size(_s6.GuestsInParkHistory); i++)

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -251,7 +251,7 @@ namespace RCT2
                 gameState.ScenarioDetails = loadMaybeUTF8(_s6.ScenarioDescription);
             }
 
-            gameState.Date = OpenRCT2::Date(_s6.ElapsedMonths, _s6.CurrentDay);
+            gameState.Date = OpenRCT2::Date{ _s6.ElapsedMonths, _s6.CurrentDay };
             gameState.CurrentTicks = _s6.GameTicks1;
 
             ScenarioRandSeed(_s6.ScenarioSrand0, _s6.ScenarioSrand1);

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5321,11 +5321,11 @@ bool Ride::IsRide() const
 
 money64 RideGetPrice(const Ride& ride)
 {
-    if (GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY)
+    if (GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY)
         return 0;
     if (ride.IsRide())
     {
-        if (!ParkRidePricesUnlocked())
+        if (!Park::RidePricesUnlocked())
         {
             return 0;
         }

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1942,8 +1942,8 @@ static bool TrackDesignPlacePreview(TrackDesignState& tds, TrackDesign* td6, mon
 
     _trackDesignDrawingPreview = true;
     uint8_t backup_rotation = _currentTrackPieceDirection;
-    uint32_t backup_park_flags = gameState.ParkFlags;
-    gameState.ParkFlags &= ~PARK_FLAGS_FORBID_HIGH_CONSTRUCTION;
+    uint32_t backup_park_flags = gameState.Park.Flags;
+    gameState.Park.Flags &= ~PARK_FLAGS_FORBID_HIGH_CONSTRUCTION;
     auto mapSize = TileCoordsXY{ gameState.MapSize.x * 16, gameState.MapSize.y * 16 };
 
     _currentTrackPieceDirection = 0;
@@ -1967,7 +1967,7 @@ static bool TrackDesignPlacePreview(TrackDesignState& tds, TrackDesign* td6, mon
     auto res = TrackDesignPlaceVirtual(
         tds, td6, PTD_OPERATION_PLACE_TRACK_PREVIEW, placeScenery, *ride,
         { mapSize.x, mapSize.y, z, _currentTrackPieceDirection });
-    gameState.ParkFlags = backup_park_flags;
+    gameState.Park.Flags = backup_park_flags;
 
     if (res.Error == GameActions::Status::Ok)
     {

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -4530,9 +4530,9 @@ static void ride_train_crash(Ride& ride, uint16_t numFatalities)
         }
 
         auto& gameState = GetGameState();
-        if (gameState.ParkRatingCasualtyPenalty < 500)
+        if (gameState.Park.RatingCasualtyPenalty < 500)
         {
-            gameState.ParkRatingCasualtyPenalty += 200;
+            gameState.Park.RatingCasualtyPenalty += 200;
         }
     }
 }

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -149,7 +149,7 @@ void ScenarioReset(GameState_t& gameState)
     FinanceResetHistory();
     AwardReset();
     ResetAllRideBuildDates();
-    GetContext()->GetGameState()->ResetDate();
+    ResetDate();
     Duck::RemoveAll();
     ParkCalculateSize();
     MapCountRemainingLandRights();

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -100,9 +100,9 @@ void ScenarioReset(GameState_t& gameState)
     ScenerySetDefaultPlacementConfiguration();
     News::InitQueue();
 
-    gameState.ParkRating = CalculateParkRating();
-    gameState.ParkValue = CalculateParkValue();
-    gameState.CompanyValue = CalculateCompanyValue();
+    gameState.Park.Rating = Park::CalculateParkRating();
+    gameState.Park.Value = Park::CalculateParkValue();
+    gameState.CompanyValue = Park::CalculateCompanyValue();
     gameState.HistoricalProfit = gameState.InitialCash - gameState.BankLoan;
     gameState.Cash = gameState.InitialCash;
 
@@ -140,17 +140,17 @@ void ScenarioReset(GameState_t& gameState)
     gameState.TotalAdmissions = 0;
     gameState.TotalIncomeFromAdmissions = 0;
 
-    gameState.ParkFlags &= ~PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT;
+    gameState.Park.Flags &= ~PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT;
     gameState.ScenarioCompletedCompanyValue = kMoney64Undefined;
     gameState.ScenarioCompletedBy = "?";
 
-    ResetParkHistories(gameState);
+    Park::ResetHistories(gameState);
     FinanceResetHistory();
     AwardReset();
     ResetAllRideBuildDates();
     ResetDate();
     Duck::RemoveAll();
-    ParkUpdateSize(gameState);
+    Park::UpdateSize(gameState);
     MapCountRemainingLandRights();
     Staff::ResetStats();
 
@@ -163,16 +163,16 @@ void ScenarioReset(GameState_t& gameState)
     }
 
     gMarketingCampaigns.clear();
-    gameState.ParkRatingCasualtyPenalty = 0;
+    gameState.Park.RatingCasualtyPenalty = 0;
 
     // Open park with free entry when there is no money
-    if (gameState.ParkFlags & PARK_FLAGS_NO_MONEY)
+    if (gameState.Park.Flags & PARK_FLAGS_NO_MONEY)
     {
-        gameState.ParkFlags |= PARK_FLAGS_PARK_OPEN;
-        gameState.ParkEntranceFee = 0;
+        gameState.Park.Flags |= PARK_FLAGS_PARK_OPEN;
+        gameState.Park.EntranceFee = 0;
     }
 
-    gameState.ParkFlags |= PARK_FLAGS_SPRITES_INITIALISED;
+    gameState.Park.Flags |= PARK_FLAGS_SPRITES_INITIALISED;
     gGamePaused = false;
 }
 
@@ -208,7 +208,7 @@ void ScenarioSuccess(GameState_t& gameState)
     if (ScenarioRepositoryTryRecordHighscore(gScenarioFileName.c_str(), companyValue, nullptr))
     {
         // Allow name entry
-        GetGameState().ParkFlags |= PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT;
+        GetGameState().Park.Flags |= PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT;
         gameState.ScenarioCompanyValueRecord = companyValue;
     }
     ScenarioEnd();
@@ -224,7 +224,7 @@ void ScenarioSuccessSubmitName(GameState_t& gameState, const char* name)
     {
         gameState.ScenarioCompletedBy = name;
     }
-    gameState.ParkFlags &= ~PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT;
+    gameState.Park.Flags &= ~PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT;
 }
 
 /**
@@ -236,11 +236,11 @@ static void ScenarioCheckEntranceFeeTooHigh()
     const auto& gameState = GetGameState();
     const auto max_fee = AddClamp_money64(gameState.TotalRideValueForMoney, gameState.TotalRideValueForMoney / 2);
 
-    if ((gameState.ParkFlags & PARK_FLAGS_PARK_OPEN) && ParkGetEntranceFee() > max_fee)
+    if ((gameState.Park.Flags & PARK_FLAGS_PARK_OPEN) && Park::GetEntranceFee() > max_fee)
     {
-        if (!gameState.ParkEntrances.empty())
+        if (!gameState.Park.Entrances.empty())
         {
-            const auto& entrance = gameState.ParkEntrances[0];
+            const auto& entrance = gameState.Park.Entrances[0];
             auto x = entrance.x + 16;
             auto y = entrance.y + 16;
 
@@ -308,8 +308,8 @@ static void ScenarioDayUpdate(GameState_t& gameState)
     }
 
     // Lower the casualty penalty
-    uint16_t casualtyPenaltyModifier = (gameState.ParkFlags & PARK_FLAGS_NO_MONEY) ? 40 : 7;
-    gameState.ParkRatingCasualtyPenalty = std::max(0, gameState.ParkRatingCasualtyPenalty - casualtyPenaltyModifier);
+    uint16_t casualtyPenaltyModifier = (gameState.Park.Flags & PARK_FLAGS_NO_MONEY) ? 40 : 7;
+    gameState.Park.RatingCasualtyPenalty = std::max(0, gameState.Park.RatingCasualtyPenalty - casualtyPenaltyModifier);
 
     auto intent = Intent(INTENT_ACTION_UPDATE_DATE);
     ContextBroadcastIntent(&intent);
@@ -600,7 +600,7 @@ ResultWithMessage ScenarioPrepareForSave(GameState_t& gameState)
     }
 
     if (gameState.ScenarioObjective.Type == OBJECTIVE_GUESTS_AND_RATING)
-        GetGameState().ParkFlags |= PARK_FLAGS_PARK_OPEN;
+        GetGameState().Park.Flags |= PARK_FLAGS_PARK_OPEN;
 
     ScenarioReset(gameState);
 
@@ -609,7 +609,7 @@ ResultWithMessage ScenarioPrepareForSave(GameState_t& gameState)
 
 ObjectiveStatus Objective::CheckGuestsBy() const
 {
-    auto parkRating = GetGameState().ParkRating;
+    auto parkRating = GetGameState().Park.Rating;
     int32_t currentMonthYear = GetDate().GetMonthsElapsed();
 
     if (currentMonthYear == MONTH_COUNT * Year || AllowEarlyCompletion())
@@ -632,7 +632,7 @@ ObjectiveStatus Objective::CheckParkValueBy() const
 {
     int32_t currentMonthYear = GetDate().GetMonthsElapsed();
     money64 objectiveParkValue = Currency;
-    money64 parkValue = GetGameState().ParkValue;
+    money64 parkValue = GetGameState().Park.Value;
 
     if (currentMonthYear == MONTH_COUNT * Year || AllowEarlyCompletion())
     {
@@ -689,7 +689,7 @@ ObjectiveStatus Objective::Check10RollerCoasters() const
 ObjectiveStatus Objective::CheckGuestsAndRating() const
 {
     auto& gameState = GetGameState();
-    if (gameState.ParkRating < 700 && GetDate().GetMonthsElapsed() >= 1)
+    if (gameState.Park.Rating < 700 && GetDate().GetMonthsElapsed() >= 1)
     {
         gameState.ScenarioParkRatingWarningDays++;
         if (gameState.ScenarioParkRatingWarningDays == 1)
@@ -723,7 +723,7 @@ ObjectiveStatus Objective::CheckGuestsAndRating() const
         else if (gameState.ScenarioParkRatingWarningDays == 29)
         {
             News::AddItemToQueue(News::ItemType::Graph, STR_PARK_HAS_BEEN_CLOSED_DOWN, 0, {});
-            gameState.ParkFlags &= ~PARK_FLAGS_PARK_OPEN;
+            gameState.Park.Flags &= ~PARK_FLAGS_PARK_OPEN;
             gameState.GuestInitialHappiness = 50;
             return ObjectiveStatus::Failure;
         }
@@ -733,7 +733,7 @@ ObjectiveStatus Objective::CheckGuestsAndRating() const
         gameState.ScenarioParkRatingWarningDays = 0;
     }
 
-    if (gameState.ParkRating >= 700)
+    if (gameState.Park.Rating >= 700)
         if (gameState.NumGuestsInPark >= NumGuests)
             return ObjectiveStatus::Success;
 
@@ -817,7 +817,7 @@ ObjectiveStatus Objective::CheckFinish5RollerCoasters() const
 ObjectiveStatus Objective::CheckRepayLoanAndParkValue() const
 {
     const auto& gameState = GetGameState();
-    money64 parkValue = gameState.ParkValue;
+    money64 parkValue = gameState.Park.Value;
     money64 currentLoan = gameState.BankLoan;
 
     if (currentLoan <= 0 && parkValue >= Currency)

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -100,7 +100,7 @@ void ScenarioReset(GameState_t& gameState)
     ScenerySetDefaultPlacementConfiguration();
     News::InitQueue();
 
-    auto& park = GetContext()->GetGameState()->GetPark();
+    auto& park = GetGameState().Park;
     gameState.ParkRating = park.CalculateParkRating();
     gameState.ParkValue = park.CalculateParkValue();
     gameState.CompanyValue = park.CalculateCompanyValue();

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -100,10 +100,9 @@ void ScenarioReset(GameState_t& gameState)
     ScenerySetDefaultPlacementConfiguration();
     News::InitQueue();
 
-    auto& park = GetGameState().Park;
-    gameState.ParkRating = park.CalculateParkRating();
-    gameState.ParkValue = park.CalculateParkValue();
-    gameState.CompanyValue = park.CalculateCompanyValue();
+    gameState.ParkRating = CalculateParkRating();
+    gameState.ParkValue = CalculateParkValue();
+    gameState.CompanyValue = CalculateCompanyValue();
     gameState.HistoricalProfit = gameState.InitialCash - gameState.BankLoan;
     gameState.Cash = gameState.InitialCash;
 
@@ -120,7 +119,7 @@ void ScenarioReset(GameState_t& gameState)
             }
             if (localisedStringIds[1] != STR_NONE)
             {
-                park.Name = LanguageGetString(localisedStringIds[1]);
+                gameState.Park.Name = LanguageGetString(localisedStringIds[1]);
             }
             if (localisedStringIds[2] != STR_NONE)
             {
@@ -132,7 +131,7 @@ void ScenarioReset(GameState_t& gameState)
     // Set the last saved game path
     auto env = GetContext()->GetPlatformEnvironment();
     auto savePath = env->GetDirectoryPath(DIRBASE::USER, DIRID::SAVE);
-    gScenarioSavePath = Path::Combine(savePath, park.Name + u8".park");
+    gScenarioSavePath = Path::Combine(savePath, gameState.Park.Name + u8".park");
 
     gameState.CurrentExpenditure = 0;
     gameState.CurrentProfit = 0;
@@ -145,13 +144,13 @@ void ScenarioReset(GameState_t& gameState)
     gameState.ScenarioCompletedCompanyValue = kMoney64Undefined;
     gameState.ScenarioCompletedBy = "?";
 
-    park.ResetHistories();
+    ResetParkHistories(gameState);
     FinanceResetHistory();
     AwardReset();
     ResetAllRideBuildDates();
     ResetDate();
     Duck::RemoveAll();
-    ParkCalculateSize();
+    ParkUpdateSize(gameState);
     MapCountRemainingLandRights();
     Staff::ResetStats();
 

--- a/src/openrct2/scripting/bindings/world/ScDate.hpp
+++ b/src/openrct2/scripting/bindings/world/ScDate.hpp
@@ -43,10 +43,10 @@ namespace OpenRCT2::Scripting
             return date.GetMonthsElapsed();
         }
 
-        void monthsElapsed_set(int32_t value)
+        void monthsElapsed_set(uint32_t value)
         {
             ThrowIfGameStateNotMutable();
-            GetGameState().Date = Date(value, GetDate().GetMonthTicks());
+            GetGameState().Date = Date{ value, GetDate().GetMonthTicks() };
         }
 
         uint32_t monthProgress_get() const
@@ -58,7 +58,7 @@ namespace OpenRCT2::Scripting
         void monthProgress_set(int32_t value)
         {
             ThrowIfGameStateNotMutable();
-            GetGameState().Date = Date(GetDate().GetMonthsElapsed(), value);
+            GetGameState().Date = Date{ GetDate().GetMonthsElapsed(), static_cast<uint16_t>(value) };
         }
 
         uint32_t yearsElapsed_get() const

--- a/src/openrct2/scripting/bindings/world/ScDate.hpp
+++ b/src/openrct2/scripting/bindings/world/ScDate.hpp
@@ -46,7 +46,7 @@ namespace OpenRCT2::Scripting
         void monthsElapsed_set(int32_t value)
         {
             ThrowIfGameStateNotMutable();
-            GetContext()->GetGameState()->SetDate(Date(value, GetDate().GetMonthTicks()));
+            GetGameState().Date = Date(value, GetDate().GetMonthTicks());
         }
 
         uint32_t monthProgress_get() const
@@ -58,7 +58,7 @@ namespace OpenRCT2::Scripting
         void monthProgress_set(int32_t value)
         {
             ThrowIfGameStateNotMutable();
-            GetContext()->GetGameState()->SetDate(Date(GetDate().GetMonthsElapsed(), value));
+            GetGameState().Date = Date(GetDate().GetMonthsElapsed(), value);
         }
 
         uint32_t yearsElapsed_get() const
@@ -74,27 +74,17 @@ namespace OpenRCT2::Scripting
 
         int32_t day_get() const
         {
-            const auto& date = GetDate();
-            return date.GetDay() + 1;
+            return GetGameState().Date.GetDay() + 1;
         }
 
         int32_t month_get() const
         {
-            const auto& date = GetDate();
-            return date.GetMonth();
+            return GetGameState().Date.GetMonth();
         }
 
         int32_t year_get() const
         {
-            const auto& date = GetDate();
-            return date.GetYear() + 1;
-        }
-
-    private:
-        const Date& GetDate() const
-        {
-            auto gameState = GetContext()->GetGameState();
-            return gameState->GetDate();
+            return GetGameState().Date.GetYear() + 1;
         }
     };
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/world/ScPark.cpp
+++ b/src/openrct2/scripting/bindings/world/ScPark.cpp
@@ -68,7 +68,7 @@ namespace OpenRCT2::Scripting
 
     int32_t ScPark::rating_get() const
     {
-        return GetGameState().ParkRating;
+        return GetGameState().Park.Rating;
     }
     void ScPark::rating_set(int32_t value)
     {
@@ -76,9 +76,9 @@ namespace OpenRCT2::Scripting
 
         auto valueClamped = std::min(std::max(0, value), 999);
         auto& gameState = GetGameState();
-        if (gameState.ParkRating != valueClamped)
+        if (gameState.Park.Rating != valueClamped)
         {
-            gameState.ParkRating = std::min(std::max(0, value), 999);
+            gameState.Park.Rating = std::min(std::max(0, value), 999);
             auto intent = Intent(INTENT_ACTION_UPDATE_PARK_RATING);
             ContextBroadcastIntent(&intent);
         }
@@ -121,16 +121,16 @@ namespace OpenRCT2::Scripting
 
     money64 ScPark::entranceFee_get() const
     {
-        return GetGameState().ParkEntranceFee;
+        return GetGameState().Park.EntranceFee;
     }
     void ScPark::entranceFee_set(money64 value)
     {
         ThrowIfGameStateNotMutable();
 
         auto& gameState = GetGameState();
-        if (gameState.ParkEntranceFee != value)
+        if (gameState.Park.EntranceFee != value)
         {
-            gameState.ParkEntranceFee = value;
+            gameState.Park.EntranceFee = value;
             WindowInvalidateByClass(WindowClass::ParkInformation);
         }
     }
@@ -172,16 +172,16 @@ namespace OpenRCT2::Scripting
 
     money64 ScPark::value_get() const
     {
-        return GetGameState().ParkValue;
+        return GetGameState().Park.Value;
     }
     void ScPark::value_set(money64 value)
     {
         ThrowIfGameStateNotMutable();
 
         auto& gameState = GetGameState();
-        if (gameState.ParkValue != value)
+        if (gameState.Park.Value != value)
         {
-            gameState.ParkValue = value;
+            gameState.Park.Value = value;
             auto intent = Intent(INTENT_ACTION_UPDATE_CASH);
             ContextBroadcastIntent(&intent);
         }
@@ -263,17 +263,17 @@ namespace OpenRCT2::Scripting
 
     int16_t ScPark::casualtyPenalty_get() const
     {
-        return GetGameState().ParkRatingCasualtyPenalty;
+        return GetGameState().Park.RatingCasualtyPenalty;
     }
     void ScPark::casualtyPenalty_set(int16_t value)
     {
         ThrowIfGameStateNotMutable();
-        GetGameState().ParkRatingCasualtyPenalty = value;
+        GetGameState().Park.RatingCasualtyPenalty = value;
     }
 
     uint16_t ScPark::parkSize_get() const
     {
-        return GetGameState().ParkSize;
+        return GetGameState().Park.Size;
     }
 
     std::string ScPark::name_get() const
@@ -295,7 +295,7 @@ namespace OpenRCT2::Scripting
     bool ScPark::getFlag(const std::string& key) const
     {
         auto mask = ParkFlagMap[key];
-        return (GetGameState().ParkFlags & mask) != 0;
+        return (GetGameState().Park.Flags & mask) != 0;
     }
 
     void ScPark::setFlag(const std::string& key, bool value)
@@ -304,9 +304,9 @@ namespace OpenRCT2::Scripting
         auto mask = ParkFlagMap[key];
         auto& gameState = GetGameState();
         if (value)
-            gameState.ParkFlags |= mask;
+            gameState.Park.Flags |= mask;
         else
-            gameState.ParkFlags &= ~mask;
+            gameState.Park.Flags &= ~mask;
         GfxInvalidateScreen();
     }
 

--- a/src/openrct2/scripting/bindings/world/ScPark.cpp
+++ b/src/openrct2/scripting/bindings/world/ScPark.cpp
@@ -278,13 +278,13 @@ namespace OpenRCT2::Scripting
 
     std::string ScPark::name_get() const
     {
-        return GetContext()->GetGameState()->GetPark().Name;
+        return GetGameState().Park.Name;
     }
     void ScPark::name_set(std::string value)
     {
         ThrowIfGameStateNotMutable();
 
-        auto& park = GetContext()->GetGameState()->GetPark();
+        auto& park = GetGameState().Park;
         if (park.Name != value)
         {
             park.Name = std::move(value);

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -39,8 +39,7 @@ using namespace OpenRCT2;
 bool gPreviewingTitleSequenceInGame;
 static TitleScreen* _singleton = nullptr;
 
-TitleScreen::TitleScreen(GameState& gameState)
-    : _gameState(gameState)
+TitleScreen::TitleScreen()
 {
     _singleton = this;
 }
@@ -129,7 +128,7 @@ void TitleScreen::Load()
     GetContext()->GetNetwork().Close();
 #endif
     OpenRCT2::Audio::StopAll();
-    GetContext()->GetGameState()->InitAll(DEFAULT_MAP_SIZE);
+    gameStateInitAll(GetGameState(), DEFAULT_MAP_SIZE);
     ViewportInitAll();
     ContextOpenWindow(WindowClass::MainWindow);
     CreateWindows();
@@ -173,7 +172,7 @@ void TitleScreen::Tick()
         }
         for (int32_t i = 0; i < numUpdates; i++)
         {
-            _gameState.UpdateLogic();
+            gameStateUpdateLogic();
         }
         UpdatePaletteEffects();
         // update_weather_animation();
@@ -336,7 +335,7 @@ bool TitleScreen::TryLoadSequence(bool loadPreview)
         _loadedTitleSequenceId = SIZE_MAX;
         if (!loadPreview)
         {
-            GetContext()->GetGameState()->InitAll(DEFAULT_MAP_SIZE);
+            gameStateInitAll(GetGameState(), DEFAULT_MAP_SIZE);
             GameNotifyMapChanged();
         }
         return false;

--- a/src/openrct2/title/TitleScreen.h
+++ b/src/openrct2/title/TitleScreen.h
@@ -16,12 +16,10 @@ struct ITitleSequencePlayer;
 
 namespace OpenRCT2
 {
-    class GameState;
-
     class TitleScreen final
     {
     public:
-        TitleScreen(GameState& gameState);
+        TitleScreen();
         ~TitleScreen();
 
         ITitleSequencePlayer* GetSequencePlayer();
@@ -38,8 +36,6 @@ namespace OpenRCT2
         void ChangePresetSequence(size_t preset);
 
     private:
-        GameState& _gameState;
-
         ITitleSequencePlayer* _sequencePlayer = nullptr;
         size_t _loadedTitleSequenceId = SIZE_MAX;
         size_t _currentSequence = SIZE_MAX;

--- a/src/openrct2/world/ConstructionClearance.cpp
+++ b/src/openrct2/world/ConstructionClearance.cpp
@@ -36,13 +36,13 @@ static int32_t MapPlaceClearFunc(
     auto* scenery = (*tile_element)->AsSmallScenery()->GetEntry();
 
     auto& gameState = GetGameState();
-    if (gameState.ParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL)
+    if (gameState.Park.Flags & PARK_FLAGS_FORBID_TREE_REMOVAL)
     {
         if (scenery != nullptr && scenery->HasFlag(SMALL_SCENERY_FLAG_IS_TREE))
             return 1;
     }
 
-    if (!(gameState.ParkFlags & PARK_FLAGS_NO_MONEY) && scenery != nullptr)
+    if (!(gameState.Park.Flags & PARK_FLAGS_NO_MONEY) && scenery != nullptr)
         *price += scenery->removal_price;
 
     if (flags & GAME_COMMAND_FLAG_GHOST)
@@ -189,7 +189,7 @@ GameActions::Result MapCanConstructWithClearAt(
             }
         }
 
-        if (GetGameState().ParkFlags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION && !isTree)
+        if (GetGameState().Park.Flags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION && !isTree)
         {
             const auto heightFromGround = pos.clearanceZ - tileElement->GetBaseZ();
 

--- a/src/openrct2/world/Entrance.cpp
+++ b/src/openrct2/world/Entrance.cpp
@@ -70,7 +70,7 @@ void ParkEntranceRemoveGhost()
 int32_t ParkEntranceGetIndex(const CoordsXYZ& entrancePos)
 {
     int32_t i = 0;
-    for (const auto& entrance : GetGameState().ParkEntrances)
+    for (const auto& entrance : GetGameState().Park.Entrances)
     {
         if (entrancePos == entrance)
         {
@@ -83,7 +83,7 @@ int32_t ParkEntranceGetIndex(const CoordsXYZ& entrancePos)
 
 void ParkEntranceReset()
 {
-    GetGameState().ParkEntrances.clear();
+    GetGameState().Park.Entrances.clear();
 }
 
 void RideEntranceExitPlaceProvisionalGhost()
@@ -214,17 +214,17 @@ void ParkEntranceFixLocations(void)
 {
     auto& gameState = GetGameState();
     // Fix ParkEntrance locations for which the tile_element no longer exists
-    gameState.ParkEntrances.erase(
+    gameState.Park.Entrances.erase(
         std::remove_if(
-            gameState.ParkEntrances.begin(), gameState.ParkEntrances.end(),
+            gameState.Park.Entrances.begin(), gameState.Park.Entrances.end(),
             [](const auto& entrance) { return MapGetParkEntranceElementAt(entrance, false) == nullptr; }),
-        gameState.ParkEntrances.end());
+        gameState.Park.Entrances.end());
 }
 
 void ParkEntranceUpdateLocations()
 {
     auto& gameState = GetGameState();
-    gameState.ParkEntrances.clear();
+    gameState.Park.Entrances.clear();
     TileElementIterator it;
     TileElementIteratorBegin(&it);
     while (TileElementIteratorNext(&it))
@@ -234,7 +234,7 @@ void ParkEntranceUpdateLocations()
             && entranceElement->GetSequenceIndex() == 0 && !entranceElement->IsGhost())
         {
             auto entrance = TileCoordsXYZD(it.x, it.y, it.element->BaseHeight, it.element->GetDirection()).ToCoordsXYZD();
-            gameState.ParkEntrances.push_back(entrance);
+            gameState.Park.Entrances.push_back(entrance);
         }
     }
 }

--- a/src/openrct2/world/Entrance.h
+++ b/src/openrct2/world/Entrance.h
@@ -41,6 +41,7 @@ extern CoordsXYZD gRideEntranceExitGhostPosition;
 extern StationIndex gRideEntranceExitGhostStationIndex;
 
 void ParkEntranceRemoveGhost();
+int32_t ParkEntranceGetIndex(const CoordsXYZ& entrancePos);
 
 void ParkEntranceReset();
 void MazeEntranceHedgeReplacement(const CoordsXYE& entrance);

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1366,7 +1366,7 @@ void MapRemoveOutOfRangeElements()
                 if (surfaceElement != nullptr)
                 {
                     surfaceElement->SetOwnership(OWNERSHIP_UNOWNED);
-                    ParkUpdateFencesAroundTile({ x, y });
+                    Park::UpdateFencesAroundTile({ x, y });
                 }
                 ClearElementsAt({ x, y });
             }
@@ -1430,7 +1430,7 @@ void MapExtendBoundarySurfaceY()
             MapExtendBoundarySurfaceExtendTile(*existingTileElement, *newTileElement);
         }
 
-        ParkUpdateFences({ x << 5, y << 5 });
+        Park::UpdateFences({ x << 5, y << 5 });
     }
 }
 
@@ -1448,7 +1448,7 @@ void MapExtendBoundarySurfaceX()
         {
             MapExtendBoundarySurfaceExtendTile(*existingTileElement, *newTileElement);
         }
-        ParkUpdateFences({ x << 5, y << 5 });
+        Park::UpdateFences({ x << 5, y << 5 });
     }
 }
 
@@ -2229,7 +2229,7 @@ void FixLandOwnershipTilesWithOwnership(std::initializer_list<TileCoordsXY> tile
                 continue;
 
             surfaceElement->SetOwnership(ownership);
-            ParkUpdateFencesAroundTile({ (*tile).x * 32, (*tile).y * 32 });
+            Park::UpdateFencesAroundTile({ (*tile).x * 32, (*tile).y * 32 });
         }
     }
 }

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -47,725 +47,729 @@
 
 using namespace OpenRCT2;
 
-// If this value is more than or equal to 0, the park rating is forced to this value. Used for cheat
-static int32_t _forcedParkRating = -1;
-
-static money64 calculateRideValue(const Ride& ride);
-static money64 calculateTotalRideValueForMoney();
-static uint32_t calculateSuggestedMaxGuests();
-static uint32_t calculateGuestGenerationProbability();
-
-static void generateGuests(GameState_t& gameState);
-static Guest* generateGuestFromCampaign(int32_t campaign);
-
-/**
- * Choose a random peep spawn and iterates through until defined spawn is found.
- */
-static PeepSpawn* GetRandomPeepSpawn()
+namespace OpenRCT2::Park
 {
-    auto& gameState = GetGameState();
-    if (!gameState.PeepSpawns.empty())
+    // If this value is more than or equal to 0, the park rating is forced to this value. Used for cheat
+    static int32_t _forcedParkRating = -1;
+
+    static money64 calculateRideValue(const Ride& ride);
+    static money64 calculateTotalRideValueForMoney();
+    static uint32_t calculateSuggestedMaxGuests();
+    static uint32_t calculateGuestGenerationProbability();
+
+    static void generateGuests(GameState_t& gameState);
+    static Guest* generateGuestFromCampaign(int32_t campaign);
+
+    /**
+     * Choose a random peep spawn and iterates through until defined spawn is found.
+     */
+    static PeepSpawn* GetRandomPeepSpawn()
     {
-        return &gameState.PeepSpawns[ScenarioRand() % gameState.PeepSpawns.size()];
+        auto& gameState = GetGameState();
+        if (!gameState.PeepSpawns.empty())
+        {
+            return &gameState.PeepSpawns[ScenarioRand() % gameState.PeepSpawns.size()];
+        }
+
+        return nullptr;
     }
 
-    return nullptr;
-}
-
-void ParkSetOpen(bool open)
-{
-    auto parkSetParameter = ParkSetParameterAction(open ? ParkParameter::Open : ParkParameter::Close);
-    GameActions::Execute(&parkSetParameter);
-}
-
-/**
- *
- *  rct2: 0x00664D05
- */
-void ParkUpdateFences(const CoordsXY& coords)
-{
-    if (MapIsEdge(coords))
-        return;
-
-    auto surfaceElement = MapGetSurfaceElementAt(coords);
-    if (surfaceElement == nullptr)
-        return;
-
-    uint8_t newFences = 0;
-    if ((surfaceElement->GetOwnership() & OWNERSHIP_OWNED) == 0)
+    static money64 calculateRideValue(const Ride& ride)
     {
-        bool fenceRequired = true;
-
-        TileElement* tileElement = MapGetFirstElementAt(coords);
-        if (tileElement == nullptr)
-            return;
-        // If an entrance element do not place flags around surface
-        do
+        money64 result = 0;
+        if (ride.value != RIDE_VALUE_UNDEFINED)
         {
-            if (tileElement->GetType() != TileElementType::Entrance)
+            const auto& rtd = ride.GetRideTypeDescriptor();
+            result = (ride.value * 10) * (static_cast<money64>(RideCustomersInLast5Minutes(ride)) + rtd.BonusValue * 4LL);
+        }
+        return result;
+    }
+
+    static money64 calculateTotalRideValueForMoney()
+    {
+        money64 totalRideValue = 0;
+        bool ridePricesUnlocked = RidePricesUnlocked() && !(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY);
+        for (auto& ride : GetRideManager())
+        {
+            if (ride.status != RideStatus::Open)
+                continue;
+            if (ride.lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN)
+                continue;
+            if (ride.lifecycle_flags & RIDE_LIFECYCLE_CRASHED)
                 continue;
 
-            if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_PARK_ENTRANCE)
+            // Add ride value
+            if (ride.value != RIDE_VALUE_UNDEFINED)
+            {
+                money64 rideValue = ride.value;
+                if (ridePricesUnlocked)
+                {
+                    rideValue -= ride.price[0];
+                }
+                if (rideValue > 0)
+                {
+                    totalRideValue += rideValue * 2;
+                }
+            }
+        }
+        return totalRideValue;
+    }
+
+    static uint32_t calculateSuggestedMaxGuests()
+    {
+        uint32_t suggestedMaxGuests = 0;
+        uint32_t difficultGenerationBonus = 0;
+
+        auto& gameState = GetGameState();
+
+        for (auto& ride : GetRideManager())
+        {
+            if (ride.status != RideStatus::Open)
+                continue;
+            if (ride.lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN)
+                continue;
+            if (ride.lifecycle_flags & RIDE_LIFECYCLE_CRASHED)
                 continue;
 
-            if (!(tileElement->IsGhost()))
-            {
-                fenceRequired = false;
-                break;
-            }
-        } while (!(tileElement++)->IsLastForTile());
+            // Add guest score for ride type
+            suggestedMaxGuests += ride.GetRideTypeDescriptor().BonusValue;
 
-        if (fenceRequired)
+            // If difficult guest generation, extra guests are available for good rides
+            if (gameState.Park.Flags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION)
+            {
+                if (!(ride.lifecycle_flags & RIDE_LIFECYCLE_TESTED))
+                    continue;
+                if (!ride.GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_HAS_TRACK))
+                    continue;
+                if (!ride.GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_HAS_DATA_LOGGING))
+                    continue;
+                if (ride.GetStation().SegmentLength < (600 << 16))
+                    continue;
+                if (ride.excitement < RIDE_RATING(6, 00))
+                    continue;
+
+                // Bonus guests for good ride
+                difficultGenerationBonus += ride.GetRideTypeDescriptor().BonusValue * 2;
+            }
+        }
+
+        if (gameState.Park.Flags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION)
         {
-            if (MapIsLocationInPark({ coords.x - COORDS_XY_STEP, coords.y }))
-            {
-                newFences |= 0x8;
-            }
+            suggestedMaxGuests = std::min<uint32_t>(suggestedMaxGuests, 1000);
+            suggestedMaxGuests += difficultGenerationBonus;
+        }
 
-            if (MapIsLocationInPark({ coords.x, coords.y - COORDS_XY_STEP }))
-            {
-                newFences |= 0x4;
-            }
+        suggestedMaxGuests = std::min<uint32_t>(suggestedMaxGuests, 65535);
+        return suggestedMaxGuests;
+    }
 
-            if (MapIsLocationInPark({ coords.x + COORDS_XY_STEP, coords.y }))
-            {
-                newFences |= 0x2;
-            }
+    static uint32_t calculateGuestGenerationProbability()
+    {
+        auto& gameState = GetGameState();
 
-            if (MapIsLocationInPark({ coords.x, coords.y + COORDS_XY_STEP }))
+        // Begin with 50 + park rating
+        uint32_t probability = 50 + std::clamp(gameState.Park.Rating - 200, 0, 650);
+
+        // The more guests, the lower the chance of a new one
+        uint32_t numGuests = gameState.NumGuestsInPark + gameState.NumGuestsHeadingForPark;
+        if (numGuests > gameState.SuggestedGuestMaximum)
+        {
+            probability /= 4;
+            // Even lower for difficult guest generation
+            if (gameState.Park.Flags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION)
             {
-                newFences |= 0x1;
+                probability /= 4;
+            }
+        }
+
+        // Reduces chance for any more than 7000 guests
+        if (numGuests > 7000)
+        {
+            probability /= 4;
+        }
+
+        // Penalty for overpriced entrance fee relative to total ride value
+        auto entranceFee = GetEntranceFee();
+        if (entranceFee > gameState.TotalRideValueForMoney)
+        {
+            probability /= 4;
+            // Extra penalty for very overpriced entrance fee
+            if (entranceFee / 2 > gameState.TotalRideValueForMoney)
+            {
+                probability /= 4;
+            }
+        }
+
+        // Reward or penalties for park awards
+        for (const auto& award : GetGameState().CurrentAwards)
+        {
+            // +/- 0.25% of the probability
+            if (AwardIsPositive(award.Type))
+            {
+                probability += probability / 4;
+            }
+            else
+            {
+                probability -= probability / 4;
+            }
+        }
+
+        return probability;
+    }
+
+    static void generateGuests(GameState_t& gameState)
+    {
+        // Generate a new guest for some probability
+        if (static_cast<int32_t>(ScenarioRand() & 0xFFFF) < gameState.GuestGenerationProbability)
+        {
+            bool difficultGeneration = (gameState.Park.Flags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION) != 0;
+            if (!difficultGeneration || gameState.SuggestedGuestMaximum + 150 >= gameState.NumGuestsInPark)
+            {
+                GenerateGuest();
+            }
+        }
+
+        // Extra guests generated by advertising campaigns
+        for (const auto& campaign : gMarketingCampaigns)
+        {
+            // Random chance of guest generation
+            auto probability = MarketingGetCampaignGuestGenerationProbability(campaign.Type);
+            auto random = ScenarioRandMax(std::numeric_limits<uint16_t>::max());
+            if (random < probability)
+            {
+                generateGuestFromCampaign(campaign.Type);
             }
         }
     }
 
-    if (surfaceElement->GetParkFences() != newFences)
+    static Guest* generateGuestFromCampaign(int32_t campaign)
     {
-        int32_t baseZ = surfaceElement->GetBaseZ();
-        int32_t clearZ = baseZ + 16;
-        MapInvalidateTile({ coords, baseZ, clearZ });
-        surfaceElement->SetParkFences(newFences);
-    }
-}
-
-void ParkUpdateFencesAroundTile(const CoordsXY& coords)
-{
-    ParkUpdateFences(coords);
-    ParkUpdateFences({ coords.x + COORDS_XY_STEP, coords.y });
-    ParkUpdateFences({ coords.x - COORDS_XY_STEP, coords.y });
-    ParkUpdateFences({ coords.x, coords.y + COORDS_XY_STEP });
-    ParkUpdateFences({ coords.x, coords.y - COORDS_XY_STEP });
-}
-
-void ParkSetForcedRating(int32_t rating)
-{
-    _forcedParkRating = rating;
-    GetGameState().ParkRating = CalculateParkRating();
-    auto intent = Intent(INTENT_ACTION_UPDATE_PARK_RATING);
-    ContextBroadcastIntent(&intent);
-}
-
-int32_t ParkGetForcedRating()
-{
-    return _forcedParkRating;
-}
-
-money64 ParkGetEntranceFee()
-{
-    const auto& gameState = GetGameState();
-    if (gameState.ParkFlags & PARK_FLAGS_NO_MONEY)
-    {
-        return 0;
-    }
-    if (!ParkEntranceFeeUnlocked())
-    {
-        return 0;
-    }
-    return gameState.ParkEntranceFee;
-}
-
-bool ParkRidePricesUnlocked()
-{
-    const auto& gameState = GetGameState();
-    if (gameState.ParkFlags & PARK_FLAGS_UNLOCK_ALL_PRICES)
-    {
-        return true;
-    }
-    if (gameState.ParkFlags & PARK_FLAGS_PARK_FREE_ENTRY)
-    {
-        return true;
-    }
-    return false;
-}
-
-bool ParkEntranceFeeUnlocked()
-{
-    const auto& gameState = GetGameState();
-    if (gameState.ParkFlags & PARK_FLAGS_UNLOCK_ALL_PRICES)
-    {
-        return true;
-    }
-    if (!(gameState.ParkFlags & PARK_FLAGS_PARK_FREE_ENTRY))
-    {
-        return true;
-    }
-    return false;
-}
-
-bool Park::IsOpen() const
-{
-    return (GetGameState().ParkFlags & PARK_FLAGS_PARK_OPEN) != 0;
-}
-
-void ParkInitialise(GameState_t& gameState)
-{
-    gameState.Park.Name = LanguageGetString(STR_UNNAMED_PARK);
-    gameState.PluginStorage = {};
-    gameState.StaffHandymanColour = COLOUR_BRIGHT_RED;
-    gameState.StaffMechanicColour = COLOUR_LIGHT_BLUE;
-    gameState.StaffSecurityColour = COLOUR_YELLOW;
-    gameState.NumGuestsInPark = 0;
-    gameState.NumGuestsInParkLastWeek = 0;
-    gameState.NumGuestsHeadingForPark = 0;
-    gameState.GuestChangeModifier = 0;
-    gameState.ParkRating = 0;
-    gameState.GuestGenerationProbability = 0;
-    gameState.TotalRideValueForMoney = 0;
-    gameState.SuggestedGuestMaximum = 0;
-    gameState.ResearchLastItem = std::nullopt;
-    gMarketingCampaigns.clear();
-
-    ResearchResetItems(gameState);
-    FinanceInit();
-
-    SetEveryRideTypeNotInvented();
-
-    SetAllSceneryItemsInvented();
-
-    gameState.ParkEntranceFee = 10.00_GBP;
-
-    gameState.PeepSpawns.clear();
-    ParkEntranceReset();
-
-    gameState.ResearchPriorities = EnumsToFlags(
-        ResearchCategory::Transport, ResearchCategory::Gentle, ResearchCategory::Rollercoaster, ResearchCategory::Thrill,
-        ResearchCategory::Water, ResearchCategory::Shop, ResearchCategory::SceneryGroup);
-    gameState.ResearchFundingLevel = RESEARCH_FUNDING_NORMAL;
-
-    gameState.GuestInitialCash = 50.00_GBP;
-    gameState.GuestInitialHappiness = CalculateGuestInitialHappiness(50);
-    gameState.GuestInitialHunger = 200;
-    gameState.GuestInitialThirst = 200;
-    gameState.ScenarioObjective.Type = OBJECTIVE_GUESTS_BY;
-    gameState.ScenarioObjective.Year = 4;
-    gameState.ScenarioObjective.NumGuests = 1000;
-    gameState.LandPrice = 90.00_GBP;
-    gameState.ConstructionRightsPrice = 40.00_GBP;
-    gameState.ParkFlags = PARK_FLAGS_NO_MONEY | PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
-    ResetParkHistories(gameState);
-    FinanceResetHistory();
-    AwardReset();
-
-    gameState.ScenarioName.clear();
-    gameState.ScenarioDetails = String::ToStd(LanguageGetString(STR_NO_DETAILS_YET));
-}
-
-void ParkUpdate(GameState_t& gameState, const Date& date)
-{
-    PROFILED_FUNCTION();
-
-    // Every new week
-    if (date.IsWeekStart())
-    {
-        UpdateParkHistories(gameState);
+        auto peep = GenerateGuest();
+        if (peep != nullptr)
+        {
+            MarketingSetGuestCampaign(peep, campaign);
+        }
+        return peep;
     }
 
-    const auto currentTicks = gameState.CurrentTicks;
-
-    // Every ~13 seconds
-    if (currentTicks % 512 == 0)
+    template<typename T, size_t TSize> static void HistoryPushRecord(T history[TSize], T newItem)
     {
-        gameState.ParkRating = CalculateParkRating();
-        gameState.ParkValue = CalculateParkValue();
-        gameState.CompanyValue = CalculateCompanyValue();
-        gameState.TotalRideValueForMoney = calculateTotalRideValueForMoney();
-        gameState.SuggestedGuestMaximum = calculateSuggestedMaxGuests();
-        gameState.GuestGenerationProbability = calculateGuestGenerationProbability();
+        for (size_t i = TSize - 1; i > 0; i--)
+        {
+            history[i] = history[i - 1];
+        }
+        history[0] = newItem;
+    }
 
+    void Initialise(GameState_t& gameState)
+    {
+        gameState.Park.Name = LanguageGetString(STR_UNNAMED_PARK);
+        gameState.PluginStorage = {};
+        gameState.StaffHandymanColour = COLOUR_BRIGHT_RED;
+        gameState.StaffMechanicColour = COLOUR_LIGHT_BLUE;
+        gameState.StaffSecurityColour = COLOUR_YELLOW;
+        gameState.NumGuestsInPark = 0;
+        gameState.NumGuestsInParkLastWeek = 0;
+        gameState.NumGuestsHeadingForPark = 0;
+        gameState.GuestChangeModifier = 0;
+        gameState.Park.Rating = 0;
+        gameState.GuestGenerationProbability = 0;
+        gameState.TotalRideValueForMoney = 0;
+        gameState.SuggestedGuestMaximum = 0;
+        gameState.ResearchLastItem = std::nullopt;
+        gMarketingCampaigns.clear();
+
+        ResearchResetItems(gameState);
+        FinanceInit();
+
+        SetEveryRideTypeNotInvented();
+
+        SetAllSceneryItemsInvented();
+
+        gameState.Park.EntranceFee = 10.00_GBP;
+
+        gameState.PeepSpawns.clear();
+        ParkEntranceReset();
+
+        gameState.ResearchPriorities = EnumsToFlags(
+            ResearchCategory::Transport, ResearchCategory::Gentle, ResearchCategory::Rollercoaster, ResearchCategory::Thrill,
+            ResearchCategory::Water, ResearchCategory::Shop, ResearchCategory::SceneryGroup);
+        gameState.ResearchFundingLevel = RESEARCH_FUNDING_NORMAL;
+
+        gameState.GuestInitialCash = 50.00_GBP;
+        gameState.GuestInitialHappiness = Park::CalculateGuestInitialHappiness(50);
+        gameState.GuestInitialHunger = 200;
+        gameState.GuestInitialThirst = 200;
+        gameState.ScenarioObjective.Type = OBJECTIVE_GUESTS_BY;
+        gameState.ScenarioObjective.Year = 4;
+        gameState.ScenarioObjective.NumGuests = 1000;
+        gameState.LandPrice = 90.00_GBP;
+        gameState.ConstructionRightsPrice = 40.00_GBP;
+        gameState.Park.Flags = PARK_FLAGS_NO_MONEY | PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
+        ResetHistories(gameState);
+        FinanceResetHistory();
+        AwardReset();
+
+        gameState.ScenarioName.clear();
+        gameState.ScenarioDetails = String::ToStd(LanguageGetString(STR_NO_DETAILS_YET));
+    }
+
+    void Update(GameState_t& gameState, const Date& date)
+    {
+        PROFILED_FUNCTION();
+
+        // Every new week
+        if (date.IsWeekStart())
+        {
+            UpdateHistories(gameState);
+        }
+
+        const auto currentTicks = gameState.CurrentTicks;
+
+        // Every ~13 seconds
+        if (currentTicks % 512 == 0)
+        {
+            gameState.Park.Rating = CalculateParkRating();
+            gameState.Park.Value = Park::CalculateParkValue();
+            gameState.CompanyValue = CalculateCompanyValue();
+            gameState.TotalRideValueForMoney = calculateTotalRideValueForMoney();
+            gameState.SuggestedGuestMaximum = calculateSuggestedMaxGuests();
+            gameState.GuestGenerationProbability = calculateGuestGenerationProbability();
+
+            WindowInvalidateByClass(WindowClass::Finances);
+            auto intent = Intent(INTENT_ACTION_UPDATE_PARK_RATING);
+            ContextBroadcastIntent(&intent);
+        }
+
+        // Every ~102 seconds
+        if (currentTicks % 4096 == 0)
+        {
+            gameState.Park.Size = CalculateParkSize();
+            WindowInvalidateByClass(WindowClass::ParkInformation);
+        }
+
+        generateGuests(gameState);
+    }
+
+    uint32_t CalculateParkSize()
+    {
+        uint32_t tiles = 0;
+        TileElementIterator it;
+        TileElementIteratorBegin(&it);
+        do
+        {
+            if (it.element->GetType() == TileElementType::Surface)
+            {
+                if (it.element->AsSurface()->GetOwnership() & (OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED | OWNERSHIP_OWNED))
+                {
+                    tiles++;
+                }
+            }
+        } while (TileElementIteratorNext(&it));
+
+        auto& gameState = GetGameState();
+        if (tiles != gameState.Park.Size)
+        {
+            gameState.Park.Size = tiles;
+            WindowInvalidateByClass(WindowClass::ParkInformation);
+        }
+
+        return tiles;
+    }
+
+    int32_t CalculateParkRating()
+    {
+        if (_forcedParkRating >= 0)
+        {
+            return _forcedParkRating;
+        }
+
+        auto& gameState = GetGameState();
+        int32_t result = 1150;
+        if (gameState.Park.Flags & PARK_FLAGS_DIFFICULT_PARK_RATING)
+        {
+            result = 1050;
+        }
+
+        // Guests
+        {
+            // -150 to +3 based on a range of guests from 0 to 2000
+            result -= 150 - (std::min<int32_t>(2000, gameState.NumGuestsInPark) / 13);
+
+            // Find the number of happy peeps and the number of peeps who can't find the park exit
+            uint32_t happyGuestCount = 0;
+            uint32_t lostGuestCount = 0;
+            for (auto peep : EntityList<Guest>())
+            {
+                if (!peep->OutsideOfPark)
+                {
+                    if (peep->Happiness > 128)
+                    {
+                        happyGuestCount++;
+                    }
+                    if ((peep->PeepFlags & PEEP_FLAGS_LEAVING_PARK) && (peep->GuestIsLostCountdown < 90))
+                    {
+                        lostGuestCount++;
+                    }
+                }
+            }
+
+            // Peep happiness -500 to +0
+            result -= 500;
+            if (gameState.NumGuestsInPark > 0)
+            {
+                result += 2 * std::min(250u, (happyGuestCount * 300) / gameState.NumGuestsInPark);
+            }
+
+            // Up to 25 guests can be lost without affecting the park rating.
+            if (lostGuestCount > 25)
+            {
+                result -= (lostGuestCount - 25) * 7;
+            }
+        }
+
+        // Rides
+        {
+            int32_t rideCount = 0;
+            int32_t excitingRideCount = 0;
+            int32_t totalRideUptime = 0;
+            int32_t totalRideIntensity = 0;
+            int32_t totalRideExcitement = 0;
+            for (auto& ride : GetRideManager())
+            {
+                totalRideUptime += 100 - ride.downtime;
+                if (RideHasRatings(ride))
+                {
+                    totalRideExcitement += ride.excitement / 8;
+                    totalRideIntensity += ride.intensity / 8;
+                    excitingRideCount++;
+                }
+                rideCount++;
+            }
+            result -= 200;
+            if (rideCount > 0)
+            {
+                result += (totalRideUptime / rideCount) * 2;
+            }
+            result -= 100;
+            if (excitingRideCount > 0)
+            {
+                int32_t averageExcitement = totalRideExcitement / excitingRideCount;
+                int32_t averageIntensity = totalRideIntensity / excitingRideCount;
+
+                averageExcitement -= 46;
+                if (averageExcitement < 0)
+                {
+                    averageExcitement = -averageExcitement;
+                }
+
+                averageIntensity -= 65;
+                if (averageIntensity < 0)
+                {
+                    averageIntensity = -averageIntensity;
+                }
+
+                averageExcitement = std::min(averageExcitement / 2, 50);
+                averageIntensity = std::min(averageIntensity / 2, 50);
+                result += 100 - averageExcitement - averageIntensity;
+            }
+
+            totalRideExcitement = std::min<int32_t>(1000, totalRideExcitement);
+            totalRideIntensity = std::min<int32_t>(1000, totalRideIntensity);
+            result -= 200 - ((totalRideExcitement + totalRideIntensity) / 10);
+        }
+
+        // Litter
+        {
+            // Counts the amount of litter whose age is min. 7680 ticks (5~ min) old.
+            const auto litterList = EntityList<Litter>();
+            const auto litterCount = std::count_if(
+                litterList.begin(), litterList.end(), [](auto* litter) { return litter->GetAge() >= 7680; });
+
+            result -= 600 - (4 * (150 - std::min<int32_t>(150, litterCount)));
+        }
+
+        result -= gameState.Park.RatingCasualtyPenalty;
+        result = std::clamp(result, 0, 999);
+        return result;
+    }
+
+    money64 CalculateParkValue()
+    {
+        // Sum ride values
+        money64 result = 0;
+        for (const auto& ride : GetRideManager())
+        {
+            result += calculateRideValue(ride);
+        }
+
+        // +7.00 per guest
+        result += static_cast<money64>(GetGameState().NumGuestsInPark) * 7.00_GBP;
+
+        return result;
+    }
+
+    money64 CalculateCompanyValue()
+    {
+        const auto& gameState = GetGameState();
+
+        auto result = gameState.Park.Value - gameState.BankLoan;
+
+        // Clamp addition to prevent overflow
+        result = AddClamp_money64(result, FinanceGetCurrentCash());
+
+        return result;
+    }
+
+    uint8_t CalculateGuestInitialHappiness(uint8_t percentage)
+    {
+        percentage = std::clamp<uint8_t>(percentage, 15, 98);
+
+        // The percentages follow this sequence:
+        //   15 17 18 20 21 23 25 26 28 29 31 32 34 36 37 39 40 42 43 45 47 48 50 51 53...
+        // This sequence can be defined as PI*(9+n)/2 (the value is floored)
+        for (uint8_t n = 1; n < 55; n++)
+        {
+            // Avoid floating point math by rescaling PI up.
+            constexpr int32_t SCALE = 100000;
+            constexpr int32_t PI_SCALED = 314159; // PI * SCALE;
+            if (((PI_SCALED * (9 + n)) / SCALE) / 2 >= percentage)
+            {
+                return (9 + n) * 4;
+            }
+        }
+
+        // This is the lowest possible value:
+        return 40;
+    }
+
+    Guest* GenerateGuest()
+    {
+        Guest* peep = nullptr;
+        const auto spawn = GetRandomPeepSpawn();
+        if (spawn != nullptr)
+        {
+            auto direction = DirectionReverse(spawn->direction);
+            peep = Guest::Generate({ spawn->x, spawn->y, spawn->z });
+            if (peep != nullptr)
+            {
+                peep->Orientation = direction << 3;
+
+                auto destination = peep->GetLocation().ToTileCentre();
+                peep->SetDestination(destination, 5);
+                peep->PeepDirection = direction;
+                peep->Var37 = 0;
+                peep->State = PeepState::EnteringPark;
+            }
+        }
+        return peep;
+    }
+
+    void ResetHistories(GameState_t& gameState)
+    {
+        std::fill(std::begin(gameState.Park.RatingHistory), std::end(gameState.Park.RatingHistory), ParkRatingHistoryUndefined);
+        std::fill(
+            std::begin(gameState.GuestsInParkHistory), std::end(gameState.GuestsInParkHistory), GuestsInParkHistoryUndefined);
+    }
+
+    void UpdateHistories(GameState_t& gameState)
+    {
+        uint8_t guestChangeModifier = 1;
+        int32_t changeInGuestsInPark = static_cast<int32_t>(gameState.NumGuestsInPark)
+            - static_cast<int32_t>(gameState.NumGuestsInParkLastWeek);
+        if (changeInGuestsInPark > -20)
+        {
+            guestChangeModifier++;
+            if (changeInGuestsInPark < 20)
+            {
+                guestChangeModifier = 0;
+            }
+        }
+        gameState.GuestChangeModifier = guestChangeModifier;
+        gameState.NumGuestsInParkLastWeek = gameState.NumGuestsInPark;
+
+        // Update park rating, guests in park and current cash history
+        HistoryPushRecord<uint8_t, 32>(gameState.Park.RatingHistory, gameState.Park.Rating / 4);
+        HistoryPushRecord<uint32_t, 32>(gameState.GuestsInParkHistory, gameState.NumGuestsInPark);
+
+        constexpr auto cashHistorySize = std::extent_v<decltype(GameState_t::CashHistory)>;
+        HistoryPushRecord<money64, cashHistorySize>(gameState.CashHistory, FinanceGetCurrentCash() - gameState.BankLoan);
+
+        // Update weekly profit history
+        auto currentWeeklyProfit = gameState.WeeklyProfitAverageDividend;
+        if (gameState.WeeklyProfitAverageDivisor != 0)
+        {
+            currentWeeklyProfit /= gameState.WeeklyProfitAverageDivisor;
+        }
+        constexpr auto profitHistorySize = std::extent_v<decltype(GameState_t::WeeklyProfitHistory)>;
+        HistoryPushRecord<money64, profitHistorySize>(gameState.WeeklyProfitHistory, currentWeeklyProfit);
+        gameState.WeeklyProfitAverageDividend = 0;
+        gameState.WeeklyProfitAverageDivisor = 0;
+
+        // Update park value history
+        constexpr auto parkValueHistorySize = std::extent_v<decltype(GameState_t::WeeklyProfitHistory)>;
+        HistoryPushRecord<money64, parkValueHistorySize>(gameState.Park.ValueHistory, gameState.Park.Value);
+
+        // Invalidate relevant windows
+        auto intent = Intent(INTENT_ACTION_UPDATE_GUEST_COUNT);
+        ContextBroadcastIntent(&intent);
+        WindowInvalidateByClass(WindowClass::ParkInformation);
         WindowInvalidateByClass(WindowClass::Finances);
+    }
+
+    uint32_t UpdateSize(GameState_t& gameState)
+    {
+        auto tiles = CalculateParkSize();
+        if (tiles != gameState.Park.Size)
+        {
+            gameState.Park.Size = tiles;
+            WindowInvalidateByClass(WindowClass::ParkInformation);
+        }
+        return tiles;
+    }
+
+    void SetOpen(bool open)
+    {
+        auto parkSetParameter = ParkSetParameterAction(open ? ParkParameter::Open : ParkParameter::Close);
+        GameActions::Execute(&parkSetParameter);
+    }
+
+    /**
+     *
+     *  rct2: 0x00664D05
+     */
+    void UpdateFences(const CoordsXY& coords)
+    {
+        if (MapIsEdge(coords))
+            return;
+
+        auto surfaceElement = MapGetSurfaceElementAt(coords);
+        if (surfaceElement == nullptr)
+            return;
+
+        uint8_t newFences = 0;
+        if ((surfaceElement->GetOwnership() & OWNERSHIP_OWNED) == 0)
+        {
+            bool fenceRequired = true;
+
+            TileElement* tileElement = MapGetFirstElementAt(coords);
+            if (tileElement == nullptr)
+                return;
+            // If an entrance element do not place flags around surface
+            do
+            {
+                if (tileElement->GetType() != TileElementType::Entrance)
+                    continue;
+
+                if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_PARK_ENTRANCE)
+                    continue;
+
+                if (!(tileElement->IsGhost()))
+                {
+                    fenceRequired = false;
+                    break;
+                }
+            } while (!(tileElement++)->IsLastForTile());
+
+            if (fenceRequired)
+            {
+                if (MapIsLocationInPark({ coords.x - COORDS_XY_STEP, coords.y }))
+                {
+                    newFences |= 0x8;
+                }
+
+                if (MapIsLocationInPark({ coords.x, coords.y - COORDS_XY_STEP }))
+                {
+                    newFences |= 0x4;
+                }
+
+                if (MapIsLocationInPark({ coords.x + COORDS_XY_STEP, coords.y }))
+                {
+                    newFences |= 0x2;
+                }
+
+                if (MapIsLocationInPark({ coords.x, coords.y + COORDS_XY_STEP }))
+                {
+                    newFences |= 0x1;
+                }
+            }
+        }
+
+        if (surfaceElement->GetParkFences() != newFences)
+        {
+            int32_t baseZ = surfaceElement->GetBaseZ();
+            int32_t clearZ = baseZ + 16;
+            MapInvalidateTile({ coords, baseZ, clearZ });
+            surfaceElement->SetParkFences(newFences);
+        }
+    }
+
+    void UpdateFencesAroundTile(const CoordsXY& coords)
+    {
+        UpdateFences(coords);
+        UpdateFences({ coords.x + COORDS_XY_STEP, coords.y });
+        UpdateFences({ coords.x - COORDS_XY_STEP, coords.y });
+        UpdateFences({ coords.x, coords.y + COORDS_XY_STEP });
+        UpdateFences({ coords.x, coords.y - COORDS_XY_STEP });
+    }
+
+    void SetForcedRating(int32_t rating)
+    {
+        _forcedParkRating = rating;
+        GetGameState().Park.Rating = CalculateParkRating();
         auto intent = Intent(INTENT_ACTION_UPDATE_PARK_RATING);
         ContextBroadcastIntent(&intent);
     }
 
-    // Every ~102 seconds
-    if (currentTicks % 4096 == 0)
-    {
-        gameState.ParkSize = CalculateParkSize();
-        WindowInvalidateByClass(WindowClass::ParkInformation);
-    }
-
-    generateGuests(gameState);
-}
-
-uint32_t CalculateParkSize()
-{
-    uint32_t tiles = 0;
-    TileElementIterator it;
-    TileElementIteratorBegin(&it);
-    do
-    {
-        if (it.element->GetType() == TileElementType::Surface)
-        {
-            if (it.element->AsSurface()->GetOwnership() & (OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED | OWNERSHIP_OWNED))
-            {
-                tiles++;
-            }
-        }
-    } while (TileElementIteratorNext(&it));
-
-    auto& gameState = GetGameState();
-    if (tiles != gameState.ParkSize)
-    {
-        gameState.ParkSize = tiles;
-        WindowInvalidateByClass(WindowClass::ParkInformation);
-    }
-
-    return tiles;
-}
-
-int32_t CalculateParkRating()
-{
-    if (_forcedParkRating >= 0)
+    int32_t GetForcedRating()
     {
         return _forcedParkRating;
     }
 
-    auto& gameState = GetGameState();
-    int32_t result = 1150;
-    if (gameState.ParkFlags & PARK_FLAGS_DIFFICULT_PARK_RATING)
+    money64 GetEntranceFee()
     {
-        result = 1050;
-    }
-
-    // Guests
-    {
-        // -150 to +3 based on a range of guests from 0 to 2000
-        result -= 150 - (std::min<int32_t>(2000, gameState.NumGuestsInPark) / 13);
-
-        // Find the number of happy peeps and the number of peeps who can't find the park exit
-        uint32_t happyGuestCount = 0;
-        uint32_t lostGuestCount = 0;
-        for (auto peep : EntityList<Guest>())
+        const auto& gameState = GetGameState();
+        if (gameState.Park.Flags & PARK_FLAGS_NO_MONEY)
         {
-            if (!peep->OutsideOfPark)
-            {
-                if (peep->Happiness > 128)
-                {
-                    happyGuestCount++;
-                }
-                if ((peep->PeepFlags & PEEP_FLAGS_LEAVING_PARK) && (peep->GuestIsLostCountdown < 90))
-                {
-                    lostGuestCount++;
-                }
-            }
+            return 0;
         }
-
-        // Peep happiness -500 to +0
-        result -= 500;
-        if (gameState.NumGuestsInPark > 0)
+        if (!EntranceFeeUnlocked())
         {
-            result += 2 * std::min(250u, (happyGuestCount * 300) / gameState.NumGuestsInPark);
+            return 0;
         }
+        return gameState.Park.EntranceFee;
+    }
 
-        // Up to 25 guests can be lost without affecting the park rating.
-        if (lostGuestCount > 25)
+    bool RidePricesUnlocked()
+    {
+        const auto& gameState = GetGameState();
+        if (gameState.Park.Flags & PARK_FLAGS_UNLOCK_ALL_PRICES)
         {
-            result -= (lostGuestCount - 25) * 7;
+            return true;
         }
-    }
-
-    // Rides
-    {
-        int32_t rideCount = 0;
-        int32_t excitingRideCount = 0;
-        int32_t totalRideUptime = 0;
-        int32_t totalRideIntensity = 0;
-        int32_t totalRideExcitement = 0;
-        for (auto& ride : GetRideManager())
+        if (gameState.Park.Flags & PARK_FLAGS_PARK_FREE_ENTRY)
         {
-            totalRideUptime += 100 - ride.downtime;
-            if (RideHasRatings(ride))
-            {
-                totalRideExcitement += ride.excitement / 8;
-                totalRideIntensity += ride.intensity / 8;
-                excitingRideCount++;
-            }
-            rideCount++;
+            return true;
         }
-        result -= 200;
-        if (rideCount > 0)
+        return false;
+    }
+
+    bool EntranceFeeUnlocked()
+    {
+        const auto& gameState = GetGameState();
+        if (gameState.Park.Flags & PARK_FLAGS_UNLOCK_ALL_PRICES)
         {
-            result += (totalRideUptime / rideCount) * 2;
+            return true;
         }
-        result -= 100;
-        if (excitingRideCount > 0)
+        if (!(gameState.Park.Flags & PARK_FLAGS_PARK_FREE_ENTRY))
         {
-            int32_t averageExcitement = totalRideExcitement / excitingRideCount;
-            int32_t averageIntensity = totalRideIntensity / excitingRideCount;
-
-            averageExcitement -= 46;
-            if (averageExcitement < 0)
-            {
-                averageExcitement = -averageExcitement;
-            }
-
-            averageIntensity -= 65;
-            if (averageIntensity < 0)
-            {
-                averageIntensity = -averageIntensity;
-            }
-
-            averageExcitement = std::min(averageExcitement / 2, 50);
-            averageIntensity = std::min(averageIntensity / 2, 50);
-            result += 100 - averageExcitement - averageIntensity;
+            return true;
         }
-
-        totalRideExcitement = std::min<int32_t>(1000, totalRideExcitement);
-        totalRideIntensity = std::min<int32_t>(1000, totalRideIntensity);
-        result -= 200 - ((totalRideExcitement + totalRideIntensity) / 10);
+        return false;
     }
 
-    // Litter
+    bool ParkData::IsOpen() const
     {
-        // Counts the amount of litter whose age is min. 7680 ticks (5~ min) old.
-        const auto litterList = EntityList<Litter>();
-        const auto litterCount = std::count_if(
-            litterList.begin(), litterList.end(), [](auto* litter) { return litter->GetAge() >= 7680; });
-
-        result -= 600 - (4 * (150 - std::min<int32_t>(150, litterCount)));
+        return (Flags & PARK_FLAGS_PARK_OPEN) != 0;
     }
-
-    result -= gameState.ParkRatingCasualtyPenalty;
-    result = std::clamp(result, 0, 999);
-    return result;
-}
-
-money64 CalculateParkValue()
-{
-    // Sum ride values
-    money64 result = 0;
-    for (const auto& ride : GetRideManager())
-    {
-        result += calculateRideValue(ride);
-    }
-
-    // +7.00 per guest
-    result += static_cast<money64>(GetGameState().NumGuestsInPark) * 7.00_GBP;
-
-    return result;
-}
-
-static money64 calculateRideValue(const Ride& ride)
-{
-    money64 result = 0;
-    if (ride.value != RIDE_VALUE_UNDEFINED)
-    {
-        const auto& rtd = ride.GetRideTypeDescriptor();
-        result = (ride.value * 10) * (static_cast<money64>(RideCustomersInLast5Minutes(ride)) + rtd.BonusValue * 4LL);
-    }
-    return result;
-}
-
-money64 CalculateCompanyValue()
-{
-    const auto& gameState = GetGameState();
-
-    auto result = gameState.ParkValue - gameState.BankLoan;
-
-    // Clamp addition to prevent overflow
-    result = AddClamp_money64(result, FinanceGetCurrentCash());
-
-    return result;
-}
-
-static money64 calculateTotalRideValueForMoney()
-{
-    money64 totalRideValue = 0;
-    bool ridePricesUnlocked = ParkRidePricesUnlocked() && !(GetGameState().ParkFlags & PARK_FLAGS_NO_MONEY);
-    for (auto& ride : GetRideManager())
-    {
-        if (ride.status != RideStatus::Open)
-            continue;
-        if (ride.lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN)
-            continue;
-        if (ride.lifecycle_flags & RIDE_LIFECYCLE_CRASHED)
-            continue;
-
-        // Add ride value
-        if (ride.value != RIDE_VALUE_UNDEFINED)
-        {
-            money64 rideValue = ride.value;
-            if (ridePricesUnlocked)
-            {
-                rideValue -= ride.price[0];
-            }
-            if (rideValue > 0)
-            {
-                totalRideValue += rideValue * 2;
-            }
-        }
-    }
-    return totalRideValue;
-}
-
-static uint32_t calculateSuggestedMaxGuests()
-{
-    uint32_t suggestedMaxGuests = 0;
-    uint32_t difficultGenerationBonus = 0;
-
-    auto& gameState = GetGameState();
-
-    for (auto& ride : GetRideManager())
-    {
-        if (ride.status != RideStatus::Open)
-            continue;
-        if (ride.lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN)
-            continue;
-        if (ride.lifecycle_flags & RIDE_LIFECYCLE_CRASHED)
-            continue;
-
-        // Add guest score for ride type
-        suggestedMaxGuests += ride.GetRideTypeDescriptor().BonusValue;
-
-        // If difficult guest generation, extra guests are available for good rides
-        if (gameState.ParkFlags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION)
-        {
-            if (!(ride.lifecycle_flags & RIDE_LIFECYCLE_TESTED))
-                continue;
-            if (!ride.GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_HAS_TRACK))
-                continue;
-            if (!ride.GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_HAS_DATA_LOGGING))
-                continue;
-            if (ride.GetStation().SegmentLength < (600 << 16))
-                continue;
-            if (ride.excitement < RIDE_RATING(6, 00))
-                continue;
-
-            // Bonus guests for good ride
-            difficultGenerationBonus += ride.GetRideTypeDescriptor().BonusValue * 2;
-        }
-    }
-
-    if (gameState.ParkFlags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION)
-    {
-        suggestedMaxGuests = std::min<uint32_t>(suggestedMaxGuests, 1000);
-        suggestedMaxGuests += difficultGenerationBonus;
-    }
-
-    suggestedMaxGuests = std::min<uint32_t>(suggestedMaxGuests, 65535);
-    return suggestedMaxGuests;
-}
-
-static uint32_t calculateGuestGenerationProbability()
-{
-    auto& gameState = GetGameState();
-
-    // Begin with 50 + park rating
-    uint32_t probability = 50 + std::clamp(gameState.ParkRating - 200, 0, 650);
-
-    // The more guests, the lower the chance of a new one
-    uint32_t numGuests = gameState.NumGuestsInPark + gameState.NumGuestsHeadingForPark;
-    if (numGuests > gameState.SuggestedGuestMaximum)
-    {
-        probability /= 4;
-        // Even lower for difficult guest generation
-        if (gameState.ParkFlags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION)
-        {
-            probability /= 4;
-        }
-    }
-
-    // Reduces chance for any more than 7000 guests
-    if (numGuests > 7000)
-    {
-        probability /= 4;
-    }
-
-    // Penalty for overpriced entrance fee relative to total ride value
-    auto entranceFee = ParkGetEntranceFee();
-    if (entranceFee > gameState.TotalRideValueForMoney)
-    {
-        probability /= 4;
-        // Extra penalty for very overpriced entrance fee
-        if (entranceFee / 2 > gameState.TotalRideValueForMoney)
-        {
-            probability /= 4;
-        }
-    }
-
-    // Reward or penalties for park awards
-    for (const auto& award : GetGameState().CurrentAwards)
-    {
-        // +/- 0.25% of the probability
-        if (AwardIsPositive(award.Type))
-        {
-            probability += probability / 4;
-        }
-        else
-        {
-            probability -= probability / 4;
-        }
-    }
-
-    return probability;
-}
-
-uint8_t CalculateGuestInitialHappiness(uint8_t percentage)
-{
-    percentage = std::clamp<uint8_t>(percentage, 15, 98);
-
-    // The percentages follow this sequence:
-    //   15 17 18 20 21 23 25 26 28 29 31 32 34 36 37 39 40 42 43 45 47 48 50 51 53...
-    // This sequence can be defined as PI*(9+n)/2 (the value is floored)
-    for (uint8_t n = 1; n < 55; n++)
-    {
-        // Avoid floating point math by rescaling PI up.
-        constexpr int32_t SCALE = 100000;
-        constexpr int32_t PI_SCALED = 314159; // PI * SCALE;
-        if (((PI_SCALED * (9 + n)) / SCALE) / 2 >= percentage)
-        {
-            return (9 + n) * 4;
-        }
-    }
-
-    // This is the lowest possible value:
-    return 40;
-}
-
-static void generateGuests(GameState_t& gameState)
-{
-    // Generate a new guest for some probability
-    if (static_cast<int32_t>(ScenarioRand() & 0xFFFF) < gameState.GuestGenerationProbability)
-    {
-        bool difficultGeneration = (gameState.ParkFlags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION) != 0;
-        if (!difficultGeneration || gameState.SuggestedGuestMaximum + 150 >= gameState.NumGuestsInPark)
-        {
-            GenerateGuest();
-        }
-    }
-
-    // Extra guests generated by advertising campaigns
-    for (const auto& campaign : gMarketingCampaigns)
-    {
-        // Random chance of guest generation
-        auto probability = MarketingGetCampaignGuestGenerationProbability(campaign.Type);
-        auto random = ScenarioRandMax(std::numeric_limits<uint16_t>::max());
-        if (random < probability)
-        {
-            generateGuestFromCampaign(campaign.Type);
-        }
-    }
-}
-
-static Guest* generateGuestFromCampaign(int32_t campaign)
-{
-    auto peep = GenerateGuest();
-    if (peep != nullptr)
-    {
-        MarketingSetGuestCampaign(peep, campaign);
-    }
-    return peep;
-}
-
-Guest* GenerateGuest()
-{
-    Guest* peep = nullptr;
-    const auto spawn = GetRandomPeepSpawn();
-    if (spawn != nullptr)
-    {
-        auto direction = DirectionReverse(spawn->direction);
-        peep = Guest::Generate({ spawn->x, spawn->y, spawn->z });
-        if (peep != nullptr)
-        {
-            peep->Orientation = direction << 3;
-
-            auto destination = peep->GetLocation().ToTileCentre();
-            peep->SetDestination(destination, 5);
-            peep->PeepDirection = direction;
-            peep->Var37 = 0;
-            peep->State = PeepState::EnteringPark;
-        }
-    }
-    return peep;
-}
-
-template<typename T, size_t TSize> static void HistoryPushRecord(T history[TSize], T newItem)
-{
-    for (size_t i = TSize - 1; i > 0; i--)
-    {
-        history[i] = history[i - 1];
-    }
-    history[0] = newItem;
-}
-
-void ResetParkHistories(GameState_t& gameState)
-{
-    std::fill(std::begin(gameState.ParkRatingHistory), std::end(gameState.ParkRatingHistory), ParkRatingHistoryUndefined);
-    std::fill(std::begin(gameState.GuestsInParkHistory), std::end(gameState.GuestsInParkHistory), GuestsInParkHistoryUndefined);
-}
-
-void UpdateParkHistories(GameState_t& gameState)
-{
-    uint8_t guestChangeModifier = 1;
-    int32_t changeInGuestsInPark = static_cast<int32_t>(gameState.NumGuestsInPark)
-        - static_cast<int32_t>(gameState.NumGuestsInParkLastWeek);
-    if (changeInGuestsInPark > -20)
-    {
-        guestChangeModifier++;
-        if (changeInGuestsInPark < 20)
-        {
-            guestChangeModifier = 0;
-        }
-    }
-    gameState.GuestChangeModifier = guestChangeModifier;
-    gameState.NumGuestsInParkLastWeek = gameState.NumGuestsInPark;
-
-    // Update park rating, guests in park and current cash history
-    HistoryPushRecord<uint8_t, 32>(gameState.ParkRatingHistory, gameState.ParkRating / 4);
-    HistoryPushRecord<uint32_t, 32>(gameState.GuestsInParkHistory, gameState.NumGuestsInPark);
-
-    constexpr auto cashHistorySize = std::extent_v<decltype(GameState_t::CashHistory)>;
-    HistoryPushRecord<money64, cashHistorySize>(gameState.CashHistory, FinanceGetCurrentCash() - gameState.BankLoan);
-
-    // Update weekly profit history
-    auto currentWeeklyProfit = gameState.WeeklyProfitAverageDividend;
-    if (gameState.WeeklyProfitAverageDivisor != 0)
-    {
-        currentWeeklyProfit /= gameState.WeeklyProfitAverageDivisor;
-    }
-    constexpr auto profitHistorySize = std::extent_v<decltype(GameState_t::WeeklyProfitHistory)>;
-    HistoryPushRecord<money64, profitHistorySize>(gameState.WeeklyProfitHistory, currentWeeklyProfit);
-    gameState.WeeklyProfitAverageDividend = 0;
-    gameState.WeeklyProfitAverageDivisor = 0;
-
-    // Update park value history
-    constexpr auto parkValueHistorySize = std::extent_v<decltype(GameState_t::WeeklyProfitHistory)>;
-    HistoryPushRecord<money64, parkValueHistorySize>(gameState.ParkValueHistory, gameState.ParkValue);
-
-    // Invalidate relevant windows
-    auto intent = Intent(INTENT_ACTION_UPDATE_GUEST_COUNT);
-    ContextBroadcastIntent(&intent);
-    WindowInvalidateByClass(WindowClass::ParkInformation);
-    WindowInvalidateByClass(WindowClass::Finances);
-}
-
-uint32_t ParkUpdateSize(GameState_t& gameState)
-{
-    auto tiles = CalculateParkSize();
-    if (tiles != gameState.ParkSize)
-    {
-        gameState.ParkSize = tiles;
-        WindowInvalidateByClass(WindowClass::ParkInformation);
-    }
-    return tiles;
-}
+} // namespace OpenRCT2::Park

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -152,7 +152,7 @@ void ParkUpdateFencesAroundTile(const CoordsXY& coords)
 void ParkSetForcedRating(int32_t rating)
 {
     _forcedParkRating = rating;
-    auto& park = GetContext()->GetGameState()->GetPark();
+    auto& park = GetGameState().Park;
     GetGameState().ParkRating = park.CalculateParkRating();
     auto intent = Intent(INTENT_ACTION_UPDATE_PARK_RATING);
     ContextBroadcastIntent(&intent);
@@ -776,13 +776,13 @@ void Park::UpdateHistories()
 
 int32_t ParkIsOpen()
 {
-    return GetContext()->GetGameState()->GetPark().IsOpen();
+    return GetGameState().Park.IsOpen();
 }
 
 uint32_t ParkCalculateSize()
 {
     auto& gameState = GetGameState();
-    auto tiles = GetContext()->GetGameState()->GetPark().CalculateParkSize();
+    auto tiles = GetGameState().Park.CalculateParkSize();
     if (tiles != gameState.ParkSize)
     {
         gameState.ParkSize = tiles;

--- a/src/openrct2/world/Park.h
+++ b/src/openrct2/world/Park.h
@@ -47,57 +47,35 @@ enum : uint32_t
 };
 
 struct Guest;
-struct rct_ride;
 
 namespace OpenRCT2
 {
     struct Date;
 
-    class Park final
+    struct Park final
     {
-    public:
         std::string Name;
-        std::string PluginStorage;
-
-        Park() = default;
-        Park(const Park&) = delete;
 
         bool IsOpen() const;
-
-        uint16_t GetParkRating() const;
-        money64 GetParkValue() const;
-        money64 GetCompanyValue() const;
-
-        void Initialise();
-        void Update(const Date& date);
-
-        uint32_t CalculateParkSize() const;
-        int32_t CalculateParkRating() const;
-        money64 CalculateParkValue() const;
-        money64 CalculateCompanyValue() const;
-        static uint8_t CalculateGuestInitialHappiness(uint8_t percentage);
-
-        Guest* GenerateGuest();
-
-        void ResetHistories();
-        void UpdateHistories();
-
-    private:
-        money64 CalculateRideValue(const Ride& ride) const;
-        money64 CalculateTotalRideValueForMoney() const;
-        uint32_t CalculateSuggestedMaxGuests() const;
-        uint32_t CalculateGuestGenerationProbability() const;
-
-        void GenerateGuests();
-        Guest* GenerateGuestFromCampaign(int32_t campaign);
     };
 } // namespace OpenRCT2
 
+void ParkInitialise(OpenRCT2::GameState_t& gameState);
+void ParkUpdate(OpenRCT2::GameState_t& gameState, const OpenRCT2::Date& date);
+
+uint32_t CalculateParkSize();
+int32_t CalculateParkRating();
+money64 CalculateParkValue();
+money64 CalculateCompanyValue();
+
+Guest* GenerateGuest();
+
+void ResetParkHistories(OpenRCT2::GameState_t& gameState);
+void UpdateParkHistories(OpenRCT2::GameState_t& gameState);
 void ParkSetForcedRating(int32_t rating);
 int32_t ParkGetForcedRating();
 
-int32_t ParkIsOpen();
-uint32_t ParkCalculateSize();
+uint32_t ParkUpdateSize(OpenRCT2::GameState_t& gameState);
 
 void ParkUpdateFences(const CoordsXY& coords);
 void ParkUpdateFencesAroundTile(const CoordsXY& coords);

--- a/src/openrct2/world/Park.h
+++ b/src/openrct2/world/Park.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../common.h"
+#include "../management/Finance.h"
 #include "Map.h"
 
 constexpr auto MAX_ENTRANCE_FEE = 999.00_GBP;
@@ -52,39 +53,51 @@ namespace OpenRCT2
 {
     struct Date;
 
-    struct Park final
+    namespace Park
     {
-        std::string Name;
+        struct ParkData final
+        {
+            std::string Name;
+            uint64_t Flags;
+            uint16_t Rating;
+            uint8_t RatingHistory[kParkRatingHistorySize];
+            int16_t RatingCasualtyPenalty;
+            money64 EntranceFee;
+            std::vector<CoordsXYZD> Entrances;
+            uint32_t Size;
+            money64 Value;
+            money64 ValueHistory[FINANCE_GRAPH_SIZE];
 
-        bool IsOpen() const;
-    };
+            bool IsOpen() const;
+        };
+
+        void Initialise(OpenRCT2::GameState_t& gameState);
+        void Update(OpenRCT2::GameState_t& gameState, const OpenRCT2::Date& date);
+
+        uint32_t CalculateParkSize();
+        int32_t CalculateParkRating();
+        money64 CalculateParkValue();
+        money64 CalculateCompanyValue();
+
+        Guest* GenerateGuest();
+
+        void ResetHistories(OpenRCT2::GameState_t& gameState);
+        void UpdateHistories(OpenRCT2::GameState_t& gameState);
+        void SetForcedRating(int32_t rating);
+        int32_t GetForcedRating();
+
+        uint32_t UpdateSize(OpenRCT2::GameState_t& gameState);
+
+        void UpdateFences(const CoordsXY& coords);
+        void UpdateFencesAroundTile(const CoordsXY& coords);
+
+        uint8_t CalculateGuestInitialHappiness(uint8_t percentage);
+
+        void SetOpen(bool open);
+        money64 GetEntranceFee();
+
+        bool RidePricesUnlocked();
+        bool EntranceFeeUnlocked();
+    } // namespace Park
+
 } // namespace OpenRCT2
-
-void ParkInitialise(OpenRCT2::GameState_t& gameState);
-void ParkUpdate(OpenRCT2::GameState_t& gameState, const OpenRCT2::Date& date);
-
-uint32_t CalculateParkSize();
-int32_t CalculateParkRating();
-money64 CalculateParkValue();
-money64 CalculateCompanyValue();
-
-Guest* GenerateGuest();
-
-void ResetParkHistories(OpenRCT2::GameState_t& gameState);
-void UpdateParkHistories(OpenRCT2::GameState_t& gameState);
-void ParkSetForcedRating(int32_t rating);
-int32_t ParkGetForcedRating();
-
-uint32_t ParkUpdateSize(OpenRCT2::GameState_t& gameState);
-
-void ParkUpdateFences(const CoordsXY& coords);
-void ParkUpdateFencesAroundTile(const CoordsXY& coords);
-
-uint8_t CalculateGuestInitialHappiness(uint8_t percentage);
-
-void ParkSetOpen(bool open);
-int32_t ParkEntranceGetIndex(const CoordsXYZ& entrancePos);
-money64 ParkGetEntranceFee();
-
-bool ParkRidePricesUnlocked();
-bool ParkEntranceFeeUnlocked();

--- a/src/openrct2/world/Park.h
+++ b/src/openrct2/world/Park.h
@@ -51,7 +51,7 @@ struct rct_ride;
 
 namespace OpenRCT2
 {
-    class Date;
+    struct Date;
 
     class Park final
     {

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -503,7 +503,7 @@ namespace OpenRCT2::TileInspector
             if (!showFences)
                 surfaceelement->SetParkFences(0);
             else
-                ParkUpdateFences(loc);
+                Park::UpdateFences(loc);
         }
 
         return GameActions::Result();

--- a/test/tests/MultiLaunch.cpp
+++ b/test/tests/MultiLaunch.cpp
@@ -48,7 +48,7 @@ TEST(MultiLaunchTest, all)
         auto gs = context->GetGameState();
         ASSERT_NE(gs, nullptr);
 
-        auto& date = gs->GetDate();
+        auto& date = GetGameState().Date;
         // NOTE: This value is saved in the SV6 file, after the import this will be the current state.
         // In case the save file gets replaced this needs to be adjusted.
         ASSERT_EQ(date.GetMonthTicks(), 0x1e98);

--- a/test/tests/MultiLaunch.cpp
+++ b/test/tests/MultiLaunch.cpp
@@ -45,8 +45,6 @@ TEST(MultiLaunchTest, all)
 
         // Check ride count to check load was successful
         ASSERT_EQ(RideGetCount(), 134);
-        auto gs = context->GetGameState();
-        ASSERT_NE(gs, nullptr);
 
         auto& date = GetGameState().Date;
         // NOTE: This value is saved in the SV6 file, after the import this will be the current state.
@@ -55,7 +53,7 @@ TEST(MultiLaunchTest, all)
 
         for (int j = 0; j < updatesToTest; j++)
         {
-            gs->UpdateLogic();
+            gameStateUpdateLogic();
         }
 
         ASSERT_EQ(date.GetMonthTicks(), 7862 + updatesToTest);

--- a/test/tests/PlayTests.cpp
+++ b/test/tests/PlayTests.cpp
@@ -101,7 +101,7 @@ TEST_F(PlayTests, SecondGuestInQueueShouldNotRideIfNoFunds)
     // Open park for free but charging for rides
     execute<ParkSetParameterAction>(ParkParameter::Open);
     execute<ParkSetEntranceFeeAction>(0);
-    gameState.ParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
+    gameState.Park.Flags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
 
     // Find ferris wheel
     auto rideManager = GetRideManager();
@@ -118,7 +118,7 @@ TEST_F(PlayTests, SecondGuestInQueueShouldNotRideIfNoFunds)
     gameState.Cheats.IgnoreRideIntensity = true;
 
     // Insert a rich guest
-    auto richGuest = gameState.Park.GenerateGuest();
+    auto richGuest = Park::GenerateGuest();
     richGuest->CashInPocket = 3000;
 
     // Wait for rich guest to get in queue
@@ -126,7 +126,7 @@ TEST_F(PlayTests, SecondGuestInQueueShouldNotRideIfNoFunds)
     ASSERT_TRUE(matched);
 
     // Insert poor guest
-    auto poorGuest = gameState.Park.GenerateGuest();
+    auto poorGuest = Park::GenerateGuest();
     poorGuest->CashInPocket = 5;
 
     // Wait for poor guest to get in queue
@@ -161,7 +161,7 @@ TEST_F(PlayTests, CarRideWithOneCarOnlyAcceptsTwoGuests)
     // Open park for free but charging for rides
     execute<ParkSetParameterAction>(ParkParameter::Open);
     execute<ParkSetEntranceFeeAction>(0);
-    gameState.ParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
+    gameState.Park.Flags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
 
     // Find car ride
     auto rideManager = GetRideManager();
@@ -180,7 +180,7 @@ TEST_F(PlayTests, CarRideWithOneCarOnlyAcceptsTwoGuests)
     std::vector<Peep*> guests;
     for (int i = 0; i < 25; i++)
     {
-        guests.push_back(gameState.Park.GenerateGuest());
+        guests.push_back(Park::GenerateGuest());
     }
 
     // Wait until one of them is riding

--- a/test/tests/PlayTests.cpp
+++ b/test/tests/PlayTests.cpp
@@ -98,11 +98,13 @@ TEST_F(PlayTests, SecondGuestInQueueShouldNotRideIfNoFunds)
 
     auto gs = context->GetGameState();
     ASSERT_NE(gs, nullptr);
+    
+    auto& gameState = GetGameState();
 
     // Open park for free but charging for rides
     execute<ParkSetParameterAction>(ParkParameter::Open);
     execute<ParkSetEntranceFeeAction>(0);
-    GetGameState().ParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
+    gameState.ParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
 
     // Find ferris wheel
     auto rideManager = GetRideManager();
@@ -116,10 +118,10 @@ TEST_F(PlayTests, SecondGuestInQueueShouldNotRideIfNoFunds)
     execute<RideSetPriceAction>(ferrisWheel.id, 0, true);
 
     // Ignore intensity to stimulate peeps to queue into ferris wheel
-    GetGameState().Cheats.IgnoreRideIntensity = true;
+    gameState.Cheats.IgnoreRideIntensity = true;
 
     // Insert a rich guest
-    auto richGuest = gs->GetPark().GenerateGuest();
+    auto richGuest = gameState.Park.GenerateGuest();
     richGuest->CashInPocket = 3000;
 
     // Wait for rich guest to get in queue
@@ -127,7 +129,7 @@ TEST_F(PlayTests, SecondGuestInQueueShouldNotRideIfNoFunds)
     ASSERT_TRUE(matched);
 
     // Insert poor guest
-    auto poorGuest = gs->GetPark().GenerateGuest();
+    auto poorGuest = gameState.Park.GenerateGuest();
     poorGuest->CashInPocket = 5;
 
     // Wait for poor guest to get in queue
@@ -159,11 +161,13 @@ TEST_F(PlayTests, CarRideWithOneCarOnlyAcceptsTwoGuests)
 
     auto gs = context->GetGameState();
     ASSERT_NE(gs, nullptr);
+    
+    auto& gameState = GetGameState();
 
     // Open park for free but charging for rides
     execute<ParkSetParameterAction>(ParkParameter::Open);
     execute<ParkSetEntranceFeeAction>(0);
-    GetGameState().ParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
+    gameState.ParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
 
     // Find car ride
     auto rideManager = GetRideManager();
@@ -176,13 +180,13 @@ TEST_F(PlayTests, CarRideWithOneCarOnlyAcceptsTwoGuests)
     execute<RideSetPriceAction>(carRide.id, 0, true);
 
     // Ignore intensity to stimulate peeps to queue into the ride
-    GetGameState().Cheats.IgnoreRideIntensity = true;
+    gameState.Cheats.IgnoreRideIntensity = true;
 
     // Create some guests
     std::vector<Peep*> guests;
     for (int i = 0; i < 25; i++)
     {
-        guests.push_back(gs->GetPark().GenerateGuest());
+        guests.push_back(gameState.Park.GenerateGuest());
     }
 
     // Wait until one of them is riding

--- a/test/tests/ReplayTests.cpp
+++ b/test/tests/ReplayTests.cpp
@@ -81,9 +81,6 @@ TEST_P(ReplayTests, RunReplay)
     bool initialised = context->Initialise();
     ASSERT_TRUE(initialised);
 
-    auto gs = context->GetGameState();
-    ASSERT_NE(gs, nullptr);
-
     IReplayManager* replayManager = context->GetReplayManager();
     ASSERT_NE(replayManager, nullptr);
 
@@ -92,7 +89,7 @@ TEST_P(ReplayTests, RunReplay)
 
     while (replayManager->IsReplaying())
     {
-        gs->UpdateLogic();
+        gameStateUpdateLogic();
         if (replayManager->IsPlaybackStateMismatching())
             break;
     }

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -138,10 +138,9 @@ static void RecordGameStateSnapshot(std::unique_ptr<IContext>& context, MemorySt
 
 static void AdvanceGameTicks(uint32_t ticks, std::unique_ptr<IContext>& context)
 {
-    auto* gameState = context->GetGameState();
     for (uint32_t i = 0; i < ticks; i++)
     {
-        gameState->UpdateLogic();
+        gameStateUpdateLogic();
     }
 }
 


### PR DESCRIPTION
Part of https://github.com/OpenRCT2/OpenRCT2/issues/21193.

Moves all the members from the class to GameState_t, moves the remaining functions out of the class, and modifies InitAll to take a GameState_t. Allows for eliminating many TODOs as well.