### PR TITLE
Fix #22102: Inverted scrollwheel behaviour for terraform tools

### DIFF
--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -464,6 +464,8 @@ static bool WindowOtherWheelInput(WindowBase& w, WidgetIndex widgetIndex, int32_
     }
 
     const auto entryWidgetType = w.widgets[*spinnerGroupIndex].type;
+    auto targetWidgetIndex = *spinnerGroupIndex;
+
     if (entryWidgetType == WindowWidgetType::ImgBtn)
     {
         auto expectedContent1 = ImageId(SPR_LAND_TOOL_DECREASE, FilterPaletteID::PaletteNull);
@@ -475,6 +477,9 @@ static bool WindowOtherWheelInput(WindowBase& w, WidgetIndex widgetIndex, int32_
         {
             return false;
         }
+
+        // Expected widget order: decrease, increase
+        targetWidgetIndex += wheel < 0 ? 2 : 1;
     }
     else if (entryWidgetType == WindowWidgetType::Spinner)
     {
@@ -484,9 +489,11 @@ static bool WindowOtherWheelInput(WindowBase& w, WidgetIndex widgetIndex, int32_
         {
             return false;
         }
+
+        // Expected widget order: increase, decrease
+        targetWidgetIndex += wheel < 0 ? 1 : 2;
     }
 
-    const auto targetWidgetIndex = wheel < 0 ? *spinnerGroupIndex + 1 : *spinnerGroupIndex + 2;
     if (WidgetIsDisabled(w, targetWidgetIndex))
     {
         return false;


### PR DESCRIPTION
For OpenRCT2, the widget order is [decrease, increase] for the tools, but [increase, decrease] for the spinner widgets. The OpenLoco code I adapted to replace the original implementation assumes the widget order is [decrease, increase] for both, however. Unfortunately, we didn't catch it in review, and generalised it for OpenRCT2 as well.