### PR TITLE
Speed up TerrainSurfaceObject::GetImageId()

### DIFF
--- a/src/openrct2-ui/interface/LandTool.cpp
+++ b/src/openrct2-ui/interface/LandTool.cpp
@@ -69,7 +69,7 @@ void LandTool::ShowSurfaceStyleDropdown(WindowBase* w, Widget* widget, ObjectEnt
         if (surfaceObj != nullptr && !surfaceObj->UsesFallbackImages())
         {
             auto imageId = ImageId(surfaceObj->IconImageId);
-            if (surfaceObj->Colour != 255)
+            if (surfaceObj->Colour != TerrainSurfaceObject::kNoValue)
                 imageId = imageId.WithPrimary(surfaceObj->Colour);
 
             gDropdownItems[itemIndex].Format = Dropdown::FormatLandPicker;

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -325,7 +325,7 @@ static Widget window_land_widgets[] = {
             if (surfaceObj != nullptr)
             {
                 surfaceImage = ImageId(surfaceObj->IconImageId);
-                if (surfaceObj->Colour != 255)
+                if (surfaceObj->Colour != TerrainSurfaceObject::kNoValue)
                     surfaceImage = surfaceImage.WithPrimary(surfaceObj->Colour);
             }
 

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -678,7 +678,7 @@ static uint64_t PressedWidgets[WINDOW_MAPGEN_PAGE_COUNT] = {
             if (surfaceObj != nullptr)
             {
                 surfaceImage = ImageId(surfaceObj->IconImageId);
-                if (surfaceObj->Colour != 255)
+                if (surfaceObj->Colour != TerrainSurfaceObject::kNoValue)
                 {
                     surfaceImage = surfaceImage.WithPrimary(surfaceObj->Colour);
                 }

--- a/src/openrct2/object/TerrainSurfaceObject.cpp
+++ b/src/openrct2/object/TerrainSurfaceObject.cpp
@@ -12,11 +12,9 @@
 #include "TerrainSurfaceObject.h"
 
 #include "../Context.h"
-#include "../core/IStream.hpp"
+#include "../core/Guard.hpp"
 #include "../core/Json.hpp"
-#include "../core/String.hpp"
 #include "../drawing/Drawing.h"
-#include "../localisation/Localisation.h"
 #include "../world/Location.hpp"
 #include "ObjectManager.h"
 
@@ -34,7 +32,7 @@ void TerrainSurfaceObject::Load()
     {
         EntryBaseImageId = IconImageId + 1;
     }
-    NumEntries = (GetImageTable().GetCount() - EntryBaseImageId) / NUM_IMAGES_IN_ENTRY;
+    NumEntries = (GetImageTable().GetCount() - EntryBaseImageId) / kNumImagesInEntry;
 }
 
 void TerrainSurfaceObject::Unload()
@@ -52,7 +50,7 @@ void TerrainSurfaceObject::Unload()
 void TerrainSurfaceObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const
 {
     auto imageId = ImageId(GetImageId({}, 1, 0, 0, false, false));
-    if (Colour != 255)
+    if (Colour != kNoValue)
     {
         imageId = imageId.WithPrimary(Colour);
     }
@@ -84,7 +82,7 @@ void TerrainSurfaceObject::ReadJson(IReadObjectContext* context, json_t& root)
 
     if (properties.is_object())
     {
-        Colour = Colour::FromString(Json::GetString(properties["colour"]), 255);
+        Colour = Colour::FromString(Json::GetString(properties["colour"]), kNoValue);
         Rotations = Json::GetNumber<int8_t>(properties["rotations"], 1);
         Price = Json::GetNumber<money64>(properties["price"]);
         Flags = Json::GetFlags<TERRAIN_SURFACE_FLAGS>(
@@ -108,13 +106,17 @@ void TerrainSurfaceObject::ReadJson(IReadObjectContext* context, json_t& root)
             if (el.is_object())
             {
                 SpecialEntry entry;
-                entry.Index = Json::GetNumber<uint32_t>(el["index"]);
-                entry.Length = Json::GetNumber<int32_t>(el["length"], -1);
-                entry.Rotation = Json::GetNumber<int32_t>(el["rotation"], -1);
-                entry.Variation = Json::GetNumber<int32_t>(el["variation"], -1);
-                entry.Grid = Json::GetBoolean(el["grid"]);
-                entry.Underground = Json::GetBoolean(el["underground"]);
-                SpecialEntries.push_back(std::move(entry));
+                entry.Index = Json::GetNumber<uint8_t>(el["index"]);
+                entry.Length = Json::GetNumber<uint8_t>(el["length"], kNoValue);
+                entry.Rotation = Json::GetNumber<uint8_t>(el["rotation"], kNoValue);
+                entry.Variation = Json::GetNumber<uint8_t>(el["variation"], kNoValue);
+
+                if (Json::GetBoolean(el["underground"]))
+                    SpecialEntriesUnderground.push_back(entry);
+                else if (Json::GetBoolean(el["grid"]))
+                    SpecialEntriesGrid.push_back(entry);
+                else
+                    SpecialEntries.push_back(entry);
             }
         }
     }
@@ -136,24 +138,43 @@ void TerrainSurfaceObject::ReadJson(IReadObjectContext* context, json_t& root)
     PopulateTablesFromJson(context, root);
 }
 
-uint32_t TerrainSurfaceObject::GetImageId(
-    const CoordsXY& position, int32_t length, int32_t rotation, int32_t offset, bool grid, bool underground) const
+ImageId TerrainSurfaceObject::GetImageId(
+    const CoordsXY& position, uint8_t length, uint8_t rotation, uint8_t offset, bool grid, bool underground) const
 {
-    uint32_t result = (underground ? DefaultUndergroundEntry : (grid ? DefaultGridEntry : DefaultEntry));
+    uint32_t result = DefaultEntry;
+    std::span<const SpecialEntry> entries(SpecialEntries);
+    if (underground)
+    {
+        result = DefaultUndergroundEntry;
+        entries = std::span<const SpecialEntry>(SpecialEntriesUnderground);
+    }
+    else if (grid)
+    {
+        result = DefaultGridEntry;
+        entries = std::span<const SpecialEntry>(SpecialEntriesGrid);
+    }
+
+    TileCoordsXY tilePos(position);
+    uint8_t variation = ((tilePos.x << 1) & 0b10) | (tilePos.y & 0b01);
 
     // Look for a matching special
-    auto variation = ((position.x << 1) & 0b10) | (position.y & 0b01);
-    for (const auto& special : SpecialEntries)
+    for (const SpecialEntry& special : entries)
     {
-        if ((special.Length == -1 || special.Length == length) && (special.Rotation == -1 || special.Rotation == rotation)
-            && (special.Variation == -1 || special.Variation == variation) && special.Grid == grid
-            && special.Underground == underground)
+        if ((special.Length == kNoValue || special.Length == length)
+            && (special.Rotation == kNoValue || special.Rotation == rotation)
+            && (special.Variation == kNoValue || special.Variation == variation))
         {
             result = special.Index;
             break;
         }
     }
-    return EntryBaseImageId + (result * NUM_IMAGES_IN_ENTRY) + offset;
+
+    ImageId image(EntryBaseImageId + (result * kNumImagesInEntry) + offset);
+    if (Colour != kNoValue)
+    {
+        image = image.WithPrimary(Colour);
+    }
+    return image;
 }
 
 TerrainSurfaceObject* TerrainSurfaceObject::GetById(ObjectEntryIndex entryIndex)

--- a/src/openrct2/object/TerrainSurfaceObject.h
+++ b/src/openrct2/object/TerrainSurfaceObject.h
@@ -26,17 +26,16 @@ class TerrainSurfaceObject final : public Object
 private:
     struct SpecialEntry
     {
-        uint32_t Index{};
-        int32_t Length{};
-        int32_t Rotation{};
-        int32_t Variation{};
-        bool Grid{};
-        bool Underground{};
+        uint8_t Index{};
+        uint8_t Length{};
+        uint8_t Rotation{};
+        uint8_t Variation{};
     };
 
-    static constexpr auto NUM_IMAGES_IN_ENTRY = 19;
+    static constexpr auto kNumImagesInEntry = 19;
 
 public:
+    static constexpr uint8_t kNoValue = 0xFF;
     StringId NameStringId{};
     uint32_t IconImageId{};
     uint32_t PatternBaseImageId{};
@@ -47,7 +46,8 @@ public:
     uint32_t DefaultGridEntry{};
     uint32_t DefaultUndergroundEntry{};
     std::vector<SpecialEntry> SpecialEntries;
-    std::vector<uint32_t> SpecialEntryMap;
+    std::vector<SpecialEntry> SpecialEntriesUnderground;
+    std::vector<SpecialEntry> SpecialEntriesGrid;
 
     colour_t Colour{};
     uint8_t Rotations{};
@@ -61,8 +61,8 @@ public:
 
     void DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const override;
 
-    uint32_t GetImageId(
-        const CoordsXY& position, int32_t length, int32_t rotation, int32_t offset, bool grid, bool underground) const;
+    ImageId GetImageId(
+        const CoordsXY& position, uint8_t length, uint8_t rotation, uint8_t offset, bool grid, bool underground) const;
 
     static TerrainSurfaceObject* GetById(ObjectEntryIndex entryIndex);
 };


### PR DESCRIPTION
When using opengl to draw the fully zoomed out build your own six flags park with an -O2 build, this change reduced the total runtime in this function from 3.32% to 1.95%. Hopefully more in Debug builds as I get 8 fps there.

Changes: 
* Remove the helper function in `Paint.Surface.cpp` and move the small logic it does to `TerrainSurfaceObject.cpp`.
* Reduce the size of the `SpecialEntry` struct from 20 bytes to 4 bytes by using `uint8_t` instead of bigger types.
* Make multiple special lists based on the `underground` and `grid` flags as these are mutually exclusive. (This is most of the speedup as now rendering a grass tile only checks 16 entries instead of 32).
* Other stuff like rename a constant and clean up headers.

I checked the values with this search to make sure they don't overflow the smaller `uint8_t`: https://github.com/search?q=repo%3AOpenRCT2%2Fobjects%20%22special%22%3A%20%5B&type=code
Also the original parameters going into the function were sourced from 8 bit types anyway.

It's sort of annoying because by making some more assumptions about the values in the Json you could probably make this a lot faster, but then it would be fragile if the json changes (is it realistic that it would change??)


