### PR TITLE
 Move fixed point and money types into FixedPoint.hpp and Money.hpp 

### DIFF
--- a/src/openrct2-ui/interface/Graph.h
+++ b/src/openrct2-ui/interface/Graph.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <openrct2/common.h>
+#include <openrct2/core/Money.hpp>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/world/Location.hpp>
 

--- a/src/openrct2/Cheats.h
+++ b/src/openrct2/Cheats.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "common.h"
+#include "core/Money.hpp"
 
 enum class StaffSpeedCheat
 {

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -27,6 +27,7 @@
 #include "core/Console.hpp"
 #include "core/File.h"
 #include "core/FileScanner.h"
+#include "core/Money.hpp"
 #include "core/Path.hpp"
 #include "entity/EntityRegistry.h"
 #include "entity/PatrolArea.h"

--- a/src/openrct2/common.h
+++ b/src/openrct2/common.h
@@ -38,58 +38,6 @@ using datetime64 = uint64_t;
 
 constexpr datetime64 DATETIME64_MIN = 0;
 
-// Money is stored as a multiple of 0.10.
-using money16 = fixed16_1dp;
-using money32 = fixed32_1dp;
-using money64 = fixed64_1dp;
-
-// For a user defined floating point literal, the parameter type must be a
-// `long double` which is problematic on ppc64el, as the architecture uses a
-// pair of `doubles` to represent that type. This cannot be converted to a
-// `constexpr`. As a workaround, statically cast the `long double` down to a
-// `double`. All of the uses of _GBP constants fit just fine, and if anyone
-// really tries to use a gigantic constant that can't fit in a double, they are
-// probably going to be breaking other things anyways.
-// For more details, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=26374
-constexpr money64 operator"" _GBP(long double money) noexcept
-{
-    return static_cast<double>(money) * 10;
-}
-
-constexpr money64 ToMoney64FromGBP(int32_t money) noexcept
-{
-    return money * 10;
-}
-
-constexpr money64 ToMoney64FromGBP(int64_t money) noexcept
-{
-    return money * 10;
-}
-
-constexpr money64 ToMoney64FromGBP(double money) noexcept
-{
-    return money * 10;
-}
-
-constexpr money16 kMoney16Undefined = static_cast<money16>(static_cast<uint16_t>(0xFFFF));
-constexpr money32 kMoney32Undefined = static_cast<money32>(0x80000000);
-constexpr money64 kMoney64Undefined = static_cast<money64>(0x8000000000000000);
-
-constexpr money16 ToMoney16(money64 value)
-{
-    return value == kMoney64Undefined ? kMoney16Undefined : value;
-}
-
-constexpr money64 ToMoney64(money32 value)
-{
-    return value == kMoney32Undefined ? kMoney64Undefined : value;
-}
-
-constexpr money64 ToMoney64(money16 value)
-{
-    return value == kMoney16Undefined ? kMoney64Undefined : value;
-}
-
 using StringId = uint16_t;
 
 #define abstract = 0

--- a/src/openrct2/common.h
+++ b/src/openrct2/common.h
@@ -38,25 +38,10 @@ using datetime64 = uint64_t;
 
 constexpr datetime64 DATETIME64_MIN = 0;
 
-// Represent fixed point numbers. dp = decimal point
-using fixed8_1dp = uint8_t;
-using fixed8_2dp = uint8_t;
-using fixed16_1dp = int16_t;
-using fixed16_2dp = int16_t;
-using fixed32_1dp = int32_t;
-using fixed32_2dp = int32_t;
-using fixed64_1dp = int64_t;
-
 // Money is stored as a multiple of 0.10.
 using money16 = fixed16_1dp;
 using money32 = fixed32_1dp;
 using money64 = fixed64_1dp;
-
-// Construct a fixed point number. For example, to create the value 3.65 you
-// would write FIXED_2DP(3,65)
-#define FIXED_XDP(x, whole, fraction) ((whole) * (10 * (x)) + (fraction))
-#define FIXED_1DP(whole, fraction) FIXED_XDP(1, whole, fraction)
-#define FIXED_2DP(whole, fraction) FIXED_XDP(10, whole, fraction)
 
 // For a user defined floating point literal, the parameter type must be a
 // `long double` which is problematic on ppc64el, as the architecture uses a

--- a/src/openrct2/core/FixedPoint.hpp
+++ b/src/openrct2/core/FixedPoint.hpp
@@ -1,0 +1,27 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2024 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+// Represent fixed point numbers. dp = decimal point
+using fixed8_1dp = uint8_t;
+using fixed8_2dp = uint8_t;
+using fixed16_1dp = int16_t;
+using fixed16_2dp = int16_t;
+using fixed32_1dp = int32_t;
+using fixed32_2dp = int32_t;
+using fixed64_1dp = int64_t;
+
+// Construct a fixed point number. For example, to create the value 3.65 you
+// would write FIXED_2DP(3,65)
+#define FIXED_XDP(x, whole, fraction) ((whole) * (10 * (x)) + (fraction))
+#define FIXED_1DP(whole, fraction) FIXED_XDP(1, whole, fraction)
+#define FIXED_2DP(whole, fraction) FIXED_XDP(10, whole, fraction)

--- a/src/openrct2/core/Money.hpp
+++ b/src/openrct2/core/Money.hpp
@@ -1,0 +1,64 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2024 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include "FixedPoint.hpp"
+
+// Money is stored as a multiple of 0.10.
+using money16 = fixed16_1dp;
+using money32 = fixed32_1dp;
+using money64 = fixed64_1dp;
+
+// For a user defined floating point literal, the parameter type must be a
+// `long double` which is problematic on ppc64el, as the architecture uses a
+// pair of `doubles` to represent that type. This cannot be converted to a
+// `constexpr`. As a workaround, statically cast the `long double` down to a
+// `double`. All of the uses of _GBP constants fit just fine, and if anyone
+// really tries to use a gigantic constant that can't fit in a double, they are
+// probably going to be breaking other things anyways.
+// For more details, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=26374
+constexpr money64 operator"" _GBP(long double money) noexcept
+{
+    return static_cast<double>(money) * 10;
+}
+
+constexpr money64 ToMoney64FromGBP(int32_t money) noexcept
+{
+    return money * 10;
+}
+
+constexpr money64 ToMoney64FromGBP(int64_t money) noexcept
+{
+    return money * 10;
+}
+
+constexpr money64 ToMoney64FromGBP(double money) noexcept
+{
+    return money * 10;
+}
+
+constexpr money16 kMoney16Undefined = static_cast<money16>(static_cast<uint16_t>(0xFFFF));
+constexpr money32 kMoney32Undefined = static_cast<money32>(0x80000000);
+constexpr money64 kMoney64Undefined = static_cast<money64>(0x8000000000000000);
+
+constexpr money16 ToMoney16(money64 value)
+{
+    return value == kMoney64Undefined ? kMoney16Undefined : value;
+}
+
+constexpr money64 ToMoney64(money32 value)
+{
+    return value == kMoney32Undefined ? kMoney64Undefined : value;
+}
+
+constexpr money64 ToMoney64(money16 value)
+{
+    return value == kMoney16Undefined ? kMoney64Undefined : value;
+}

--- a/src/openrct2/entity/MoneyEffect.h
+++ b/src/openrct2/entity/MoneyEffect.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "../core/Money.hpp"
 #include "EntityBase.h"
 
 class DataSerialiser;

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -212,6 +212,7 @@
     <ClInclude Include="core\Memory.hpp" />
     <ClInclude Include="core\MemoryStream.h" />
     <ClInclude Include="core\Meta.hpp" />
+    <ClInclude Include="core\Money.hpp" />
     <ClInclude Include="core\Numerics.hpp" />
     <ClInclude Include="core\OrcaStream.hpp" />
     <ClInclude Include="core\Path.hpp" />

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -199,6 +199,7 @@
     <ClInclude Include="core\FileStream.h" />
     <ClInclude Include="core\FileSystem.hpp" />
     <ClInclude Include="core\FileWatcher.h" />
+    <ClInclude Include="core\FixedPoint.hpp" />
     <ClInclude Include="core\GroupVector.hpp" />
     <ClInclude Include="core\Guard.hpp" />
     <ClInclude Include="core\Http.h" />

--- a/src/openrct2/localisation/Formatter.h
+++ b/src/openrct2/localisation/Formatter.h
@@ -12,6 +12,7 @@
 #include "../Identifiers.h"
 #include "../common.h"
 #include "../core/Guard.hpp"
+#include "../core/Money.hpp"
 #include "../core/String.hpp"
 
 #include <array>

--- a/src/openrct2/management/Finance.h
+++ b/src/openrct2/management/Finance.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "../common.h"
+#include "../core/Money.hpp"
 #include "Research.h"
 
 enum class ExpenditureType : int32_t

--- a/src/openrct2/object/BannerSceneryEntry.h
+++ b/src/openrct2/object/BannerSceneryEntry.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../common.h"
+#include "../core/Money.hpp"
 #include "ObjectTypes.h"
 
 enum

--- a/src/openrct2/object/LargeSceneryEntry.h
+++ b/src/openrct2/object/LargeSceneryEntry.h
@@ -8,7 +8,8 @@
  *****************************************************************************/
 
 #pragma once
-#include "../common.h"
+
+#include "../core/Money.hpp"
 #include "../interface/Cursors.h"
 #include "../world/Location.hpp"
 #include "ObjectTypes.h"

--- a/src/openrct2/object/PathAdditionEntry.h
+++ b/src/openrct2/object/PathAdditionEntry.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "../common.h"
+#include "../core/Money.hpp"
 #include "../interface/Cursors.h"
 #include "ObjectTypes.h"
 

--- a/src/openrct2/object/SmallSceneryEntry.h
+++ b/src/openrct2/object/SmallSceneryEntry.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "../common.h"
+#include "../core/Money.hpp"
 #include "../interface/Cursors.h"
 #include "ObjectTypes.h"
 

--- a/src/openrct2/object/WallSceneryEntry.h
+++ b/src/openrct2/object/WallSceneryEntry.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "../common.h"
+#include "../core/Money.hpp"
 #include "../interface/Cursors.h"
 #include "ObjectTypes.h"
 

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "../core/FixedPoint.hpp"
 #include "../rct12/RCT12.h"
 #include "../ride/RideRatings.h"
 #include "../world/Park.h"

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -11,6 +11,7 @@
 
 #include "../common.h"
 #include "../core/FileSystem.hpp"
+#include "../core/FixedPoint.hpp"
 #include "../rct12/RCT12.h"
 #include "../ride/RideRatings.h"
 #include "../world/Park.h"

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -13,6 +13,7 @@
 #include "../actions/ResultWithMessage.h"
 #include "../common.h"
 #include "../core/BitSet.hpp"
+#include "../core/FixedPoint.hpp"
 #include "../object/MusicObject.h"
 #include "../rct2/DATLimits.h"
 #include "../rct2/Limits.h"

--- a/src/openrct2/ride/RideRatings.h
+++ b/src/openrct2/ride/RideRatings.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../common.h"
+#include "../core/FixedPoint.hpp"
 #include "../world/Location.hpp"
 #include "RideTypes.h"
 

--- a/src/openrct2/ride/ShopItem.h
+++ b/src/openrct2/ride/ShopItem.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../common.h"
+#include "../core/Money.hpp"
 #include "../entity/Litter.h"
 #include "../util/Util.h"
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -19,6 +19,7 @@
 #include "../audio/AudioMixer.h"
 #include "../audio/audio.h"
 #include "../config/Config.h"
+#include "../core/FixedPoint.hpp"
 #include "../core/Memory.hpp"
 #include "../core/Speed.hpp"
 #include "../entity/EntityRegistry.h"

--- a/src/openrct2/util/Util.h
+++ b/src/openrct2/util/Util.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../common.h"
+#include "../core/Money.hpp"
 #include "../core/String.hpp"
 
 #include <cstdio>

--- a/src/openrct2/world/Scenery.h
+++ b/src/openrct2/world/Scenery.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "../common.h"
+#include "../core/Money.hpp"
 #include "Location.hpp"
 #include "ScenerySelection.h"
 


### PR DESCRIPTION
Moving types out of `common.h` continues...

I'm not sure what to do with the clang-tidy warning. Ideally, we'd turn the fixed point related `#define`s into functions, but it's loosely defined in terms of return types. I'd rather this be tackled in another PR. Could you weigh in, @ZehMatt?