### PR TITLE
Remove STR_VIEWPORT

### DIFF
--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -385,7 +385,7 @@ static void WidgetText(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetInde
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
 
-    if (widget.text == STR_NONE || widget.text == STR_VIEWPORT)
+    if (widget.text == STR_NONE || widget.content == kWidgetContentEmpty)
         return;
 
     // Get the colour

--- a/src/openrct2-ui/interface/Widget.h
+++ b/src/openrct2-ui/interface/Widget.h
@@ -19,7 +19,10 @@ ImageId GetColourButtonImage(colour_t colour);
 Widget* GetWidgetByIndex(const WindowBase& w, WidgetIndex widgetIndex);
 
 constexpr auto kWidgetsEnd = Widget{ WindowWidgetType::Last, 0, 0, 0, 0, 0, 0, 0 };
+constexpr uint32_t kWidgetContentEmpty = 0xFFFFFFFF;
 constexpr auto kBarBlink = (1u << 31);
+constexpr uint8_t kScrollBarWidth = 10;
+constexpr ScreenSize kTabSize = { 31, 27 };
 
 enum class WindowColour : uint8_t
 {
@@ -29,13 +32,9 @@ enum class WindowColour : uint8_t
     Quaternary,
 };
 
-constexpr uint8_t kScrollBarWidth = 10;
-
-constexpr ScreenSize kTabSize = { 31, 27 };
-
 constexpr Widget MakeWidget(
     const ScreenCoordsXY& origin, const ScreenSize& size, WindowWidgetType type, WindowColour colour,
-    uint32_t content = 0xFFFFFFFF, StringId tooltip = STR_NONE)
+    uint32_t content = kWidgetContentEmpty, StringId tooltip = STR_NONE)
 {
     Widget out = {};
     out.left = origin.x;
@@ -91,7 +90,7 @@ constexpr Widget MakeTab(const ScreenCoordsXY& origin, StringId tooltip = STR_NO
 
 constexpr Widget MakeSpinnerDecreaseWidget(
     const ScreenCoordsXY& origin, const ScreenSize& size, [[maybe_unused]] WindowWidgetType type, WindowColour colour,
-    [[maybe_unused]] uint32_t content = 0xFFFFFFFF, StringId tooltip = STR_NONE)
+    [[maybe_unused]] uint32_t content = kWidgetContentEmpty, StringId tooltip = STR_NONE)
 {
     const int16_t xPos = origin.x + size.width - 26;
     const int16_t yPos = origin.y + 1;
@@ -103,7 +102,7 @@ constexpr Widget MakeSpinnerDecreaseWidget(
 
 constexpr Widget MakeSpinnerIncreaseWidget(
     const ScreenCoordsXY& origin, const ScreenSize& size, [[maybe_unused]] WindowWidgetType type, WindowColour colour,
-    [[maybe_unused]] uint32_t content = 0xFFFFFFFF, StringId tooltip = STR_NONE)
+    [[maybe_unused]] uint32_t content = kWidgetContentEmpty, StringId tooltip = STR_NONE)
 {
     const int16_t xPos = origin.x + size.width - 13;
     const int16_t yPos = origin.y + 1;
@@ -118,14 +117,14 @@ constexpr Widget MakeSpinnerIncreaseWidget(
 
 constexpr Widget MakeDropdownBoxWidget(
     const ScreenCoordsXY& origin, const ScreenSize& size, [[maybe_unused]] WindowWidgetType type, WindowColour colour,
-    [[maybe_unused]] uint32_t content = 0xFFFFFFFF, StringId tooltip = STR_NONE)
+    [[maybe_unused]] uint32_t content = kWidgetContentEmpty, StringId tooltip = STR_NONE)
 {
     return MakeWidget(origin, size, type, colour, content);
 }
 
 constexpr Widget MakeDropdownButtonWidget(
     const ScreenCoordsXY& origin, const ScreenSize& size, [[maybe_unused]] WindowWidgetType type, WindowColour colour,
-    [[maybe_unused]] uint32_t content = 0xFFFFFFFF, StringId tooltip = STR_NONE)
+    [[maybe_unused]] uint32_t content = kWidgetContentEmpty, StringId tooltip = STR_NONE)
 {
     const int16_t xPos = origin.x + size.width - 11;
     const int16_t yPos = origin.y + 1;

--- a/src/openrct2-ui/windows/Main.cpp
+++ b/src/openrct2-ui/windows/Main.cpp
@@ -19,7 +19,7 @@ namespace OpenRCT2::Ui::Windows
 {
     // clang-format off
 static Widget _mainWidgets[] = {
-    MakeWidget({0, 0}, {0, 0}, WindowWidgetType::Viewport, WindowColour::Primary, STR_VIEWPORT),
+    MakeWidget({0, 0}, {0, 0}, WindowWidgetType::Viewport, WindowColour::Primary),
     kWidgetsEnd,
 };
     // clang-format on

--- a/src/openrct2-ui/windows/Main.cpp
+++ b/src/openrct2-ui/windows/Main.cpp
@@ -12,7 +12,6 @@
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
 #include <openrct2/config/Config.h>
-#include <openrct2/localisation/StringIds.h>
 #include <openrct2/world/Footpath.h>
 
 namespace OpenRCT2::Ui::Windows

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -242,11 +242,11 @@ constexpr int32_t RCT1_LIGHT_OFFSET = 4;
 // 0x009ADC34
 static Widget _mainWidgets[] = {
     MAIN_RIDE_WIDGETS,
-    MakeWidget({  3,  60}, {288, 107}, WindowWidgetType::Viewport,      WindowColour::Secondary, STR_VIEWPORT                                           ),
-    MakeWidget({ 35,  46}, {222,  12}, WindowWidgetType::DropdownMenu,      WindowColour::Secondary, 0xFFFFFFFF,                 STR_VIEW_SELECTION         ),
-    MakeWidget({245,  47}, { 11,  10}, WindowWidgetType::Button,        WindowColour::Secondary, STR_DROPDOWN_GLYPH,         STR_VIEW_SELECTION         ),
-    MakeWidget({  3, 167}, {288,  11}, WindowWidgetType::LabelCentred, WindowColour::Secondary                                                         ),
-    MakeWidget({291,  46}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, 0xFFFFFFFF,                 STR_OPEN_CLOSE_OR_TEST_RIDE),
+    MakeWidget({  3,  60}, {288, 107}, WindowWidgetType::Viewport,      WindowColour::Secondary                                                                  ),
+    MakeWidget({ 35,  46}, {222,  12}, WindowWidgetType::DropdownMenu,  WindowColour::Secondary, kWidgetContentEmpty,                 STR_VIEW_SELECTION         ),
+    MakeWidget({245,  47}, { 11,  10}, WindowWidgetType::Button,        WindowColour::Secondary, STR_DROPDOWN_GLYPH,                  STR_VIEW_SELECTION         ),
+    MakeWidget({  3, 167}, {288,  11}, WindowWidgetType::LabelCentred,  WindowColour::Secondary                                                                  ),
+    MakeWidget({291,  46}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, kWidgetContentEmpty,                 STR_OPEN_CLOSE_OR_TEST_RIDE),
     MakeWidget({291,  70}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_CONSTRUCTION),           STR_CONSTRUCTION           ),
     MakeWidget({291,  94}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_RENAME),                 STR_NAME_RIDE_TIP          ),
     MakeWidget({291, 118}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_LOCATE),                 STR_LOCATE_SUBJECT_TIP     ),

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -47,11 +47,11 @@ enum WindowSignWidgetIdx {
 // 0x9AEE00
 static Widget _signWidgets[] = {
     WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({      3,      17}, {85, 60}, WindowWidgetType::Viewport,  WindowColour::Secondary, STR_VIEWPORT                                 ), // Viewport
+    MakeWidget({      3,      17}, {85, 60}, WindowWidgetType::Viewport,  WindowColour::Secondary                                                        ), // Viewport
     MakeWidget({WW - 25,      19}, {24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_RENAME),   STR_CHANGE_SIGN_TEXT_TIP       ), // change sign button
     MakeWidget({WW - 25,      67}, {24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_DEMOLISH), STR_DEMOLISH_SIGN_TIP          ), // demolish button
-    MakeWidget({      5, WH - 16}, {12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,   STR_SELECT_MAIN_SIGN_COLOUR_TIP), // Main colour
-    MakeWidget({     17, WH - 16}, {12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,   STR_SELECT_TEXT_COLOUR_TIP     ), // Text colour
+    MakeWidget({      5, WH - 16}, {12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, kWidgetContentEmpty,   STR_SELECT_MAIN_SIGN_COLOUR_TIP), // Main colour
+    MakeWidget({     17, WH - 16}, {12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, kWidgetContentEmpty,   STR_SELECT_TEXT_COLOUR_TIP     ), // Text colour
     kWidgetsEnd,
 };
 

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -12,7 +12,6 @@
 #include "../common.h"
 
 constexpr StringId STR_NONE = 0xFFFF;
-constexpr StringId STR_VIEWPORT = 0xFFFE;
 
 enum : uint16_t
 {


### PR DESCRIPTION
This removes `STR_VIEWPORT` from StringIds.h. It's used in two places, but not for any particularly unique purpose.

I've replaced the test in `WidgetText` with one on `kWidgetContentEmpty`, a new constant I've introduced in Widget.h, just set to `0xFFFF'FFFF`.