### PR TITLE
debian/control: Update g++ dependency; update description

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Section: misc
 Priority: optional
 Standards-Version: 3.9.2
 Multi-Arch: same
-Build-Depends: debhelper (>= 9), cmake (>= 3.8), libsdl2-dev, g++ (>= 4:7), pkg-config, nlohmann-json3-dev (>= 3.6.0), libspeex-dev, libspeexdsp-dev, libcurl4-openssl-dev, libcrypto++-dev, libfontconfig1-dev, libfreetype6-dev, libpng-dev, libssl-dev, libzip-dev (>= 1.0.0), libicu-dev (>= 59.0), libflac-dev, libvorbis-dev
+Build-Depends: debhelper (>= 9), cmake (>= 3.8), libsdl2-dev, g++ (>= 4:10), pkg-config, nlohmann-json3-dev (>= 3.6.0), libspeex-dev, libspeexdsp-dev, libcurl4-openssl-dev, libcrypto++-dev, libfontconfig1-dev, libfreetype6-dev, libpng-dev, libssl-dev, libzip-dev (>= 1.0.0), libicu-dev (>= 59.0), libflac-dev, libvorbis-dev
 
 Package: openrct2
 Architecture: any
@@ -13,7 +13,14 @@ Vcs-Browser: https://github.com/OpenRCT2/OpenRCT2
 Vcs-Git: https://github.com/OpenRCT2/OpenRCT2
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Recommends: innoextract
-Description: An open source re-implementation of Roller Coaster Tycoon 2.
- An open source clone of RollerCoaster Tycoon 2 built by decompiling the
- original game one bit at a time.
- Requires original game assets.
+Description: An open source re-implementation of RollerCoaster Tycoon 2.
+ OpenRCT2 is an open-source re-implementation of RollerCoaster Tycoon 2,
+ expanding the game with new features, fixing bugs and raising game limits.
+ The gameplay revolves around building and maintaining an amusement park
+ containing attractions, shops and facilities. The player must try to make a
+ profit and maintain a good park reputation whilst keeping the guests happy.
+ 
+ OpenRCT2 allows for both scenario and sandbox play. Scenarios require the
+ player to complete a certain objective in a set time limit whilst sandbox
+ allows the player to build a more flexible park with optionally no
+ restrictions or finance.


### PR DESCRIPTION
Use of `<span>` means g++ version 10 or later is required.  See https://en.cppreference.com/w/cpp/compiler_support/20.

While we are here anyways, update the description (based off the description at https://openrct2.org).

Partial fix for https://github.com/OpenRCT2/OpenRCT2/issues/21801