### PR TITLE
Refactor metal supports

### DIFF
--- a/src/openrct2/paint/support/MetalSupports.cpp
+++ b/src/openrct2/paint/support/MetalSupports.cpp
@@ -135,48 +135,62 @@ static constexpr uint8_t supportTypeToHeight[] = {
 };
 
 struct MetalSupportsImages {
-    uint16_t base_id;
-    uint16_t beam_id;
+    ImageIndex base;
+    ImageIndex beamA;
+    ImageIndex beamB;
 };
 
-/** rct2: 0x0097B15C */
-static constexpr MetalSupportsImages _97B15C[] = {
-    { 3243, 3209 }, // MetalSupportType::Tubes
-    { 3279, 3262 }, // MetalSupportType::Fork
-    { 3298, 3262 }, // MetalSupportType::ForkAlt
-    { 3334, 3317 }, // MetalSupportType::Boxed
-    {    0, 3658 }, // MetalSupportType::Stick
-    {    0, 3658 }, // MetalSupportType::StickAlt
-    {    0, 3141 }, // MetalSupportType::ThickCentred
-    {    0, 3158 }, // MetalSupportType::Thick
-    {    0, 3175 }, // MetalSupportType::ThickAlt
-    {    0, 3192 }, // MetalSupportType::ThickAltCentred
-    {    0, 3124 }, // MetalSupportType::Truss
-    { 3243, 3209 }, // MetalSupportType::TubesInverted
-    { 3334, 3353 }, // MetalSupportType::BoxedCoated
-};
-
-/** rct2: 0x0097B190 */
-static constexpr MetalSupportsImages _97B190[] = {
-    { 3243, 3226 }, // 3209
-    { 3279, 3262 },
-    { 3298, 3262 },
-    { 3334, 3317 },
-    {    0, 3658 },
-    {    0, 3658 },
-    {    0, 3141 },
-    {    0, 3158 },
-    {    0, 3175 },
-    {    0, 3192 },
-    {    0, 3124 },
-    { 3243, 3226 }, // 3209
-    { 3334, 3353 },
+/** rct2: 0x0097B15C, 0x0097B190 */
+static constexpr MetalSupportsImages kSupportBasesAndBeams[] = {
+    { 3243, 3209, 3226 }, // MetalSupportType::Tubes
+    { 3279, 3262, 3262 }, // MetalSupportType::Fork
+    { 3298, 3262, 3262 }, // MetalSupportType::ForkAlt
+    { 3334, 3317, 3317 }, // MetalSupportType::Boxed
+    {    0, 3658, 3658 }, // MetalSupportType::Stick
+    {    0, 3658, 3658 }, // MetalSupportType::StickAlt
+    {    0, 3141, 3141 }, // MetalSupportType::ThickCentred
+    {    0, 3158, 3158 }, // MetalSupportType::Thick
+    {    0, 3175, 3175 }, // MetalSupportType::ThickAlt
+    {    0, 3192, 3192 }, // MetalSupportType::ThickAltCentred
+    {    0, 3124, 3124 }, // MetalSupportType::Truss
+    { 3243, 3209, 3226 }, // MetalSupportType::TubesInverted
+    { 3334, 3353, 3353 }, // MetalSupportType::BoxedCoated
 };
 
 /** rct2: 0x0097B404 */
-static constexpr uint8_t metal_supports_slope_image_map[] = {
-     0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,  0,
-     0,  0,  0,  0,  0,  0,  0, 15,  0,  0,  0, 16,  0, 17, 18,  0,
+static constexpr uint8_t kMetalSupportsSlopeImageOffsetMap[] = {
+    0,  // kTileSlopeFlat
+    1,  // kTileSlopeNCornerUp
+    2,  // kTileSlopeECornerUp
+    3,  // kTileSlopeNESideUp
+    4,  // kTileSlopeSCornerUp
+    5,  // kTileSlopeNSValley
+    6,  // kTileSlopeSESideUp
+    7,  // kTileSlopeWCornerDown
+    8,  // kTileSlopeWCornerUp
+    9,  // kTileSlopeNWSideUp
+    10, // kTileSlopeWEValley
+    11, // kTileSlopeSCornerDown
+    12, // kTileSlopeSWSideUp
+    13, // kTileSlopeECornerDown
+    14, // kTileSlopeNCornerDown
+    0,  // (invalid)
+    0,  // (invalid)
+    0,  // (invalid)
+    0,  // (invalid)
+    0,  // (invalid)
+    0,  // (invalid)
+    0,  // (invalid)
+    0,  // (invalid)
+    15, // kTileSlopeDiagonalFlag | kTileSlopeWCornerDown
+    0,  // (invalid)
+    0,  // (invalid)
+    0,  // (invalid)
+    16, // kTileSlopeDiagonalFlag | kTileSlopeSCornerDown
+    0,  // (invalid)
+    17, // kTileSlopeDiagonalFlag | kTileSlopeECornerDown
+    18, // kTileSlopeDiagonalFlag | kTileSlopeNCornerDown
+    0,  // (invalid)
 };
 // clang-format on
 
@@ -296,7 +310,7 @@ bool MetalASupportsPaintSetup(
     }
     int16_t si = height;
     if (supportSegments[segment].slope & kTileSlopeAboveTrackOrScenery || height - supportSegments[segment].height < 6
-        || _97B15C[supportType].base_id == 0)
+        || kSupportBasesAndBeams[supportType].base == 0)
     {
         height = supportSegments[segment].height;
     }
@@ -305,8 +319,8 @@ bool MetalASupportsPaintSetup(
         int8_t xOffset = SupportBoundBoxes[segment].x;
         int8_t yOffset = SupportBoundBoxes[segment].y;
 
-        uint32_t imageIndex = _97B15C[supportType].base_id;
-        imageIndex += metal_supports_slope_image_map[supportSegments[segment].slope & kTileSlopeMask];
+        auto imageIndex = kSupportBasesAndBeams[supportType].base;
+        imageIndex += kMetalSupportsSlopeImageOffsetMap[supportSegments[segment].slope & kTileSlopeMask];
         auto image_id = imageTemplate.WithIndex(imageIndex);
 
         PaintAddImageAsParent(session, image_id, { xOffset, yOffset, supportSegments[segment].height }, { 0, 0, 5 });
@@ -329,7 +343,7 @@ bool MetalASupportsPaintSetup(
         int8_t xOffset = SupportBoundBoxes[segment].x;
         int8_t yOffset = SupportBoundBoxes[segment].y;
 
-        uint32_t imageIndex = _97B15C[supportType].beam_id;
+        uint32_t imageIndex = kSupportBasesAndBeams[supportType].beamA;
         imageIndex += heightDiff - 1;
         auto image_id = imageTemplate.WithIndex(imageIndex);
 
@@ -357,7 +371,7 @@ bool MetalASupportsPaintSetup(
         int8_t xOffset = SupportBoundBoxes[segment].x;
         int8_t yOffset = SupportBoundBoxes[segment].y;
 
-        uint32_t imageIndex = _97B15C[supportType].beam_id;
+        uint32_t imageIndex = kSupportBasesAndBeams[supportType].beamA;
         imageIndex += beamLength - 1;
 
         if (count == 3 && beamLength == 0x10)
@@ -401,7 +415,7 @@ bool MetalASupportsPaintSetup(
         int8_t xOffset = SupportBoundBoxes[segment].x;
         int8_t yOffset = SupportBoundBoxes[segment].y;
 
-        uint32_t imageIndex = _97B190[supportType].beam_id;
+        auto imageIndex = kSupportBasesAndBeams[supportType].beamB;
         imageIndex += beamLength - 1;
         auto image_id = imageTemplate.WithIndex(imageIndex);
 
@@ -505,14 +519,14 @@ bool MetalBSupportsPaintSetup(
     int32_t si = baseHeight;
 
     if ((supportSegments[segment].slope & kTileSlopeAboveTrackOrScenery) || (baseHeight - supportSegments[segment].height < 6)
-        || (_97B15C[supportType].base_id == 0))
+        || (kSupportBasesAndBeams[supportType].beamA == 0))
     {
         baseHeight = supportSegments[segment].height;
     }
     else
     {
-        uint32_t imageOffset = metal_supports_slope_image_map[supportSegments[segment].slope & kTileSlopeMask];
-        uint32_t imageId = _97B15C[supportType].base_id + imageOffset;
+        uint32_t imageOffset = kMetalSupportsSlopeImageOffsetMap[supportSegments[segment].slope & kTileSlopeMask];
+        uint32_t imageId = kSupportBasesAndBeams[supportType].base + imageOffset;
 
         PaintAddImageAsParent(
             session, imageTemplate.WithIndex(imageId), { SupportBoundBoxes[segment], supportSegments[segment].height },
@@ -531,7 +545,7 @@ bool MetalBSupportsPaintSetup(
     if (heightDiff > 0)
     {
         PaintAddImageAsParent(
-            session, imageTemplate.WithIndex(_97B15C[supportType].beam_id + (heightDiff - 1)),
+            session, imageTemplate.WithIndex(kSupportBasesAndBeams[supportType].beamA + (heightDiff - 1)),
             { SupportBoundBoxes[segment], baseHeight }, { 0, 0, heightDiff - 1 });
     }
 
@@ -555,7 +569,7 @@ bool MetalBSupportsPaintSetup(
             break;
         }
 
-        uint32_t imageId = _97B15C[supportType].beam_id + (beamLength - 1);
+        uint32_t imageId = kSupportBasesAndBeams[supportType].beamA + (beamLength - 1);
 
         if (i % 4 == 0)
         {
@@ -594,7 +608,7 @@ bool MetalBSupportsPaintSetup(
                 break;
             }
 
-            uint32_t imageId = _97B15C[supportType].beam_id + (beamLength - 1);
+            uint32_t imageId = kSupportBasesAndBeams[supportType].beamA + (beamLength - 1);
             PaintAddImageAsParent(
                 session, imageTemplate.WithIndex(imageId), { SupportBoundBoxes[segment], baseHeight },
                 { { SupportBoundBoxes[segment], height }, { 0, 0, 0 } });
@@ -679,7 +693,7 @@ bool PathPoleSupportsPaintSetup(
     }
     else
     {
-        uint8_t imageOffset = metal_supports_slope_image_map[supportSegments[segment].slope & kTileSlopeMask];
+        uint8_t imageOffset = kMetalSupportsSlopeImageOffsetMap[supportSegments[segment].slope & kTileSlopeMask];
         baseHeight = supportSegments[segment].height;
 
         PaintAddImageAsParent(


### PR DESCRIPTION
There are two functions to draw metal supports which are very similar. This makes some changes to make them more similar in terms of variable names.

It also refactors/names some table related to metal supports.