### PR TITLE
Fix #22072: Localisation: Separate objective date string from staff tenure date string

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -1739,8 +1739,8 @@ STR_2382    :Land
 STR_2383    :Water
 STR_2384    :{WINDOW_COLOUR_2}Your objective:
 STR_2385    :{BLACK}None
-STR_2386    :{BLACK}To have at least {COMMA32} guests in your park at the end of {MONTHYEAR}, with a park rating of at least 600
-STR_2387    :{BLACK}To achieve a park value of at least {POP16}{POP16}{CURRENCY} at the end of {PUSH16}{PUSH16}{PUSH16}{PUSH16}{PUSH16}{MONTHYEAR}
+STR_2386    :{BLACK}To have at least {COMMA32} guests in your park at the end of {MONTHYEAR_SENTENCE}, with a park rating of at least 600
+STR_2387    :{BLACK}To achieve a park value of at least {POP16}{POP16}{CURRENCY} at the end of {PUSH16}{PUSH16}{PUSH16}{PUSH16}{PUSH16}{MONTHYEAR_SENTENCE}
 STR_2388    :{BLACK}Have Fun!
 STR_2389    :{BLACK}Build the best {STRINGID} you can!
 STR_2390    :{BLACK}To have 10 different types of roller coasters operating in your park, each with an excitement value of at least 6.00
@@ -1950,6 +1950,7 @@ STR_2732    :{COMMA32} ft
 STR_2733    :{COMMA32} m
 STR_2734    :{COMMA16} mph
 STR_2735    :{COMMA16} km/h
+# Used only as part of label-value pair.
 STR_2736    :{MONTH}, Year {COMMA16}
 STR_2737    :{STRINGID} {MONTH}, Year {COMMA16}
 STR_2738    :Title screen music:
@@ -3743,6 +3744,8 @@ STR_6670    :Guest behaviour
 STR_6671    :Show ‘real’ names of staff
 STR_6672    :Toggle between showing ‘real’ names of staff and staff numbers
 STR_6673    :Transparent
