### PR TITLE
Reduce algorithm include

### DIFF
--- a/src/openrct2-ui/TextComposition.cpp
+++ b/src/openrct2-ui/TextComposition.cpp
@@ -13,7 +13,6 @@
 #include "interface/InGameConsole.h"
 
 #include <SDL.h>
-#include <algorithm>
 #include <openrct2-ui/interface/Window.h>
 #include <openrct2/common.h>
 #include <openrct2/core/Memory.hpp>

--- a/src/openrct2-ui/UiContext.Linux.cpp
+++ b/src/openrct2-ui/UiContext.Linux.cpp
@@ -12,6 +12,7 @@
 #    include "UiContext.h"
 
 #    include <SDL.h>
+#    include <algorithm>
 #    include <dlfcn.h>
 #    include <openrct2/common.h>
 #    include <openrct2/core/Path.hpp>

--- a/src/openrct2-ui/UiContext.Win32.cpp
+++ b/src/openrct2-ui/UiContext.Win32.cpp
@@ -21,7 +21,6 @@
 
 #    include <SDL.h>
 #    include <SDL_syswm.h>
-#    include <algorithm>
 #    include <openrct2/common.h>
 #    include <openrct2/core/Path.hpp>
 #    include <openrct2/core/String.hpp>

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -21,7 +21,6 @@
 #include "title/TitleSequencePlayer.h"
 
 #include <SDL.h>
-#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <cstdlib>

--- a/src/openrct2-ui/drawing/BitmapReader.cpp
+++ b/src/openrct2-ui/drawing/BitmapReader.cpp
@@ -10,7 +10,6 @@
 #include "BitmapReader.h"
 
 #include <SDL.h>
-#include <algorithm>
 #include <cstring>
 #include <openrct2/core/Imaging.h>
 #include <stdexcept>

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -22,7 +22,6 @@
 #    include "TransparencyDepth.h"
 
 #    include <SDL.h>
-#    include <algorithm>
 #    include <cmath>
 #    include <openrct2-ui/interface/Window.h>
 #    include <openrct2/config/Config.h>

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
@@ -13,7 +13,6 @@
 #include "OpenGLAPI.h"
 
 #include <SDL_pixels.h>
-#include <algorithm>
 #include <array>
 #include <mutex>
 #include <openrct2/common.h>

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <cmath>
 #include <iterator>
 #include <openrct2-ui/interface/Dropdown.h>

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -11,7 +11,6 @@
 
 #include "Theme.h"
 
-#include <algorithm>
 #include <cstring>
 #include <openrct2/Context.h>
 #include <openrct2/Version.h>

--- a/src/openrct2-ui/interface/Theme.cpp
+++ b/src/openrct2-ui/interface/Theme.cpp
@@ -13,7 +13,6 @@
 
 #include "Window.h"
 
-#include <algorithm>
 #include <memory>
 #include <openrct2/Context.h>
 #include <openrct2/PlatformEnvironment.h>

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -11,7 +11,6 @@
 #include "Viewport.h"
 #include "Window.h"
 
-#include <algorithm>
 #include <openrct2/Context.h>
 #include <openrct2/Editor.h>
 #include <openrct2/Game.h>

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -11,7 +11,6 @@
 
 #include "Window.h"
 
-#include <algorithm>
 #include <cmath>
 #include <openrct2/Context.h>
 #include <openrct2/Input.h>

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -14,7 +14,6 @@
 #include "openrct2/world/Location.hpp"
 
 #include <SDL.h>
-#include <algorithm>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
 #include <openrct2/Input.h>

--- a/src/openrct2-ui/scripting/ScUi.hpp
+++ b/src/openrct2-ui/scripting/ScUi.hpp
@@ -18,7 +18,6 @@
 #    include "ScViewport.hpp"
 #    include "ScWindow.hpp"
 
-#    include <algorithm>
 #    include <memory>
 #    include <openrct2/Context.h>
 #    include <openrct2/Input.h>

--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -11,7 +11,6 @@
 
 #include "../interface/Window.h"
 
-#include <algorithm>
 #include <memory>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <fstream>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <iterator>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Widget.h>

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <openrct2-ui/interface/LandTool.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>

--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <bitset>
 #include <iterator>
 #include <openrct2-ui/interface/Dropdown.h>

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <cctype>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Widget.h>

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -12,7 +12,6 @@
 #include "../interface/Window.h"
 #include "Window.h"
 
-#include <algorithm>
 #include <openrct2/Context.h>
 #include <openrct2/GameState.h>
 #include <openrct2/OpenRCT2.h>

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -12,7 +12,6 @@
 #include "../interface/Window.h"
 #include "Window.h"
 
