### PR TITLE
Replace assertions in DecodeChunkRLEWithSize()

### DIFF
--- a/src/openrct2/util/SawyerCoding.cpp
+++ b/src/openrct2/util/SawyerCoding.cpp
@@ -219,8 +219,9 @@ static size_t DecodeChunkRLEWithSize(const uint8_t* src_buffer, uint8_t* dst_buf
 
     dst = dst_buffer;
 
-    assert(length > 0);
-    assert(dstSize > 0);
+    if (length <= 0 || dstSize <= 0)
+        throw std::out_of_range("Invalid RLE string!");
+
     for (size_t i = 0; i < length; i++)
     {
         rleCodeByte = src_buffer[i];
@@ -235,8 +236,8 @@ static size_t DecodeChunkRLEWithSize(const uint8_t* src_buffer, uint8_t* dst_buf
         }
         else
         {
-            assert(dst + rleCodeByte + 1 <= dst_buffer + dstSize);
-            assert(i + 1 < length);
+            if ((dst + rleCodeByte + 1 > dst_buffer + dstSize) || (i + 1 >= length))
+                throw std::out_of_range("Invalid RLE string!");
             std::memcpy(dst, src_buffer + i + 1, rleCodeByte + 1);
             dst = reinterpret_cast<uint8_t*>(reinterpret_cast<uintptr_t>(dst) + rleCodeByte + 1);
             i += rleCodeByte + 1;


### PR DESCRIPTION
If the game tries to decode something as RLE that isn’t RLE, or is damaged, assertions might get hit, crashing the game.

Examples are https://github.com/OpenRCT2/OpenRCT2/issues/21393.

Replace these assertions with exceptions, so that the callers can take appropriate action (e.g. show an error message saying the file is corrupted).