### PR TITLE
Add scripting support for cost expenditures (requires #21932)

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -641,6 +641,23 @@ declare global {
         "research" |
         "interest";
 
+    enum ExpenditureTypeEnum {
+        "ride_construction",
+        "ride_runningcosts",
+        "land_purchase",
+        "landscaping",
+        "park_entrance_tickets",
+        "park_ride_tickets",
+        "shop_sales",
+        "shop_stock",
+        "food_drink_sales",
+        "food_drink_stock",
+        "wages",
+        "marketing",
+        "research",
+        "interest"
+    }
+
     type ActionType =
         "balloonpress" |
         "bannerplace" |
@@ -3687,6 +3704,23 @@ declare global {
          * drowned guests and crashed coaster cars.
          */
         casualtyPenalty: number;
+
+
+        /**
+         * Gets the current expenditure multiplier for a given expenditure type,
+         * as a pecentage point of the base cost.
+         *
+         * Default value is 100.
+         */
+        getExpenditureMultiplier(expenditureType: ExpenditureTypeEnum): number
+
+        /**
+         * Sets the current expenditure multiplier for a given expenditure type,
+         * as a pecentage point of the base cost.
+         *
+         * Default value is 100.
+         */
+        setExpenditureMultiplier(expenditureType: ExpenditureTypeEnum, value: number): void
 
         /**
          * The number of tiles on the map with park ownership or construction rights.

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -194,7 +194,7 @@ namespace OpenRCT2::Ui::Windows
                 && !(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
-                auto modifiedCost = FinanceGetModifiedCost(gClearSceneryCost,ExpenditureType::Landscaping);
+                auto modifiedCost = FinanceGetModifiedCost(gClearSceneryCost, ExpenditureType::Landscaping);
                 ft.Add<money64>(modifiedCost);
                 screenCoords.x = window_clear_scenery_widgets[WIDX_PREVIEW].midX() + windowPos.x;
                 screenCoords.y = window_clear_scenery_widgets[WIDX_PREVIEW].bottom + windowPos.y + 5 + 27;

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -194,7 +194,8 @@ namespace OpenRCT2::Ui::Windows
                 && !(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
-                ft.Add<money64>(gClearSceneryCost);
+                auto modifiedCost = FinanceGetModifiedCost(gClearSceneryCost,ExpenditureType::Landscaping);
+                ft.Add<money64>(modifiedCost);
                 screenCoords.x = window_clear_scenery_widgets[WIDX_PREVIEW].midX() + windowPos.x;
                 screenCoords.y = window_clear_scenery_widgets[WIDX_PREVIEW].bottom + windowPos.y + 5 + 27;
                 DrawTextBasic(dpi, screenCoords, STR_COST_AMOUNT, ft, { TextAlignment::CENTRE });

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -88,7 +88,7 @@ static Widget window_ride_demolish_widgets[] =
                                                                                   : STR_DEMOLISH_RIDE_ID_MONEY;
                 auto ft = Formatter();
                 currentRide->FormatNameTo(ft);
-                auto modifiedCost = FinanceGetModifiedCost(_demolishRideCost,ExpenditureType::RideConstruction);
+                auto modifiedCost = FinanceGetModifiedCost(_demolishRideCost, ExpenditureType::RideConstruction);
                 ft.Add<money64>(modifiedCost);
 
                 ScreenCoordsXY stringCoords(windowPos.x + WW / 2, windowPos.y + (WH / 2) - 3);

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -88,7 +88,8 @@ static Widget window_ride_demolish_widgets[] =
                                                                                   : STR_DEMOLISH_RIDE_ID_MONEY;
                 auto ft = Formatter();
                 currentRide->FormatNameTo(ft);
-                ft.Add<money64>(_demolishRideCost);
+                auto modifiedCost = FinanceGetModifiedCost(_demolishRideCost,ExpenditureType::RideConstruction);
+                ft.Add<money64>(modifiedCost);
 
                 ScreenCoordsXY stringCoords(windowPos.x + WW / 2, windowPos.y + (WH / 2) - 3);
                 DrawTextWrapped(dpi, stringCoords, WW - 4, stringId, ft, { TextAlignment::CENTRE });

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -506,7 +506,8 @@ static constexpr uint8_t ConstructionPreviewImages[][4] = {
                 if (!(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
                 {
                     auto ft = Formatter();
-                    ft.Add<money64>(_windowFootpathCost);
+                    auto updatedCost = FinanceGetModifiedCost(_windowFootpathCost,ExpenditureType::Landscaping);
+                    ft.Add<money64>(updatedCost);
                     DrawTextBasic(dpi, screenCoords, STR_COST_LABEL, ft, { TextAlignment::CENTRE });
                 }
             }

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -506,7 +506,7 @@ static constexpr uint8_t ConstructionPreviewImages[][4] = {
                 if (!(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
                 {
                     auto ft = Formatter();
-                    auto updatedCost = FinanceGetModifiedCost(_windowFootpathCost,ExpenditureType::Landscaping);
+                    auto updatedCost = FinanceGetModifiedCost(_windowFootpathCost, ExpenditureType::Landscaping);
                     ft.Add<money64>(updatedCost);
                     DrawTextBasic(dpi, screenCoords, STR_COST_LABEL, ft, { TextAlignment::CENTRE });
                 }

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -354,7 +354,8 @@ static Widget window_install_track_widgets[] = {
             if (td6->cost != 0)
             {
                 auto ft = Formatter();
-                ft.Add<money64>(td6->cost);
+                auto cost = FinanceGetModifiedCost(td6->cost, ExpenditureType::RideConstruction);
+                ft.Add<money64>(cost);
                 DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_COST_AROUND, ft);
             }
         }

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -270,7 +270,8 @@ static Widget window_land_widgets[] = {
                 if (gLandToolRaiseCost != kMoney64Undefined && gLandToolRaiseCost != 0)
                 {
                     auto ft = Formatter();
-                    ft.Add<money64>(gLandToolRaiseCost);
+                    auto raiseCost = FinanceGetModifiedCost(gLandToolRaiseCost, ExpenditureType::Landscaping);
+                    ft.Add<money64>(raiseCost);
                     DrawTextBasic(dpi, screenCoords, STR_RAISE_COST_AMOUNT, ft, { TextAlignment::CENTRE });
                 }
                 screenCoords.y += 10;
@@ -279,7 +280,8 @@ static Widget window_land_widgets[] = {
                 if (gLandToolLowerCost != kMoney64Undefined && gLandToolLowerCost != 0)
                 {
                     auto ft = Formatter();
-                    ft.Add<money64>(gLandToolLowerCost);
+                    auto lowerCost = FinanceGetModifiedCost(gLandToolLowerCost, ExpenditureType::Landscaping);
+                    ft.Add<money64>(lowerCost);
                     DrawTextBasic(dpi, screenCoords, STR_LOWER_COST_AMOUNT, ft, { TextAlignment::CENTRE });
                 }
                 screenCoords.y += 50;
@@ -304,7 +306,8 @@ static Widget window_land_widgets[] = {
                 if (price != 0)
                 {
                     auto ft = Formatter();
-                    ft.Add<money64>(price);
+                    auto modifiedPrice = FinanceGetModifiedCost(price, ExpenditureType::Landscaping);
+                    ft.Add<money64>(modifiedPrice);
                     DrawTextBasic(dpi, screenCoords, STR_COST_AMOUNT, ft, { TextAlignment::CENTRE });
                 }
             }

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -232,7 +232,8 @@ static Widget window_land_rights_widgets[] = {
                 && !(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
-                ft.Add<money64>(_landRightsCost);
+                auto modifiedCost = FinanceGetModifiedCost(_landRightsCost, ExpenditureType::LandPurchase);
+                ft.Add<money64>(modifiedCost);
                 screenCoords = { window_land_rights_widgets[WIDX_PREVIEW].midX() + windowPos.x,
                                  window_land_rights_widgets[WIDX_PREVIEW].bottom + windowPos.y + 32 };
                 DrawTextBasic(dpi, screenCoords, STR_COST_AMOUNT, ft, { TextAlignment::CENTRE });

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -968,7 +968,7 @@ static Widget window_new_ride_widgets[] = {
                     stringId = STR_NEW_RIDE_COST_FROM;
 
                 ft = Formatter();
-                auto modifiedPrice = FinanceGetModifiedCost(price,ExpenditureType::RideConstruction);
+                auto modifiedPrice = FinanceGetModifiedCost(price, ExpenditureType::RideConstruction);
                 ft.Add<money64>(modifiedPrice);
                 DrawTextBasic(dpi, screenPos + ScreenCoordsXY{ textWidth, 51 }, stringId, ft, { TextAlignment::RIGHT });
             }

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -968,7 +968,8 @@ static Widget window_new_ride_widgets[] = {
                     stringId = STR_NEW_RIDE_COST_FROM;
 
                 ft = Formatter();
-                ft.Add<money64>(price);
+                auto modifiedPrice = FinanceGetModifiedCost(price,ExpenditureType::RideConstruction);
+                ft.Add<money64>(modifiedPrice);
                 DrawTextBasic(dpi, screenPos + ScreenCoordsXY{ textWidth, 51 }, stringId, ft, { TextAlignment::RIGHT });
             }
         }

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1581,7 +1581,7 @@ static Widget _rideConstructionWidgets[] = {
             if (_currentTrackPrice != kMoney64Undefined && !(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
-                ft.Add<money64>(FinanceGetModifiedCost(_currentTrackPrice,ExpenditureType::RideConstruction));
+                ft.Add<money64>(FinanceGetModifiedCost(_currentTrackPrice, ExpenditureType::RideConstruction));
                 DrawTextBasic(dpi, screenCoords, STR_COST_LABEL, ft, { TextAlignment::CENTRE });
             }
         }

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1581,7 +1581,7 @@ static Widget _rideConstructionWidgets[] = {
             if (_currentTrackPrice != kMoney64Undefined && !(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
-                ft.Add<money64>(_currentTrackPrice);
+                ft.Add<money64>(FinanceGetModifiedCost(_currentTrackPrice,ExpenditureType::RideConstruction));
                 DrawTextBasic(dpi, screenCoords, STR_COST_LABEL, ft, { TextAlignment::CENTRE });
             }
         }

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -802,7 +802,7 @@ static Widget WindowSceneryBaseWidgets[] = {
             }
 
             auto [name, price] = GetNameAndPrice(selectedSceneryEntry);
-            auto modifiedPrice = FinanceGetModifiedCost(price,ExpenditureType::Landscaping);
+            auto modifiedPrice = FinanceGetModifiedCost(price, ExpenditureType::Landscaping);
             if (modifiedPrice != kMoney64Undefined && !(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -802,10 +802,11 @@ static Widget WindowSceneryBaseWidgets[] = {
             }
 
             auto [name, price] = GetNameAndPrice(selectedSceneryEntry);
-            if (price != kMoney64Undefined && !(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
+            auto modifiedPrice = FinanceGetModifiedCost(price,ExpenditureType::Landscaping);
+            if (modifiedPrice != kMoney64Undefined && !(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
-                ft.Add<money64>(price);
+                ft.Add<money64>(modifiedPrice);
 
                 // -14
                 DrawTextBasic(

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -935,7 +935,8 @@ static Widget _staffOptionsWidgets[] = {
             if (!(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
-                ft.Add<money64>(GetStaffWage(staff->AssignedStaffType));
+                auto modifiedCost = FinanceGetModifiedCost(GetStaffWage(staff->AssignedStaffType),ExpenditureType::Wages);
+                ft.Add<money64>(modifiedCost);
                 DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_WAGES, ft);
                 screenCoords.y += kListRowHeight;
             }

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -935,7 +935,7 @@ static Widget _staffOptionsWidgets[] = {
             if (!(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
-                auto modifiedCost = FinanceGetModifiedCost(GetStaffWage(staff->AssignedStaffType),ExpenditureType::Wages);
+                auto modifiedCost = FinanceGetModifiedCost(GetStaffWage(staff->AssignedStaffType), ExpenditureType::Wages);
                 ft.Add<money64>(modifiedCost);
                 DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_WAGES, ft);
                 screenCoords.y += kListRowHeight;

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -293,7 +293,8 @@ static Widget _staffListWidgets[] = {
             if (!(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
-                ft.Add<money64>(GetStaffWage(GetSelectedStaffType()));
+                auto modifiedWage = FinanceGetModifiedCost(GetStaffWage(GetSelectedStaffType()),ExpenditureType::Wages);
+                ft.Add<money64>(modifiedWage);
                 DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ width - 155, 32 }, STR_COST_PER_MONTH, ft);
             }
 

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -293,7 +293,7 @@ static Widget _staffListWidgets[] = {
             if (!(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
-                auto modifiedWage = FinanceGetModifiedCost(GetStaffWage(GetSelectedStaffType()),ExpenditureType::Wages);
+                auto modifiedWage = FinanceGetModifiedCost(GetStaffWage(GetSelectedStaffType()), ExpenditureType::Wages);
                 ft.Add<money64>(modifiedWage);
                 DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ width - 155, 32 }, STR_COST_PER_MONTH, ft);
             }

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -194,7 +194,15 @@ static Widget _trackPlaceWidgets[] = {
                         }
                     });
                     res = GameActions::Execute(&tdAction);
-                    cost = res.Error == GameActions::Status::Ok ? res.Cost : kMoney64Undefined;
+                    if (res.Error != GameActions::Status::Ok)
+                    {
+                        cost = kMoney64Undefined;
+                    }
+                    else
+                    {
+                        auto modifiedCost = FinanceGetModifiedCost(res.Cost,ExpenditureType::RideConstruction);
+                        cost = modifiedCost;
+                    }
                 }
             }
 

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -200,7 +200,7 @@ static Widget _trackPlaceWidgets[] = {
                     }
                     else
                     {
-                        auto modifiedCost = FinanceGetModifiedCost(res.Cost,ExpenditureType::RideConstruction);
+                        auto modifiedCost = FinanceGetModifiedCost(res.Cost, ExpenditureType::RideConstruction);
                         cost = modifiedCost;
                     }
                 }

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -669,7 +669,7 @@ static Widget _trackListWidgets[] = {
             {
                 // Cost
                 ft = Formatter();
-                auto modifiedCost = FinanceGetModifiedCost(_loadedTrackDesign->cost,ExpenditureType::RideConstruction);
+                auto modifiedCost = FinanceGetModifiedCost(_loadedTrackDesign->cost, ExpenditureType::RideConstruction);
                 ft.Add<uint32_t>(modifiedCost);
                 DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_COST_AROUND, ft);
             }

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -667,6 +667,7 @@ static Widget _trackListWidgets[] = {
 
             if (_loadedTrackDesign->cost != 0)
             {
+                // Cost
                 ft = Formatter();
                 auto modifiedCost = FinanceGetModifiedCost(_loadedTrackDesign->cost,ExpenditureType::RideConstruction);
                 ft.Add<uint32_t>(modifiedCost);

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -668,7 +668,8 @@ static Widget _trackListWidgets[] = {
             if (_loadedTrackDesign->cost != 0)
             {
                 ft = Formatter();
-                ft.Add<uint32_t>(_loadedTrackDesign->cost);
+                auto modifiedCost = FinanceGetModifiedCost(_loadedTrackDesign->cost,ExpenditureType::RideConstruction);
+                ft.Add<uint32_t>(modifiedCost);
                 DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_COST_AROUND, ft);
             }
         }

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -77,6 +77,7 @@ namespace OpenRCT2
         uint8_t BankLoanInterestRate;
         money64 MaxBankLoan;
         money64 ExpenditureTable[kExpenditureTableMonthCount][EnumValue(ExpenditureType::Count)];
+        uint16_t CostMultiplierExpenditureTable[EnumValue(ExpenditureType::Count)];
         random_engine_t ScenarioRand;
         TileCoordsXY MapSize;
         money64 LandPrice;

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -93,7 +93,7 @@ void FinancePayment(money64 amount, ExpenditureType type)
 
 /**
  * Calculate the cost multiplier with the expenditure modifier applied.
-*/
+ */
 money64 FinanceGetModifiedCost(money64 cost, ExpenditureType type)
 {
     return cost * GetGameState().CostMultiplierExpenditureTable[EnumValue(type)] / 100;

--- a/src/openrct2/management/Finance.h
+++ b/src/openrct2/management/Finance.h
@@ -57,3 +57,4 @@ money64 FinanceGetMaximumLoan();
 money64 FinanceGetCurrentCash();
 
 money64 FinanceGetLastMonthShopProfit();
+money64 FinanceGetModifiedCost(money64 cost, ExpenditureType type);

--- a/src/openrct2/scripting/bindings/world/ScPark.cpp
+++ b/src/openrct2/scripting/bindings/world/ScPark.cpp
@@ -453,7 +453,7 @@ namespace OpenRCT2::Scripting
         dukglue_register_method(ctx, &ScPark::getFlag, "getFlag");
         dukglue_register_method(ctx, &ScPark::setFlag, "setFlag");
         dukglue_register_method(ctx, &ScPark::postMessage, "postMessage");
-        dukglue_register_method(ctx, &ScPark::expenditureMultiplier_get, "getExpentitureMultiplier");
+        dukglue_register_method(ctx, &ScPark::expenditureMultiplier_get, "getExpenditureMultiplier");
         dukglue_register_method(ctx, &ScPark::expenditureMultiplier_set, "setExpenditureMultiplier");
     }
 

--- a/src/openrct2/scripting/bindings/world/ScPark.cpp
+++ b/src/openrct2/scripting/bindings/world/ScPark.cpp
@@ -410,7 +410,7 @@ namespace OpenRCT2::Scripting
         return GetGameState().CostMultiplierExpenditureTable[expenditureType];
     }
 
-    void ScPark::expenditureMultiplier_set(uint8_t expenditureType,  uint16_t value)
+    void ScPark::expenditureMultiplier_set(uint8_t expenditureType, uint16_t value)
     {
         ThrowIfGameStateNotMutable();
         if (expenditureType >= EnumValue(ExpenditureType::Count))

--- a/src/openrct2/scripting/bindings/world/ScPark.cpp
+++ b/src/openrct2/scripting/bindings/world/ScPark.cpp
@@ -401,6 +401,27 @@ namespace OpenRCT2::Scripting
         }
     }
 
+    uint16_t ScPark::expenditureMultiplier_get(uint8_t expenditureType) const
+    {
+        if (expenditureType >= EnumValue(ExpenditureType::Count))
+        {
+            duk_error(_context, DUK_ERR_RANGE_ERROR, "Invalid expenditure type.");
+        }
+        return GetGameState().CostMultiplierExpenditureTable[expenditureType];
+    }
+
+    void ScPark::expenditureMultiplier_set(uint8_t expenditureType,  uint16_t value)
+    {
+        ThrowIfGameStateNotMutable();
+        if (expenditureType >= EnumValue(ExpenditureType::Count))
+        {
+            duk_error(_context, DUK_ERR_RANGE_ERROR, "Invalid expenditure type.");
+        }
+        GetGameState().CostMultiplierExpenditureTable[expenditureType] = value;
+        WindowInvalidateByClass(WindowClass::Ride);
+        WindowInvalidateByClass(WindowClass::RideConstruction);
+    }
+
     void ScPark::Register(duk_context* ctx)
     {
         dukglue_register_property(ctx, &ScPark::cash_get, &ScPark::cash_set, "cash");
@@ -432,6 +453,8 @@ namespace OpenRCT2::Scripting
         dukglue_register_method(ctx, &ScPark::getFlag, "getFlag");
         dukglue_register_method(ctx, &ScPark::setFlag, "setFlag");
         dukglue_register_method(ctx, &ScPark::postMessage, "postMessage");
+        dukglue_register_method(ctx, &ScPark::expenditureMultiplier_get, "getExpentitureMultiplier");
+        dukglue_register_method(ctx, &ScPark::expenditureMultiplier_set, "setExpenditureMultiplier");
     }
 
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/world/ScPark.hpp
+++ b/src/openrct2/scripting/bindings/world/ScPark.hpp
@@ -98,6 +98,10 @@ namespace OpenRCT2::Scripting
 
         void postMessage(DukValue message);
 
+        uint16_t expenditureMultiplier_get(uint8_t expenditureType) const;
+
+        void expenditureMultiplier_set(uint8_t expenditureType,  uint16_t value);
+
         static void Register(duk_context* ctx);
     };
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/world/ScPark.hpp
+++ b/src/openrct2/scripting/bindings/world/ScPark.hpp
@@ -100,7 +100,7 @@ namespace OpenRCT2::Scripting
 
         uint16_t expenditureMultiplier_get(uint8_t expenditureType) const;
 
