### PR TITLE
Fix #22174: Cheats are reset when starting a server

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -38,6 +38,7 @@
 - Fix: [#22012] [Plugin] Images on ImgButton widgets cannot be updated.
 - Fix: [#22121] Some news items in the “Recent Messages” window have the wrong text colour.
 - Fix: [#22152] [Plugin] Negative signed integers are truncated.
+- Fix: [#22174] Cheats are reset when starting a server.
 - Fix: [objects#323] Incorrect wall boundaries on large WW/TT scenery objects.
 - Fix: [objects#331] Incorrect hover car capacity string.
 - Fix: [objects#334] Incorrect school bus capacity string.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -385,7 +385,6 @@ bool NetworkBase::BeginServer(uint16_t port, const std::string& address)
 
     IsServerPlayerInvisible = gOpenRCT2Headless;
 
-    CheatsReset();
     LoadGroups();
     BeginChatLog();
     BeginServerLog();


### PR DESCRIPTION
Fixes #22174.

This issue was introduced more than 8 years ago, in #2812. At that time cheats were not able to function properly in multiplayer games, so all cheats were set to false when loading a save file for a multiplayer game. However, #2652 was resolved pretty quickly, but the function to reset cheats wasn't removed accordingly: https://github.com/OpenRCT2/OpenRCT2/blob/1cd8ed4ade900fe62fd54f91d98036145b4ca481/src/openrct2/network/NetworkBase.cpp#L388

Removing this function fixes the problem.