### PR TITLE
Fix support type of Monorail Cycles

### DIFF
--- a/src/openrct2/ride/gentle/MonorailCycles.cpp
+++ b/src/openrct2/ride/gentle/MonorailCycles.cpp
@@ -19,7 +19,7 @@
 #include "../TrackPaint.h"
 #include "../VehiclePaint.h"
 
-static constexpr MetalSupportType kSupportType = MetalSupportType::Tubes;
+static constexpr MetalSupportType kSupportType = MetalSupportType::Stick;
 
 enum
 {


### PR DESCRIPTION
No changelog entry is needed, as this is the result of a refactor that was merged on 12 May.