### PR TITLE
Introduce SPR_DEFAULT_PALETTE

### DIFF
--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -781,13 +781,12 @@ void LoadPalette()
         return;
     }
 
+    uint32_t palette = SPR_DEFAULT_PALETTE;
+
     auto water_type = OpenRCT2::ObjectManager::GetObjectEntry<WaterObjectEntry>(0);
-
-    uint32_t palette = 0x5FC;
-
     if (water_type != nullptr)
     {
-        Guard::Assert(water_type->image_id != 0xFFFFFFFF, "Failed to load water palette");
+        Guard::Assert(water_type->image_id != ImageIndexUndefined, "Failed to load water palette");
         palette = water_type->image_id;
     }
 

--- a/src/openrct2/sprites.h
+++ b/src/openrct2/sprites.h
@@ -19,6 +19,8 @@ enum
     // Used for on-demand drawing of dynamic memory
     SPR_TEMP = 0x7FFFE,
 
+    SPR_DEFAULT_PALETTE = 1532,
+
     SPR_SCROLLING_TEXT_LEGACY_START = 1542,
     SPR_SCROLLING_TEXT_LEGACY_END = SPR_SCROLLING_TEXT_LEGACY_START + OpenRCT2::MaxScrollingTextLegacyEntries,
     SPR_SCROLLING_TEXT_DEFAULT = 1574,


### PR DESCRIPTION
Recently, I've been musing about implementing a new feature that requires the default/fallback palette from G1.dat. To my pleasant surprise, this is already supported by `LoadPalette`, though it doesn't make it explicit. In this PR, I am introducing a constant that makes it more clear what's going on.

For consistency with the legacy `sprites.h` file, I have still used SCREAMING_SNAKE_CASE for this new constant.

In the spirit of completeness, here's a dump of the palette 'image' in question:
![01532](https://github.com/OpenRCT2/OpenRCT2/assets/604665/139926bf-87a9-4e2b-b110-015c37142d6e)
