### PR TITLE
Fix building on *BSD's

### DIFF
--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -14,7 +14,7 @@
 #include <stdexcept>
 #include <vector>
 #ifndef _WIN32
-#    ifndef __FreeBSD__
+#    if !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__OpenBSD__)
 #        include <alloca.h>
 #    endif
 #    include <unicode/ucnv.h>


### PR DESCRIPTION
None of the *BSD's have the alloca.h header.