### PR TITLE
JSON: allow/ignore comments in parser

### DIFF
--- a/src/openrct2/core/Json.cpp
+++ b/src/openrct2/core/Json.cpp
@@ -32,7 +32,7 @@ namespace Json
 
         try
         {
-            json = json_t::parse(fileData);
+            json = json_t::parse(fileData, /* callback */ nullptr, /* allow_exceptions */ true, /* ignore_comments */ true);
         }
         catch (const json_t::exception& e)
         {
@@ -59,7 +59,7 @@ namespace Json
 
         try
         {
-            json = json_t::parse(raw);
+            json = json_t::parse(raw, /* callback */ nullptr, /* allow_exceptions */ true, /* ignore_comments */ true);
         }
         catch (const json_t::exception& e)
         {
@@ -75,7 +75,8 @@ namespace Json
 
         try
         {
-            json = json_t::parse(vec.begin(), vec.end());
+            json = json_t::parse(
+                vec.begin(), vec.end(), /* callback */ nullptr, /* allow_exceptions */ true, /* ignore_comments */ true);
         }
         catch (const json_t::exception& e)
         {


### PR DESCRIPTION
We've been using JSON for objects for quite a while, but not being able to annotate some lines has been a continued limitation. For example, an effort to migrate title sequences to JSON (#4575) was abandoned due to comments not being supported by the JSON standard.

The library we initially used was relatively inflexible in this regard, but we have since moved to the excellent 'JSON for Modern C++' library (nlohmann-json, #12667). This library actually provides a parser option to ignore comments. Many JSON parser libraries provide similar functionality, so I think we should go for it.