### PR TITLE
Improve line drawing code

### DIFF
--- a/data/shaders/drawline.vert
+++ b/data/shaders/drawline.vert
@@ -7,7 +7,6 @@ uniform ivec2 uScreenSize;
 
 // clang-format off
 in ivec4 vBounds;
-in ivec4 vClip;
 in uint  vColour;
 in int   vDepth;
 // clang-format on
@@ -18,7 +17,7 @@ flat out uint fColour;
 
 void main()
 {
-    vec2 pos = clamp(vVertMat * vec4(vBounds), vec2(vClip.xy), vec2(vClip.zw));
+    vec2 pos = vVertMat * vec4(vBounds);
 
     // Transform screen coordinates to viewport coordinates
     pos = (pos * (2.0 / vec2(uScreenSize))) - 1.0;

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -32,6 +32,7 @@
 - Fix: [#22265] Button for switching covered tracks on slides doesn’t stay pressed.
 - Fix: [#22284] Unrated rides cause high amount of nausea.
 - Fix: [#22304] Graphs don’t draw lines on the left edge of the screen.
+- Fix: [#22308] OpenGL draws lines incorrectly in some cases.
 - Fix: [#22318] Water sparkles are missing if transparent water is enabled without RCT1 linked.
 - Fix: [#22333] Tile inspector closes other tool windows.
 - Fix: [#22339] Printing ui.tool.cursor in console crashes the game.

--- a/src/openrct2-ui/drawing/engines/opengl/DrawCommands.h
+++ b/src/openrct2-ui/drawing/engines/opengl/DrawCommands.h
@@ -93,7 +93,6 @@ namespace OpenRCT2::Ui
 
     struct DrawLineCommand
     {
-        ivec4 clip;
         ivec4 bounds;
         GLuint colour;
         GLint depth;

--- a/src/openrct2-ui/drawing/engines/opengl/DrawLineShader.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/DrawLineShader.cpp
@@ -51,7 +51,6 @@ DrawLineShader::DrawLineShader()
         vVertMat + 3, 2, GL_FLOAT, GL_FALSE, sizeof(VDStruct), reinterpret_cast<void*>(offsetof(VDStruct, mat[3])));
 
     glBindBuffer(GL_ARRAY_BUFFER, _vboInstances);
-    glVertexAttribIPointer(vClip, 4, GL_INT, sizeof(DrawLineCommand), reinterpret_cast<void*>(offsetof(DrawLineCommand, clip)));
     glVertexAttribIPointer(
         vBounds, 4, GL_INT, sizeof(DrawLineCommand), reinterpret_cast<void*>(offsetof(DrawLineCommand, bounds)));
     glVertexAttribIPointer(
@@ -69,7 +68,6 @@ DrawLineShader::DrawLineShader()
     glEnableVertexAttribArray(vColour);
     glEnableVertexAttribArray(vDepth);
 
-    glVertexAttribDivisor(vClip, 1);
     glVertexAttribDivisor(vBounds, 1);
     glVertexAttribDivisor(vColour, 1);
     glVertexAttribDivisor(vDepth, 1);
@@ -87,7 +85,6 @@ void DrawLineShader::GetLocations()
 {
     uScreenSize = GetUniformLocation("uScreenSize");
 
-    vClip = GetAttributeLocation("vClip");
     vBounds = GetAttributeLocation("vBounds");
     vColour = GetAttributeLocation("vColour");
     vDepth = GetAttributeLocation("vDepth");

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -578,12 +578,17 @@ void OpenGLDrawingContext::FilterRect(
 
 void OpenGLDrawingContext::DrawLine(DrawPixelInfo& dpi, uint32_t colour, const ScreenLine& line)
 {
+    // Note: this function does not respect DPI bounds.
     CalculcateClipping(dpi);
 
     DrawLineCommand& command = _commandBuffers.lines.allocate();
 
-    command.clip = { _clipLeft, _clipTop, _clipRight, _clipBottom };
-    command.bounds = { line.GetX1() + _offsetX, line.GetY1() + _offsetY, line.GetX2() + _offsetX, line.GetY2() + _offsetY };
+    const int32_t x1 = dpi.zoom_level.ApplyInversedTo(line.GetX1() - dpi.x) + _clipLeft;
+    const int32_t y1 = dpi.zoom_level.ApplyInversedTo(line.GetY1() - dpi.y) + _clipTop;
+    const int32_t x2 = dpi.zoom_level.ApplyInversedTo(line.GetX2() - dpi.x) + _clipLeft;
+    const int32_t y2 = dpi.zoom_level.ApplyInversedTo(line.GetY2() - dpi.y) + _clipTop;
+
+    command.bounds = { x1, y1, x2, y2 };
     command.colour = colour & 0xFF;
     command.depth = _drawCount++;
 }

--- a/src/openrct2/drawing/Line.cpp
+++ b/src/openrct2/drawing/Line.cpp
@@ -20,10 +20,16 @@ static void GfxDrawLineOnBuffer(DrawPixelInfo& dpi, char colour, const ScreenCoo
 {
     ScreenCoordsXY offset{ coords.x - dpi.x, coords.y - dpi.y };
 
+    offset.x = dpi.zoom_level.ApplyInversedTo(offset.x);
+    offset.y = dpi.zoom_level.ApplyInversedTo(offset.y);
+    no_pixels = dpi.zoom_level.ApplyInversedTo(no_pixels);
+    const int32_t width = dpi.zoom_level.ApplyInversedTo(dpi.width);
+    const int32_t height = dpi.zoom_level.ApplyInversedTo(dpi.height);
+
     // Check to make sure point is in the y range
     if (offset.y < 0)
         return;
-    if (offset.y >= dpi.height)
+    if (offset.y >= height)
         return;
     // Check to make sure we are drawing at least a pixel
     if (!no_pixels)
@@ -41,18 +47,17 @@ static void GfxDrawLineOnBuffer(DrawPixelInfo& dpi, char colour, const ScreenCoo
     }
 
     // Ensure that the end point of the line is within range
-    if (offset.x + no_pixels - dpi.width > 0)
+    if (offset.x + no_pixels - width > 0)
     {
         // If the end point has any pixels outside range
         // cut them off. If there are now no pixels return.
-        no_pixels -= offset.x + no_pixels - dpi.width;
+        no_pixels -= offset.x + no_pixels - width;
         if (no_pixels <= 0)
             return;
     }
 
     // Get the buffer we are drawing to and move to the first coordinate.
-    uint8_t* bits_pointer = dpi.bits
-        + offset.y * (static_cast<int64_t>(static_cast<int64_t>(dpi.pitch) + static_cast<int64_t>(dpi.width))) + offset.x;
+    uint8_t* bits_pointer = dpi.bits + offset.y * (static_cast<int64_t>(dpi.pitch) + static_cast<int64_t>(width)) + offset.x;
 
     // Draw the line to the specified colour
     for (; no_pixels > 0; --no_pixels, ++bits_pointer)

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -536,7 +536,7 @@ static void PaintDrawStruct(PaintSession& session, PaintStruct* ps)
     }
 
     auto imageId = PaintPSColourifyImage(ps, ps->image_id, session.ViewFlags);
-    if (gPaintBoundingBoxes && session.DPI.zoom_level == ZoomLevel{ 0 })
+    if (gPaintBoundingBoxes)
     {
         PaintPSImageWithBoundingBoxes(session, ps, imageId, screenPos.x, screenPos.y);
     }


### PR DESCRIPTION
Fixes #22308 by introducing [a proper line clipping algorithm](https://en.wikipedia.org/wiki/Cohen%E2%80%93Sutherland_algorithm) to the OpenGL renderer.

Fixes the line drawing code to work with all zoom levels for both opengl and software rendering.  This allows you to now zoom in and out with the bounding box debug display. 