### PR TITLE
Fix #21959: No save prompt when starting a new game

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -244,6 +244,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Kaavya Ramachandhran (ayvaak)
 * Mike Harvey (harvito)
 * Robert Yan (lewyche)
+* Tom Matalenas (tmatale)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,7 +1,7 @@
 0.4.15 (in development)
 ------------------------------------------------------------------------
 - Feature: [#15642] Track design placement can now use contruction modifier keys (ctrl/shift).
-- Fix: [#21959] "Save this before...?" message does not appear when selecting "New Game".
+- Fix: [#21959] “Save this before...?” message does not appear when selecting “New Game”.
 - Fix: [#22231] Invalid object version can cause a crash.
 - Fix: [#22653] Add several .parkpatch files for missing water tiles in RCT1 and RCT2 scenarios.
 

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.15 (in development)
 ------------------------------------------------------------------------
 - Feature: [#15642] Track design placement can now use contruction modifier keys (ctrl/shift).
+- Fix: [#21959] "Save this before...?" message does not appear when selecting "New Game".
 - Fix: [#22231] Invalid object version can cause a crash.
 - Fix: [#22653] Add several .parkpatch files for missing water tiles in RCT1 and RCT2 scenarios.
 

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -267,8 +267,6 @@ namespace OpenRCT2::Ui::Windows
     };
     // clang-format on
 
-    static void ScenarioSelectCallback(const utf8* path);
-
     class TopToolbar final : public Window
     {
     private:
@@ -447,9 +445,9 @@ namespace OpenRCT2::Ui::Windows
                     {
                         case DDIDX_NEW_GAME:
                         {
-                            auto intent = Intent(WindowClass::ScenarioSelect);
-                            intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<void*>(ScenarioSelectCallback));
-                            ContextOpenIntent(&intent);
+                            auto loadOrQuitAction = LoadOrQuitAction(
+                                LoadOrQuitModes::OpenSavePrompt, PromptMode::SaveBeforeNewGame);
+                            GameActions::Execute(&loadOrQuitAction);
                             break;
                         }
                         case DDIDX_LOAD_GAME:
@@ -990,15 +988,6 @@ namespace OpenRCT2::Ui::Windows
             }
         }
     };
-
-    static void ScenarioSelectCallback(const utf8* path)
-    {
-        WindowCloseByClass(WindowClass::EditorObjectSelection);
-        GameNotifyMapChange();
-        GetContext()->LoadParkFromFile(path, false, true);
-        GameLoadScripts();
-        GameNotifyMapChanged();
-    }
 
     /**
      * Creates the main game top toolbar window.


### PR DESCRIPTION
Resolves #21959 

Instead of directly linking to the new game menu, it will first ask the user if you want to save the game if necessary. The SaveBeforeNewGame functionality was already present.