-#include <algorithm>
 #include <openrct2/Context.h>
 #include <openrct2/Editor.h>
 #include <openrct2/Game.h>

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Graph.h>
 #include <openrct2-ui/interface/Widget.h>

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -9,7 +9,6 @@
 
 #include "../interface/Theme.h"
 
-#include <algorithm>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <memory>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <openrct2-ui/interface/LandTool.h>
 #include <openrct2-ui/interface/Viewport.h>
 #include <openrct2-ui/interface/Widget.h>

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <ctime>
 #include <iterator>
 #include <memory>

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <openrct2-ui/interface/LandTool.h>
 #include <openrct2-ui/interface/Viewport.h>
 #include <openrct2-ui/interface/Widget.h>

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/LandTool.h>
 #include <openrct2-ui/interface/Widget.h>

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <iterator>
 #include <limits>
 #include <openrct2-ui/interface/Widget.h>

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -14,7 +14,6 @@
 
 #include "../interface/Theme.h"
 
-#include <algorithm>
 #include <cmath>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Viewport.h>

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -9,7 +9,6 @@
 
 #include "../interface/Theme.h"
 
-#include <algorithm>
 #include <array>
 #include <limits>
 #include <openrct2-ui/interface/Dropdown.h>

--- a/src/openrct2-ui/windows/PatrolArea.cpp
+++ b/src/openrct2-ui/windows/PatrolArea.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <openrct2-ui/interface/LandTool.h>
 #include <openrct2-ui/interface/Viewport.h>
 #include <openrct2-ui/interface/Widget.h>

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -9,7 +9,6 @@
 
 #include "../interface/Theme.h"
 
-#include <algorithm>
 #include <cmath>
 #include <iterator>
 #include <limits>

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -9,7 +9,6 @@
 
 #include "../ride/Construction.h"
 
-#include <algorithm>
 #include <limits>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Viewport.h>

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <deque>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Viewport.h>

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -9,7 +9,6 @@
 
 #include <SDL.h>
 #include <SDL_keycode.h>
-#include <algorithm>
 #include <iterator>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <iterator>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Widget.h>

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -11,7 +11,6 @@
 #include "../interface/InGameConsole.h"
 #include "../scripting/CustomMenu.h"
 
-#include <algorithm>
 #include <iterator>
 #include <limits>
 #include <openrct2-ui/interface/Dropdown.h>

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <openrct2-ui/interface/Viewport.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/ride/Construction.h>
 #include <openrct2-ui/windows/Window.h>

--- a/src/openrct2-ui/windows/Transparency.cpp
+++ b/src/openrct2-ui/windows/Transparency.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <iterator>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Theme.h>

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <cmath>
 #include <openrct2-ui/interface/Viewport.h>
 #include <openrct2-ui/interface/Widget.h>

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <openrct2-ui/interface/LandTool.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>

--- a/src/openrct2-win/openrct2-win.cpp
+++ b/src/openrct2-win/openrct2-win.cpp
@@ -16,6 +16,7 @@
     "\"/manifestdependency:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")
 
 // Then the rest
+#include <algorithm>
 #include <iterator>
 #include <openrct2-ui/Ui.h>
 #include <openrct2/core/String.hpp>

--- a/src/openrct2-win/openrct2-win.cpp
+++ b/src/openrct2-win/openrct2-win.cpp
@@ -16,7 +16,6 @@
     "\"/manifestdependency:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")
 
 // Then the rest
-#include <algorithm>
 #include <iterator>
 #include <openrct2-ui/Ui.h>
 #include <openrct2/core/String.hpp>

--- a/src/openrct2/AssetPack.cpp
+++ b/src/openrct2/AssetPack.cpp
@@ -17,8 +17,6 @@
 #include "localisation/LocalisationService.h"
 #include "object/Object.h"
 
-#include <algorithm>
-
 using namespace OpenRCT2;
 
 constexpr std::string_view ManifestFileName = "manifest.json";

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -76,7 +76,6 @@
 #include "util/Util.h"
 #include "world/Park.h"
 
-#include <algorithm>
 #include <cmath>
 #include <exception>
 #include <future>

--- a/src/openrct2/Date.cpp
+++ b/src/openrct2/Date.cpp
@@ -15,8 +15,6 @@
 #include "GameState.h"
 #include "core/Guard.hpp"
 
-#include <algorithm>
-
 using namespace OpenRCT2;
 
 constexpr int32_t kMonthTicksIncrement = 4;

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -48,7 +48,6 @@
 #include "world/Park.h"
 #include "world/Scenery.h"
 
