### PR TITLE
Pause state setter for plugin API

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Feature: [#22046] [Plugin] Add interface for crashed vehicle particle.
 - Feature: [#22085] [Plugin] The result of actions that create banners now includes the bannerIndex.
 - Feature: [#22087] [Plugin] Expose guests’ favourite rides to the plugin API.
+- Feature: [#22090] [Plugin] Allow writing of paused state in non-networked settings.
 - Feature: [#22140] Add option to automatically close dropdown menus if Enlarged UI is enabled.
 - Improved: [#19870] Allow using new colours in UI themes.
 - Improved: [#21853] Dropdowns now automatically use multiple columns if they are too tall for the screen.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -217,9 +217,9 @@ declare global {
         readonly mode: GameMode;
 
         /**
-         * Whether the game is currently paused or not.
+         * Whether the game is currently paused or not. Readonly in network mode.
          */
-        readonly paused: boolean;
+        paused: boolean;
 
         /**
          * Render the current state of the map and save to disc.

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -47,7 +47,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 92;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 93;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;

--- a/src/openrct2/scripting/bindings/game/ScContext.hpp
+++ b/src/openrct2/scripting/bindings/game/ScContext.hpp
@@ -133,15 +133,7 @@ namespace OpenRCT2::Scripting
 
         void paused_set(const bool& value)
         {
-#    ifndef DISABLE_NETWORK
-            if (NetworkGetMode() != NETWORK_MODE_NONE)
-            {
-                auto ctx = GetContext()->GetScriptEngine().GetContext();
-                duk_error(
-                    ctx, DUK_ERR_ERROR, "Setting paused state is not network safe. Use the pausetoggle game action instead.");
-                return;
-            }
-#    endif
+            ThrowIfGameStateNotMutable();
             if (value != GameIsPaused())
                 PauseToggle();
         }

--- a/src/openrct2/scripting/bindings/game/ScContext.hpp
+++ b/src/openrct2/scripting/bindings/game/ScContext.hpp
@@ -131,6 +131,21 @@ namespace OpenRCT2::Scripting
             return GameIsPaused();
         }
 
+        void paused_set(const bool& value)
+        {
+#    ifndef DISABLE_NETWORK
+            if (NetworkGetMode() != NETWORK_MODE_NONE)
+            {
+                auto ctx = GetContext()->GetScriptEngine().GetContext();
+                duk_error(
+                    ctx, DUK_ERR_ERROR, "Setting paused state is not network safe. Use the pausetoggle game action instead.");
+                return;
+            }
+#    endif
+            if (value != GameIsPaused())
+                PauseToggle();
+        }
+
         void captureImage(const DukValue& options)
         {
             auto ctx = GetContext()->GetScriptEngine().GetContext();
@@ -438,7 +453,7 @@ namespace OpenRCT2::Scripting
             dukglue_register_property(ctx, &ScContext::sharedStorage_get, nullptr, "sharedStorage");
             dukglue_register_method(ctx, &ScContext::getParkStorage, "getParkStorage");
             dukglue_register_property(ctx, &ScContext::mode_get, nullptr, "mode");
-            dukglue_register_property(ctx, &ScContext::paused_get, nullptr, "paused");
+            dukglue_register_property(ctx, &ScContext::paused_get, &ScContext::paused_set, "paused");
             dukglue_register_method(ctx, &ScContext::captureImage, "captureImage");
             dukglue_register_method(ctx, &ScContext::getObject, "getObject");
             dukglue_register_method(ctx, &ScContext::getAllObjects, "getAllObjects");


### PR DESCRIPTION
It is impossible to set pause state on loading without losing 1 frame when hooked to `map.changed` and it is impossible to set pause state before park save when hooked to `map.save`. This PR fixes that by allowing plugins to set pause state directly.

Setter is disabled in networked mode because it is not network-safe to call PauseToggle without extra stuff that the game action does perfectly well.