### PR TITLE
Fix #21748: TileElement out of bounds

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Fix: [#18723, #21870] Attempting to demolish a flat ride in pause mode allows you to place multiple copies.
 - Fix: [#19559] Custom rides with long descriptions extend into lower widgets.
 - Fix: [#21696] Fullscreen window option not correctly applied on macOS.
+- Fix: [#21749] Crash when loading park bigger than current limits.
 - Fix: [#21787] Map generator heightmap should respect increased height limits.
 - Fix: [#21829] When creating a new scenario, the default name contains formatting codes.
 - Fix: [#21937] Build errors with the ORIGINAL_RATINGS flag.

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -300,14 +300,7 @@ int32_t TileElementIteratorNext(TileElementIterator* it)
     if (it->element == nullptr)
     {
         it->element = MapGetFirstElementAt(TileCoordsXY{ it->x, it->y });
-        if (it->element == nullptr)
-        {
-            return 0;
-        }
-        else
-        {
-            return 1;
-        }
+        return it->element == nullptr ? 0 : 1;
     }
 
     if (!it->element->IsLastForTile())
@@ -321,14 +314,7 @@ int32_t TileElementIteratorNext(TileElementIterator* it)
     {
         it->y++;
         it->element = MapGetFirstElementAt(TileCoordsXY{ it->x, it->y });
-        if (it->element == nullptr)
-        {
-            return 0;
-        }
-        else
-        {
-            return 1;
-        }
+        return it->element == nullptr ? 0 : 1;
     }
 
     if (it->x < (gameState.MapSize.x - 2))
@@ -336,14 +322,7 @@ int32_t TileElementIteratorNext(TileElementIterator* it)
         it->y = 1;
         it->x++;
         it->element = MapGetFirstElementAt(TileCoordsXY{ it->x, it->y });
-        if (it->element == nullptr)
-        {
-            return 0;
-        }
-        else
-        {
-            return 1;
-        }
+        return it->element == nullptr ? 0 : 1;
     }
 
     return 0;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -300,7 +300,14 @@ int32_t TileElementIteratorNext(TileElementIterator* it)
     if (it->element == nullptr)
     {
         it->element = MapGetFirstElementAt(TileCoordsXY{ it->x, it->y });
-        return 1;
+        if (it->element == nullptr)
+        {
+            return 0;
+        }
+        else
+        {
+            return 1;
+        }
     }
 
     if (!it->element->IsLastForTile())
@@ -314,7 +321,14 @@ int32_t TileElementIteratorNext(TileElementIterator* it)
     {
         it->y++;
         it->element = MapGetFirstElementAt(TileCoordsXY{ it->x, it->y });
-        return 1;
+        if (it->element == nullptr)
+        {
+            return 0;
+        }
+        else
+        {
+            return 1;
+        }
     }
 
     if (it->x < (gameState.MapSize.x - 2))
@@ -322,7 +336,14 @@ int32_t TileElementIteratorNext(TileElementIterator* it)
         it->y = 1;
         it->x++;
         it->element = MapGetFirstElementAt(TileCoordsXY{ it->x, it->y });
-        return 1;
+        if (it->element == nullptr)
+        {
+            return 0;
+        }
+        else
+        {
+            return 1;
+        }
     }
 
     return 0;

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -619,6 +619,10 @@ void MapAnimationAutoCreate()
 
 void MapAnimationAutoCreateAtTileElement(TileCoordsXY coords, TileElement* el)
 {
+    if (el == nullptr)
+    {
+        return;
+    }
     auto loc = CoordsXYZ{ coords.ToCoordsXY(), el->GetBaseZ() };
     switch (el->GetType())
     {


### PR DESCRIPTION
This fixes crashes observed and allows the park to load. The park is overlarge and breaks some assumptions we have in our code.