-#include <algorithm>
 #include <array>
 #include <vector>
 

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -70,7 +70,6 @@
 #include "world/Scenery.h"
 #include "world/Surface.h"
 
-#include <algorithm>
 #include <cstdio>
 #include <iterator>
 #include <memory>

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -44,7 +44,6 @@
 #include "world/Park.h"
 #include "world/Scenery.h"
 
-#include <algorithm>
 #include <chrono>
 
 using namespace OpenRCT2;

--- a/src/openrct2/actions/ClearAction.cpp
+++ b/src/openrct2/actions/ClearAction.cpp
@@ -22,8 +22,6 @@
 #include "SmallSceneryRemoveAction.h"
 #include "WallRemoveAction.h"
 
-#include <algorithm>
-
 ClearAction::ClearAction(MapRange range, ClearableItems itemsToClear)
     : _range(range)
     , _itemsToClear(itemsToClear)

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -30,7 +30,6 @@
 #include "../world/Park.h"
 #include "../world/Scenery.h"
 
-#include <algorithm>
 #include <iterator>
 
 using namespace OpenRCT2;

--- a/src/openrct2/actions/GameActionResult.cpp
+++ b/src/openrct2/actions/GameActionResult.cpp
@@ -2,6 +2,8 @@
 
 #include "../localisation/Localisation.h"
 
