### PR TITLE
Move speed literal _mph to Speed.hpp

### DIFF
--- a/src/openrct2/common.h
+++ b/src/openrct2/common.h
@@ -105,14 +105,6 @@ constexpr money64 ToMoney64(money16 value)
     return value == kMoney16Undefined ? kMoney64Undefined : value;
 }
 
-// Note: Only valid for 5 decimal places.
-constexpr int32_t operator"" _mph(long double speedMph)
-{
-    uint32_t wholeNumber = speedMph;
-    uint64_t fraction = (speedMph - wholeNumber) * 100000;
-    return wholeNumber << 16 | ((fraction << 16) / 100000);
-}
-
 using StringId = uint16_t;
 
 #define abstract = 0

--- a/src/openrct2/core/Speed.hpp
+++ b/src/openrct2/core/Speed.hpp
@@ -1,0 +1,20 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2024 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+// Note: Only valid for 5 decimal places.
+constexpr int32_t operator"" _mph(long double speedMph)
+{
+    uint32_t wholeNumber = speedMph;
+    uint64_t fraction = (speedMph - wholeNumber) * 100000;
+    return wholeNumber << 16 | ((fraction << 16) / 100000);
+}

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -218,6 +218,7 @@
     <ClInclude Include="core\Range.hpp" />
     <ClInclude Include="core\RTL.h" />
     <ClInclude Include="core\FixedVector.h" />
+    <ClInclude Include="core\Speed.hpp" />
     <ClInclude Include="core\String.hpp" />
     <ClInclude Include="core\StringBuilder.h" />
     <ClInclude Include="core\StringReader.h" />

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -20,6 +20,7 @@
 #include "../audio/audio.h"
 #include "../config/Config.h"
 #include "../core/Memory.hpp"
+#include "../core/Speed.hpp"
 #include "../entity/EntityRegistry.h"
 #include "../entity/Particle.h"
 #include "../entity/Yaw.hpp"

--- a/src/openrct2/ride/VehiclePaint.cpp
+++ b/src/openrct2/ride/VehiclePaint.cpp
@@ -11,6 +11,7 @@
 
 #include "../Game.h"
 #include "../GameState.h"
+#include "../core/Speed.hpp"
 #include "../drawing/Drawing.h"
 #include "../drawing/LightFX.h"
 #include "../entity/EntityRegistry.h"

--- a/src/openrct2/ride/VehicleRiderControl.cpp
+++ b/src/openrct2/ride/VehicleRiderControl.cpp
@@ -7,6 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#include "../core/Speed.hpp"
 #include "../entity/EntityRegistry.h"
 #include "Vehicle.h"
 


### PR DESCRIPTION
Moving things out of `common.h`, one thing at a time...

To do: add header to libopenrct2.vcxproj