### PR TITLE
Scripting: when changing staff type, reset state to walking

### DIFF
--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -84,6 +84,10 @@ namespace OpenRCT2::Scripting
                 peep->AssignedStaffType = StaffType::Entertainer;
                 peep->SpriteType = PeepSpriteType::EntertainerPanda;
             }
+
+            // Reset state to walking to prevent invalid actions from carrying over
+            peep->Action = PeepActionType::Walking;
+            peep->ActionSpriteType = peep->NextActionSpriteType = PeepActionSpriteType::None;
         }
     }
 


### PR DESCRIPTION
When changing staff type for a staff member using plugins, invalid actions could carry over. For example, a handyman mowing lawn being changed into an entertainer... still mowing lawn. This PR resets the action state to walking when changing staff type, preventing any invalid actions from carrying over.

@Manticore-007, could you test if this fixes the problem with the Peep Editor you mentioned? 