### PR TITLE
Revert "Add owner property to tile elements for scripting"

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#21734] Park admittance price can now be set via text input.
 - Improved: [#21769] Expose “animation is backwards” wall property in Tile Inspector.
+- Change: [#21715] [Plugin] Remove access to the internal `owner` property. Note: `ownership` is still accessible.
 - Fix: [#866] Boat Hire boats get stuck entering track.
 
 0.4.10 (2024-04-02)

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1476,7 +1476,6 @@ declare global {
         occupiedQuadrants: number;
         isGhost: boolean;
         isHidden: boolean; /** Take caution when changing this field, it may invalidate TileElements you have stored in your script. */
-        owner: number;
     }
 
     interface SurfaceElement extends BaseTileElement {

--- a/src/openrct2/scripting/bindings/world/ScTileElement.cpp
+++ b/src/openrct2/scripting/bindings/world/ScTileElement.cpp
@@ -2072,19 +2072,6 @@ namespace OpenRCT2::Scripting
         }
     }
 
-    DukValue ScTileElement::owner_get() const
-    {
-        auto& scriptEngine = GetContext()->GetScriptEngine();
-        auto* ctx = scriptEngine.GetContext();
-        duk_push_uint(ctx, _element->GetOwner());
-        return DukValue::take_from_stack(ctx);
-    }
-    void ScTileElement::owner_set(uint8_t value)
-    {
-        ThrowIfGameStateNotMutable();
-        _element->SetOwner(value);
-    }
-
     DukValue ScTileElement::bannerText_get() const
     {
         auto& scriptEngine = GetContext()->GetScriptEngine();
@@ -2166,7 +2153,6 @@ namespace OpenRCT2::Scripting
             ctx, &ScTileElement::occupiedQuadrants_get, &ScTileElement::occupiedQuadrants_set, "occupiedQuadrants");
         dukglue_register_property(ctx, &ScTileElement::isGhost_get, &ScTileElement::isGhost_set, "isGhost");
         dukglue_register_property(ctx, &ScTileElement::isHidden_get, &ScTileElement::isHidden_set, "isHidden");
-        dukglue_register_property(ctx, &ScTileElement::owner_get, &ScTileElement::owner_set, "owner");
 
         // Track | Small Scenery | Wall | Entrance | Large Scenery | Banner
         dukglue_register_property(ctx, &ScTileElement::direction_get, &ScTileElement::direction_set, "direction");

--- a/src/openrct2/scripting/bindings/world/ScTileElement.hpp
+++ b/src/openrct2/scripting/bindings/world/ScTileElement.hpp
@@ -202,9 +202,6 @@ namespace OpenRCT2::Scripting
         DukValue direction_get() const;
         void direction_set(uint8_t value);
 
-        DukValue owner_get() const;
-        void owner_set(uint8_t value);
-
         DukValue bannerText_get() const;
         void bannerText_set(std::string value);
 


### PR DESCRIPTION
In #20853, the owner attribute was exposed though the scripting API. This allows plug-ins to write values to this field. However, these values are not restricted, and are likely to lead to conflicts when the field is eventually used to actually distinguish between different park companies.

We should hide the field now to prevent strange bugs or disappointment down the line.

This reverts commit b4376ab5907d582574eb38b074daac7dd970e2a1.