+# Used as part of a sentence (see https://github.com/OpenRCT2/OpenRCT2/issues/22072).
+STR_6674    :{MONTH}, Year {COMMA16}
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Fix: [#7672] Wide path status is set to all ‘wide’ paths, instead of only a quarter, impeding pathfinding.
 - Fix: [#15406] Tunnels on steep Side-Friction track are drawn too low.
 - Fix: [#21959] “Save this before...?” message does not appear when selecting “New Game”.
+- Fix: [#22072] Objective date string and staff tenure date string cannot be reused on agglutinative languages.
 - Fix: [#22231] Invalid object version can cause a crash.
 - Fix: [#22562] Bottom row of pixels is not always drawn by the OpenGL renderer when zoomed in.
 - Fix: [#22653] Missing water tiles in RCT1 and RCT2 scenarios.

--- a/src/openrct2/localisation/FormatCodes.cpp
+++ b/src/openrct2/localisation/FormatCodes.cpp
@@ -38,6 +38,7 @@ static const EnumMap<FormatToken> FormatTokenMap = {
     { "STRINGID",             FormatToken::StringById,          },
     { "STRING",               FormatToken::String,              },
     { "MONTHYEAR",            FormatToken::MonthYear,           },
+    { "MONTHYEAR_SENTENCE",   FormatToken::MonthYearSentence,   },
     { "MONTH",                FormatToken::Month,               },
     { "VELOCITY",             FormatToken::Velocity,            },
     { "POP16",                FormatToken::Pop16,               },
@@ -98,6 +99,7 @@ bool FormatTokenTakesArgument(FormatToken token)
         case FormatToken::StringById:
         case FormatToken::String:
         case FormatToken::MonthYear:
+        case FormatToken::MonthYearSentence:
         case FormatToken::Month:
         case FormatToken::Velocity:
         case FormatToken::DurationShort:

--- a/src/openrct2/localisation/FormatCodes.h
+++ b/src/openrct2/localisation/FormatCodes.h
@@ -37,6 +37,7 @@ enum class FormatToken
     StringById,
     String,
     MonthYear,
+    MonthYearSentence,
     Month,
     Velocity,
     DurationShort,

--- a/src/openrct2/localisation/Formatting.cpp
+++ b/src/openrct2/localisation/Formatting.cpp
@@ -25,7 +25,7 @@
 
 namespace OpenRCT2
 {
-    static void FormatMonthYear(FormatBuffer& ss, int32_t month, int32_t year);
+    static void FormatMonthYear(FormatBuffer& ss, int32_t month, int32_t year, bool inSentence);
 
     static std::optional<int32_t> ParseNumericToken(std::string_view s)
     {
@@ -589,7 +589,15 @@ namespace OpenRCT2
                 {
                     auto month = DateGetMonth(arg);
                     auto year = DateGetYear(arg) + 1;
-                    FormatMonthYear(ss, month, year);
+                    FormatMonthYear(ss, month, year, false);
+                }
+                break;
+            case FormatToken::MonthYearSentence:
+                if constexpr (std::is_integral<T>())
+                {
+                    auto month = DateGetMonth(arg);
+                    auto year = DateGetYear(arg) + 1;
+                    FormatMonthYear(ss, month, year, true);
                 }
                 break;
             case FormatToken::Month:
@@ -779,6 +787,7 @@ namespace OpenRCT2
                     break;
                 case FormatToken::UInt16:
                 case FormatToken::MonthYear:
+                case FormatToken::MonthYearSentence:
                 case FormatToken::Month:
                 case FormatToken::Velocity:
                 case FormatToken::DurationShort:
@@ -815,12 +824,13 @@ namespace OpenRCT2
         }
     }
 
-    static void FormatMonthYear(FormatBuffer& ss, int32_t month, int32_t year)
+    static void FormatMonthYear(FormatBuffer& ss, int32_t month, int32_t year, bool inSentence)
     {
         thread_local std::vector<FormatArg_t> tempArgs;
         tempArgs.clear();
 
-        auto fmt = GetFmtStringById(STR_DATE_FORMAT_MY);
+        auto stringId = inSentence ? STR_DATE_FORMAT_MY_SENTENCE : STR_DATE_FORMAT_MY;
+        auto fmt = GetFmtStringById(stringId);
         Formatter ft;
         ft.Add<uint16_t>(month);
         ft.Add<uint16_t>(year);

--- a/src/openrct2/localisation/Formatting.cpp
+++ b/src/openrct2/localisation/Formatting.cpp
@@ -585,19 +585,12 @@ namespace OpenRCT2
                 }
                 break;
             case FormatToken::MonthYear:
-                if constexpr (std::is_integral<T>())
-                {
-                    auto month = DateGetMonth(arg);
-                    auto year = DateGetYear(arg) + 1;
-                    FormatMonthYear(ss, month, year, false);
-                }
-                break;
             case FormatToken::MonthYearSentence:
                 if constexpr (std::is_integral<T>())
                 {
                     auto month = DateGetMonth(arg);
                     auto year = DateGetYear(arg) + 1;
-                    FormatMonthYear(ss, month, year, true);
+                    FormatMonthYear(ss, month, year, token == FormatToken::MonthYearSentence);
                 }
                 break;
             case FormatToken::Month:

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -1692,6 +1692,8 @@ enum : StringId
 
     STR_CHEAT_IGNORE_PRICE = 6659,
 
+    STR_DATE_FORMAT_MY_SENTENCE = 6674,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/test/tests/FormattingTests.cpp
+++ b/test/tests/FormattingTests.cpp
@@ -42,7 +42,7 @@ TEST_F(FmtStringTests, iteration)
         actual += String::StdFormat("[%d:%s]", t.kind, std::string(t.text).c_str());
     }
 
-    ASSERT_EQ("[29:{BLACK}][1:Guests: ][8:{INT32}]", actual);
+    ASSERT_EQ("[30:{BLACK}][1:Guests: ][8:{INT32}]", actual);
 }
 
 TEST_F(FmtStringTests, iteration_escaped)


### PR DESCRIPTION
Attempts to fix #22072.

I was able to build the game locally and have the issue addressed. I tested the changes by setting 
`STR_2736    :{MONTH}, Year {COMMA16}` (used for label-value pairs), and 
`STR_6640    :{MONTH}, Year {COMMA16}` (used in sentences)
to different values. I then replaced `{MONTHYEAR}` to `{MONTHYEAR_SENTENCE}` in `STR_2836` and `STR_2837`, and the change can be observed in-game.

![image](https://github.com/OpenRCT2/OpenRCT2/assets/104749673/cd0db078-074f-45d9-a2d9-8f45a4a3fc75)
![image](https://github.com/OpenRCT2/OpenRCT2/assets/104749673/dc613106-699f-4d36-8d94-d24b359f1c94)

As I am new to contributing to this project, please review carefully for any mistakes I might have made. Thanks!