### PR TITLE
Ride/add absolute speed functions

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1547,7 +1547,7 @@ namespace OpenRCT2::Ui::Windows
                 uint16_t brakeSpeed2 = ((_currentBrakeSpeed * 9) >> 2) & 0xFFFF;
                 if (TrackTypeIsBooster(_selectedTrackType) || TrackTypeIsBooster(_currentlySelectedTrack.trackType))
                 {
-                    brakeSpeed2 = GetBoosterSpeed(currentRide->type, brakeSpeed2);
+                    brakeSpeed2 = GetUnifiedBoosterSpeed(currentRide->type, brakeSpeed2);
                 }
                 ft.Add<uint16_t>(brakeSpeed2);
             }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5485,10 +5485,9 @@ bool RideHasRatings(const Ride& ride)
     return !ride.ratings.isNull();
 }
 
-int32_t GetBoosterSpeed(ride_type_t rideType, int32_t rawSpeed)
+int32_t GetUnifiedBoosterSpeed(ride_type_t rideType, int32_t relativeSpeed)
 {
-    // BoosterSpeedFactor has valid values of 1, 2, 4 representing a 1/2, 1, and 2 multiplier.
-    return rawSpeed * GetRideTypeDescriptor(rideType).LegacyBoosterSettings.BoosterSpeedFactor / 2;
+    return GetRideTypeDescriptor(rideType).GetUnifiedBoosterSpeed(relativeSpeed);
 }
 
 void FixInvalidVehicleSpriteSizes()

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -993,7 +993,7 @@ bool RideHasAdjacentStation(const Ride& ride);
 bool RideHasStationShelter(const Ride& ride);
 bool RideHasRatings(const Ride& ride);
 
-int32_t GetBoosterSpeed(ride_type_t rideType, int32_t rawSpeed);
+int32_t GetUnifiedBoosterSpeed(ride_type_t rideType, int32_t relativeSpeed);
 void FixInvalidVehicleSpriteSizes();
 bool RideEntryHasCategory(const RideObjectEntry& rideEntry, uint8_t category);
 

--- a/src/openrct2/ride/RideData.cpp
+++ b/src/openrct2/ride/RideData.cpp
@@ -456,3 +456,10 @@ TrackDrawerEntry getTrackDrawerEntry(const RideTypeDescriptor& rtd, bool isInver
 
     return descriptor.Regular;
 }
+
+int32_t RideTypeDescriptor::GetUnifiedBoosterSpeed(int32_t compressedSpeed) const
+{
+    // BoosterSpeedFactor has valid values of 1, 2, 4 representing a 1/2, 1, and 2 multiplier of legacy speed to unified
+    // speed.
+    return compressedSpeed * LegacyBoosterSettings.BoosterSpeedFactor / 2;
+}

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -536,6 +536,11 @@ struct RideTypeDescriptor
     bool SupportsTrackGroup(const TrackGroup trackGroup) const;
     ResearchCategory GetResearchCategory() const;
     bool SupportsRideMode(RideMode rideMode) const;
