### PR TITLE
Fix #21691: Use correct iterator in RideCheckTrackContainsBanked

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -28,6 +28,7 @@
 - Fix: [#21641] Crash when creating track iterator from an invalid tile element.
 - Fix: [#21652] Dialog window to confirm overwriting files does not apply the theme colours correctly.
 - Fix: [#21668] Crash when on null ride in Guest::UpdateRideLeaveExit.
+- Fix: [#21691] Crash when validating rides which can't contain banked track.
 - Fix: [objects#290] “Haunted Mansion” cars have a non-functional third remap colour.
 - Fix: [objects#296] Incorrect wall placement around large Kremlin/drab pieces.
 - Fix: [objects#300] Incorrect Colosseum and volcano corner clearances.

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2858,7 +2858,7 @@ static bool RideCheckTrackContainsBanked(const CoordsXYE& input, CoordsXYE* outp
 
     while (TrackCircuitIteratorNext(&it))
     {
-        auto trackType = output->element->AsTrack()->GetTrackType();
+        auto trackType = it.current.element->AsTrack()->GetTrackType();
         const auto& ted = GetTrackElementDescriptor(trackType);
         if (ted.Flags & TRACK_ELEM_FLAG_BANKED)
         {


### PR DESCRIPTION
Test case: try opening/testing `Monorail 1` in attached park.

[park_21691_objects.park.txt](https://github.com/OpenRCT2/OpenRCT2/files/14817738/park_21691_objects.park.txt)
