### PR TITLE
Fix #21696: Fullscreen window option not correctly applied on macOS

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Improved: [#21769] Expose “animation is backwards” wall property in Tile Inspector.
 - Change: [#21715] [Plugin] Remove access to the internal `owner` property. Note: `ownership` is still accessible.
 - Fix: [#866] Boat Hire boats get stuck entering track.
+- Fix: [#21696] Fullscreen window option not correctly applied on macOS.
 - Fix: [#21787] Map generator heightmap should respect increased height limits.
 
 0.4.10 (2024-04-02)

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -762,8 +762,6 @@ private:
 
         UpdateFullscreenResolutions();
 
-        // Fix #4022: Force Mac to windowed to avoid cursor offset on launch issue
-        // Fix #21696: This workaround is obsolete, reverting it so that Mac remembers window mode
         SetFullscreenMode(static_cast<FULLSCREEN_MODE>(gConfigGeneral.FullscreenMode));
         TriggerResize();
     }

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -763,11 +763,8 @@ private:
         UpdateFullscreenResolutions();
 
         // Fix #4022: Force Mac to windowed to avoid cursor offset on launch issue
-#ifdef __MACOSX__
-        gConfigGeneral.FullscreenMode = static_cast<int32_t>(OpenRCT2::Ui::FULLSCREEN_MODE::WINDOWED);
-#else
+        // Fix #21696: This workaround is obsolete, reverting it so that Mac remembers window mode
         SetFullscreenMode(static_cast<FULLSCREEN_MODE>(gConfigGeneral.FullscreenMode));
-#endif
         TriggerResize();
     }
 


### PR DESCRIPTION
Removes a previously implemented workaround that was forcing Mac to open the program in windowed mode. This was implemented to keep a cursor issue from happening, but this cursor issue no longer occurs.