### PR TITLE
Re-introduce message on successful screenshot

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,7 +4,7 @@
 - Feature: [#21913] [Plugin] Allow precise and safe control of peep animations.
 - Improved: [#21981] Rendering performance of the map window has been improved considerably.
 - Improved: [#21981] The map window now defaults to showing as much of the map as fits the screen.
-- Improved: [#21983] Taking a screenshot now shows a 'success' message again, closing when taking another.
+- Improved: [#21983] Taking a screenshot now shows a message again, closing when taking another.
 - Change: [#7248] Small mini-maps are now centred in the map window.
 - Fix: [#13294] Map corners are cut off in some directions (original bug).
 - Fix: [#21974] No reason specified when attempting to place benches, lamps, or bins on path with no unconnected edges (original bug).

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Feature: [#21913] [Plugin] Allow precise and safe control of peep animations.
 - Improved: [#21981] Rendering performance of the map window has been improved considerably.
 - Improved: [#21981] The map window now defaults to showing as much of the map as fits the screen.
+- Improved: [#21983] Taking a screenshot now shows a 'success' message again, closing when taking another.
 - Change: [#7248] Small mini-maps are now centred in the map window.
 - Fix: [#13294] Map corners are cut off in some directions (original bug).
 - Fix: [#21974] No reason specified when attempting to place benches, lamps, or bins on path with no unconnected edges (original bug).

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -209,14 +209,14 @@ public:
         }
     }
 
-    WindowBase* ShowError(StringId title, StringId message, const Formatter& args) override
+    WindowBase* ShowError(StringId title, StringId message, const Formatter& args, bool autoClose /* = false */) override
     {
-        return ErrorOpen(title, message, args);
+        return ErrorOpen(title, message, args, autoClose);
     }
 
-    WindowBase* ShowError(std::string_view title, std::string_view message) override
+    WindowBase* ShowError(std::string_view title, std::string_view message, bool autoClose /* = false */) override
     {
-        return ErrorOpen(title, message);
+        return ErrorOpen(title, message, autoClose);
     }
 
     WindowBase* OpenIntent(Intent* intent) override

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -38,11 +38,13 @@ static Widget window_error_widgets[] = {
         std::string _text;
         uint16_t _numLines;
         uint8_t _staleCount;
+        bool _autoClose;
 
     public:
-        ErrorWindow(std::string text, uint16_t numLines)
+        ErrorWindow(std::string text, uint16_t numLines, bool autoClose)
             : _text(std::move(text))
             , _numLines(numLines)
+            , _autoClose(autoClose)
         {
         }
 
@@ -114,9 +116,8 @@ static Widget window_error_widgets[] = {
         void OnUpdate() override
         {
             // Automatically close previous screenshot messages before new screenshot is taken
-            if (number == 1 && gScreenshotCountdown > 0)
+            if (_autoClose && gScreenshotCountdown > 0)
             {
-                GetContext()->WriteLine("Closing error window");
                 Close();
             }
         }
@@ -171,9 +172,7 @@ static Widget window_error_widgets[] = {
             windowPosition.y = std::min(windowPosition.y - height - 40, maxY);
         }
 
-        auto errorWindow = std::make_unique<ErrorWindow>(std::move(buffer), numLines);
-        errorWindow->number = autoClose ? 1 : 0;
-
+        auto errorWindow = std::make_unique<ErrorWindow>(std::move(buffer), numLines, autoClose);
         return WindowCreate(
             std::move(errorWindow), WindowClass::Error, windowPosition, width, height,
             WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_RESIZABLE);

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -15,6 +15,7 @@
 #include <openrct2/audio/audio.h>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Font.h>
+#include <openrct2/interface/Screenshot.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Localisation.h>
 
@@ -109,9 +110,19 @@ static Widget window_error_widgets[] = {
                 Close();
             }
         }
+
+        void OnUpdate() override
+        {
+            // Automatically close previous screenshot messages before new screenshot is taken
+            if (number == 1 && gScreenshotCountdown > 0)
+            {
+                GetContext()->WriteLine("Closing error window");
+                Close();
+            }
+        }
     };
 
-    WindowBase* ErrorOpen(std::string_view title, std::string_view message)
+    WindowBase* ErrorOpen(std::string_view title, std::string_view message, bool autoClose)
     {
         std::string buffer = "{BLACK}";
         buffer.append(title);
@@ -161,15 +172,17 @@ static Widget window_error_widgets[] = {
         }
 
         auto errorWindow = std::make_unique<ErrorWindow>(std::move(buffer), numLines);
+        errorWindow->number = autoClose ? 1 : 0;
+
         return WindowCreate(
             std::move(errorWindow), WindowClass::Error, windowPosition, width, height,
             WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_RESIZABLE);
     }
 
-    WindowBase* ErrorOpen(StringId title, StringId message, const Formatter& args)
+    WindowBase* ErrorOpen(StringId title, StringId message, const Formatter& args, bool autoClose)
     {
         auto titlez = FormatStringIDLegacy(title, args.Data());
         auto messagez = FormatStringIDLegacy(message, args.Data());
-        return ErrorOpen(titlez, messagez);
+        return ErrorOpen(titlez, messagez, autoClose);
     }
 } // namespace OpenRCT2::Ui::Windows

--- a/src/openrct2-ui/windows/Window.h
+++ b/src/openrct2-ui/windows/Window.h
@@ -107,8 +107,8 @@ namespace OpenRCT2::Ui::Windows
     WindowBase* ScenarioselectOpen(scenarioselect_callback callback);
     WindowBase* ScenarioselectOpen(std::function<void(std::string_view)> callback);
 
-    WindowBase* ErrorOpen(StringId title, StringId message, const class Formatter& formatter);
-    WindowBase* ErrorOpen(std::string_view title, std::string_view message);
+    WindowBase* ErrorOpen(StringId title, StringId message, const class Formatter& formatter, bool autoClose = false);
+    WindowBase* ErrorOpen(std::string_view title, std::string_view message, bool autoClose = false);
 
     WindowBase* LoadsaveOpen(
         int32_t type, std::string_view defaultPath, std::function<void(int32_t result, std::string_view)> callback,

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -1570,10 +1570,10 @@ void ContextForceCloseWindowByClass(WindowClass windowClass)
     windowManager->ForceClose(windowClass);
 }
 
-WindowBase* ContextShowError(StringId title, StringId message, const Formatter& args)
+WindowBase* ContextShowError(StringId title, StringId message, const Formatter& args, const bool autoClose /* = false */)
 {
     auto windowManager = GetContext()->GetUiContext()->GetWindowManager();
-    return windowManager->ShowError(title, message, args);
+    return windowManager->ShowError(title, message, args, autoClose);
 }
 
 void ContextHandleInput()

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -221,7 +221,7 @@ void ContextSetCursorTrap(bool value);
 WindowBase* ContextOpenWindow(WindowClass wc);
 WindowBase* ContextOpenDetailWindow(uint8_t type, int32_t id);
 WindowBase* ContextOpenWindowView(uint8_t view);
-WindowBase* ContextShowError(StringId title, StringId message, const class Formatter& args);
+WindowBase* ContextShowError(StringId title, StringId message, const class Formatter& args, bool autoClose = false);
 WindowBase* ContextOpenIntent(Intent* intent);
 void ContextBroadcastIntent(Intent* intent);
 void ContextForceCloseWindowByClass(WindowClass wc);

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -91,6 +91,13 @@ void ScreenshotCheck()
             if (!screenshotPath.empty())
             {
                 OpenRCT2::Audio::Play(OpenRCT2::Audio::SoundId::WindowOpen, 100, ContextGetWidth() / 2);
+
+                // Show user that screenshot saved successfully
+                const auto filename = Path::GetFileName(screenshotPath);
+                Formatter ft;
+                ft.Add<StringId>(STR_STRING);
+                ft.Add<const utf8*>(filename.c_str());
+                ContextShowError(STR_SCREENSHOT_SAVED_AS, STR_NONE, ft);
             }
             else
             {

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -26,6 +26,7 @@
 #include "../drawing/X8DrawingEngine.h"
 #include "../localisation/Formatter.h"
 #include "../localisation/Localisation.h"
+#include "../paint/Painter.h"
 #include "../platform/Platform.h"
 #include "../util/Util.h"
 #include "../world/Climate.h"
@@ -97,11 +98,11 @@ void ScreenshotCheck()
                 Formatter ft;
                 ft.Add<StringId>(STR_STRING);
                 ft.Add<const utf8*>(filename.c_str());
-                ContextShowError(STR_SCREENSHOT_SAVED_AS, STR_NONE, ft);
+                ContextShowError(STR_SCREENSHOT_SAVED_AS, STR_NONE, ft, true);
             }
             else
             {
-                ContextShowError(STR_SCREENSHOT_FAILED, STR_NONE, {});
+                ContextShowError(STR_SCREENSHOT_FAILED, STR_NONE, {}, true);
             }
 
             // redraw_weather();
@@ -391,12 +392,12 @@ void ScreenshotGiant()
         Formatter ft;
         ft.Add<StringId>(STR_STRING);
         ft.Add<const utf8*>(filename.c_str());
-        ContextShowError(STR_SCREENSHOT_SAVED_AS, STR_NONE, ft);
+        ContextShowError(STR_SCREENSHOT_SAVED_AS, STR_NONE, ft, true);
     }
     catch (const std::exception& e)
     {
         LOG_ERROR("%s", e.what());
-        ContextShowError(STR_SCREENSHOT_FAILED, STR_NONE, {});
+        ContextShowError(STR_SCREENSHOT_FAILED, STR_NONE, {}, true);
     }
 
     ReleaseDPI(dpi);

--- a/src/openrct2/ui/DummyWindowManager.cpp
+++ b/src/openrct2/ui/DummyWindowManager.cpp
@@ -27,7 +27,8 @@ namespace OpenRCT2::Ui
         {
             return nullptr;
         }
-        WindowBase* ShowError(StringId /*title*/, StringId /*message*/, const Formatter& /*formatter*/, bool /*autoClose*/) override
+        WindowBase* ShowError(
+            StringId /*title*/, StringId /*message*/, const Formatter& /*formatter*/, bool /*autoClose*/) override
         {
             return nullptr;
         }

--- a/src/openrct2/ui/DummyWindowManager.cpp
+++ b/src/openrct2/ui/DummyWindowManager.cpp
@@ -27,11 +27,11 @@ namespace OpenRCT2::Ui
         {
             return nullptr;
         }
-        WindowBase* ShowError(StringId /*title*/, StringId /*message*/, const Formatter& /*formatter*/) override
+        WindowBase* ShowError(StringId /*title*/, StringId /*message*/, const Formatter& /*formatter*/, bool /*autoClose*/) override
         {
             return nullptr;
         }
-        WindowBase* ShowError(std::string_view /*title*/, std::string_view /*message*/) override
+        WindowBase* ShowError(std::string_view /*title*/, std::string_view /*message*/, bool /*autoClose*/) override
         {
             return nullptr;
         }

--- a/src/openrct2/ui/WindowManager.h
+++ b/src/openrct2/ui/WindowManager.h
@@ -33,7 +33,8 @@ namespace OpenRCT2::Ui
         virtual WindowBase* OpenDetails(uint8_t type, int32_t id) abstract;
         virtual WindowBase* OpenIntent(Intent* intent) abstract;
         virtual void BroadcastIntent(const Intent& intent) abstract;
-        virtual WindowBase* ShowError(StringId title, StringId message, const Formatter& formatter, bool autoClose = false) abstract;
+        virtual WindowBase* ShowError(
+            StringId title, StringId message, const Formatter& formatter, bool autoClose = false) abstract;
         virtual WindowBase* ShowError(std::string_view title, std::string_view message, bool autoClose = false) abstract;
         virtual void ForceClose(WindowClass windowClass) abstract;
         virtual void UpdateMapTooltip() abstract;

--- a/src/openrct2/ui/WindowManager.h
+++ b/src/openrct2/ui/WindowManager.h
@@ -33,8 +33,8 @@ namespace OpenRCT2::Ui
         virtual WindowBase* OpenDetails(uint8_t type, int32_t id) abstract;
         virtual WindowBase* OpenIntent(Intent* intent) abstract;
         virtual void BroadcastIntent(const Intent& intent) abstract;
-        virtual WindowBase* ShowError(StringId title, StringId message, const Formatter& formatter) abstract;
-        virtual WindowBase* ShowError(std::string_view title, std::string_view message) abstract;
+        virtual WindowBase* ShowError(StringId title, StringId message, const Formatter& formatter, bool autoClose = false) abstract;
+        virtual WindowBase* ShowError(std::string_view title, std::string_view message, bool autoClose = false) abstract;
         virtual void ForceClose(WindowClass windowClass) abstract;
         virtual void UpdateMapTooltip() abstract;
         virtual void HandleInput() abstract;


### PR DESCRIPTION
This re-introduces the popup message when a screenshot has been taken successfully.

Previously, this functionality removed out of frustration that the popup message would also appear in successive screenshots. However, the only feedback right now is through audio. When audio is disabled, that means the user has no way of knowing if their screenshot was saved. This does not make for good UX, in my opinion.

I've considered automatically closing all error windows when a screenshot is taken. However, that would hinder users that want to report a strange error when executing a game action, for example.

Submitting for discussion. In my opinion, the benefits outweigh the disadvantages.