-        void expenditureMultiplier_set(uint8_t expenditureType,  uint16_t value);
+        void expenditureMultiplier_set(uint8_t expenditureType, uint16_t value);
 
         static void Register(duk_context* ctx);
     };


### PR DESCRIPTION
TODO:
* why is it failing on x64 but not arm?
* add native window in the scenario editor with the same functionality

This PR adds on scripting functionality to #21932. 

A few comments:
* I've opted to put the getExpenditureMultiplier and setExpenditureMultiplier functions inside of the Park interface. Potentially this could go inside of Scenario instead, but that seems more closely related with the objective needed to win the park.
* I've also created a `ExpenditureTypeEnum` enum in the `.d.ts` instead of a number for the functions. It's duplicative with the text of the existing `ExpenditureType`, but serves a different purpose. If it decided that this makes the .d.ts file too bloated, another option is to add these number as comments into the ExpenditureType so developers have something to reference.
* The current build uses a percentage-point system to represent multiples (100=100%, 50=50%), but that could be changed to using a dime system like ride costs (1.2 = 120%, 2.5 = 250%). Some feedback was given about which to use, but this could also be transformed on the frontend as well.

I'd appreciate any testing to ensure this works as expected. You can download the built version of this on many systems via the built tests (though some failed and I'm not sure why), and I've [attached a plugin](https://github.com/ltsSmitty/testingOpenRCTStuff/releases/tag/v0.0.1) you can use to test the main functionality.