### PR TITLE
Fix #21728 "Fix all rides" cheat ignores rides currently being fixed by mechanic

### DIFF
--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -512,10 +512,17 @@ void CheatSetAction::FixBrokenRides() const
 {
     for (auto& ride : GetRideManager())
     {
-        if (ride.lifecycle_flags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN))
+        if ((ride.mechanic_status != RIDE_MECHANIC_STATUS_FIXING)
+            && (ride.lifecycle_flags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN)))
         {
+            auto mechanic = RideGetAssignedMechanic(ride);
+            if (mechanic != nullptr)
+            {
+                mechanic->RemoveFromRide();
+            }
+
             RideFixBreakdown(ride, 0);
-            ride.window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAIN | RIDE_INVALIDATE_RIDE_LIST;         
+            ride.window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAIN | RIDE_INVALIDATE_RIDE_LIST;
         }
     }
 }

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -512,17 +512,10 @@ void CheatSetAction::FixBrokenRides() const
 {
     for (auto& ride : GetRideManager())
     {
-        if ((ride.mechanic_status != RIDE_MECHANIC_STATUS_FIXING)
-            && (ride.lifecycle_flags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN)))
+        if (ride.lifecycle_flags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN))
         {
-            auto mechanic = RideGetAssignedMechanic(ride);
-            if (mechanic != nullptr)
-            {
-                mechanic->RemoveFromRide();
-            }
-
             RideFixBreakdown(ride, 0);
-            ride.window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAIN | RIDE_INVALIDATE_RIDE_LIST;
+            ride.window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAIN | RIDE_INVALIDATE_RIDE_LIST;         
         }
     }
 }

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -512,13 +512,23 @@ void CheatSetAction::FixBrokenRides() const
 {
     for (auto& ride : GetRideManager())
     {
-        if ((ride.mechanic_status != RIDE_MECHANIC_STATUS_FIXING)
-            && (ride.lifecycle_flags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN)))
+        if (ride.lifecycle_flags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN))
         {
             auto mechanic = RideGetAssignedMechanic(ride);
-            if (mechanic != nullptr)
+
+            if ((ride.mechanic_status == RIDE_MECHANIC_STATUS_FIXING))
             {
-                mechanic->RemoveFromRide();
+                if (mechanic != nullptr)
+                {
+                    mechanic->RideSubState = PeepRideSubState::ApproachExitWaypoints;
+                }
+            }
+            else
+            {
+                if (mechanic != nullptr)
+                {
+                    mechanic->RemoveFromRide();
+                }
             }
 
             RideFixBreakdown(ride, 0);

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -516,7 +516,7 @@ void CheatSetAction::FixBrokenRides() const
         {
             auto mechanic = RideGetAssignedMechanic(ride);
 
-            if ((ride.mechanic_status == RIDE_MECHANIC_STATUS_FIXING))
+            if (ride.mechanic_status == RIDE_MECHANIC_STATUS_FIXING)
             {
                 if (mechanic != nullptr)
                 {


### PR DESCRIPTION
I have re-worked and added more checks and logic if the ride is currently being repaired. 