### PR TITLE
add framework for obeying max speed

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -47,6 +47,9 @@
 #include <openrct2/world/Footpath.h>
 #include <openrct2/world/Park.h>
 
+constexpr int8_t kDefaultSpeedIncrement = 2;
+constexpr int8_t kDefaultMinimumSpeed = 2;
+
 using namespace OpenRCT2::TrackMetaData;
 namespace OpenRCT2::Ui::Windows
 {
@@ -1336,9 +1339,10 @@ static Widget _rideConstructionWidgets[] = {
                     }
                     else
                     {
-                        uint8_t* brakesSpeedPtr = &_currentBrakeSpeed;
-                        uint8_t brakesSpeed = *brakesSpeedPtr + 2;
-                        if (brakesSpeed <= kMaximumBrakeSpeed)
+                        auto trackSpeedMaximum = kMaximumTrackSpeed;
+                        auto trackSpeedIncrement = kDefaultSpeedIncrement;
+                        uint8_t brakesSpeed = std::min<int16_t>(trackSpeedMaximum, _currentBrakeSpeed + trackSpeedIncrement);
+                        if (brakesSpeed != _currentBrakeSpeed)
                         {
                             if (_rideConstructionState == RideConstructionState::Selected)
                             {
@@ -1346,7 +1350,7 @@ static Widget _rideConstructionWidgets[] = {
                             }
                             else
                             {
-                                *brakesSpeedPtr = brakesSpeed;
+                                _currentBrakeSpeed = brakesSpeed;
                                 WindowRideConstructionUpdateActiveElements();
                             }
                         }
@@ -1362,9 +1366,14 @@ static Widget _rideConstructionWidgets[] = {
                     }
                     else
                     {
-                        uint8_t* brakesSpeedPtr = &_currentBrakeSpeed;
-                        uint8_t brakesSpeed = *brakesSpeedPtr - 2;
-                        if (brakesSpeed >= 2)
+                        auto trackSpeedIncrement = kDefaultSpeedIncrement;
+                        auto trackSpeedMinimum = kDefaultMinimumSpeed;
+                        if (GetGameState().Cheats.UnlockOperatingLimits)
+                        {
+                            trackSpeedMinimum = 0;
+                        }
+                        uint8_t brakesSpeed = std::max<int16_t>(trackSpeedMinimum, _currentBrakeSpeed - trackSpeedIncrement);
+                        if (brakesSpeed != _currentBrakeSpeed)
                         {
                             if (_rideConstructionState == RideConstructionState::Selected)
                             {
@@ -1372,7 +1381,7 @@ static Widget _rideConstructionWidgets[] = {
                             }
                             else
                             {
-                                *brakesSpeedPtr = brakesSpeed;
+                                _currentBrakeSpeed = brakesSpeed;
                                 WindowRideConstructionUpdateActiveElements();
                             }
                         }

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -105,7 +105,7 @@ GameActions::Result TrackPlaceAction::Query() const
             GameActions::Status::InvalidParameters, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, STR_ERR_VALUE_OUT_OF_RANGE);
     }
 
-    if (_brakeSpeed > kMaximumBrakeSpeed)
+    if (_brakeSpeed > kMaximumTrackSpeed)
     {
         LOG_WARNING("Invalid speed for track placement, speed = %d", _brakeSpeed);
         return GameActions::Result(

--- a/src/openrct2/actions/TrackSetBrakeSpeedAction.cpp
+++ b/src/openrct2/actions/TrackSetBrakeSpeedAction.cpp
@@ -68,7 +68,7 @@ GameActions::Result TrackSetBrakeSpeedAction::QueryExecute(bool isExecuting) con
             GameActions::Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_TILE_ELEMENT_NOT_FOUND);
     }
 
-    if (_brakeSpeed > kMaximumBrakeSpeed)
+    if (_brakeSpeed > kMaximumTrackSpeed)
     {
         LOG_WARNING("Invalid speed for track, speed = %d", _brakeSpeed);
         return GameActions::Result(GameActions::Status::InvalidParameters, STR_SPEED_TOO_HIGH, STR_NONE);

--- a/src/openrct2/ride/Track.h
+++ b/src/openrct2/ride/Track.h
@@ -22,7 +22,7 @@ constexpr uint8_t kRCT2DefaultBlockBrakeSpeed = 2;
 constexpr int32_t kBlockBrakeBaseSpeed = 0x20364;
 constexpr int32_t kBlockBrakeSpeedOffset = kBlockBrakeBaseSpeed - (kRCT2DefaultBlockBrakeSpeed << 16);
 
-constexpr uint8_t kMaximumBrakeSpeed = 30;
+constexpr uint8_t kMaximumTrackSpeed = 30;
 
 using track_type_t = uint16_t;
 


### PR DESCRIPTION
Spun off from #16692

The actual obeying RideTypeDescriptor.TrackSpeedSettings is added in unify speed because the range for all brakes and boosters is identical until then - 0-30. I could have added conversions to and from absolute speed, but that would add lines that would have to be removed later. So this sets up some of the local variables that will be tweaked to fit unify speed.

It also renames `kMaximumBrakeSpeed` to `kMaximumTrackSpeed`, since boosters use the setting too and there may be more users in the future.