### PR TITLE
Reduce inclusion of FixedVector.h

### DIFF
--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -7,6 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#include <algorithm>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -10,7 +10,6 @@
 #pragma once
 
 #include "../common.h"
-#include "../core/FixedVector.h"
 #include "../drawing/Drawing.h"
 #include "../interface/Colour.h"
 #include "../world/Location.hpp"

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -19,6 +19,7 @@
 #include "../actions/RideSetVehicleAction.h"
 #include "../actions/TrackRemoveAction.h"
 #include "../common.h"
+#include "../core/FixedVector.h"
 #include "../entity/EntityList.h"
 #include "../entity/EntityRegistry.h"
 #include "../entity/Staff.h"


### PR DESCRIPTION
FixedVector class requires use of algorithm include, one of C++'s heaviest, while in practice it is used only in handful of places.

See #21947 for methodology

372-266=106 `#include <algorithm>`s fewer

```diff
--- includes_old        2024-05-09 14:01:08.237696753 +0200
+++ includes_new        2024-05-09 13:23:20.737759061 +0200
@@ -12,7 +12,7 @@
       3 /usr/include/asm-generic/sockios.h
       6 /usr/include/asm-generic/types.h
     562 /usr/include/assert.h
-    372 /usr/include/c++/11/algorithm
+    266 /usr/include/c++/11/algorithm
     225 /usr/include/c++/11/any
     556 /usr/include/c++/11/array
     298 /usr/include/c++/11/atomic
@@ -92,11 +92,11 @@
     185 /usr/include/c++/11/bits/random.tcc
     567 /usr/include/c++/11/bits/range_access.h
     544 /usr/include/c++/11/bits/ranges_algobase.h
-    372 /usr/include/c++/11/bits/ranges_algo.h
+    266 /usr/include/c++/11/bits/ranges_algo.h
     567 /usr/include/c++/11/bits/ranges_base.h
     567 /usr/include/c++/11/bits/ranges_cmp.h
     541 /usr/include/c++/11/bits/ranges_uninitialized.h
-    372 /usr/include/c++/11/bits/ranges_util.h
+    266 /usr/include/c++/11/bits/ranges_util.h
     546 /usr/include/c++/11/bits/refwrap.h
     236 /usr/include/c++/11/bits/semaphore_base.h
     541 /usr/include/c++/11/bits/shared_ptr_atomic.h
@@ -209,7 +209,7 @@
     549 /usr/include/c++/11/optional
     543 /usr/include/c++/11/ostream
     544 /usr/include/c++/11/pstl/execution_defs.h
-    372 /usr/include/c++/11/pstl/glue_algorithm_defs.h
+    266 /usr/include/c++/11/pstl/glue_algorithm_defs.h
     541 /usr/include/c++/11/pstl/glue_memory_defs.h
     219 /usr/include/c++/11/pstl/glue_numeric_defs.h
     572 /usr/include/c++/11/pstl/pstl_config.h
```