### PR TITLE
Close #18305: Move Translate3DTo2DWithZ() from Map.h into Viewport.h

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -237,6 +237,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Harry Hopkinson (Harry-Hopkinson)
 * Jan Kelemen (jan-kelemen)
 * Cory Ye (CoryfY)
+* Karsten Van Fossan (karstenvanf)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -29,6 +29,7 @@
 #include <openrct2/actions/TrackSetBrakeSpeedAction.h>
 #include <openrct2/audio/audio.h>
 #include <openrct2/config/Config.h>
+#include <openrct2/interface/Viewport.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/network/network.h>

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -2156,6 +2156,13 @@ std::optional<CoordsXY> ScreenGetMapXYSideWithZ(const ScreenCoordsXY& screenCoor
     return mapCoords->ToTileStart();
 }
 
+ScreenCoordsXY Translate3DTo2DWithZ(int32_t rotation, const CoordsXYZ& pos)
+{
+    auto rotated = pos.Rotate(rotation);
+    // Use right shift to avoid issues like #9301
+    return ScreenCoordsXY{ rotated.y - rotated.x, ((rotated.x + rotated.y) >> 1) - pos.z };
+}
+
 /**
  * Get current viewport rotation.
  *

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -172,6 +172,8 @@ std::optional<CoordsXY> ScreenGetMapXYQuadrantWithZ(const ScreenCoordsXY& screen
 std::optional<CoordsXY> ScreenGetMapXYSide(const ScreenCoordsXY& screenCoords, uint8_t* side);
 std::optional<CoordsXY> ScreenGetMapXYSideWithZ(const ScreenCoordsXY& screenCoords, int32_t z, uint8_t* side);
 
+ScreenCoordsXY Translate3DTo2DWithZ(int32_t rotation, const CoordsXYZ& pos);
+
 uint8_t GetCurrentRotation();
 int32_t GetHeightMarkerOffset();
 

--- a/src/openrct2/ride/RideAudio.cpp
+++ b/src/openrct2/ride/RideAudio.cpp
@@ -16,6 +16,7 @@
 #include "../audio/AudioMixer.h"
 #include "../audio/audio.h"
 #include "../config/Config.h"
+#include "../interface/Viewport.h"
 #include "../object/AudioObject.h"
 #include "../object/MusicObject.h"
 #include "../object/ObjectManager.h"

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -35,6 +35,7 @@
 #include "../core/Numerics.hpp"
 #include "../core/String.hpp"
 #include "../drawing/X8DrawingEngine.h"
+#include "../interface/Viewport.h"
 #include "../localisation/Localisation.h"
 #include "../localisation/StringIds.h"
 #include "../management/Finance.h"

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -23,6 +23,7 @@
 #include "../config/Config.h"
 #include "../core/Guard.hpp"
 #include "../interface/Cursors.h"
+#include "../interface/Viewport.h"
 #include "../interface/Window.h"
 #include "../localisation/Date.h"
 #include "../localisation/Localisation.h"
@@ -287,7 +288,6 @@ bool MapCheckCapacityAndReorganise(const CoordsXY& loc, size_t numElements)
 }
 
 static void ClearElementsAt(const CoordsXY& loc);
-static ScreenCoordsXY Translate3DTo2D(int32_t rotation, const CoordsXY& pos);
 
 void TileElementIteratorBegin(TileElementIterator* it)
 {
@@ -1102,7 +1102,7 @@ static void MapGetBoundingBox(const MapRange& _range, int32_t* left, int32_t* to
 
     for (const auto& corner : corners)
     {
-        auto screenCoord = Translate3DTo2D(rotation, corner);
+        auto screenCoord = Translate3DTo2DWithZ(rotation, CoordsXYZ{ corner, 0 });
         if (screenCoord.x < *left)
             *left = screenCoord.x;
         if (screenCoord.x > *right)
@@ -1769,18 +1769,6 @@ bool MapLargeScenerySignSetColour(const CoordsXYZD& signPos, int32_t sequence, u
     }
 
     return true;
-}
-
-static ScreenCoordsXY Translate3DTo2D(int32_t rotation, const CoordsXY& pos)
-{
-    return Translate3DTo2DWithZ(rotation, CoordsXYZ{ pos, 0 });
-}
-
-ScreenCoordsXY Translate3DTo2DWithZ(int32_t rotation, const CoordsXYZ& pos)
-{
-    auto rotated = pos.Rotate(rotation);
-    // Use right shift to avoid issues like #9301
-    return ScreenCoordsXY{ rotated.y - rotated.x, ((rotated.x + rotated.y) >> 1) - pos.z };
 }
 
 static void MapInvalidateTileUnderZoom(int32_t x, int32_t y, int32_t z0, int32_t z1, ZoomLevel maxZoom)

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -239,8 +239,6 @@ LargeSceneryElement* MapGetLargeScenerySegment(const CoordsXYZD& sceneryPos, int
 std::optional<CoordsXYZ> MapLargeSceneryGetOrigin(
     const CoordsXYZD& sceneryPos, int32_t sequence, LargeSceneryElement** outElement);
 
-ScreenCoordsXY Translate3DTo2DWithZ(int32_t rotation, const CoordsXYZ& pos);
-
 TrackElement* MapGetTrackElementAt(const CoordsXYZ& trackPos);
 TileElement* MapGetTrackElementAtOfType(const CoordsXYZ& trackPos, track_type_t trackType);
 TileElement* MapGetTrackElementAtOfTypeSeq(const CoordsXYZ& trackPos, track_type_t trackType, int32_t sequence);


### PR DESCRIPTION
Moved Translate3DTo2DWithZ to Viewport.h as suggested by ducanspumpkin in #18305 and updated references. I also removed the redundant function Translate3Dto2D, since it was only referenced once and only passed slightly modified parameters into Translate3DTo2DWithZ.