### PR TITLE
[Plugin API] Feat: expose guest's favourite ride (ID) to plugin API

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -119,6 +119,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Tiago Reul (reul) - Misc.
 * Fredrik Tegnell (fredriktegnell) - Misc.
 * Alex Parisi (alex-parisi) - Added API for returning metadata from all registered plugins.
+* Arnold Zhou (mrmagic2020) - Added plugin API for getting and setting guests' favourite rides.
 
 ## Bug fixes & Refactors
 * Claudio Tiecher (janclod)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Feature: [#21853] Enlarged UI mode.
 - Feature: [#21893, #22065] On launch, the game now indicates what system is being initialised.
 - Feature: [#21913] [Plugin] Allow precise and safe control of peep animations.
+- Feature: [#22087] [Plugin] Expose guests' favourite rides to the plugin API.
 - Improved: [#19870] Allow using new colours in UI themes.
 - Improved: [#21853] Dropdowns now automatically use multiple columns if they are too tall for the screen.
 - Improved: [#21981] Rendering performance of the map window has been improved considerably.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,7 +6,7 @@
 - Feature: [#21853] Enlarged UI mode.
 - Feature: [#21893, #22065] On launch, the game now indicates what system is being initialised.
 - Feature: [#21913] [Plugin] Allow precise and safe control of peep animations.
-- Feature: [#22087] [Plugin] Expose guests' favourite rides to the plugin API.
+- Feature: [#22087] [Plugin] Expose guests’ favourite rides to the plugin API.
 - Improved: [#19870] Allow using new colours in UI themes.
 - Improved: [#21853] Dropdowns now automatically use multiple columns if they are too tall for the screen.
 - Improved: [#21981] Rendering performance of the map window has been improved considerably.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -2874,6 +2874,11 @@ declare global {
          * The total number of frames in the current animation.
          */
         readonly animationLength: number;
+
+        /**
+         * The ride ID of the guest's favourite ride.
+         */
+        favouriteRide: number;
     }
 
     /**

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -2878,7 +2878,7 @@ declare global {
         /**
          * The ride ID of the guest's favourite ride.
          */
-        favouriteRide: number;
+        favouriteRide: number | null;
     }
 
     /**

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -47,7 +47,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 88;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 89;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -47,7 +47,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 89;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 90;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;

--- a/src/openrct2/scripting/bindings/entity/ScGuest.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.cpp
@@ -511,7 +511,7 @@ namespace OpenRCT2::Scripting
     uint16_t ScGuest::favouriteRide_get() const
     {
         auto peep = GetGuest();
-        return peep != nullptr ? peep->FavouriteRide.ToUnderlying() : 0;
+        return peep != nullptr ? peep->FavouriteRide.ToUnderlying() : RideId::GetNull().ToUnderlying();
     }
 
     void ScGuest::favouriteRide_set(uint16_t value)

--- a/src/openrct2/scripting/bindings/entity/ScGuest.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.cpp
@@ -11,9 +11,11 @@
 
 #    include "ScGuest.hpp"
 
+#    include "../../../GameState.h"
 #    include "../../../entity/Guest.h"
 #    include "../../../localisation/Localisation.h"
 #    include "../../../peep/PeepAnimationData.h"
+#    include "../../../ride/RideEntry.h"
 
 namespace OpenRCT2::Scripting
 {
@@ -537,7 +539,7 @@ namespace OpenRCT2::Scripting
         auto peep = GetGuest();
         if (peep != nullptr)
         {
-            if (value.type() == DukValue::Type::NUMBER)
+            if (value.type() == DukValue::Type::NUMBER && value.as_uint() < GetGameState().Rides.size() && GetGameState().Rides[value.as_uint()].type != RIDE_TYPE_NULL)
             {
                 peep->FavouriteRide = RideId::FromUnderlying(value.as_uint());
             }

--- a/src/openrct2/scripting/bindings/entity/ScGuest.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.cpp
@@ -539,7 +539,8 @@ namespace OpenRCT2::Scripting
         auto peep = GetGuest();
         if (peep != nullptr)
         {
-            if (value.type() == DukValue::Type::NUMBER && value.as_uint() < GetGameState().Rides.size() && GetGameState().Rides[value.as_uint()].type != RIDE_TYPE_NULL)
+            if (value.type() == DukValue::Type::NUMBER && value.as_uint() < GetGameState().Rides.size()
+                && GetGameState().Rides[value.as_uint()].type != RIDE_TYPE_NULL)
             {
                 peep->FavouriteRide = RideId::FromUnderlying(value.as_uint());
             }

--- a/src/openrct2/scripting/bindings/entity/ScGuest.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.cpp
@@ -508,19 +508,43 @@ namespace OpenRCT2::Scripting
         }
     }
 
-    uint16_t ScGuest::favouriteRide_get() const
+    DukValue ScGuest::favouriteRide_get() const
     {
+        auto& scriptEngine = GetContext()->GetScriptEngine();
+        auto* ctx = scriptEngine.GetContext();
         auto peep = GetGuest();
-        return peep != nullptr ? peep->FavouriteRide.ToUnderlying() : RideId::GetNull().ToUnderlying();
+        if (peep != nullptr)
+        {
+            if (peep->FavouriteRide != RideId::GetNull())
+            {
+                duk_push_int(ctx, peep->FavouriteRide.ToUnderlying());
+            }
+            else
+            {
+                duk_push_null(ctx);
+            }
+        }
+        else
+        {
+            duk_push_null(ctx);
+        }
+        return DukValue::take_from_stack(ctx);
     }
 
-    void ScGuest::favouriteRide_set(uint16_t value)
+    void ScGuest::favouriteRide_set(const DukValue& value)
     {
         ThrowIfGameStateNotMutable();
         auto peep = GetGuest();
         if (peep != nullptr)
         {
-            peep->FavouriteRide = RideId::FromUnderlying(value);
+            if (value.type() == DukValue::Type::NUMBER)
+            {
+                peep->FavouriteRide = RideId::FromUnderlying(value.as_uint());
+            }
+            else
+            {
+                peep->FavouriteRide = RideId::GetNull();
+            }
         }
     }
 

--- a/src/openrct2/scripting/bindings/entity/ScGuest.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.cpp
@@ -202,6 +202,7 @@ namespace OpenRCT2::Scripting
         dukglue_register_property(ctx, &ScGuest::isInPark_get, nullptr, "isInPark");
         dukglue_register_property(ctx, &ScGuest::isLost_get, nullptr, "isLost");
         dukglue_register_property(ctx, &ScGuest::lostCountdown_get, &ScGuest::lostCountdown_set, "lostCountdown");
+        dukglue_register_property(ctx, &ScGuest::favouriteRide_get, &ScGuest::favouriteRide_set, "favouriteRide");
         dukglue_register_property(ctx, &ScGuest::thoughts_get, nullptr, "thoughts");
         dukglue_register_property(ctx, &ScGuest::items_get, nullptr, "items");
         dukglue_register_property(ctx, &ScGuest::availableAnimations_get, nullptr, "availableAnimations");
@@ -504,6 +505,22 @@ namespace OpenRCT2::Scripting
         if (peep != nullptr)
         {
             peep->GuestIsLostCountdown = value;
+        }
+    }
+
+    uint16_t ScGuest::favouriteRide_get() const
+    {
+        auto peep = GetGuest();
+        return peep != nullptr ? peep->FavouriteRide.ToUnderlying() : 0;
+    }
+
+    void ScGuest::favouriteRide_set(uint16_t value)
+    {
+        ThrowIfGameStateNotMutable();
+        auto peep = GetGuest();
+        if (peep != nullptr)
+        {
+            peep->FavouriteRide = RideId::FromUnderlying(value);
         }
     }
 

--- a/src/openrct2/scripting/bindings/entity/ScGuest.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.hpp
@@ -167,8 +167,8 @@ namespace OpenRCT2::Scripting
         uint8_t lostCountdown_get() const;
         void lostCountdown_set(uint8_t value);
 
-        uint16_t favouriteRide_get() const;
-        void favouriteRide_set(uint16_t value);
+        DukValue favouriteRide_get() const;
+        void favouriteRide_set(const DukValue& value);
 
         DukValue thoughts_get() const;
 

--- a/src/openrct2/scripting/bindings/entity/ScGuest.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.hpp
@@ -167,6 +167,9 @@ namespace OpenRCT2::Scripting
         uint8_t lostCountdown_get() const;
         void lostCountdown_set(uint8_t value);
 
+        uint16_t favouriteRide_get() const;
+        void favouriteRide_set(uint16_t value);
+
         DukValue thoughts_get() const;
 
         DukValue items_get() const;


### PR DESCRIPTION
Add a new writeable property `favouriteRide: number` to `interface Guest`. The changes are tested locally.