### PR TITLE
Make usage of Audio namespace explicit in Context

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -84,12 +84,13 @@
 #include <string>
 
 using namespace OpenRCT2;
-using namespace OpenRCT2::Audio;
 using namespace OpenRCT2::Drawing;
 using namespace OpenRCT2::Localisation;
 using namespace OpenRCT2::Paint;
 using namespace OpenRCT2::Scripting;
 using namespace OpenRCT2::Ui;
+
+using OpenRCT2::Audio::IAudioContext;
 
 namespace OpenRCT2
 {
@@ -451,9 +452,9 @@ namespace OpenRCT2
             if (!gOpenRCT2Headless)
             {
                 Audio::Init();
-                PopulateDevices();
-                InitRideSoundsAndInfo();
-                gGameSoundsOff = !gConfigSound.MasterSoundEnabled;
+                Audio::PopulateDevices();
+                Audio::InitRideSoundsAndInfo();
+                Audio::gGameSoundsOff = !gConfigSound.MasterSoundEnabled;
             }
 
             ChatInit();
@@ -1343,7 +1344,7 @@ namespace OpenRCT2
 
     std::unique_ptr<IContext> CreateContext()
     {
-        return CreateContext(CreatePlatformEnvironment(), CreateDummyAudioContext(), CreateDummyUiContext());
+        return CreateContext(CreatePlatformEnvironment(), Audio::CreateDummyAudioContext(), CreateDummyUiContext());
     }
 
     std::unique_ptr<IContext> CreateContext(

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -450,7 +450,7 @@ namespace OpenRCT2
 
             if (!gOpenRCT2Headless)
             {
-                Init();
+                Audio::Init();
                 PopulateDevices();
                 InitRideSoundsAndInfo();
                 gGameSoundsOff = !gConfigSound.MasterSoundEnabled;


### PR DESCRIPTION
While working on the `Context::Initialise` function, I ran into an `Init()` function call I couldn't immediately place. It turns out to be from the Audio namespace, which was included in full. This is clearly not ideal.

Initially, I replaced it with just `Audio::Init()` (first commit), but I decided to instead get rid of the `using namespace OpenRCT2::Audio` and invoke the namespace explicitly (second commit).

Admittedly, this is an (OpenLoco) code style preference. Personally, I think the second commit is the way to go, but we should disambiguate the call at the very least.