### PR TITLE
Prevent going out of bounds listing 'peep' entertainers

### DIFF
--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -828,7 +828,12 @@ static Widget _staffOptionsWidgets[] = {
                     widgets[WIDX_CHECKBOX_4].type = WindowWidgetType::Empty;
                     widgets[WIDX_COSTUME_BOX].type = WindowWidgetType::DropdownMenu;
                     widgets[WIDX_COSTUME_BTN].type = WindowWidgetType::Button;
-                    widgets[WIDX_COSTUME_BOX].text = StaffCostumeNames[EnumValue(staff->SpriteType) - 4];
+
+                    // TODO: retrieve string from object instead
+                    if (EnumValue(staff->SpriteType) >= 4)
+                        widgets[WIDX_COSTUME_BOX].text = StaffCostumeNames[EnumValue(staff->SpriteType) - 4];
+                    else
+                        widgets[WIDX_COSTUME_BOX].text = STR_UNKNOWN_OBJECT_TYPE;
                     break;
                 case StaffType::Handyman:
                     widgets[WIDX_CHECKBOX_1].type = WindowWidgetType::Checkbox;

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -822,6 +822,7 @@ static Widget _staffOptionsWidgets[] = {
             switch (staff->AssignedStaffType)
             {
                 case StaffType::Entertainer:
+                {
                     widgets[WIDX_CHECKBOX_1].type = WindowWidgetType::Empty;
                     widgets[WIDX_CHECKBOX_2].type = WindowWidgetType::Empty;
                     widgets[WIDX_CHECKBOX_3].type = WindowWidgetType::Empty;
@@ -830,11 +831,13 @@ static Widget _staffOptionsWidgets[] = {
                     widgets[WIDX_COSTUME_BTN].type = WindowWidgetType::Button;
 
                     // TODO: retrieve string from object instead
-                    if (EnumValue(staff->SpriteType) >= 4)
-                        widgets[WIDX_COSTUME_BOX].text = StaffCostumeNames[EnumValue(staff->SpriteType) - 4];
+                    auto costumeType = EnumValue(staff->SpriteType) - EnumValue(PeepSpriteType::EntertainerPanda);
+                    if (costumeType >= 0)
+                        widgets[WIDX_COSTUME_BOX].text = StaffCostumeNames[costumeType];
                     else
                         widgets[WIDX_COSTUME_BOX].text = STR_UNKNOWN_OBJECT_TYPE;
                     break;
+                }
                 case StaffType::Handyman:
                     widgets[WIDX_CHECKBOX_1].type = WindowWidgetType::Checkbox;
                     widgets[WIDX_CHECKBOX_1].text = STR_STAFF_OPTION_SWEEP_FOOTPATHS;

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -729,7 +729,6 @@ static Widget _staffListWidgets[] = {
         {
             switch (type)
             {
-                default:
                 case PeepSpriteType::EntertainerPanda:
                     return SPR_STAFF_COSTUME_PANDA;
                 case PeepSpriteType::EntertainerTiger:
@@ -752,6 +751,9 @@ static Widget _staffListWidgets[] = {
                     return SPR_STAFF_COSTUME_SHERIFF;
                 case PeepSpriteType::EntertainerPirate:
                     return SPR_STAFF_COSTUME_PIRATE;
+                case PeepSpriteType::Normal:
+                default:
+                    return SPR_PEEP_SMALL_FACE_HAPPY;
             }
         }
     };


### PR DESCRIPTION
This prevents the costume list from going out of bounds when showing the properties for 'peep' entertainers. Normally, this isn't possible in-game, but the scripting system has allowed the Peep Editor plugin to do just that. Note that this behaviour has been more defined since #21714, but we still should ensure the game doesn't get into undefined behaviour. I've therefore changed it to show 'Unknown type' when an abnormal costume is detected.

I've also changed the staff list such that these edited/'costumeless' entertainers show up as peeps in the entertainer list, so they can be spotted more easily. Before, they would show up as pandas.

In the future, I'd like us to rely on 'staff' objects for these properties. That should clean all this up considerably.

<img width="495" alt="Screenshot 2024-05-27 at 22 33 53" src="https://github.com/OpenRCT2/OpenRCT2/assets/604665/9240a2ae-4814-409b-89fa-681a643304ac">