### PR TITLE
Dukvalue uint int fixes

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -33,7 +33,7 @@
 - Fix: [#22008] Uninverted Lay-down roller coaster uses the wrong support type.
 - Fix: [#22012] [Plugin] Images on ImgButton widgets cannot be updated.
 - Fix: [#22121] Some news items in the “Recent Messages” window have the wrong text colour.
-- Fix: [#22152] [Plugin] Fix dukvalue unsigned integer type cast mismatch.
+- Fix: [#22152] [Plugin] Negative signed integers are truncated.
 - Fix: [objects#323] Incorrect wall boundaries on large WW/TT scenery objects.
 - Fix: [objects#331] Incorrect hover car capacity string.
 - Fix: [objects#334] Incorrect school bus capacity string.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -32,7 +32,8 @@
 - Fix: [#21974] No reason specified when attempting to place benches, lamps, or bins on path with no unconnected edges (original bug).
 - Fix: [#22008] Uninverted Lay-down roller coaster uses the wrong support type.
 - Fix: [#22012] [Plugin] Images on ImgButton widgets cannot be updated.
-- Fix: [#22121] Some news items in the “Recent Messages” window have the wrong text colour.  
+- Fix: [#22121] Some news items in the “Recent Messages” window have the wrong text colour.
+- Fix: [#22152] [Plugin] Fix dukvalue unsigned integer type cast mismatch.
 - Fix: [objects#323] Incorrect wall boundaries on large WW/TT scenery objects.
 - Fix: [objects#331] Incorrect hover car capacity string.
 - Fix: [objects#334] Incorrect school bus capacity string.

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -215,7 +215,7 @@ namespace OpenRCT2::Ui::Windows
             }
             else if (dukImage.type() == DukValue::Type::OBJECT)
             {
-                result.imageFrameBase = ImageId::FromUInt32(static_cast<uint32_t>(dukImage["frameBase"].as_int()));
+                result.imageFrameBase = ImageId::FromUInt32(dukImage["frameBase"].as_uint());
                 result.imageFrameCount = AsOrDefault(dukImage["frameCount"], 0);
                 result.imageFrameDuration = AsOrDefault(dukImage["frameDuration"], 0);
 
@@ -305,8 +305,8 @@ namespace OpenRCT2::Ui::Windows
                     ColourWithFlags c = { COLOUR_BLACK };
                     if (w.type() == DukValue::Type::NUMBER)
                     {
-                        colour_t colour = w.as_int() & ~kLegacyColourFlagTranslucent;
-                        auto isTranslucent = (w.as_int() & kLegacyColourFlagTranslucent);
+                        colour_t colour = w.as_uint() & ~kLegacyColourFlagTranslucent;
+                        auto isTranslucent = (w.as_uint() & kLegacyColourFlagTranslucent);
                         c.colour = std::clamp<colour_t>(colour, COLOUR_BLACK, COLOUR_COUNT - 1);
                         c.flags = (isTranslucent ? EnumToFlag(ColourFlag::translucent) : 0);
                     }

--- a/src/openrct2-ui/scripting/ScGraphicsContext.hpp
+++ b/src/openrct2-ui/scripting/ScGraphicsContext.hpp
@@ -75,7 +75,7 @@ namespace OpenRCT2::Scripting
         void colour_set(DukValue value)
         {
             if (value.type() == DukValue::NUMBER)
-                _colour = static_cast<colour_t>(value.as_int());
+                _colour = static_cast<colour_t>(value.as_uint());
             else
                 _colour = {};
         }
@@ -88,7 +88,7 @@ namespace OpenRCT2::Scripting
         void secondaryColour_set(DukValue value)
         {
             if (value.type() == DukValue::NUMBER)
-                _secondaryColour = static_cast<colour_t>(value.as_int());
+                _secondaryColour = static_cast<colour_t>(value.as_uint());
             else
                 _secondaryColour = {};
         }
@@ -101,7 +101,7 @@ namespace OpenRCT2::Scripting
         void tertiaryColour_set(DukValue value)
         {
             if (value.type() == DukValue::NUMBER)
-                _tertiaryColour = static_cast<colour_t>(value.as_int());
+                _tertiaryColour = static_cast<colour_t>(value.as_uint());
             else
                 _tertiaryColour = {};
         }
@@ -114,7 +114,7 @@ namespace OpenRCT2::Scripting
         void paletteId_set(DukValue value)
         {
             if (value.type() == DukValue::NUMBER)
-                _paletteId = static_cast<uint8_t>(value.as_int());
+                _paletteId = static_cast<uint8_t>(value.as_uint());
             else
                 _paletteId = {};
         }

--- a/src/openrct2-ui/scripting/ScImageManager.hpp
+++ b/src/openrct2-ui/scripting/ScImageManager.hpp
@@ -93,8 +93,8 @@ namespace OpenRCT2::Scripting
 
         void free(const DukValue& dukRange)
         {
-            auto start = dukRange["start"].as_int();
-            auto count = dukRange["count"].as_int();
+            auto start = dukRange["start"].as_uint();
+            auto count = dukRange["count"].as_uint();
 
             ImageList range(start, count);
 

--- a/src/openrct2-ui/scripting/ScTitleSequence.hpp
+++ b/src/openrct2-ui/scripting/ScTitleSequence.hpp
@@ -130,26 +130,26 @@ namespace OpenRCT2::Scripting
         switch (type)
         {
             case TitleScript::Load:
-                command = LoadParkCommand{ static_cast<uint8_t>(value["index"].as_int()) };
+                command = LoadParkCommand{ static_cast<uint8_t>(value["index"].as_uint()) };
                 break;
             case TitleScript::Location:
                 command = SetLocationCommand{
-                    static_cast<uint8_t>(value["x"].as_int()),
-                    static_cast<uint8_t>(value["y"].as_int()),
+                    static_cast<uint8_t>(value["x"].as_uint()),
+                    static_cast<uint8_t>(value["y"].as_uint()),
                 };
                 break;
             case TitleScript::Rotate:
-                command = RotateViewCommand{ static_cast<uint8_t>(value["rotations"].as_int()) };
+                command = RotateViewCommand{ static_cast<uint8_t>(value["rotations"].as_uint()) };
                 break;
             case TitleScript::Zoom:
-                command = SetZoomCommand{ static_cast<uint8_t>(value["zoom"].as_int()) };
+                command = SetZoomCommand{ static_cast<uint8_t>(value["zoom"].as_uint()) };
                 break;
             case TitleScript::Follow:
             {
                 auto dukId = value["id"];
                 if (dukId.type() == DukValue::Type::NUMBER)
                 {
-                    command = FollowEntityCommand{ EntityId::FromUnderlying(dukId.as_int()) };
+                    command = FollowEntityCommand{ EntityId::FromUnderlying(dukId.as_uint()) };
                 }
                 else
                 {
@@ -158,10 +158,10 @@ namespace OpenRCT2::Scripting
                 break;
             }
             case TitleScript::Speed:
-                command = SetSpeedCommand{ static_cast<uint8_t>(value["speed"].as_int()) };
+                command = SetSpeedCommand{ static_cast<uint8_t>(value["speed"].as_uint()) };
                 break;
             case TitleScript::Wait:
-                command = WaitCommand{ static_cast<uint16_t>(value["duration"].as_int()) };
+                command = WaitCommand{ static_cast<uint16_t>(value["duration"].as_uint()) };
                 break;
             case TitleScript::LoadSc:
             {

--- a/src/openrct2-ui/scripting/ScUi.hpp
+++ b/src/openrct2-ui/scripting/ScUi.hpp
@@ -206,7 +206,7 @@ namespace OpenRCT2::Scripting
             if (a.type() == DukValue::Type::NUMBER)
             {
                 auto index = a.as_uint();
-                auto i = 0;
+                size_t i = 0;
                 for (const auto& w : g_window_list)
                 {
                     if (i == index)

--- a/src/openrct2-ui/scripting/ScUi.hpp
+++ b/src/openrct2-ui/scripting/ScUi.hpp
@@ -187,7 +187,7 @@ namespace OpenRCT2::Scripting
             {
                 if (id.type() == DukValue::Type::NUMBER)
                 {
-                    WindowCloseByNumber(cls, id.as_int());
+                    WindowCloseByNumber(cls, id.as_uint());
                 }
                 else
                 {
@@ -205,7 +205,7 @@ namespace OpenRCT2::Scripting
         {
             if (a.type() == DukValue::Type::NUMBER)
             {
-                auto index = a.as_int();
+                auto index = a.as_uint();
                 auto i = 0;
                 for (const auto& w : g_window_list)
                 {

--- a/src/openrct2/scripting/Plugin.cpp
+++ b/src/openrct2/scripting/Plugin.cpp
@@ -160,13 +160,13 @@ PluginMetadata Plugin::GetMetadata(const DukValue& dukMetadata)
         auto dukMinApiVersion = dukMetadata["minApiVersion"];
         if (dukMinApiVersion.type() == DukValue::Type::NUMBER)
         {
-            metadata.MinApiVersion = dukMinApiVersion.as_int();
+            metadata.MinApiVersion = dukMinApiVersion.as_uint();
         }
 
         auto dukTargetApiVersion = dukMetadata["targetApiVersion"];
         if (dukTargetApiVersion.type() == DukValue::Type::NUMBER)
         {
-            metadata.TargetApiVersion = dukTargetApiVersion.as_int();
+            metadata.TargetApiVersion = dukTargetApiVersion.as_uint();
         }
         else
         {

--- a/src/openrct2/scripting/bindings/entity/ScParticle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScParticle.cpp
@@ -183,11 +183,11 @@ namespace OpenRCT2::Scripting
             }
             if (value["timeToLive"].type() == DukValue::Type::NUMBER)
             {
-                entity->time_to_live = value["timeToLive"].as_int();
+                entity->time_to_live = value["timeToLive"].as_uint();
             }
             if (value["frame"].type() == DukValue::Type::NUMBER)
             {
-                entity->frame = std::clamp<uint16_t>(value["frame"].as_int(), 0, kCrashedVehicleParticleNumberSprites - 1)
+                entity->frame = std::clamp<uint16_t>(value["frame"].as_uint(), 0, kCrashedVehicleParticleNumberSprites - 1)
                     * kCrashedVehicleParticleFrameToSprite;
             }
             if (value["crashParticleType"].type() == DukValue::Type::STRING)

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
@@ -191,7 +191,7 @@ namespace OpenRCT2::Scripting
         {
             if (value.type() == DukValue::Type::NUMBER)
             {
-                vehicle->next_vehicle_on_train = EntityId::FromUnderlying(value.as_int());
+                vehicle->next_vehicle_on_train = EntityId::FromUnderlying(value.as_uint());
             }
             else
             {

--- a/src/openrct2/scripting/bindings/game/ScContext.hpp
+++ b/src/openrct2/scripting/bindings/game/ScContext.hpp
@@ -138,8 +138,8 @@ namespace OpenRCT2::Scripting
             {
                 CaptureOptions captureOptions;
                 captureOptions.Filename = fs::u8path(AsOrDefault(options["filename"], ""));
-                captureOptions.Rotation = options["rotation"].as_int() & 3;
-                captureOptions.Zoom = ZoomLevel(options["zoom"].as_int());
+                captureOptions.Rotation = options["rotation"].as_uint() & 3;
+                captureOptions.Zoom = ZoomLevel(options["zoom"].as_uint());
                 captureOptions.Transparent = AsOrDefault(options["transparent"], false);
 
                 auto dukPosition = options["position"];

--- a/src/openrct2/scripting/bindings/network/ScNetwork.cpp
+++ b/src/openrct2/scripting/bindings/network/ScNetwork.cpp
@@ -268,7 +268,7 @@ namespace OpenRCT2::Scripting
                 {
                     if (item.type() == DukValue::Type::NUMBER)
                     {
-                        playerIds.push_back(static_cast<uint8_t>(item.as_int()));
+                        playerIds.push_back(static_cast<uint8_t>(item.as_uint()));
                     }
                 }
                 if (!playerArray.empty())

--- a/src/openrct2/scripting/bindings/object/ScObjectManager.cpp
+++ b/src/openrct2/scripting/bindings/object/ScObjectManager.cpp
@@ -105,7 +105,7 @@ DukValue ScObjectManager::load(const DukValue& p1, const DukValue& p2)
                 if (p2.type() != DukValue::NUMBER)
                     throw DukException() << "Expected number for 'index'.";
 
-                auto index = static_cast<size_t>(p2.as_int());
+                auto index = static_cast<size_t>(p2.as_uint());
                 auto limit = getObjectTypeLimit(installedObject->Type);
                 if (index < limit)
                 {
@@ -155,7 +155,7 @@ void ScObjectManager::unload(const DukValue& p1, const DukValue& p2)
             if (p2.type() != DukValue::NUMBER)
                 throw DukException() << "'index' is invalid.";
 
-            auto objIndex = p2.as_int();
+            auto objIndex = p2.as_uint();
             auto obj = objectManager.GetLoadedObject(*objType, objIndex);
             if (obj != nullptr)
             {

--- a/src/openrct2/scripting/bindings/world/ScPark.cpp
+++ b/src/openrct2/scripting/bindings/world/ScPark.cpp
@@ -390,7 +390,7 @@ namespace OpenRCT2::Scripting
                 auto dukSubject = message["subject"];
                 if (dukSubject.type() == DukValue::Type::NUMBER)
                 {
-                    assoc = static_cast<uint32_t>(dukSubject.as_int());
+                    assoc = static_cast<uint32_t>(dukSubject.as_uint());
                 }
             }
             News::AddItemToQueue(type, text.c_str(), assoc);

--- a/src/openrct2/scripting/bindings/world/ScParkMessage.hpp
+++ b/src/openrct2/scripting/bindings/world/ScParkMessage.hpp
@@ -53,10 +53,10 @@ namespace OpenRCT2::Scripting
     {
         News::Item result{};
         result.Type = GetParkMessageType(value["type"].as_string());
-        result.Assoc = value["subject"].as_int();
-        result.Ticks = value["tickCount"].as_int();
-        result.MonthYear = value["month"].as_int();
-        result.Day = value["day"].as_int();
+        result.Assoc = value["subject"].as_uint();
+        result.Ticks = value["tickCount"].as_uint();
+        result.MonthYear = value["month"].as_uint();
+        result.Day = value["day"].as_uint();
         result.Text = value["text"].as_string();
         return result;
     }

--- a/src/openrct2/scripting/bindings/world/ScResearch.cpp
+++ b/src/openrct2/scripting/bindings/world/ScResearch.cpp
@@ -83,8 +83,8 @@ namespace OpenRCT2::Scripting
         result.type = FromDuk<Research::EntryType>(d["type"]);
         auto baseRideType = d["rideType"];
         if (baseRideType.type() == DukValue::NUMBER)
-            result.baseRideType = baseRideType.as_int();
-        result.entryIndex = d["object"].as_int();
+            result.baseRideType = baseRideType.as_uint();
+        result.entryIndex = d["object"].as_uint();
         return result;
     }
 

--- a/src/openrct2/scripting/bindings/world/ScTileElement.cpp
+++ b/src/openrct2/scripting/bindings/world/ScTileElement.cpp
@@ -1866,7 +1866,7 @@ namespace OpenRCT2::Scripting
             if (value.type() == DukValue::Type::NUMBER)
             {
                 auto addition = value.as_uint();
-                if (addition >= 0 && addition <= 254)
+                if (addition <= 254)
                 {
                     el->SetAdditionEntryIndex(addition);
                 }

--- a/src/openrct2/scripting/bindings/world/ScTileElement.cpp
+++ b/src/openrct2/scripting/bindings/world/ScTileElement.cpp
@@ -1662,7 +1662,7 @@ namespace OpenRCT2::Scripting
             if (value.type() == DukValue::Type::NUMBER)
             {
                 el->SetSloped(true);
-                el->SetSlopeDirection(value.as_int());
+                el->SetSlopeDirection(value.as_uint());
             }
             else
             {
@@ -1715,7 +1715,7 @@ namespace OpenRCT2::Scripting
             if (value.type() == DukValue::Type::NUMBER)
             {
                 el->SetHasQueueBanner(true);
-                el->SetQueueBannerDirection(value.as_int());
+                el->SetQueueBannerDirection(value.as_uint());
             }
             else
             {
@@ -1865,7 +1865,7 @@ namespace OpenRCT2::Scripting
         {
             if (value.type() == DukValue::Type::NUMBER)
             {
-                auto addition = value.as_int();
+                auto addition = value.as_uint();
                 if (addition >= 0 && addition <= 254)
                 {
                     el->SetAdditionEntryIndex(addition);

--- a/src/thirdparty/dukglue/dukvalue.h
+++ b/src/thirdparty/dukglue/dukvalue.h
@@ -336,7 +336,7 @@ public:
 	inline duk_int_t as_int() const {
 		if (mType != NUMBER)
 			throw DukException() << "Expected number, got " << type_name();
-		return static_cast<uint32_t>(mPOD.number);
+		return static_cast<int32_t>(mPOD.number);
 	}
 
 	inline duk_uint_t as_uint() const {


### PR DESCRIPTION
1. Fix the problem where `DukValue::as_int()` casts the value to `uint32_t`.
2. Fix all occurrences of `DukValue::as_int()` where `DukValue::as_uint()` should be used instead. Some common cases include casting values to `RideId`, `colour_t`, `rct_windownumber`, `ZoomLevel`, etc.