### PR TITLE
Allow plugins to focus on textboxes in custom windows

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -18,6 +18,7 @@
 - Feature: [#22150] [Plugin] Expose monthly expenditure history to the plugin API.
 - Feature: [#22210] [Plugin] Peeps can now be made stationary or completely frozen.
 - Feature: [#22210] [Plugin] The direction in which a peep is facing can now be manipulated.
+- Feature: [#22213] [Plugin] Allow plugins to focus on textboxes in custom windows.
 - Improved: [#19870] Allow using new colours in UI themes.
 - Improved: [#21774] The Alpine Coaster now supports using the alternative colour schemes.
 - Improved: [#21853] Dropdowns now automatically use multiple columns if they are too tall for the screen.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.13 (in development)
 ------------------------------------------------------------------------
 - Feature: [#22172] [Plugin] Expose ride satisfaction ratings to the plugin API.
+- Feature: [#22213] [Plugin] Allow plugins to focus on textboxes in custom windows.
 
 0.4.12 (2024-07-07)
 ------------------------------------------------------------------------
@@ -18,7 +19,6 @@
 - Feature: [#22150] [Plugin] Expose monthly expenditure history to the plugin API.
 - Feature: [#22210] [Plugin] Peeps can now be made stationary or completely frozen.
 - Feature: [#22210] [Plugin] The direction in which a peep is facing can now be manipulated.
-- Feature: [#22213] [Plugin] Allow plugins to focus on textboxes in custom windows.
 - Improved: [#19870] Allow using new colours in UI themes.
 - Improved: [#21774] The Alpine Coaster now supports using the alternative colour schemes.
 - Improved: [#21853] Dropdowns now automatically use multiple columns if they are too tall for the screen.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -4502,6 +4502,7 @@ declare global {
         type: "textbox";
         text: string;
         maxLength: number;
+        focus(): void;
     }
 
     interface ViewportWidget extends WidgetBase {

--- a/src/openrct2-ui/scripting/ScWidget.hpp
+++ b/src/openrct2-ui/scripting/ScWidget.hpp
@@ -969,7 +969,8 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr && IsCustomWindow())
             {
-                w->OnMouseDown(_widgetIndex);
+                WindowStartTextbox(
+                    *w, _widgetIndex, GetWidget()->string, OpenRCT2::Ui::Windows::GetWidgetMaxLength(w, _widgetIndex));
             }
         }
     };

--- a/src/openrct2-ui/scripting/ScWidget.hpp
+++ b/src/openrct2-ui/scripting/ScWidget.hpp
@@ -941,6 +941,7 @@ namespace OpenRCT2::Scripting
             // Explicit template due to text being a base method
             dukglue_register_property<ScTextBoxWidget, std::string, std::string>(
                 ctx, &ScTextBoxWidget::text_get, &ScTextBoxWidget::text_set, "text");
+            dukglue_register_method(ctx, &ScTextBoxWidget::focus, "focus");
         }
 
     private:
@@ -960,6 +961,15 @@ namespace OpenRCT2::Scripting
             if (w != nullptr && IsCustomWindow())
             {
                 OpenRCT2::Ui::Windows::SetWidgetMaxLength(w, _widgetIndex, value);
+            }
+        }
+
+        void focus()
+        {
+            auto w = GetWindow();
+            if (w != nullptr && IsCustomWindow())
+            {
+                w->OnMouseDown(_widgetIndex);
             }
         }
     };

--- a/src/openrct2-ui/scripting/ScWidget.hpp
+++ b/src/openrct2-ui/scripting/ScWidget.hpp
@@ -969,8 +969,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr && IsCustomWindow())
             {
-                WindowStartTextbox(
-                    *w, _widgetIndex, GetWidget()->string, OpenRCT2::Ui::Windows::GetWidgetMaxLength(w, _widgetIndex));
+                WindowStartTextbox(*w, _widgetIndex, GetWidget()->string, Ui::Windows::GetWidgetMaxLength(w, _widgetIndex));
             }
         }
     };


### PR DESCRIPTION
Inspired by #21584. 

<details>
<summary>Click here for test plugin</summary>

```js
registerPlugin({
    name: "Textbox Focus Test",
    authors: ["mrmagic2020"],
    version: "0.0.1",
    licence: "MIT",
    type: "local",
    minApiVersion: 94,
    targetApiVersion: 94,
    main: function () {
      ui.registerMenuItem("Textbox Focus Test", function () {
        var wdw = ui.openWindow({
          classification: "textbox_focus_test",
          title: "Textbox Focus Test",
          width: 240,
          height: 50,
          widgets: [
            {
              type: "textbox",
              name: "textbox-result",
              x: 5,
              y: 30,
              width: 180,
              height: 14,
            },
            {
              type: "button",
              name: "button-submit",
              x: 190,
              y: 30,
              width: 40,
              height: 14,
              text: "Submit",
              onClick: function () {
                wdw.findWidget("textbox-result").text = "";
                wdw.findWidget("textbox-result").focus();
              }
            }
          ]
        });
      });
    }
  });
```

</details>