### PR TITLE
Remove <algorithm> include from Location.hpp

### DIFF
--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -11,6 +11,7 @@
 
 #include "Theme.h"
 
+#include <algorithm>
 #include <cstring>
 #include <openrct2/Context.h>
 #include <openrct2/Version.h>

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -7,6 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#include <algorithm>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -7,6 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#include <algorithm>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/LandTool.h>
 #include <openrct2-ui/interface/Widget.h>

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -7,6 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#include <algorithm>
 #include <openrct2-ui/interface/LandTool.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
@@ -15,6 +16,7 @@
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/world/Scenery.h>
+
 namespace OpenRCT2::Ui::Windows
 {
     enum WindowSceneryScatterWidgetIdx

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -7,6 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#include <algorithm>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>

--- a/src/openrct2/actions/FootpathPlaceAction.cpp
+++ b/src/openrct2/actions/FootpathPlaceAction.cpp
@@ -27,6 +27,8 @@
 #include "../world/TileElementsView.h"
 #include "../world/Wall.h"
 
+#include <algorithm>
+
 using namespace OpenRCT2;
 
 FootpathPlaceAction::FootpathPlaceAction(

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -12,8 +12,6 @@
 #include "../common.h"
 #include "../util/Math.hpp"
 
-#include <algorithm>
-
 constexpr int16_t LOCATION_NULL = -32768;
 
 constexpr int32_t COORDS_XY_STEP = 32;
@@ -810,9 +808,14 @@ struct MapRange : public RectRange<CoordsXY>
 
     constexpr MapRange Normalise() const
     {
+        // Don't use std::min/max, as they require <algorithm>, one of C++'s heaviest
+        // in this very common header.
         auto result = MapRange(
-            std::min(GetLeft(), GetRight()), std::min(GetTop(), GetBottom()), std::max(GetLeft(), GetRight()),
-            std::max(GetTop(), GetBottom()));
+            GetLeft() > GetRight() ? GetRight() : GetLeft(), // min
+            GetTop() > GetBottom() ? GetBottom() : GetTop(), // min
+            GetLeft() > GetRight() ? GetLeft() : GetRight(), // max
+            GetTop() > GetBottom() ? GetTop() : GetBottom()  // max
+        );
         return result;
     }
 };

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -811,8 +811,8 @@ struct MapRange : public RectRange<CoordsXY>
         // Don't use std::min/max, as they require <algorithm>, one of C++'s heaviest
         // in this very common header.
         auto result = MapRange(
-            GetLeft() > GetRight() ? GetRight() : GetLeft(), // min
-            GetTop() > GetBottom() ? GetBottom() : GetTop(), // min
+            GetLeft() < GetRight() ? GetLeft() : GetRight(), // min
+            GetTop() < GetBottom() ? GetTop() : GetBottom(), // min
             GetLeft() > GetRight() ? GetLeft() : GetRight(), // max
             GetTop() > GetBottom() ? GetTop() : GetBottom()  // max
         );


### PR DESCRIPTION
See https://github.com/OpenRCT2/OpenRCT2/pull/21947 for methodology

