### PR TITLE
Fix width calculation in asset packs window

### DIFF
--- a/src/openrct2-ui/windows/AssetPacks.cpp
+++ b/src/openrct2-ui/windows/AssetPacks.cpp
@@ -238,7 +238,7 @@ static Widget WindowAssetPacksWidgets[] = {
     private:
         void PaintItem(DrawPixelInfo& dpi, int32_t y, Formatter& ft, bool isChecked, bool isSelected, bool isHighlighted)
         {
-            auto listWidth = dpi.width - 1;
+            auto listWidth = widgets[WIDX_LIST].right - widgets[WIDX_LIST].left;
             auto stringId = STR_BLACK_STRING;
             auto fillRectangle = ScreenRect{ { 0, y }, { listWidth, y + ItemHeight - 1 } };
             if (isSelected)


### PR DESCRIPTION
Due to how the software render engine works, the `dpi.width` property is not a reliable source for getting the scrollview width (cf. #11238). This makes descriptions in the 'Asset Packs' window appear shorter than needed when using the software renderer. OpenGL is not affected.

Before:
![asset_packs_before](https://github.com/OpenRCT2/OpenRCT2/assets/604665/01affacf-65d0-4bc6-b1d2-a8398af630c6)

After:
![asset_packs_after](https://github.com/OpenRCT2/OpenRCT2/assets/604665/36a2ec84-0226-43c9-8e1b-c2c56aad7b6d)