### PR TITLE
fix #21987: API cannot handle negative removal prices

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -30,7 +30,7 @@
 - Fix: [#13294] Map corners are cut off in some directions (original bug).
 - Fix: [#14630] Non-ASCII thousands and decimal separators not processed correctly.
 - Fix: [#21974] No reason specified when attempting to place benches, lamps, or bins on path with no unconnected edges (original bug).
-- Fix: [#21987] [Plugin] API can now handle negative removal prices.
+- Fix: [#21987] [Plugin] API cannot handle negative removal prices.
 - Fix: [#22008] Uninverted Lay-down roller coaster uses the wrong support type.
 - Fix: [#22012] [Plugin] Images on ImgButton widgets cannot be updated.
 - Fix: [#22121] Some news items in the “Recent Messages” window have the wrong text colour.  

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -30,6 +30,7 @@
 - Fix: [#13294] Map corners are cut off in some directions (original bug).
 - Fix: [#14630] Non-ASCII thousands and decimal separators not processed correctly.
 - Fix: [#21974] No reason specified when attempting to place benches, lamps, or bins on path with no unconnected edges (original bug).
+- Fix: [#21987] [Plugin] API can now handle negative removal prices.
 - Fix: [#22008] Uninverted Lay-down roller coaster uses the wrong support type.
 - Fix: [#22012] [Plugin] Images on ImgButton widgets cannot be updated.
 - Fix: [#22121] Some news items in the “Recent Messages” window have the wrong text colour.  

--- a/src/openrct2/scripting/bindings/object/ScObject.hpp
+++ b/src/openrct2/scripting/bindings/object/ScObject.hpp
@@ -864,7 +864,7 @@ namespace OpenRCT2::Scripting
             return 0;
         }
 
-        uint8_t price_get() const
+        money64 price_get() const
         {
             auto sceneryEntry = GetLegacyData();
             if (sceneryEntry != nullptr)
@@ -874,7 +874,7 @@ namespace OpenRCT2::Scripting
             return 0;
         }
 
-        uint8_t removalPrice_get() const
+        money64 removalPrice_get() const
         {
             auto sceneryEntry = GetLegacyData();
             if (sceneryEntry != nullptr)


### PR DESCRIPTION
Changes the return type of the getter from uint8 to money64 (=int64), which is the type that the actual property has.
Applies the same to `price`, which couldn't handle prices above ~255~ 25.50 GBP before.