### PR TITLE
Fix #22161: Using arrow keys in textboxes crashes the game

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -38,6 +38,7 @@
 - Fix: [#22012] [Plugin] Images on ImgButton widgets cannot be updated.
 - Fix: [#22121] Some news items in the “Recent Messages” window have the wrong text colour.
 - Fix: [#22152] [Plugin] Negative signed integers are truncated.
+- Fix: [#22161] Using arrow keys in textboxes crashes the game.
 - Fix: [#22174] Cheats are reset when starting a server.
 - Fix: [objects#323] Incorrect wall boundaries on large WW/TT scenery objects.
 - Fix: [objects#331] Incorrect hover car capacity string.

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -1169,7 +1169,8 @@ static void WidgetTextBoxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex wid
         // Make a new 1 character wide string for measuring the width
         // of the character that the cursor is under. (NOTE: this is broken for multi byte utf8 codepoints)
         width = std::max(
-            GfxGetStringWidthNoFormatting(u8string{ textInput->Buffer[textInput->SelectionStart] }, FontStyle::Medium) - 2, 4);
+            GfxGetStringWidthNoFormatting(u8string{ (*textInput->Buffer)[textInput->SelectionStart] }, FontStyle::Medium) - 2,
+            4);
     }
 
     if (OpenRCT2::Ui::Windows::TextBoxCaretIsFlashed())


### PR DESCRIPTION
Requires **regular** merge to preserve commit author.