### PR TITLE
Fix #14630: Number separators not processed correctly

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Change: [#20240] Heavy snow and blizzards now make guests buy and use umbrellas.
 - Change: [#21214] Wacky Worlds and Time Twister’s scenario names now match their park names.
 - Fix: [#13294] Map corners are cut off in some directions (original bug).
+- Fix: [#14630] Non-ASCII thousands and decimal separators not processed correctly.
 - Fix: [#21974] No reason specified when attempting to place benches, lamps, or bins on path with no unconnected edges (original bug).
 - Fix: [#22008] Uninverted Lay-down roller coaster uses the wrong support type.
 - Fix: [#22012] [Plugin] Images on ImgButton widgets cannot be updated.

--- a/src/openrct2/localisation/Formatting.cpp
+++ b/src/openrct2/localisation/Formatting.cpp
@@ -295,14 +295,17 @@ namespace OpenRCT2
         }
     }
 
-    template<size_t TSize, typename TIndex> static void AppendSeparator(char (&buffer)[TSize], TIndex& i, std::string_view sep)
+    template<size_t TSize, typename TIndex>
+    static void AppendSeparatorReversed(char (&buffer)[TSize], TIndex& i, std::string_view sep)
     {
-        if (i < TSize)
+        if (i + sep.size() >= TSize)
+            return;
+
+        utf8 sepBuffer[32];
+        std::memcpy(&sepBuffer[0], sep.data(), sep.size());
+        for (int32_t j = static_cast<int32_t>(sep.size()) - 1; j >= 0; j--)
         {
-            auto remainingLen = TSize - i;
-            auto cpyLen = std::min(sep.size(), remainingLen);
-            std::memcpy(&buffer[i], sep.data(), cpyLen);
-            i += static_cast<TIndex>(cpyLen);
+            buffer[i++] = sepBuffer[j];
         }
     }
 
@@ -353,7 +356,7 @@ namespace OpenRCT2
             }
 
             auto decSep = GetDecimalSeparator();
-            AppendSeparator(buffer, i, decSep);
+            AppendSeparatorReversed(buffer, i, decSep);
         }
 
         // Whole digits
@@ -366,7 +369,7 @@ namespace OpenRCT2
                 if (groupLen >= 3)
                 {
                     groupLen = 0;
-                    AppendSeparator(buffer, i, digitSep);
+                    AppendSeparatorReversed(buffer, i, digitSep);
                 }
             }
             buffer[i++] = static_cast<char>('0' + (num % 10));


### PR DESCRIPTION
The bug was caused because numbers are formatted in reverse order, but this did not take into account that thousands separators may consist of multiple bytes - the non-breaking space being one example. To keep things something, this reverses the byte order of the separators when copying them into the temporary buffer, so that everything is in the correct order when it gets reversed for the final time. 

As a bonus, this also fixes a bug where it would truncate multibyte sequences if the buffer was almost full.

To test this, replace STR_5151 with a multibyte character, or multiple different characters and compare the results between `develop` and this PR.