### PR TITLE
[Plugin API] Fix: add missing hook types, order & style

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -496,20 +496,20 @@ declare global {
          */
         subscribe(hook: HookType, callback: Function): IDisposable;
 
-        subscribe(hook: "action.query", callback: (e: GameActionEventArgs) => void): IDisposable;
         subscribe(hook: "action.execute", callback: (e: GameActionEventArgs) => void): IDisposable;
         subscribe(hook: "action.location", callback: (e: ActionLocationArgs) => void): IDisposable;
-        subscribe(hook: "interval.tick", callback: () => void): IDisposable;
+        subscribe(hook: "action.query", callback: (e: GameActionEventArgs) => void): IDisposable;
+        subscribe(hook: "guest.generation", callback: (e: GuestGenerationArgs) => void): IDisposable;
         subscribe(hook: "interval.day", callback: () => void): IDisposable;
-        subscribe(hook: "network.chat", callback: (e: NetworkChatEventArgs) => void): IDisposable;
+        subscribe(hook: "interval.tick", callback: () => void): IDisposable;
+        subscribe(hook: "map.change", callback: () => void): IDisposable;
+        subscribe(hook: "map.save", callback: () => void): IDisposable;
         subscribe(hook: "network.authenticate", callback: (e: NetworkAuthenticateEventArgs) => void): IDisposable;
+        subscribe(hook: "network.chat", callback: (e: NetworkChatEventArgs) => void): IDisposable;
         subscribe(hook: "network.join", callback: (e: NetworkEventArgs) => void): IDisposable;
         subscribe(hook: "network.leave", callback: (e: NetworkEventArgs) => void): IDisposable;
         subscribe(hook: "ride.ratings.calculate", callback: (e: RideRatingsCalculateArgs) => void): IDisposable;
-        subscribe(hook: "guest.generation", callback: (e: GuestGenerationArgs) => void): IDisposable;
         subscribe(hook: "vehicle.crash", callback: (e: VehicleCrashArgs) => void): IDisposable;
-        subscribe(hook: "map.save", callback: () => void): IDisposable;
-        subscribe(hook: "map.change", callback: () => void): IDisposable;
 
         /**
          * Can only be used in intransient plugins.
@@ -620,21 +620,21 @@ declare global {
         "footpath_railings";
 
     type HookType =
-        "action.query" |
         "action.execute" |
         "action.location" |
-        "interval.tick" | 
+        "action.query" |
+        "guest.generation" |
         "interval.day" |
-        "network.chat" |
+        "interval.tick" |
+        "map.change" |
+        "map.changed" |
+        "map.save" |
         "network.authenticate" |
+        "network.chat" |
         "network.join" |
         "network.leave" |
         "ride.ratings.calculate" |
-        "guest.generation" |
-        "vehicle.crash" |
-        "map.save" |
-        "map.change" |
-        "map.changed";
+        "vehicle.crash";
 
     type ExpenditureType =
         "ride_construction" |

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -498,6 +498,7 @@ declare global {
 
         subscribe(hook: "action.query", callback: (e: GameActionEventArgs) => void): IDisposable;
         subscribe(hook: "action.execute", callback: (e: GameActionEventArgs) => void): IDisposable;
+        subscribe(hook: "action.location", callback: (e: ActionLocationArgs) => void): IDisposable;
         subscribe(hook: "interval.tick", callback: () => void): IDisposable;
         subscribe(hook: "interval.day", callback: () => void): IDisposable;
         subscribe(hook: "network.chat", callback: (e: NetworkChatEventArgs) => void): IDisposable;
@@ -505,7 +506,6 @@ declare global {
         subscribe(hook: "network.join", callback: (e: NetworkEventArgs) => void): IDisposable;
         subscribe(hook: "network.leave", callback: (e: NetworkEventArgs) => void): IDisposable;
         subscribe(hook: "ride.ratings.calculate", callback: (e: RideRatingsCalculateArgs) => void): IDisposable;
-        subscribe(hook: "action.location", callback: (e: ActionLocationArgs) => void): IDisposable;
         subscribe(hook: "guest.generation", callback: (e: GuestGenerationArgs) => void): IDisposable;
         subscribe(hook: "vehicle.crash", callback: (e: VehicleCrashArgs) => void): IDisposable;
         subscribe(hook: "map.save", callback: () => void): IDisposable;
@@ -620,10 +620,21 @@ declare global {
         "footpath_railings";
 
     type HookType =
-        "interval.tick" | "interval.day" |
-        "network.chat" | "network.action" | "network.join" | "network.leave" |
-        "ride.ratings.calculate" | "action.location" | "vehicle.crash" |
-        "map.change" | "map.changed" | "map.save";
+        "action.query" |
+        "action.execute" |
+        "action.location" |
+        "interval.tick" | 
+        "interval.day" |
+        "network.chat" |
+        "network.authenticate" |
+        "network.join" |
+        "network.leave" |
+        "ride.ratings.calculate" |
+        "guest.generation" |
+        "vehicle.crash" |
+        "map.save" |
+        "map.change" |
+        "map.changed";
 
     type ExpenditureType =
         "ride_construction" |


### PR DESCRIPTION
Some `HookType`s in `openrct2.d.ts` were missing or wrong (`network.action` doesn't exist in the codebase). This PR fixes the issue.