### PR TITLE
Close #7226: Remove duplicate sprite_map in TrackPaint.cpp

### DIFF
--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -1625,19 +1625,12 @@ constexpr CoordsXY defaultRightQuarterTurn3TilesBoundLengths[4][3] = {
     },
 };
 
-static constexpr int8_t right_quarter_turn_3_tiles_sprite_map[] = {
-    0,
-    -1,
-    1,
-    2,
-};
-
 void TrackPaintUtilRightQuarterTurn3TilesPaint(
     PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId colourFlags, const uint32_t sprites[4][3], const CoordsXY offsets[4][3], const CoordsXY boundsLengths[4][3],
     const CoordsXYZ boundsOffsets[4][3])
 {
-    int32_t index = right_quarter_turn_3_tiles_sprite_map[trackSequence];
+    int32_t index = kRightQuarterTurn3TilesSpriteMap[trackSequence];
     if (index < 0)
     {
         return;
@@ -1665,7 +1658,7 @@ void TrackPaintUtilRightQuarterTurn3TilesPaint2WithHeightOffset(
     PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId colourFlags, const uint32_t sprites[4][3], int32_t heightOffset)
 {
-    int8_t sprite = right_quarter_turn_3_tiles_sprite_map[trackSequence];
+    int8_t sprite = kRightQuarterTurn3TilesSpriteMap[trackSequence];
     if (sprite < 0)
     {
         return;
@@ -1753,7 +1746,7 @@ void TrackPaintUtilRightQuarterTurn3TilesPaint3(
     PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId colourFlags,
     const SpriteBb sprites[4][3])
 {
-    int8_t sprite = right_quarter_turn_3_tiles_sprite_map[trackSequence];
+    int8_t sprite = kRightQuarterTurn3TilesSpriteMap[trackSequence];
     if (sprite < 0)
     {
         return;
@@ -1770,7 +1763,7 @@ void TrackPaintUtilRightQuarterTurn3TilesPaint4(
     PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId colourFlags,
     const SpriteBb sprites[4][3])
 {
-    int8_t sprite = right_quarter_turn_3_tiles_sprite_map[trackSequence];
+    int8_t sprite = kRightQuarterTurn3TilesSpriteMap[trackSequence];
     if (sprite < 0)
     {
         return;

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -258,6 +258,8 @@ extern const CoordsXY defaultRightQuarterTurn3TilesOffsets[4][3];
 extern const CoordsXYZ defaultRightQuarterTurn3TilesBoundOffsets[4][3];
 extern const CoordsXY defaultRightQuarterTurn3TilesBoundLengths[4][3];
 
+constexpr int8_t kRightQuarterTurn3TilesSpriteMap[] = { 0, -1, 1, 2 };
+
 extern const CoordsXY defaultRightHelixUpSmallQuarterBoundLengths[4][3][2];
 extern const CoordsXYZ defaultRightHelixUpSmallQuarterBoundOffsets[4][3][2];
 

--- a/src/openrct2/ride/transport/MiniatureRailway.cpp
+++ b/src/openrct2/ride/transport/MiniatureRailway.cpp
@@ -1392,9 +1392,7 @@ static void PaintMiniatureRailwayTrackRightQuarterTurn3Tiles(
             miniature_railway_right_quarter_turn_3_tile_track_floor, nullptr, defaultRightQuarterTurn3TilesBoundLengths,
             miniature_railway_right_quarter_turn_3_tile_bound_offsets);
 
-        static constexpr int8_t _right_quarter_turn_3_tiles_sprite_map[] = { 0, -1, 1, 2 };
-
-        int32_t index = _right_quarter_turn_3_tiles_sprite_map[trackSequence];
+        int32_t index = kRightQuarterTurn3TilesSpriteMap[trackSequence];
 
         auto imageId = session.TrackColours.WithIndex(
             miniature_railway_track_pieces_flat_quarter_turn_3_tiles[direction][index]);


### PR DESCRIPTION
Close https://github.com/OpenRCT2/OpenRCT2/issues/7226 - remove duplicate sprite_map in TrackPaint.cpp