### PR TITLE
Allow setting “no draw on zoom flag” in image JSON

### DIFF
--- a/src/openrct2-ui/scripting/CustomImages.cpp
+++ b/src/openrct2-ui/scripting/CustomImages.cpp
@@ -322,7 +322,8 @@ namespace OpenRCT2::Scripting
                 auto importMode = getImportModeFromPalette(pixelData.Palette);
                 auto pngData = DukGetDataFromBufferLikeObject(pixelData.Data);
                 auto image = Imaging::ReadFromBuffer(pngData, imageFormat);
-                ImageImportMeta meta = { { 0, 0 }, palette, ImportFlags::RLE, importMode };
+                uint8_t flags = EnumToFlag(ImportFlags::RLE);
+                ImageImportMeta meta = { { 0, 0 }, palette, flags, importMode };
 
                 ImageImporter importer;
                 auto importResult = importer.Import(image, meta);

--- a/src/openrct2/CommandLineSprite.cpp
+++ b/src/openrct2/CommandLineSprite.cpp
@@ -498,7 +498,8 @@ int32_t CommandLineForSprite(const char** argv, int32_t argc)
             }
         }
 
-        ImageImportMeta meta = { { xOffset, yOffset }, Palette::OpenRCT2, ImportFlags::RLE, gSpriteMode };
+        uint8_t importFlags = EnumToFlag(ImportFlags::RLE);
+        ImageImportMeta meta = { { xOffset, yOffset }, Palette::OpenRCT2, importFlags, gSpriteMode };
         auto importResult = SpriteImageImport(imagePath, meta);
         if (!importResult.has_value())
             return -1;

--- a/src/openrct2/drawing/ImageImporter.h
+++ b/src/openrct2/drawing/ImageImporter.h
@@ -31,6 +31,7 @@ namespace OpenRCT2::Drawing
     {
         None = 0,
         RLE = 1 << 1,
+        NoDrawOnZoom = 1 << 2,
     };
 
     enum class Palette : uint8_t

--- a/src/openrct2/drawing/ImageImporter.h
+++ b/src/openrct2/drawing/ImageImporter.h
@@ -11,6 +11,7 @@
 
 #include "../core/Imaging.h"
 #include "../core/JsonFwd.hpp"
+#include "../util/Util.h"
 #include "Drawing.h"
 
 #include <string_view>
@@ -27,11 +28,10 @@ namespace OpenRCT2::Drawing
         Dithering,
     };
 
-    enum ImportFlags : uint8_t
+    enum class ImportFlags : uint8_t
     {
-        None = 0,
-        RLE = 1 << 1,
-        NoDrawOnZoom = 1 << 2,
+        RLE,
+        NoDrawOnZoom,
     };
 
     enum class Palette : uint8_t
@@ -44,7 +44,7 @@ namespace OpenRCT2::Drawing
     {
         ScreenCoordsXY offset{};
         Palette palette = Palette::OpenRCT2;
-        ImportFlags importFlags = ImportFlags::RLE;
+        uint8_t importFlags = EnumToFlag(ImportFlags::RLE);
         ImportMode importMode = ImportMode::Default;
         ScreenCoordsXY srcOffset{};
         ScreenSize srcSize{};

--- a/src/openrct2/util/Util.h
+++ b/src/openrct2/util/Util.h
@@ -127,6 +127,12 @@ template<typename TEnum> constexpr auto EnumValue(TEnum enumerator) noexcept
     return static_cast<std::underlying_type_t<TEnum>>(enumerator);
 }
 
+template<typename T> constexpr bool HasFlag(uint64_t holder, T v)
+{
+    static_assert(std::is_enum_v<T>);
+    return (holder & EnumToFlag(v)) != 0;
+}
+
 constexpr uint8_t HiByte(uint16_t value)
 {
     return static_cast<uint8_t>(value >> 8);


### PR DESCRIPTION
There are several flags that could be exposed to json for convenience of custom object creators. This is one of them.