### PR TITLE
Remove Config.h include from many places

### DIFF
--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -17,7 +17,6 @@
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/actions/CheatSetAction.h>
 #include <openrct2/actions/ParkSetDateAction.h>
-#include <openrct2/config/Config.h>
 #include <openrct2/localisation/Date.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Localisation.h>

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -14,6 +14,7 @@
 #include <openrct2/core/String.hpp>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/interface/Colour.h>
+#include <openrct2/localisation/Currency.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/util/Util.h>

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -16,7 +16,6 @@
 #include <openrct2/GameState.h>
 #include <openrct2/actions/ParkSetLoanAction.h>
 #include <openrct2/actions/ParkSetResearchFundingAction.h>
-#include <openrct2/config/Config.h>
 #include <openrct2/localisation/Date.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Localisation.h>

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -14,7 +14,6 @@
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
 #include <openrct2/GameState.h>
-#include <openrct2/config/Config.h>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/entity/EntityRegistry.h>
 #include <openrct2/entity/Guest.h>

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -18,7 +18,6 @@
 #include <openrct2/GameState.h>
 #include <openrct2/actions/RideDemolishAction.h>
 #include <openrct2/actions/RideSetStatusAction.h>
-#include <openrct2/config/Config.h>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/interface/Colour.h>
 #include <openrct2/localisation/Formatter.h>

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -13,7 +13,6 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
-#include <openrct2/config/Config.h>
 #include <openrct2/core/String.hpp>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Formatter.h>

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -15,7 +15,6 @@
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
 #include <openrct2/Input.h>
-#include <openrct2/config/Config.h>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Localisation.h>

--- a/src/openrct2-ui/windows/TitleExit.cpp
+++ b/src/openrct2-ui/windows/TitleExit.cpp
@@ -10,7 +10,6 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
-#include <openrct2/config/Config.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/sprites.h>
 

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -18,7 +18,6 @@
 #include <openrct2/ParkImporter.h>
 #include <openrct2/PlatformEnvironment.h>
 #include <openrct2/actions/LoadOrQuitAction.h>
-#include <openrct2/config/Config.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/sprites.h>
 #include <openrct2/ui/UiContext.h>

--- a/src/openrct2-ui/windows/TitleOptions.cpp
+++ b/src/openrct2-ui/windows/TitleOptions.cpp
@@ -10,7 +10,6 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
-#include <openrct2/config/Config.h>
 #include <openrct2/localisation/Localisation.h>
 
 namespace OpenRCT2::Ui::Windows

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -12,7 +12,6 @@
 #include "GameState.h"
 #include "actions/CheatSetAction.h"
 #include "actions/ParkSetLoanAction.h"
-#include "config/Config.h"
 #include "core/DataSerialiser.h"
 #include "localisation/Localisation.h"
 #include "network/network.h"

--- a/src/openrct2/PlatformEnvironment.cpp
+++ b/src/openrct2/PlatformEnvironment.cpp
@@ -15,6 +15,7 @@
 #include "core/Path.hpp"
 #include "core/String.hpp"
 #include "platform/Platform.h"
+#include "util/Util.h"
 
 using namespace OpenRCT2;
 

--- a/src/openrct2/actions/ParkSetNameAction.cpp
+++ b/src/openrct2/actions/ParkSetNameAction.cpp
@@ -11,7 +11,6 @@
 
 #include "../Context.h"
 #include "../GameState.h"
-#include "../config/Config.h"
 #include "../core/MemoryStream.h"
 #include "../drawing/Drawing.h"
 #include "../localisation/Localisation.h"

--- a/src/openrct2/command_line/CommandLine.cpp
+++ b/src/openrct2/command_line/CommandLine.cpp
@@ -12,6 +12,7 @@
 #include "../OpenRCT2.h"
 #include "../core/Console.hpp"
 #include "../core/String.hpp"
+#include "../drawing/Font.h"
 #include "../platform/Platform.h"
 
 #include <cstring>

--- a/src/openrct2/command_line/SimulateCommands.cpp
+++ b/src/openrct2/command_line/SimulateCommands.cpp
@@ -11,6 +11,7 @@
 #include "../Game.h"
 #include "../GameState.h"
 #include "../OpenRCT2.h"
+#include "../config/ConfigTypes.h"
 #include "../core/Console.hpp"
 #include "../entity/EntityRegistry.h"
 #include "../network/network.h"

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -10,12 +10,13 @@
 #pragma once
 
 #include "../core/String.hpp"
