### PR TITLE
Keep options window centred after a resize

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Improved: [#21981] Rendering performance of the map window has been improved considerably.
 - Improved: [#21981] The map window now defaults to showing as much of the map as fits the screen.
 - Improved: [#21983] Taking a screenshot now shows a message again, closing when taking another.
+- Improved: [#22026] The options window now stays centred when window scaling is changed.
 - Change: [#7248] Small mini-maps are now centred in the map window.
 - Fix: [#13294] Map corners are cut off in some directions (original bug).
 - Fix: [#21974] No reason specified when attempting to place benches, lamps, or bins on path with no unconnected edges (original bug).

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -785,14 +785,6 @@ private:
             WindowRelocateWindows(_width, _height);
         }
 
-        // Keep options window centred after a resize
-        auto* optionsWindow = WindowFindByClass(WindowClass::Options);
-        if (optionsWindow != nullptr)
-        {
-            optionsWindow->windowPos.x = (ContextGetWidth() - optionsWindow->width) / 2;
-            optionsWindow->windowPos.y = (ContextGetHeight() - optionsWindow->height) / 2;
-        }
-
         GfxInvalidateScreen();
 
         // Check if the window has been resized in windowed mode and update the config file accordingly

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -785,6 +785,14 @@ private:
             WindowRelocateWindows(_width, _height);
         }
 
+        // Keep options window centred after a resize
+        auto* optionsWindow = WindowFindByClass(WindowClass::Options);
+        if (optionsWindow != nullptr)
+        {
+            optionsWindow->windowPos.x = (ContextGetWidth() - optionsWindow->width) / 2;
+            optionsWindow->windowPos.y = (ContextGetHeight() - optionsWindow->height) / 2;
+        }
+
         GfxInvalidateScreen();
 
         // Check if the window has been resized in windowed mode and update the config file accordingly

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -1402,6 +1402,14 @@ void WindowResizeGui(int32_t width, int32_t height)
         optionsWind->windowPos.x = width - 80;
     }
 
+    // Keep options window centred after a resize
+    WindowBase* optionsWindow = WindowFindByClass(WindowClass::Options);
+    if (optionsWindow != nullptr)
+    {
+        optionsWindow->windowPos.x = (ContextGetWidth() - optionsWindow->width) / 2;
+        optionsWindow->windowPos.y = (ContextGetHeight() - optionsWindow->height) / 2;
+    }
+
     GfxInvalidateScreen();
 }
 


### PR DESCRIPTION
When the window scaling is changed, the options window is often moved far from when the cursor is. Changing the window scaling factor by more than one increment (e.g. 1.0 -> 1.25 -> 1.5) becomes quite cumbersome in this way. This PR changes the process such that the options window is always repositioned to the centre when the window scale factor is resized.