### PR TITLE
Move a number of ui only updates into UiContext tick

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -141,24 +141,6 @@ public:
     {
         _inGameConsole.Update();
 
-        // the flickering frequency is reduced by 4, compared to the original
-        // it was done due to inability to reproduce original frequency
-        // and decision that the original one looks too fast
-        if (gCurrentRealTimeTicks % 4 == 0)
-            gWindowMapFlashingFlags ^= MapFlashingFlags::SwitchColour;
-
-        // Handle guest map flashing
-        gWindowMapFlashingFlags &= ~MapFlashingFlags::FlashGuests;
-        if (gWindowMapFlashingFlags & MapFlashingFlags::GuestListOpen)
-            gWindowMapFlashingFlags |= MapFlashingFlags::FlashGuests;
-        gWindowMapFlashingFlags &= ~MapFlashingFlags::GuestListOpen;
-
-        // Handle staff map flashing
-        gWindowMapFlashingFlags &= ~MapFlashingFlags::FlashStaff;
-        if (gWindowMapFlashingFlags & MapFlashingFlags::StaffListOpen)
-            gWindowMapFlashingFlags |= MapFlashingFlags::FlashStaff;
-        gWindowMapFlashingFlags &= ~MapFlashingFlags::StaffListOpen;
-
         _windowManager->UpdateMapTooltip();
 
         WindowDispatchUpdateAll();

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -140,6 +140,28 @@ public:
     void Tick() override
     {
         _inGameConsole.Update();
+
+        // the flickering frequency is reduced by 4, compared to the original
+        // it was done due to inability to reproduce original frequency
+        // and decision that the original one looks too fast
+        if (gCurrentRealTimeTicks % 4 == 0)
+            gWindowMapFlashingFlags ^= MapFlashingFlags::SwitchColour;
+
+        // Handle guest map flashing
+        gWindowMapFlashingFlags &= ~MapFlashingFlags::FlashGuests;
+        if (gWindowMapFlashingFlags & MapFlashingFlags::GuestListOpen)
+            gWindowMapFlashingFlags |= MapFlashingFlags::FlashGuests;
+        gWindowMapFlashingFlags &= ~MapFlashingFlags::GuestListOpen;
+
+        // Handle staff map flashing
+        gWindowMapFlashingFlags &= ~MapFlashingFlags::FlashStaff;
+        if (gWindowMapFlashingFlags & MapFlashingFlags::StaffListOpen)
+            gWindowMapFlashingFlags |= MapFlashingFlags::FlashStaff;
+        gWindowMapFlashingFlags &= ~MapFlashingFlags::StaffListOpen;
+
+        _windowManager->UpdateMapTooltip();
+
+        WindowDispatchUpdateAll();
     }
 
     void Draw(DrawPixelInfo& dpi) override

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -275,8 +275,6 @@ static Widget window_guest_list_widgets[] = {
             if (_tabAnimationIndex >= (_selectedTab == TabId::Individual ? 24uL : 32uL))
                 _tabAnimationIndex = 0;
             InvalidateWidget(WIDX_TAB_1 + static_cast<int32_t>(_selectedTab));
-
-            gWindowMapFlashingFlags |= MapFlashingFlags::GuestListOpen;
         }
 
         void OnMouseUp(WidgetIndex widgetIndex) override

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -198,7 +198,6 @@ static Widget _staffListWidgets[] = {
                 // Enable highlighting of these staff members in map window
                 if (WindowFindByClass(WindowClass::Map) != nullptr)
                 {
-                    gWindowMapFlashingFlags |= MapFlashingFlags::StaffListOpen;
                     for (auto peep : EntityList<Staff>())
                     {
                         EntitySetFlashing(peep, false);

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -1561,12 +1561,6 @@ WindowBase* ContextShowError(StringId title, StringId message, const Formatter& 
     return windowManager->ShowError(title, message, args);
 }
 
-void ContextUpdateMapTooltip()
-{
-    auto windowManager = GetContext()->GetUiContext()->GetWindowManager();
-    windowManager->UpdateMapTooltip();
-}
-
 void ContextHandleInput()
 {
     auto windowManager = GetContext()->GetUiContext()->GetWindowManager();

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -225,7 +225,6 @@ WindowBase* ContextShowError(StringId title, StringId message, const class Forma
 WindowBase* ContextOpenIntent(Intent* intent);
 void ContextBroadcastIntent(Intent* intent);
 void ContextForceCloseWindowByClass(WindowClass wc);
-void ContextUpdateMapTooltip();
 void ContextHandleInput();
 void ContextInputHandleKeyboard(bool isTitle);
 void ContextQuit();

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -222,26 +222,6 @@ namespace OpenRCT2
         if (!gOpenRCT2Headless)
         {
             InputSetFlag(INPUT_FLAG_VIEWPORT_SCROLLING, false);
-
-            // the flickering frequency is reduced by 4, compared to the original
-            // it was done due to inability to reproduce original frequency
-            // and decision that the original one looks too fast
-            if (gCurrentRealTimeTicks % 4 == 0)
-                gWindowMapFlashingFlags ^= MapFlashingFlags::SwitchColour;
-
-            // Handle guest map flashing
-            gWindowMapFlashingFlags &= ~MapFlashingFlags::FlashGuests;
-            if (gWindowMapFlashingFlags & MapFlashingFlags::GuestListOpen)
-                gWindowMapFlashingFlags |= MapFlashingFlags::FlashGuests;
-            gWindowMapFlashingFlags &= ~MapFlashingFlags::GuestListOpen;
-
-            // Handle staff map flashing
-            gWindowMapFlashingFlags &= ~MapFlashingFlags::FlashStaff;
-            if (gWindowMapFlashingFlags & MapFlashingFlags::StaffListOpen)
-                gWindowMapFlashingFlags |= MapFlashingFlags::FlashStaff;
-            gWindowMapFlashingFlags &= ~MapFlashingFlags::StaffListOpen;
-
-            ContextUpdateMapTooltip();
         }
 
         // Always perform autosave check, even when paused
@@ -250,8 +230,6 @@ namespace OpenRCT2
         {
             ScenarioAutosaveCheck();
         }
-
-        WindowDispatchUpdateAll();
 
         if (didRunSingleFrame && GameIsNotPaused() && !(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO))
         {

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -48,7 +48,6 @@ WindowBase* gWindowAudioExclusive;
 WindowCloseModifier gLastCloseModifier = { { WindowClass::Null, 0 }, CloseWindowModifier::None };
 
 uint32_t gWindowUpdateTicks;
-uint16_t gWindowMapFlashingFlags;
 colour_t gCurrentWindowColours[4];
 
 // converted from uint16_t values at 0x009A41EC - 0x009A4230

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -489,15 +489,6 @@ constexpr int8_t kWindowLimitReserved = 4; // Used to reserve room for the main 
 extern WindowBase* gWindowAudioExclusive;
 
 extern uint32_t gWindowUpdateTicks;
-namespace MapFlashingFlags
-{
-    constexpr uint16_t GuestListOpen = (1 << 0);
-    constexpr uint16_t FlashGuests = (1 << 1);
-    constexpr uint16_t StaffListOpen = (1 << 2);
-    constexpr uint16_t FlashStaff = (1 << 3);
-    constexpr uint16_t SwitchColour = (1 << 15); // Every couple ticks the colour switches
-} // namespace MapFlashingFlags
-extern uint16_t gWindowMapFlashingFlags;
 
 extern colour_t gCurrentWindowColours[4];
 

--- a/src/openrct2/scenes/title/TitleScene.cpp
+++ b/src/openrct2/scenes/title/TitleScene.cpp
@@ -168,9 +168,6 @@ void TitleScene::Tick()
 
     InputSetFlag(INPUT_FLAG_VIEWPORT_SCROLLING, false);
 
-    ContextUpdateMapTooltip();
-    WindowDispatchUpdateAll();
-
     ContextHandleInput();
 
     gInUpdateCode = false;


### PR DESCRIPTION
This was just to clear up where the window dispatch update was being called but thought i might as well also move over these other Ui only items.