### PR TITLE
Fix #21690: Muting ride music doesn't mute title music

### DIFF
--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1324,6 +1324,11 @@ static Widget *window_options_page_widgets[] = {
                     if (!gConfigSound.RideMusicEnabled)
                     {
                         OpenRCT2::RideAudio::StopAllChannels();
+                        OpenRCT2::Audio::StopTitleMusic();
+                    }
+                    else
+                    {
+                        OpenRCT2::Audio::PlayTitleMusic();
                     }
                     ConfigSaveDefault();
                     Invalidate();

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -294,7 +294,8 @@ namespace OpenRCT2::Audio
 
     void PlayTitleMusic()
     {
-        if (gGameSoundsOff || !(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) || gIntroState != IntroState::None)
+        if (gGameSoundsOff || !(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) || gIntroState != IntroState::None
+            || !gConfigSound.RideMusicEnabled)
         {
             StopTitleMusic();
             return;


### PR DESCRIPTION
Slightly modifies the Audio.cpp and Options.cpp files to make the "mute ride audio" checkbox affect the title music.