### PR TITLE
Optionally align the top toolbar buttons horizontally centred

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3700,6 +3700,8 @@ STR_6625    :Invalid colour
 STR_6626    :Animation is backwards
 STR_6627    :Track speed too high!
 STR_6628    :Can only be placed on path edges!
+STR_6629    :Align toolbar buttons horizontally centred
+STR_6630    :This setting will align toolbar the buttons horizontally in the centre of the screen. The traditional way of aligning them is to in left and right corner.
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.12 (in development)
 ------------------------------------------------------------------------
+- Feature: [#622] Add option to align the top toolbar buttons horizontally centred (off by default).
 - Feature: [#21714] [Plugin] Costume assignment is now tailored to each staff type.
 - Feature: [#21913] [Plugin] Allow precise and safe control of peep animations.
 - Improved: [#21981] Rendering performance of the map window has been improved considerably.

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -9,8 +9,6 @@
 
 #include "Widget.h"
 
-#include "Window.h"
-
 #include <cmath>
 #include <openrct2/Context.h>
 #include <openrct2/Input.h>
@@ -567,13 +565,13 @@ static void WidgetCaptionDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex wid
     int32_t width = widget->width() - 4;
     if ((widget + 1)->type == WindowWidgetType::CloseBox)
     {
-        width -= CloseButtonWidth;
+        width -= kCloseButtonWidth;
         if ((widget + 2)->type == WindowWidgetType::CloseBox)
-            width -= CloseButtonWidth;
+            width -= kCloseButtonWidth;
     }
     topLeft.x += width / 2;
     if (Config::Get().interface.WindowButtonsOnTheLeft)
-        topLeft.x += CloseButtonWidth;
+        topLeft.x += kCloseButtonWidth;
 
     DrawTextEllipsised(
         dpi, topLeft, width, widget->text, Formatter::Common(),

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -828,7 +828,7 @@ void WindowAlignTabs(WindowBase* w, WidgetIndex start_tab_id, WidgetIndex end_ta
 
 ScreenCoordsXY WindowGetViewportSoundIconPos(WindowBase& w)
 {
-    const uint8_t buttonOffset = (Config::Get().interface.WindowButtonsOnTheLeft) ? CloseButtonWidth + 2 : 0;
+    const uint8_t buttonOffset = (Config::Get().interface.WindowButtonsOnTheLeft) ? kCloseButtonWidth + 2 : 0;
     return w.windowPos + ScreenCoordsXY{ 2 + buttonOffset, 2 };
 }
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1538,6 +1538,14 @@ static Widget *window_options_page_widgets[] = {
 #pragma endregion
 
 #pragma region Controls tab events
+        void ToggleToolbarSetting(bool& setting)
+        {
+            setting ^= true;
+            Config::Save();
+            Invalidate();
+            WindowInvalidateByClass(WindowClass::TopToolbar);
+        }
+
         void ControlsMouseUp(WidgetIndex widgetIndex)
         {
             switch (widgetIndex)
@@ -1562,52 +1570,28 @@ static Widget *window_options_page_widgets[] = {
                     Invalidate();
                     break;
                 case WIDX_TOOLBAR_BUTTONS_CENTRED:
-                    Config::Get().interface.ToolbarButtonsCentred ^= 1;
-                    Config::Save();
-                    Invalidate();
-                    WindowInvalidateByClass(WindowClass::TopToolbar);
+                    ToggleToolbarSetting(Config::Get().interface.ToolbarButtonsCentred);
                     break;
                 case WIDX_TOOLBAR_SHOW_FINANCES:
-                    Config::Get().interface.ToolbarShowFinances ^= 1;
-                    Config::Save();
-                    Invalidate();
-                    WindowInvalidateByClass(WindowClass::TopToolbar);
+                    ToggleToolbarSetting(Config::Get().interface.ToolbarShowFinances);
                     break;
                 case WIDX_TOOLBAR_SHOW_RESEARCH:
-                    Config::Get().interface.ToolbarShowResearch ^= 1;
-                    Config::Save();
-                    Invalidate();
-                    WindowInvalidateByClass(WindowClass::TopToolbar);
+                    ToggleToolbarSetting(Config::Get().interface.ToolbarShowResearch);
                     break;
                 case WIDX_TOOLBAR_SHOW_CHEATS:
-                    Config::Get().interface.ToolbarShowCheats ^= 1;
-                    Config::Save();
-                    Invalidate();
-                    WindowInvalidateByClass(WindowClass::TopToolbar);
+                    ToggleToolbarSetting(Config::Get().interface.ToolbarShowCheats);
                     break;
                 case WIDX_TOOLBAR_SHOW_NEWS:
-                    Config::Get().interface.ToolbarShowNews ^= 1;
-                    Config::Save();
-                    Invalidate();
-                    WindowInvalidateByClass(WindowClass::TopToolbar);
+                    ToggleToolbarSetting(Config::Get().interface.ToolbarShowNews);
                     break;
                 case WIDX_TOOLBAR_SHOW_MUTE:
-                    Config::Get().interface.ToolbarShowMute ^= 1;
-                    Config::Save();
-                    Invalidate();
-                    WindowInvalidateByClass(WindowClass::TopToolbar);
+                    ToggleToolbarSetting(Config::Get().interface.ToolbarShowMute);
                     break;
                 case WIDX_TOOLBAR_SHOW_CHAT:
-                    Config::Get().interface.ToolbarShowChat ^= 1;
-                    Config::Save();
-                    Invalidate();
-                    WindowInvalidateByClass(WindowClass::TopToolbar);
+                    ToggleToolbarSetting(Config::Get().interface.ToolbarShowChat);
                     break;
                 case WIDX_TOOLBAR_SHOW_ZOOM:
-                    Config::Get().interface.ToolbarShowZoom ^= 1;
-                    Config::Save();
-                    Invalidate();
-                    WindowInvalidateByClass(WindowClass::TopToolbar);
+                    ToggleToolbarSetting(Config::Get().interface.ToolbarShowZoom);
                     break;
                 case WIDX_WINDOW_BUTTONS_ON_THE_LEFT:
                     Config::Get().interface.WindowButtonsOnTheLeft ^= 1;

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -169,6 +169,7 @@ enum WindowOptionsWidgetIdx {
     WIDX_THEMES_DROPDOWN,
     WIDX_THEMES_BUTTON,
     WIDX_TOOLBAR_BUTTONS_GROUP,
+    WIDX_TOOLBAR_BUTTONS_CENTRED,
     WIDX_TOOLBAR_BUTTONS_SHOW_FOR_LABEL,
     WIDX_TOOLBAR_SHOW_FINANCES,
     WIDX_TOOLBAR_SHOW_RESEARCH,
@@ -337,15 +338,18 @@ static Widget window_options_controls_and_interface_widgets[] = {
     MakeWidget({155, THEMES_GROUP_START + 30}, {145, 13}, WindowWidgetType::Button,       WindowColour::Secondary, STR_EDIT_THEMES_BUTTON,         STR_EDIT_THEMES_BUTTON_TIP), // Themes button
 #undef THEMES_GROUP_START
 #define TOOLBAR_GROUP_START 215
-    MakeWidget({  5, TOOLBAR_GROUP_START +  0}, {300, 92}, WindowWidgetType::Groupbox, WindowColour::Secondary, STR_TOOLBAR_BUTTONS_GROUP                                                   ), // Toolbar buttons group
-    MakeWidget({ 10, TOOLBAR_GROUP_START + 14}, {280, 12}, WindowWidgetType::Label,    WindowColour::Secondary, STR_SHOW_TOOLBAR_BUTTONS_FOR                                                ),
-    MakeWidget({ 24, TOOLBAR_GROUP_START + 31}, {122, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_FINANCES_BUTTON_ON_TOOLBAR,      STR_FINANCES_BUTTON_ON_TOOLBAR_TIP     ), // Finances
-    MakeWidget({ 24, TOOLBAR_GROUP_START + 46}, {122, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_RESEARCH_BUTTON_ON_TOOLBAR,      STR_RESEARCH_BUTTON_ON_TOOLBAR_TIP     ), // Research
-    MakeWidget({155, TOOLBAR_GROUP_START + 31}, {145, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_CHEATS_BUTTON_ON_TOOLBAR,        STR_CHEATS_BUTTON_ON_TOOLBAR_TIP       ), // Cheats
-    MakeWidget({155, TOOLBAR_GROUP_START + 46}, {145, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_SHOW_RECENT_MESSAGES_ON_TOOLBAR, STR_SHOW_RECENT_MESSAGES_ON_TOOLBAR_TIP), // Recent messages
-    MakeWidget({ 24, TOOLBAR_GROUP_START + 61}, {162, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_MUTE_BUTTON_ON_TOOLBAR,          STR_MUTE_BUTTON_ON_TOOLBAR_TIP         ), // Mute
-    MakeWidget({155, TOOLBAR_GROUP_START + 61}, {145, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_CHAT_BUTTON_ON_TOOLBAR,          STR_CHAT_BUTTON_ON_TOOLBAR_TIP         ), // Chat
-    MakeWidget({ 24, TOOLBAR_GROUP_START + 76}, {122, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_ZOOM_BUTTON_ON_TOOLBAR,          STR_ZOOM_BUTTON_ON_TOOLBAR_TIP         ), // Zoom
+
+
+    MakeWidget({  5, TOOLBAR_GROUP_START +  0}, {300,107}, WindowWidgetType::Groupbox, WindowColour::Secondary, STR_TOOLBAR_BUTTONS_GROUP                                                   ), // Toolbar buttons group
+    MakeWidget({ 10, TOOLBAR_GROUP_START + 14}, {280, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary,  STR_OPTIONS_TOOLBAR_BUTTONS_CENTRED, STR_OPTIONS_TOOLBAR_BUTTONS_CENTRED_TIP),
+    MakeWidget({ 10, TOOLBAR_GROUP_START + 31}, {280, 12}, WindowWidgetType::Label,    WindowColour::Secondary, STR_SHOW_TOOLBAR_BUTTONS_FOR                                                ),
+    MakeWidget({ 24, TOOLBAR_GROUP_START + 46}, {122, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_FINANCES_BUTTON_ON_TOOLBAR,      STR_FINANCES_BUTTON_ON_TOOLBAR_TIP     ), // Finances
+    MakeWidget({ 24, TOOLBAR_GROUP_START + 61}, {122, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_RESEARCH_BUTTON_ON_TOOLBAR,      STR_RESEARCH_BUTTON_ON_TOOLBAR_TIP     ), // Research
+    MakeWidget({155, TOOLBAR_GROUP_START + 46}, {145, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_CHEATS_BUTTON_ON_TOOLBAR,        STR_CHEATS_BUTTON_ON_TOOLBAR_TIP       ), // Cheats
+    MakeWidget({155, TOOLBAR_GROUP_START + 61}, {145, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_SHOW_RECENT_MESSAGES_ON_TOOLBAR, STR_SHOW_RECENT_MESSAGES_ON_TOOLBAR_TIP), // Recent messages
+    MakeWidget({ 24, TOOLBAR_GROUP_START + 76}, {162, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_MUTE_BUTTON_ON_TOOLBAR,          STR_MUTE_BUTTON_ON_TOOLBAR_TIP         ), // Mute
+    MakeWidget({155, TOOLBAR_GROUP_START + 76}, {145, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_CHAT_BUTTON_ON_TOOLBAR,          STR_CHAT_BUTTON_ON_TOOLBAR_TIP         ), // Chat
+    MakeWidget({ 24, TOOLBAR_GROUP_START + 91}, {122, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_ZOOM_BUTTON_ON_TOOLBAR,          STR_ZOOM_BUTTON_ON_TOOLBAR_TIP         ), // Zoom
     kWidgetsEnd,
 #undef TOOLBAR_GROUP_START
 };
@@ -1557,6 +1561,12 @@ static Widget *window_options_page_widgets[] = {
                     Config::Save();
                     Invalidate();
                     break;
+                case WIDX_TOOLBAR_BUTTONS_CENTRED:
+                    Config::Get().interface.ToolbarButtonsCentred ^= 1;
+                    Config::Save();
+                    Invalidate();
+                    WindowInvalidateByClass(WindowClass::TopToolbar);
+                    break;
                 case WIDX_TOOLBAR_SHOW_FINANCES:
                     Config::Get().interface.ToolbarShowFinances ^= 1;
                     Config::Save();
@@ -1662,6 +1672,7 @@ static Widget *window_options_page_widgets[] = {
             SetCheckboxValue(WIDX_TRAP_CURSOR, Config::Get().general.TrapCursor);
             SetCheckboxValue(WIDX_INVERT_DRAG, Config::Get().general.InvertViewportDrag);
             SetCheckboxValue(WIDX_ZOOM_TO_CURSOR, Config::Get().general.ZoomToCursor);
+            SetCheckboxValue(WIDX_TOOLBAR_BUTTONS_CENTRED, Config::Get().interface.ToolbarButtonsCentred);
             SetCheckboxValue(WIDX_TOOLBAR_SHOW_FINANCES, Config::Get().interface.ToolbarShowFinances);
             SetCheckboxValue(WIDX_TOOLBAR_SHOW_RESEARCH, Config::Get().interface.ToolbarShowResearch);
             SetCheckboxValue(WIDX_TOOLBAR_SHOW_CHEATS, Config::Get().interface.ToolbarShowCheats);

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -209,45 +209,45 @@ namespace OpenRCT2::Ui::Windows
 #pragma region Toolbar_widget_ordering
 
     // clang-format off
-// from left to right
-static constexpr int32_t left_aligned_widgets_order[] = {
-    WIDX_PAUSE,
-    WIDX_FASTFORWARD,
-    WIDX_FILE_MENU,
-    WIDX_MUTE,
-    WIDX_NETWORK,
-    WIDX_CHAT,
-    WIDX_CHEATS,
-    WIDX_DEBUG,
+    // from left to right
+    static constexpr std::array kWidgetOrderLeftGroup = {
+        WIDX_PAUSE,
+        WIDX_FASTFORWARD,
+        WIDX_FILE_MENU,
+        WIDX_MUTE,
+        WIDX_NETWORK,
+        WIDX_CHAT,
+        WIDX_CHEATS,
+        WIDX_DEBUG,
 
-    WIDX_SEPARATOR,
+        WIDX_SEPARATOR,
 
-    WIDX_ZOOM_OUT,
-    WIDX_ZOOM_IN,
-    WIDX_ROTATE,
-    WIDX_VIEW_MENU,
-    WIDX_MAP,
-};
+        WIDX_ZOOM_OUT,
+        WIDX_ZOOM_IN,
+        WIDX_ROTATE,
+        WIDX_VIEW_MENU,
+        WIDX_MAP,
+    };
 
-// from right to left
-static constexpr int32_t right_aligned_widgets_order[] = {
-    WIDX_NEWS,
-    WIDX_GUESTS,
-    WIDX_STAFF,
-    WIDX_PARK,
-    WIDX_RIDES,
-    WIDX_RESEARCH,
-    WIDX_FINANCES,
+    // from right to left
+    static constexpr std::array kWidgetOrderRightGroup = {
+        WIDX_NEWS,
+        WIDX_GUESTS,
+        WIDX_STAFF,
+        WIDX_PARK,
+        WIDX_RIDES,
+        WIDX_RESEARCH,
+        WIDX_FINANCES,
 
-    WIDX_SEPARATOR,
+        WIDX_SEPARATOR,
 
-    WIDX_CONSTRUCT_RIDE,
-    WIDX_PATH,
-    WIDX_SCENERY,
-    WIDX_WATER,
-    WIDX_LAND,
-    WIDX_CLEAR_SCENERY,
-};
+        WIDX_CONSTRUCT_RIDE,
+        WIDX_PATH,
+        WIDX_SCENERY,
+        WIDX_WATER,
+        WIDX_LAND,
+        WIDX_CLEAR_SCENERY,
+    };
 
 #pragma endregion
 
@@ -3120,9 +3120,9 @@ static Widget _topToolbarWidgets[] = {
             // Align left hand side toolbar buttons
             firstAlignment = 1;
             x = 0;
-            for (size_t i = 0; i < std::size(left_aligned_widgets_order); ++i)
+            for (size_t i = 0; i < std::size(kWidgetOrderLeftGroup); ++i)
             {
-                widgetIndex = left_aligned_widgets_order[i];
+                widgetIndex = kWidgetOrderLeftGroup[i];
                 widget = &widgets[widgetIndex];
                 if (widget->type == WindowWidgetType::Empty && widgetIndex != WIDX_SEPARATOR)
                     continue;
@@ -3142,9 +3142,9 @@ static Widget _topToolbarWidgets[] = {
             int32_t screenWidth = ContextGetWidth();
             firstAlignment = 1;
             x = std::max(640, screenWidth);
-            for (size_t i = 0; i < std::size(right_aligned_widgets_order); ++i)
+            for (size_t i = 0; i < std::size(kWidgetOrderRightGroup); ++i)
             {
-                widgetIndex = right_aligned_widgets_order[i];
+                widgetIndex = kWidgetOrderRightGroup[i];
                 widget = &widgets[widgetIndex];
                 if (widget->type == WindowWidgetType::Empty && widgetIndex != WIDX_SEPARATOR)
                     continue;

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -70,7 +70,6 @@
 #include <openrct2/world/Scenery.h>
 #include <openrct2/world/Surface.h>
 #include <openrct2/world/Wall.h>
-#include <ranges>
 #include <string>
 
 namespace OpenRCT2::Ui::Windows
@@ -229,23 +228,24 @@ namespace OpenRCT2::Ui::Windows
         WIDX_MAP,
     };
 
+    // NB: this array in reverse order!
     static constexpr std::array kWidgetOrderRightGroup = {
-        WIDX_CLEAR_SCENERY,
-        WIDX_LAND,
-        WIDX_WATER,
-        WIDX_SCENERY,
-        WIDX_PATH,
-        WIDX_CONSTRUCT_RIDE,
+        WIDX_NEWS,
+        WIDX_GUESTS,
+        WIDX_STAFF,
+        WIDX_PARK,
+        WIDX_RIDES,
+        WIDX_RESEARCH,
+        WIDX_FINANCES,
 
         WIDX_SEPARATOR,
 
-        WIDX_FINANCES,
-        WIDX_RESEARCH,
-        WIDX_RIDES,
-        WIDX_PARK,
-        WIDX_STAFF,
-        WIDX_GUESTS,
-        WIDX_NEWS,
+        WIDX_CONSTRUCT_RIDE,
+        WIDX_PATH,
+        WIDX_SCENERY,
+        WIDX_WATER,
+        WIDX_LAND,
+        WIDX_CLEAR_SCENERY,
     };
 
     static constexpr size_t _totalToolbarElements = kWidgetOrderLeftGroup.size() + kWidgetOrderRightGroup.size();
@@ -256,7 +256,7 @@ namespace OpenRCT2::Ui::Windows
 
         auto halfWayPoint = std::copy(kWidgetOrderLeftGroup.begin(), kWidgetOrderLeftGroup.end(), combined.begin());
         *halfWayPoint = WIDX_SEPARATOR;
-        std::copy(kWidgetOrderRightGroup.begin(), kWidgetOrderRightGroup.end(), halfWayPoint + 1);
+        std::reverse_copy(kWidgetOrderRightGroup.begin(), kWidgetOrderRightGroup.end(), halfWayPoint + 1);
 
         return combined;
     }();
@@ -3153,7 +3153,7 @@ namespace OpenRCT2::Ui::Windows
             int32_t screenWidth = ContextGetWidth();
             firstAlignment = true;
             x = std::max(640, screenWidth);
-            for (auto widgetIndex : std::ranges::reverse_view(kWidgetOrderRightGroup))
+            for (auto widgetIndex : kWidgetOrderRightGroup)
             {
                 auto* widget = &widgets[widgetIndex];
                 if (widget->type == WindowWidgetType::Empty && widgetIndex != WIDX_SEPARATOR)

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -248,6 +248,19 @@ namespace OpenRCT2::Ui::Windows
         WIDX_NEWS,
     };
 
+    static constexpr size_t _totalToolbarElements = kWidgetOrderLeftGroup.size() + kWidgetOrderRightGroup.size();
+
+    // Make a combined version of both halves of the toolbar, with a separator halfway.
+    static constexpr std::array<int, _totalToolbarElements + 1> kWidgetOrderCombined = []() {
+        std::array<int, _totalToolbarElements + 1> combined;
+
+        auto halfWayPoint = std::copy(kWidgetOrderLeftGroup.begin(), kWidgetOrderLeftGroup.end(), combined.begin());
+        *halfWayPoint = WIDX_SEPARATOR;
+        std::copy(kWidgetOrderRightGroup.begin(), kWidgetOrderRightGroup.end(), halfWayPoint + 1);
+
+        return combined;
+    }();
+
 #pragma endregion
 
     static Widget _topToolbarWidgets[] = {
@@ -3159,6 +3172,36 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
+        void AlignButtonsCentre()
+        {
+            // First, we figure out how much space we'll be needing
+            auto totalWidth = 0;
+            for (auto widgetIndex : kWidgetOrderCombined)
+            {
+                auto* widget = &widgets[widgetIndex];
+                if (widget->type == WindowWidgetType::Empty && widgetIndex != WIDX_SEPARATOR)
+                    continue;
+
+                totalWidth += widget->width();
+            }
+
+            // We'll start from the centre of the UI...
+            auto xPos = (ContextGetWidth() - totalWidth) / 2;
+
+            for (auto widgetIndex : kWidgetOrderCombined)
+            {
+                auto* widget = &widgets[widgetIndex];
+                if (widget->type == WindowWidgetType::Empty && widgetIndex != WIDX_SEPARATOR)
+                    continue;
+
+                auto widgetWidth = widget->width();
+                widget->left = xPos;
+                xPos += widgetWidth;
+                widget->right = xPos;
+                xPos += 1;
+            }
+        }
+
         void OnPrepareDraw() override
         {
             ResetWidgetToDefaultState();
@@ -3173,7 +3216,10 @@ namespace OpenRCT2::Ui::Windows
             ApplyMapRotation();
             ApplyFootpathPressed();
 
-            AlignButtonsLeftRight();
+            if (false)
+                AlignButtonsLeftRight();
+            else
+                AlignButtonsCentre();
         }
 
         void OnDraw(DrawPixelInfo& dpi) override

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -70,6 +70,7 @@
 #include <openrct2/world/Scenery.h>
 #include <openrct2/world/Surface.h>
 #include <openrct2/world/Wall.h>
+#include <ranges>
 #include <string>
 
 namespace OpenRCT2::Ui::Windows
@@ -209,7 +210,6 @@ namespace OpenRCT2::Ui::Windows
 #pragma region Toolbar_widget_ordering
 
     // clang-format off
-    // from left to right
     static constexpr std::array kWidgetOrderLeftGroup = {
         WIDX_PAUSE,
         WIDX_FASTFORWARD,
@@ -229,24 +229,23 @@ namespace OpenRCT2::Ui::Windows
         WIDX_MAP,
     };
 
-    // from right to left
     static constexpr std::array kWidgetOrderRightGroup = {
-        WIDX_NEWS,
-        WIDX_GUESTS,
-        WIDX_STAFF,
-        WIDX_PARK,
-        WIDX_RIDES,
-        WIDX_RESEARCH,
-        WIDX_FINANCES,
+        WIDX_CLEAR_SCENERY,
+        WIDX_LAND,
+        WIDX_WATER,
+        WIDX_SCENERY,
+        WIDX_PATH,
+        WIDX_CONSTRUCT_RIDE,
 
         WIDX_SEPARATOR,
 
-        WIDX_CONSTRUCT_RIDE,
-        WIDX_PATH,
-        WIDX_SCENERY,
-        WIDX_WATER,
-        WIDX_LAND,
-        WIDX_CLEAR_SCENERY,
+        WIDX_FINANCES,
+        WIDX_RESEARCH,
+        WIDX_RIDES,
+        WIDX_PARK,
+        WIDX_STAFF,
+        WIDX_GUESTS,
+        WIDX_NEWS,
     };
 
 #pragma endregion
@@ -3114,50 +3113,49 @@ namespace OpenRCT2::Ui::Windows
 
         void AlignButtonsLeftRight()
         {
-            int32_t x, widgetIndex, widgetWidth, firstAlignment;
-            Widget* widget;
+            // TODO: make a function that handles both loops
 
             // Align left hand side toolbar buttons
-            firstAlignment = 1;
-            x = 0;
-            for (size_t i = 0; i < std::size(kWidgetOrderLeftGroup); ++i)
+            bool firstAlignment = true;
+            auto x = 0;
+            for (auto widgetIndex : kWidgetOrderLeftGroup)
             {
-                widgetIndex = kWidgetOrderLeftGroup[i];
-                widget = &widgets[widgetIndex];
+                auto* widget = &widgets[widgetIndex];
                 if (widget->type == WindowWidgetType::Empty && widgetIndex != WIDX_SEPARATOR)
                     continue;
 
                 if (firstAlignment && widgetIndex == WIDX_SEPARATOR)
                     continue;
 
-                widgetWidth = widget->width();
+                auto widgetWidth = widget->width();
                 widget->left = x;
                 x += widgetWidth;
                 widget->right = x;
                 x += 1;
-                firstAlignment = 0;
+
+                firstAlignment = false;
             }
 
             // Align right hand side toolbar buttons if necessary
             int32_t screenWidth = ContextGetWidth();
-            firstAlignment = 1;
+            firstAlignment = true;
             x = std::max(640, screenWidth);
-            for (size_t i = 0; i < std::size(kWidgetOrderRightGroup); ++i)
+            for (auto widgetIndex : std::ranges::reverse_view(kWidgetOrderRightGroup))
             {
-                widgetIndex = kWidgetOrderRightGroup[i];
-                widget = &widgets[widgetIndex];
+                auto* widget = &widgets[widgetIndex];
                 if (widget->type == WindowWidgetType::Empty && widgetIndex != WIDX_SEPARATOR)
                     continue;
 
                 if (firstAlignment && widgetIndex == WIDX_SEPARATOR)
                     continue;
 
-                widgetWidth = widget->width();
+                auto widgetWidth = widget->width();
                 x -= 1;
                 widget->right = x;
                 x -= widgetWidth;
                 widget->left = x;
-                firstAlignment = 0;
+
+                firstAlignment = false;
             }
         }
 

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -3216,7 +3216,7 @@ namespace OpenRCT2::Ui::Windows
             ApplyMapRotation();
             ApplyFootpathPressed();
 
-            if (false)
+            if (!Config::Get().interface.ToolbarButtonsCentred)
                 AlignButtonsLeftRight();
             else
                 AlignButtonsCentre();

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -251,36 +251,36 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma endregion
 
-static Widget _topToolbarWidgets[] = {
-    MakeRemapWidget({  0, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Primary   , SPR_TOOLBAR_PAUSE,          STR_PAUSE_GAME_TIP                ), // Pause
-    MakeRemapWidget({ 60, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Primary   , SPR_TOOLBAR_FILE,           STR_DISC_AND_GAME_OPTIONS_TIP     ), // File menu
-    MakeRemapWidget({250, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Primary   , SPR_G2_TOOLBAR_MUTE,        STR_TOOLBAR_MUTE_TIP              ), // Mute
-    MakeRemapWidget({100, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Secondary , SPR_TOOLBAR_ZOOM_OUT,       STR_ZOOM_OUT_TIP                  ), // Zoom out
-    MakeRemapWidget({130, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Secondary , SPR_TOOLBAR_ZOOM_IN,        STR_ZOOM_IN_TIP                   ), // Zoom in
-    MakeRemapWidget({160, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Secondary , SPR_TOOLBAR_ROTATE,         STR_ROTATE_TIP                    ), // Rotate camera
-    MakeRemapWidget({190, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Secondary , SPR_TOOLBAR_VIEW,           STR_VIEW_OPTIONS_TIP              ), // Transparency menu
-    MakeRemapWidget({220, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Secondary , SPR_TOOLBAR_MAP,            STR_SHOW_MAP_TIP                  ), // Map
-    MakeRemapWidget({267, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Tertiary  , SPR_TOOLBAR_LAND,           STR_ADJUST_LAND_TIP               ), // Land
-    MakeRemapWidget({297, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Tertiary  , SPR_TOOLBAR_WATER,          STR_ADJUST_WATER_TIP              ), // Water
-    MakeRemapWidget({327, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Tertiary  , SPR_TOOLBAR_SCENERY,        STR_PLACE_SCENERY_TIP             ), // Scenery
-    MakeRemapWidget({357, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Tertiary  , SPR_TOOLBAR_FOOTPATH,       STR_BUILD_FOOTPATH_TIP            ), // Path
-    MakeRemapWidget({387, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Tertiary  , SPR_TOOLBAR_CONSTRUCT_RIDE, STR_BUILD_RIDE_TIP                ), // Construct ride
-    MakeRemapWidget({490, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Quaternary, SPR_TOOLBAR_RIDES,          STR_RIDES_IN_PARK_TIP             ), // Rides
-    MakeRemapWidget({520, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Quaternary, SPR_TOOLBAR_PARK,           STR_PARK_INFORMATION_TIP          ), // Park
-    MakeRemapWidget({550, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Quaternary, SPR_TAB_TOOLBAR,            STR_STAFF_TIP                     ), // Staff
-    MakeRemapWidget({560, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Quaternary, SPR_TOOLBAR_GUESTS,         STR_GUESTS_TIP                    ), // Guests
-    MakeRemapWidget({560, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Tertiary  , SPR_TOOLBAR_CLEAR_SCENERY,  STR_CLEAR_SCENERY_TIP             ), // Clear scenery
-    MakeRemapWidget({ 30, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Primary   , SPR_TAB_TOOLBAR,            STR_GAME_SPEED_TIP                ), // Fast forward
-    MakeRemapWidget({ 30, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Primary   , SPR_TAB_TOOLBAR,            STR_CHEATS_TIP                    ), // Cheats
-    MakeRemapWidget({ 30, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Primary   , SPR_TAB_TOOLBAR,            STR_DEBUG_TIP                     ), // Debug
-    MakeRemapWidget({ 30, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Quaternary, SPR_TAB_TOOLBAR,            STR_SCENARIO_OPTIONS_FINANCIAL_TIP), // Finances
-    MakeRemapWidget({ 30, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Quaternary, SPR_TAB_TOOLBAR,            STR_FINANCES_RESEARCH_TIP         ), // Research
-    MakeRemapWidget({ 30, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Quaternary, SPR_TAB_TOOLBAR,            STR_SHOW_RECENT_MESSAGES_TIP      ), // News
-    MakeRemapWidget({ 30, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Primary   , SPR_G2_TOOLBAR_MULTIPLAYER, STR_SHOW_MULTIPLAYER_STATUS_TIP   ), // Network
-    MakeRemapWidget({ 30, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Primary   , SPR_TAB_TOOLBAR,            STR_TOOLBAR_CHAT_TIP              ), // Chat
-    MakeWidget     ({  0, 0}, {10,                     1}, WindowWidgetType::Empty,  WindowColour::Primary                                                                   ), // Artificial widget separator
-    kWidgetsEnd,
-};
+    static Widget _topToolbarWidgets[] = {
+        MakeRemapWidget({  0, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Primary   , SPR_TOOLBAR_PAUSE,          STR_PAUSE_GAME_TIP                ), // Pause
+        MakeRemapWidget({ 60, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Primary   , SPR_TOOLBAR_FILE,           STR_DISC_AND_GAME_OPTIONS_TIP     ), // File menu
+        MakeRemapWidget({250, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Primary   , SPR_G2_TOOLBAR_MUTE,        STR_TOOLBAR_MUTE_TIP              ), // Mute
+        MakeRemapWidget({100, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Secondary , SPR_TOOLBAR_ZOOM_OUT,       STR_ZOOM_OUT_TIP                  ), // Zoom out
+        MakeRemapWidget({130, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Secondary , SPR_TOOLBAR_ZOOM_IN,        STR_ZOOM_IN_TIP                   ), // Zoom in
+        MakeRemapWidget({160, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Secondary , SPR_TOOLBAR_ROTATE,         STR_ROTATE_TIP                    ), // Rotate camera
+        MakeRemapWidget({190, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Secondary , SPR_TOOLBAR_VIEW,           STR_VIEW_OPTIONS_TIP              ), // Transparency menu
+        MakeRemapWidget({220, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Secondary , SPR_TOOLBAR_MAP,            STR_SHOW_MAP_TIP                  ), // Map
+        MakeRemapWidget({267, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Tertiary  , SPR_TOOLBAR_LAND,           STR_ADJUST_LAND_TIP               ), // Land
+        MakeRemapWidget({297, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Tertiary  , SPR_TOOLBAR_WATER,          STR_ADJUST_WATER_TIP              ), // Water
+        MakeRemapWidget({327, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Tertiary  , SPR_TOOLBAR_SCENERY,        STR_PLACE_SCENERY_TIP             ), // Scenery
+        MakeRemapWidget({357, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Tertiary  , SPR_TOOLBAR_FOOTPATH,       STR_BUILD_FOOTPATH_TIP            ), // Path
+        MakeRemapWidget({387, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Tertiary  , SPR_TOOLBAR_CONSTRUCT_RIDE, STR_BUILD_RIDE_TIP                ), // Construct ride
+        MakeRemapWidget({490, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Quaternary, SPR_TOOLBAR_RIDES,          STR_RIDES_IN_PARK_TIP             ), // Rides
+        MakeRemapWidget({520, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Quaternary, SPR_TOOLBAR_PARK,           STR_PARK_INFORMATION_TIP          ), // Park
+        MakeRemapWidget({550, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Quaternary, SPR_TAB_TOOLBAR,            STR_STAFF_TIP                     ), // Staff
+        MakeRemapWidget({560, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Quaternary, SPR_TOOLBAR_GUESTS,         STR_GUESTS_TIP                    ), // Guests
+        MakeRemapWidget({560, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Tertiary  , SPR_TOOLBAR_CLEAR_SCENERY,  STR_CLEAR_SCENERY_TIP             ), // Clear scenery
+        MakeRemapWidget({ 30, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Primary   , SPR_TAB_TOOLBAR,            STR_GAME_SPEED_TIP                ), // Fast forward
+        MakeRemapWidget({ 30, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Primary   , SPR_TAB_TOOLBAR,            STR_CHEATS_TIP                    ), // Cheats
+        MakeRemapWidget({ 30, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Primary   , SPR_TAB_TOOLBAR,            STR_DEBUG_TIP                     ), // Debug
+        MakeRemapWidget({ 30, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Quaternary, SPR_TAB_TOOLBAR,            STR_SCENARIO_OPTIONS_FINANCIAL_TIP), // Finances
+        MakeRemapWidget({ 30, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Quaternary, SPR_TAB_TOOLBAR,            STR_FINANCES_RESEARCH_TIP         ), // Research
+        MakeRemapWidget({ 30, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Quaternary, SPR_TAB_TOOLBAR,            STR_SHOW_RECENT_MESSAGES_TIP      ), // News
+        MakeRemapWidget({ 30, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Primary   , SPR_G2_TOOLBAR_MULTIPLAYER, STR_SHOW_MULTIPLAYER_STATUS_TIP   ), // Network
+        MakeRemapWidget({ 30, 0}, {30, kTopToolbarHeight + 1}, WindowWidgetType::TrnBtn, WindowColour::Primary   , SPR_TAB_TOOLBAR,            STR_TOOLBAR_CHAT_TIP              ), // Chat
+        MakeWidget     ({  0, 0}, {10,                     1}, WindowWidgetType::Empty,  WindowColour::Primary                                                                   ), // Artificial widget separator
+        kWidgetsEnd,
+    };
     // clang-format on
 
     static void ScenarioSelectCallback(const utf8* path);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -335,6 +335,7 @@ namespace OpenRCT2::Config
         if (reader->ReadSection("interface"))
         {
             auto model = &_config.interface;
+            model->ToolbarButtonsCentred = reader->GetBoolean("toolbar_buttons_centred", false);
             model->ToolbarShowFinances = reader->GetBoolean("toolbar_show_finances", true);
             model->ToolbarShowResearch = reader->GetBoolean("toolbar_show_research", true);
             model->ToolbarShowCheats = reader->GetBoolean("toolbar_show_cheats", false);
@@ -357,6 +358,7 @@ namespace OpenRCT2::Config
     {
         auto model = &_config.interface;
         writer->WriteSection("interface");
+        writer->WriteBoolean("toolbar_buttons_centred", model->ToolbarButtonsCentred);
         writer->WriteBoolean("toolbar_show_finances", model->ToolbarShowFinances);
         writer->WriteBoolean("toolbar_show_research", model->ToolbarShowResearch);
         writer->WriteBoolean("toolbar_show_cheats", model->ToolbarShowCheats);

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -119,6 +119,7 @@ namespace OpenRCT2::Config
 
     struct Interface
     {
+        bool ToolbarButtonsCentred;
         bool ToolbarShowFinances;
         bool ToolbarShowResearch;
         bool ToolbarShowCheats;

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -9,7 +9,11 @@
 
 #pragma once
 
-#include "Window.h"
+#include <cstdint>
+
+struct WindowBase;
+
+using WidgetIndex = int16_t;
 
 enum class WindowWidgetType : uint8_t
 {
@@ -38,6 +42,18 @@ enum class WindowWidgetType : uint8_t
     TextBox = 27,
     Last = 26,
 };
+
+constexpr uint8_t kCloseButtonWidth = 10;
+
+constexpr int32_t kScrollableRowHeight = 12;
+constexpr uint8_t kListRowHeight = 12;
+constexpr uint8_t kTableCellHeight = 12;
+constexpr uint8_t kButtonFaceHeight = 12;
+constexpr uint8_t kSpinnerHeight = 12;
+constexpr uint8_t kDropdownHeight = 12;
+
+constexpr uint16_t kTextInputSize = 1024;
+constexpr uint16_t kTopToolbarHeight = 27;
 
 enum
 {

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -1849,11 +1849,11 @@ void WindowBase::ResizeFrame()
     if (Config::Get().interface.WindowButtonsOnTheLeft)
     {
         widgets[2].left = 2;
-        widgets[2].right = 2 + CloseButtonWidth;
+        widgets[2].right = 2 + kCloseButtonWidth;
     }
     else
     {
-        widgets[2].left = width - 3 - CloseButtonWidth;
+        widgets[2].left = width - 3 - kCloseButtonWidth;
         widgets[2].right = width - 3;
     }
 }

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -18,6 +18,7 @@
 #include "../windows/TileInspectorGlobals.h"
 #include "../world/Location.hpp"
 #include "../world/ScenerySelection.h"
+#include "Widget.h"
 #include "WindowClasses.h"
 #include "ZoomLevel.h"
 
@@ -39,20 +40,7 @@ enum class CursorID : uint8_t;
 enum class RideConstructionState : uint8_t;
 enum class CloseWindowModifier : uint8_t;
 
-constexpr uint8_t CloseButtonWidth = 10;
-
-constexpr int32_t kScrollableRowHeight = 12;
-constexpr uint8_t kListRowHeight = 12;
-constexpr uint8_t kTableCellHeight = 12;
-constexpr uint8_t kButtonFaceHeight = 12;
-constexpr uint8_t kSpinnerHeight = 12;
-constexpr uint8_t kDropdownHeight = 12;
-
-constexpr uint16_t kTextInputSize = 1024;
-constexpr uint16_t kTopToolbarHeight = 27;
-
 using rct_windownumber = uint16_t;
-using WidgetIndex = int16_t;
 
 struct WindowIdentifier
 {

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3856,6 +3856,9 @@ enum : uint16_t
 
     STR_CAN_ONLY_BE_PLACED_ON_PATH_EDGES = 6628,
 
+    STR_OPTIONS_TOOLBAR_BUTTONS_CENTRED = 6629,
+    STR_OPTIONS_TOOLBAR_BUTTONS_CENTRED_TIP = 6630,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -119,16 +119,23 @@ void Painter::PaintFPS(DrawPixelInfo& dpi)
     if (!ShouldShowFPS())
         return;
 
-    ScreenCoordsXY screenCoords(_uiContext->GetWidth() / 2, 2);
-
     MeasureFPS();
 
     char buffer[64]{};
     FormatStringToBuffer(buffer, sizeof(buffer), "{OUTLINE}{WHITE}{INT32}", _currentFPS);
+    const int32_t stringWidth = GfxGetStringWidth(buffer, FontStyle::Medium);
 
-    // Draw Text
-    int32_t stringWidth = GfxGetStringWidth(buffer, FontStyle::Medium);
+    // Figure out where counter should be rendered
+    ScreenCoordsXY screenCoords(_uiContext->GetWidth() / 2, 2);
     screenCoords.x = screenCoords.x - (stringWidth / 2);
+
+    // Move counter below toolbar if buttons are centred
+    const bool isTitle = gScreenFlags == SCREEN_FLAGS_TITLE_DEMO;
+    if (!isTitle && Config::Get().interface.ToolbarButtonsCentred)
+    {
+        screenCoords.y = 30; // kTopToolbarHeight; don't want to include Window.h here
+    }
+
     DrawText(dpi, screenCoords, { COLOUR_WHITE }, buffer);
 
     // Make area dirty so the text doesn't get drawn over the last

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -18,6 +18,7 @@
 #include "../drawing/Text.h"
 #include "../interface/Chat.h"
 #include "../interface/InteractiveConsole.h"
+#include "../interface/Widget.h"
 #include "../localisation/FormatCodes.h"
 #include "../localisation/Formatting.h"
 #include "../localisation/Language.h"
@@ -133,7 +134,7 @@ void Painter::PaintFPS(DrawPixelInfo& dpi)
     const bool isTitle = gScreenFlags == SCREEN_FLAGS_TITLE_DEMO;
     if (!isTitle && Config::Get().interface.ToolbarButtonsCentred)
     {
-        screenCoords.y = 30; // kTopToolbarHeight; don't want to include Window.h here
+        screenCoords.y = kTopToolbarHeight + 3;
     }
 
     DrawText(dpi, screenCoords, { COLOUR_WHITE }, buffer);


### PR DESCRIPTION
Implements #622 / #15643 as an optional alternative toolbar mode.

- [x] It seems clang-tidy, macOS, and Ubuntu Jammy don't support [`std::ranges::reverse_view`](https://en.cppreference.com/w/cpp/ranges/reverse_view) yet?
- [x] Fix potential overlap with FPS counter
- [x] Test toggling the setting a bit.
- [x] Add string ids for the new option strings.
- [x] What should be the default layout? (on or off?) -> off

For a follow-up PR, we could look into moving the bottom panels to the top as well, or indeed moving the buttons to the bottom. I'd prefer not to move the goal posts for this PR too much.

Setting on:
![centre](https://github.com/OpenRCT2/OpenRCT2/assets/604665/575f4f1b-33e4-4d36-8244-c3aedb275f20)

Setting off:
![left_right](https://github.com/OpenRCT2/OpenRCT2/assets/604665/856c1006-1089-4ff5-93a3-00b84244f282)