### PR TITLE
Fix #21837: Formatter being overwritten - RideConstruction.cpp

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1536,7 +1536,7 @@ static Widget _rideConstructionWidgets[] = {
             }
 
             // Set window title arguments
-            ft = Formatter::Common();
+            ft.Rewind();
             ft.Increment(4);
             currentRide->FormatNameTo(ft);
         }

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1515,6 +1515,10 @@ static Widget _rideConstructionWidgets[] = {
                 }
                 ft.Add<uint16_t>(brakeSpeed2);
             }
+            else
+            {
+                ft.Increment(2);
+            }
 
             widgets[WIDX_SEAT_ROTATION_ANGLE_SPINNER].text = RideConstructionSeatAngleRotationStrings
                 [_currentSeatRotationAngle];
@@ -1536,8 +1540,6 @@ static Widget _rideConstructionWidgets[] = {
             }
 
             // Set window title arguments
-            ft.Rewind();
-            ft.Increment(4);
             currentRide->FormatNameTo(ft);
         }
 


### PR DESCRIPTION
Fix https://github.com/OpenRCT2/OpenRCT2/issues/21837 - remove unnecessary lines as the value in the Formatter is overwritten.