### PR TITLE
Fix Issue #21904 - Path Inspector

### DIFF
--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -846,11 +846,33 @@ static std::pair<uint8_t, uint8_t> PathPaintGetRotatedEdgesAndCorners(
     const PaintSession& session, const PathElement& pathElement)
 {
     // Rol edges around rotation
-    uint8_t edges = ((pathElement.GetEdges() << session.CurrentRotation) & 0xF)
-        | (((pathElement.GetEdges()) << session.CurrentRotation) >> 4);
+    uint8_t rawEdges = pathElement.GetEdges();
+    uint8_t edges = ((rawEdges << session.CurrentRotation) & 0xF)
+        | ((rawEdges << session.CurrentRotation) >> 4);
+    uint8_t rawCorners = pathElement.GetCorners();
+    uint8_t validCorners = 0x0;
 
-    uint8_t corners = (((pathElement.GetCorners()) << session.CurrentRotation) & 0xF)
-        | (((pathElement.GetCorners()) << session.CurrentRotation) >> 4);
+    // Only paint corners that exist between two edges
+    if ((rawEdges & EDGE_SE) && (rawEdges & EDGE_SW))
+    {
+        validCorners |= (rawCorners & FOOTPATH_CORNER_1);
+    }
+    if ((rawEdges & EDGE_NE) && (rawEdges & EDGE_NW))
+    {
+        validCorners |= (rawCorners & FOOTPATH_CORNER_3);
+    }
+    if ((rawEdges & EDGE_SW) && (rawEdges & EDGE_NW))
+    {
+        validCorners |= (rawCorners & FOOTPATH_CORNER_2);
+    }
+    if ((rawEdges & EDGE_NE) && (rawEdges & EDGE_SE))
+    {
+        validCorners |= (rawCorners & FOOTPATH_CORNER_0);
+    }
+
+    // Roll corners around rotation
+    uint8_t corners = ((validCorners << session.CurrentRotation) & 0xF)
+        | ((validCorners << session.CurrentRotation) >> 4);
 
     return std::make_pair(edges, corners);
 }

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -847,8 +847,7 @@ static std::pair<uint8_t, uint8_t> PathPaintGetRotatedEdgesAndCorners(
 {
     // Rol edges around rotation
     uint8_t rawEdges = pathElement.GetEdges();
-    uint8_t edges = ((rawEdges << session.CurrentRotation) & 0xF)
-        | ((rawEdges << session.CurrentRotation) >> 4);
+    uint8_t edges = ((rawEdges << session.CurrentRotation) & 0xF) | ((rawEdges << session.CurrentRotation) >> 4);
     uint8_t rawCorners = pathElement.GetCorners();
     uint8_t validCorners = 0x0;
 
@@ -871,8 +870,7 @@ static std::pair<uint8_t, uint8_t> PathPaintGetRotatedEdgesAndCorners(
     }
 
     // Roll corners around rotation
-    uint8_t corners = ((validCorners << session.CurrentRotation) & 0xF)
-        | ((validCorners << session.CurrentRotation) >> 4);
+    uint8_t corners = ((validCorners << session.CurrentRotation) & 0xF) | ((validCorners << session.CurrentRotation) >> 4);
 
     return std::make_pair(edges, corners);
 }


### PR DESCRIPTION
Previously, when a user selected a footpath in the tile inspector, toggling a corner that is not between two edges would result in all corners disappearing (as described in #21904).
This fix modifies PathPaintGetRotatedEdgesAndCorners to check which corners can be painted based on the adjacent edges. If a corner is not between two selected edges, it will not be returned. The end result is that selecting invalid corners in the Tile Inspector will not result in any valid corners disappearing:
![image](https://github.com/OpenRCT2/OpenRCT2/assets/156536454/714f02cf-0917-4e1c-858b-822efa027b1f)