### PR TITLE
[Plugin API] Feat: Expose staff statistics

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -37,6 +37,7 @@
 - Feature: [#22150] [Plugin] Expose monthly expenditure history to the plugin API.
 - Feature: [#22210] [Plugin] Peeps can now be made stationary or completely frozen.
 - Feature: [#22210] [Plugin] The direction in which a peep is facing can now be manipulated.
+- Feature: [#22184] [Plugin] Expose staff statistics to the plugin API.
 - Improved: [#19870] Allow using new colours in UI themes.
 - Improved: [#21774] The Alpine Coaster now supports using the alternative colour schemes.
 - Improved: [#21853] Dropdowns now automatically use multiple columns if they are too tall for the screen.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#20831] The ride selection window now shows object authors if debugging tools are active.
 - Feature: [#20832] The ride music tab now shows a track listing for the current music style.
 - Feature: [#22172] [Plugin] Expose ride satisfaction ratings to the plugin API.
+- Feature: [#22184] [Plugin] Expose staff statistics to the plugin API.
 - Feature: [#22213] [Plugin] Allow plugins to focus on textboxes in custom windows.
 - Feature: [#22301] Loading save games or scenarios now indicates loading progress.
 - Feature: [OpenMusic#54] Added Progressive ride music style (feat. Approaching Nirvana).
@@ -35,7 +36,6 @@
 - Feature: [#22090] [Plugin] Allow writing of paused state in non-networked settings.
 - Feature: [#22140] Add option to automatically close dropdown menus if Enlarged UI is enabled.
 - Feature: [#22150] [Plugin] Expose monthly expenditure history to the plugin API.
-- Feature: [#22184] [Plugin] Expose staff statistics to the plugin API.
 - Feature: [#22210] [Plugin] Peeps can now be made stationary or completely frozen.
 - Feature: [#22210] [Plugin] The direction in which a peep is facing can now be manipulated.
 - Improved: [#19870] Allow using new colours in UI themes.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -35,9 +35,9 @@
 - Feature: [#22090] [Plugin] Allow writing of paused state in non-networked settings.
 - Feature: [#22140] Add option to automatically close dropdown menus if Enlarged UI is enabled.
 - Feature: [#22150] [Plugin] Expose monthly expenditure history to the plugin API.
+- Feature: [#22184] [Plugin] Expose staff statistics to the plugin API.
 - Feature: [#22210] [Plugin] Peeps can now be made stationary or completely frozen.
 - Feature: [#22210] [Plugin] The direction in which a peep is facing can now be manipulated.
-- Feature: [#22184] [Plugin] Expose staff statistics to the plugin API.
 - Improved: [#19870] Allow using new colours in UI themes.
 - Improved: [#21774] The Alpine Coaster now supports using the alternative colour schemes.
 - Improved: [#21853] Dropdowns now automatically use multiple columns if they are too tall for the screen.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -3355,22 +3355,22 @@ declare global {
         /**
          * The number of lawns mown by the handyman.
          */
-        lawnsMown: number;
+        readonly lawnsMown: number;
 
         /**
          * The number of gardens watered by the handyman.
          */
-        gardensWatered: number;
+        readonly gardensWatered: number;
 
         /**
          * The number of litter swept by the handyman.
          */
-        litterSwept: number;
+        readonly litterSwept: number;
 
         /**
          * The number of bins emptied by the handyman.
          */
-        binsEmptied: number;
+        readonly binsEmptied: number;
     }
 
     /**
@@ -3382,12 +3382,12 @@ declare global {
         /**
          * The number of rides fixed by the mechanic.
          */
-        ridesFixed: number;
+        readonly ridesFixed: number;
 
         /**
          * The number of inspections performed by the mechanic.
          */
-        ridesInspected: number;
+        readonly ridesInspected: number;
     }
 
     /**
@@ -3399,7 +3399,7 @@ declare global {
         /**
          * The number of vandals stopped by the security guard.
          */
-        vandalsStopped: number;
+        readonly vandalsStopped: number;
     }
 
     interface Entertainer extends BaseStaff {

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -3340,23 +3340,59 @@ declare global {
          * The total number of frames in the current animation.
          */
         readonly animationLength: number;
-
-        lawnsMown: number | null;
-
-        gardensWatered: number | null;
-
-        litterSwept: number | null;
-
-        binsEmptied: number | null;
-
-        ridesFixed: number | null;
-
-        ridesInspected: number | null;
-
-        vandalsStopped: number | null;
     }
 
     type StaffType = "handyman" | "mechanic" | "security" | "entertainer";
+
+    /**
+     * Represents a handyman.
+     */
+    interface Handyman extends Staff {
+        /**
+         * The number of lawns mown by the handyman.
+         */
+        lawnsMown: number;
+
+        /**
+         * The number of gardens watered by the handyman.
+         */
+        gardensWatered: number;
+
+        /**
+         * The number of litter swept by the handyman.
+         */
+        litterSwept: number;
+
+        /**
+         * The number of bins emptied by the handyman.
+         */
+        binsEmptied: number;
+    }
+
+    /**
+     * Represents a mechanic.
+     */
+    interface Mechanic extends Staff {
+        /**
+         * The number of rides fixed by the mechanic.
+         */
+        ridesFixed: number;
+
+        /**
+         * The number of inspections performed by the mechanic.
+         */
+        ridesInspected: number;
+    }
+
+    /**
+     * Represents a security guard.
+     */
+    interface Security extends Staff {
+        /**
+         * The number of vandals stopped by the security guard.
+         */
+        vandalsStopped: number;
+    }
 
     interface PatrolArea {
         /**

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -3340,6 +3340,20 @@ declare global {
          * The total number of frames in the current animation.
          */
         readonly animationLength: number;
+
+        lawnsMown: number | null;
+
+        gardensWatered: number | null;
+
+        litterSwept: number | null;
+
+        binsEmptied: number | null;
+
+        ridesFixed: number | null;
+
+        ridesInspected: number | null;
+
+        vandalsStopped: number | null;
     }
 
     type StaffType = "handyman" | "mechanic" | "security" | "entertainer";

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -3285,7 +3285,7 @@ declare global {
     /**
      * Represents a staff member.
      */
-    interface Staff extends Peep {
+    interface BaseStaff extends Peep {
         /**
          * The type of staff member, e.g. handyman, mechanic.
          */
@@ -3344,10 +3344,14 @@ declare global {
 
     type StaffType = "handyman" | "mechanic" | "security" | "entertainer";
 
+    type Staff = Handyman | Mechanic | Security | Entertainer;
+
     /**
      * Represents a handyman.
      */
-    interface Handyman extends Staff {
+    interface Handyman extends BaseStaff {
+        staffType: "handyman";
+
         /**
          * The number of lawns mown by the handyman.
          */
@@ -3372,7 +3376,9 @@ declare global {
     /**
      * Represents a mechanic.
      */
-    interface Mechanic extends Staff {
+    interface Mechanic extends BaseStaff {
+        staffType: "mechanic";
+
         /**
          * The number of rides fixed by the mechanic.
          */
@@ -3387,11 +3393,17 @@ declare global {
     /**
      * Represents a security guard.
      */
-    interface Security extends Staff {
+    interface Security extends BaseStaff {
+        staffType: "security";
+
         /**
          * The number of vandals stopped by the security guard.
          */
         vandalsStopped: number;
+    }
+
+    interface Entertainer extends BaseStaff {
+        staffType: "entertainer";
     }
 
     interface PatrolArea {

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -450,6 +450,9 @@ void ScriptEngine::Initialise()
     ScScenarioObjective::Register(ctx);
     ScPatrolArea::Register(ctx);
     ScStaff::Register(ctx);
+    ScHandyman::Register(ctx);
+    ScMechanic::Register(ctx);
+    ScSecurity::Register(ctx);
     ScPlugin::Register(ctx);
 
     dukglue_register_global(ctx, std::make_shared<ScCheats>(), "cheats");

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -46,7 +46,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 95;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 96;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -78,13 +78,6 @@ namespace OpenRCT2::Scripting
         dukglue_register_property(ctx, &ScStaff::animationOffset_get, &ScStaff::animationOffset_set, "animationOffset");
         dukglue_register_property(ctx, &ScStaff::animationLength_get, nullptr, "animationLength");
         dukglue_register_method(ctx, &ScStaff::getAnimationSpriteIds, "getAnimationSpriteIds");
-        dukglue_register_property(ctx, &ScStaff::lawnsMown_get, &ScStaff::lawnsMown_set, "lawnsMown");
-        dukglue_register_property(ctx, &ScStaff::gardensWatered_get, &ScStaff::gardensWatered_set, "gardensWatered");
-        dukglue_register_property(ctx, &ScStaff::litterSwept_get, &ScStaff::litterSwept_set, "litterSwept");
-        dukglue_register_property(ctx, &ScStaff::binsEmptied_get, &ScStaff::binsEmptied_set, "binsEmptied");
-        dukglue_register_property(ctx, &ScStaff::ridesFixed_get, &ScStaff::ridesFixed_set, "ridesFixed");
-        dukglue_register_property(ctx, &ScStaff::ridesInspected_get, &ScStaff::ridesInspected_set, "ridesInspected");
-        dukglue_register_property(ctx, &ScStaff::vandalsStopped_get, &ScStaff::vandalsStopped_set, "vandalsStopped");
     }
 
     Staff* ScStaff::GetStaff() const
@@ -445,182 +438,234 @@ namespace OpenRCT2::Scripting
         return static_cast<uint8_t>(animationGroup.frame_offsets.size());
     }
 
-    DukValue ScStaff::lawnsMown_get() const
+    ScHandyman::ScHandyman(EntityId Id)
+        : ScStaff(Id)
+    {
+    }
+
+    void ScHandyman::Register(duk_context* ctx)
+    {
+        dukglue_set_base_class<ScStaff, ScHandyman>(ctx);
+        dukglue_register_property(ctx, &ScHandyman::lawnsMown_get, &ScHandyman::lawnsMown_set, "lawnsMown");
+        dukglue_register_property(ctx, &ScHandyman::gardensWatered_get, &ScHandyman::gardensWatered_set, "gardensWatered");
+        dukglue_register_property(ctx, &ScHandyman::litterSwept_get, &ScHandyman::litterSwept_set, "litterSwept");
+        dukglue_register_property(ctx, &ScHandyman::binsEmptied_get, &ScHandyman::binsEmptied_set, "binsEmptied");
+    }
+
+    Staff* ScHandyman::GetHandyman() const
+    {
+        return ::GetEntity<Staff>(_id);
+    }
+
+    DukValue ScHandyman::lawnsMown_get() const
     {
         auto& scriptEngine = GetContext()->GetScriptEngine();
         auto* ctx = scriptEngine.GetContext();
-        auto peep = GetStaff();
+        auto peep = GetHandyman();
         if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
         {
             duk_push_uint(ctx, peep->StaffLawnsMown);
         }
         else
         {
-            duk_push_null(ctx);
+            duk_push_undefined(ctx);
         }
         return DukValue::take_from_stack(ctx);
     }
 
-    void ScStaff::lawnsMown_set(uint32_t value)
+    void ScHandyman::lawnsMown_set(uint32_t value)
     {
         ThrowIfGameStateNotMutable();
-        auto peep = GetStaff();
+        auto peep = GetHandyman();
         if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
         {
             peep->StaffLawnsMown = value;
         }
     }
 
-    DukValue ScStaff::gardensWatered_get() const
+    DukValue ScHandyman::gardensWatered_get() const
     {
         auto& scriptEngine = GetContext()->GetScriptEngine();
         auto* ctx = scriptEngine.GetContext();
-        auto peep = GetStaff();
+        auto peep = GetHandyman();
         if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
         {
             duk_push_uint(ctx, peep->StaffGardensWatered);
         }
         else
         {
-            duk_push_null(ctx);
+            duk_push_undefined(ctx);
         }
         return DukValue::take_from_stack(ctx);
     }
 
-    void ScStaff::gardensWatered_set(uint32_t value)
+    void ScHandyman::gardensWatered_set(uint32_t value)
     {
         ThrowIfGameStateNotMutable();
-        auto peep = GetStaff();
+        auto peep = GetHandyman();
         if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
         {
             peep->StaffGardensWatered = value;
         }
     }
 
-    DukValue ScStaff::litterSwept_get() const
+    DukValue ScHandyman::litterSwept_get() const
     {
         auto& scriptEngine = GetContext()->GetScriptEngine();
         auto* ctx = scriptEngine.GetContext();
-        auto peep = GetStaff();
+        auto peep = GetHandyman();
         if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
         {
             duk_push_uint(ctx, peep->StaffLitterSwept);
         }
         else
         {
-            duk_push_null(ctx);
+            duk_push_undefined(ctx);
         }
         return DukValue::take_from_stack(ctx);
     }
 
-    void ScStaff::litterSwept_set(uint32_t value)
+    void ScHandyman::litterSwept_set(uint32_t value)
     {
         ThrowIfGameStateNotMutable();
-        auto peep = GetStaff();
+        auto peep = GetHandyman();
         if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
         {
             peep->StaffLitterSwept = value;
         }
     }
 
-    DukValue ScStaff::binsEmptied_get() const
+    DukValue ScHandyman::binsEmptied_get() const
     {
         auto& scriptEngine = GetContext()->GetScriptEngine();
         auto* ctx = scriptEngine.GetContext();
-        auto peep = GetStaff();
+        auto peep = GetHandyman();
         if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
         {
             duk_push_uint(ctx, peep->StaffBinsEmptied);
         }
         else
         {
-            duk_push_null(ctx);
+            duk_push_undefined(ctx);
         }
         return DukValue::take_from_stack(ctx);
     }
 
-    void ScStaff::binsEmptied_set(uint32_t value)
+    void ScHandyman::binsEmptied_set(uint32_t value)
     {
         ThrowIfGameStateNotMutable();
-        auto peep = GetStaff();
+        auto peep = GetHandyman();
         if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
         {
             peep->StaffBinsEmptied = value;
         }
     }
 
-    DukValue ScStaff::ridesFixed_get() const
+    ScMechanic::ScMechanic(EntityId Id)
+        : ScStaff(Id)
+    {
+    }
+
+    void ScMechanic::Register(duk_context* ctx)
+    {
+        dukglue_set_base_class<ScStaff, ScMechanic>(ctx);
+        dukglue_register_property(ctx, &ScMechanic::ridesFixed_get, &ScMechanic::ridesFixed_set, "ridesFixed");
+        dukglue_register_property(ctx, &ScMechanic::ridesInspected_get, &ScMechanic::ridesInspected_set, "ridesInspected");
+    }
+
+    Staff* ScMechanic::GetMechanic() const
+    {
+        return ::GetEntity<Staff>(_id);
+    }
+
+    DukValue ScMechanic::ridesFixed_get() const
     {
         auto& scriptEngine = GetContext()->GetScriptEngine();
         auto* ctx = scriptEngine.GetContext();
-        auto peep = GetStaff();
+        auto peep = GetMechanic();
         if (peep != nullptr && peep->AssignedStaffType == StaffType::Mechanic)
         {
             duk_push_uint(ctx, peep->StaffRidesFixed);
         }
         else
         {
-            duk_push_null(ctx);
+            duk_push_undefined(ctx);
         }
         return DukValue::take_from_stack(ctx);
     }
 
-    void ScStaff::ridesFixed_set(uint32_t value)
+    void ScMechanic::ridesFixed_set(uint32_t value)
     {
         ThrowIfGameStateNotMutable();
-        auto peep = GetStaff();
+        auto peep = GetMechanic();
         if (peep != nullptr && peep->AssignedStaffType == StaffType::Mechanic)
         {
             peep->StaffRidesFixed = value;
         }
     }
 
-    DukValue ScStaff::ridesInspected_get() const
+    DukValue ScMechanic::ridesInspected_get() const
     {
         auto& scriptEngine = GetContext()->GetScriptEngine();
         auto* ctx = scriptEngine.GetContext();
-        auto peep = GetStaff();
+        auto peep = GetMechanic();
         if (peep != nullptr && peep->AssignedStaffType == StaffType::Mechanic)
         {
             duk_push_uint(ctx, peep->StaffRidesInspected);
         }
         else
         {
-            duk_push_null(ctx);
+            duk_push_undefined(ctx);
         }
         return DukValue::take_from_stack(ctx);
     }
 
-    void ScStaff::ridesInspected_set(uint32_t value)
+    void ScMechanic::ridesInspected_set(uint32_t value)
     {
         ThrowIfGameStateNotMutable();
-        auto peep = GetStaff();
+        auto peep = GetMechanic();
         if (peep != nullptr && peep->AssignedStaffType == StaffType::Mechanic)
         {
             peep->StaffRidesInspected = value;
         }
     }
 
-    DukValue ScStaff::vandalsStopped_get() const
+    ScSecurity::ScSecurity(EntityId Id)
+        : ScStaff(Id)
+    {
+    }
+
+    void ScSecurity::Register(duk_context* ctx)
+    {
+        dukglue_set_base_class<ScStaff, ScSecurity>(ctx);
+        dukglue_register_property(ctx, &ScSecurity::vandalsStopped_get, &ScSecurity::vandalsStopped_set, "vandalsStopped");
+    }
+
+    Staff* ScSecurity::GetSecurity() const
+    {
+        return ::GetEntity<Staff>(_id);
+    }
+
+    DukValue ScSecurity::vandalsStopped_get() const
     {
         auto& scriptEngine = GetContext()->GetScriptEngine();
         auto* ctx = scriptEngine.GetContext();
-        auto peep = GetStaff();
+        auto peep = GetSecurity();
         if (peep != nullptr && peep->AssignedStaffType == StaffType::Security)
         {
             duk_push_uint(ctx, peep->StaffVandalsStopped);
         }
         else
         {
-            duk_push_null(ctx);
+            duk_push_undefined(ctx);
         }
         return DukValue::take_from_stack(ctx);
     }
 
-    void ScStaff::vandalsStopped_set(uint32_t value)
+    void ScSecurity::vandalsStopped_set(uint32_t value)
     {
         ThrowIfGameStateNotMutable();
-        auto peep = GetStaff();
+        auto peep = GetSecurity();
         if (peep != nullptr && peep->AssignedStaffType == StaffType::Security)
         {
             peep->StaffVandalsStopped = value;

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -78,6 +78,13 @@ namespace OpenRCT2::Scripting
         dukglue_register_property(ctx, &ScStaff::animationOffset_get, &ScStaff::animationOffset_set, "animationOffset");
         dukglue_register_property(ctx, &ScStaff::animationLength_get, nullptr, "animationLength");
         dukglue_register_method(ctx, &ScStaff::getAnimationSpriteIds, "getAnimationSpriteIds");
+        dukglue_register_property(ctx, &ScStaff::lawnsMown_get, &ScStaff::lawnsMown_set, "lawnsMown");
+        dukglue_register_property(ctx, &ScStaff::gardensWatered_get, &ScStaff::gardensWatered_set, "gardensWatered");
+        dukglue_register_property(ctx, &ScStaff::litterSwept_get, &ScStaff::litterSwept_set, "litterSwept");
+        dukglue_register_property(ctx, &ScStaff::binsEmptied_get, &ScStaff::binsEmptied_set, "binsEmptied");
+        dukglue_register_property(ctx, &ScStaff::ridesFixed_get, &ScStaff::ridesFixed_set, "ridesFixed");
+        dukglue_register_property(ctx, &ScStaff::ridesInspected_get, &ScStaff::ridesInspected_set, "ridesInspected");
+        dukglue_register_property(ctx, &ScStaff::vandalsStopped_get, &ScStaff::vandalsStopped_set, "vandalsStopped");
     }
 
     Staff* ScStaff::GetStaff() const
@@ -436,6 +443,188 @@ namespace OpenRCT2::Scripting
 
         auto& animationGroup = GetPeepAnimation(peep->SpriteType, peep->ActionSpriteType);
         return static_cast<uint8_t>(animationGroup.frame_offsets.size());
+    }
+
+    DukValue ScStaff::lawnsMown_get() const
+    {
+        auto& scriptEngine = GetContext()->GetScriptEngine();
+        auto* ctx = scriptEngine.GetContext();
+        auto peep = GetStaff();
+        if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
+        {
+            duk_push_uint(ctx, peep->StaffLawnsMown);
+        }
+        else
+        {
+            duk_push_null(ctx);
+        }
+        return DukValue::take_from_stack(ctx);
+    }
+
+    void ScStaff::lawnsMown_set(uint32_t value)
+    {
+        ThrowIfGameStateNotMutable();
+        auto peep = GetStaff();
+        if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
+        {
+            peep->StaffLawnsMown = value;
+        }
+    }
+
+    DukValue ScStaff::gardensWatered_get() const
+    {
+        auto& scriptEngine = GetContext()->GetScriptEngine();
+        auto* ctx = scriptEngine.GetContext();
+        auto peep = GetStaff();
+        if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
+        {
+            duk_push_uint(ctx, peep->StaffGardensWatered);
+        }
+        else
+        {
+            duk_push_null(ctx);
+        }
+        return DukValue::take_from_stack(ctx);
+    }
+
+    void ScStaff::gardensWatered_set(uint32_t value)
+    {
+        ThrowIfGameStateNotMutable();
+        auto peep = GetStaff();
+        if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
+        {
+            peep->StaffGardensWatered = value;
+        }
+    }
+
+    DukValue ScStaff::litterSwept_get() const
+    {
+        auto& scriptEngine = GetContext()->GetScriptEngine();
+        auto* ctx = scriptEngine.GetContext();
+        auto peep = GetStaff();
+        if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
+        {
+            duk_push_uint(ctx, peep->StaffLitterSwept);
+        }
+        else
+        {
+            duk_push_null(ctx);
+        }
+        return DukValue::take_from_stack(ctx);
+    }
+
+    void ScStaff::litterSwept_set(uint32_t value)
+    {
+        ThrowIfGameStateNotMutable();
+        auto peep = GetStaff();
+        if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
+        {
+            peep->StaffLitterSwept = value;
+        }
+    }
+
+    DukValue ScStaff::binsEmptied_get() const
+    {
+        auto& scriptEngine = GetContext()->GetScriptEngine();
+        auto* ctx = scriptEngine.GetContext();
+        auto peep = GetStaff();
+        if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
+        {
+            duk_push_uint(ctx, peep->StaffBinsEmptied);
+        }
+        else
+        {
+            duk_push_null(ctx);
+        }
+        return DukValue::take_from_stack(ctx);
+    }
+
+    void ScStaff::binsEmptied_set(uint32_t value)
+    {
+        ThrowIfGameStateNotMutable();
+        auto peep = GetStaff();
+        if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
+        {
+            peep->StaffBinsEmptied = value;
+        }
+    }
+
+    DukValue ScStaff::ridesFixed_get() const
+    {
+        auto& scriptEngine = GetContext()->GetScriptEngine();
+        auto* ctx = scriptEngine.GetContext();
+        auto peep = GetStaff();
+        if (peep != nullptr && peep->AssignedStaffType == StaffType::Mechanic)
+        {
+            duk_push_uint(ctx, peep->StaffRidesFixed);
+        }
+        else
+        {
+            duk_push_null(ctx);
+        }
+        return DukValue::take_from_stack(ctx);
+    }
+
+    void ScStaff::ridesFixed_set(uint32_t value)
+    {
+        ThrowIfGameStateNotMutable();
+        auto peep = GetStaff();
+        if (peep != nullptr && peep->AssignedStaffType == StaffType::Mechanic)
+        {
+            peep->StaffRidesFixed = value;
+        }
+    }
+
+    DukValue ScStaff::ridesInspected_get() const
+    {
+        auto& scriptEngine = GetContext()->GetScriptEngine();
+        auto* ctx = scriptEngine.GetContext();
+        auto peep = GetStaff();
+        if (peep != nullptr && peep->AssignedStaffType == StaffType::Mechanic)
+        {
+            duk_push_uint(ctx, peep->StaffRidesInspected);
+        }
+        else
+        {
+            duk_push_null(ctx);
+        }
+        return DukValue::take_from_stack(ctx);
+    }
+
+    void ScStaff::ridesInspected_set(uint32_t value)
+    {
+        ThrowIfGameStateNotMutable();
+        auto peep = GetStaff();
+        if (peep != nullptr && peep->AssignedStaffType == StaffType::Mechanic)
+        {
+            peep->StaffRidesInspected = value;
+        }
+    }
+
+    DukValue ScStaff::vandalsStopped_get() const
+    {
+        auto& scriptEngine = GetContext()->GetScriptEngine();
+        auto* ctx = scriptEngine.GetContext();
+        auto peep = GetStaff();
+        if (peep != nullptr && peep->AssignedStaffType == StaffType::Security)
+        {
+            duk_push_uint(ctx, peep->StaffVandalsStopped);
+        }
+        else
+        {
+            duk_push_null(ctx);
+        }
+        return DukValue::take_from_stack(ctx);
+    }
+
+    void ScStaff::vandalsStopped_set(uint32_t value)
+    {
+        ThrowIfGameStateNotMutable();
+        auto peep = GetStaff();
+        if (peep != nullptr && peep->AssignedStaffType == StaffType::Security)
+        {
+            peep->StaffVandalsStopped = value;
+        }
     }
 
     ScPatrolArea::ScPatrolArea(EntityId id)

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -468,7 +468,7 @@ namespace OpenRCT2::Scripting
         }
         else
         {
-            duk_push_undefined(ctx);
+            duk_push_null(ctx);
         }
         return DukValue::take_from_stack(ctx);
     }
@@ -484,7 +484,7 @@ namespace OpenRCT2::Scripting
         }
         else
         {
-            duk_push_undefined(ctx);
+            duk_push_null(ctx);
         }
         return DukValue::take_from_stack(ctx);
     }
@@ -500,7 +500,7 @@ namespace OpenRCT2::Scripting
         }
         else
         {
-            duk_push_undefined(ctx);
+            duk_push_null(ctx);
         }
         return DukValue::take_from_stack(ctx);
     }
@@ -516,7 +516,7 @@ namespace OpenRCT2::Scripting
         }
         else
         {
-            duk_push_undefined(ctx);
+            duk_push_null(ctx);
         }
         return DukValue::take_from_stack(ctx);
     }
@@ -549,7 +549,7 @@ namespace OpenRCT2::Scripting
         }
         else
         {
-            duk_push_undefined(ctx);
+            duk_push_null(ctx);
         }
         return DukValue::take_from_stack(ctx);
     }
@@ -565,7 +565,7 @@ namespace OpenRCT2::Scripting
         }
         else
         {
-            duk_push_undefined(ctx);
+            duk_push_null(ctx);
         }
         return DukValue::take_from_stack(ctx);
     }
@@ -597,7 +597,7 @@ namespace OpenRCT2::Scripting
         }
         else
         {
-            duk_push_undefined(ctx);
+            duk_push_null(ctx);
         }
         return DukValue::take_from_stack(ctx);
     }

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -446,10 +446,10 @@ namespace OpenRCT2::Scripting
     void ScHandyman::Register(duk_context* ctx)
     {
         dukglue_set_base_class<ScStaff, ScHandyman>(ctx);
-        dukglue_register_property(ctx, &ScHandyman::lawnsMown_get, &ScHandyman::lawnsMown_set, "lawnsMown");
-        dukglue_register_property(ctx, &ScHandyman::gardensWatered_get, &ScHandyman::gardensWatered_set, "gardensWatered");
-        dukglue_register_property(ctx, &ScHandyman::litterSwept_get, &ScHandyman::litterSwept_set, "litterSwept");
-        dukglue_register_property(ctx, &ScHandyman::binsEmptied_get, &ScHandyman::binsEmptied_set, "binsEmptied");
+        dukglue_register_property(ctx, &ScHandyman::lawnsMown_get, nullptr, "lawnsMown");
+        dukglue_register_property(ctx, &ScHandyman::gardensWatered_get, nullptr, "gardensWatered");
+        dukglue_register_property(ctx, &ScHandyman::litterSwept_get, nullptr, "litterSwept");
+        dukglue_register_property(ctx, &ScHandyman::binsEmptied_get, nullptr, "binsEmptied");
     }
 
     Staff* ScHandyman::GetHandyman() const
@@ -473,16 +473,6 @@ namespace OpenRCT2::Scripting
         return DukValue::take_from_stack(ctx);
     }
 
-    void ScHandyman::lawnsMown_set(uint32_t value)
-    {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetHandyman();
-        if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
-        {
-            peep->StaffLawnsMown = value;
-        }
-    }
-
     DukValue ScHandyman::gardensWatered_get() const
     {
         auto& scriptEngine = GetContext()->GetScriptEngine();
@@ -497,16 +487,6 @@ namespace OpenRCT2::Scripting
             duk_push_undefined(ctx);
         }
         return DukValue::take_from_stack(ctx);
-    }
-
-    void ScHandyman::gardensWatered_set(uint32_t value)
-    {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetHandyman();
-        if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
-        {
-            peep->StaffGardensWatered = value;
-        }
     }
 
     DukValue ScHandyman::litterSwept_get() const
@@ -525,16 +505,6 @@ namespace OpenRCT2::Scripting
         return DukValue::take_from_stack(ctx);
     }
 
-    void ScHandyman::litterSwept_set(uint32_t value)
-    {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetHandyman();
-        if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
-        {
-            peep->StaffLitterSwept = value;
-        }
-    }
-
     DukValue ScHandyman::binsEmptied_get() const
     {
         auto& scriptEngine = GetContext()->GetScriptEngine();
@@ -551,16 +521,6 @@ namespace OpenRCT2::Scripting
         return DukValue::take_from_stack(ctx);
     }
 
-    void ScHandyman::binsEmptied_set(uint32_t value)
-    {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetHandyman();
-        if (peep != nullptr && peep->AssignedStaffType == StaffType::Handyman)
-        {
-            peep->StaffBinsEmptied = value;
-        }
-    }
-
     ScMechanic::ScMechanic(EntityId Id)
         : ScStaff(Id)
     {
@@ -569,8 +529,8 @@ namespace OpenRCT2::Scripting
     void ScMechanic::Register(duk_context* ctx)
     {
         dukglue_set_base_class<ScStaff, ScMechanic>(ctx);
-        dukglue_register_property(ctx, &ScMechanic::ridesFixed_get, &ScMechanic::ridesFixed_set, "ridesFixed");
-        dukglue_register_property(ctx, &ScMechanic::ridesInspected_get, &ScMechanic::ridesInspected_set, "ridesInspected");
+        dukglue_register_property(ctx, &ScMechanic::ridesFixed_get, nullptr, "ridesFixed");
+        dukglue_register_property(ctx, &ScMechanic::ridesInspected_get, nullptr, "ridesInspected");
     }
 
     Staff* ScMechanic::GetMechanic() const
@@ -594,16 +554,6 @@ namespace OpenRCT2::Scripting
         return DukValue::take_from_stack(ctx);
     }
 
-    void ScMechanic::ridesFixed_set(uint32_t value)
-    {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetMechanic();
-        if (peep != nullptr && peep->AssignedStaffType == StaffType::Mechanic)
-        {
-            peep->StaffRidesFixed = value;
-        }
-    }
-
     DukValue ScMechanic::ridesInspected_get() const
     {
         auto& scriptEngine = GetContext()->GetScriptEngine();
@@ -620,16 +570,6 @@ namespace OpenRCT2::Scripting
         return DukValue::take_from_stack(ctx);
     }
 
-    void ScMechanic::ridesInspected_set(uint32_t value)
-    {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetMechanic();
-        if (peep != nullptr && peep->AssignedStaffType == StaffType::Mechanic)
-        {
-            peep->StaffRidesInspected = value;
-        }
-    }
-
     ScSecurity::ScSecurity(EntityId Id)
         : ScStaff(Id)
     {
@@ -638,7 +578,7 @@ namespace OpenRCT2::Scripting
     void ScSecurity::Register(duk_context* ctx)
     {
         dukglue_set_base_class<ScStaff, ScSecurity>(ctx);
-        dukglue_register_property(ctx, &ScSecurity::vandalsStopped_get, &ScSecurity::vandalsStopped_set, "vandalsStopped");
+        dukglue_register_property(ctx, &ScSecurity::vandalsStopped_get, nullptr, "vandalsStopped");
     }
 
     Staff* ScSecurity::GetSecurity() const
@@ -660,16 +600,6 @@ namespace OpenRCT2::Scripting
             duk_push_undefined(ctx);
         }
         return DukValue::take_from_stack(ctx);
-    }
-
-    void ScSecurity::vandalsStopped_set(uint32_t value)
-    {
-        ThrowIfGameStateNotMutable();
-        auto peep = GetSecurity();
-        if (peep != nullptr && peep->AssignedStaffType == StaffType::Security)
-        {
-            peep->StaffVandalsStopped = value;
-        }
     }
 
     ScPatrolArea::ScPatrolArea(EntityId id)

--- a/src/openrct2/scripting/bindings/entity/ScStaff.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.hpp
@@ -76,7 +76,7 @@ namespace OpenRCT2::Scripting
         uint8_t animationOffset_get() const;
         void animationOffset_set(uint8_t offset);
         uint8_t animationLength_get() const;
-        
+
         DukValue lawnsMown_get() const;
         void lawnsMown_set(uint32_t value);
 

--- a/src/openrct2/scripting/bindings/entity/ScStaff.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.hpp
@@ -76,6 +76,17 @@ namespace OpenRCT2::Scripting
         uint8_t animationOffset_get() const;
         void animationOffset_set(uint8_t offset);
         uint8_t animationLength_get() const;
+    };
+
+    class ScHandyman : public ScStaff
+    {
+    public:
+        ScHandyman(EntityId Id);
+
+        static void Register(duk_context* ctx);
+
+    private:
+        Staff* GetHandyman() const;
 
         DukValue lawnsMown_get() const;
         void lawnsMown_set(uint32_t value);
@@ -88,12 +99,34 @@ namespace OpenRCT2::Scripting
 
         DukValue binsEmptied_get() const;
         void binsEmptied_set(uint32_t value);
+    };
+
+    class ScMechanic : public ScStaff
+    {
+    public:
+        ScMechanic(EntityId Id);
+
+        static void Register(duk_context* ctx);
+
+    private:
+        Staff* GetMechanic() const;
 
         DukValue ridesFixed_get() const;
         void ridesFixed_set(uint32_t value);
 
         DukValue ridesInspected_get() const;
         void ridesInspected_set(uint32_t value);
+    };
+
+    class ScSecurity : public ScStaff
+    {
+    public:
+        ScSecurity(EntityId Id);
+
+        static void Register(duk_context* ctx);
+
+    private:
+        Staff* GetSecurity() const;
 
         DukValue vandalsStopped_get() const;
         void vandalsStopped_set(uint32_t value);

--- a/src/openrct2/scripting/bindings/entity/ScStaff.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.hpp
@@ -76,6 +76,27 @@ namespace OpenRCT2::Scripting
         uint8_t animationOffset_get() const;
         void animationOffset_set(uint8_t offset);
         uint8_t animationLength_get() const;
+        
+        DukValue lawnsMown_get() const;
+        void lawnsMown_set(uint32_t value);
+
+        DukValue gardensWatered_get() const;
+        void gardensWatered_set(uint32_t value);
+
+        DukValue litterSwept_get() const;
+        void litterSwept_set(uint32_t value);
+
+        DukValue binsEmptied_get() const;
+        void binsEmptied_set(uint32_t value);
+
+        DukValue ridesFixed_get() const;
+        void ridesFixed_set(uint32_t value);
+
+        DukValue ridesInspected_get() const;
+        void ridesInspected_set(uint32_t value);
+
+        DukValue vandalsStopped_get() const;
+        void vandalsStopped_set(uint32_t value);
     };
 
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/entity/ScStaff.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.hpp
@@ -89,16 +89,12 @@ namespace OpenRCT2::Scripting
         Staff* GetHandyman() const;
 
         DukValue lawnsMown_get() const;
-        void lawnsMown_set(uint32_t value);
 
         DukValue gardensWatered_get() const;
-        void gardensWatered_set(uint32_t value);
 
         DukValue litterSwept_get() const;
-        void litterSwept_set(uint32_t value);
 
         DukValue binsEmptied_get() const;
-        void binsEmptied_set(uint32_t value);
     };
 
     class ScMechanic : public ScStaff
@@ -112,10 +108,8 @@ namespace OpenRCT2::Scripting
         Staff* GetMechanic() const;
 
         DukValue ridesFixed_get() const;
-        void ridesFixed_set(uint32_t value);
 
         DukValue ridesInspected_get() const;
-        void ridesInspected_set(uint32_t value);
     };
 
     class ScSecurity : public ScStaff
@@ -129,7 +123,6 @@ namespace OpenRCT2::Scripting
         Staff* GetSecurity() const;
 
         DukValue vandalsStopped_get() const;
-        void vandalsStopped_set(uint32_t value);
     };
 
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/world/ScMap.cpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.cpp
@@ -158,7 +158,22 @@ namespace OpenRCT2::Scripting
         {
             for (auto sprite : EntityList<Staff>())
             {
-                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScStaff>(sprite->Id)));
+                auto staff = GetEntity<Staff>(sprite->Id);
+                switch (staff->AssignedStaffType)
+                {
+                    case StaffType::Handyman:
+                        result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScHandyman>(sprite->Id)));
+                        break;
+                    case StaffType::Mechanic:
+                        result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScMechanic>(sprite->Id)));
+                        break;
+                    case StaffType::Security:
+                        result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScSecurity>(sprite->Id)));
+                        break;
+                    default:
+                        result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScStaff>(sprite->Id)));
+                        break;
+                }
             }
         }
         else if (type == "crashed_vehicle_particle")
@@ -225,7 +240,22 @@ namespace OpenRCT2::Scripting
         {
             for (auto sprite : EntityTileList<Staff>(pos))
             {
-                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScStaff>(sprite->Id)));
+                auto staff = GetEntity<Staff>(sprite->Id);
+                switch (staff->AssignedStaffType)
+                {
+                    case StaffType::Handyman:
+                        result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScHandyman>(sprite->Id)));
+                        break;
+                    case StaffType::Mechanic:
+                        result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScMechanic>(sprite->Id)));
+                        break;
+                    case StaffType::Security:
+                        result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScSecurity>(sprite->Id)));
+                        break;
+                    default:
+                        result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScStaff>(sprite->Id)));
+                        break;
+                }
             }
         }
         else if (type == "crashed_vehicle_particle")