+    /**
+     * Converts booster speed from the ride type's speed regime (Junior, Default, Giga) to to the unified values used by the
+     * vehicle. See https://github.com/OpenRCT2/OpenRCT2/discussions/23119 for more information about unified speed.
+     */
+    int32_t GetUnifiedBoosterSpeed(int32_t relativeSpeed) const;
 };
 
 extern const RideTypeDescriptor RideTypeDescriptors[RIDE_TYPE_COUNT];

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7110,9 +7110,9 @@ bool Vehicle::UpdateTrackMotionForwards(const CarEntry* carEntry, const Ride& cu
                 && curRide.breakdown_reason_pending == BREAKDOWN_BRAKES_FAILURE;
             if (!hasBrakesFailure || curRide.mechanic_status == RIDE_MECHANIC_STATUS_HAS_FIXED_STATION_BRAKES)
             {
-                auto brakeSpeed = ChooseBrakeSpeed();
+                auto brakeSpeed = ChooseBrakeSpeed() << kTrackSpeedShiftAmount;
 
-                if ((brakeSpeed << 16) < _vehicleVelocityF64E08)
+                if ((brakeSpeed) < _vehicleVelocityF64E08)
                 {
                     acceleration = -_vehicleVelocityF64E08 * 16;
                 }
@@ -7128,11 +7128,11 @@ bool Vehicle::UpdateTrackMotionForwards(const CarEntry* carEntry, const Ride& cu
         }
         else if (TrackTypeIsBooster(trackType))
         {
-            auto boosterSpeed = GetBoosterSpeed(curRide.type, brake_speed) << kTrackSpeedShiftAmount;
+            auto boosterSpeed = GetUnifiedBoosterSpeed(curRide.type, brake_speed) << kTrackSpeedShiftAmount;
             if (boosterSpeed > _vehicleVelocityF64E08)
             {
                 acceleration = GetRideTypeDescriptor(curRide.type).LegacyBoosterSettings.BoosterAcceleration
-                    << kBoosterAccelerationShiftAmount; //_vehicleVelocityF64E08 * 1.2;
+                    << kBoosterAccelerationShiftAmount;
             }
         }
         else if (rideEntry.flags & RIDE_ENTRY_FLAG_RIDER_CONTROLS_SPEED && num_peeps > 0)
@@ -7143,7 +7143,8 @@ bool Vehicle::UpdateTrackMotionForwards(const CarEntry* carEntry, const Ride& cu
         if ((trackType == TrackElemType::Flat && curRide.GetRideTypeDescriptor().HasFlag(RtdFlag::hasLsmBehaviourOnFlat))
             || (trackType == TrackElemType::PoweredLift))
         {
-            acceleration = GetRideTypeDescriptor(curRide.type).LegacyBoosterSettings.PoweredLiftAcceleration << kBoosterAccelerationShiftAmount;
+            acceleration = GetRideTypeDescriptor(curRide.type).LegacyBoosterSettings.PoweredLiftAcceleration
+                << kBoosterAccelerationShiftAmount;
         }
         if (trackType == TrackElemType::BrakeForDrop)
         {

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7511,15 +7511,6 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
             }
         }
 
-        if (trackType == TrackElemType::Booster)
-        {
-            auto boosterSpeed = GetBoosterSpeed(curRide.type, (brake_speed << 16));
-            if (boosterSpeed < _vehicleVelocityF64E08)
-            {
-                acceleration = GetRideTypeDescriptor(curRide.type).LegacyBoosterSettings.BoosterAcceleration << 16;
-            }
-        }
-
         uint16_t newTrackProgress = track_progress - 1;
         if (newTrackProgress == 0xFFFF)
         {

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -79,6 +79,9 @@ constexpr int16_t VEHICLE_MAX_SPIN_SPEED_WATER_RIDE = 512;
 constexpr int16_t VEHICLE_MIN_SPIN_SPEED_WATER_RIDE = -VEHICLE_MAX_SPIN_SPEED_WATER_RIDE;
 constexpr int16_t VEHICLE_STOPPING_SPIN_SPEED = 600;
 
+constexpr uint8_t kTrackSpeedShiftAmount = 16;
+constexpr uint8_t kBoosterAccelerationShiftAmount = 16;
+
 Vehicle* gCurrentVehicle;
 
 static uint8_t _vehicleBreakdown;
@@ -5457,7 +5460,7 @@ void Vehicle::ApplyNonStopBlockBrake()
             velocity = kBlockBrakeBaseSpeed;
             acceleration = 0;
         }
-        else if (velocity > (brake_speed << 16) + kBlockBrakeSpeedOffset)
+        else if (velocity > (brake_speed << kTrackSpeedShiftAmount) + kBlockBrakeSpeedOffset)
         {
             velocity -= velocity >> 4;
             acceleration = 0;
@@ -7125,11 +7128,11 @@ bool Vehicle::UpdateTrackMotionForwards(const CarEntry* carEntry, const Ride& cu
         }
         else if (TrackTypeIsBooster(trackType))
         {
-            auto boosterSpeed = GetBoosterSpeed(curRide.type, (brake_speed << 16));
+            auto boosterSpeed = GetBoosterSpeed(curRide.type, brake_speed) << kTrackSpeedShiftAmount;
             if (boosterSpeed > _vehicleVelocityF64E08)
             {
                 acceleration = GetRideTypeDescriptor(curRide.type).LegacyBoosterSettings.BoosterAcceleration
-                    << 16; //_vehicleVelocityF64E08 * 1.2;
+                    << kBoosterAccelerationShiftAmount; //_vehicleVelocityF64E08 * 1.2;
             }
         }
         else if (rideEntry.flags & RIDE_ENTRY_FLAG_RIDER_CONTROLS_SPEED && num_peeps > 0)
@@ -7140,7 +7143,7 @@ bool Vehicle::UpdateTrackMotionForwards(const CarEntry* carEntry, const Ride& cu
         if ((trackType == TrackElemType::Flat && curRide.GetRideTypeDescriptor().HasFlag(RtdFlag::hasLsmBehaviourOnFlat))
             || (trackType == TrackElemType::PoweredLift))
         {
-            acceleration = GetRideTypeDescriptor(curRide.type).LegacyBoosterSettings.PoweredLiftAcceleration << 16;
+            acceleration = GetRideTypeDescriptor(curRide.type).LegacyBoosterSettings.PoweredLiftAcceleration << kBoosterAccelerationShiftAmount;
         }
         if (trackType == TrackElemType::BrakeForDrop)
         {
@@ -7505,7 +7508,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
         {
             auto brakeSpeed = ChooseBrakeSpeed();
 
-            if (-(brakeSpeed << 16) > _vehicleVelocityF64E08)
+            if (-(brakeSpeed << kTrackSpeedShiftAmount) > _vehicleVelocityF64E08)
             {
                 acceleration = _vehicleVelocityF64E08 * -16;
             }


### PR DESCRIPTION
Some more changes spun off from #16692

Reverse boosters never worked because boosterSpeed is positive and _vehicleVelocityF64E08 is negative, so the condition is always false. A separate PR adding booster modes can add this back.