### PR TITLE
Clean OrcaStream includes

### DIFF
--- a/src/openrct2/core/OrcaStream.hpp
+++ b/src/openrct2/core/OrcaStream.hpp
@@ -15,10 +15,9 @@
 #include "Identifier.hpp"
 #include "MemoryStream.h"
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
-#include <fstream>
-#include <sstream>
 #include <stack>
 #include <type_traits>
 #include <vector>


### PR DESCRIPTION
I need `algorithm` in there for it to compile, otherwise it can't find `std::find_if`.

I also found the other includes were not necessary.