528-372=156 `#include <algorithm>`s fewer
```diff
--- includes_old        2024-05-09 13:23:04.649275421 +0200
+++ includes_new        2024-05-09 13:23:20.737759061 +0200
@@ -12,7 +12,7 @@
       3 /usr/include/asm-generic/sockios.h
       6 /usr/include/asm-generic/types.h
     562 /usr/include/assert.h
-    528 /usr/include/c++/11/algorithm
+    372 /usr/include/c++/11/algorithm
     225 /usr/include/c++/11/any
     556 /usr/include/c++/11/array
     298 /usr/include/c++/11/atomic
@@ -42,7 +42,7 @@
     566 /usr/include/c++/11/bits/cxxabi_init_exception.h
     104 /usr/include/c++/11/bits/deque.tcc
     555 /usr/include/c++/11/bits/enable_special_members.h
-    534 /usr/include/c++/11/bits/erase_if.h
+    514 /usr/include/c++/11/bits/erase_if.h
       4 /usr/include/c++/11/bitset
     567 /usr/include/c++/11/bits/exception_defines.h
     567 /usr/include/c++/11/bits/exception.h
@@ -59,16 +59,16 @@
      37 /usr/include/c++/11/bits/gslice_array.h
      37 /usr/include/c++/11/bits/gslice.h
     567 /usr/include/c++/11/bits/hash_bytes.h
-    533 /usr/include/c++/11/bits/hashtable.h
-    533 /usr/include/c++/11/bits/hashtable_policy.h
+    512 /usr/include/c++/11/bits/hashtable.h
+    512 /usr/include/c++/11/bits/hashtable_policy.h
      37 /usr/include/c++/11/bits/indirect_array.h
-    551 /usr/include/c++/11/bits/invoke.h
-    553 /usr/include/c++/11/bits/ios_base.h
+    547 /usr/include/c++/11/bits/invoke.h
+    549 /usr/include/c++/11/bits/ios_base.h
     358 /usr/include/c++/11/bits/istream.tcc
     567 /usr/include/c++/11/bits/iterator_concepts.h
     437 /usr/include/c++/11/bits/list.tcc
-    553 /usr/include/c++/11/bits/locale_classes.h
-    553 /usr/include/c++/11/bits/locale_classes.tcc
+    549 /usr/include/c++/11/bits/locale_classes.h
+    549 /usr/include/c++/11/bits/locale_classes.tcc
     269 /usr/include/c++/11/bits/locale_conv.h
     543 /usr/include/c++/11/bits/locale_facets.h
     269 /usr/include/c++/11/bits/locale_facets_nonio.h
@@ -80,7 +80,7 @@
     567 /usr/include/c++/11/bits/memoryfwd.h
     567 /usr/include/c++/11/bits/move.h
     566 /usr/include/c++/11/bits/nested_exception.h
-    534 /usr/include/c++/11/bits/node_handle.h
+    514 /usr/include/c++/11/bits/node_handle.h
     567 /usr/include/c++/11/bits/ostream_insert.h
     543 /usr/include/c++/11/bits/ostream.tcc
     482 /usr/include/c++/11/bits/parse_numbers.h
@@ -91,13 +91,13 @@
     185 /usr/include/c++/11/bits/random.h
     185 /usr/include/c++/11/bits/random.tcc
     567 /usr/include/c++/11/bits/range_access.h
-    548 /usr/include/c++/11/bits/ranges_algobase.h
-    528 /usr/include/c++/11/bits/ranges_algo.h
+    544 /usr/include/c++/11/bits/ranges_algobase.h
+    372 /usr/include/c++/11/bits/ranges_algo.h
     567 /usr/include/c++/11/bits/ranges_base.h
     567 /usr/include/c++/11/bits/ranges_cmp.h
     541 /usr/include/c++/11/bits/ranges_uninitialized.h
-    528 /usr/include/c++/11/bits/ranges_util.h
-    550 /usr/include/c++/11/bits/refwrap.h
+    372 /usr/include/c++/11/bits/ranges_util.h
+    546 /usr/include/c++/11/bits/refwrap.h
     236 /usr/include/c++/11/bits/semaphore_base.h
     541 /usr/include/c++/11/bits/shared_ptr_atomic.h
     542 /usr/include/c++/11/bits/shared_ptr_base.h
@@ -106,7 +106,7 @@
     438 /usr/include/c++/11/bits/specfun.h
     290 /usr/include/c++/11/bits/sstream.tcc
     567 /usr/include/c++/11/bits/std_abs.h
-    533 /usr/include/c++/11/bits/std_function.h
+    509 /usr/include/c++/11/bits/std_function.h
     544 /usr/include/c++/11/bits/std_mutex.h
     236 /usr/include/c++/11/bits/std_thread.h
     567 /usr/include/c++/11/bits/stl_algobase.h
@@ -134,19 +134,19 @@
     478 /usr/include/c++/11/bits/stl_tree.h
     562 /usr/include/c++/11/bits/stl_uninitialized.h
     560 /usr/include/c++/11/bits/stl_vector.h
-    553 /usr/include/c++/11/bits/streambuf_iterator.h
-    553 /usr/include/c++/11/bits/streambuf.tcc
-    551 /usr/include/c++/11/bits/stream_iterator.h
+    549 /usr/include/c++/11/bits/streambuf_iterator.h
+    549 /usr/include/c++/11/bits/streambuf.tcc
+    547 /usr/include/c++/11/bits/stream_iterator.h
     567 /usr/include/c++/11/bits/stringfwd.h
     567 /usr/include/c++/11/bits/string_view.tcc
     236 /usr/include/c++/11/bits/this_thread_sleep.h
     567 /usr/include/c++/11/bits/uniform_int_dist.h
     241 /usr/include/c++/11/bits/unique_lock.h
     543 /usr/include/c++/11/bits/unique_ptr.h
-    532 /usr/include/c++/11/bits/unordered_map.h
+    511 /usr/include/c++/11/bits/unordered_map.h
      80 /usr/include/c++/11/bits/unordered_set.h
     541 /usr/include/c++/11/bits/uses_allocator_args.h
-    551 /usr/include/c++/11/bits/uses_allocator.h
+    547 /usr/include/c++/11/bits/uses_allocator.h
      37 /usr/include/c++/11/bits/valarray_after.h
      37 /usr/include/c++/11/bits/valarray_array.h
      37 /usr/include/c++/11/bits/valarray_array.tcc
@@ -176,7 +176,7 @@
     567 /usr/include/c++/11/debug/debug.h
     104 /usr/include/c++/11/deque
     566 /usr/include/c++/11/exception
-    551 /usr/include/c++/11/ext/aligned_buffer.h
+    547 /usr/include/c++/11/ext/aligned_buffer.h
     567 /usr/include/c++/11/ext/alloc_traits.h
     567 /usr/include/c++/11/ext/atomicity.h
     542 /usr/include/c++/11/ext/concurrence.h
@@ -187,7 +187,7 @@
      88 /usr/include/c++/11/filesystem
      37 /usr/include/c++/11/forward_list
      14 /usr/include/c++/11/fstream
-    532 /usr/include/c++/11/functional
+    508 /usr/include/c++/11/functional
      44 /usr/include/c++/11/future
     567 /usr/include/c++/11/initializer_list
     268 /usr/include/c++/11/iomanip
@@ -195,7 +195,7 @@
     567 /usr/include/c++/11/iosfwd
     264 /usr/include/c++/11/iostream
     358 /usr/include/c++/11/istream
-    551 /usr/include/c++/11/iterator
+    547 /usr/include/c++/11/iterator
     545 /usr/include/c++/11/limits
     437 /usr/include/c++/11/list
     269 /usr/include/c++/11/locale
@@ -208,8 +208,8 @@
     219 /usr/include/c++/11/numeric
     549 /usr/include/c++/11/optional
     543 /usr/include/c++/11/ostream
-    548 /usr/include/c++/11/pstl/execution_defs.h
-    528 /usr/include/c++/11/pstl/glue_algorithm_defs.h
+    544 /usr/include/c++/11/pstl/execution_defs.h
+    372 /usr/include/c++/11/pstl/glue_algorithm_defs.h
     541 /usr/include/c++/11/pstl/glue_memory_defs.h
     219 /usr/include/c++/11/pstl/glue_numeric_defs.h
     572 /usr/include/c++/11/pstl/pstl_config.h
@@ -225,10 +225,10 @@
     557 /usr/include/c++/11/stdexcept
      79 /usr/include/c++/11/stdlib.h
     236 /usr/include/c++/11/stop_token
-    553 /usr/include/c++/11/streambuf
+    549 /usr/include/c++/11/streambuf
     567 /usr/include/c++/11/string
     567 /usr/include/c++/11/string_view
-    554 /usr/include/c++/11/system_error
+    550 /usr/include/c++/11/system_error
     235 /usr/include/c++/11/thread
     438 /usr/include/c++/11/tr1/bessel_function.tcc
     438 /usr/include/c++/11/tr1/beta_function.tcc
@@ -242,11 +242,11 @@
     438 /usr/include/c++/11/tr1/poly_laguerre.tcc
     438 /usr/include/c++/11/tr1/riemann_zeta.tcc
     438 /usr/include/c++/11/tr1/special_function_util.h
-    551 /usr/include/c++/11/tuple
+    547 /usr/include/c++/11/tuple
      43 /usr/include/c++/11/typeindex
     566 /usr/include/c++/11/typeinfo
     567 /usr/include/c++/11/type_traits
-    532 /usr/include/c++/11/unordered_map
+    511 /usr/include/c++/11/unordered_map
      80 /usr/include/c++/11/unordered_set
     562 /usr/include/c++/11/utility
      37 /usr/include/c++/11/valarray
@@ -670,7 +670,7 @@
     572 /usr/include/x86_64-linux-gnu/c++/11/bits/cpu_defines.h
     543 /usr/include/x86_64-linux-gnu/c++/11/bits/ctype_base.h
     543 /usr/include/x86_64-linux-gnu/c++/11/bits/ctype_inline.h
-    554 /usr/include/x86_64-linux-gnu/c++/11/bits/error_constants.h
+    550 /usr/include/x86_64-linux-gnu/c++/11/bits/error_constants.h
     567 /usr/include/x86_64-linux-gnu/c++/11/bits/gthr-default.h
     567 /usr/include/x86_64-linux-gnu/c++/11/bits/gthr.h
     269 /usr/include/x86_64-linux-gnu/c++/11/bits/messages_members.h
```