### PR TITLE
Open NetworkStatus window quietly

### DIFF
--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -141,7 +141,7 @@ static Widget window_network_status_widgets[] = {
         else
         {
             window = WindowCreate<NetworkStatusWindow>(
-                WindowClass::NetworkStatus, 420, 90, WF_10 | WF_TRANSPARENT | WF_CENTRE_SCREEN);
+                WindowClass::NetworkStatus, 420, 90, WF_10 | WF_TRANSPARENT | WF_CENTRE_SCREEN | WF_STICK_TO_FRONT);
         }
 
         window->SetCloseCallBack(onClose);


### PR DESCRIPTION
The NetworkStatus window currently opens with a regular 'window open' sound effect. This is a bit distracting, particularly when the preloader passes quickly and the player never sees it. Adding the `WF_STICK_TO_FRONT` flag to the window suppresses the sound effect. Interestingly, the flag should probably have been added to this window in the first place.