### PR TITLE
Expose progress bar widget to scripting

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -119,6 +119,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Tiago Reul (reul) - Misc.
 * Fredrik Tegnell (fredriktegnell) - Misc.
 * Alex Parisi (alex-parisi) - Added API for returning metadata from all registered plugins.
+* Smitty Penman (ltsSmitty) - Plugin api extension, misc.
 
 ## Bug fixes & Refactors
 * Claudio Tiecher (janclod)

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -4363,21 +4363,6 @@ declare global {
         textAlign: TextAlignment;
     }
 
-    interface ProgressBarWidget extends WidgetBase {
-        colour: number;
-        /**
-         * The percentage of the bar to fill, ranging from 0-100 (inclusive).
-         */
-        percentage: number;
-        /**
-         * Used to specify a range of values between which the bar will start blinking.
-         * Set both of these to the same value to disable blinking entirely.
-         * The range is inclusive.
-         */
-        lowerBlinkBound: number;
-        upperBlinkBound: number;
-    }
-
     type SortOrder = "none" | "ascending" | "descending";
 
     type ScrollbarType = "none" | "horizontal" | "vertical" | "both";
@@ -4412,6 +4397,25 @@ declare global {
         canSelect: boolean;
     }
 
+    interface ProgressBarWidget extends WidgetBase {
+        colour: number;
+        /**
+         * The percentage of the bar to fill, ranging from 0-100 (inclusive).
+         */
+        percentage: number;
+        /**
+         * Used to specify a range of values between which the bar will start blinking.
+         * The bar will blink when lowerBlinkBound <= percentage <= upperBlinkBound.
+         * Set both upper and lower bounds to the same value to disable blinking.
+         */
+        lowerBlinkBound: number;
+        /**
+         * Used to specify a range of values between which the bar will start blinking.
+         * The bar will blink when lowerBlinkBound <= percentage <= upperBlinkBound.
+         * Set both upper and lower bounds to the same value to disable blinking.
+         */
+        upperBlinkBound: number;
+    }
     interface SpinnerWidget extends WidgetBase {
         type: "spinner";
         text: string;

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -4277,11 +4277,11 @@ declare global {
      */
     type WidgetType =
         "button" | "checkbox" | "colourpicker" | "custom" | "dropdown" | "groupbox" |
-        "label" | "listview" | "spinner" | "textbox" | "viewport";
+        "label" | "listview" | "spinner" | "textbox" | "viewport" | "progress_bar";
 
     type Widget =
         ButtonWidget | CheckboxWidget | ColourPickerWidget | CustomWidget | DropdownWidget | GroupBoxWidget |
-        LabelWidget | ListViewWidget | SpinnerWidget | TextBoxWidget | ViewportWidget;
+        LabelWidget | ListViewWidget | SpinnerWidget | TextBoxWidget | ViewportWidget | ProgressBarWidget;
 
     type IconName = "arrow_down" | "arrow_up" | "chat" | "cheats" | "copy" | "empty" | "eyedropper" |
         "fast_forward" | "game_speed_indicator" | "game_speed_indicator_double" | "glassy_recolourable" |
@@ -4333,7 +4333,7 @@ declare global {
         text: string;
         isChecked: boolean;
     }
-
+    
     interface ColourPickerWidget extends WidgetBase {
         type: "colourpicker";
         colour: number;
@@ -4361,6 +4361,21 @@ declare global {
         type: "label";
         text: string;
         textAlign: TextAlignment;
+    }
+
+    interface ProgressBarWidget extends WidgetBase {
+        colour: number;
+        /**
+         * The percentage of the bar to fill, ranging from 0-100 (inclusive).
+         */
+        percentage: number;
+        /**
+         * Used to specify a range of values between which the bar will start blinking.
+         * Set both of these to the same value to disable blinking entirely.
+         * The range is inclusive.
+         */
+        lowerBlinkBound: number;
+        uppperBlinkBound: number;
     }
 
 

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -4281,7 +4281,7 @@ declare global {
 
     type Widget =
         ButtonWidget | CheckboxWidget | ColourPickerWidget | CustomWidget | DropdownWidget | GroupBoxWidget |
-        LabelWidget | ListViewWidget |ProgressBarWidget | SpinnerWidget | TextBoxWidget | ViewportWidget;
+        LabelWidget | ListViewWidget | ProgressBarWidget | SpinnerWidget | TextBoxWidget | ViewportWidget;
 
     type IconName = "arrow_down" | "arrow_up" | "chat" | "cheats" | "copy" | "empty" | "eyedropper" |
         "fast_forward" | "game_speed_indicator" | "game_speed_indicator_double" | "glassy_recolourable" |

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -4277,11 +4277,11 @@ declare global {
      */
     type WidgetType =
         "button" | "checkbox" | "colourpicker" | "custom" | "dropdown" | "groupbox" |
-        "label" | "listview" | "spinner" | "textbox" | "viewport" | "progress_bar";
+        "label" | "listview" | "progressbar" | "spinner" | "textbox" | "viewport";
 
     type Widget =
         ButtonWidget | CheckboxWidget | ColourPickerWidget | CustomWidget | DropdownWidget | GroupBoxWidget |
-        LabelWidget | ListViewWidget | SpinnerWidget | TextBoxWidget | ViewportWidget | ProgressBarWidget;
+        LabelWidget | ProgressBarWidget | ListViewWidget | SpinnerWidget | TextBoxWidget | ViewportWidget;
 
     type IconName = "arrow_down" | "arrow_up" | "chat" | "cheats" | "copy" | "empty" | "eyedropper" |
         "fast_forward" | "game_speed_indicator" | "game_speed_indicator_double" | "glassy_recolourable" |
@@ -4333,7 +4333,7 @@ declare global {
         text: string;
         isChecked: boolean;
     }
-    
+
     interface ColourPickerWidget extends WidgetBase {
         type: "colourpicker";
         colour: number;
@@ -4375,9 +4375,8 @@ declare global {
          * The range is inclusive.
          */
         lowerBlinkBound: number;
-        uppperBlinkBound: number;
+        upperBlinkBound: number;
     }
-
 
     type SortOrder = "none" | "ascending" | "descending";
 
@@ -4546,6 +4545,14 @@ declare global {
         canSelect?: boolean;
         onHighlight?: (item: number, column: number) => void;
         onClick?: (item: number, column: number) => void;
+    }
+
+    interface ProgressBarDesc extends WidgetBaseDesc {
+        type: "progressbar";
+        colour?: number;
+        percentage?: number;
+        lowerBlinkBound?: number;
+        upperBlinkBound?: number;
     }
 
     interface SpinnerDesc extends WidgetBaseDesc {

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -4281,7 +4281,7 @@ declare global {
 
     type Widget =
         ButtonWidget | CheckboxWidget | ColourPickerWidget | CustomWidget | DropdownWidget | GroupBoxWidget |
-        LabelWidget | ProgressBarWidget | ListViewWidget | SpinnerWidget | TextBoxWidget | ViewportWidget;
+        LabelWidget | ListViewWidget |ProgressBarWidget | SpinnerWidget | TextBoxWidget | ViewportWidget;
 
     type IconName = "arrow_down" | "arrow_up" | "chat" | "cheats" | "copy" | "empty" | "eyedropper" |
         "fast_forward" | "game_speed_indicator" | "game_speed_indicator_double" | "glassy_recolourable" |
@@ -4461,7 +4461,7 @@ declare global {
 
     type WidgetDesc =
         ButtonDesc | CheckboxDesc | ColourPickerDesc | CustomDesc | DropdownDesc | GroupBoxDesc |
-        LabelDesc | ListViewDesc | SpinnerDesc | TextBoxDesc | ViewportDesc;
+        LabelDesc | ListViewDesc | ProgressBarDesc | SpinnerDesc | TextBoxDesc | ViewportDesc;
 
     interface WidgetBaseDesc {
         type: WidgetType;

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -66,8 +66,8 @@ namespace OpenRCT2::Ui::Windows
         TextAlignment TextAlign{};
         colour_t Colour{};
         uint8_t Percentage{};      // progress bar value
-        uint8_t LowerBlinkBound{}; // progress bar blink when below
-        uint8_t UpperBlinkBound{}; // progress bar blink when above
+        uint8_t LowerBlinkBound{}; // progress bar will blink when above the lower bound
+        uint8_t UpperBlinkBound{}; // and below upper bound
         std::string Tooltip;
         std::vector<std::string> Items;
         std::vector<ListViewItem> ListViewItems;

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -65,7 +65,7 @@ namespace OpenRCT2::Ui::Windows
         std::string Text;
         TextAlignment TextAlign{};
         colour_t Colour{};
-        uint8_t Percentage{}; // progress bar value
+        uint8_t Percentage{};      // progress bar value
         uint8_t LowerBlinkBound{}; // progress bar blink when below
         uint8_t UpperBlinkBound{}; // progress bar blink when above
         std::string Tooltip;

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -65,6 +65,9 @@ namespace OpenRCT2::Ui::Windows
         std::string Text;
         TextAlignment TextAlign{};
         colour_t Colour{};
+        uint8_t Percentage{}; // progress bar value
+        uint8_t LowerBlinkBound{}; // progress bar blink when below
+        uint8_t UpperBlinkBound{}; // progress bar blink when above
         std::string Tooltip;
         std::vector<std::string> Items;
         std::vector<ListViewItem> ListViewItems;
@@ -176,6 +179,17 @@ namespace OpenRCT2::Ui::Windows
                     result.Scrollbars = ScrollbarType::Vertical;
                 else
                     result.Scrollbars = FromDuk<ScrollbarType>(desc["scrollbars"]);
+            }
+            else if (result.Type == "progressbar")
+            {
+                result.Percentage = AsOrDefault(desc["percentage"], 0);
+                result.LowerBlinkBound = AsOrDefault(desc["lowerBlinkBound"], 0);
+                result.UpperBlinkBound = AsOrDefault(desc["upperBlinkBound"], 0);
+                auto colour = AsOrDefault(desc["colour"], 1); // use white for the
+                if (colour < COLOUR_COUNT)
+                {
+                    result.Colour = colour;
+                }
             }
             else if (result.Type == "spinner")
             {
@@ -1053,6 +1067,21 @@ namespace OpenRCT2::Ui::Windows
                     widget.content = SCROLL_VERTICAL;
                 else if (desc.Scrollbars == ScrollbarType::Both)
                     widget.content = SCROLL_BOTH;
+                widgetList.push_back(widget);
+            }
+            else if (desc.Type == "progressbar")
+            {
+                widget.type = WindowWidgetType::ProgressBar;
+                if (desc.IsDisabled)
+                {
+                    widget.colour = 1;
+                    widget.content = 100;
+                }
+                else
+                {
+                    widget.colour = desc.Colour;
+                    widget.content = desc.Percentage | (desc.LowerBlinkBound << 8) | (desc.UpperBlinkBound << 16);
+                }
                 widgetList.push_back(widget);
             }
             else if (desc.Type == "spinner")

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -1072,16 +1072,8 @@ namespace OpenRCT2::Ui::Windows
             else if (desc.Type == "progressbar")
             {
                 widget.type = WindowWidgetType::ProgressBar;
-                if (desc.IsDisabled)
-                {
-                    widget.colour = 1;
-                    widget.content = 100;
-                }
-                else
-                {
-                    widget.colour = desc.Colour;
-                    widget.content = desc.Percentage | (desc.LowerBlinkBound << 8) | (desc.UpperBlinkBound << 16);
-                }
+                widget.colour = desc.Colour;
+                widget.content = desc.Percentage | (desc.LowerBlinkBound << 8) | (desc.UpperBlinkBound << 16);
                 widgetList.push_back(widget);
             }
             else if (desc.Type == "spinner")

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -20,6 +20,7 @@
 #    include "ScUi.hpp"
 #    include "ScWindow.hpp"
 
+#    include <algorithm>
 #    include <limits>
 #    include <openrct2/drawing/Drawing.h>
 #    include <openrct2/interface/Window.h>
@@ -1073,7 +1074,9 @@ namespace OpenRCT2::Ui::Windows
             {
                 widget.type = WindowWidgetType::ProgressBar;
                 widget.colour = desc.Colour;
-                widget.content = desc.Percentage | (desc.LowerBlinkBound << 8) | (desc.UpperBlinkBound << 16);
+
+                auto clampedPercent = std::clamp(desc.Percentage, static_cast<uint8_t>(0), static_cast<uint8_t>(100));
+                widget.content = clampedPercent | (desc.LowerBlinkBound << 8) | (desc.UpperBlinkBound << 16);
                 widgetList.push_back(widget);
             }
             else if (desc.Type == "spinner")

--- a/src/openrct2-ui/scripting/ScWidget.hpp
+++ b/src/openrct2-ui/scripting/ScWidget.hpp
@@ -582,9 +582,6 @@ namespace OpenRCT2::Scripting
                 ctx, &ScProgressBarWidget::lowerBlinkBound_get, &ScProgressBarWidget::lowerBlinkBound_set, "lowerBlinkBound");
             dukglue_register_property(
                 ctx, &ScProgressBarWidget::upperBlinkBound_get, &ScProgressBarWidget::upperBlinkBound_set, "upperBlinkBound");
-            // Explicit template due to text being a base method
-            dukglue_register_property<ScProgressBarWidget, std::string, std::string>(
-                ctx, &ScProgressBarWidget::text_get, &ScProgressBarWidget::text_set, "text");
         }
 
     private:

--- a/src/openrct2-ui/scripting/UiExtensions.cpp
+++ b/src/openrct2-ui/scripting/UiExtensions.cpp
@@ -43,6 +43,7 @@ void UiScriptExtensions::Extend(ScriptEngine& scriptEngine)
     ScButtonWidget::Register(ctx);
     ScColourPickerWidget::Register(ctx);
     ScCheckBoxWidget::Register(ctx);
+    ScProgressBarWidget::Register(ctx);
     ScDropdownWidget::Register(ctx);
     ScGroupBoxWidget::Register(ctx);
     ScLabelWidget::Register(ctx);


### PR DESCRIPTION
Todo:
- [ ] Testing
- [x] Updating openrct2.d.ts
- [ ] Move bitshifting/masking to functions/methods
- [ ] Does colour need to be exposed manually, or is that part of the default specs already (like size and position is)?