### PR TITLE
Don't include windows.h when not used

### DIFF
--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -137,21 +137,3 @@ public:
 };
 
 #endif // __ANDROID__
-
-#ifdef _WIN32
-#    ifndef NOMINMAX
-#        define NOMINMAX
-#    endif
-#    ifndef WIN32_LEAN_AND_MEAN
-#        define WIN32_LEAN_AND_MEAN
-#    endif
-#    include <windows.h>
-#    undef CreateDirectory
-#    undef CreateWindow
-#    undef GetMessage
-
-// This function cannot be marked as 'static', even though it may seem to be,
-// as it requires external linkage, which 'static' prevents
-__declspec(dllexport) int32_t
-    StartOpenRCT2(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCommandLine, int32_t nCmdShow);
-#endif // _WIN32

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -23,6 +23,16 @@
 #include <ctime>
 #include <random>
 
+#ifdef _WIN32
+#    ifndef NOMINMAX
+#        define NOMINMAX
+#    endif
+#    ifndef WIN32_LEAN_AND_MEAN
+#        define WIN32_LEAN_AND_MEAN
+#    endif
+#    include <windows.h>
+#endif // _WIN32
+
 int32_t SquaredMetresToSquaredFeet(int32_t squaredMetres)
 {
     // 1 metre squared = 10.7639104 feet squared


### PR DESCRIPTION
Fixes issue for https://github.com/OpenRCT2/OpenRCT2/pull/21996 (also should improve build times on windows)