### PR TITLE
Close #22173: Patrol path tiles change colour to show selection.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -30,6 +30,7 @@
 - Change: [#21214] Wacky Worlds and Time Twister’s scenario names now match their park names.
 - Change: [#21991] UI themes JSON now use colour names and a translucency bool, instead of a number (old themes still work).
 - Change: [#22057] Reorder Time Twister’s scenarios and adjust their difficulty classification.
+- Change: [#22173] Patrol path selection is visible over existing patrol paths.
 - Change: [#22196] Make track nagivation buttons holdable.
 - Fix: [#13234] Vehicle weight sometimes wrong after using Remove All Guests cheat.
 - Fix: [#13294] Map corners are cut off in some directions (original bug).

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -858,12 +858,16 @@ static std::pair<int32_t, int32_t> SurfaceGetHeightAboveWater(
 
 std::optional<colour_t> GetPatrolAreaTileColour(const CoordsXY& pos)
 {
+    bool selected = gMapSelectFlags & MAP_SELECT_FLAG_ENABLE && gMapSelectType == MAP_SELECT_TYPE_FULL
+        && pos.x >= gMapSelectPositionA.x && pos.x <= gMapSelectPositionB.x && pos.y >= gMapSelectPositionA.y
+        && pos.y <= gMapSelectPositionB.y;
+
     auto patrolAreaToRender = GetPatrolAreaToRender();
     if (const auto* staffType = std::get_if<StaffType>(&patrolAreaToRender))
     {
         if (IsPatrolAreaSetForStaffType(*staffType, pos))
         {
-            return COLOUR_GREY;
+            return selected ? COLOUR_WHITE : COLOUR_GREY;
         }
     }
     else
@@ -874,11 +878,11 @@ std::optional<colour_t> GetPatrolAreaTileColour(const CoordsXY& pos)
         {
             if (staff->IsPatrolAreaSet(pos))
             {
-                return COLOUR_LIGHT_BLUE;
+                return selected ? COLOUR_ICY_BLUE : COLOUR_LIGHT_BLUE;
             }
             else if (IsPatrolAreaSetForStaffType(staff->AssignedStaffType, pos))
             {
-                return COLOUR_GREY;
+                return selected ? COLOUR_WHITE : COLOUR_GREY;
             }
         }
     }


### PR DESCRIPTION
Fixes #22173

![screenshot-2024-06-27_19:21:34](https://github.com/OpenRCT2/OpenRCT2/assets/7877312/28d146c0-3043-41a1-9d90-adfc86fff93f)
