### PR TITLE
Readd algorithm header where it is used

### DIFF
--- a/src/openrct2/actions/LandSmoothAction.cpp
+++ b/src/openrct2/actions/LandSmoothAction.cpp
@@ -26,6 +26,8 @@
 #include "../world/Surface.h"
 #include "../world/SurfaceData.h"
 
+#include <algorithm>
+
 LandSmoothAction::LandSmoothAction(const CoordsXY& coords, MapRange range, uint8_t selectionType, bool isLowering)
     : _coords(coords)
     , _range(range)

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -30,6 +30,7 @@
 #include "SmallSceneryObject.h"
 #include "WallObject.h"
 
+#include <algorithm>
 #include <array>
 #include <memory>
 #include <mutex>

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -26,6 +26,7 @@
 #include "Paint.Entity.h"
 #include "tile_element/Paint.TileElement.h"
 
+#include <algorithm>
 #include <array>
 
 using namespace OpenRCT2;

--- a/src/openrct2/ride/RideAudio.cpp
+++ b/src/openrct2/ride/RideAudio.cpp
@@ -23,6 +23,7 @@
 #include "Ride.h"
 #include "RideData.h"
 
+#include <algorithm>
 #include <vector>
 
 using namespace OpenRCT2;

--- a/src/openrct2/scenes/title/TitleSequenceManager.cpp
+++ b/src/openrct2/scenes/title/TitleSequenceManager.cpp
@@ -22,6 +22,7 @@
 #include "../../platform/Platform.h"
 #include "TitleSequence.h"
 
+#include <algorithm>
 #include <iterator>
 #include <vector>
 

--- a/src/openrct2/world/MapHelpers.cpp
+++ b/src/openrct2/world/MapHelpers.cpp
@@ -12,6 +12,8 @@
 #include "Map.h"
 #include "Surface.h"
 
+#include <algorithm>
+
 static uint8_t GetBaseHeightOrZero(int32_t x, int32_t y)
 {
     auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });


### PR DESCRIPTION
~~Project fails to compile on latest versions of MSVC std library without including algorithm.~~ Looks like the reason ci doesn't have this issue is due to the ci using a PCH that includes algorithm. Likely something was assuming it was included transitively.