### PR TITLE
Fix #21829: {POP16}{POP16} in Scenario editor

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -188,7 +188,7 @@ STR_0768    :Handyman {INT32}
 STR_0769    :Mechanic {INT32}
 STR_0770    :Security Guard {INT32}
 STR_0771    :Entertainer {INT32}
-STR_0777    :Unnamed park{POP16}{POP16}
+STR_0777    :Unnamed park
 STR_0778    :Sign
 STR_0779    :1st
 STR_0780    :2nd

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Change: [#21715] [Plugin] Remove access to the internal `owner` property. Note: `ownership` is still accessible.
 - Fix: [#866] Boat Hire boats get stuck entering track.
 - Fix: [#21787] Map generator heightmap should respect increased height limits.
+- Fix: [#21829] When creating a new scenario, the default name contains formatting codes.
 
 0.4.10 (2024-04-02)
 ------------------------------------------------------------------------


### PR DESCRIPTION
Remove notation from string