### PR TITLE
Abstract flags access in track design scenery

### DIFF
--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -70,6 +70,20 @@
 #include <iterator>
 #include <memory>
 
+namespace TrackDesignSceneryElementFlags
+{
+    static constexpr uint8_t kRotationMask = 0b00000011;
+
+    static constexpr uint8_t kQuadrantMask = 0b00001100;
+
+    static constexpr uint8_t kEdgesMask = 0b00001111;
+    static constexpr uint8_t kHasSlopeMask = 0b00010000;
+    static constexpr uint8_t kSlopeDirectionMask = 0b01100000;
+    static constexpr uint8_t kIsQueueMask = 0b10000000;
+} // namespace TrackDesignSceneryElementFlags
+
+using namespace TrackDesignSceneryElementFlags;
+
 using namespace OpenRCT2;
 using namespace OpenRCT2::Drawing;
 using namespace OpenRCT2::TrackMetaData;
@@ -1958,6 +1972,89 @@ static bool TrackDesignPlacePreview(TrackDesignState& tds, TrackDesign* td6, mon
     ride->Delete();
     _trackDesignDrawingPreview = false;
     return false;
+}
+
+Direction TrackDesignSceneryElement::getRotation() const
+{
+    return flags & kRotationMask;
+}
+
+void TrackDesignSceneryElement::setRotation(Direction rotation)
+{
+    flags &= ~kRotationMask;
+    flags |= (rotation & kRotationMask);
+}
+
+// Small scenery
+uint8_t TrackDesignSceneryElement::getQuadrant() const
+{
+    return (flags & kQuadrantMask) >> 2;
+}
+
+void TrackDesignSceneryElement::setQuadrant(uint8_t quadrant)
+{
+    flags &= ~kQuadrantMask;
+    flags |= ((quadrant << 2) & kQuadrantMask);
+}
+
+// Path
+bool TrackDesignSceneryElement::hasSlope() const
+{
+    return (flags & kHasSlopeMask) != 0;
+}
+
+void TrackDesignSceneryElement::setHasSlope(bool on)
+{
+    if (on)
+        flags |= kHasSlopeMask;
+    else
+        flags &= ~kHasSlopeMask;
+}
+
+Direction TrackDesignSceneryElement::getSlopeDirection() const
+{
+    return (flags >> 5) % NumOrthogonalDirections;
+}
+
+void TrackDesignSceneryElement::setSlopeDirection(Direction slope)
+{
+    flags &= ~kSlopeDirectionMask;
+    flags |= ((slope << 5) & kSlopeDirectionMask);
+}
+
+uint8_t TrackDesignSceneryElement::getEdges() const
+{
+    return (flags & kEdgesMask);
+}
+
+void TrackDesignSceneryElement::setEdges(uint8_t edges)
+{
+    flags &= ~kEdgesMask;
+    flags |= (edges & kEdgesMask);
+}
+
+bool TrackDesignSceneryElement::isQueue() const
+{
+    return (flags & kIsQueueMask) != 0;
+}
+
+void TrackDesignSceneryElement::setIsQueue(bool on)
+{
+    if (on)
+        flags |= kIsQueueMask;
+    else
+        flags &= ~kIsQueueMask;
+}
+
+bool TrackDesignSceneryElement::operator==(const TrackDesignSceneryElement& rhs)
+{
+    return sceneryObject == rhs.sceneryObject && loc == rhs.loc && flags == rhs.flags && primaryColour == rhs.primaryColour
+        && secondaryColour == rhs.secondaryColour && tertiaryColour == rhs.tertiaryColour;
+}
+
+bool TrackDesignSceneryElement::operator!=(const TrackDesignSceneryElement& rhs)
+{
+    return !((*this) == rhs);
 }
 
 #pragma region Track Design Preview

--- a/src/openrct2/ride/TrackDesign.h
+++ b/src/openrct2/ride/TrackDesign.h
@@ -53,88 +53,28 @@ struct TrackDesignSceneryElement
     colour_t secondaryColour{};
     colour_t tertiaryColour = COLOUR_DARK_BROWN;
 
-    Direction getRotation() const
-    {
-        return flags & 0x3;
-    }
-
-    void setRotation(Direction rotation)
-    {
-        flags &= ~0x3;
-        flags |= (rotation & 0x3);
-    }
+    Direction getRotation() const;
+    void setRotation(Direction rotation);
 
     // Small scenery
-    uint8_t getQuadrant() const
-    {
-        return (flags >> 2) & 0x3;
-    }
-
-    void setQuadrant(uint8_t quadrant)
-    {
-        flags &= ~0b00001100;
-        flags |= (quadrant & 0x3) << 2;
-    }
+    uint8_t getQuadrant() const;
+    void setQuadrant(uint8_t quadrant);
 
     // Path
