### PR TITLE
Ignore partially hidden sprites for viewport interaction

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -23,6 +23,7 @@
 - Improved: [#22065] Joining a network game now indicates progress using coaster trains.
 - Improved: [#22075] [Plugin] Plugins can now use G1 Icons.
 - Improved: [#22084] The game now temporarily pauses while the load/save window is open.
+- Improved: [#22217] See-through items are ignored again in viewport/pointer interaction.
 - Improved: [objects#238] Add preview image for invisible queue.
 - Improved: [objects#329] Add RCT1AA lay-down coaster trains (for import only).
 - Change: [#7248] Small mini-maps are now centred in the map window.

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1888,7 +1888,7 @@ InteractionInfo SetInteractionInfoFromPaintSession(PaintSession* session, uint32
             ps = next_ps;
             if (IsSpriteInteractedWith(session->DPI, ps->image_id, ps->ScreenPos))
             {
-                if (PSSpriteTypeIsInFilter(ps, filter) && GetPaintStructVisibility(ps, viewFlags) != VisibilityKind::Hidden)
+                if (PSSpriteTypeIsInFilter(ps, filter) && GetPaintStructVisibility(ps, viewFlags) == VisibilityKind::Visible)
                 {
                     info = { ps };
                 }
@@ -1902,7 +1902,7 @@ InteractionInfo SetInteractionInfoFromPaintSession(PaintSession* session, uint32
         {
             if (IsSpriteInteractedWith(session->DPI, attached_ps->image_id, ps->ScreenPos + attached_ps->RelativePos))
             {
-                if (PSSpriteTypeIsInFilter(ps, filter) && GetPaintStructVisibility(ps, viewFlags) != VisibilityKind::Hidden)
+                if (PSSpriteTypeIsInFilter(ps, filter) && GetPaintStructVisibility(ps, viewFlags) == VisibilityKind::Visible)
                 {
                     info = { ps };
                 }


### PR DESCRIPTION
Currently, when considering what element is being interacted with, we check `!= VisibilityKind::Hidden`. Before #16797, this would imply `== VisibilityKind::Visible`. However, since we introduced `VisibilityKind::Partial` in that PR, this now implies partial visibility is treated the same as full visiblity! To me, this is very counter-intuitive. 

This PR changes the viewport interaction logic such that partial visibility ('shadow' state) is treated the same as 'full' invisibility. Consequently, you can e.g. easily reach footpath when 'see-though' scenery is enabled, or easily access a ride when obstructing footpath is translucent.

Consider the following toy example with 'See-through paths' enabled:

Before (path interaction):
<img width="268" alt="Screenshot 2024-07-02 at 22 10 21_" src="https://github.com/OpenRCT2/OpenRCT2/assets/604665/cb398709-40ad-4aea-b5aa-9edd1e97b921">

After (no path interaction):
<img width="268" alt="Screenshot 2024-07-02 at 22 10 56_" src="https://github.com/OpenRCT2/OpenRCT2/assets/604665/57f69e28-9a1b-4a52-bee0-974db3d3b847">

(Looking at the viewport interaction code, I think there is improvement to be gained by splitting up the `ViewportInteractionItem` enum, such that e.g. `Vegetation` is actually split off from `Scenery`. The viewport flags treat both differently, but the interaction code treats both the same when checking what is being pointed at. Only after `SetInteractionInfoFromPaintSession` does it check whether interaction should be triggered, but at that point, vegetation or scenery have already potentially overruled each other.)