### PR TITLE
Fix sound effects not working

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -554,6 +554,9 @@ namespace OpenRCT2
             preloaderScene->UpdateCaption(STR_CHECKING_OBJECT_FILES);
             _objectRepository->LoadOrConstruct(currentLanguage);
 
+            preloaderScene->UpdateCaption(STR_LOADING_GENERIC);
+            Audio::LoadAudioObjects();
+
             if (!gOpenRCT2Headless)
             {
                 preloaderScene->UpdateCaption(STR_CHECKING_ASSET_PACKS);

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -93,7 +93,6 @@ namespace OpenRCT2::Audio
                 }
             }
         }
-        LoadAudioObjects();
     }
 
     void LoadAudioObjects()


### PR DESCRIPTION
The object repository used to be initialised before `Audio::Init`. However, as of #21893, it is invoked before the object repository is ready.

My solution is to still call `Audio::Init` in its old place, but to invoke `Audo::LoadAudioObjects` only after the object repository is ready. This returns behaviour back to normal.

Fixes #22051
Fixes #22052