@@ -357,7 +387,20 @@ namespace OpenRCT2::Scripting
             case EntityType::Vehicle:
                 return GetObjectAsDukValue(_context, std::make_shared<ScVehicle>(spriteId));
             case EntityType::Staff:
-                return GetObjectAsDukValue(_context, std::make_shared<ScStaff>(spriteId));
+            {
+                auto staff = GetEntity<Staff>(spriteId);
+                switch (staff->AssignedStaffType)
+                {
+                    case StaffType::Handyman:
+                        return GetObjectAsDukValue(_context, std::make_shared<ScHandyman>(spriteId));
+                    case StaffType::Mechanic:
+                        return GetObjectAsDukValue(_context, std::make_shared<ScMechanic>(spriteId));
+                    case StaffType::Security:
+                        return GetObjectAsDukValue(_context, std::make_shared<ScSecurity>(spriteId));
+                    default:
+                        return GetObjectAsDukValue(_context, std::make_shared<ScStaff>(spriteId));
+                }
+            }
             case EntityType::Guest:
                 return GetObjectAsDukValue(_context, std::make_shared<ScGuest>(spriteId));
             case EntityType::Litter:

--- a/src/openrct2/scripting/bindings/world/ScMap.cpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.cpp
@@ -159,20 +159,27 @@ namespace OpenRCT2::Scripting
             for (auto sprite : EntityList<Staff>())
             {
                 auto staff = GetEntity<Staff>(sprite->Id);
-                switch (staff->AssignedStaffType)
+                if (staff != nullptr)
                 {
-                    case StaffType::Handyman:
-                        result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScHandyman>(sprite->Id)));
-                        break;
-                    case StaffType::Mechanic:
-                        result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScMechanic>(sprite->Id)));
-                        break;
-                    case StaffType::Security:
-                        result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScSecurity>(sprite->Id)));
-                        break;
-                    default:
-                        result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScStaff>(sprite->Id)));
-                        break;
+                    switch (staff->AssignedStaffType)
+                    {
+                        case StaffType::Handyman:
+                            result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScHandyman>(sprite->Id)));
+                            break;
+                        case StaffType::Mechanic:
+                            result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScMechanic>(sprite->Id)));
+                            break;
+                        case StaffType::Security:
+                            result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScSecurity>(sprite->Id)));
+                            break;
+                        default:
+                            result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScStaff>(sprite->Id)));
+                            break;
+                    }
+                }
+                else
+                {
+                    result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScStaff>(sprite->Id)));
                 }
             }
         }
