### PR TITLE
Fix text colour in Recent Messages

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -27,6 +27,7 @@
 - Fix: [#21974] No reason specified when attempting to place benches, lamps, or bins on path with no unconnected edges (original bug).
 - Fix: [#22008] Uninverted Lay-down roller coaster uses the wrong support type.
 - Fix: [#22012] [Plugin] Images on ImgButton widgets cannot be updated.
+- Fix: [#22121] Some news items in the “Recent Messages” window have the wrong text colour.
 
 0.4.11 (2024-05-05)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -208,7 +208,9 @@ static Widget window_news_widgets[] = {
                 {
                     auto ft = Formatter();
                     ft.Add<const char*>(newsItem.Text.c_str());
-                    DrawTextWrapped(dpi, { 2, y + lineHeight }, 325, STR_BOTTOM_TOOLBAR_NEWS_TEXT, ft, { FontStyle::Small });
+                    DrawTextWrapped(
+                        dpi, { 2, y + lineHeight }, 325, STR_BOTTOM_TOOLBAR_NEWS_TEXT, ft,
+                        { COLOUR_BRIGHT_GREEN, FontStyle::Small });
                 }
                 // Subject button
                 if ((newsItem.TypeHasSubject()) && !(newsItem.HasButton()))


### PR DESCRIPTION
Messages that don’t have an explicit colour set (easily testable with add_news_item) are drawn as green in the news ticker. This PR also applies that to the Recent Messages window.

Before:
![Schermafdruk van 2024-05-28 20-27-57](https://github.com/OpenRCT2/OpenRCT2/assets/1478678/f9ff2b75-7211-468f-9ab8-898059528085)

After:
![afbeelding](https://github.com/OpenRCT2/OpenRCT2/assets/1478678/8468bc5c-ca3e-4db5-a8fa-88541efd4f8d)