-    bool hasSlope() const
-    {
-        return (flags & 0b00010000) != 0;
-    }
+    bool hasSlope() const;
+    void setHasSlope(bool on);
 
-    void setHasSlope(bool on)
-    {
-        if (on)
-            flags |= 0b00010000;
-        else
-            flags &= ~0b00010000;
-    }
+    Direction getSlopeDirection() const;
+    void setSlopeDirection(Direction slope);
 
-    Direction getSlopeDirection() const
-    {
-        return (flags >> 5) % NumOrthogonalDirections;
-    }
+    uint8_t getEdges() const;
+    void setEdges(uint8_t edges);
 
-    void setSlopeDirection(Direction slope)
-    {
-        flags &= 0x9F;
-        flags |= ((slope & 3) << 5);
-    }
+    bool isQueue() const;
+    void setIsQueue(bool on);
 
-    uint8_t getEdges() const
-    {
-        return (flags & 0xF);
-    }
-
-    void setEdges(uint8_t edges)
-    {
-        flags &= ~0xF;
-        flags |= (edges & 0xF);
-    }
-
-    bool isQueue() const
-    {
-        return (flags & (1 << 7)) != 0;
-    }
-
-    void setIsQueue(bool on)
-    {
-        if (on)
-            flags |= 0b10000000;
-        else
-            flags &= ~0b10000000;
-    }
-
-    bool operator==(const TrackDesignSceneryElement& rhs)
-    {
-        return sceneryObject == rhs.sceneryObject && loc == rhs.loc && flags == rhs.flags && primaryColour == rhs.primaryColour
-            && secondaryColour == rhs.secondaryColour && tertiaryColour == rhs.tertiaryColour;
-    }
-
-    bool operator!=(const TrackDesignSceneryElement& rhs)
-    {
-        return !((*this) == rhs);
-    }
+    bool operator==(const TrackDesignSceneryElement& rhs);
+    bool operator!=(const TrackDesignSceneryElement& rhs);
 };
 
 enum class TrackDesignTrackElementFlag : uint8_t

--- a/src/openrct2/ride/TrackDesign.h
+++ b/src/openrct2/ride/TrackDesign.h
@@ -46,16 +46,94 @@ struct TrackDesignEntranceElement
 
 struct TrackDesignSceneryElement
 {
-    ObjectEntryDescriptor sceneryObject;
-    CoordsXYZ loc;
-    uint8_t flags;
-    colour_t primaryColour;
-    colour_t secondaryColour;
+    ObjectEntryDescriptor sceneryObject{};
+    CoordsXYZ loc{};
+    uint8_t flags{};
+    colour_t primaryColour{};
+    colour_t secondaryColour{};
     colour_t tertiaryColour = COLOUR_DARK_BROWN;
 
-    bool IsQueue() const
+    Direction getRotation() const
+    {
+        return flags & 0x3;
+    }
+
+    void setRotation(Direction rotation)
+    {
+        flags &= ~0x3;
+        flags |= (rotation & 0x3);
+    }
+
+    // Small scenery
+    uint8_t getQuadrant() const
+    {
+        return (flags >> 2) & 0x3;
+    }
+
+    void setQuadrant(uint8_t quadrant)
+    {
+        flags &= ~0b00001100;
+        flags |= (quadrant & 0x3) << 2;
+    }
+
+    // Path
+    bool hasSlope() const
+    {
+        return (flags & 0b00010000) != 0;
+    }
+
+    void setHasSlope(bool on)
+    {
+        if (on)
+            flags |= 0b00010000;
+        else
+            flags &= ~0b00010000;
+    }
+
+    Direction getSlopeDirection() const
+    {
+        return (flags >> 5) % NumOrthogonalDirections;
+    }
+
+    void setSlopeDirection(Direction slope)
+    {
+        flags &= 0x9F;
+        flags |= ((slope & 3) << 5);
+    }
+
+    uint8_t getEdges() const
+    {
+        return (flags & 0xF);
+    }
+
+    void setEdges(uint8_t edges)
+    {
+        flags &= ~0xF;
+        flags |= (edges & 0xF);
+    }
+
+    bool isQueue() const
     {
         return (flags & (1 << 7)) != 0;
+    }
+
+    void setIsQueue(bool on)
+    {
+        if (on)
+            flags |= 0b10000000;
+        else
+            flags &= ~0b10000000;
+    }
+
+    bool operator==(const TrackDesignSceneryElement& rhs)
+    {
+        return sceneryObject == rhs.sceneryObject && loc == rhs.loc && flags == rhs.flags && primaryColour == rhs.primaryColour
+            && secondaryColour == rhs.secondaryColour && tertiaryColour == rhs.tertiaryColour;
+    }
+
+    bool operator!=(const TrackDesignSceneryElement& rhs)
+    {
+        return !((*this) == rhs);
     }
 };
 


### PR DESCRIPTION
Removes direct access/bitshifting in the `flags` field and replaces it with member functions.