@@ -241,20 +248,27 @@ namespace OpenRCT2::Scripting
             for (auto sprite : EntityTileList<Staff>(pos))
             {
                 auto staff = GetEntity<Staff>(sprite->Id);
-                switch (staff->AssignedStaffType)
+                if (staff != nullptr)
                 {
-                    case StaffType::Handyman:
-                        result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScHandyman>(sprite->Id)));
-                        break;
-                    case StaffType::Mechanic:
-                        result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScMechanic>(sprite->Id)));
-                        break;
-                    case StaffType::Security:
-                        result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScSecurity>(sprite->Id)));
-                        break;
-                    default:
-                        result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScStaff>(sprite->Id)));
-                        break;
+                    switch (staff->AssignedStaffType)
+                    {
+                        case StaffType::Handyman:
+                            result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScHandyman>(sprite->Id)));
+                            break;
+                        case StaffType::Mechanic:
+                            result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScMechanic>(sprite->Id)));
+                            break;
+                        case StaffType::Security:
+                            result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScSecurity>(sprite->Id)));
+                            break;
+                        default:
+                            result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScStaff>(sprite->Id)));
+                            break;
+                    }
+                }
+                else
+                {
+                    result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScStaff>(sprite->Id)));
                 }
             }
         }
