### PR TITLE
Fix gcc12 compile error

### DIFF
--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -235,7 +235,7 @@ void FinanceInit()
     gameState.ScenarioCompletedCompanyValue = kMoney64Undefined;
     gameState.TotalAdmissions = 0;
     gameState.TotalIncomeFromAdmissions = 0;
-    gameState.ScenarioCompletedBy = "?";
+    gameState.ScenarioCompletedBy = std::string("?");
 }
 
 /**


### PR DESCRIPTION
Compiling v0.4.10 on bookworm with gcc 12.2.0 produces the following error:

```
[ 38%] Building CXX object CMakeFiles/libopenrct2.dir/src/openrct2/network/NetworkServerAdvertiser.cpp.o
/usr/bin/c++ -DDOCDIR=\"/usr/share/doc/openrct2\" -DOPENGL_NO_LINK -D_FILE_OFFSET_BITS=64 -D__WARN_SUGGEST_FINAL_METHODS__ -D__WARN_SUGGEST_FINAL_TYPES__ -I/build/openrct2-0.4.10+ds -I/build/openrct2-0.4.10+ds/libopenrct2 -isystem /usr/include/freetype2 -isystem /usr/include/libpng16 -isystem /build/openrct2-0.4.10+ds/src/openrct2/../thirdparty -g -O2 -ffile-prefix-map=/build/openrct2-0.4.10+ds=. -fstack-protector-strong -Wformat -Werror=format-security -DNDEBUG -Wdate-time -D_FORTIFY_SOURCE=2 -fstrict-overflow -fstrict-aliasing -Werror -Wundef -Wmissing-declarations -Winit-self -Wall -Wextra -Wshadow -Wno-unknown-pragmas -Wno-missing-braces -Wno-comment -Wnonnull -Wno-unused-parameter -Wno-attributes -DDEBUG=0 -fno-char8_t -Wno-deprecated-declarations -fPIC -Wsuggest-override -Wduplicated-cond -Wnon-virtual-dtor -Wduplicated-branches -Wrestrict -Wmissing-field-initializers -Wlogical-op -Wold-style-cast -Wunused-const-variable=1 -Wno-clobbered -Wredundant-decls -Wnull-dereference -Wsuggest-final-types -Wsuggest-final-methods -Wignored-qualifiers -Wstrict-overflow=1 -DENABLE_SCRIPTING -std=gnu++20 -MD -MT CMakeFiles/libopenrct2.dir/src/openrct2/network/NetworkServerAdvertiser.cpp.o -MF CMakeFiles/libopenrct2.dir/src/openrct2/network/NetworkServerAdvertiser.cpp.o.d -o CMakeFiles/libopenrct2.dir/src/openrct2/network/NetworkServerAdvertiser.cpp.o -c /build/openrct2-0.4.10+ds/src/openrct2/network/NetworkServerAdvertiser.cpp
In file included from /usr/include/c++/12/string:40,
                 from /build/openrct2-0.4.10+ds/src/openrct2/management/../util/../core/String.hpp:17,
                 from /build/openrct2-0.4.10+ds/src/openrct2/management/../util/Util.h:13,
                 from /build/openrct2-0.4.10+ds/src/openrct2/management/Research.h:16,
                 from /build/openrct2-0.4.10+ds/src/openrct2/management/Finance.h:13,
                 from /build/openrct2-0.4.10+ds/src/openrct2/management/Finance.cpp:10:
In static member function 'static constexpr std::char_traits<char>::char_type* std::char_traits<char>::copy(char_type*, const char_type*, std::size_t)',
    inlined from 'static constexpr void std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_S_copy(_CharT*, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /usr/include/c++/12/bits/basic_string.h:423:21,
    inlined from 'static constexpr void std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_S_copy(_CharT*, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /usr/include/c++/12/bits/basic_string.h:418:7,
    inlined from 'constexpr std::__cxx11::basic_string<_CharT, _Traits, _Allocator>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_M_replace(size_type, size_type, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /usr/include/c++/12/bits/basic_string.tcc:532:22,
    inlined from 'constexpr std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::assign(const _CharT*) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /usr/include/c++/12/bits/basic_string.h:1647:19,
    inlined from 'constexpr std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::operator=(const _CharT*) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /usr/include/c++/12/bits/basic_string.h:815:28,
    inlined from 'void FinanceInit()' at /build/openrct2-0.4.10+ds/src/openrct2/management/Finance.cpp:238:37:
/usr/include/c++/12/bits/char_traits.h:431:56: error: 'void* __builtin_memcpy(void*, const void*, long unsigned int)' accessing 9223372036854775810 or more bytes at offsets -4611686018427387902 and [-4611686018427387903, 4611686018427387904] may overlap up to 9223372036854775813 bytes at offset -3 [-Werror=restrict]
  431 |         return static_cast<char_type*>(__builtin_memcpy(__s1, __s2, __n));
      |                                        ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

gcc 13.2.0 in sid builds fine. Looks like [GCC bug 105329](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329), [RedHat bug 2047428](https://bugzilla.redhat.com/show_bug.cgi?id=2047428).

(Not sure why `src/openrct2/scenario/Scenario.cpp` line 143 didn't also trigger an error, but since it didn't I decided not to touch it.)