### PR TITLE
Add literal suffix rule to clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,9 +3,12 @@ Checks: >
     -*,
     cppcoreguidelines-macro-usage,
     modernize-use-nullptr,
-    modernize-use-override
+    modernize-use-override,
+    readability-uppercase-literal-suffix
 CheckOptions:
     - key: cppcoreguidelines-macro-usage.AllowedRegexp
       value: 'validate_global_widx|NETWORK_STREAM_VERSION'
+    - key: readability-uppercase-literal-suffix.NewSuffixes
+      value: 'u;L;uL;LL;uLL'
 WarningsAsErrors: true
 FormatStyle: 'file'


### PR DESCRIPTION
This is what the codebase already uses (at least in most places).