### PR TITLE
Ensure TTF system is torn down in correct order

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -29,6 +29,7 @@
 - Fix: [#21652] Dialog window to confirm overwriting files does not apply the theme colours correctly.
 - Fix: [#21654] No sound effects when using RCT Classic as an asset base.
 - Fix: [#21654] Extraneous reports of an object conflict between `rct2.audio.base` and `rct2.audio.base.rctc`.
+- Fix: [#21664] Crash when switching between languages that use TTF.
 - Fix: [#21668] Crash when on null ride in Guest::UpdateRideLeaveExit.
 - Fix: [#21691] Crash when validating rides which can't contain banked track.
 - Fix: [objects#290] “Haunted Mansion” cars have a non-functional third remap colour.

--- a/src/openrct2/interface/Fonts.cpp
+++ b/src/openrct2/interface/Fonts.cpp
@@ -117,10 +117,11 @@ static void LoadSpriteFont(LocalisationService& localisationService)
 #ifndef NO_TTF
 static bool LoadFont(LocalisationService& localisationService, TTFFontSetDescriptor* font)
 {
+    TTFDispose();
     localisationService.UseTrueTypeFont(true);
+
     gCurrentTTFFontSet = font;
 
-    TTFDispose();
     bool fontInitialised = TTFInitialise();
     return fontInitialised;
 }


### PR DESCRIPTION
`TTFDispose` uses `gCurrentTTFFontSet` to deallocate internal resources. Having the function called after global variable got changed meant it tried to deallocate incorrect font and would subsequently call `FT_Done_Face` on a struct having internal data set to nullptr.

Reproduction is fairly easy:
1. launch the game in Korean (I made sure to have all the indexes primed for this language beforehand - i.e. launch it twice),
2. switch to Japanese,
3. switch back to Korean

Fixes #21664