### PR TITLE
Let heavy snow and blizzards make guests buy and use umbrellas

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Improved: [#21983] Taking a screenshot now shows a message again, closing when taking another.
 - Improved: [#22026] The options window now stays centred when window scaling is changed.
 - Change: [#7248] Small mini-maps are now centred in the map window.
+- Change: [#20240] Heavy snow and blizzards now make guests buy and use umbrellas.
 - Fix: [#13294] Map corners are cut off in some directions (original bug).
 - Fix: [#21974] No reason specified when attempting to place benches, lamps, or bins on path with no unconnected edges (original bug).
 - Fix: [#22008] Uninverted Lay-down roller coaster uses the wrong support type.

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -1479,9 +1479,9 @@ bool Guest::DecideAndBuyItem(Ride& ride, const ShopItem shopItem, money64 price)
 
     bool hasVoucher = false;
 
-    const bool isPrecipitation = ClimateIsRaining() || ClimateIsSnowingHeavily();
+    const bool isPrecipitating = ClimateIsRaining() || ClimateIsSnowingHeavily();
     const bool isUmbrella = shopItem == ShopItem::Umbrella;
-    const bool isRainingAndUmbrella = isPrecipitation && isUmbrella;
+    const bool isRainingAndUmbrella = isPrecipitating && isUmbrella;
 
     if ((HasItem(ShopItem::Voucher)) && (VoucherType == VOUCHER_TYPE_FOOD_OR_DRINK_FREE) && (VoucherShopItem == shopItem))
     {
@@ -1510,7 +1510,7 @@ bool Guest::DecideAndBuyItem(Ride& ride, const ShopItem shopItem, money64 price)
 
     if ((shopItem == ShopItem::Balloon || shopItem == ShopItem::IceCream || shopItem == ShopItem::Candyfloss
          || shopItem == ShopItem::Sunglasses)
-        && isPrecipitation)
+        && isPrecipitating)
     {
         return false;
     }
@@ -2058,8 +2058,8 @@ bool Guest::ShouldGoOnRide(Ride& ride, StationIndex entranceNum, bool atQueue, b
                 }
                 else
                 {
-                    const bool isPrecipitation = ClimateIsRaining() || ClimateIsSnowingHeavily();
-                    if (isPrecipitation && !ShouldRideWhileRaining(ride))
+                    const bool isPrecipitating = ClimateIsRaining() || ClimateIsSnowingHeavily();
+                    if (isPrecipitating && !ShouldRideWhileRaining(ride))
                     {
                         if (peepAtRide)
                         {
@@ -2075,7 +2075,7 @@ bool Guest::ShouldGoOnRide(Ride& ride, StationIndex entranceNum, bool atQueue, b
                     }
                     // If it is raining and the ride provides shelter skip the
                     // ride intensity check and get me on a sheltered ride!
-                    if (!isPrecipitation || !ShouldRideWhileRaining(ride))
+                    if (!isPrecipitating || !ShouldRideWhileRaining(ride))
                     {
                         if (!GetGameState().Cheats.IgnoreRideIntensity)
                         {
@@ -6824,8 +6824,8 @@ void Guest::UpdateSpriteType()
         WindowInvalidateFlags |= PEEP_INVALIDATE_PEEP_INVENTORY;
     }
 
-    const bool isPrecipitation = ClimateIsRaining() || ClimateIsSnowingHeavily();
-    if (isPrecipitation && (HasItem(ShopItem::Umbrella)) && x != LOCATION_NULL)
+    const bool isPrecipitating = ClimateIsRaining() || ClimateIsSnowingHeavily();
+    if (isPrecipitating && (HasItem(ShopItem::Umbrella)) && x != LOCATION_NULL)
     {
         CoordsXY loc = { x, y };
         if (MapIsLocationValid(loc.ToTileStart()))

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -1479,7 +1479,9 @@ bool Guest::DecideAndBuyItem(Ride& ride, const ShopItem shopItem, money64 price)
 
     bool hasVoucher = false;
 
-    bool isRainingAndUmbrella = shopItem == ShopItem::Umbrella && ClimateIsRaining();
+    const bool isPrecipitation = ClimateIsRaining() || ClimateIsSnowingHeavily();
+    const bool isUmbrella = shopItem == ShopItem::Umbrella;
+    const bool isRainingAndUmbrella = isPrecipitation && isUmbrella;
 
     if ((HasItem(ShopItem::Voucher)) && (VoucherType == VOUCHER_TYPE_FOOD_OR_DRINK_FREE) && (VoucherShopItem == shopItem))
     {
@@ -1508,7 +1510,7 @@ bool Guest::DecideAndBuyItem(Ride& ride, const ShopItem shopItem, money64 price)
 
     if ((shopItem == ShopItem::Balloon || shopItem == ShopItem::IceCream || shopItem == ShopItem::Candyfloss
          || shopItem == ShopItem::Sunglasses)
-        && ClimateIsRaining())
+        && isPrecipitation)
     {
         return false;
     }
@@ -2056,7 +2058,8 @@ bool Guest::ShouldGoOnRide(Ride& ride, StationIndex entranceNum, bool atQueue, b
                 }
                 else
                 {
-                    if (ClimateIsRaining() && !ShouldRideWhileRaining(ride))
+                    const bool isPrecipitation = ClimateIsRaining() || ClimateIsSnowingHeavily();
+                    if (isPrecipitation && !ShouldRideWhileRaining(ride))
                     {
                         if (peepAtRide)
                         {
@@ -2072,7 +2075,7 @@ bool Guest::ShouldGoOnRide(Ride& ride, StationIndex entranceNum, bool atQueue, b
                     }
                     // If it is raining and the ride provides shelter skip the
                     // ride intensity check and get me on a sheltered ride!
-                    if (!ClimateIsRaining() || !ShouldRideWhileRaining(ride))
+                    if (!isPrecipitation || !ShouldRideWhileRaining(ride))
                     {
                         if (!GetGameState().Cheats.IgnoreRideIntensity)
                         {
@@ -6821,7 +6824,8 @@ void Guest::UpdateSpriteType()
         WindowInvalidateFlags |= PEEP_INVALIDATE_PEEP_INVENTORY;
     }
 
-    if (ClimateIsRaining() && (HasItem(ShopItem::Umbrella)) && x != LOCATION_NULL)
+    const bool isPrecipitation = ClimateIsRaining() || ClimateIsSnowingHeavily();
+    if (isPrecipitation && (HasItem(ShopItem::Umbrella)) && x != LOCATION_NULL)
     {
         CoordsXY loc = { x, y };
         if (MapIsLocationValid(loc.ToTileStart()))

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -233,29 +233,25 @@ void ClimateUpdateSound()
 
 bool ClimateIsRaining()
 {
-    auto& gameState = GetGameState();
-    return gameState.ClimateCurrent.Weather == WeatherType::Rain || gameState.ClimateCurrent.Weather == WeatherType::HeavyRain
-        || gameState.ClimateCurrent.Weather == WeatherType::Thunder;
+    auto& weather = GetGameState().ClimateCurrent.Weather;
+    return weather == WeatherType::Rain || weather == WeatherType::HeavyRain || weather == WeatherType::Thunder;
 }
 
 bool ClimateIsSnowing()
 {
-    auto& gameState = GetGameState();
-    return gameState.ClimateCurrent.Weather == WeatherType::Snow || gameState.ClimateCurrent.Weather == WeatherType::HeavySnow
-        || gameState.ClimateCurrent.Weather == WeatherType::Blizzard;
+    auto& weather = GetGameState().ClimateCurrent.Weather;
+    return weather == WeatherType::Snow || weather == WeatherType::HeavySnow || weather == WeatherType::Blizzard;
 }
 
 bool ClimateIsSnowingHeavily()
 {
-    auto& gameState = GetGameState();
-    return gameState.ClimateCurrent.Weather == WeatherType::HeavySnow
-        || gameState.ClimateCurrent.Weather == WeatherType::Blizzard;
+    auto& weather = GetGameState().ClimateCurrent.Weather;
+    return weather == WeatherType::HeavySnow || weather == WeatherType::Blizzard;
 }
 
-bool WeatherIsDry(WeatherType weatherType)
+bool WeatherIsDry(WeatherType weather)
 {
-    return weatherType == WeatherType::Sunny || weatherType == WeatherType::PartiallyCloudy
-        || weatherType == WeatherType::Cloudy;
+    return weather == WeatherType::Sunny || weather == WeatherType::PartiallyCloudy || weather == WeatherType::Cloudy;
 }
 
 FilterPaletteID ClimateGetWeatherGloomPaletteId(const ClimateState& state)

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -234,25 +234,22 @@ void ClimateUpdateSound()
 bool ClimateIsRaining()
 {
     auto& gameState = GetGameState();
-    if (gameState.ClimateCurrent.Weather == WeatherType::Rain || gameState.ClimateCurrent.Weather == WeatherType::HeavyRain
-        || gameState.ClimateCurrent.Weather == WeatherType::Thunder)
-    {
-        return true;
-    }
-
-    return false;
+    return gameState.ClimateCurrent.Weather == WeatherType::Rain || gameState.ClimateCurrent.Weather == WeatherType::HeavyRain
+        || gameState.ClimateCurrent.Weather == WeatherType::Thunder;
 }
 
 bool ClimateIsSnowing()
 {
     auto& gameState = GetGameState();
-    if (gameState.ClimateCurrent.Weather == WeatherType::Snow || gameState.ClimateCurrent.Weather == WeatherType::HeavySnow
-        || gameState.ClimateCurrent.Weather == WeatherType::Blizzard)
-    {
-        return true;
-    }
+    return gameState.ClimateCurrent.Weather == WeatherType::Snow || gameState.ClimateCurrent.Weather == WeatherType::HeavySnow
+        || gameState.ClimateCurrent.Weather == WeatherType::Blizzard;
+}
 
-    return false;
+bool ClimateIsSnowingHeavily()
+{
+    auto& gameState = GetGameState();
+    return gameState.ClimateCurrent.Weather == WeatherType::HeavySnow
+        || gameState.ClimateCurrent.Weather == WeatherType::Blizzard;
 }
 
 bool WeatherIsDry(WeatherType weatherType)

--- a/src/openrct2/world/Climate.h
+++ b/src/openrct2/world/Climate.h
@@ -81,6 +81,7 @@ void ClimateForceWeather(WeatherType weather);
 
 bool ClimateIsRaining();
 bool ClimateIsSnowing();
+bool ClimateIsSnowingHeavily();
 bool WeatherIsDry(WeatherType);
 FilterPaletteID ClimateGetWeatherGloomPaletteId(const ClimateState& state);
 uint32_t ClimateGetWeatherSpriteId(const ClimateState& state);


### PR DESCRIPTION
A few years ago, we introduced snowy weather effects to OpenRCT2. However, these never had any effect on guests' behaviour. This PR changes that, such that heavy snow and blizzard weather makes guests buy and use umbrellas, just like rain.

I've chosen to let normal 'snow' weather not have the same effect, as its effect appears much gentler. I think it would be more realistic for umbrellas to stay hidden in such weather.

It might be nice for snowy weather to have an effect on hat sales, but that's up for debate -- and something for another PR, I think.

Implements #20240