### PR TITLE
Resolve #21494: Automatically set window scaling based on DPI

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Feature: [#22213] [Plugin] Allow plugins to focus on textboxes in custom windows.
 - Feature: [#22301] Loading save games or scenarios now indicates loading progress.
 - Feature: [OpenMusic#54] Added Progressive ride music style (feat. Approaching Nirvana).
+- Change: [#21494] Display pixel density is now taken into account for the initial window scale setting.
 - Change: [#22230] The plugin/script engine is now initialised off the main thread.
 - Change: [#22251] Hide author info in the scenery window unless debug tools are active.
 - Change: [#22309] The scenario editor now supports loading landscapes from .sea save files.

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -120,7 +120,7 @@ public:
         {
             SDLException::Throw("SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK)");
         }
-        if (gConfigGeneral.RefreshDPIScaling)
+        if (gConfigGeneral.InferDisplayDPI)
         {
             float ddpi, hdpi, vdpi;
             if (!SDL_GetDisplayDPI(0, &ddpi, &hdpi, &vdpi))
@@ -130,7 +130,7 @@ public:
 
                 LOG_VERBOSE("Changing DPI scaling to %f\n", gConfigGeneral.WindowScale);
             }
-            gConfigGeneral.RefreshDPIScaling = false;
+            gConfigGeneral.InferDisplayDPI = false;
             auto configPath = env->GetFilePath(PATHID::CONFIG);
             ConfigSave(configPath.c_str());
         }

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -743,9 +743,9 @@ private:
 
         auto renderer = SDL_GetRenderer(_window);
         int rWidth, rHeight;
-        SDL_GetRendererOutputSize(renderer, &rWidth, &rHeight);
+        if (SDL_GetRendererOutputSize(renderer, &rWidth, &rHeight) == 0)
+            config.WindowScale = rWidth / wWidth;
 
-        config.WindowScale = rWidth / wWidth;
         config.InferDisplayDPI = false;
         Config::Save();
     }

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -31,7 +31,6 @@
 #include <openrct2/Context.h>
 #include <openrct2/Diagnostic.h>
 #include <openrct2/Input.h>
-#include <openrct2/PlatformEnvironment.h>
 #include <openrct2/Version.h>
 #include <openrct2/audio/AudioContext.h>
 #include <openrct2/audio/AudioMixer.h>
@@ -741,12 +740,10 @@ private:
 
         int wWidth, wHeight;
         SDL_GetWindowSize(_window, &wWidth, &wHeight);
-        LOG_INFO("SDL_GetWindowSize: %d, %d", wWidth, wHeight);
 
         auto renderer = SDL_GetRenderer(_window);
         int rWidth, rHeight;
         SDL_GetRendererOutputSize(renderer, &rWidth, &rHeight);
-        LOG_INFO("SDL_GetRendererOutputSize: %d, %d", rWidth, rHeight);
 
         config.WindowScale = rWidth / wWidth;
         config.InferDisplayDPI = false;

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -739,15 +739,16 @@ private:
         if (!config.InferDisplayDPI)
             return;
 
-        float ddpi, hdpi, vdpi;
-        if (SDL_GetDisplayDPI(0, &ddpi, &hdpi, &vdpi) == 0)
-        {
-            constexpr auto regularDPI = 96.0f;
-            config.WindowScale = std::round(ddpi / regularDPI * 2.0) / 2.0;
+        int wWidth, wHeight;
+        SDL_GetWindowSize(_window, &wWidth, &wHeight);
+        LOG_INFO("SDL_GetWindowSize: %d, %d", wWidth, wHeight);
 
-            LOG_VERBOSE("Changing DPI scaling to %f\n", config.WindowScale);
-        }
+        auto renderer = SDL_GetRenderer(_window);
+        int rWidth, rHeight;
+        SDL_GetRendererOutputSize(renderer, &rWidth, &rHeight);
+        LOG_INFO("SDL_GetRendererOutputSize: %d, %d", rWidth, rHeight);
 
+        config.WindowScale = rWidth / wWidth;
         config.InferDisplayDPI = false;
         Config::Save();
     }
@@ -775,7 +776,6 @@ private:
             SDLException::Throw("SDL_CreateWindow(...)");
         }
 
-        InferDisplayDPI();
         ApplyScreenSaverLockSetting();
 
         SDL_SetWindowMinimumSize(_window, 720, 480);
@@ -784,6 +784,7 @@ private:
 
         // Initialise the surface, palette and draw buffer
         DrawingEngineInit();
+        InferDisplayDPI();
         OnResize(width, height);
 
         UpdateFullscreenResolutions();

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -31,6 +31,7 @@
 #include <openrct2/Context.h>
 #include <openrct2/Diagnostic.h>
 #include <openrct2/Input.h>
+#include <openrct2/PlatformEnvironment.h>
 #include <openrct2/Version.h>
 #include <openrct2/audio/AudioContext.h>
 #include <openrct2/audio/AudioMixer.h>
@@ -118,6 +119,20 @@ public:
         if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK) < 0)
         {
             SDLException::Throw("SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK)");
+        }
+        if (gConfigGeneral.RefreshDPIScaling)
+        {
+            float ddpi, hdpi, vdpi;
+            if (!SDL_GetDisplayDPI(0, &ddpi, &hdpi, &vdpi))
+            {
+                // If DPI can be read, divide DPI by regular DPI (96.0f) and round to nearest 0.25
+                gConfigGeneral.WindowScale = std::round(ddpi / 96.0f * 4.0) / 4.0;
+
+                LOG_VERBOSE("Changing DPI scaling to %f\n", gConfigGeneral.WindowScale);
+            }
+            gConfigGeneral.RefreshDPIScaling = false;
+            auto configPath = env->GetFilePath(PATHID::CONFIG);
+            ConfigSave(configPath.c_str());
         }
         _cursorRepository.LoadCursors();
         _shortcutManager.LoadUserBindings();

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -123,10 +123,10 @@ public:
         if (gConfigGeneral.InferDisplayDPI)
         {
             float ddpi, hdpi, vdpi;
-            if (!SDL_GetDisplayDPI(0, &ddpi, &hdpi, &vdpi))
+            if (SDL_GetDisplayDPI(0, &ddpi, &hdpi, &vdpi) == 0)
             {
-                // If DPI can be read, divide DPI by regular DPI (96.0f) and round to nearest 0.25
-                gConfigGeneral.WindowScale = std::round(ddpi / 96.0f * 4.0) / 4.0;
+                constexpr auto regularDPI = 96.0f;
+                gConfigGeneral.WindowScale = std::round(ddpi / regularDPI * 4.0) / 4.0;
 
                 LOG_VERBOSE("Changing DPI scaling to %f\n", gConfigGeneral.WindowScale);
             }

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -213,6 +213,7 @@ namespace OpenRCT2::Config
             model->DisableLightningEffect = reader->GetBoolean("disable_lightning_effect", false);
             model->SteamOverlayPause = reader->GetBoolean("steam_overlay_pause", true);
             model->WindowScale = reader->GetFloat("window_scale", Platform::GetDefaultScale());
+            model->RefreshDPIScaling = reader->GetBoolean("refresh_dpi_scaling", true);
             model->ShowFPS = reader->GetBoolean("show_fps", false);
 #ifdef _DEBUG
             // Always have multi-threading disabled in debug builds, this makes things slower.
@@ -303,6 +304,7 @@ namespace OpenRCT2::Config
         writer->WriteBoolean("disable_lightning_effect", model->DisableLightningEffect);
         writer->WriteBoolean("steam_overlay_pause", model->SteamOverlayPause);
         writer->WriteFloat("window_scale", model->WindowScale);
+        writer->WriteBoolean("refresh_dpi_scaling", model->RefreshDPIScaling);
         writer->WriteBoolean("show_fps", model->ShowFPS);
         writer->WriteBoolean("multithreading", model->MultiThreading);
         writer->WriteBoolean("trap_cursor", model->TrapCursor);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -213,7 +213,7 @@ namespace OpenRCT2::Config
             model->DisableLightningEffect = reader->GetBoolean("disable_lightning_effect", false);
             model->SteamOverlayPause = reader->GetBoolean("steam_overlay_pause", true);
             model->WindowScale = reader->GetFloat("window_scale", Platform::GetDefaultScale());
-            model->InferDisplayDPI = reader->GetBoolean("refresh_dpi_scaling", true);
+            model->InferDisplayDPI = reader->GetBoolean("infer_display_dpi", true);
             model->ShowFPS = reader->GetBoolean("show_fps", false);
 #ifdef _DEBUG
             // Always have multi-threading disabled in debug builds, this makes things slower.
@@ -304,7 +304,7 @@ namespace OpenRCT2::Config
         writer->WriteBoolean("disable_lightning_effect", model->DisableLightningEffect);
         writer->WriteBoolean("steam_overlay_pause", model->SteamOverlayPause);
         writer->WriteFloat("window_scale", model->WindowScale);
-        writer->WriteBoolean("refresh_dpi_scaling", model->InferDisplayDPI);
+        writer->WriteBoolean("infer_display_dpi", model->InferDisplayDPI);
         writer->WriteBoolean("show_fps", model->ShowFPS);
         writer->WriteBoolean("multithreading", model->MultiThreading);
         writer->WriteBoolean("trap_cursor", model->TrapCursor);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -213,7 +213,7 @@ namespace OpenRCT2::Config
             model->DisableLightningEffect = reader->GetBoolean("disable_lightning_effect", false);
             model->SteamOverlayPause = reader->GetBoolean("steam_overlay_pause", true);
             model->WindowScale = reader->GetFloat("window_scale", Platform::GetDefaultScale());
-            model->RefreshDPIScaling = reader->GetBoolean("refresh_dpi_scaling", true);
+            model->InferDisplayDPI = reader->GetBoolean("refresh_dpi_scaling", true);
             model->ShowFPS = reader->GetBoolean("show_fps", false);
 #ifdef _DEBUG
             // Always have multi-threading disabled in debug builds, this makes things slower.
@@ -304,7 +304,7 @@ namespace OpenRCT2::Config
         writer->WriteBoolean("disable_lightning_effect", model->DisableLightningEffect);
         writer->WriteBoolean("steam_overlay_pause", model->SteamOverlayPause);
         writer->WriteFloat("window_scale", model->WindowScale);
-        writer->WriteBoolean("refresh_dpi_scaling", model->RefreshDPIScaling);
+        writer->WriteBoolean("refresh_dpi_scaling", model->InferDisplayDPI);
         writer->WriteBoolean("show_fps", model->ShowFPS);
         writer->WriteBoolean("multithreading", model->MultiThreading);
         writer->WriteBoolean("trap_cursor", model->TrapCursor);

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -36,6 +36,7 @@ namespace OpenRCT2::Config
         int32_t FullscreenWidth;
         int32_t FullscreenHeight;
         float WindowScale;
+        bool RefreshDPIScaling;
         ::DrawingEngine DrawingEngine;
         bool UncapFPS;
         bool UseVSync;

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -36,7 +36,7 @@ namespace OpenRCT2::Config
         int32_t FullscreenWidth;
         int32_t FullscreenHeight;
         float WindowScale;
-        bool RefreshDPIScaling;
+        bool InferDisplayDPI;
         ::DrawingEngine DrawingEngine;
         bool UncapFPS;
         bool UseVSync;


### PR DESCRIPTION
I used a similar to solution to #6991, but modified it to include a config option that flags whether the DPI has been checked instead of setting an invalid scaling factor. If the DPI check returns an error, it does not change from the default of 1.