+#include <algorithm>
+
 namespace GameActions
 {
     Result::Result(GameActions::Status error, StringId title, StringId message, uint8_t* args /*= nullptr*/)

--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -26,8 +26,6 @@
 #include "../scenario/Scenario.h"
 #include "../world/Park.h"
 
-#include <algorithm>
-
 using namespace OpenRCT2;
 
 RideCreateAction::RideCreateAction(

--- a/src/openrct2/actions/ScenarioSetSettingAction.cpp
+++ b/src/openrct2/actions/ScenarioSetSettingAction.cpp
@@ -18,8 +18,6 @@
 #include "../util/Util.h"
 #include "../world/Park.h"
 
-#include <algorithm>
-
 using namespace OpenRCT2;
 
 void ScenarioSetSettingAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -33,7 +33,6 @@
 #include "AudioContext.h"
 #include "AudioMixer.h"
 
-#include <algorithm>
 #include <cmath>
 #include <memory>
 #include <vector>

--- a/src/openrct2/command_line/CommandLine.cpp
+++ b/src/openrct2/command_line/CommandLine.cpp
@@ -14,7 +14,6 @@
 #include "../core/String.hpp"
 #include "../platform/Platform.h"
 
-#include <algorithm>
 #include <cstring>
 
 #pragma region CommandLineArgEnumerator

--- a/src/openrct2/core/Algorithm.hpp
+++ b/src/openrct2/core/Algorithm.hpp
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include <algorithm>
 #include <functional>
 
 template<class ForwardIt, class T, class Compare = std::less<>>

--- a/src/openrct2/core/BitSet.hpp
+++ b/src/openrct2/core/BitSet.hpp
@@ -8,7 +8,6 @@
  *****************************************************************************/
 #pragma once
 
-#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>

--- a/src/openrct2/core/Crypt.OpenRCT2.cpp
+++ b/src/openrct2/core/Crypt.OpenRCT2.cpp
@@ -9,7 +9,6 @@
 
 #include "Crypt.h"
 
-#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <cstdlib>

--- a/src/openrct2/core/FileStream.cpp
+++ b/src/openrct2/core/FileStream.cpp
@@ -12,7 +12,6 @@
 #include "Path.hpp"
 #include "String.hpp"
 
-#include <algorithm>
 #include <string_view>
 
 #ifndef _WIN32

--- a/src/openrct2/core/FileWatcher.cpp
+++ b/src/openrct2/core/FileWatcher.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <array>
 #include <cstdio>
 #include <stdexcept>

--- a/src/openrct2/core/Imaging.cpp
+++ b/src/openrct2/core/Imaging.cpp
@@ -19,7 +19,6 @@
 #include "Memory.hpp"
 #include "String.hpp"
 
-#include <algorithm>
 #include <fstream>
 #include <png.h>
 #include <stdexcept>

--- a/src/openrct2/core/JobPool.cpp
+++ b/src/openrct2/core/JobPool.cpp
@@ -9,7 +9,6 @@
 
 #include "JobPool.h"
 
-#include <algorithm>
 #include <cassert>
 
 JobPool::TaskData::TaskData(std::function<void()> workFn, std::function<void()> completionFn)

--- a/src/openrct2/core/MemoryStream.cpp
+++ b/src/openrct2/core/MemoryStream.cpp
@@ -11,7 +11,6 @@
 
 #include "Memory.hpp"
 
-#include <algorithm>
 #include <cstring>
 
 namespace OpenRCT2

--- a/src/openrct2/core/OrcaStream.hpp
+++ b/src/openrct2/core/OrcaStream.hpp
@@ -15,7 +15,6 @@
 #include "Identifier.hpp"
 #include "MemoryStream.h"
 
-#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <fstream>

--- a/src/openrct2/core/Path.cpp
+++ b/src/openrct2/core/Path.cpp
@@ -17,7 +17,6 @@
 #include "Memory.hpp"
 #include "String.hpp"
 
-#include <algorithm>
 #include <iterator>
 
 namespace Path

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <algorithm>
 #include <cctype>
 #include <cwctype>
 #include <iomanip>

--- a/src/openrct2/core/StringBuilder.cpp
+++ b/src/openrct2/core/StringBuilder.cpp
@@ -11,7 +11,6 @@
 
 #include "String.hpp"
 
-#include <algorithm>
 #include <iterator>
 
 StringBuilder::StringBuilder(size_t capacity)

--- a/src/openrct2/core/Zip.cpp
+++ b/src/openrct2/core/Zip.cpp
@@ -11,7 +11,6 @@
 
 #include "IStream.hpp"
 
-#include <algorithm>
 #ifndef __ANDROID__
 #    include <zip.h>
 #endif

--- a/src/openrct2/drawing/Drawing.Sprite.RLE.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.RLE.cpp
@@ -9,7 +9,6 @@
 
 #include "Drawing.h"
 
-#include <algorithm>
 #include <cstring>
 
 template<DrawBlendOp TBlendOp, size_t TZoom>

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -22,7 +22,6 @@
 #include "../util/Util.h"
 #include "ScrollingText.h"
 
-#include <algorithm>
 #include <memory>
 #include <stdexcept>
 #include <vector>

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -23,8 +23,6 @@
 #include "../sprites.h"
 #include "TTF.h"
 
-#include <algorithm>
-
 using namespace OpenRCT2;
 
 static int32_t TTFGetStringWidth(std::string_view text, FontStyle fontStyle, bool noFormatting);

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -25,7 +25,6 @@
 #include "../world/Map.h"
 #include "Drawing.h"
 
-#include <algorithm>
 #include <cmath>
 #include <cstring>
 

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -21,7 +21,6 @@
 #include "Drawing.h"
 #include "TTF.h"
 
-#include <algorithm>
 #include <mutex>
 
 using namespace OpenRCT2;

--- a/src/openrct2/drawing/TTFSDLPort.cpp
+++ b/src/openrct2/drawing/TTFSDLPort.cpp
@@ -35,7 +35,6 @@ misrepresented as being the original software.
 3. This notice may not be removed or altered from any source distribution.
 */
 
-#    include <algorithm>
 #    include <cmath>
 #    include <cstring>
 #    include <stdio.h>

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -24,7 +24,6 @@
 #include "LightFX.h"
 #include "Weather.h"
 
-#include <algorithm>
 #include <cstring>
 
 using namespace OpenRCT2;

--- a/src/openrct2/entity/Duck.cpp
+++ b/src/openrct2/entity/Duck.cpp
@@ -20,7 +20,6 @@
 #include "../world/Surface.h"
 #include "EntityRegistry.h"
 
-#include <algorithm>
 #include <iterator>
 #include <limits>
 

--- a/src/openrct2/entity/EntityRegistry.cpp
+++ b/src/openrct2/entity/EntityRegistry.cpp
@@ -31,7 +31,6 @@
 #include "MoneyEffect.h"
 #include "Particle.h"
 
-#include <algorithm>
 #include <cmath>
 #include <iterator>
 #include <numeric>

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -61,7 +61,6 @@
 #include "Peep.h"
 #include "Staff.h"
 
-#include <algorithm>
 #include <functional>
 #include <iterator>
 

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -58,7 +58,6 @@
 #include "PatrolArea.h"
 #include "Staff.h"
 
-#include <algorithm>
 #include <iterator>
 #include <limits>
 #include <map>

--- a/src/openrct2/entity/Peep.h
+++ b/src/openrct2/entity/Peep.h
@@ -17,7 +17,6 @@
 #include "../util/Util.h"
 #include "../world/Location.hpp"
 
-#include <algorithm>
 #include <array>
 #include <optional>
 

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -47,7 +47,6 @@
 #include "PatrolArea.h"
 #include "Peep.h"
 
-#include <algorithm>
 #include <iterator>
 
 using namespace OpenRCT2;

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -21,8 +21,6 @@
 #include "../util/Util.h"
 #include "../world/Location.hpp"
 
-#include <algorithm>
-
 using namespace OpenRCT2;
 using namespace OpenRCT2::Audio;
 

--- a/src/openrct2/interface/Colour.cpp
+++ b/src/openrct2/interface/Colour.cpp
@@ -13,7 +13,6 @@
 #include "../drawing/Drawing.h"
 #include "../sprites.h"
 
-#include <algorithm>
 #include <cmath>
 
 ColourShadeMap ColourMapA[COLOUR_COUNT] = {};

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -64,7 +64,6 @@
 #include "../world/Scenery.h"
 #include "Viewport.h"
 
-#include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstdarg>

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -33,7 +33,6 @@
 #include "../world/Surface.h"
 #include "Viewport.h"
 
-#include <algorithm>
 #include <cctype>
 #include <chrono>
 #include <cstdlib>

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -41,7 +41,6 @@
 #include "Window.h"
 #include "Window_internal.h"
 
-#include <algorithm>
 #include <cstring>
 #include <list>
 #include <unordered_map>

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -34,7 +34,6 @@
 #include "Widget.h"
 #include "Window_internal.h"
 
-#include <algorithm>
 #include <cmath>
 #include <functional>
 #include <iterator>

--- a/src/openrct2/localisation/Convert.cpp
+++ b/src/openrct2/localisation/Convert.cpp
@@ -11,7 +11,6 @@
 #include "ConversionTables.h"
 #include "Language.h"
 
-#include <algorithm>
 #include <limits>
 #include <stdexcept>
 

--- a/src/openrct2/localisation/LanguagePack.cpp
+++ b/src/openrct2/localisation/LanguagePack.cpp
@@ -21,7 +21,6 @@
 #include "Localisation.h"
 #include "LocalisationService.h"
 
-#include <algorithm>
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -30,7 +30,6 @@
 #include "Formatting.h"
 #include "Localisation.h"
 
-#include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <ctype.h>

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -22,8 +22,6 @@
 #include "../world/Park.h"
 #include "NewsItem.h"
 
-#include <algorithm>
-
 using namespace OpenRCT2;
 
 constexpr uint8_t NEGATIVE = 0;

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -39,7 +39,6 @@
 #include "Finance.h"
 #include "NewsItem.h"
 
-#include <algorithm>
 #include <iterator>
 
 using namespace OpenRCT2;

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -36,7 +36,6 @@
 #include "../world/Location.hpp"
 #include "network.h"
 
-#include <algorithm>
 #include <iterator>
 #include <stdexcept>
 
@@ -92,7 +91,6 @@ static constexpr uint32_t MaxPacketsPerUpdate = 100;
 #    include "NetworkUser.h"
 #    include "Socket.h"
 
-#    include <algorithm>
 #    include <array>
 #    include <cerrno>
 #    include <cmath>

--- a/src/openrct2/network/ServerList.cpp
+++ b/src/openrct2/network/ServerList.cpp
@@ -26,7 +26,6 @@
 #    include "Socket.h"
 #    include "network.h"
 
-#    include <algorithm>
 #    include <numeric>
 #    include <optional>
 

--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -23,7 +23,6 @@
 #include "Object.h"
 #include "ObjectFactory.h"
 
-#include <algorithm>
 #include <memory>
 #include <stdexcept>
 

--- a/src/openrct2/object/LargeSceneryObject.cpp
+++ b/src/openrct2/object/LargeSceneryObject.cpp
@@ -20,7 +20,6 @@
 #include "../world/Banner.h"
 #include "../world/Location.hpp"
 
-#include <algorithm>
 #include <iterator>
 
 static RCTLargeSceneryText ReadLegacy3DFont(OpenRCT2::IStream& stream)

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -23,7 +23,6 @@
 #include "ObjectLimits.h"
 #include "ObjectRepository.h"
 
-#include <algorithm>
 #include <cstring>
 #include <stdexcept>
 

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -44,7 +44,6 @@
 #include "WallObject.h"
 #include "WaterObject.h"
 
-#include <algorithm>
 #include <memory>
 #include <unordered_map>
 

--- a/src/openrct2/object/ObjectList.cpp
+++ b/src/openrct2/object/ObjectList.cpp
@@ -18,7 +18,6 @@
 #include "ObjectManager.h"
 #include "ObjectRepository.h"
 
-#include <algorithm>
 #include <array>
 #include <cstring>
 

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -30,7 +30,6 @@
 #include "SmallSceneryObject.h"
 #include "WallObject.h"
 
-#include <algorithm>
 #include <array>
 #include <memory>
 #include <mutex>

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -41,7 +41,6 @@
 #include "ObjectManager.h"
 #include "RideObject.h"
 
-#include <algorithm>
 #include <memory>
 #include <unordered_map>
 #include <vector>

--- a/src/openrct2/object/ObjectTypes.cpp
+++ b/src/openrct2/object/ObjectTypes.cpp
@@ -12,8 +12,6 @@
 #include "../util/Util.h"
 #include "Object.h"
 
-#include <algorithm>
-
 constexpr std::array kAllObjectTypes = {
     ObjectType::Ride,
     ObjectType::SmallScenery,

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -31,7 +31,6 @@
 #include "../ride/Vehicle.h"
 #include "ObjectRepository.h"
 
-#include <algorithm>
 #include <iterator>
 #include <unordered_map>
 

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -20,8 +20,6 @@
 #include "../localisation/Language.h"
 #include "../world/Scenery.h"
 
-#include <algorithm>
-
 void SmallSceneryObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream)
 {
     stream->Seek(6, OpenRCT2::STREAM_SEEK_CURRENT);

--- a/src/openrct2/object/StringTable.cpp
+++ b/src/openrct2/object/StringTable.cpp
@@ -18,8 +18,6 @@
 #include "../localisation/LocalisationService.h"
 #include "Object.h"
 
-#include <algorithm>
-
 static constexpr uint8_t RCT2ToOpenRCT2LanguageId[] = {
     LANGUAGE_ENGLISH_UK,
     LANGUAGE_ENGLISH_US,

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -25,7 +25,6 @@
 #include "Paint.Entity.h"
 #include "tile_element/Paint.TileElement.h"
 
-#include <algorithm>
 #include <array>
 
 using namespace OpenRCT2;

--- a/src/openrct2/paint/VirtualFloor.cpp
+++ b/src/openrct2/paint/VirtualFloor.cpp
@@ -24,7 +24,6 @@
 #include "VirtualFloor.h"
 #include "tile_element/Paint.TileElement.h"
 
-#include <algorithm>
 #include <limits>
 
 using namespace OpenRCT2;

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -32,7 +32,6 @@
 #include "../Paint.SessionFlags.h"
 #include "Paint.TileElement.h"
 
-#include <algorithm>
 #include <cstring>
 #include <iterator>
 

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -33,8 +33,6 @@
 #include "../support/WoodenSupports.h"
 #include "Paint.Surface.h"
 
-#include <algorithm>
-
 static void BlankTilesPaint(PaintSession& session, int32_t x, int32_t y);
 static void PaintTileElementBase(PaintSession& session, const CoordsXY& origCoords);
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -71,7 +71,6 @@
 #include "RCT1.h"
 #include "Tables.h"
 
-#include <algorithm>
 #include <iterator>
 #include <memory>
 #include <vector>

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -75,8 +75,6 @@
 #include "../world/Surface.h"
 #include "../world/TilePointerIndex.hpp"
 
-#include <algorithm>
-
 using namespace OpenRCT2;
 
 namespace RCT2

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -19,8 +19,6 @@
 #include "Vehicle.h"
 #include "VehicleData.h"
 
-#include <algorithm>
-
 Vehicle* CableLiftSegmentCreate(
     Ride& ride, int32_t x, int32_t y, int32_t z, int32_t direction, uint16_t var_44, int32_t remaining_distance, bool head)
 {

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -76,7 +76,6 @@
 #include "TrainManager.h"
 #include "Vehicle.h"
 
-#include <algorithm>
 #include <cassert>
 #include <climits>
 #include <cstdlib>

--- a/src/openrct2/ride/RideAudio.cpp
+++ b/src/openrct2/ride/RideAudio.cpp
@@ -23,7 +23,6 @@
 #include "Ride.h"
 #include "RideData.h"
 
-#include <algorithm>
 #include <vector>
 
 using namespace OpenRCT2;

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -25,7 +25,6 @@
 #include "Station.h"
 #include "Track.h"
 
-#include <algorithm>
 #include <iterator>
 
 using namespace OpenRCT2;

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -66,7 +66,6 @@
 #include "TrackDesignRepository.h"
 #include "Vehicle.h"
 
-#include <algorithm>
 #include <iterator>
 #include <memory>
 

--- a/src/openrct2/ride/TrackDesignRepository.cpp
+++ b/src/openrct2/ride/TrackDesignRepository.cpp
@@ -25,7 +25,6 @@
 #include "../util/Util.h"
 #include "TrackDesign.h"
 
-#include <algorithm>
 #include <memory>
 #include <vector>
 

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -34,8 +34,6 @@
 #include "TrackDesign.h"
 #include "TrackDesignRepository.h"
 
-#include <algorithm>
-
 constexpr size_t TRACK_MAX_SAVED_TILE_ELEMENTS = 1500;
 constexpr int32_t TRACK_NEARBY_SCENERY_DISTANCE = 1;
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -55,7 +55,6 @@
 #include "VehicleData.h"
 #include "VehicleSubpositionData.h"
 
-#include <algorithm>
 #include <iterator>
 
 using namespace OpenRCT2;

--- a/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
@@ -19,8 +19,6 @@
 #include "../TrackData.h"
 #include "../TrackPaint.h"
 
-#include <algorithm>
-
 enum class JuniorRCSubType : uint8_t
 {
     Junior = 1,

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -58,8 +58,6 @@
 #include "ScenarioRepository.h"
 #include "ScenarioSources.h"
 
-#include <algorithm>
-
 using namespace OpenRCT2;
 
 const StringId ScenarioCategoryStringIds[SCENARIO_CATEGORY_COUNT] = {

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -32,7 +32,6 @@
 #include "Scenario.h"
 #include "ScenarioSources.h"
 
-#include <algorithm>
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/openrct2/scenes/title/Command/Wait.cpp
+++ b/src/openrct2/scenes/title/Command/Wait.cpp
@@ -11,8 +11,6 @@
 
 #include "../../../Context.h"
 
-#include <algorithm>
-
 namespace OpenRCT2::Title
 {
     int16_t WaitCommand::operator()(int16_t timer)

--- a/src/openrct2/scenes/title/TitleSequence.cpp
+++ b/src/openrct2/scenes/title/TitleSequence.cpp
@@ -26,7 +26,6 @@
 #include "../../scenario/ScenarioSources.h"
 #include "../../util/Util.h"
 
-#include <algorithm>
 #include <array>
 #include <memory>
 #include <optional>

--- a/src/openrct2/scenes/title/TitleSequenceManager.cpp
+++ b/src/openrct2/scenes/title/TitleSequenceManager.cpp
@@ -22,7 +22,6 @@
 #include "../../platform/Platform.h"
 #include "TitleSequence.h"
 
-#include <algorithm>
 #include <iterator>
 #include <vector>
 

--- a/src/openrct2/scripting/Plugin.cpp
+++ b/src/openrct2/scripting/Plugin.cpp
@@ -17,7 +17,6 @@
 #    include "Duktape.hpp"
 #    include "ScriptEngine.h"
 
-#    include <algorithm>
 #    include <fstream>
 #    include <memory>
 

--- a/src/openrct2/scripting/bindings/entity/ScEntity.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScEntity.hpp
@@ -20,7 +20,6 @@
 #    include "../../Duktape.hpp"
 #    include "../../ScriptEngine.h"
 
-#    include <algorithm>
 #    include <string_view>
 #    include <unordered_map>
 

--- a/src/openrct2/scripting/bindings/network/ScSocket.hpp
+++ b/src/openrct2/scripting/bindings/network/ScSocket.hpp
@@ -18,7 +18,6 @@
 #        include "../../Duktape.hpp"
 #        include "../../ScriptEngine.h"
 
-#        include <algorithm>
 #        include <memory>
 #        include <vector>
 

--- a/src/openrct2/scripting/bindings/world/ScPark.cpp
+++ b/src/openrct2/scripting/bindings/world/ScPark.cpp
@@ -24,8 +24,6 @@
 #    include "../../ScriptEngine.h"
 #    include "ScParkMessage.hpp"
 
-#    include <algorithm>
-
 namespace OpenRCT2::Scripting
 {
     static const DukEnumMap<uint64_t> ParkFlagMap({

--- a/src/openrct2/scripting/bindings/world/ScPark.hpp
+++ b/src/openrct2/scripting/bindings/world/ScPark.hpp
@@ -17,7 +17,6 @@
 #    include "ScParkMessage.hpp"
 #    include "ScResearch.hpp"
 
-#    include <algorithm>
 #    include <vector>
 
 namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/world/ScParkMessage.cpp
+++ b/src/openrct2/scripting/bindings/world/ScParkMessage.cpp
@@ -23,8 +23,6 @@
 #    include "../../Duktape.hpp"
 #    include "../../ScriptEngine.h"
 
-#    include <algorithm>
-
 namespace OpenRCT2::Scripting
 {
     ScParkMessage::ScParkMessage(size_t index)

--- a/src/openrct2/scripting/bindings/world/ScParkMessage.hpp
+++ b/src/openrct2/scripting/bindings/world/ScParkMessage.hpp
@@ -17,7 +17,6 @@
 #    include "../../Duktape.hpp"
 #    include "../../ScriptEngine.h"
 
-#    include <algorithm>
 #    include <string>
 
 namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/world/ScScenario.hpp
+++ b/src/openrct2/scripting/bindings/world/ScScenario.hpp
@@ -20,8 +20,6 @@
 #    include "../../Duktape.hpp"
 #    include "../../ScriptEngine.h"
 
-#    include <algorithm>
-
 namespace OpenRCT2::Scripting
 {
     static const DukEnumMap<uint32_t> ScenarioObjectiveTypeMap({

--- a/src/openrct2/util/SawyerCoding.cpp
+++ b/src/openrct2/util/SawyerCoding.cpp
@@ -14,7 +14,6 @@
 #include "../scenario/Scenario.h"
 #include "Util.h"
 
-#include <algorithm>
 #include <cstring>
 #include <stdexcept>
 

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -18,7 +18,6 @@
 #include "../scenes/title/TitleScene.h"
 #include "zlib.h"
 
-#include <algorithm>
 #include <cctype>
 #include <cmath>
 #include <ctime>

--- a/src/openrct2/world/Banner.cpp
+++ b/src/openrct2/world/Banner.cpp
@@ -32,7 +32,6 @@
 #include "Park.h"
 #include "Scenery.h"
 
-#include <algorithm>
 #include <cstring>
 #include <iterator>
 #include <limits>

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -27,7 +27,6 @@
 #include "../util/Util.h"
 #include "../windows/Intent.h"
 
-#include <algorithm>
 #include <iterator>
 #include <memory>
 

--- a/src/openrct2/world/Entrance.cpp
+++ b/src/openrct2/world/Entrance.cpp
@@ -31,8 +31,6 @@
 #include "MapAnimation.h"
 #include "Park.h"
 
-#include <algorithm>
-
 using namespace OpenRCT2;
 
 bool gParkEntranceGhostExists = false;

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -44,7 +44,6 @@
 #include "Surface.h"
 #include "TileElement.h"
 
-#include <algorithm>
 #include <iterator>
 
 using namespace OpenRCT2::TrackMetaData;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -54,7 +54,6 @@
 #include "TileInspector.h"
 #include "Wall.h"
 
-#include <algorithm>
 #include <iterator>
 #include <memory>
 

--- a/src/openrct2/world/MapGen.cpp
+++ b/src/openrct2/world/MapGen.cpp
@@ -31,7 +31,6 @@
 #include "Scenery.h"
 #include "Surface.h"
 
-#include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <iterator>

--- a/src/openrct2/world/MapHelpers.cpp
+++ b/src/openrct2/world/MapHelpers.cpp
@@ -12,8 +12,6 @@
 #include "Map.h"
 #include "Surface.h"
 
-#include <algorithm>
-
 static uint8_t GetBaseHeightOrZero(int32_t x, int32_t y)
 {
     auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -41,7 +41,6 @@
 #include "Map.h"
 #include "Surface.h"
 
-#include <algorithm>
 #include <limits>
 #include <type_traits>
 

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -32,7 +32,6 @@
 #include "Scenery.h"
 #include "Surface.h"
 
-#include <algorithm>
 #include <optional>
 
 TileCoordsXY windowTileInspectorTile;

--- a/src/thirdparty/filesystem.hpp
+++ b/src/thirdparty/filesystem.hpp
@@ -114,7 +114,6 @@
 #include <Availability.h>
 #endif
 
-#include <algorithm>
 #include <cctype>
 #include <chrono>
 #include <clocale>


### PR DESCRIPTION
This removes `#include <algorithm>` in several files, but after deeper inspection, I've found there are only literally a few dependencies with GCC 11 saved - the header is either included later on, or via another our include or via C++'s headers which don't necessarily include `<algorithm>`, but the files that make it.

The inspection was done with `make` - one of side effects of its compilation is generation of `compiler_depend` files to track rebuilds:

1. `mkdir build && cd build`
2. `cmake ../`
3. `make -j$(nproc)`
4. `make # single threaded and once again, the dependencies are not generated the first time and we want it single threaded to ensure same order`
5. `find . -name compiler_depend.make`
6. Inspect `./CMakeFiles/libopenrct2.dir/compiler_depend.make`, copy it out of tree and redo with other commit.

It's easier to just look at total lines in the files to not get confused about changed order. Here's output for this PR:
```
  179381 ../libopenrct2-new-depend
  179497 ../libopenrct2-old-depend
```