### PR TITLE
Pause the game while LoadSave window is open

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Improved: [#21981] The map window now defaults to showing as much of the map as fits the screen.
 - Improved: [#21983] Taking a screenshot now shows a message again, closing when taking another.
 - Improved: [#22026] The options window now stays centred when window scaling is changed.
+- Improved: [#22084] The game now temporarily pauses while the load/save window is open.
 - Change: [#7248] Small mini-maps are now centred in the map window.
 - Change: [#20240] Heavy snow and blizzards now make guests buy and use umbrellas.
 - Change: [#21214] Wacky Worlds and Time Twister’s scenario names now match their park names.

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -17,7 +17,9 @@
 #include <openrct2/FileClassifier.h>
 #include <openrct2/Game.h>
 #include <openrct2/GameState.h>
+#include <openrct2/OpenRCT2.h>
 #include <openrct2/PlatformEnvironment.h>
+#include <openrct2/audio/audio.h>
 #include <openrct2/config/Config.h>
 #include <openrct2/core/File.h>
 #include <openrct2/core/FileScanner.h>
@@ -26,6 +28,7 @@
 #include <openrct2/core/String.hpp>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Localisation.h>
+#include <openrct2/network/network.h>
 #include <openrct2/platform/Platform.h>
 #include <openrct2/rct2/T6Exporter.h>
 #include <openrct2/ride/TrackDesign.h>
@@ -676,6 +679,13 @@ static Widget window_loadsave_widgets[] =
             const bool isSave = (type & 0x01) == LOADSAVETYPE_SAVE;
             const auto path = GetDir(type);
 
+            // Pause the game if not on title scene, nor in network play.
+            if (!(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) && NetworkGetMode() == NETWORK_MODE_NONE)
+            {
+                gGamePaused |= GAME_PAUSED_MODAL;
+                Audio::StopAll();
+            }
+
             const char* pattern = GetFilterPatternByType(type, isSave);
             PopulateList(isSave, path, pattern);
             no_list_items = static_cast<uint16_t>(_listItems.size());
@@ -693,6 +703,13 @@ static Widget window_loadsave_widgets[] =
         {
             _listItems.clear();
             WindowCloseByClass(WindowClass::LoadsaveOverwritePrompt);
+
+            // Unpause the game if not on title scene, nor in network play.
+            if (!(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) && NetworkGetMode() == NETWORK_MODE_NONE)
+            {
+                gGamePaused &= ~GAME_PAUSED_MODAL;
+                Audio::Resume();
+            }
         }
 
         void OnResize() override


### PR DESCRIPTION
It's puzzled me that the game continues while the LoadSave window is open, unless the player manually pauses it. As of the new save format, the pause state is saved, though, so this could lead to unexpected side effects.

This PR addresses this by automatically pausing the game while the LoadSave window is open, in such a way that this _temporary_ pause state is not saved into any save files. I believe this to be more intuitive, and matches vanilla behaviour.