### PR TITLE
Fix build errors with the ORIGINAL_RATINGS flag

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,6 +13,7 @@
 - Fix: [#21696] Fullscreen window option not correctly applied on macOS.
 - Fix: [#21787] Map generator heightmap should respect increased height limits.
 - Fix: [#21829] When creating a new scenario, the default name contains formatting codes.
+- Fix: [#21937] Build errors with the ORIGINAL_RATINGS flag.
 - Fix: [objects#324] Cannot build Colosseum inside a turn or helix.
 - Fix: [objects#325] Sloped castle walls are vertically offset by one pixel (original bug).
 

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -1050,9 +1050,9 @@ static void RideRatingsCalculate(RideRatingUpdateState& state, Ride& ride)
     if (ride.ratings.Excitement != -1)
     {
         // Address underflows allowed by original RCT2 code
-        ride.ratings.Excitement = std::max(0, (int)ride.ratings.Excitement);
-        ride.ratings.Intensity = std::max(0, (int)ride.ratings.Intensity);
-        ride.ratings.Nausea = std::max(0, (int)ride.ratings.Nausea);
+        ride.ratings.Excitement = std::max<uint16_t>(0, ride.ratings.Excitement);
+        ride.ratings.Intensity = std::max<uint16_t>(0, ride.ratings.Intensity);
+        ride.ratings.Nausea = std::max<uint16_t>(0, ride.ratings.Nausea);
     }
 #endif
 

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -1047,12 +1047,12 @@ static void RideRatingsCalculate(RideRatingUpdateState& state, Ride& ride)
     ride.window_invalidate_flags |= RIDE_INVALIDATE_RIDE_INCOME;
 
 #ifdef ORIGINAL_RATINGS
-    if (ride.ratings.excitement != -1)
+    if (ride.ratings.Excitement != -1)
     {
         // Address underflows allowed by original RCT2 code
-        ride.ratings.excitement = max(0, ride.ratings.excitement);
-        ride.ratings.intensity = max(0, ride.ratings.intensity);
-        ride.ratings.nausea = max(0, ride.ratings.nausea);
+        ride.ratings.Excitement = std::max(0, (int)ride.ratings.Excitement);
+        ride.ratings.Intensity = std::max(0, (int)ride.ratings.Intensity);
+        ride.ratings.Nausea = std::max(0, (int)ride.ratings.Nausea);
     }
 #endif
 
@@ -1295,14 +1295,14 @@ static void RideRatingsApplyAdjustments(const Ride& ride, RatingTuple& ratings)
             if (totalAirTime >= 96)
             {
                 totalAirTime -= 96;
-                ratings.excitement -= totalAirTime / 8;
-                ratings.nausea += totalAirTime / 16;
+                ratings.Excitement -= totalAirTime / 8;
+                ratings.Nausea += totalAirTime / 16;
             }
         }
         else
         {
-            ratings.excitement += totalAirTime / 8;
-            ratings.nausea += totalAirTime / 16;
+            ratings.Excitement += totalAirTime / 8;
+            ratings.Nausea += totalAirTime / 16;
         }
     }
 #else
@@ -1714,14 +1714,14 @@ static RatingTuple ride_ratings_get_gforce_ratings(const Ride& ride)
 #ifdef ORIGINAL_RATINGS
     if (ride.max_lateral_g > FIXED_2DP(2, 80))
     {
-        result.intensity += FIXED_2DP(3, 75);
-        result.nausea += FIXED_2DP(2, 00);
+        result.Intensity += FIXED_2DP(3, 75);
+        result.Nausea += FIXED_2DP(2, 00);
     }
     if (ride.max_lateral_g > FIXED_2DP(3, 10))
     {
-        result.excitement /= 2;
-        result.intensity += FIXED_2DP(8, 50);
-        result.nausea += FIXED_2DP(4, 00);
+        result.Excitement /= 2;
+        result.Intensity += FIXED_2DP(8, 50);
+        result.Nausea += FIXED_2DP(4, 00);
     }
 #endif
 
@@ -2071,7 +2071,7 @@ static void RideRatingsApplyBonusLaunchedFreefallSpecial(
     RideRatingsAdd(ratings, excitement, 0, 0);
 
 #ifdef ORIGINAL_RATINGS
-    RideRatingsApplyBonusOperationOptionFreefall(&ratings, ride, modifier);
+    RideRatingsApplyBonusOperationOptionFreefall(ratings, ride, modifier);
 #else
     // Only apply "launch speed" effects when the setting can be modified
     if (ride.mode == RideMode::UpwardLaunch)
@@ -2223,6 +2223,7 @@ static void RideRatingsApplyRequirementSplashdown(RatingTuple& ratings, const Ri
     }
 }
 
+#ifndef ORIGINAL_RATINGS
 static RatingTuple ride_ratings_get_excessive_lateral_g_penalty(const Ride& ride)
 {
     RatingTuple result{};
@@ -2252,6 +2253,7 @@ static RatingTuple ride_ratings_get_excessive_lateral_g_penalty(const Ride& ride
     }
     return result;
 }
+#endif
 
 static void RideRatingsApplyPenaltyLateralGs(RatingTuple& ratings, const Ride& ride, RatingsModifier modifier)
 {


### PR DESCRIPTION
Fixing some build errors when using the ORIGINAL_RATINGS flag, since nobody applied the same changes that the rest of the code got.