### PR TITLE
Refactor constants in TrackPaint.cpp

### DIFF
--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -50,27 +50,6 @@ static constexpr TileCoordsXY EntranceOffsetEdgeNW[] = {
     { -1, 0 },
 };
 
-// clang-format off
-const uint8_t edges_4x4[] = {
-    EDGE_NE | EDGE_NW,
-    EDGE_NE,
-    EDGE_NE,
-    EDGE_NE | EDGE_SE,
-    EDGE_NW,
-    0,
-    0,
-    EDGE_SE,
-    EDGE_NW,
-    0,
-    0,
-    EDGE_SE,
-    EDGE_NW | EDGE_SW,
-    EDGE_SW,
-    EDGE_SW,
-    EDGE_SW | EDGE_SE,
-};
-// clang-format on
-
 const int32_t DiagBlockedSegments[] = {
     EnumsToFlags(PaintSegment::centre, PaintSegment::topRightSide, PaintSegment::bottomRightSide, PaintSegment::rightCorner),
     EnumsToFlags(PaintSegment::centre, PaintSegment::topRightSide, PaintSegment::topLeftSide, PaintSegment::topCorner),

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -50,13 +50,6 @@ static constexpr TileCoordsXY EntranceOffsetEdgeNW[] = {
     { -1, 0 },
 };
 
-const uint8_t track_map_3x3[][9] = {
-    { 0, 1, 2, 3, 4, 5, 6, 7, 8 },
-    { 0, 3, 5, 7, 2, 8, 1, 6, 4 },
-    { 0, 7, 8, 6, 5, 4, 3, 1, 2 },
-    { 0, 6, 4, 1, 8, 2, 7, 3, 5 },
-};
-
 // clang-format off
 const uint8_t edges_3x3[] = {
     0,

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -50,13 +50,6 @@ static constexpr TileCoordsXY EntranceOffsetEdgeNW[] = {
     { -1, 0 },
 };
 
-const uint8_t track_map_2x2[][4] = {
-    { 0, 1, 2, 3 },
-    { 1, 3, 0, 2 },
-    { 3, 2, 1, 0 },
-    { 2, 0, 3, 1 },
-};
-
 const uint8_t edges_2x2[] = {
     EDGE_NE | EDGE_NW,
     EDGE_NE | EDGE_SE,

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -50,13 +50,6 @@ static constexpr TileCoordsXY EntranceOffsetEdgeNW[] = {
     { -1, 0 },
 };
 
-const int32_t DiagBlockedSegments[] = {
-    EnumsToFlags(PaintSegment::centre, PaintSegment::topRightSide, PaintSegment::bottomRightSide, PaintSegment::rightCorner),
-    EnumsToFlags(PaintSegment::centre, PaintSegment::topRightSide, PaintSegment::topLeftSide, PaintSegment::topCorner),
-    EnumsToFlags(PaintSegment::bottomLeftSide, PaintSegment::centre, PaintSegment::bottomCorner, PaintSegment::bottomRightSide),
-    EnumsToFlags(PaintSegment::bottomLeftSide, PaintSegment::centre, PaintSegment::leftCorner, PaintSegment::topLeftSide),
-};
-
 const MetalSupportPlace DiagSupportPlacement[] = {
     MetalSupportPlace::LeftCorner,
     MetalSupportPlace::TopCorner,

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -50,20 +50,6 @@ static constexpr TileCoordsXY EntranceOffsetEdgeNW[] = {
     { -1, 0 },
 };
 
-// clang-format off
-const uint8_t edges_3x3[] = {
-    0,
-    EDGE_NE | EDGE_NW,
-    EDGE_NE,
-    EDGE_NE | EDGE_SE,
-    EDGE_NW,
-    EDGE_SE,
-    EDGE_SW | EDGE_NW,
-    EDGE_SW | EDGE_SE,
-    EDGE_SW,
-};
-// clang-format on
-
 const uint8_t track_map_4x4[][16] = {
     { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 },
     { 3, 7, 11, 15, 2, 6, 10, 14, 1, 5, 9, 13, 0, 4, 8, 12 },

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -50,13 +50,6 @@ static constexpr TileCoordsXY EntranceOffsetEdgeNW[] = {
     { -1, 0 },
 };
 
-const uint8_t edges_2x2[] = {
-    EDGE_NE | EDGE_NW,
-    EDGE_NE | EDGE_SE,
-    EDGE_SW | EDGE_NW,
-    EDGE_SW | EDGE_SE,
-};
-
 const uint8_t track_map_3x3[][9] = {
     { 0, 1, 2, 3, 4, 5, 6, 7, 8 },
     { 0, 3, 5, 7, 2, 8, 1, 6, 4 },

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -50,13 +50,6 @@ static constexpr TileCoordsXY EntranceOffsetEdgeNW[] = {
     { -1, 0 },
 };
 
-const uint8_t track_map_4x4[][16] = {
-    { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 },
-    { 3, 7, 11, 15, 2, 6, 10, 14, 1, 5, 9, 13, 0, 4, 8, 12 },
-    { 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 },
-    { 12, 8, 4, 0, 13, 9, 5, 1, 14, 10, 6, 2, 15, 11, 7, 3 },
-};
-
 // clang-format off
 const uint8_t edges_4x4[] = {
     EDGE_NE | EDGE_NW,

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -64,13 +64,6 @@ const MetalSupportPlace DiagSupportPlacement[] = {
     MetalSupportPlace::BottomCorner,
 };
 
-const uint8_t track_map_1x4[][4] = {
-    { 0, 1, 2, 3 },
-    { 2, 3, 0, 1 },
-    { 2, 3, 0, 1 },
-    { 0, 1, 2, 3 },
-};
-
 const uint32_t floorSpritesCork[] = {
     SPR_FLOOR_CORK_SE_SW,
     SPR_FLOOR_CORK_SW,

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -50,7 +50,12 @@ constexpr uint8_t kEdges3x3[] = {
 };
 // clang-format on
 
-extern const uint8_t track_map_4x4[][16];
+constexpr uint8_t kTrackMap4x4[][16] = {
+    { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 },
+    { 3, 7, 11, 15, 2, 6, 10, 14, 1, 5, 9, 13, 0, 4, 8, 12 },
+    { 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 },
+    { 12, 8, 4, 0, 13, 9, 5, 1, 14, 10, 6, 2, 15, 11, 7, 3 },
+};
 extern const uint8_t edges_4x4[];
 
 extern const uint8_t track_map_1x4[][4];

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -23,7 +23,12 @@ constexpr uint8_t kTrackMap2x2[][4] = {
     { 3, 2, 1, 0 },
     { 2, 0, 3, 1 },
 };
-extern const uint8_t edges_2x2[];
+constexpr uint8_t kEdges2x2[] = {
+    EDGE_NE | EDGE_NW,
+    EDGE_NE | EDGE_SE,
+    EDGE_SW | EDGE_NW,
+    EDGE_SW | EDGE_SE,
+};
 
 extern const uint8_t track_map_3x3[][9];
 extern const uint8_t edges_3x3[];

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -77,7 +77,12 @@ constexpr uint8_t kEdges4x4[] = {
 };
 // clang-format on
 
-extern const uint8_t track_map_1x4[][4];
+constexpr uint8_t kTrackMap1x4[][4] = {
+    { 0, 1, 2, 3 },
+    { 2, 3, 0, 1 },
+    { 2, 3, 0, 1 },
+    { 0, 1, 2, 3 },
+};
 
 extern const int32_t DiagBlockedSegments[];
 extern const MetalSupportPlace DiagSupportPlacement[];

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -30,7 +30,12 @@ constexpr uint8_t kEdges2x2[] = {
     EDGE_SW | EDGE_SE,
 };
 
-extern const uint8_t track_map_3x3[][9];
+constexpr uint8_t kTrackMap3x3[][9] = {
+    { 0, 1, 2, 3, 4, 5, 6, 7, 8 },
+    { 0, 3, 5, 7, 2, 8, 1, 6, 4 },
+    { 0, 7, 8, 6, 5, 4, 3, 1, 2 },
+    { 0, 6, 4, 1, 8, 2, 7, 3, 5 },
+};
 extern const uint8_t edges_3x3[];
 
 extern const uint8_t track_map_4x4[][16];

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -36,7 +36,19 @@ constexpr uint8_t kTrackMap3x3[][9] = {
     { 0, 7, 8, 6, 5, 4, 3, 1, 2 },
     { 0, 6, 4, 1, 8, 2, 7, 3, 5 },
 };
-extern const uint8_t edges_3x3[];
+// clang-format off
+constexpr uint8_t kEdges3x3[] = {
+    0,
+    EDGE_NE | EDGE_NW,
+    EDGE_NE,
+    EDGE_NE | EDGE_SE,
+    EDGE_NW,
+    EDGE_SE,
+    EDGE_SW | EDGE_NW,
+    EDGE_SW | EDGE_SE,
+    EDGE_SW,
+};
+// clang-format on
 
 extern const uint8_t track_map_4x4[][16];
 extern const uint8_t edges_4x4[];

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -17,7 +17,12 @@
 
 class StationObject;
 
-extern const uint8_t track_map_2x2[][4];
+constexpr uint8_t kTrackMap2x2[][4] = {
+    { 0, 1, 2, 3 },
+    { 1, 3, 0, 2 },
+    { 3, 2, 1, 0 },
+    { 2, 0, 3, 1 },
+};
 extern const uint8_t edges_2x2[];
 
 extern const uint8_t track_map_3x3[][9];

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -84,7 +84,12 @@ constexpr uint8_t kTrackMap1x4[][4] = {
     { 0, 1, 2, 3 },
 };
 
-extern const int32_t DiagBlockedSegments[];
+constexpr int32_t kDiagBlockedSegments[] = {
+    EnumsToFlags(PaintSegment::centre, PaintSegment::topRightSide, PaintSegment::bottomRightSide, PaintSegment::rightCorner),
+    EnumsToFlags(PaintSegment::centre, PaintSegment::topRightSide, PaintSegment::topLeftSide, PaintSegment::topCorner),
+    EnumsToFlags(PaintSegment::bottomLeftSide, PaintSegment::centre, PaintSegment::bottomCorner, PaintSegment::bottomRightSide),
+    EnumsToFlags(PaintSegment::bottomLeftSide, PaintSegment::centre, PaintSegment::leftCorner, PaintSegment::topLeftSide),
+};
 extern const MetalSupportPlace DiagSupportPlacement[];
 
 enum

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -56,7 +56,26 @@ constexpr uint8_t kTrackMap4x4[][16] = {
     { 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 },
     { 12, 8, 4, 0, 13, 9, 5, 1, 14, 10, 6, 2, 15, 11, 7, 3 },
 };
-extern const uint8_t edges_4x4[];
+// clang-format off
+constexpr uint8_t kEdges4x4[] = {
+    EDGE_NE | EDGE_NW,
+    EDGE_NE,
+    EDGE_NE,
+    EDGE_NE | EDGE_SE,
+    EDGE_NW,
+    0,
+    0,
+    EDGE_SE,
+    EDGE_NW,
+    0,
+    0,
+    EDGE_SE,
+    EDGE_NW | EDGE_SW,
+    EDGE_SW,
+    EDGE_SW,
+    EDGE_SW | EDGE_SE,
+};
+// clang-format on
 
 extern const uint8_t track_map_1x4[][4];
 

--- a/src/openrct2/ride/coaster/BolligerMabillardTrack.hpp
+++ b/src/openrct2/ride/coaster/BolligerMabillardTrack.hpp
@@ -14748,7 +14748,7 @@ static void BolligerMabillardTrackDiagBrakes(
         MetalASupportsPaintSetup(session, supportType, DiagSupportPlacement[direction], 0, height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
@@ -14768,7 +14768,7 @@ static void BolligerMabillardTrackDiagBlockBrakes(
         MetalASupportsPaintSetup(session, supportType, DiagSupportPlacement[direction], 0, height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }

--- a/src/openrct2/ride/coaster/CompactInvertedCoaster.cpp
+++ b/src/openrct2/ride/coaster/CompactInvertedCoaster.cpp
@@ -6897,7 +6897,7 @@ static void CompactInvertedRCTrackDiagBrakes(
         session, 3, height + 29, direction, trackSequence, session.TrackColours, CompactInvertedDiagBrakeImages,
         defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
 
     if (trackSequence == 3)
@@ -6917,7 +6917,7 @@ static void CompactInvertedRCTrackDiagBlockBrakes(
         CompactInvertedDiagBlockBrakeImages[trackElement.IsBrakeClosed()], defaultDiagTileOffsets, defaultDiagBoundLengths,
         nullptr);
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
 
     if (trackSequence == 3)

--- a/src/openrct2/ride/coaster/CorkscrewRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/CorkscrewRollerCoaster.cpp
@@ -6668,7 +6668,7 @@ static void CorkscrewRCTrackDiagBrakes(
             session, MetalSupportType::Tubes, DiagSupportPlacement[direction], 0, height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
@@ -6688,7 +6688,7 @@ static void CorkscrewRCTrackDiagBlockBrakes(
             session, MetalSupportType::Tubes, DiagSupportPlacement[direction], 0, height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }

--- a/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
@@ -10161,7 +10161,7 @@ static void FlyingRCTrackDiagBrakesInverted(
         session, 1, height + 24, direction, trackSequence, session.TrackColours, InvertedRCDiagBrakeImages,
         defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
 
     if (trackSequence == 3)

--- a/src/openrct2/ride/coaster/InvertedRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedRollerCoaster.cpp
@@ -6602,7 +6602,7 @@ static void inverted_rc_track_diag_brakes(
         session, 1, height + 29, direction, trackSequence, session.TrackColours, InvertedRCDiagBrakeImages,
         defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
 
     if (trackSequence == 3)

--- a/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
@@ -4642,7 +4642,7 @@ static void JuniorRCPaintTrackDiagFlat(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
@@ -4662,7 +4662,7 @@ static void JuniorRCTrackDiagBrakes(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
 }
@@ -4683,7 +4683,7 @@ static void JuniorRCTrackDiagBlockBrakes(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
 }
@@ -4705,7 +4705,7 @@ static void JuniorRCPaintTrackDiag25DegUp(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
@@ -4727,7 +4727,7 @@ static void JuniorRCPaintTrackDiagFlatTo25DegUp(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
 }
@@ -4750,7 +4750,7 @@ static void JuniorRCPaintTrackDiagFlatTo60DegUp(
             height + 6, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 64, 0x20);
 }
@@ -4772,7 +4772,7 @@ static void JuniorRCPaintTrackDiag25DegUpToFlat(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
@@ -4795,7 +4795,7 @@ static void JuniorRCPaintTrackDiag60DegUpToFlat(
             height + 13, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 64, 0x20);
 }
@@ -4817,7 +4817,7 @@ static void JuniorRCPaintTrackDiag25DegDown(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
@@ -4840,7 +4840,7 @@ static void JuniorRCPaintTrackDiagFlatTo25DegDown(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
@@ -4864,7 +4864,7 @@ static void JuniorRCPaintTrackDiagFlatTo60DegDown(
             height + 7, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
 }
@@ -4887,7 +4887,7 @@ static void JuniorRCPaintTrackDiag25DegDownToFlat(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
 }
@@ -4911,7 +4911,7 @@ static void JuniorRCPaintTrackDiag60DegDownToFlat(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
@@ -4938,7 +4938,7 @@ static void JuniorRCDiagFlatToLeftBankPaintSetup(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
@@ -4965,7 +4965,7 @@ static void JuniorRCDiagFlatToRightBankPaintSetup(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
@@ -4992,7 +4992,7 @@ static void JuniorRCDiagLeftBankToFlatPaintSetup(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
@@ -5019,7 +5019,7 @@ static void JuniorRCDiagRightBankToFlatPaintSetup(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
@@ -5046,7 +5046,7 @@ static void JuniorRCDiagLeftBankTo25DegUpPaintSetup(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
 }
@@ -5073,7 +5073,7 @@ static void JuniorRCDiagRightBankTo25DegUpPaintSetup(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
 }
@@ -5100,7 +5100,7 @@ static void JuniorRCDiag25DegUpToLeftBankPaintSetup(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
@@ -5127,7 +5127,7 @@ static void JuniorRCDiag25DegUpToRightBankPaintSetup(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
@@ -5154,7 +5154,7 @@ static void JuniorRCDiagLeftBankTo25DegDownPaintSetup(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
@@ -5181,7 +5181,7 @@ static void JuniorRCDiagRightBankTo25DegDownPaintSetup(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
@@ -5208,7 +5208,7 @@ static void JuniorRCDiag25DegDownToLeftBankPaintSetup(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
 }
@@ -5235,7 +5235,7 @@ static void JuniorRCDiag25DegDownToRightBankPaintSetup(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
 }
@@ -5271,7 +5271,7 @@ static void JuniorRCDiagLeftBankPaintSetup(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
@@ -5293,7 +5293,7 @@ static void JuniorRCDiagRightBankPaintSetup(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
@@ -5547,7 +5547,7 @@ static void JuniorRCPaintTrackDiag60DegUp(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
 }
@@ -5570,7 +5570,7 @@ static void JuniorRCPaintTrackDiag60DegDown(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
 }
@@ -5594,7 +5594,7 @@ static void JuniorRCPaintTrackDiag25DegUpTo60DegUp(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
 }
@@ -5628,7 +5628,7 @@ static void JuniorRCPaintTrackDiag60DegUpTo25DegUp(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
 }
@@ -5662,7 +5662,7 @@ static void JuniorRCPaintTrackDiag25DegDownTo60DegDown(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
 }
@@ -5686,7 +5686,7 @@ static void JuniorRCPaintTrackDiag60DegDownTo25DegDown(
             height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
 }

--- a/src/openrct2/ride/coaster/LayDownRollerCoasterInverted.cpp
+++ b/src/openrct2/ride/coaster/LayDownRollerCoasterInverted.cpp
@@ -4076,7 +4076,7 @@ static void LayDownRCTrackDiagBrakes(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
 
     TrackPaintUtilDiagTilesPaint(
         session, -3, height + 24, direction, trackSequence, session.TrackColours, LaydownDiagBrakeImages,
@@ -4096,7 +4096,7 @@ static void LayDownRCTrackDiagBlockBrakes(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
 
     TrackPaintUtilDiagTilesPaint(
         session, -3, height + 24, direction, trackSequence, session.TrackColours,

--- a/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
@@ -7710,7 +7710,7 @@ static void MultiDimensionRCTrackDiagBrakes(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     if (trackElement.IsInverted())
     {
         TrackPaintUtilDiagTilesPaint(
@@ -7748,7 +7748,7 @@ static void MultiDimensionRCTrackDiagBlockBrakes(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     if (trackElement.IsInverted())
     {
         TrackPaintUtilDiagTilesPaint(

--- a/src/openrct2/ride/coaster/StandUpRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/StandUpRollerCoaster.cpp
@@ -6340,7 +6340,7 @@ static void StandUpRCTrackDiagBrakes(
             session, MetalSupportType::Tubes, DiagSupportPlacement[direction], 8, height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
@@ -6359,7 +6359,7 @@ static void StandUpRCTrackDiagBlockBrakes(
             session, MetalSupportType::Tubes, DiagSupportPlacement[direction], 8, height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }

--- a/src/openrct2/ride/coaster/Steeplechase.cpp
+++ b/src/openrct2/ride/coaster/Steeplechase.cpp
@@ -1642,7 +1642,7 @@ static void SteeplechaseTrackDiagBrakes(
             session, MetalSupportType::Stick, DiagSupportPlacement[direction], 0, height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }

--- a/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
@@ -9732,7 +9732,7 @@ static void WoodenRCTrackDiagBrakes(
             session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
@@ -10003,7 +10003,7 @@ static void WoodenRCTrackDiagBlockBrakes(
             session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }

--- a/src/openrct2/ride/gentle/Circus.cpp
+++ b/src/openrct2/ride/gentle/Circus.cpp
@@ -52,7 +52,7 @@ static void PaintCircus(
 {
     trackSequence = kTrackMap3x3[direction][trackSequence];
 
-    int32_t edges = edges_3x3[trackSequence];
+    int32_t edges = kEdges3x3[trackSequence];
 
     WoodenASupportsPaintSetupRotated(
         session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height,

--- a/src/openrct2/ride/gentle/Circus.cpp
+++ b/src/openrct2/ride/gentle/Circus.cpp
@@ -50,7 +50,7 @@ static void PaintCircus(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    trackSequence = track_map_3x3[direction][trackSequence];
+    trackSequence = kTrackMap3x3[direction][trackSequence];
 
     int32_t edges = edges_3x3[trackSequence];
 

--- a/src/openrct2/ride/gentle/CrookedHouse.cpp
+++ b/src/openrct2/ride/gentle/CrookedHouse.cpp
@@ -84,7 +84,7 @@ static void PaintCrookedHouse(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    trackSequence = track_map_3x3[direction][trackSequence];
+    trackSequence = kTrackMap3x3[direction][trackSequence];
 
     int32_t edges = edges_3x3[trackSequence];
 

--- a/src/openrct2/ride/gentle/CrookedHouse.cpp
+++ b/src/openrct2/ride/gentle/CrookedHouse.cpp
@@ -86,7 +86,7 @@ static void PaintCrookedHouse(
 {
     trackSequence = kTrackMap3x3[direction][trackSequence];
 
-    int32_t edges = edges_3x3[trackSequence];
+    int32_t edges = kEdges3x3[trackSequence];
 
     WoodenASupportsPaintSetupRotated(
         session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height,

--- a/src/openrct2/ride/gentle/Dodgems.cpp
+++ b/src/openrct2/ride/gentle/Dodgems.cpp
@@ -47,7 +47,7 @@ static void PaintDodgems(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint8_t relativeTrackSequence = track_map_4x4[direction][trackSequence];
+    uint8_t relativeTrackSequence = kTrackMap4x4[direction][trackSequence];
 
     int32_t edges = edges_4x4[relativeTrackSequence];
 

--- a/src/openrct2/ride/gentle/Dodgems.cpp
+++ b/src/openrct2/ride/gentle/Dodgems.cpp
@@ -49,7 +49,7 @@ static void PaintDodgems(
 {
     uint8_t relativeTrackSequence = kTrackMap4x4[direction][trackSequence];
 
-    int32_t edges = edges_4x4[relativeTrackSequence];
+    int32_t edges = kEdges4x4[relativeTrackSequence];
 
     WoodenASupportsPaintSetupRotated(
         session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height,

--- a/src/openrct2/ride/gentle/FerrisWheel.cpp
+++ b/src/openrct2/ride/gentle/FerrisWheel.cpp
@@ -104,7 +104,7 @@ static void PaintFerrisWheel(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint8_t relativeTrackSequence = track_map_1x4[direction][trackSequence];
+    uint8_t relativeTrackSequence = kTrackMap1x4[direction][trackSequence];
 
     int32_t edges;
     if (direction & 1)

--- a/src/openrct2/ride/gentle/FlyingSaucers.cpp
+++ b/src/openrct2/ride/gentle/FlyingSaucers.cpp
@@ -40,7 +40,7 @@ static void PaintFlyingSaucers(
 {
     uint8_t relativeTrackSequence = kTrackMap4x4[direction][trackSequence];
 
-    int32_t edges = edges_4x4[relativeTrackSequence];
+    int32_t edges = kEdges4x4[relativeTrackSequence];
 
     WoodenASupportsPaintSetupRotated(
         session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height,

--- a/src/openrct2/ride/gentle/FlyingSaucers.cpp
+++ b/src/openrct2/ride/gentle/FlyingSaucers.cpp
@@ -38,7 +38,7 @@ static void PaintFlyingSaucers(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint8_t relativeTrackSequence = track_map_4x4[direction][trackSequence];
+    uint8_t relativeTrackSequence = kTrackMap4x4[direction][trackSequence];
 
     int32_t edges = edges_4x4[relativeTrackSequence];
 

--- a/src/openrct2/ride/gentle/HauntedHouse.cpp
+++ b/src/openrct2/ride/gentle/HauntedHouse.cpp
@@ -64,7 +64,7 @@ static void PaintHauntedHouse(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    trackSequence = track_map_3x3[direction][trackSequence];
+    trackSequence = kTrackMap3x3[direction][trackSequence];
 
     int32_t edges = edges_3x3[trackSequence];
 

--- a/src/openrct2/ride/gentle/HauntedHouse.cpp
+++ b/src/openrct2/ride/gentle/HauntedHouse.cpp
@@ -66,7 +66,7 @@ static void PaintHauntedHouse(
 {
     trackSequence = kTrackMap3x3[direction][trackSequence];
 
-    int32_t edges = edges_3x3[trackSequence];
+    int32_t edges = kEdges3x3[trackSequence];
 
     WoodenASupportsPaintSetupRotated(
         session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height,

--- a/src/openrct2/ride/gentle/MerryGoRound.cpp
+++ b/src/openrct2/ride/gentle/MerryGoRound.cpp
@@ -105,7 +105,7 @@ static void PaintMerryGoRound(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    trackSequence = track_map_3x3[direction][trackSequence];
+    trackSequence = kTrackMap3x3[direction][trackSequence];
 
     int32_t edges = edges_3x3[trackSequence];
 

--- a/src/openrct2/ride/gentle/MerryGoRound.cpp
+++ b/src/openrct2/ride/gentle/MerryGoRound.cpp
@@ -107,7 +107,7 @@ static void PaintMerryGoRound(
 {
     trackSequence = kTrackMap3x3[direction][trackSequence];
 
-    int32_t edges = edges_3x3[trackSequence];
+    int32_t edges = kEdges3x3[trackSequence];
 
     WoodenASupportsPaintSetupRotated(
         session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height,

--- a/src/openrct2/ride/gentle/ObservationTower.cpp
+++ b/src/openrct2/ride/gentle/ObservationTower.cpp
@@ -85,7 +85,7 @@ static void PaintObservationTowerBase(
 {
     trackSequence = kTrackMap3x3[direction][trackSequence];
 
-    int32_t edges = edges_3x3[trackSequence];
+    int32_t edges = kEdges3x3[trackSequence];
     CoordsXY position = session.MapPosition;
 
     WoodenASupportsPaintSetupRotated(

--- a/src/openrct2/ride/gentle/ObservationTower.cpp
+++ b/src/openrct2/ride/gentle/ObservationTower.cpp
@@ -83,7 +83,7 @@ static void PaintObservationTowerBase(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    trackSequence = track_map_3x3[direction][trackSequence];
+    trackSequence = kTrackMap3x3[direction][trackSequence];
 
     int32_t edges = edges_3x3[trackSequence];
     CoordsXY position = session.MapPosition;

--- a/src/openrct2/ride/gentle/SpaceRings.cpp
+++ b/src/openrct2/ride/gentle/SpaceRings.cpp
@@ -87,7 +87,7 @@ static void PaintSpaceRings(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    trackSequence = track_map_3x3[direction][trackSequence];
+    trackSequence = kTrackMap3x3[direction][trackSequence];
 
     int32_t edges = edges_3x3[trackSequence];
     CoordsXY position = session.MapPosition;

--- a/src/openrct2/ride/gentle/SpaceRings.cpp
+++ b/src/openrct2/ride/gentle/SpaceRings.cpp
@@ -89,7 +89,7 @@ static void PaintSpaceRings(
 {
     trackSequence = kTrackMap3x3[direction][trackSequence];
 
-    int32_t edges = edges_3x3[trackSequence];
+    int32_t edges = kEdges3x3[trackSequence];
     CoordsXY position = session.MapPosition;
 
     ImageId imageId;

--- a/src/openrct2/ride/gentle/SpiralSlide.cpp
+++ b/src/openrct2/ride/gentle/SpiralSlide.cpp
@@ -202,7 +202,7 @@ static void PaintSpiralSlide(
 
     trackSequence = kTrackMap2x2[direction][trackSequence];
 
-    int32_t edges = edges_2x2[trackSequence];
+    int32_t edges = kEdges2x2[trackSequence];
 
     WoodenASupportsPaintSetupRotated(
         session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height,

--- a/src/openrct2/ride/gentle/SpiralSlide.cpp
+++ b/src/openrct2/ride/gentle/SpiralSlide.cpp
@@ -200,7 +200,7 @@ static void PaintSpiralSlide(
     if (rideEntry == nullptr)
         return;
 
-    trackSequence = track_map_2x2[direction][trackSequence];
+    trackSequence = kTrackMap2x2[direction][trackSequence];
 
     int32_t edges = edges_2x2[trackSequence];
 

--- a/src/openrct2/ride/thrill/3dCinema.cpp
+++ b/src/openrct2/ride/thrill/3dCinema.cpp
@@ -52,7 +52,7 @@ static void Paint3dCinema(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    trackSequence = track_map_3x3[direction][trackSequence];
+    trackSequence = kTrackMap3x3[direction][trackSequence];
 
     int32_t edges = edges_3x3[trackSequence];
 

--- a/src/openrct2/ride/thrill/3dCinema.cpp
+++ b/src/openrct2/ride/thrill/3dCinema.cpp
@@ -54,7 +54,7 @@ static void Paint3dCinema(
 {
     trackSequence = kTrackMap3x3[direction][trackSequence];
 
-    int32_t edges = edges_3x3[trackSequence];
+    int32_t edges = kEdges3x3[trackSequence];
 
     auto stationColour = GetStationColourScheme(session, trackElement);
     WoodenASupportsPaintSetupRotated(

--- a/src/openrct2/ride/thrill/Enterprise.cpp
+++ b/src/openrct2/ride/thrill/Enterprise.cpp
@@ -93,7 +93,7 @@ static void PaintEnterprise(
 {
     trackSequence = kTrackMap4x4[direction][trackSequence];
 
-    int32_t edges = edges_4x4[trackSequence];
+    int32_t edges = kEdges4x4[trackSequence];
 
     WoodenASupportsPaintSetupRotated(
         session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height,

--- a/src/openrct2/ride/thrill/Enterprise.cpp
+++ b/src/openrct2/ride/thrill/Enterprise.cpp
@@ -91,7 +91,7 @@ static void PaintEnterprise(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    trackSequence = track_map_4x4[direction][trackSequence];
+    trackSequence = kTrackMap4x4[direction][trackSequence];
 
     int32_t edges = edges_4x4[trackSequence];
 

--- a/src/openrct2/ride/thrill/LaunchedFreefall.cpp
+++ b/src/openrct2/ride/thrill/LaunchedFreefall.cpp
@@ -93,7 +93,7 @@ static void PaintLaunchedFreefallBase(
 {
     trackSequence = kTrackMap3x3[direction][trackSequence];
 
-    int32_t edges = edges_3x3[trackSequence];
+    int32_t edges = kEdges3x3[trackSequence];
 
     WoodenASupportsPaintSetupRotated(
         session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height,

--- a/src/openrct2/ride/thrill/LaunchedFreefall.cpp
+++ b/src/openrct2/ride/thrill/LaunchedFreefall.cpp
@@ -91,7 +91,7 @@ static void PaintLaunchedFreefallBase(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    trackSequence = track_map_3x3[direction][trackSequence];
+    trackSequence = kTrackMap3x3[direction][trackSequence];
 
     int32_t edges = edges_3x3[trackSequence];
 

--- a/src/openrct2/ride/thrill/MagicCarpet.cpp
+++ b/src/openrct2/ride/thrill/MagicCarpet.cpp
@@ -213,7 +213,7 @@ static void PaintMagicCarpet(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint8_t relativeTrackSequence = track_map_1x4[direction][trackSequence];
+    uint8_t relativeTrackSequence = kTrackMap1x4[direction][trackSequence];
 
     // The end tiles do not have a platform
     switch (relativeTrackSequence)

--- a/src/openrct2/ride/thrill/MotionSimulator.cpp
+++ b/src/openrct2/ride/thrill/MotionSimulator.cpp
@@ -104,7 +104,7 @@ static void PaintMotionSimulator(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    trackSequence = track_map_2x2[direction][trackSequence];
+    trackSequence = kTrackMap2x2[direction][trackSequence];
 
     int32_t edges = edges_2x2[trackSequence];
 

--- a/src/openrct2/ride/thrill/MotionSimulator.cpp
+++ b/src/openrct2/ride/thrill/MotionSimulator.cpp
@@ -106,7 +106,7 @@ static void PaintMotionSimulator(
 {
     trackSequence = kTrackMap2x2[direction][trackSequence];
 
-    int32_t edges = edges_2x2[trackSequence];
+    int32_t edges = kEdges2x2[trackSequence];
 
     auto stationColour = GetStationColourScheme(session, trackElement);
     WoodenASupportsPaintSetupRotated(

--- a/src/openrct2/ride/thrill/RotoDrop.cpp
+++ b/src/openrct2/ride/thrill/RotoDrop.cpp
@@ -103,7 +103,7 @@ static void PaintRotoDropBase(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    trackSequence = track_map_3x3[direction][trackSequence];
+    trackSequence = kTrackMap3x3[direction][trackSequence];
 
     int32_t edges = edges_3x3[trackSequence];
 

--- a/src/openrct2/ride/thrill/RotoDrop.cpp
+++ b/src/openrct2/ride/thrill/RotoDrop.cpp
@@ -105,7 +105,7 @@ static void PaintRotoDropBase(
 {
     trackSequence = kTrackMap3x3[direction][trackSequence];
 
-    int32_t edges = edges_3x3[trackSequence];
+    int32_t edges = kEdges3x3[trackSequence];
 
     WoodenASupportsPaintSetupRotated(
         session, WoodenSupportType::Truss, WoodenSupportSubType::NeSw, direction, height,

--- a/src/openrct2/ride/thrill/SwingingInverterShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingInverterShip.cpp
@@ -127,7 +127,7 @@ static void PaintSwingingInverterShip(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    uint8_t relativeTrackSequence = track_map_1x4[direction][trackSequence];
+    uint8_t relativeTrackSequence = kTrackMap1x4[direction][trackSequence];
     ImageId imageId;
 
     const StationObject* stationObject = ride.GetStationObject();

--- a/src/openrct2/ride/thrill/TopSpin.cpp
+++ b/src/openrct2/ride/thrill/TopSpin.cpp
@@ -184,7 +184,7 @@ static void PaintTopSpin(
 {
     trackSequence = kTrackMap3x3[direction][trackSequence];
 
-    int32_t edges = edges_3x3[trackSequence];
+    int32_t edges = kEdges3x3[trackSequence];
 
     auto stationColour = GetStationColourScheme(session, trackElement);
     WoodenASupportsPaintSetupRotated(

--- a/src/openrct2/ride/thrill/TopSpin.cpp
+++ b/src/openrct2/ride/thrill/TopSpin.cpp
@@ -182,7 +182,7 @@ static void PaintTopSpin(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    trackSequence = track_map_3x3[direction][trackSequence];
+    trackSequence = kTrackMap3x3[direction][trackSequence];
 
     int32_t edges = edges_3x3[trackSequence];
 

--- a/src/openrct2/ride/thrill/Twist.cpp
+++ b/src/openrct2/ride/thrill/Twist.cpp
@@ -87,7 +87,7 @@ static void PaintTwist(
 {
     trackSequence = kTrackMap3x3[direction][trackSequence];
 
-    const uint8_t edges = edges_3x3[trackSequence];
+    const uint8_t edges = kEdges3x3[trackSequence];
 
     ImageId imageId;
 

--- a/src/openrct2/ride/thrill/Twist.cpp
+++ b/src/openrct2/ride/thrill/Twist.cpp
@@ -85,7 +85,7 @@ static void PaintTwist(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    trackSequence = track_map_3x3[direction][trackSequence];
+    trackSequence = kTrackMap3x3[direction][trackSequence];
 
     const uint8_t edges = edges_3x3[trackSequence];
 

--- a/src/openrct2/ride/transport/Lift.cpp
+++ b/src/openrct2/ride/transport/Lift.cpp
@@ -50,7 +50,7 @@ static void PaintLiftBase(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    trackSequence = track_map_3x3[direction][trackSequence];
+    trackSequence = kTrackMap3x3[direction][trackSequence];
 
     if (trackSequence == 0)
     {

--- a/src/openrct2/ride/transport/Lift.cpp
+++ b/src/openrct2/ride/transport/Lift.cpp
@@ -68,7 +68,7 @@ static void PaintLiftBase(
         return;
     }
 
-    int32_t edges = edges_3x3[trackSequence];
+    int32_t edges = kEdges3x3[trackSequence];
 
     auto imageId = session.SupportColours.WithIndex(SPR_FLOOR_METAL_B);
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 0, 0, height }, { 32, 32, 1 } });

--- a/src/openrct2/ride/transport/Monorail.cpp
+++ b/src/openrct2/ride/transport/Monorail.cpp
@@ -1168,7 +1168,7 @@ static void PaintMonorailTrackDiagFlat(
             session, MetalSupportType::Boxed, DiagSupportPlacement[direction], 0, height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
@@ -1190,7 +1190,7 @@ static void PaintMonorailTrackDiag25DegUp(
             session, MetalSupportType::Boxed, DiagSupportPlacement[direction], 8, height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
@@ -1212,7 +1212,7 @@ static void PaintMonorailTrackDiagFlatTo25DegUp(
             session, MetalSupportType::Boxed, DiagSupportPlacement[direction], 0, height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
 }
@@ -1234,7 +1234,7 @@ static void PaintMonorailTrackDiag25DegUpToFlat(
             session, MetalSupportType::Boxed, DiagSupportPlacement[direction], 4, height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
@@ -1256,7 +1256,7 @@ static void PaintMonorailTrackDiag25DegDown(
             session, MetalSupportType::Boxed, DiagSupportPlacement[direction], 8, height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
@@ -1278,7 +1278,7 @@ static void PaintMonorailTrackDiagFlatTo25DegDown(
             session, MetalSupportType::Boxed, DiagSupportPlacement[direction], 4, height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
@@ -1300,7 +1300,7 @@ static void PaintMonorailTrackDiag25DegDownToFlat(
             session, MetalSupportType::Boxed, DiagSupportPlacement[direction], 0, height, session.SupportColours);
     }
 
-    int32_t blockedSegments = DiagBlockedSegments[trackSequence];
+    int32_t blockedSegments = kDiagBlockedSegments[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
 }


### PR DESCRIPTION
Rename constants to follow the new notation. Move `extern consts` to `constexpr`.