### PR TITLE
Fix #2287: Sound not disabled when starting without focus

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -238,6 +238,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Jan Kelemen (jan-kelemen)
 * Cory Ye (CoryfY)
 * Karsten Van Fossan (karstenvanf)
+* Daniel Lightbourn (Daniel-Lightbourn)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -1100,6 +1100,14 @@ namespace OpenRCT2
 
             _uiContext->ProcessMessages();
 
+            // Start the title music now that focus events have been processed.
+            if (static bool firstTime = true; firstTime)
+            {
+                firstTime = false;
+
+                OpenRCT2::Audio::PlayTitleMusic();
+            }
+
             if (_ticksAccumulator < kGameUpdateTimeMS)
             {
                 const auto sleepTimeSec = (kGameUpdateTimeMS - _ticksAccumulator);

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -1100,14 +1100,6 @@ namespace OpenRCT2
 
             _uiContext->ProcessMessages();
 
-            // Start the title music now that focus events have been processed.
-            if (static bool firstTime = true; firstTime)
-            {
-                firstTime = false;
-
-                OpenRCT2::Audio::PlayTitleMusic();
-            }
-
             if (_ticksAccumulator < kGameUpdateTimeMS)
             {
                 const auto sleepTimeSec = (kGameUpdateTimeMS - _ticksAccumulator);

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -133,7 +133,6 @@ void TitleScreen::Load()
     ContextOpenWindow(WindowClass::MainWindow);
     CreateWindows();
     TitleInitialise();
-    OpenRCT2::Audio::PlayTitleMusic();
 
     if (gOpenRCT2ShowChangelog)
     {
@@ -164,6 +163,7 @@ void TitleScreen::Tick()
     {
         TryLoadSequence();
         _sequencePlayer->Update();
+        OpenRCT2::Audio::PlayTitleMusic();
 
         int32_t numUpdates = 1;
         if (gGameSpeed > 1)

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -133,16 +133,7 @@ void TitleScreen::Load()
     ContextOpenWindow(WindowClass::MainWindow);
     CreateWindows();
     TitleInitialise();
-
-    // Defer the title music until window messages can be processed.
-    if (static bool firstTime = true; firstTime)
-    {
-        firstTime = false;
-    }
-    else
-    {
-        OpenRCT2::Audio::PlayTitleMusic();
-    }
+    OpenRCT2::Audio::PlayTitleMusic();
 
     if (gOpenRCT2ShowChangelog)
     {

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -133,7 +133,16 @@ void TitleScreen::Load()
     ContextOpenWindow(WindowClass::MainWindow);
     CreateWindows();
     TitleInitialise();
-    OpenRCT2::Audio::PlayTitleMusic();
+
+    // Defer the title music until window messages can be processed.
+    if (static bool firstTime = true; firstTime)
+    {
+        firstTime = false;
+    }
+    else
+    {
+        OpenRCT2::Audio::PlayTitleMusic();
+    }
 
     if (gOpenRCT2ShowChangelog)
     {


### PR DESCRIPTION
For #2287
Defer calling `PlayTitleMusic()` the first time when OpenRCT2 starts until after SDL events have been polled. This allows the code to process focus events to mute the audio before the title music starts playing.

This slightly changes the current behavior in that the music no longer starts right when the window is created but about when the game starts rendering (about 1 second later on my machine).