@@ -389,16 +403,23 @@ namespace OpenRCT2::Scripting
             case EntityType::Staff:
             {
                 auto staff = GetEntity<Staff>(spriteId);
-                switch (staff->AssignedStaffType)
+                if (staff != nullptr)
                 {
-                    case StaffType::Handyman:
-                        return GetObjectAsDukValue(_context, std::make_shared<ScHandyman>(spriteId));
-                    case StaffType::Mechanic:
-                        return GetObjectAsDukValue(_context, std::make_shared<ScMechanic>(spriteId));
-                    case StaffType::Security:
-                        return GetObjectAsDukValue(_context, std::make_shared<ScSecurity>(spriteId));
-                    default:
-                        return GetObjectAsDukValue(_context, std::make_shared<ScStaff>(spriteId));
+                    switch (staff->AssignedStaffType)
+                    {
+                        case StaffType::Handyman:
+                            return GetObjectAsDukValue(_context, std::make_shared<ScHandyman>(spriteId));
+                        case StaffType::Mechanic:
+                            return GetObjectAsDukValue(_context, std::make_shared<ScMechanic>(spriteId));
+                        case StaffType::Security:
+                            return GetObjectAsDukValue(_context, std::make_shared<ScSecurity>(spriteId));
+                        default:
+                            return GetObjectAsDukValue(_context, std::make_shared<ScStaff>(spriteId));
+                    }
+                }
+                else
+                {
+                    return GetObjectAsDukValue(_context, std::make_shared<ScStaff>(spriteId));
                 }
             }
             case EntityType::Guest:


