### PR TITLE
Rework map window to take map size into account

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,10 @@
 ------------------------------------------------------------------------
 - Feature: [#21714] [Plugin] Costume assignment is now tailored to each staff type.
 - Feature: [#21913] [Plugin] Allow precise and safe control of peep animations.
+- Improved: [#21981] Rendering performance of the map window has been improved considerably.
+- Improved: [#21981] The map window now defaults to showing as much of the map as fits the screen.
+- Change: [#7248] Small mini-maps are now centred in the map window.
+- Fix: [#13294] Map corners are cut off in some directions (original bug).
 
 0.4.11 (2024-05-05)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -53,8 +53,23 @@ namespace OpenRCT2::Ui::Windows
     {
         return MapColour2((colour & 0xFF00) >> 8, PALETTE_INDEX_10);
     }
-
-    constexpr int32_t MAP_WINDOW_MAP_SIZE = kMaximumMapSizeTechnical * 2;
+    static int32_t getTechnicalMapSize()
+    {
+        // Take non-square maps into account
+        return std::max(GetGameState().MapSize.x, GetGameState().MapSize.y) - 2;
+    }
+    static int32_t getTechnicalMapSizeBig()
+    {
+        return getTechnicalMapSize() * COORDS_XY_STEP;
+    }
+    static int32_t getMaxTileStartXY()
+    {
+        return getTechnicalMapSizeBig() - COORDS_XY_STEP;
+    }
+    static int32_t getMiniMapWidth()
+    {
+        return getTechnicalMapSize() * 2;
+    }
 
     static constexpr StringId WINDOW_TITLE = STR_MAP_LABEL;
     static constexpr int32_t WH = 259;
@@ -126,16 +141,17 @@ static Widget window_map_widgets[] = {
     MakeWidget        ({110, 189}, {131,  14}, WindowWidgetType::Button,    WindowColour::Secondary, STR_MAPGEN_WINDOW_TITLE,         STR_MAP_GENERATOR_TIP                          ),
     kWidgetsEnd,
 };
-
-// used in transforming viewport view coordinates to minimap coordinates
-// rct2: 0x00981BBC
-static constexpr ScreenCoordsXY MiniMapOffsets[] = {
-    {     kMaximumMapSizeTechnical - 8,                              0 },
-    { 2 * kMaximumMapSizeTechnical - 8,     kMaximumMapSizeTechnical },
-    {     kMaximumMapSizeTechnical - 8, 2 * kMaximumMapSizeTechnical },
-    {                              0 - 8,     kMaximumMapSizeTechnical },
-};
     // clang-format on
+
+    // These represent a coefficient for the map size to be multiplied
+    // Used in transforming viewport view coordinates to minimap coordinates
+    // rct2: 0x00981BBC (analogous)
+    static constexpr ScreenCoordsXY MiniMapOffsetFactors[] = {
+        { 1, 0 },
+        { 2, 1 },
+        { 1, 2 },
+        { 0, 1 },
+    };
 
     static constexpr StringId MapLabels[] = {
         STR_MAP_RIDE,       STR_MAP_FOOD_STALL, STR_MAP_DRINK_STALL,  STR_MAP_SOUVENIR_STALL,
@@ -209,11 +225,6 @@ static constexpr ScreenCoordsXY MiniMapOffsets[] = {
         uint16_t _flashingFlags = 0;
 
     public:
-        MapWindow()
-        {
-            _mapImageData.resize(MAP_WINDOW_MAP_SIZE * MAP_WINDOW_MAP_SIZE);
-        }
-
         void OnOpen() override
         {
             widgets = window_map_widgets;
@@ -224,9 +235,11 @@ static constexpr ScreenCoordsXY MiniMapOffsets[] = {
 
             flags |= WF_RESIZABLE;
             min_width = WW;
-            max_width = 800;
             min_height = WH;
-            max_height = 560;
+
+            // TODO: use actual constants
+            max_width = getMapWindowSize() + 20;
+            max_height = getMapWindowSize() + 100;
 
             ResizeMap();
             InitScrollWidgets();
@@ -734,14 +747,14 @@ static constexpr ScreenCoordsXY MiniMapOffsets[] = {
 
         ScreenSize OnScrollGetSize(int32_t scrollIndex) override
         {
-            return ScreenSize(MAP_WINDOW_MAP_SIZE, MAP_WINDOW_MAP_SIZE);
+            return ScreenSize(getMiniMapWidth(), getMiniMapWidth());
         }
 
         void OnScrollMouseDown(int32_t scrollIndex, const ScreenCoordsXY& screenCoords) override
         {
             CoordsXY c = ScreenToMap(screenCoords);
-            auto mapCoords = CoordsXY{ std::clamp(c.x, 0, MAXIMUM_MAP_SIZE_BIG - 1),
-                                       std::clamp(c.y, 0, MAXIMUM_MAP_SIZE_BIG - 1) };
+            auto mapCoords = CoordsXY{ std::clamp(c.x, 0, getTechnicalMapSizeBig() - 1),
+                                       std::clamp(c.y, 0, getTechnicalMapSizeBig() - 1) };
             auto mapZ = TileElementHeight(mapCoords);
 
             WindowBase* mainWindow = WindowGetMain();
@@ -803,8 +816,8 @@ static constexpr ScreenCoordsXY MiniMapOffsets[] = {
 
             G1Element g1temp = {};
             g1temp.offset = _mapImageData.data();
-            g1temp.width = MAP_WINDOW_MAP_SIZE;
-            g1temp.height = MAP_WINDOW_MAP_SIZE;
+            g1temp.width = getMiniMapWidth();
+            g1temp.height = getMiniMapWidth();
             g1temp.x_offset = -8;
             g1temp.y_offset = -8;
             GfxSetG1Element(SPR_TEMP, &g1temp);
@@ -1017,6 +1030,7 @@ static constexpr ScreenCoordsXY MiniMapOffsets[] = {
     private:
         void InitMap()
         {
+            _mapImageData.resize(getMiniMapWidth() * getMiniMapWidth());
             std::fill(_mapImageData.begin(), _mapImageData.end(), PALETTE_INDEX_10);
             _currentLine = 0;
         }
@@ -1030,14 +1044,14 @@ static constexpr ScreenCoordsXY MiniMapOffsets[] = {
             if (mainWindow == nullptr || mainWindow->viewport == nullptr)
                 return;
 
-            auto offset = MiniMapOffsets[GetCurrentRotation()];
+            auto offset = MiniMapOffsetFactors[GetCurrentRotation()];
 
             // calculate centre view point of viewport and transform it to minimap coordinates
 
             cx = ((mainWindow->viewport->view_width >> 1) + mainWindow->viewport->viewPos.x) >> 5;
             dx = ((mainWindow->viewport->view_height >> 1) + mainWindow->viewport->viewPos.y) >> 4;
-            cx += offset.x;
-            dx += offset.y;
+            cx += offset.x * getTechnicalMapSize() - 8;
+            dx += offset.y * getTechnicalMapSize();
 
             // calculate width and height of minimap
 
@@ -1093,9 +1107,9 @@ static constexpr ScreenCoordsXY MiniMapOffsets[] = {
         {
             int32_t x = 0, y = 0, dx = 0, dy = 0;
 
-            int32_t pos = (_currentLine * (MAP_WINDOW_MAP_SIZE - 1)) + kMaximumMapSizeTechnical - 1;
-            auto destinationPosition = ScreenCoordsXY{ pos % MAP_WINDOW_MAP_SIZE, pos / MAP_WINDOW_MAP_SIZE };
-            auto destination = _mapImageData.data() + (destinationPosition.y * MAP_WINDOW_MAP_SIZE) + destinationPosition.x;
+            int32_t pos = (_currentLine * (getMiniMapWidth() - 1)) + getTechnicalMapSize() - 1;
+            auto destinationPosition = ScreenCoordsXY{ pos % getMiniMapWidth(), pos / getMiniMapWidth() };
+            auto destination = _mapImageData.data() + (destinationPosition.y * getMiniMapWidth()) + destinationPosition.x;
             switch (GetCurrentRotation())
             {
                 case 0:
@@ -1105,26 +1119,26 @@ static constexpr ScreenCoordsXY MiniMapOffsets[] = {
                     dy = COORDS_XY_STEP;
                     break;
                 case 1:
-                    x = MAXIMUM_TILE_START_XY;
+                    x = getMaxTileStartXY();
                     y = _currentLine * COORDS_XY_STEP;
                     dx = -COORDS_XY_STEP;
                     dy = 0;
                     break;
                 case 2:
-                    x = MAXIMUM_MAP_SIZE_BIG - ((_currentLine + 1) * COORDS_XY_STEP);
-                    y = MAXIMUM_TILE_START_XY;
+                    x = getTechnicalMapSizeBig() - ((_currentLine + 1) * COORDS_XY_STEP);
+                    y = getMaxTileStartXY();
                     dx = 0;
                     dy = -COORDS_XY_STEP;
                     break;
                 case 3:
                     x = 0;
-                    y = MAXIMUM_MAP_SIZE_BIG - ((_currentLine + 1) * COORDS_XY_STEP);
+                    y = getTechnicalMapSizeBig() - ((_currentLine + 1) * COORDS_XY_STEP);
                     dx = COORDS_XY_STEP;
                     dy = 0;
                     break;
             }
 
-            for (int32_t i = 0; i < kMaximumMapSizeTechnical; i++)
+            for (int32_t i = 0; i < getTechnicalMapSize(); i++)
             {
                 if (!MapIsEdge({ x, y }))
                 {
@@ -1146,10 +1160,10 @@ static constexpr ScreenCoordsXY MiniMapOffsets[] = {
 
                 destinationPosition.x++;
                 destinationPosition.y++;
-                destination = _mapImageData.data() + (destinationPosition.y * MAP_WINDOW_MAP_SIZE) + destinationPosition.x;
+                destination = _mapImageData.data() + (destinationPosition.y * getMiniMapWidth()) + destinationPosition.x;
             }
             _currentLine++;
-            if (_currentLine >= kMaximumMapSizeTechnical)
+            if (_currentLine >= static_cast<uint32_t>(getTechnicalMapSize()))
                 _currentLine = 0;
         }
 
@@ -1346,11 +1360,13 @@ static constexpr ScreenCoordsXY MiniMapOffsets[] = {
             if (mainViewport == nullptr)
                 return;
 
-            auto offset = MiniMapOffsets[GetCurrentRotation()];
-            auto leftTop = ScreenCoordsXY{ (mainViewport->viewPos.x >> 5) + offset.x,
-                                           (mainViewport->viewPos.y >> 4) + offset.y };
-            auto rightBottom = ScreenCoordsXY{ ((mainViewport->viewPos.x + mainViewport->view_width) >> 5) + offset.x,
-                                               ((mainViewport->viewPos.y + mainViewport->view_height) >> 4) + offset.y };
+            auto offset = MiniMapOffsetFactors[GetCurrentRotation()];
+            auto leftTop = ScreenCoordsXY{ (mainViewport->viewPos.x >> 5) + offset.x * getTechnicalMapSize() - 8,
+                                           (mainViewport->viewPos.y >> 4) + offset.y * getTechnicalMapSize() };
+            auto rightBottom = ScreenCoordsXY{
+                ((mainViewport->viewPos.x + mainViewport->view_width) >> 5) + offset.x * getTechnicalMapSize() - 8,
+                ((mainViewport->viewPos.y + mainViewport->view_height) >> 4) + offset.y * getTechnicalMapSize()
+            };
             auto rightTop = ScreenCoordsXY{ rightBottom.x, leftTop.y };
             auto leftBottom = ScreenCoordsXY{ leftTop.x, rightBottom.y };
 
@@ -1438,7 +1454,7 @@ static constexpr ScreenCoordsXY MiniMapOffsets[] = {
 
         CoordsXY ScreenToMap(ScreenCoordsXY screenCoords)
         {
-            screenCoords.x = ((screenCoords.x + 8) - kMaximumMapSizeTechnical) / 2;
+            screenCoords.x = ((screenCoords.x + 8) - getTechnicalMapSize()) / 2;
             screenCoords.y = ((screenCoords.y + 8)) / 2;
             auto location = TileCoordsXY(screenCoords.y - screenCoords.x, screenCoords.x + screenCoords.y).ToCoordsXY();
 
@@ -1447,11 +1463,11 @@ static constexpr ScreenCoordsXY MiniMapOffsets[] = {
                 case 0:
                     return location;
                 case 1:
-                    return { MAXIMUM_MAP_SIZE_BIG - 1 - location.y, location.x };
+                    return { getTechnicalMapSizeBig() - 1 - location.y, location.x };
                 case 2:
-                    return { MAXIMUM_MAP_SIZE_BIG - 1 - location.x, MAXIMUM_MAP_SIZE_BIG - 1 - location.y };
+                    return { getTechnicalMapSizeBig() - 1 - location.x, getTechnicalMapSizeBig() - 1 - location.y };
                 case 3:
-                    return { location.y, MAXIMUM_MAP_SIZE_BIG - 1 - location.x };
+                    return { location.y, getTechnicalMapSizeBig() - 1 - location.x };
             }
 
             return { 0, 0 }; // unreachable
@@ -1465,15 +1481,15 @@ static constexpr ScreenCoordsXY MiniMapOffsets[] = {
             {
                 case 3:
                     std::swap(x, y);
-                    x = MAXIMUM_MAP_SIZE_BIG - 1 - x;
+                    x = getTechnicalMapSizeBig() - 1 - x;
                     break;
                 case 2:
-                    x = MAXIMUM_MAP_SIZE_BIG - 1 - x;
-                    y = MAXIMUM_MAP_SIZE_BIG - 1 - y;
+                    x = getTechnicalMapSizeBig() - 1 - x;
+                    y = getTechnicalMapSizeBig() - 1 - y;
                     break;
                 case 1:
                     std::swap(x, y);
-                    y = MAXIMUM_MAP_SIZE_BIG - 1 - y;
+                    y = getTechnicalMapSizeBig() - 1 - y;
                     break;
                 case 0:
                     break;
@@ -1481,7 +1497,7 @@ static constexpr ScreenCoordsXY MiniMapOffsets[] = {
             x /= 32;
             y /= 32;
 
-            return { -x + y + kMaximumMapSizeTechnical - 8, x + y - 8 };
+            return { -x + y + getTechnicalMapSize() - 8, x + y - 8 };
         }
 
         void ResizeMap()

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -818,8 +818,6 @@ static Widget window_map_widgets[] = {
             g1temp.offset = _mapImageData.data();
             g1temp.width = getMiniMapWidth();
             g1temp.height = getMiniMapWidth();
-            g1temp.x_offset = -8;
-            g1temp.y_offset = -8;
             GfxSetG1Element(SPR_TEMP, &g1temp);
             DrawingEngineInvalidateImage(SPR_TEMP);
             GfxDrawSprite(dpi, ImageId(SPR_TEMP), { 0, 0 });
@@ -1050,7 +1048,7 @@ static Widget window_map_widgets[] = {
 
             cx = ((mainWindow->viewport->view_width >> 1) + mainWindow->viewport->viewPos.x) >> 5;
             dx = ((mainWindow->viewport->view_height >> 1) + mainWindow->viewport->viewPos.y) >> 4;
-            cx += offset.x * getTechnicalMapSize() - 8;
+            cx += offset.x * getTechnicalMapSize();
             dx += offset.y * getTechnicalMapSize();
 
             // calculate width and height of minimap
@@ -1361,11 +1359,14 @@ static Widget window_map_widgets[] = {
                 return;
 
             auto offset = MiniMapOffsetFactors[GetCurrentRotation()];
-            auto leftTop = ScreenCoordsXY{ (mainViewport->viewPos.x >> 5) + offset.x * getTechnicalMapSize() - 8,
-                                           (mainViewport->viewPos.y >> 4) + offset.y * getTechnicalMapSize() };
+            offset.x *= getTechnicalMapSize();
+            offset.y *= getTechnicalMapSize();
+
+            auto leftTop = ScreenCoordsXY{ (mainViewport->viewPos.x >> 5) + offset.x,
+                                           (mainViewport->viewPos.y >> 4) + offset.y };
             auto rightBottom = ScreenCoordsXY{
-                ((mainViewport->viewPos.x + mainViewport->view_width) >> 5) + offset.x * getTechnicalMapSize() - 8,
-                ((mainViewport->viewPos.y + mainViewport->view_height) >> 4) + offset.y * getTechnicalMapSize()
+                ((mainViewport->viewPos.x + mainViewport->view_width) >> 5) + offset.x,
+                ((mainViewport->viewPos.y + mainViewport->view_height) >> 4) + offset.y
             };
             auto rightTop = ScreenCoordsXY{ rightBottom.x, leftTop.y };
             auto leftBottom = ScreenCoordsXY{ leftTop.x, rightBottom.y };
@@ -1497,7 +1498,7 @@ static Widget window_map_widgets[] = {
             x /= 32;
             y /= 32;
 
-            return { -x + y + getTechnicalMapSize() - 8, x + y - 8 };
+            return { -x + y + getTechnicalMapSize(), x + y };
         }
 
         void ResizeMap()


### PR DESCRIPTION
The map window on develop does not take the current map size into account, instead working with the internal 'technical' maximum size of 1001x1001 tiles. This is relatively slow, and unnecessary. This PR reworks this, such that the current map size is used instead.

In addition, the initial and minimum size is reworked to fit any reasonably sized map, while constraining it to screen sizes. The maximum dimensions of the window are also changed to fit the current map size. The minimum sizes haven't changed.

Maps that are smaller than the window size are now offset to the centre of the scrollview. This closes #7248.

Finally, the map corners are no longer cut off. This is done by removing the `-8` offset, which was present in vanilla. This fixes #13294, a vanilla bug.

Some changelog entries are probably in order, but let's reserve those for after testing.

This PR:
![Forest Frontiers 2024-05-07 14-40-26](https://github.com/OpenRCT2/OpenRCT2/assets/604665/db1a5a69-745e-427c-8c7a-f3b68af1f4e0)

On develop:
![Forest Frontiers 2024-05-07 14-41-07](https://github.com/OpenRCT2/OpenRCT2/assets/604665/3905cbad-709e-4e9a-a725-5fa128582737)