### PR TITLE
Close #21728: Apply "Fix all rides" even if mechanic is already working

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#11512] Coloured usernames by group on multiplayer servers.
 - Feature: [#21734] Park admittance price can now be set via text input.
+- Improved: [#21728] “Fix all rides” cheat now also works if a mechanic is already fixing the ride.
 - Improved: [#21769] Expose “animation is backwards” wall property in Tile Inspector.
 - Improved: [#21855] Add a separator between “Load Game” and “Save Game”, to avoid accidental overwriting.
 - Change: [#21715] [Plugin] Remove access to the internal `owner` property. Note: `ownership` is still accessible.

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -512,13 +512,22 @@ void CheatSetAction::FixBrokenRides() const
 {
     for (auto& ride : GetRideManager())
     {
-        if ((ride.mechanic_status != RIDE_MECHANIC_STATUS_FIXING)
-            && (ride.lifecycle_flags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN)))
+        if (ride.lifecycle_flags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN))
         {
             auto mechanic = RideGetAssignedMechanic(ride);
+
             if (mechanic != nullptr)
             {
-                mechanic->RemoveFromRide();
+                if (ride.mechanic_status == RIDE_MECHANIC_STATUS_FIXING)
+                {
+                    mechanic->RideSubState = PeepRideSubState::ApproachExit;
+                }
+                else if (
+                    ride.mechanic_status == RIDE_MECHANIC_STATUS_CALLING
+                    || ride.mechanic_status == RIDE_MECHANIC_STATUS_HEADING)
+                {
+                    mechanic->RemoveFromRide();
+                }
             }
 
             RideFixBreakdown(ride, 0);


### PR DESCRIPTION
Fixes #21728 Fix all rides cheat ignores when ride is being fixed my mechanic