### PR TITLE
Rework (preloader) scene completion functionality

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -573,10 +573,7 @@ namespace OpenRCT2
             OpenProgress(STR_CHECKING_TITLE_SEQUENCES);
             TitleSequenceManager::Scan();
 
-            if (GetPreloaderScene()->GetCompletionScene() == GetTitleScene())
-                OpenProgress(STR_LOADING_TITLE_SEQUENCE);
-            else
-                OpenProgress(STR_LOADING_GENERIC);
+            OpenProgress(STR_LOADING_GENERIC);
         }
 
     public:

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -310,9 +310,7 @@ namespace OpenRCT2
             return EXIT_FAILURE;
         }
 
-        // NB: This takes some liberty in returning PreloaderScene* instead of IScene*.
-        // PreloaderScene adds some methods to Scene, which are used internally by Context.
-        PreloaderScene* GetPreloaderScene() override
+        IScene* GetPreloaderScene() override
         {
             if (auto* scene = _preloaderScene.get())
                 return scene;
@@ -520,7 +518,7 @@ namespace OpenRCT2
 
             if (!gOpenRCT2Headless)
             {
-                auto* preloaderScene = GetPreloaderScene();
+                auto* preloaderScene = static_cast<PreloaderScene*>(GetPreloaderScene());
                 SetActiveScene(preloaderScene);
 
                 // TODO: preload the title scene in another (parallel) job.

--- a/src/openrct2/scenes/Scene.cpp
+++ b/src/openrct2/scenes/Scene.cpp
@@ -31,13 +31,13 @@ GameState_t& Scene::GetGameState()
 
 void Scene::FinishScene()
 {
-    if (_onFinish != nullptr)
+    if (_onComplete != nullptr)
     {
-        _onFinish();
+        _onComplete();
     }
 }
 
-void Scene::SetOnComplete(std::function<void()> onFinish)
+void Scene::SetOnComplete(std::function<void()> onComplete)
 {
-    _onFinish = onFinish;
+    _onComplete = onComplete;
 }

--- a/src/openrct2/scenes/Scene.cpp
+++ b/src/openrct2/scenes/Scene.cpp
@@ -38,11 +38,6 @@ void Scene::FinishScene()
     }
 }
 
-IScene* Scene::GetCompletionScene()
-{
-    return _nextScene;
-}
-
 void Scene::SetCompletionScene(IScene* scene)
 {
     _nextScene = scene;

--- a/src/openrct2/scenes/Scene.cpp
+++ b/src/openrct2/scenes/Scene.cpp
@@ -31,14 +31,13 @@ GameState_t& Scene::GetGameState()
 
 void Scene::FinishScene()
 {
-    if (_nextScene != nullptr)
+    if (_onFinish != nullptr)
     {
-        _context.SetActiveScene(_nextScene);
-        _nextScene = nullptr;
+        _onFinish();
     }
 }
 
-void Scene::SetCompletionScene(IScene* scene)
+void Scene::SetOnComplete(std::function<void()> onFinish)
 {
-    _nextScene = scene;
+    _onFinish = onFinish;
 }

--- a/src/openrct2/scenes/Scene.h
+++ b/src/openrct2/scenes/Scene.h
@@ -48,7 +48,7 @@ namespace OpenRCT2
 
     protected:
         IContext& _context;
-        std::function<void()> _onFinish{};
+        std::function<void()> _onComplete{};
     };
 
 } // namespace OpenRCT2

--- a/src/openrct2/scenes/Scene.h
+++ b/src/openrct2/scenes/Scene.h
@@ -28,7 +28,6 @@ namespace OpenRCT2
         virtual void Tick() = 0;
         virtual void Stop() = 0;
 
-        virtual IScene* GetCompletionScene() = 0;
         virtual void SetCompletionScene(IScene* scene) = 0;
     };
 
@@ -40,7 +39,6 @@ namespace OpenRCT2
         GameState_t& GetGameState() override;
         IContext& GetContext() override;
 
-        IScene* GetCompletionScene() override;
         void SetCompletionScene(IScene* scene) override;
 
     protected:

--- a/src/openrct2/scenes/Scene.h
+++ b/src/openrct2/scenes/Scene.h
@@ -11,6 +11,8 @@
 
 #include "../common.h"
 
+#include <functional>
+
 namespace OpenRCT2
 {
     struct GameState_t;
@@ -28,7 +30,7 @@ namespace OpenRCT2
         virtual void Tick() = 0;
         virtual void Stop() = 0;
 
-        virtual void SetCompletionScene(IScene* scene) = 0;
+        virtual void SetOnComplete(std::function<void()>) = 0;
     };
 
     class Scene : public IScene
@@ -39,14 +41,14 @@ namespace OpenRCT2
         GameState_t& GetGameState() override;
         IContext& GetContext() override;
 
-        void SetCompletionScene(IScene* scene) override;
+        void SetOnComplete(std::function<void()>) override;
 
     protected:
         void FinishScene();
 
     protected:
         IContext& _context;
-        IScene* _nextScene = nullptr;
+        std::function<void()> _onFinish{};
     };
 
 } // namespace OpenRCT2

--- a/src/openrct2/scenes/title/TitleScene.cpp
+++ b/src/openrct2/scenes/title/TitleScene.cpp
@@ -121,6 +121,9 @@ void TitleScene::Load()
     ViewportInitAll();
     ContextOpenWindow(WindowClass::MainWindow);
     CreateWindows();
+
+    GetContext().OpenProgress(STR_LOADING_TITLE_SEQUENCE);
+
     TitleInitialise();
     OpenRCT2::Audio::PlayTitleMusic();
 
@@ -138,6 +141,8 @@ void TitleScene::Load()
         TryLoadSequence();
         _sequencePlayer->Update();
     }
+
+    GetContext().CloseProgress();
 
     LOG_VERBOSE("TitleScene::Load() finished");
 }


### PR DESCRIPTION
When we introduced the preloader scene a few weeks ago (#21893), we added a way for scenes to transition to the next scene whenever a scene determined it was 'finished'. Using this method, we set up the preloader to transition to e.g. the title scene, or an in-game scene. 

However, this method turned out not to be sufficient for handling file associations. The game would, in such cases, try to the save while it was still indexing objects off the main thread. This could lead to object errors when opening a save at startup.

This PR replaces the old `SetCompletionScene` method with a more generic `SetOnComplete` method, which allows running an entire transition function instead. Such functions can handle loading files when needed, and only once the (object) repositories have been initialised.

Fixes #22107.