### PR TITLE
Fix #21496: RCT1 scenery hidden after reloading

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -30,6 +30,7 @@
 - Fix: [#13234] Vehicle weight sometimes wrong after using Remove All Guests cheat.
 - Fix: [#13294] Map corners are cut off in some directions (original bug).
 - Fix: [#14630] Non-ASCII thousands and decimal separators not processed correctly.
+- Fix: [#21496] Some RCT1 scenery is hidden after saving and reloading.
 - Fix: [#21974] No reason specified when attempting to place benches, lamps, or bins on path with no unconnected edges (original bug).
 - Fix: [#21987] [Plugin] API cannot handle negative removal prices.
 - Fix: [#22008] Uninverted Lay-down roller coaster uses the wrong support type.


### PR DESCRIPTION
The problem was caused by the incorrect handling of scenery that was not part of any group, but which attached itself to one. Many scenery ported from RCT1 falls in that category.

Needs testing with some RCT1 and RCT2 scenarios, to see if the behaviour is now correct across the board.