### PR DESCRIPTION
Expose the following staff statistics to the plugin API:

```typescript
lawnsMown: number | null;

gardensWatered: number | null;

litterSwept: number | null;

binsEmptied: number | null;

ridesFixed: number | null;

ridesInspected: number | null;

vandalsStopped: number | null;
```

Currently, I made it so that if the staff type does not match the queried data, `null` is returned.

<details>
<summary>Click here for test plugin</summary>

```js
registerPlugin({
  name: "Test staff statistics",
  version: "0.0.1",
  authors: ["mrmagic2020"],
  targetApiVersion: 93,
  type: "local",
  licence: "MIT",
  main() {
    ui.registerMenuItem("Test staff statistics", function () {
      var staffList = map.getAllEntities("staff").sort(function (l, r) {
        return l.name.localeCompare(r.name);
      });
      var staff = staffList[0];
      var stats = [
        "lawnsMown",
        "gardensWatered",
        "litterSwept",
        "binsEmptied",
        "ridesFixed",
        "ridesInspected",
        "vandalsStopped"
      ];
      var stat = stats[0];
      var num = 0;
      var window = ui.openWindow({
        classification: "test-staff-statistics",
        title: "Staff statistics",
        width: 210,
        height: 100,
        onUpdate: function () {},
        widgets: [
          {
            type: "dropdown",
            x: 5,
            y: 20,
            width: 200,
            height: 15,
            items: staffList.map(function (staff) {
              return staff.name
            }),
            onChange: function (index) {
              staff = staffList[index];
            }
          },
          {
            type: "label",
            x: 5,
            y: 40,
            width: 200,
            height: 15,
            text: "Type: " + staff.staffType
          },
          {
            type: "dropdown",
            x: 5,
            y: 60,
            width: 100,
            height: 15,
            items: stats,
            onChange: function (index) {
              stat = stats[index];
            }
          },
          {
            type: "button",
            text: "Get stats",
            x: 110,
            y: 60,
            width: 90,
            height: 15,
            onClick: function () {
                num = staff[stat];
                if (num == null) window.findWidget("set-stat").text = "Invalid";
                else window.findWidget("set-stat").text = num.toString();
            }
          },
          {
            type: "spinner",
            name: "set-stat",
            x: 5,
            y: 80,
            width: 100,
            height: 15,
            min: 0,
            text: num == null ? "Invalid" : num.toString(),
            onDecrement: function () {
                num--;
                window.findWidget("set-stat").text = num.toString();
            },
            onIncrement: function () {
                num++;
                window.findWidget("set-stat").text = num.toString();
            }
          },
          {
            type: "button",
            text: "Set stat",
            x: 110,
            y: 80,
            width: 90,
            height: 15,
            onClick: function () {
                staff[stat] = num;
            }
          }
        ]
      });
    });
  }
});
```

</details>