### PR TITLE
Allow forcing guest energy to 0

### DIFF
--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -832,11 +832,13 @@ void Guest::Loc68FA89()
     uint8_t newTargetEnergy = EnergyTarget;
     if (newEnergy >= newTargetEnergy)
     {
-        newEnergy -= 2;
+        if (newEnergy >= kPeepMinEnergy + 2)
+            newEnergy -= 2;
+
         if (newEnergy < newTargetEnergy)
             newEnergy = newTargetEnergy;
     }
-    else
+    else if (newEnergy != 0)
     {
         newEnergy = std::min<uint16_t>(kPeepMaxEnergyTarget, newEnergy + 4);
         if (newEnergy > newTargetEnergy)

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -843,11 +843,9 @@ void Guest::Loc68FA89()
             newEnergy = newTargetEnergy;
     }
 
-    if (newEnergy < kPeepMinEnergy)
-        newEnergy = kPeepMinEnergy;
-
-    /* Previous code here suggested maximum energy is 128. */
-    newEnergy = std::min(kPeepMaxEnergy, newEnergy);
+    // Keep guest energy balanced between min and max, unless it's been forced to 0
+    if (newEnergy != 0)
+        newEnergy = std::clamp(newEnergy, kPeepMinEnergy, kPeepMaxEnergy);
 
     if (newEnergy != Energy)
     {

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -900,6 +900,12 @@ void Guest::Loc68FA89()
 
 void Guest::Tick128UpdateGuest(uint32_t index)
 {
+    // Leave guest alone if energy has been forced to 0
+    if (Energy == 0)
+    {
+        return;
+    }
+
     const auto currentTicks = GetGameState().CurrentTicks;
 
     if ((index & 0x1FF) == (currentTicks & 0x1FF))

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -955,6 +955,12 @@ static void GuestUpdateThoughts(Guest* peep)
  */
 void Peep::Update()
 {
+    // Leave peep alone if energy has been forced to 0
+    if (Energy == 0)
+    {
+        return;
+    }
+
     auto* guest = As<Guest>();
     if (guest != nullptr)
     {


### PR DESCRIPTION
The guest update code keeps guest energy balanced between a set min and max constant. Unlike staff, this makes it impossible to 'force' guests through the script API. This PR is an attempt to make it possible to allow scripts to force guest energy to 0 as well.

@Manticore-007, could you test this out?