### PR TITLE
Feature: #20157 - Hide FPS Counter if Top Toolbar and Widgets are Hidden.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Improved: [#21855] Add a separator between “Load Game” and “Save Game”, to avoid accidental overwriting.
 - Change: [#21715] [Plugin] Remove access to the internal `owner` property. Note: `ownership` is still accessible.
 - Change: [#21855] Cheats menu dropdown no longer requires dragging.
+- Change: [#21866] Hide the FPS Counter when the top toolbar/widgets have been toggled off.
 - Fix: [#866] Boat Hire boats get stuck entering track (original bug).
 - Fix: [#10701] No reason specified when placing door over unsuitable track.
 - Fix: [#18723, #21870] Attempting to demolish a flat ride in pause mode allows you to place multiple copies.

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -103,8 +103,22 @@ void Painter::PaintReplayNotice(DrawPixelInfo& dpi, const char* text)
     GfxSetDirtyBlocks({ screenCoords, screenCoords + ScreenCoordsXY{ stringWidth, 16 } });
 }
 
+static bool ShouldShowFPS()
+{
+    if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO && !TitleShouldHideVersionInfo())
+        return true;
+
+    if (!WindowFindByClass(WindowClass::TopToolbar))
+        return false;
+
+    return true;
+}
+
 void Painter::PaintFPS(DrawPixelInfo& dpi)
 {
+    if (!ShouldShowFPS())
+        return;
+
     ScreenCoordsXY screenCoords(_uiContext->GetWidth() / 2, 2);
 
     MeasureFPS();


### PR DESCRIPTION
As devised in https://github.com/OpenRCT2/OpenRCT2/issues/20157 - this change hides the FPS counter when the Top Toolbar has been toggled off in game or the widgets have been hidden in the Title screen.