### PR TITLE
Fix #21690: Muting ride audio mutes title screen music

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -763,11 +763,8 @@ private:
         UpdateFullscreenResolutions();
 
         // Fix #4022: Force Mac to windowed to avoid cursor offset on launch issue
-#ifdef __MACOSX__
-        gConfigGeneral.FullscreenMode = static_cast<int32_t>(OpenRCT2::Ui::FULLSCREEN_MODE::WINDOWED);
-#else
+        // Fix #21696: Workaround is obsolete, removed
         SetFullscreenMode(static_cast<FULLSCREEN_MODE>(gConfigGeneral.FullscreenMode));
-#endif
         TriggerResize();
     }
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1326,7 +1326,7 @@ static Widget *window_options_page_widgets[] = {
                         OpenRCT2::RideAudio::StopAllChannels();
                         OpenRCT2::Audio::StopTitleMusic();
                     }
-                    else 
+                    else
                     {
                         OpenRCT2::Audio::PlayTitleMusic();
                     }

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1324,6 +1324,9 @@ static Widget *window_options_page_widgets[] = {
                     if (!gConfigSound.RideMusicEnabled)
                     {
                         OpenRCT2::RideAudio::StopAllChannels();
+                        OpenRCT2::Audio::StopTitleMusic();
+                    } else {
+                        OpenRCT2::Audio::PlayTitleMusic();
                     }
                     ConfigSaveDefault();
                     Invalidate();

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1325,7 +1325,9 @@ static Widget *window_options_page_widgets[] = {
                     {
                         OpenRCT2::RideAudio::StopAllChannels();
                         OpenRCT2::Audio::StopTitleMusic();
-                    } else {
+                    }
+                    else 
+                    {
                         OpenRCT2::Audio::PlayTitleMusic();
                     }
                     ConfigSaveDefault();

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -294,7 +294,8 @@ namespace OpenRCT2::Audio
 
     void PlayTitleMusic()
     {
-        if (gGameSoundsOff || !(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) || gIntroState != IntroState::None || !gConfigSound.RideMusicEnabled)
+        if (gGameSoundsOff || !(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) || gIntroState != IntroState::None 
+            || !gConfigSound.RideMusicEnabled)
         {
             StopTitleMusic();
             return;

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -294,7 +294,7 @@ namespace OpenRCT2::Audio
 
     void PlayTitleMusic()
     {
-        if (gGameSoundsOff || !(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) || gIntroState != IntroState::None)
+        if (gGameSoundsOff || !(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) || gIntroState != IntroState::None || !gConfigSound.RideMusicEnabled)
         {
             StopTitleMusic();
             return;

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -294,7 +294,7 @@ namespace OpenRCT2::Audio
 
     void PlayTitleMusic()
     {
-        if (gGameSoundsOff || !(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) || gIntroState != IntroState::None 
+        if (gGameSoundsOff || !(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) || gIntroState != IntroState::None
             || !gConfigSound.RideMusicEnabled)
         {
             StopTitleMusic();


### PR DESCRIPTION
Fixes #21690. There was an issue where the "mute ride music" checkbox didn't affect the title screen music. This fix patches that bug by slightly modifying the code for the ride music checkbox in Options.cpp and the PlayTitleMusic() function in Audio.cpp.