-#include "../drawing/Drawing.h"
-#include "../localisation/Currency.h"
+#include "../localisation/CurrencyTypes.h"
 #include "ConfigTypes.h"
 
 #include <atomic>
 #include <string>
+
+struct Gx;
 
 struct GeneralConfiguration
 {

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -12,17 +12,10 @@
 #include "../core/String.hpp"
 #include "../drawing/Drawing.h"
 #include "../localisation/Currency.h"
+#include "ConfigTypes.h"
 
 #include <atomic>
 #include <string>
-
-enum class MeasurementFormat : int32_t;
-enum class TemperatureUnit : int32_t;
-enum class ScaleQuality : int32_t;
-enum class Sort : int32_t;
-enum class VirtualFloorStyles : int32_t;
-enum class DrawingEngine : int32_t;
-enum class TitleMusicKind : int32_t;
 
 struct GeneralConfiguration
 {
@@ -219,43 +212,6 @@ struct PluginConfiguration
 {
     bool EnableHotReloading;
     u8string AllowedHosts;
-};
-
-enum class Sort : int32_t
-{
-    NameAscending,
-    NameDescending,
-    DateAscending,
-    DateDescending,
-};
-
-enum class TemperatureUnit : int32_t
-{
-    Celsius,
-    Fahrenheit
-};
-
-enum class ScaleQuality : int32_t
-{
-    NearestNeighbour,
-    Linear,
-    SmoothNearestNeighbour
-};
-
-enum class MeasurementFormat : int32_t
-{
-    Imperial,
-    Metric,
-    SI
-};
-
-enum class TitleMusicKind : int32_t
-{
-    None,
-    Random,
-    OpenRCT2,
-    RCT1,
-    RCT2,
 };
 
 extern GeneralConfiguration gConfigGeneral;

--- a/src/openrct2/config/ConfigTypes.h
+++ b/src/openrct2/config/ConfigTypes.h
@@ -1,0 +1,58 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2024 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+enum class MeasurementFormat : int32_t;
+enum class TemperatureUnit : int32_t;
+enum class CurrencyType : uint8_t;
+enum class ScaleQuality : int32_t;
+enum class Sort : int32_t;
+enum class VirtualFloorStyles : int32_t;
+enum class DrawingEngine : int32_t;
+enum class TitleMusicKind : int32_t;
+
+enum class Sort : int32_t
+{
+    NameAscending,
+    NameDescending,
+    DateAscending,
+    DateDescending,
+};
+
+enum class TemperatureUnit : int32_t
+{
+    Celsius,
+    Fahrenheit
+};
+
+enum class ScaleQuality : int32_t
+{
+    NearestNeighbour,
+    Linear,
+    SmoothNearestNeighbour
+};
+
+enum class MeasurementFormat : int32_t
+{
+    Imperial,
+    Metric,
+    SI
+};
+
+enum class TitleMusicKind : int32_t
+{
+    None,
+    Random,
+    OpenRCT2,
+    RCT1,
+    RCT2,
+};

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -10,7 +10,6 @@
 #include "NewDrawing.h"
 
 #include "../Context.h"
-#include "../config/Config.h"
 #include "../drawing/Drawing.h"
 #include "../interface/Screenshot.h"
 #include "../localisation/StringIds.h"

--- a/src/openrct2/drawing/TTF.cpp
+++ b/src/openrct2/drawing/TTF.cpp
@@ -19,6 +19,7 @@
 #    include "../OpenRCT2.h"
 #    include "../core/Numerics.hpp"
 #    include "../core/String.hpp"
+#    include "../drawing/Font.h"
 #    include "../localisation/LocalisationService.h"
 #    include "../platform/Platform.h"
 #    include "DrawingLock.hpp"

--- a/src/openrct2/drawing/TTF.cpp
+++ b/src/openrct2/drawing/TTF.cpp
@@ -22,6 +22,7 @@
 #    include "../drawing/Font.h"
 #    include "../localisation/LocalisationService.h"
 #    include "../platform/Platform.h"
+#    include "../util/Util.h"
 #    include "DrawingLock.hpp"
 #    include "TTF.h"
 

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -15,7 +15,6 @@
 #include "../Input.h"
 #include "../actions/StaffSetOrdersAction.h"
 #include "../audio/audio.h"
-#include "../config/Config.h"
 #include "../core/DataSerialiser.h"
 #include "../entity/EntityRegistry.h"
 #include "../interface/Viewport.h"

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -16,6 +16,7 @@
 #include "../PlatformEnvironment.h"
 #include "../actions/CheatSetAction.h"
 #include "../audio/audio.h"
+#include "../config/Config.h"
 #include "../core/Console.hpp"
 #include "../core/File.h"
 #include "../core/Imaging.h"

--- a/src/openrct2/interface/StdInOutConsole.cpp
+++ b/src/openrct2/interface/StdInOutConsole.cpp
@@ -11,6 +11,7 @@
 
 #include "../Context.h"
 #include "../OpenRCT2.h"
+#include "../config/ConfigTypes.h"
 #include "../platform/Platform.h"
 #include "../scripting/ScriptEngine.h"
 

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -176,6 +176,7 @@
     <ClInclude Include="common.h" />
     <ClInclude Include="config\Config.h" />
     <ClInclude Include="config\ConfigEnum.hpp" />
+    <ClInclude Include="config\ConfigTypes.h" />
     <ClInclude Include="config\IniReader.hpp" />
     <ClInclude Include="config\IniWriter.hpp" />
     <ClInclude Include="Context.h" />
@@ -278,6 +279,7 @@
     <ClInclude Include="Limits.h" />
     <ClInclude Include="localisation\ConversionTables.h" />
     <ClInclude Include="localisation\Currency.h" />
+    <ClInclude Include="localisation\CurrencyType.h" />
     <ClInclude Include="localisation\Date.h" />
     <ClInclude Include="localisation\FormatCodes.h" />
     <ClInclude Include="localisation\Formatter.h" />

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -279,7 +279,7 @@
     <ClInclude Include="Limits.h" />
     <ClInclude Include="localisation\ConversionTables.h" />
     <ClInclude Include="localisation\Currency.h" />
-    <ClInclude Include="localisation\CurrencyType.h" />
+    <ClInclude Include="localisation\CurrencyTypes.h" />
     <ClInclude Include="localisation\Date.h" />
     <ClInclude Include="localisation\FormatCodes.h" />
     <ClInclude Include="localisation\Formatter.h" />

--- a/src/openrct2/localisation/Currency.h
+++ b/src/openrct2/localisation/Currency.h
@@ -12,13 +12,7 @@
 #include "../common.h"
 #include "../core/String.hpp"
 #include "../util/Util.h"
-#include "CurrencyType.h"
-
-enum class CurrencyAffix
-{
-    Prefix,
-    Suffix
-};
+#include "CurrencyTypes.h"
 
 #define CURRENCY_SYMBOL_MAX_SIZE 8
 #define CURRENCY_RATE_MAX_NUM_DIGITS 9

--- a/src/openrct2/localisation/Currency.h
+++ b/src/openrct2/localisation/Currency.h
@@ -12,32 +12,7 @@
 #include "../common.h"
 #include "../core/String.hpp"
 #include "../util/Util.h"
-
-// List of currencies
-enum class CurrencyType : uint8_t
-{
-    Pounds,       // British Pound
-    Dollars,      // US Dollar
-    Franc,        // French Franc
-    DeutscheMark, // Deutsche Mark
-    Yen,          // Japanese Yen
-    Peseta,       // Spanish Peseta
-    Lira,         // Italian Lira
-    Guilders,     // Dutch Gilder
-    Krona,        // Swedish Krona
-    Euros,        // Euro
-    Won,          // South Korean Won
-    Rouble,       // Russian Rouble
-    CzechKoruna,  // Czech koruna
-    HKD,          // Hong Kong Dollar
-    TWD,          // New Taiwan Dollar
-    Yuan,         // Chinese Yuan
-    Forint,       // Hungarian Forint
-
-    Custom, // Custom currency
-
-    Count // Last item
-};
+#include "CurrencyType.h"
 
 enum class CurrencyAffix
 {
@@ -62,6 +37,7 @@ struct CurrencyDescriptor
 };
 
 // List of currency formats
+// TODO: refactor into getter
 extern CurrencyDescriptor CurrencyDescriptors[EnumValue(CurrencyType::Count)];
 
 /**

--- a/src/openrct2/localisation/CurrencyType.h
+++ b/src/openrct2/localisation/CurrencyType.h
@@ -1,0 +1,38 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2024 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+// List of currencies
+enum class CurrencyType : uint8_t
+{
+    Pounds,       // British Pound
+    Dollars,      // US Dollar
+    Franc,        // French Franc
+    DeutscheMark, // Deutsche Mark
+    Yen,          // Japanese Yen
+    Peseta,       // Spanish Peseta
+    Lira,         // Italian Lira
+    Guilders,     // Dutch Gilder
+    Krona,        // Swedish Krona
+    Euros,        // Euro
+    Won,          // South Korean Won
+    Rouble,       // Russian Rouble
+    CzechKoruna,  // Czech koruna
+    HKD,          // Hong Kong Dollar
+    TWD,          // New Taiwan Dollar
+    Yuan,         // Chinese Yuan
+    Forint,       // Hungarian Forint
+
+    Custom, // Custom currency
+
+    Count // Last item
+};

--- a/src/openrct2/localisation/CurrencyTypes.h
+++ b/src/openrct2/localisation/CurrencyTypes.h
@@ -36,3 +36,9 @@ enum class CurrencyType : uint8_t
 
     Count // Last item
 };
+
+enum class CurrencyAffix
+{
+    Prefix,
+    Suffix
+};

--- a/src/openrct2/localisation/Formatting.cpp
+++ b/src/openrct2/localisation/Formatting.cpp
@@ -11,6 +11,7 @@
 
 #include "../config/Config.h"
 #include "../util/Util.h"
+#include "Currency.h"
 #include "Formatter.h"
 #include "Localisation.h"
 #include "StringIds.h"

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -26,6 +26,7 @@
 #include "../management/Marketing.h"
 #include "../ride/Ride.h"
 #include "../util/Util.h"
+#include "Currency.h"
 #include "Date.h"
 #include "Formatting.h"
 #include "Localisation.h"

--- a/src/openrct2/localisation/Localisation.h
+++ b/src/openrct2/localisation/Localisation.h
@@ -10,7 +10,6 @@
 #pragma once
 
 #include "../management/Marketing.h"
-#include "Currency.h"
 #include "Date.h"
 #include "FormatCodes.h"
 #include "Language.h"

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -13,7 +13,6 @@
 #include "../OpenRCT2.h"
 #include "../PlatformEnvironment.h"
 #include "../common.h"
-#include "../config/Config.h"
 #include "../core/Console.hpp"
 #include "../core/DataSerialiser.h"
 #include "../core/FileIndex.hpp"

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -14,6 +14,7 @@
 #include "../core/Guard.hpp"
 #include "../drawing/Drawing.h"
 #include "../interface/Viewport.h"
+#include "../localisation/Currency.h"
 #include "../localisation/Formatting.h"
 #include "../localisation/Localisation.h"
 #include "../localisation/LocalisationService.h"

--- a/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
@@ -11,7 +11,6 @@
 
 #include "../../Game.h"
 #include "../../GameState.h"
-#include "../../config/Config.h"
 #include "../../interface/Viewport.h"
 #include "../../localisation/Date.h"
 #include "../../object/SmallSceneryEntry.h"

--- a/src/openrct2/platform/Platform.Common.cpp
+++ b/src/openrct2/platform/Platform.Common.cpp
@@ -18,6 +18,7 @@
 #include "../Game.h"
 #include "../core/File.h"
 #include "../core/Path.hpp"
+#include "../localisation/Currency.h"
 #include "../localisation/Localisation.h"
 #include "Platform.h"
 

--- a/src/openrct2/platform/Platform.Common.cpp
+++ b/src/openrct2/platform/Platform.Common.cpp
@@ -16,7 +16,6 @@
 
 #include "../Context.h"
 #include "../Game.h"
-#include "../config/Config.h"
 #include "../core/File.h"
 #include "../core/Path.hpp"
 #include "../localisation/Localisation.h"

--- a/src/openrct2/platform/Platform.Posix.cpp
+++ b/src/openrct2/platform/Platform.Posix.cpp
@@ -14,7 +14,6 @@
 #    include "../Date.h"
 #    include "../core/Memory.hpp"
 #    include "../core/Path.hpp"
-#    include "../core/String.hpp"
 #    include "../util/Util.h"
 
 #    include <cerrno>

--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -10,7 +10,8 @@
 #pragma once
 
 #include "../common.h"
-#include "../config/Config.h"
+#include "../config/ConfigTypes.h"
+#include "../core/String.hpp"
 
 #include <ctime>
 #include <string>
@@ -42,6 +43,7 @@ enum class SPECIAL_FOLDER
 
 struct RealWorldDate;
 struct RealWorldTime;
+struct TTFFontDescriptor;
 
 namespace Platform
 {

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -14,7 +14,6 @@
 #include "../GameState.h"
 #include "../OpenRCT2.h"
 #include "../ParkImporter.h"
-#include "../config/Config.h"
 #include "../core/Console.hpp"
 #include "../core/FileStream.h"
 #include "../core/IStream.hpp"

--- a/src/openrct2/rct2/T6Importer.cpp
+++ b/src/openrct2/rct2/T6Importer.cpp
@@ -8,7 +8,6 @@
  *****************************************************************************/
 
 #include "../TrackImporter.h"
-#include "../config/Config.h"
 #include "../core/FileStream.h"
 #include "../core/MemoryStream.h"
 #include "../core/Path.hpp"

--- a/src/openrct2/ride/TrackDesignRepository.cpp
+++ b/src/openrct2/ride/TrackDesignRepository.cpp
@@ -11,7 +11,6 @@
 
 #include "../Context.h"
 #include "../PlatformEnvironment.h"
-#include "../config/Config.h"
 #include "../core/Collections.hpp"
 #include "../core/Console.hpp"
 #include "../core/File.h"

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -10,7 +10,6 @@
 #include "../Context.h"
 #include "../Game.h"
 #include "../audio/audio.h"
-#include "../config/Config.h"
 #include "../interface/Viewport.h"
 #include "../localisation/Localisation.h"
 #include "../localisation/StringIds.h"

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include "../../config/Config.h"
 #include "../../entity/EntityRegistry.h"
 #include "../../entity/Guest.h"
 #include "../../interface/Viewport.h"

--- a/src/openrct2/ride/thrill/LaunchedFreefall.cpp
+++ b/src/openrct2/ride/thrill/LaunchedFreefall.cpp
@@ -8,7 +8,6 @@
  *****************************************************************************/
 
 #include "../../common.h"
-#include "../../config/Config.h"
 #include "../../interface/Viewport.h"
 #include "../../paint/Paint.h"
 #include "../../paint/support/WoodenSupports.h"

--- a/src/openrct2/ride/water/SplashBoats.cpp
+++ b/src/openrct2/ride/water/SplashBoats.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include "../../config/Config.h"
 #include "../../entity/EntityRegistry.h"
 #include "../../interface/Viewport.h"
 #include "../../paint/Paint.h"

--- a/src/openrct2/ui/DummyUiContext.cpp
+++ b/src/openrct2/ui/DummyUiContext.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include "../config/Config.h"
 #include "../drawing/X8DrawingEngine.h"
 #include "UiContext.h"
 #include "WindowManager.h"

--- a/src/openrct2/ui/UiContext.h
+++ b/src/openrct2/ui/UiContext.h
@@ -11,7 +11,7 @@
 
 #include "../Context.h"
 #include "../common.h"
-#include "../config/Config.h"
+#include "../config/ConfigTypes.h"
 #include "../interface/Cursors.h"
 
 #include <memory>

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -20,7 +20,6 @@
 #include "../actions/ParkEntranceRemoveAction.h"
 #include "../actions/WallRemoveAction.h"
 #include "../audio/audio.h"
-#include "../config/Config.h"
 #include "../core/Guard.hpp"
 #include "../interface/Cursors.h"
 #include "../interface/Viewport.h"

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -16,7 +16,6 @@
 #include "../GameState.h"
 #include "../OpenRCT2.h"
 #include "../actions/ParkSetParameterAction.h"
-#include "../config/Config.h"
 #include "../core/Memory.hpp"
 #include "../core/String.hpp"
 #include "../entity/Litter.h"

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -18,7 +18,6 @@
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/ParkImporter.h>
 #include <openrct2/audio/AudioContext.h>
-#include <openrct2/config/Config.h>
 #include <openrct2/core/Crypt.h>
 #include <openrct2/core/File.h>
 #include <openrct2/core/MemoryStream.h>


### PR DESCRIPTION
Many files were including the Config.h unnecessarily, including the UiContext.h and Platform.h headers and 36 compilation units. This PR addresses this.

To achieve this, the config _types_ are moved into their own file, ConfigTypes.h, for use in headers. This suffices when the actual config is not needed.

It turns out Config.h was, in turn, including Drawing.h, just for the definition of the `Gx` struct. This is quite a hefty header, and the include becomes entirely unnecessary with a predeclaration, i.e. `struct Gx;`.

The currency types are also moved from Currency.h to a new file, CurrencyTypes.h. Further refactoring is needed on this front, e.g. by making a getter for `CurrencyDescriptors`.