### PR TITLE
Sync more TrackDesign fields with their Ride counterparts

### DIFF
--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -169,8 +169,8 @@ static Widget window_install_track_widgets[] = {
             screenPos = windowPos + ScreenCoordsXY{ widget->midX(), widget->bottom - 12 };
 
             // Warnings
-            const TrackDesign* td = _trackDesign.get();
-            if (td->gameStateData.hasFlag(TrackDesignGameStateFlag::SceneryUnavailable))
+            const TrackDesign& td = *_trackDesign;
+            if (td.gameStateData.hasFlag(TrackDesignGameStateFlag::SceneryUnavailable))
             {
                 if (!gTrackDesignSceneryToggle)
                 {
@@ -198,17 +198,17 @@ static Widget window_install_track_widgets[] = {
             {
                 auto ft = Formatter();
 
-                const auto* objectEntry = ObjectManagerLoadObject(&td->trackAndVehicle.vehicleObject.Entry);
+                const auto* objectEntry = ObjectManagerLoadObject(&td.trackAndVehicle.vehicleObject.Entry);
                 if (objectEntry != nullptr)
                 {
                     auto groupIndex = ObjectManagerGetLoadedObjectEntryIndex(objectEntry);
-                    auto rideName = GetRideNaming(td->trackAndVehicle.rtdIndex, *GetRideEntryByIndex(groupIndex));
+                    auto rideName = GetRideNaming(td.trackAndVehicle.rtdIndex, *GetRideEntryByIndex(groupIndex));
                     ft.Add<StringId>(rideName.Name);
                 }
                 else
                 {
                     // Fall back on the technical track name if the vehicle object cannot be loaded
-                    ft.Add<StringId>(GetRideTypeDescriptor(td->trackAndVehicle.rtdIndex).Naming.Name);
+                    ft.Add<StringId>(GetRideTypeDescriptor(td.trackAndVehicle.rtdIndex).Naming.Name);
                 }
 
                 DrawTextBasic(dpi, screenPos, STR_TRACK_DESIGN_TYPE, ft);
@@ -217,34 +217,34 @@ static Widget window_install_track_widgets[] = {
 
             // Stats
             {
-                fixed32_2dp rating = td->statistics.ratings.excitement;
+                fixed32_2dp rating = td.statistics.ratings.excitement;
                 auto ft = Formatter();
                 ft.Add<int32_t>(rating);
                 DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_EXCITEMENT_RATING, ft);
                 screenPos.y += kListRowHeight;
             }
             {
-                fixed32_2dp rating = td->statistics.ratings.intensity;
+                fixed32_2dp rating = td.statistics.ratings.intensity;
                 auto ft = Formatter();
                 ft.Add<int32_t>(rating);
                 DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_INTENSITY_RATING, ft);
                 screenPos.y += kListRowHeight;
             }
             {
-                fixed32_2dp rating = td->statistics.ratings.nausea;
+                fixed32_2dp rating = td.statistics.ratings.nausea;
                 auto ft = Formatter();
                 ft.Add<int32_t>(rating);
                 DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_NAUSEA_RATING, ft);
                 screenPos.y += kListRowHeight + 4;
             }
 
-            const auto& rtd = GetRideTypeDescriptor(td->trackAndVehicle.rtdIndex);
+            const auto& rtd = GetRideTypeDescriptor(td.trackAndVehicle.rtdIndex);
             if (!rtd.HasFlag(RIDE_TYPE_FLAG_IS_MAZE))
             {
-                if (td->trackAndVehicle.rtdIndex == RIDE_TYPE_MINI_GOLF)
+                if (td.trackAndVehicle.rtdIndex == RIDE_TYPE_MINI_GOLF)
                 {
                     // Holes
-                    uint16_t holes = td->statistics.holes & 0x1F;
+                    uint16_t holes = td.statistics.holes & 0x1F;
                     auto ft = Formatter();
                     ft.Add<uint16_t>(holes);
                     DrawTextBasic(dpi, screenPos, STR_HOLES, ft);
@@ -254,7 +254,7 @@ static Widget window_install_track_widgets[] = {
                 {
                     // Maximum speed
                     {
-                        uint16_t speed = ((td->statistics.maxSpeed << 16) * 9) >> 18;
+                        uint16_t speed = ((td.statistics.maxSpeed << 16) * 9) >> 18;
                         auto ft = Formatter();
                         ft.Add<uint16_t>(speed);
                         DrawTextBasic(dpi, screenPos, STR_MAX_SPEED, ft);
@@ -262,7 +262,7 @@ static Widget window_install_track_widgets[] = {
                     }
                     // Average speed
                     {
-                        uint16_t speed = ((td->statistics.averageSpeed << 16) * 9) >> 18;
+                        uint16_t speed = ((td.statistics.averageSpeed << 16) * 9) >> 18;
                         auto ft = Formatter();
                         ft.Add<uint16_t>(speed);
                         DrawTextBasic(dpi, screenPos, STR_AVERAGE_SPEED, ft);
@@ -273,16 +273,16 @@ static Widget window_install_track_widgets[] = {
                 // Ride length
                 auto ft = Formatter();
                 ft.Add<StringId>(STR_RIDE_LENGTH_ENTRY);
-                ft.Add<uint16_t>(td->statistics.rideLength);
+                ft.Add<uint16_t>(td.statistics.rideLength);
                 DrawTextEllipsised(dpi, screenPos, 214, STR_TRACK_LIST_RIDE_LENGTH, ft);
                 screenPos.y += kListRowHeight;
             }
 
-            if (GetRideTypeDescriptor(td->trackAndVehicle.rtdIndex).HasFlag(RIDE_TYPE_FLAG_HAS_G_FORCES))
+            if (GetRideTypeDescriptor(td.trackAndVehicle.rtdIndex).HasFlag(RIDE_TYPE_FLAG_HAS_G_FORCES))
             {
                 // Maximum positive vertical Gs
                 {
-                    int32_t gForces = td->statistics.maxPositiveVerticalG * 32;
+                    int32_t gForces = td.statistics.maxPositiveVerticalG * 32;
                     auto ft = Formatter();
                     ft.Add<int32_t>(gForces);
                     DrawTextBasic(dpi, screenPos, STR_MAX_POSITIVE_VERTICAL_G, ft);
@@ -290,7 +290,7 @@ static Widget window_install_track_widgets[] = {
                 }
                 // Maximum negative vertical Gs
                 {
-                    int32_t gForces = td->statistics.maxNegativeVerticalG * 32;
+                    int32_t gForces = td.statistics.maxNegativeVerticalG * 32;
                     auto ft = Formatter();
                     ft.Add<int32_t>(gForces);
                     DrawTextBasic(dpi, screenPos, STR_MAX_NEGATIVE_VERTICAL_G, ft);
@@ -298,16 +298,16 @@ static Widget window_install_track_widgets[] = {
                 }
                 // Maximum lateral Gs
                 {
-                    int32_t gForces = td->statistics.maxLateralG * 32;
+                    int32_t gForces = td.statistics.maxLateralG * 32;
                     auto ft = Formatter();
                     ft.Add<int32_t>(gForces);
                     DrawTextBasic(dpi, screenPos, STR_MAX_LATERAL_G, ft);
                     screenPos.y += kListRowHeight;
                 }
-                if (td->statistics.totalAirTime != 0)
+                if (td.statistics.totalAirTime != 0)
                 {
                     // Total air time
-                    int32_t airTime = td->statistics.totalAirTime * 25;
+                    int32_t airTime = td.statistics.totalAirTime * 25;
                     auto ft = Formatter();
                     ft.Add<int32_t>(airTime);
                     DrawTextBasic(dpi, screenPos, STR_TOTAL_AIR_TIME, ft);
@@ -315,10 +315,10 @@ static Widget window_install_track_widgets[] = {
                 }
             }
 
-            if (GetRideTypeDescriptor(td->trackAndVehicle.rtdIndex).HasFlag(RIDE_TYPE_FLAG_HAS_DROPS))
+            if (GetRideTypeDescriptor(td.trackAndVehicle.rtdIndex).HasFlag(RIDE_TYPE_FLAG_HAS_DROPS))
             {
                 // Drops
-                uint16_t drops = td->statistics.drops & 0x3F;
+                uint16_t drops = td.statistics.drops & 0x3F;
                 auto ft = Formatter();
                 ft.Add<uint16_t>(drops);
                 DrawTextBasic(dpi, screenPos, STR_DROPS, ft);
@@ -329,9 +329,9 @@ static Widget window_install_track_widgets[] = {
                 screenPos.y += kListRowHeight;
             }
 
-            if (td->trackAndVehicle.rtdIndex != RIDE_TYPE_MINI_GOLF)
+            if (td.trackAndVehicle.rtdIndex != RIDE_TYPE_MINI_GOLF)
             {
-                uint16_t inversions = td->statistics.inversions & 0x1F;
+                uint16_t inversions = td.statistics.inversions & 0x1F;
                 if (inversions != 0)
                 {
                     // Inversions
@@ -343,20 +343,20 @@ static Widget window_install_track_widgets[] = {
             }
             screenPos.y += 4;
 
-            if (!td->statistics.spaceRequired.IsNull())
+            if (!td.statistics.spaceRequired.IsNull())
             {
                 // Space required
                 auto ft = Formatter();
-                ft.Add<uint16_t>(td->statistics.spaceRequired.x);
-                ft.Add<uint16_t>(td->statistics.spaceRequired.y);
+                ft.Add<uint16_t>(td.statistics.spaceRequired.x);
+                ft.Add<uint16_t>(td.statistics.spaceRequired.y);
                 DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_SPACE_REQUIRED, ft);
                 screenPos.y += kListRowHeight;
             }
 
-            if (td->gameStateData.cost != 0)
+            if (td.gameStateData.cost != 0)
             {
                 auto ft = Formatter();
-                ft.Add<money64>(td->gameStateData.cost);
+                ft.Add<money64>(td.gameStateData.cost);
                 DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_COST_AROUND, ft);
             }
         }
@@ -369,7 +369,7 @@ static Widget window_install_track_widgets[] = {
     private:
         void UpdatePreview()
         {
-            TrackDesignDrawPreview(_trackDesign.get(), _trackDesignPreviewPixels.data());
+            TrackDesignDrawPreview(*_trackDesign, _trackDesignPreviewPixels.data());
         }
 
         void InstallTrackDesign()

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -244,9 +244,8 @@ static Widget window_install_track_widgets[] = {
                 if (td.trackAndVehicle.rtdIndex == RIDE_TYPE_MINI_GOLF)
                 {
                     // Holes
-                    uint16_t holes = td.statistics.holes & 0x1F;
                     auto ft = Formatter();
-                    ft.Add<uint16_t>(holes);
+                    ft.Add<uint16_t>(td.statistics.holes);
                     DrawTextBasic(dpi, screenPos, STR_HOLES, ft);
                     screenPos.y += kListRowHeight;
                 }
@@ -282,7 +281,7 @@ static Widget window_install_track_widgets[] = {
             {
                 // Maximum positive vertical Gs
                 {
-                    int32_t gForces = td.statistics.maxPositiveVerticalG * 32;
+                    int32_t gForces = td.statistics.maxPositiveVerticalG;
                     auto ft = Formatter();
                     ft.Add<int32_t>(gForces);
                     DrawTextBasic(dpi, screenPos, STR_MAX_POSITIVE_VERTICAL_G, ft);
@@ -290,7 +289,7 @@ static Widget window_install_track_widgets[] = {
                 }
                 // Maximum negative vertical Gs
                 {
-                    int32_t gForces = td.statistics.maxNegativeVerticalG * 32;
+                    int32_t gForces = td.statistics.maxNegativeVerticalG;
                     auto ft = Formatter();
                     ft.Add<int32_t>(gForces);
                     DrawTextBasic(dpi, screenPos, STR_MAX_NEGATIVE_VERTICAL_G, ft);
@@ -298,7 +297,7 @@ static Widget window_install_track_widgets[] = {
                 }
                 // Maximum lateral Gs
                 {
-                    int32_t gForces = td.statistics.maxLateralG * 32;
+                    int32_t gForces = td.statistics.maxLateralG;
                     auto ft = Formatter();
                     ft.Add<int32_t>(gForces);
                     DrawTextBasic(dpi, screenPos, STR_MAX_LATERAL_G, ft);
@@ -306,8 +305,7 @@ static Widget window_install_track_widgets[] = {
                 }
                 if (td.statistics.totalAirTime != 0)
                 {
-                    // Total air time
-                    int32_t airTime = td.statistics.totalAirTime * 25;
+                    int32_t airTime = td.statistics.totalAirTime * 3;
                     auto ft = Formatter();
                     ft.Add<int32_t>(airTime);
                     DrawTextBasic(dpi, screenPos, STR_TOTAL_AIR_TIME, ft);
@@ -317,10 +315,8 @@ static Widget window_install_track_widgets[] = {
 
             if (GetRideTypeDescriptor(td.trackAndVehicle.rtdIndex).HasFlag(RIDE_TYPE_FLAG_HAS_DROPS))
             {
-                // Drops
-                uint16_t drops = td.statistics.drops & 0x3F;
                 auto ft = Formatter();
-                ft.Add<uint16_t>(drops);
+                ft.Add<uint16_t>(td.statistics.drops);
                 DrawTextBasic(dpi, screenPos, STR_DROPS, ft);
                 screenPos.y += kListRowHeight;
 
@@ -329,18 +325,15 @@ static Widget window_install_track_widgets[] = {
                 screenPos.y += kListRowHeight;
             }
 
-            if (td.trackAndVehicle.rtdIndex != RIDE_TYPE_MINI_GOLF)
+            if (td.statistics.inversions != 0)
             {
-                uint16_t inversions = td.statistics.inversions & 0x1F;
-                if (inversions != 0)
-                {
-                    // Inversions
-                    auto ft = Formatter();
-                    ft.Add<uint16_t>(inversions);
-                    DrawTextBasic(dpi, screenPos, STR_INVERSIONS, ft);
-                    screenPos.y += kListRowHeight;
-                }
+                // Inversions
+                auto ft = Formatter();
+                ft.Add<uint16_t>(td.statistics.inversions);
+                DrawTextBasic(dpi, screenPos, STR_INVERSIONS, ft);
+                screenPos.y += kListRowHeight;
             }
+
             screenPos.y += 4;
 
             if (!td.statistics.spaceRequired.IsNull())

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -170,7 +170,7 @@ static Widget window_install_track_widgets[] = {
 
             // Warnings
             const TrackDesign* td = _trackDesign.get();
-            if (td->trackFlags & TRACK_DESIGN_FLAG_SCENERY_UNAVAILABLE)
+            if (td->gameStateData.hasFlag(TrackDesignGameStateFlag::SceneryUnavailable))
             {
                 if (!gTrackDesignSceneryToggle)
                 {
@@ -353,10 +353,10 @@ static Widget window_install_track_widgets[] = {
                 screenPos.y += kListRowHeight;
             }
 
-            if (td->cost != 0)
+            if (td->gameStateData.cost != 0)
             {
                 auto ft = Formatter();
-                ft.Add<money64>(td->cost);
+                ft.Add<money64>(td->gameStateData.cost);
                 DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_COST_AROUND, ft);
             }
         }

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -198,17 +198,17 @@ static Widget window_install_track_widgets[] = {
             {
                 auto ft = Formatter();
 
-                const auto* objectEntry = ObjectManagerLoadObject(&td->vehicleObject.Entry);
+                const auto* objectEntry = ObjectManagerLoadObject(&td->trackAndVehicle.vehicleObject.Entry);
                 if (objectEntry != nullptr)
                 {
                     auto groupIndex = ObjectManagerGetLoadedObjectEntryIndex(objectEntry);
-                    auto rideName = GetRideNaming(td->type, *GetRideEntryByIndex(groupIndex));
+                    auto rideName = GetRideNaming(td->trackAndVehicle.rtdIndex, *GetRideEntryByIndex(groupIndex));
                     ft.Add<StringId>(rideName.Name);
                 }
                 else
                 {
                     // Fall back on the technical track name if the vehicle object cannot be loaded
-                    ft.Add<StringId>(GetRideTypeDescriptor(td->type).Naming.Name);
+                    ft.Add<StringId>(GetRideTypeDescriptor(td->trackAndVehicle.rtdIndex).Naming.Name);
                 }
 
                 DrawTextBasic(dpi, screenPos, STR_TRACK_DESIGN_TYPE, ft);
@@ -238,10 +238,10 @@ static Widget window_install_track_widgets[] = {
                 screenPos.y += kListRowHeight + 4;
             }
 
-            const auto& rtd = GetRideTypeDescriptor(td->type);
+            const auto& rtd = GetRideTypeDescriptor(td->trackAndVehicle.rtdIndex);
             if (!rtd.HasFlag(RIDE_TYPE_FLAG_IS_MAZE))
             {
-                if (td->type == RIDE_TYPE_MINI_GOLF)
+                if (td->trackAndVehicle.rtdIndex == RIDE_TYPE_MINI_GOLF)
                 {
                     // Holes
                     uint16_t holes = td->statistics.holes & 0x1F;
@@ -278,7 +278,7 @@ static Widget window_install_track_widgets[] = {
                 screenPos.y += kListRowHeight;
             }
 
-            if (GetRideTypeDescriptor(td->type).HasFlag(RIDE_TYPE_FLAG_HAS_G_FORCES))
+            if (GetRideTypeDescriptor(td->trackAndVehicle.rtdIndex).HasFlag(RIDE_TYPE_FLAG_HAS_G_FORCES))
             {
                 // Maximum positive vertical Gs
                 {
@@ -315,7 +315,7 @@ static Widget window_install_track_widgets[] = {
                 }
             }
 
-            if (GetRideTypeDescriptor(td->type).HasFlag(RIDE_TYPE_FLAG_HAS_DROPS))
+            if (GetRideTypeDescriptor(td->trackAndVehicle.rtdIndex).HasFlag(RIDE_TYPE_FLAG_HAS_DROPS))
             {
                 // Drops
                 uint16_t drops = td->statistics.drops & 0x3F;
@@ -329,7 +329,7 @@ static Widget window_install_track_widgets[] = {
                 screenPos.y += kListRowHeight;
             }
 
-            if (td->type != RIDE_TYPE_MINI_GOLF)
+            if (td->trackAndVehicle.rtdIndex != RIDE_TYPE_MINI_GOLF)
             {
                 uint16_t inversions = td->statistics.inversions & 0x1F;
                 if (inversions != 0)
@@ -417,12 +417,12 @@ static Widget window_install_track_widgets[] = {
         }
 
         ObjectManagerUnloadAllObjects();
-        if (trackDesign->type == RIDE_TYPE_NULL)
+        if (trackDesign->trackAndVehicle.rtdIndex == RIDE_TYPE_NULL)
         {
             LOG_ERROR("Failed to load track (ride type null): %s", path);
             return nullptr;
         }
-        if (ObjectManagerLoadObject(&trackDesign->vehicleObject.Entry) == nullptr)
+        if (ObjectManagerLoadObject(&trackDesign->trackAndVehicle.vehicleObject.Entry) == nullptr)
         {
             LOG_ERROR("Failed to load track (vehicle load fail): %s", path);
             return nullptr;

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -217,21 +217,21 @@ static Widget window_install_track_widgets[] = {
 
             // Stats
             {
-                fixed32_2dp rating = td->statistics.excitement * 10;
+                fixed32_2dp rating = td->statistics.ratings.excitement;
                 auto ft = Formatter();
                 ft.Add<int32_t>(rating);
                 DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_EXCITEMENT_RATING, ft);
                 screenPos.y += kListRowHeight;
             }
             {
-                fixed32_2dp rating = td->statistics.intensity * 10;
+                fixed32_2dp rating = td->statistics.ratings.intensity;
                 auto ft = Formatter();
                 ft.Add<int32_t>(rating);
                 DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_INTENSITY_RATING, ft);
                 screenPos.y += kListRowHeight;
             }
             {
-                fixed32_2dp rating = td->statistics.nausea * 10;
+                fixed32_2dp rating = td->statistics.ratings.nausea;
                 auto ft = Formatter();
                 ft.Add<int32_t>(rating);
                 DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_NAUSEA_RATING, ft);

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -387,7 +387,7 @@ static Widget window_loadsave_widgets[] =
                 const auto withExtension = Path::WithExtension(pathBuffer, ".td6");
                 String::Set(pathBuffer, sizeof(pathBuffer), withExtension.c_str());
 
-                RCT2::T6Exporter t6Export{ _trackDesign };
+                RCT2::T6Exporter t6Export{ *_trackDesign };
 
                 auto success = t6Export.SaveTrack(pathBuffer);
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -5510,17 +5510,15 @@ static_assert(std::size(RatingNames) == 6);
 
                             // Total 'air' time
                             ft = Formatter();
-                            ft.Add<fixed32_2dp>(ride->total_air_time * 3);
+                            ft.Add<fixed32_2dp>(ride->totalAirTime * 3);
                             DrawTextBasic(dpi, screenCoords, STR_TOTAL_AIR_TIME, ft);
                             screenCoords.y += kListRowHeight;
                         }
 
                         if (ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_HAS_DROPS))
                         {
-                            // Drops
-                            auto drops = ride->drops & 0x3F;
                             ft = Formatter();
-                            ft.Add<uint16_t>(drops);
+                            ft.Add<uint16_t>(ride->getNumDrops());
                             DrawTextBasic(dpi, screenCoords, STR_DROPS, ft);
                             screenCoords.y += kListRowHeight;
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -5296,7 +5296,7 @@ static_assert(std::size(RatingNames) == 6);
                 disabled_widgets |= (1uLL << WIDX_SAVE_TRACK_DESIGN);
                 if (ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED)
                 {
-                    if (ride->excitement != kRideRatingUndefined)
+                    if (!ride->ratings.isNull())
                     {
                         disabled_widgets &= ~(1uLL << WIDX_SAVE_TRACK_DESIGN);
                         widgets[WIDX_SAVE_TRACK_DESIGN].tooltip = STR_SAVE_TRACK_DESIGN;
@@ -5338,9 +5338,9 @@ static_assert(std::size(RatingNames) == 6);
                 if (ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED)
                 {
                     // Excitement
-                    StringId ratingName = GetRatingName(ride->excitement);
+                    StringId ratingName = GetRatingName(ride->ratings.excitement);
                     auto ft = Formatter();
-                    ft.Add<uint32_t>(ride->excitement);
+                    ft.Add<uint32_t>(ride->ratings.excitement);
                     ft.Add<StringId>(ratingName);
                     StringId stringId = !RideHasRatings(*ride) ? STR_EXCITEMENT_RATING_NOT_YET_AVAILABLE
                                                                : STR_EXCITEMENT_RATING;
@@ -5348,24 +5348,24 @@ static_assert(std::size(RatingNames) == 6);
                     screenCoords.y += kListRowHeight;
 
                     // Intensity
-                    ratingName = GetRatingName(ride->intensity);
+                    ratingName = GetRatingName(ride->ratings.intensity);
                     ft = Formatter();
-                    ft.Add<uint32_t>(ride->intensity);
+                    ft.Add<uint32_t>(ride->ratings.intensity);
                     ft.Add<StringId>(ratingName);
 
                     stringId = STR_INTENSITY_RATING;
                     if (!RideHasRatings(*ride))
                         stringId = STR_INTENSITY_RATING_NOT_YET_AVAILABLE;
-                    else if (ride->intensity >= RIDE_RATING(10, 00))
+                    else if (ride->ratings.intensity >= RIDE_RATING(10, 00))
                         stringId = STR_INTENSITY_RATING_RED;
 
                     DrawTextBasic(dpi, screenCoords, stringId, ft);
                     screenCoords.y += kListRowHeight;
 
                     // Nausea
-                    ratingName = GetRatingName(ride->nausea);
+                    ratingName = GetRatingName(ride->ratings.nausea);
                     ft = Formatter();
-                    ft.Add<uint32_t>(ride->nausea);
+                    ft.Add<uint32_t>(ride->ratings.nausea);
                     ft.Add<StringId>(ratingName);
                     stringId = !RideHasRatings(*ride) ? STR_NAUSEA_RATING_NOT_YET_AVAILABLE : STR_NAUSEA_RATING;
                     DrawTextBasic(dpi, screenCoords, stringId, ft);

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -720,7 +720,7 @@ static Widget _rideListWidgets[] = {
                         if (RideHasRatings(*ridePtr))
                         {
                             formatSecondary = STR_EXCITEMENT_LABEL;
-                            ft.Add<uint16_t>(ridePtr->excitement);
+                            ft.Add<uint16_t>(ridePtr->ratings.excitement);
                         }
                         break;
                     case INFORMATION_TYPE_INTENSITY:
@@ -728,7 +728,7 @@ static Widget _rideListWidgets[] = {
                         if (RideHasRatings(*ridePtr))
                         {
                             formatSecondary = STR_INTENSITY_LABEL;
-                            ft.Add<uint16_t>(ridePtr->intensity);
+                            ft.Add<uint16_t>(ridePtr->ratings.intensity);
                         }
                         break;
                     case INFORMATION_TYPE_NAUSEA:
@@ -736,7 +736,7 @@ static Widget _rideListWidgets[] = {
                         if (RideHasRatings(*ridePtr))
                         {
                             formatSecondary = STR_NAUSEA_LABEL;
-                            ft.Add<uint16_t>(ridePtr->nausea);
+                            ft.Add<uint16_t>(ridePtr->ratings.nausea);
                         }
                         break;
                 }
@@ -915,17 +915,17 @@ static Widget _rideListWidgets[] = {
                     break;
                 case INFORMATION_TYPE_EXCITEMENT:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
-                        return thisRide.excitement <= otherRide.excitement;
+                        return thisRide.ratings.excitement <= otherRide.ratings.excitement;
                     });
                     break;
                 case INFORMATION_TYPE_INTENSITY:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
-                        return thisRide.intensity <= otherRide.intensity;
+                        return thisRide.ratings.intensity <= otherRide.ratings.intensity;
                     });
                     break;
                 case INFORMATION_TYPE_NAUSEA:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
-                        return thisRide.nausea <= otherRide.nausea;
+                        return thisRide.ratings.nausea <= otherRide.ratings.nausea;
                     });
                     break;
             }

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -116,14 +116,14 @@ static Widget _trackPlaceWidgets[] = {
                     _currentTrackPieceDirection = (_currentTrackPieceDirection + 1) & 3;
                     Invalidate();
                     _placementLoc.SetNull();
-                    DrawMiniPreview(_trackDesign.get());
+                    DrawMiniPreview(*_trackDesign);
                     break;
                 case WIDX_MIRROR:
-                    TrackDesignMirror(_trackDesign.get());
+                    TrackDesignMirror(*_trackDesign);
                     _currentTrackPieceDirection = (0 - _currentTrackPieceDirection) & 3;
                     Invalidate();
                     _placementLoc.SetNull();
-                    DrawMiniPreview(_trackDesign.get());
+                    DrawMiniPreview(*_trackDesign);
                     break;
                 case WIDX_SELECT_DIFFERENT_DESIGN:
                     Close();
@@ -165,7 +165,7 @@ static Widget _trackPlaceWidgets[] = {
             if (mapCoords == _placementLoc)
             {
                 TrackDesignPreviewDrawOutlines(
-                    tds, _trackDesign.get(), RideGetTemporaryForPreview(), { mapCoords, 0, _currentTrackPieceDirection });
+                    tds, *_trackDesign, RideGetTemporaryForPreview(), { mapCoords, 0, _currentTrackPieceDirection });
                 return;
             }
 
@@ -205,7 +205,7 @@ static Widget _trackPlaceWidgets[] = {
                 WidgetInvalidate(*this, WIDX_PRICE);
             }
 
-            TrackDesignPreviewDrawOutlines(tds, _trackDesign.get(), RideGetTemporaryForPreview(), trackLoc);
+            TrackDesignPreviewDrawOutlines(tds, *_trackDesign, RideGetTemporaryForPreview(), trackLoc);
         }
 
         void OnToolDown(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords) override
@@ -278,12 +278,12 @@ static Widget _trackPlaceWidgets[] = {
 
         void OnViewportRotate() override
         {
-            DrawMiniPreview(_trackDesign.get());
+            DrawMiniPreview(*_trackDesign);
         }
 
         void OnPrepareDraw() override
         {
-            DrawMiniPreview(_trackDesign.get());
+            DrawMiniPreview(*_trackDesign);
         }
 
         void OnDraw(DrawPixelInfo& dpi) override
@@ -326,7 +326,7 @@ static Widget _trackPlaceWidgets[] = {
                 auto provRide = GetRide(_placementGhostRideId);
                 if (provRide != nullptr)
                 {
-                    TrackDesignPreviewRemoveGhosts(_trackDesign.get(), *provRide, _placementGhostLoc);
+                    TrackDesignPreviewRemoveGhosts(*_trackDesign, *provRide, _placementGhostLoc);
                 }
             }
         }
@@ -350,7 +350,7 @@ static Widget _trackPlaceWidgets[] = {
             _trackDesign = std::move(trackDesign);
         }
 
-        void DrawMiniPreview(TrackDesign* td)
+        void DrawMiniPreview(const TrackDesign& td)
         {
             ClearMiniPreview();
 
@@ -366,7 +366,7 @@ static Widget _trackPlaceWidgets[] = {
                     origin.y -= ((max.y + min.y) >> 6) * COORDS_XY_STEP;
                 }
 
-                const auto& rtd = GetRideTypeDescriptor(td->trackAndVehicle.rtdIndex);
+                const auto& rtd = GetRideTypeDescriptor(td.trackAndVehicle.rtdIndex);
                 if (rtd.HasFlag(RIDE_TYPE_FLAG_IS_MAZE))
                 {
                     DrawMiniPreviewMaze(td, pass, origin, min, max);
@@ -402,7 +402,7 @@ static Widget _trackPlaceWidgets[] = {
                 auto newRide = GetRide(_placementGhostRideId);
                 if (newRide != nullptr)
                 {
-                    TrackDesignPreviewRemoveGhosts(_trackDesign.get(), *newRide, _placementGhostLoc);
+                    TrackDesignPreviewRemoveGhosts(*_trackDesign, *newRide, _placementGhostLoc);
                     _hasPlacementGhost = false;
                 }
             }
@@ -432,7 +432,7 @@ static Widget _trackPlaceWidgets[] = {
 
             return z
                 + TrackDesignGetZPlacement(
-                       _trackDesign.get(), RideGetTemporaryForPreview(), { loc, z, _currentTrackPieceDirection });
+                       *_trackDesign, RideGetTemporaryForPreview(), { loc, z, _currentTrackPieceDirection });
         }
 
         void DrawMiniPreviewEntrances(
@@ -468,13 +468,13 @@ static Widget _trackPlaceWidgets[] = {
             }
         }
 
-        void DrawMiniPreviewTrack(TrackDesign* td, int32_t pass, const CoordsXY& origin, CoordsXY& min, CoordsXY& max)
+        void DrawMiniPreviewTrack(const TrackDesign& td, int32_t pass, const CoordsXY& origin, CoordsXY& min, CoordsXY& max)
         {
             const uint8_t rotation = (_currentTrackPieceDirection + GetCurrentRotation()) & 3;
 
             CoordsXY curTrackStart = origin;
             uint8_t curTrackRotation = rotation;
-            for (const auto& trackElement : td->trackElements)
+            for (const auto& trackElement : td.trackElements)
             {
                 // Follow a single track piece shape
                 const auto& ted = GetTrackElementDescriptor(trackElement.type);
@@ -539,13 +539,13 @@ static Widget _trackPlaceWidgets[] = {
                 }
             }
 
-            DrawMiniPreviewEntrances(*td, pass, origin, min, max, rotation);
+            DrawMiniPreviewEntrances(td, pass, origin, min, max, rotation);
         }
 
-        void DrawMiniPreviewMaze(TrackDesign* td, int32_t pass, const CoordsXY& origin, CoordsXY& min, CoordsXY& max)
+        void DrawMiniPreviewMaze(const TrackDesign& td, int32_t pass, const CoordsXY& origin, CoordsXY& min, CoordsXY& max)
         {
             uint8_t rotation = (_currentTrackPieceDirection + GetCurrentRotation()) & 3;
-            for (const auto& mazeElement : td->mazeElements)
+            for (const auto& mazeElement : td.mazeElements)
             {
                 auto rotatedMazeCoords = origin + mazeElement.location.ToCoordsXY().Rotate(rotation);
 
@@ -575,7 +575,7 @@ static Widget _trackPlaceWidgets[] = {
                 }
             }
 
-            DrawMiniPreviewEntrances(*td, pass, origin, min, max, rotation);
+            DrawMiniPreviewEntrances(td, pass, origin, min, max, rotation);
         }
 
         ScreenCoordsXY DrawMiniPreviewGetPixelPosition(const CoordsXY& location)

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -289,7 +289,7 @@ static Widget _trackPlaceWidgets[] = {
         void OnDraw(DrawPixelInfo& dpi) override
         {
             auto ft = Formatter::Common();
-            ft.Add<char*>(_trackDesign->name.c_str());
+            ft.Add<char*>(_trackDesign->gameStateData.name.c_str());
             WindowDrawWidgets(*this, dpi);
 
             // Draw mini tile preview

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -366,7 +366,7 @@ static Widget _trackPlaceWidgets[] = {
                     origin.y -= ((max.y + min.y) >> 6) * COORDS_XY_STEP;
                 }
 
-                const auto& rtd = GetRideTypeDescriptor(td->type);
+                const auto& rtd = GetRideTypeDescriptor(td->trackAndVehicle.rtdIndex);
                 if (rtd.HasFlag(RIDE_TYPE_FLAG_IS_MAZE))
                 {
                     DrawMiniPreviewMaze(td, pass, origin, min, max);

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -136,7 +136,7 @@ static Widget _trackListWidgets[] = {
                 return;
             }
 
-            if (_loadedTrackDesign->trackFlags & TRACK_DESIGN_FLAG_SCENERY_UNAVAILABLE)
+            if (_loadedTrackDesign->gameStateData.hasFlag(TrackDesignGameStateFlag::SceneryUnavailable))
             {
                 gTrackDesignSceneryToggle = true;
             }
@@ -152,7 +152,7 @@ static Widget _trackListWidgets[] = {
             else
             {
                 if (_loadedTrackDesignIndex != TRACK_DESIGN_INDEX_UNLOADED
-                    && (_loadedTrackDesign->trackFlags & TRACK_DESIGN_FLAG_VEHICLE_UNAVAILABLE))
+                    && (_loadedTrackDesign->gameStateData.hasFlag(TrackDesignGameStateFlag::VehicleUnavailable)))
                 {
                     ContextShowError(STR_THIS_DESIGN_WILL_BE_BUILT_WITH_AN_ALTERNATIVE_VEHICLE_TYPE, STR_NONE, {});
                 }
@@ -515,7 +515,7 @@ static Widget _trackListWidgets[] = {
             screenPos.y = windowPos.y + tdWidget.bottom - 12;
 
             // Warnings
-            if ((_loadedTrackDesign->trackFlags & TRACK_DESIGN_FLAG_VEHICLE_UNAVAILABLE)
+            if ((_loadedTrackDesign->gameStateData.hasFlag(TrackDesignGameStateFlag::VehicleUnavailable))
                 && !(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER))
             {
                 // Vehicle design not available
@@ -523,7 +523,7 @@ static Widget _trackListWidgets[] = {
                 screenPos.y -= kScrollableRowHeight;
             }
 
-            if (_loadedTrackDesign->trackFlags & TRACK_DESIGN_FLAG_SCENERY_UNAVAILABLE)
+            if (_loadedTrackDesign->gameStateData.hasFlag(TrackDesignGameStateFlag::SceneryUnavailable))
             {
                 if (!gTrackDesignSceneryToggle)
                 {
@@ -665,10 +665,10 @@ static Widget _trackListWidgets[] = {
                 screenPos.y += kListRowHeight;
             }
 
-            if (_loadedTrackDesign->cost != 0)
+            if (_loadedTrackDesign->gameStateData.cost != 0)
             {
                 ft = Formatter();
-                ft.Add<uint32_t>(_loadedTrackDesign->cost);
+                ft.Add<uint32_t>(_loadedTrackDesign->gameStateData.cost);
                 DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_COST_AROUND, ft);
             }
         }

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -201,7 +201,7 @@ static Widget _trackListWidgets[] = {
             _loadedTrackDesign = TrackDesignImport(path.c_str());
             if (_loadedTrackDesign != nullptr)
             {
-                TrackDesignDrawPreview(_loadedTrackDesign.get(), _trackDesignPreviewPixels.data());
+                TrackDesignDrawPreview(*_loadedTrackDesign, _trackDesignPreviewPixels.data());
                 return true;
             }
             return false;

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -568,7 +568,7 @@ static Widget _trackListWidgets[] = {
                     {
                         // Holes
                         ft = Formatter();
-                        ft.Add<uint16_t>(_loadedTrackDesign->statistics.holes & 0x1F);
+                        ft.Add<uint16_t>(_loadedTrackDesign->statistics.holes);
                         DrawTextBasic(dpi, screenPos, STR_HOLES, ft);
                         screenPos.y += kListRowHeight;
                     }
@@ -599,19 +599,19 @@ static Widget _trackListWidgets[] = {
                 {
                     // Maximum positive vertical Gs
                     ft = Formatter();
-                    ft.Add<int32_t>(_loadedTrackDesign->statistics.maxPositiveVerticalG * 32);
+                    ft.Add<int32_t>(_loadedTrackDesign->statistics.maxPositiveVerticalG);
                     DrawTextBasic(dpi, screenPos, STR_MAX_POSITIVE_VERTICAL_G, ft);
                     screenPos.y += kListRowHeight;
 
                     // Maximum negative vertical Gs
                     ft = Formatter();
-                    ft.Add<int32_t>(_loadedTrackDesign->statistics.maxNegativeVerticalG * 32);
+                    ft.Add<int32_t>(_loadedTrackDesign->statistics.maxNegativeVerticalG);
                     DrawTextBasic(dpi, screenPos, STR_MAX_NEGATIVE_VERTICAL_G, ft);
                     screenPos.y += kListRowHeight;
 
                     // Maximum lateral Gs
                     ft = Formatter();
-                    ft.Add<int32_t>(_loadedTrackDesign->statistics.maxLateralG * 32);
+                    ft.Add<int32_t>(_loadedTrackDesign->statistics.maxLateralG);
                     DrawTextBasic(dpi, screenPos, STR_MAX_LATERAL_G, ft);
                     screenPos.y += kListRowHeight;
 
@@ -619,7 +619,7 @@ static Widget _trackListWidgets[] = {
                     {
                         // Total air time
                         ft = Formatter();
-                        ft.Add<int32_t>(_loadedTrackDesign->statistics.totalAirTime * 25);
+                        ft.Add<int32_t>(_loadedTrackDesign->statistics.totalAirTime * 3);
                         DrawTextBasic(dpi, screenPos, STR_TOTAL_AIR_TIME, ft);
                         screenPos.y += kListRowHeight;
                     }
@@ -629,7 +629,7 @@ static Widget _trackListWidgets[] = {
                 {
                     // Drops
                     ft = Formatter();
-                    ft.Add<uint16_t>(_loadedTrackDesign->statistics.drops & 0x3F);
+                    ft.Add<uint16_t>(_loadedTrackDesign->statistics.drops);
                     DrawTextBasic(dpi, screenPos, STR_DROPS, ft);
                     screenPos.y += kListRowHeight;
 
@@ -640,18 +640,14 @@ static Widget _trackListWidgets[] = {
                     screenPos.y += kListRowHeight;
                 }
 
-                if (_loadedTrackDesign->trackAndVehicle.rtdIndex != RIDE_TYPE_MINI_GOLF)
+                if (_loadedTrackDesign->statistics.inversions != 0)
                 {
-                    uint16_t inversions = _loadedTrackDesign->statistics.inversions & 0x1F;
-                    if (inversions != 0)
-                    {
-                        ft = Formatter();
-                        ft.Add<uint16_t>(inversions);
-                        // Inversions
-                        DrawTextBasic(dpi, screenPos, STR_INVERSIONS, ft);
-                        screenPos.y += kListRowHeight;
-                    }
+                    ft = Formatter();
+                    ft.Add<uint16_t>(_loadedTrackDesign->statistics.inversions);
+                    DrawTextBasic(dpi, screenPos, STR_INVERSIONS, ft);
+                    screenPos.y += kListRowHeight;
                 }
+
                 screenPos.y += 4;
             }
 

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -544,17 +544,17 @@ static Widget _trackListWidgets[] = {
 
             // Stats
             ft = Formatter();
-            ft.Add<fixed32_2dp>(_loadedTrackDesign->statistics.excitement * 10);
+            ft.Add<fixed32_2dp>(_loadedTrackDesign->statistics.ratings.excitement);
             DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_EXCITEMENT_RATING, ft);
             screenPos.y += kListRowHeight;
 
             ft = Formatter();
-            ft.Add<fixed32_2dp>(_loadedTrackDesign->statistics.intensity * 10);
+            ft.Add<fixed32_2dp>(_loadedTrackDesign->statistics.ratings.intensity);
             DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_INTENSITY_RATING, ft);
             screenPos.y += kListRowHeight;
 
             ft = Formatter();
-            ft.Add<fixed32_2dp>(_loadedTrackDesign->statistics.nausea * 10);
+            ft.Add<fixed32_2dp>(_loadedTrackDesign->statistics.ratings.nausea);
             DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_NAUSEA_RATING, ft);
             screenPos.y += kListRowHeight + 4;
 

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -559,12 +559,12 @@ static Widget _trackListWidgets[] = {
             screenPos.y += kListRowHeight + 4;
 
             // Information for tracked rides.
-            if (GetRideTypeDescriptor(_loadedTrackDesign->type).HasFlag(RIDE_TYPE_FLAG_HAS_TRACK))
+            if (GetRideTypeDescriptor(_loadedTrackDesign->trackAndVehicle.rtdIndex).HasFlag(RIDE_TYPE_FLAG_HAS_TRACK))
             {
-                const auto& rtd = GetRideTypeDescriptor(_loadedTrackDesign->type);
+                const auto& rtd = GetRideTypeDescriptor(_loadedTrackDesign->trackAndVehicle.rtdIndex);
                 if (!rtd.HasFlag(RIDE_TYPE_FLAG_IS_MAZE))
                 {
-                    if (_loadedTrackDesign->type == RIDE_TYPE_MINI_GOLF)
+                    if (_loadedTrackDesign->trackAndVehicle.rtdIndex == RIDE_TYPE_MINI_GOLF)
                     {
                         // Holes
                         ft = Formatter();
@@ -595,7 +595,7 @@ static Widget _trackListWidgets[] = {
                     screenPos.y += kListRowHeight;
                 }
 
-                if (GetRideTypeDescriptor(_loadedTrackDesign->type).HasFlag(RIDE_TYPE_FLAG_HAS_G_FORCES))
+                if (GetRideTypeDescriptor(_loadedTrackDesign->trackAndVehicle.rtdIndex).HasFlag(RIDE_TYPE_FLAG_HAS_G_FORCES))
                 {
                     // Maximum positive vertical Gs
                     ft = Formatter();
@@ -625,7 +625,7 @@ static Widget _trackListWidgets[] = {
                     }
                 }
 
-                if (GetRideTypeDescriptor(_loadedTrackDesign->type).HasFlag(RIDE_TYPE_FLAG_HAS_DROPS))
+                if (GetRideTypeDescriptor(_loadedTrackDesign->trackAndVehicle.rtdIndex).HasFlag(RIDE_TYPE_FLAG_HAS_DROPS))
                 {
                     // Drops
                     ft = Formatter();
@@ -640,7 +640,7 @@ static Widget _trackListWidgets[] = {
                     screenPos.y += kListRowHeight;
                 }
 
-                if (_loadedTrackDesign->type != RIDE_TYPE_MINI_GOLF)
+                if (_loadedTrackDesign->trackAndVehicle.rtdIndex != RIDE_TYPE_MINI_GOLF)
                 {
                     uint16_t inversions = _loadedTrackDesign->statistics.inversions & 0x1F;
                     if (inversions != 0)

--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -202,7 +202,7 @@ GameActions::Result RideCreateAction::Execute() const
 
     ride->lift_hill_speed = rtd.LiftData.minimum_speed;
 
-    ride->excitement = kRideRatingUndefined;
+    ride->ratings.setNull();
 
     auto& gameState = GetGameState();
     if (!(gameState.Park.Flags & PARK_FLAGS_NO_MONEY))

--- a/src/openrct2/actions/RideFreezeRatingAction.cpp
+++ b/src/openrct2/actions/RideFreezeRatingAction.cpp
@@ -55,13 +55,13 @@ GameActions::Result RideFreezeRatingAction::Execute() const
     switch (_type)
     {
         case RideRatingType::Excitement:
-            ride->excitement = _value;
+            ride->ratings.excitement = _value;
             break;
         case RideRatingType::Intensity:
-            ride->intensity = _value;
+            ride->ratings.intensity = _value;
             break;
         case RideRatingType::Nausea:
-            ride->nausea = _value;
+            ride->ratings.nausea = _value;
             break;
     }
 

--- a/src/openrct2/actions/TrackDesignAction.cpp
+++ b/src/openrct2/actions/TrackDesignAction.cpp
@@ -262,7 +262,7 @@ GameActions::Result TrackDesignAction::Execute() const
 
     for (int32_t count = 1; count == 1 || r.Error != GameActions::Status::Ok; ++count)
     {
-        auto name = count == 1 ? _td.name : (_td.name + " " + std::to_string(count));
+        auto name = count == 1 ? _td.gameStateData.name : (_td.gameStateData.name + " " + std::to_string(count));
         auto gameAction = RideSetNameAction(ride->id, name);
         gameAction.SetFlags(GetFlags());
         r = GameActions::ExecuteNested(&gameAction);

--- a/src/openrct2/actions/TrackDesignAction.cpp
+++ b/src/openrct2/actions/TrackDesignAction.cpp
@@ -103,11 +103,11 @@ GameActions::Result TrackDesignAction::Query() const
     if (GetFlags() & GAME_COMMAND_FLAG_REPLAY)
         flags |= GAME_COMMAND_FLAG_REPLAY;
 
-    auto queryRes = TrackDesignPlace(const_cast<TrackDesign*>(&_td), flags, placeScenery, *ride, _loc);
+    auto queryRes = TrackDesignPlace(_td, flags, placeScenery, *ride, _loc);
     if (_trackDesignPlaceStateSceneryUnavailable)
     {
         placeScenery = false;
-        queryRes = TrackDesignPlace(const_cast<TrackDesign*>(&_td), flags, placeScenery, *ride, _loc);
+        queryRes = TrackDesignPlace(_td, flags, placeScenery, *ride, _loc);
     }
 
     auto gameAction = RideDemolishAction(ride->id, RIDE_MODIFY_DEMOLISH);
@@ -178,11 +178,11 @@ GameActions::Result TrackDesignAction::Execute() const
     if (GetFlags() & GAME_COMMAND_FLAG_REPLAY)
         flags |= GAME_COMMAND_FLAG_REPLAY;
 
-    auto queryRes = TrackDesignPlace(const_cast<TrackDesign*>(&_td), flags, placeScenery, *ride, _loc);
+    auto queryRes = TrackDesignPlace(_td, flags, placeScenery, *ride, _loc);
     if (_trackDesignPlaceStateSceneryUnavailable)
     {
         placeScenery = false;
-        queryRes = TrackDesignPlace(const_cast<TrackDesign*>(&_td), flags, placeScenery, *ride, _loc);
+        queryRes = TrackDesignPlace(_td, flags, placeScenery, *ride, _loc);
     }
 
     if (queryRes.Error != GameActions::Status::Ok)
@@ -202,7 +202,7 @@ GameActions::Result TrackDesignAction::Execute() const
     // Execute.
     flags |= GAME_COMMAND_FLAG_APPLY;
 
-    auto execRes = TrackDesignPlace(const_cast<TrackDesign*>(&_td), flags, placeScenery, *ride, _loc);
+    auto execRes = TrackDesignPlace(_td, flags, placeScenery, *ride, _loc);
     if (execRes.Error != GameActions::Status::Ok)
     {
         auto gameAction = RideDemolishAction(ride->id, RIDE_MODIFY_DEMOLISH);

--- a/src/openrct2/actions/TrackDesignAction.cpp
+++ b/src/openrct2/actions/TrackDesignAction.cpp
@@ -226,10 +226,12 @@ GameActions::Result TrackDesignAction::Execute() const
 
     SetOperatingSettingNested(
         ride->id, RideSetSetting::Mode, static_cast<uint8_t>(_td.operation.rideMode), GAME_COMMAND_FLAG_APPLY);
-    auto rideSetVehicleAction2 = RideSetVehicleAction(ride->id, RideSetVehicleType::NumTrains, _td.trackAndVehicle.numberOfTrains);
+    auto rideSetVehicleAction2 = RideSetVehicleAction(
+        ride->id, RideSetVehicleType::NumTrains, _td.trackAndVehicle.numberOfTrains);
     GameActions::ExecuteNested(&rideSetVehicleAction2);
 
-    auto rideSetVehicleAction3 = RideSetVehicleAction(ride->id, RideSetVehicleType::NumCarsPerTrain, _td.trackAndVehicle.numberOfCarsPerTrain);
+    auto rideSetVehicleAction3 = RideSetVehicleAction(
+        ride->id, RideSetVehicleType::NumCarsPerTrain, _td.trackAndVehicle.numberOfCarsPerTrain);
     GameActions::ExecuteNested(&rideSetVehicleAction3);
 
     SetOperatingSettingNested(ride->id, RideSetSetting::Departure, _td.operation.departFlags, GAME_COMMAND_FLAG_APPLY);

--- a/src/openrct2/actions/TrackDesignAction.cpp
+++ b/src/openrct2/actions/TrackDesignAction.cpp
@@ -66,7 +66,7 @@ GameActions::Result TrackDesignAction::Query() const
 
     auto& gameState = GetGameState();
     auto& objManager = GetContext()->GetObjectManager();
-    auto entryIndex = objManager.GetLoadedObjectEntryIndex(_td.vehicleObject);
+    auto entryIndex = objManager.GetLoadedObjectEntryIndex(_td.trackAndVehicle.vehicleObject);
     if (entryIndex == OBJECT_ENTRY_INDEX_NULL)
     {
         // Force a fallback if the entry is not invented yet a track design of it is selected,
@@ -78,7 +78,7 @@ GameActions::Result TrackDesignAction::Query() const
     }
 
     // Colours do not matter as will be overwritten
-    auto rideCreateAction = RideCreateAction(_td.type, entryIndex, 0, 0, gameState.LastEntranceStyle);
+    auto rideCreateAction = RideCreateAction(_td.trackAndVehicle.rtdIndex, entryIndex, 0, 0, gameState.LastEntranceStyle);
     rideCreateAction.SetFlags(GetFlags());
     auto r = GameActions::ExecuteNested(&rideCreateAction);
     if (r.Error != GameActions::Status::Ok)
@@ -140,7 +140,7 @@ GameActions::Result TrackDesignAction::Execute() const
 
     auto& gameState = GetGameState();
     auto& objManager = GetContext()->GetObjectManager();
-    auto entryIndex = objManager.GetLoadedObjectEntryIndex(_td.vehicleObject);
+    auto entryIndex = objManager.GetLoadedObjectEntryIndex(_td.trackAndVehicle.vehicleObject);
     if (entryIndex != OBJECT_ENTRY_INDEX_NULL)
     {
         // Force a fallback if the entry is not invented yet a track design using it is selected.
@@ -152,7 +152,7 @@ GameActions::Result TrackDesignAction::Execute() const
     }
 
     // Colours do not matter as will be overwritten
-    auto rideCreateAction = RideCreateAction(_td.type, entryIndex, 0, 0, gameState.LastEntranceStyle);
+    auto rideCreateAction = RideCreateAction(_td.trackAndVehicle.rtdIndex, entryIndex, 0, 0, gameState.LastEntranceStyle);
     rideCreateAction.SetFlags(GetFlags());
     auto r = GameActions::ExecuteNested(&rideCreateAction);
     if (r.Error != GameActions::Status::Ok)
@@ -226,10 +226,10 @@ GameActions::Result TrackDesignAction::Execute() const
 
     SetOperatingSettingNested(
         ride->id, RideSetSetting::Mode, static_cast<uint8_t>(_td.operation.rideMode), GAME_COMMAND_FLAG_APPLY);
-    auto rideSetVehicleAction2 = RideSetVehicleAction(ride->id, RideSetVehicleType::NumTrains, _td.numberOfTrains);
+    auto rideSetVehicleAction2 = RideSetVehicleAction(ride->id, RideSetVehicleType::NumTrains, _td.trackAndVehicle.numberOfTrains);
     GameActions::ExecuteNested(&rideSetVehicleAction2);
 
-    auto rideSetVehicleAction3 = RideSetVehicleAction(ride->id, RideSetVehicleType::NumCarsPerTrain, _td.numberOfCarsPerTrain);
+    auto rideSetVehicleAction3 = RideSetVehicleAction(ride->id, RideSetVehicleType::NumCarsPerTrain, _td.trackAndVehicle.numberOfCarsPerTrain);
     GameActions::ExecuteNested(&rideSetVehicleAction3);
 
     SetOperatingSettingNested(ride->id, RideSetSetting::Departure, _td.operation.departFlags, GAME_COMMAND_FLAG_APPLY);

--- a/src/openrct2/core/DataSerialiserTraits.h
+++ b/src/openrct2/core/DataSerialiserTraits.h
@@ -824,6 +824,30 @@ template<> struct DataSerializerTraitsT<VehicleColour>
     }
 };
 
+template<> struct DataSerializerTraitsT<RatingTuple>
+{
+    static void encode(OpenRCT2::IStream* stream, const RatingTuple& val)
+    {
+        stream->Write(&val.excitement);
+        stream->Write(&val.intensity);
+        stream->Write(&val.nausea);
+    }
+    static void decode(OpenRCT2::IStream* stream, RatingTuple& val)
+    {
+        stream->Read(&val.excitement);
+        stream->Read(&val.intensity);
+        stream->Read(&val.nausea);
+    }
+    static void log(OpenRCT2::IStream* stream, const RatingTuple& val)
+    {
+        char msg[128] = {};
+        snprintf(
+            msg, sizeof(msg), "RatingTuple(excitement = %d, intensity = %d, nausea = %d)", val.excitement, val.intensity,
+            val.nausea);
+        stream->Write(msg, strlen(msg));
+    }
+};
+
 template<> struct DataSerializerTraitsT<IntensityRange>
 {
     static void encode(OpenRCT2::IStream* stream, const IntensityRange& val)

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -1852,7 +1852,7 @@ Ride* Guest::FindBestRideToGoOn()
             {
                 if (ShouldGoOnRide(ride, StationIndex::FromUnderlying(0), false, true) && RideHasRatings(ride))
                 {
-                    if (mostExcitingRide == nullptr || ride.excitement > mostExcitingRide->excitement)
+                    if (mostExcitingRide == nullptr || ride.ratings.excitement > mostExcitingRide->ratings.excitement)
                     {
                         mostExcitingRide = &ride;
                     }
@@ -1909,7 +1909,7 @@ OpenRCT2::BitSet<OpenRCT2::Limits::kMaxRidesInPark> Guest::FindRidesToGoOn()
         // Always take the tall rides into consideration (realistic as you can usually see them from anywhere in the park)
         for (auto& ride : GetRideManager())
         {
-            if (ride.highest_drop_height > 66 || ride.excitement >= RIDE_RATING(8, 00))
+            if (ride.highest_drop_height > 66 || ride.ratings.excitement >= RIDE_RATING(8, 00))
             {
                 rideConsideration[ride.id.ToUnderlying()] = true;
             }
@@ -2048,7 +2048,7 @@ bool Guest::ShouldGoOnRide(Ride& ride, StationIndex entranceNum, bool atQueue, b
                 // excitement check and will only do a basic intensity check when they arrive at the ride itself.
                 if (ride.id == GuestHeadingToRideId)
                 {
-                    if (ride.intensity > RIDE_RATING(10, 00) && !GetGameState().Cheats.IgnoreRideIntensity)
+                    if (ride.ratings.intensity > RIDE_RATING(10, 00) && !GetGameState().Cheats.IgnoreRideIntensity)
                     {
                         PeepRideIsTooIntense(this, ride, peepAtRide);
                         return false;
@@ -2082,7 +2082,7 @@ bool Guest::ShouldGoOnRide(Ride& ride, StationIndex entranceNum, bool atQueue, b
                             // intensity and decrease the min intensity by about 2.5.
                             ride_rating maxIntensity = std::min(Intensity.GetMaximum() * 100, 1000) + Happiness;
                             ride_rating minIntensity = (Intensity.GetMinimum() * 100) - Happiness;
-                            if (ride.intensity < minIntensity)
+                            if (ride.ratings.intensity < minIntensity)
                             {
                                 if (peepAtRide)
                                 {
@@ -2096,7 +2096,7 @@ bool Guest::ShouldGoOnRide(Ride& ride, StationIndex entranceNum, bool atQueue, b
                                 ChoseNotToGoOnRide(ride, peepAtRide, true);
                                 return false;
                             }
-                            if (ride.intensity > maxIntensity)
+                            if (ride.ratings.intensity > maxIntensity)
                             {
                                 PeepRideIsTooIntense(this, ride, peepAtRide);
                                 return false;
@@ -2105,7 +2105,7 @@ bool Guest::ShouldGoOnRide(Ride& ride, StationIndex entranceNum, bool atQueue, b
                             // Nausea calculations.
                             ride_rating maxNausea = NauseaMaximumThresholds[(EnumValue(NauseaTolerance) & 3)] + Happiness;
 
-                            if (ride.nausea > maxNausea)
+                            if (ride.ratings.nausea > maxNausea)
                             {
                                 if (peepAtRide)
                                 {
@@ -2121,7 +2121,7 @@ bool Guest::ShouldGoOnRide(Ride& ride, StationIndex entranceNum, bool atQueue, b
                             }
 
                             // Very nauseous peeps will only go on very gentle rides.
-                            if (ride.nausea >= FIXED_2DP(1, 40) && Nausea > 160)
+                            if (ride.ratings.nausea >= FIXED_2DP(1, 40) && Nausea > 160)
                             {
                                 ChoseNotToGoOnRide(ride, peepAtRide, false);
                                 return false;
@@ -2696,7 +2696,7 @@ static int16_t PeepCalculateRideSatisfaction(Guest* peep, const Ride& ride)
 static void PeepUpdateFavouriteRide(Guest* peep, const Ride& ride)
 {
     peep->PeepFlags &= ~PEEP_FLAGS_RIDE_SHOULD_BE_MARKED_AS_FAVOURITE;
-    uint8_t peepRideRating = std::clamp((ride.excitement / 4) + peep->Happiness, 0, kPeepMaxHappiness);
+    uint8_t peepRideRating = std::clamp((ride.ratings.excitement / 4) + peep->Happiness, 0, kPeepMaxHappiness);
     if (peepRideRating >= peep->FavouriteRideRating)
     {
         if (peep->Happiness >= 160 && peep->HappinessTarget >= 160)
@@ -2751,19 +2751,19 @@ static int16_t PeepCalculateRideIntensityNauseaSatisfaction(Guest* peep, const R
     uint8_t nauseaSatisfaction = 3;
     ride_rating maxIntensity = peep->Intensity.GetMaximum() * 100;
     ride_rating minIntensity = peep->Intensity.GetMinimum() * 100;
-    if (minIntensity <= ride.intensity && maxIntensity >= ride.intensity)
+    if (minIntensity <= ride.ratings.intensity && maxIntensity >= ride.ratings.intensity)
     {
         intensitySatisfaction--;
     }
     minIntensity -= peep->Happiness * 2;
     maxIntensity += peep->Happiness;
-    if (minIntensity <= ride.intensity && maxIntensity >= ride.intensity)
+    if (minIntensity <= ride.ratings.intensity && maxIntensity >= ride.ratings.intensity)
     {
         intensitySatisfaction--;
     }
     minIntensity -= peep->Happiness * 2;
     maxIntensity += peep->Happiness;
-    if (minIntensity <= ride.intensity && maxIntensity >= ride.intensity)
+    if (minIntensity <= ride.ratings.intensity && maxIntensity >= ride.ratings.intensity)
     {
         intensitySatisfaction--;
     }
@@ -2772,19 +2772,19 @@ static int16_t PeepCalculateRideIntensityNauseaSatisfaction(Guest* peep, const R
     // has a minimum preferred nausea value. (For peeps with None or Low, this is set to zero.)
     ride_rating minNausea = NauseaMinimumThresholds[(EnumValue(peep->NauseaTolerance) & 3)];
     ride_rating maxNausea = NauseaMaximumThresholds[(EnumValue(peep->NauseaTolerance) & 3)];
-    if (minNausea <= ride.nausea && maxNausea >= ride.nausea)
+    if (minNausea <= ride.ratings.nausea && maxNausea >= ride.ratings.nausea)
     {
         nauseaSatisfaction--;
     }
     minNausea -= peep->Happiness * 2;
     maxNausea += peep->Happiness;
-    if (minNausea <= ride.nausea && maxNausea >= ride.nausea)
+    if (minNausea <= ride.ratings.nausea && maxNausea >= ride.ratings.nausea)
     {
         nauseaSatisfaction--;
     }
     minNausea -= peep->Happiness * 2;
     maxNausea += peep->Happiness;
-    if (minNausea <= ride.nausea && maxNausea >= ride.nausea)
+    if (minNausea <= ride.ratings.nausea && maxNausea >= ride.ratings.nausea)
     {
         nauseaSatisfaction--;
     }
@@ -2843,7 +2843,7 @@ static int16_t PeepCalculateRideIntensityNauseaSatisfaction(Guest* peep, const R
 static void PeepUpdateRideNauseaGrowth(Guest* peep, const Ride& ride)
 {
     uint32_t nauseaMultiplier = std::clamp(256 - peep->HappinessTarget, 64, 200);
-    uint32_t nauseaGrowthRateChange = (ride.nausea * nauseaMultiplier) / 512;
+    uint32_t nauseaGrowthRateChange = (ride.ratings.nausea * nauseaMultiplier) / 512;
     nauseaGrowthRateChange *= std::max(static_cast<uint8_t>(128), peep->Hunger) / 64;
     nauseaGrowthRateChange >>= (EnumValue(peep->NauseaTolerance) & 3);
     peep->NauseaTarget = static_cast<uint8_t>(std::min(peep->NauseaTarget + nauseaGrowthRateChange, 255u));
@@ -2855,7 +2855,7 @@ static bool PeepShouldGoOnRideAgain(Guest* peep, const Ride& ride)
         return false;
     if (!RideHasRatings(ride))
         return false;
-    if (ride.intensity > RIDE_RATING(10, 00) && !GetGameState().Cheats.IgnoreRideIntensity)
+    if (ride.ratings.intensity > RIDE_RATING(10, 00) && !GetGameState().Cheats.IgnoreRideIntensity)
         return false;
     if (peep->Happiness < 180)
         return false;
@@ -2900,7 +2900,7 @@ static bool PeepReallyLikedRide(Guest* peep, const Ride& ride)
         return false;
     if (!RideHasRatings(ride))
         return false;
-    if (ride.intensity > RIDE_RATING(10, 00) && !GetGameState().Cheats.IgnoreRideIntensity)
+    if (ride.ratings.intensity > RIDE_RATING(10, 00) && !GetGameState().Cheats.IgnoreRideIntensity)
         return false;
     return true;
 }
@@ -6280,17 +6280,17 @@ static bool PeepShouldWatchRide(TileElement* tileElement)
     }
 
     // This is most likely to have peeps watch new rides
-    if (ride->excitement == kRideRatingUndefined)
+    if (ride->ratings.isNull())
     {
         return true;
     }
 
-    if (ride->excitement >= RIDE_RATING(4, 70))
+    if (ride->ratings.excitement >= RIDE_RATING(4, 70))
     {
         return true;
     }
 
-    if (ride->intensity >= RIDE_RATING(4, 50))
+    if (ride->ratings.intensity >= RIDE_RATING(4, 50))
     {
         return true;
     }
@@ -6324,7 +6324,7 @@ bool Loc690FD0(Peep* peep, RideId* rideToView, uint8_t* rideSeatToView, TileElem
         return false;
 
     *rideToView = ride->id;
-    if (ride->excitement == kRideRatingUndefined)
+    if (ride->ratings.isNull())
     {
         *rideSeatToView = 1;
         if (ride->status != RideStatus::Open)

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -468,7 +468,7 @@ static bool AwardIsDeservedBestCustomDesignedRides(int32_t activeAwardTypes)
             continue;
         if (ride.lifecycle_flags & RIDE_LIFECYCLE_NOT_CUSTOM_DESIGN)
             continue;
-        if (ride.excitement < RIDE_RATING(5, 50))
+        if (ride.ratings.excitement < RIDE_RATING(5, 50))
             continue;
         if (ride.status != RideStatus::Open || (ride.lifecycle_flags & RIDE_LIFECYCLE_CRASHED))
             continue;

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1446,7 +1446,7 @@ namespace OpenRCT2
                     cs.ReadWrite(ride.turn_count_sloped);
 
                     cs.ReadWrite(ride.inversions);
-                    cs.ReadWrite(ride.drops);
+                    cs.ReadWrite(ride.dropsPoweredLifts);
                     cs.ReadWrite(ride.start_drop_height);
                     cs.ReadWrite(ride.highest_drop_height);
                     cs.ReadWrite(ride.sheltered_length);
@@ -1459,7 +1459,7 @@ namespace OpenRCT2
                     }
                     cs.ReadWrite(ride.current_test_station);
                     cs.ReadWrite(ride.num_block_brakes);
-                    cs.ReadWrite(ride.total_air_time);
+                    cs.ReadWrite(ride.totalAirTime);
 
                     cs.ReadWrite(ride.ratings.excitement);
                     cs.ReadWrite(ride.ratings.intensity);

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1461,9 +1461,9 @@ namespace OpenRCT2
                     cs.ReadWrite(ride.num_block_brakes);
                     cs.ReadWrite(ride.total_air_time);
 
-                    cs.ReadWrite(ride.excitement);
-                    cs.ReadWrite(ride.intensity);
-                    cs.ReadWrite(ride.nausea);
+                    cs.ReadWrite(ride.ratings.excitement);
+                    cs.ReadWrite(ride.ratings.intensity);
+                    cs.ReadWrite(ride.ratings.nausea);
 
                     if (version <= 18)
                     {

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -324,16 +324,7 @@ namespace RCT1
         money16 Price;                                       // 0x0E8
         RCT12xy8 ChairliftBullwheelLocation[2];              // 0x0EA
         uint8_t ChairliftBullwheelZ[2];                      // 0x0EE
-        union
-        {
-            RatingTuple Ratings;
-            struct
-            {
-                ride_rating Excitement; // 0x0F0
-                ride_rating Intensity;  // 0x0F2
-                ride_rating Nausea;     // 0x0F4
-            };
-        };
+        RatingTuple ratings;                                 // 0x0F0
         money16 Value;                       // 0x0F6
         uint16_t ChairliftBullwheelRotation; // 0x0F8
         uint8_t Satisfaction;                // 0x0FA

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -325,21 +325,21 @@ namespace RCT1
         RCT12xy8 ChairliftBullwheelLocation[2];              // 0x0EA
         uint8_t ChairliftBullwheelZ[2];                      // 0x0EE
         RatingTuple ratings;                                 // 0x0F0
-        money16 Value;                       // 0x0F6
-        uint16_t ChairliftBullwheelRotation; // 0x0F8
-        uint8_t Satisfaction;                // 0x0FA
-        uint8_t SatisfactionTimeOut;         // 0x0FB
-        uint8_t SatisfactionNext;            // 0x0FC
-        uint8_t WindowInvalidateFlags;       // 0x0FD
-        uint8_t UnkFE[2];                    // 0x0FE
-        uint32_t TotalCustomers;             // 0x100
-        money32 TotalProfit;                 // 0x104
-        uint8_t Popularity;                  // 0x108
-        uint8_t PopularityTimeOut;           // 0x109
-        uint8_t PopularityNext;              // 0x10A
-        uint8_t NumRiders;                   // 0x10B
-        uint8_t MusicTuneID;                 // 0x10C
-        uint8_t SlideInUse;                  // 0x10D
+        money16 Value;                                       // 0x0F6
+        uint16_t ChairliftBullwheelRotation;                 // 0x0F8
+        uint8_t Satisfaction;                                // 0x0FA
+        uint8_t SatisfactionTimeOut;                         // 0x0FB
+        uint8_t SatisfactionNext;                            // 0x0FC
+        uint8_t WindowInvalidateFlags;                       // 0x0FD
+        uint8_t UnkFE[2];                                    // 0x0FE
+        uint32_t TotalCustomers;                             // 0x100
+        money32 TotalProfit;                                 // 0x104
+        uint8_t Popularity;                                  // 0x108
+        uint8_t PopularityTimeOut;                           // 0x109
+        uint8_t PopularityNext;                              // 0x10A
+        uint8_t NumRiders;                                   // 0x10B
+        uint8_t MusicTuneID;                                 // 0x10C
+        uint8_t SlideInUse;                                  // 0x10D
         union
         {
             uint16_t SlidePeep; // 0x10E

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1023,13 +1023,13 @@ namespace RCT1
             dst->turn_count_banked = src->TurnCountBanked;
             dst->turn_count_default = src->TurnCountDefault;
             dst->turn_count_sloped = src->TurnCountSloped;
-            dst->drops = src->NumDrops;
+            dst->dropsPoweredLifts = src->NumDrops;
             dst->start_drop_height = src->StartDropHeight / 2;
             dst->highest_drop_height = src->HighestDropHeight / 2;
             if (dst->type == RIDE_TYPE_MINI_GOLF)
-                dst->holes = src->NumInversions & 0x1F;
+                dst->holes = src->NumInversions & kRCT12InversionAndHoleMask;
             else
-                dst->inversions = src->NumInversions & 0x1F;
+                dst->inversions = src->NumInversions & kRCT12InversionAndHoleMask;
             dst->sheltered_eighths = src->NumInversions >> 5;
             dst->boat_hire_return_direction = src->BoatHireReturnDirection;
             dst->boat_hire_return_position = { src->BoatHireReturnPosition.x, src->BoatHireReturnPosition.y };

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1010,9 +1010,7 @@ namespace RCT1
             dst->broken_vehicle = src->BrokenVehicle;
 
             // Measurement data
-            dst->excitement = src->Excitement;
-            dst->intensity = src->Intensity;
-            dst->nausea = src->Nausea;
+            dst->ratings = src->ratings;
 
             dst->max_speed = src->MaxSpeed;
             dst->average_speed = src->AverageSpeed;

--- a/src/openrct2/rct1/T4Importer.cpp
+++ b/src/openrct2/rct1/T4Importer.cpp
@@ -262,7 +262,7 @@ namespace RCT1
                 }
             }
 
-            td->name = _name;
+            td->gameStateData.name = _name;
             return td;
         }
     };

--- a/src/openrct2/rct1/T4Importer.cpp
+++ b/src/openrct2/rct1/T4Importer.cpp
@@ -125,7 +125,7 @@ namespace RCT1
 
         std::unique_ptr<TrackDesign> ImportTD4Base(std::unique_ptr<TrackDesign> td, TD4& td4Base)
         {
-            td->type = RCT1::GetRideType(td4Base.Type, td4Base.VehicleType);
+            td->trackAndVehicle.rtdIndex = RCT1::GetRideType(td4Base.Type, td4Base.VehicleType);
 
             // All TD4s that use powered launch use the type that doesn't pass the station.
             td->operation.rideMode = static_cast<RideMode>(td4Base.Mode);
@@ -144,7 +144,7 @@ namespace RCT1
                 vehicleObject = RCT1::GetVehicleObject(td4Base.VehicleType);
             }
             assert(!vehicleObject.empty());
-            td->vehicleObject = ObjectEntryDescriptor(vehicleObject);
+            td->trackAndVehicle.vehicleObject = ObjectEntryDescriptor(vehicleObject);
             td->appearance.vehicleColourSettings = static_cast<VehicleColourSettings>(td4Base.VersionAndColourScheme & 0x3);
 
             // Vehicle colours
@@ -200,12 +200,12 @@ namespace RCT1
 
             td->appearance.stationObjectIdentifier = GetStationIdentifierFromStyle(RCT12_STATION_STYLE_PLAIN);
             td->operation.departFlags = td4Base.DepartFlags;
-            td->numberOfTrains = td4Base.NumberOfTrains;
-            td->numberOfCarsPerTrain = td4Base.NumberOfCarsPerTrain;
+            td->trackAndVehicle.numberOfTrains = td4Base.NumberOfTrains;
+            td->trackAndVehicle.numberOfCarsPerTrain = td4Base.NumberOfCarsPerTrain;
             td->operation.minWaitingTime = td4Base.MinWaitingTime;
             td->operation.maxWaitingTime = td4Base.MaxWaitingTime;
             td->operation.operationSetting = std::min(
-                td4Base.OperationSetting, GetRideTypeDescriptor(td->type).OperatingSettings.MaxValue);
+                td4Base.OperationSetting, GetRideTypeDescriptor(td->trackAndVehicle.rtdIndex).OperatingSettings.MaxValue);
             td->statistics.maxSpeed = td4Base.MaxSpeed;
             td->statistics.averageSpeed = td4Base.AverageSpeed;
             td->statistics.rideLength = td4Base.RideLength;
@@ -213,7 +213,7 @@ namespace RCT1
             td->statistics.maxNegativeVerticalG = td4Base.MaxNegativeVerticalG;
             td->statistics.maxLateralG = td4Base.MaxLateralG;
 
-            if (td->type == RIDE_TYPE_MINI_GOLF)
+            if (td->trackAndVehicle.rtdIndex == RIDE_TYPE_MINI_GOLF)
             {
                 td->statistics.holes = td4Base.NumHoles;
             }
@@ -232,9 +232,9 @@ namespace RCT1
             td->operation.liftHillSpeed = 5;
             td->operation.numCircuits = 0;
             td->operation.operationSetting = std::min(
-                td->operation.operationSetting, GetRideTypeDescriptor(td->type).OperatingSettings.MaxValue);
+                td->operation.operationSetting, GetRideTypeDescriptor(td->trackAndVehicle.rtdIndex).OperatingSettings.MaxValue);
 
-            const auto& rtd = GetRideTypeDescriptor(td->type);
+            const auto& rtd = GetRideTypeDescriptor(td->trackAndVehicle.rtdIndex);
             if (rtd.HasFlag(RIDE_TYPE_FLAG_IS_MAZE))
             {
                 TD46MazeElement t4MazeElement{};
@@ -256,7 +256,7 @@ namespace RCT1
                     _stream.SetPosition(_stream.GetPosition() - 1);
                     _stream.Read(&t4TrackElement, sizeof(TD46TrackElement));
                     TrackDesignTrackElement trackElement{};
-                    trackElement.type = RCT1TrackTypeToOpenRCT2(t4TrackElement.Type, td->type);
+                    trackElement.type = RCT1TrackTypeToOpenRCT2(t4TrackElement.Type, td->trackAndVehicle.rtdIndex);
                     ConvertFromTD46Flags(trackElement, t4TrackElement.Flags);
                     td->trackElements.push_back(trackElement);
                 }

--- a/src/openrct2/rct1/T4Importer.cpp
+++ b/src/openrct2/rct1/T4Importer.cpp
@@ -224,9 +224,9 @@ namespace RCT1
 
             td->statistics.drops = td4Base.NumDrops;
             td->statistics.highestDropHeight = td4Base.HighestDropHeight / 2;
-            td->statistics.excitement = td4Base.Excitement;
-            td->statistics.intensity = td4Base.Intensity;
-            td->statistics.nausea = td4Base.Nausea;
+            td->statistics.ratings.excitement = td4Base.Excitement * kTD46RatingsMultiplier;
+            td->statistics.ratings.intensity = td4Base.Intensity * kTD46RatingsMultiplier;
+            td->statistics.ratings.nausea = td4Base.Nausea * kTD46RatingsMultiplier;
             td->statistics.upkeepCost = ToMoney64(td4Base.UpkeepCost);
             td->statistics.spaceRequired.SetNull();
             td->operation.liftHillSpeed = 5;

--- a/src/openrct2/rct1/T4Importer.cpp
+++ b/src/openrct2/rct1/T4Importer.cpp
@@ -209,20 +209,16 @@ namespace RCT1
             td->statistics.maxSpeed = td4Base.MaxSpeed;
             td->statistics.averageSpeed = td4Base.AverageSpeed;
             td->statistics.rideLength = td4Base.RideLength;
-            td->statistics.maxPositiveVerticalG = td4Base.MaxPositiveVerticalG;
-            td->statistics.maxNegativeVerticalG = td4Base.MaxNegativeVerticalG;
-            td->statistics.maxLateralG = td4Base.MaxLateralG;
+            td->statistics.maxPositiveVerticalG = td4Base.MaxPositiveVerticalG * kTD46GForcesMultiplier;
+            td->statistics.maxNegativeVerticalG = td4Base.MaxNegativeVerticalG * kTD46GForcesMultiplier;
+            td->statistics.maxLateralG = td4Base.MaxLateralG * kTD46GForcesMultiplier;
 
-            if (td->trackAndVehicle.rtdIndex == RIDE_TYPE_MINI_GOLF)
-            {
-                td->statistics.holes = td4Base.NumHoles;
-            }
+            if (td4Base.Type == RideType::MiniatureGolf)
+                td->statistics.holes = td4Base.NumHoles & kRCT12InversionAndHoleMask;
             else
-            {
-                td->statistics.inversions = td4Base.NumInversions;
-            }
+                td->statistics.inversions = td4Base.NumInversions & kRCT12InversionAndHoleMask;
 
-            td->statistics.drops = td4Base.NumDrops;
+            td->statistics.drops = td4Base.NumDrops & kRCT12RideNumDropsMask;
             td->statistics.highestDropHeight = td4Base.HighestDropHeight / 2;
             td->statistics.ratings.excitement = td4Base.Excitement * kTD46RatingsMultiplier;
             td->statistics.ratings.intensity = td4Base.Intensity * kTD46RatingsMultiplier;
@@ -230,7 +226,7 @@ namespace RCT1
             td->statistics.upkeepCost = ToMoney64(td4Base.UpkeepCost);
             td->statistics.spaceRequired.SetNull();
             td->operation.liftHillSpeed = 5;
-            td->operation.numCircuits = 0;
+            td->operation.numCircuits = 1;
             td->operation.operationSetting = std::min(
                 td->operation.operationSetting, GetRideTypeDescriptor(td->trackAndVehicle.rtdIndex).OperatingSettings.MaxValue);
 

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -74,6 +74,8 @@ constexpr uint8_t RCT12PeepThoughtItemNone = std::numeric_limits<uint8_t>::max()
 constexpr uint8_t RCT12GuestsInParkHistoryFactor = 20;
 constexpr uint8_t RCT12ParkHistoryUndefined = std::numeric_limits<uint8_t>::max();
 
+constexpr uint8_t kTD46RatingsMultiplier = 10;
+
 struct TrackDesign;
 struct TrackDesignTrackElement;
 enum class RideColourScheme : uint8_t;

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -75,6 +75,10 @@ constexpr uint8_t RCT12GuestsInParkHistoryFactor = 20;
 constexpr uint8_t RCT12ParkHistoryUndefined = std::numeric_limits<uint8_t>::max();
 
 constexpr uint8_t kTD46RatingsMultiplier = 10;
+constexpr uint8_t kTD46GForcesMultiplier = 32;
+
+constexpr uint8_t kRCT12InversionAndHoleMask = 0b00011111;
+constexpr uint8_t kRCT12RideNumDropsMask = 0b00111111;
 
 struct TrackDesign;
 struct TrackDesignTrackElement;

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -188,16 +188,7 @@ namespace RCT2
         money16 Price;                                       // 0x138
         RCT12xy8 ChairliftBullwheelLocation[2];              // 0x13A
         uint8_t ChairliftBullwheelZ[2];                      // 0x13E
-        union
-        {
-            RatingTuple Ratings; // 0x140
-            struct
-            {
-                ride_rating Excitement; // 0x140
-                ride_rating Intensity;  // 0x142
-                ride_rating Nausea;     // 0x144
-            };
-        };
+        RatingTuple ratings;                                 // 0x140
         money16 Value;                       // 0x146
         uint16_t ChairliftBullwheelRotation; // 0x148
         uint8_t Satisfaction;                // 0x14A

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -189,11 +189,11 @@ namespace RCT2
         RCT12xy8 ChairliftBullwheelLocation[2];              // 0x13A
         uint8_t ChairliftBullwheelZ[2];                      // 0x13E
         RatingTuple ratings;                                 // 0x140
-        money16 Value;                       // 0x146
-        uint16_t ChairliftBullwheelRotation; // 0x148
-        uint8_t Satisfaction;                // 0x14A
-        uint8_t SatisfactionTimeOut;         // 0x14B
-        uint8_t SatisfactionNext;            // 0x14C
+        money16 Value;                                       // 0x146
+        uint16_t ChairliftBullwheelRotation;                 // 0x148
+        uint8_t Satisfaction;                                // 0x14A
+        uint8_t SatisfactionTimeOut;                         // 0x14B
+        uint8_t SatisfactionNext;                            // 0x14C
         // Various flags stating whether a window needs to be refreshed
         uint8_t WindowInvalidateFlags; // 0x14D
         uint8_t Pad14E[0x02];          // 0x14E

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -329,49 +329,25 @@ namespace RCT2
     {
         uint8_t Type; // 0x00
         RCT12ObjectEntryIndex VehicleType;
-        union
-        {
-            // After loading the track this is converted to
-            // a cost but before its a flags register
-            money32 Cost;   // 0x02
-            uint32_t Flags; // 0x02
-        };
-        union
-        {
-            // After loading the track this is converted to
-            // a flags register
-            uint8_t RideMode;   // 0x06
-            uint8_t TrackFlags; // 0x06
-        };
+        uint32_t Flags;                                               // 0x02
+        uint8_t RideMode;                                             // 0x06
         uint8_t VersionAndColourScheme;                               // 0x07 0b0000_VVCC
         RCT12VehicleColour VehicleColours[Limits::kMaxTrainsPerRide]; // 0x08
-        union
-        {
-            uint8_t Pad48;
-            uint8_t TrackSpineColourRCT1; // 0x48
-        };
-        union
-        {
-            uint8_t EntranceStyle;       // 0x49
-            uint8_t TrackRailColourRCT1; // 0x49
-        };
-        union
-        {
-            uint8_t TotalAirTime;           // 0x4A
-            uint8_t TrackSupportColourRCT1; // 0x4A
-        };
-        uint8_t DepartFlags;          // 0x4B
-        uint8_t NumberOfTrains;       // 0x4C
-        uint8_t NumberOfCarsPerTrain; // 0x4D
-        uint8_t MinWaitingTime;       // 0x4E
-        uint8_t MaxWaitingTime;       // 0x4F
-        uint8_t OperationSetting;
-        int8_t MaxSpeed;              // 0x51
-        int8_t AverageSpeed;          // 0x52
-        uint16_t RideLength;          // 0x53
-        uint8_t MaxPositiveVerticalG; // 0x55
-        int8_t MaxNegativeVerticalG;  // 0x56
-        uint8_t MaxLateralG;          // 0x57
+        uint8_t Pad48;                                                // 0x48
+        uint8_t EntranceStyle;                                        // 0x49
+        uint8_t TotalAirTime;                                         // 0x4A
+        uint8_t DepartFlags;                                          // 0x4B
+        uint8_t NumberOfTrains;                                       // 0x4C
+        uint8_t NumberOfCarsPerTrain;                                 // 0x4D
+        uint8_t MinWaitingTime;                                       // 0x4E
+        uint8_t MaxWaitingTime;                                       // 0x4F
+        uint8_t OperationSetting;                                     // 0x50
+        int8_t MaxSpeed;                                              // 0x51
+        int8_t AverageSpeed;                                          // 0x52
+        uint16_t RideLength;                                          // 0x53
+        uint8_t MaxPositiveVerticalG;                                 // 0x55
+        int8_t MaxNegativeVerticalG;                                  // 0x56
+        uint8_t MaxLateralG;                                          // 0x57
         union
         {
             uint8_t Inversions; // 0x58

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1484,7 +1484,7 @@ namespace RCT2
                                                        src->ChairliftBullwheelLocation[i].y, src->ChairliftBullwheelZ[i] };
             }
 
-            dst->ratings = src->Ratings;
+            dst->ratings = src->ratings;
             dst->value = ToMoney64(src->Value);
 
             dst->chairlift_bullwheel_rotation = src->ChairliftBullwheelRotation;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1456,12 +1456,12 @@ namespace RCT2
             dst->turn_count_default = src->TurnCountDefault;
             dst->turn_count_banked = src->TurnCountBanked;
             dst->turn_count_sloped = src->TurnCountSloped;
-            if (dst->type == RIDE_TYPE_MINI_GOLF)
-                dst->holes = src->Inversions & 0x1F;
+            if (src->Type == RIDE_TYPE_MINI_GOLF)
+                dst->holes = src->Inversions & kRCT12InversionAndHoleMask;
             else
-                dst->inversions = src->Inversions & 0x1F;
+                dst->inversions = src->Inversions & kRCT12InversionAndHoleMask;
             dst->sheltered_eighths = src->Inversions >> 5;
-            dst->drops = src->Drops;
+            dst->dropsPoweredLifts = src->Drops;
             dst->start_drop_height = src->StartDropHeight;
             dst->highest_drop_height = src->HighestDropHeight;
             dst->sheltered_length = src->ShelteredLength;
@@ -1593,7 +1593,7 @@ namespace RCT2
                 dst->vehicle_colours[i].Tertiary = src->VehicleColoursExtended[i];
             }
 
-            dst->total_air_time = src->TotalAirTime;
+            dst->totalAirTime = src->TotalAirTime;
             dst->current_test_station = StationIndex::FromUnderlying(src->CurrentTestStation);
             dst->num_circuits = src->NumCircuits;
             dst->CableLiftLoc = { src->CableLiftX, src->CableLiftY, src->CableLiftZ * COORDS_Z_STEP };

--- a/src/openrct2/rct2/T6Exporter.cpp
+++ b/src/openrct2/rct2/T6Exporter.cpp
@@ -52,7 +52,7 @@ namespace RCT2
     bool T6Exporter::SaveTrack(OpenRCT2::IStream* stream)
     {
         OpenRCT2::MemoryStream tempStream;
-        tempStream.WriteValue<uint8_t>(OpenRCT2RideTypeToRCT2RideType(_trackDesign->type));
+        tempStream.WriteValue<uint8_t>(OpenRCT2RideTypeToRCT2RideType(_trackDesign->trackAndVehicle.rtdIndex));
         tempStream.WriteValue<uint8_t>(0);
         tempStream.WriteValue<uint32_t>(0);
         tempStream.WriteValue<uint8_t>(static_cast<uint8_t>(_trackDesign->operation.rideMode));
@@ -67,8 +67,8 @@ namespace RCT2
         tempStream.WriteValue<uint8_t>(entranceStyle);
         tempStream.WriteValue<uint8_t>(_trackDesign->statistics.totalAirTime);
         tempStream.WriteValue<uint8_t>(_trackDesign->operation.departFlags);
-        tempStream.WriteValue<uint8_t>(_trackDesign->numberOfTrains);
-        tempStream.WriteValue<uint8_t>(_trackDesign->numberOfCarsPerTrain);
+        tempStream.WriteValue<uint8_t>(_trackDesign->trackAndVehicle.numberOfTrains);
+        tempStream.WriteValue<uint8_t>(_trackDesign->trackAndVehicle.numberOfCarsPerTrain);
         tempStream.WriteValue<uint8_t>(_trackDesign->operation.minWaitingTime);
         tempStream.WriteValue<uint8_t>(_trackDesign->operation.maxWaitingTime);
         tempStream.WriteValue<uint8_t>(_trackDesign->operation.operationSetting);
@@ -78,8 +78,8 @@ namespace RCT2
         tempStream.WriteValue<uint8_t>(_trackDesign->statistics.maxPositiveVerticalG);
         tempStream.WriteValue<int8_t>(_trackDesign->statistics.maxNegativeVerticalG);
         tempStream.WriteValue<uint8_t>(_trackDesign->statistics.maxLateralG);
-        tempStream.WriteValue<uint8_t>(
-            _trackDesign->type == RIDE_TYPE_MINI_GOLF ? _trackDesign->statistics.holes : _trackDesign->statistics.inversions);
+        // inversions double as hole count for mini golf
+        tempStream.WriteValue<uint8_t>(_trackDesign->statistics.inversions);
         tempStream.WriteValue<uint8_t>(_trackDesign->statistics.drops);
         tempStream.WriteValue<uint8_t>(_trackDesign->statistics.highestDropHeight);
         tempStream.WriteValue<uint8_t>(_trackDesign->statistics.ratings.excitement / kTD46RatingsMultiplier);
@@ -99,7 +99,7 @@ namespace RCT2
             tempStream.WriteValue<uint8_t>(_trackDesign->appearance.trackColours[i].supports);
         }
         tempStream.WriteValue<uint32_t>(0);
-        tempStream.Write(&_trackDesign->vehicleObject.Entry, sizeof(RCTObjectEntry));
+        tempStream.Write(&_trackDesign->trackAndVehicle.vehicleObject.Entry, sizeof(RCTObjectEntry));
         tempStream.WriteValue<uint8_t>(_trackDesign->statistics.spaceRequired.x);
         tempStream.WriteValue<uint8_t>(_trackDesign->statistics.spaceRequired.y);
         for (auto i = 0; i < RCT2::Limits::kMaxVehicleColours; i++)
@@ -108,7 +108,7 @@ namespace RCT2
         }
         tempStream.WriteValue<uint8_t>(_trackDesign->operation.liftHillSpeed | (_trackDesign->operation.numCircuits << 5));
 
-        const auto& rtd = GetRideTypeDescriptor(_trackDesign->type);
+        const auto& rtd = GetRideTypeDescriptor(_trackDesign->trackAndVehicle.rtdIndex);
         if (rtd.HasFlag(RIDE_TYPE_FLAG_IS_MAZE))
         {
             for (const auto& mazeElement : _trackDesign->mazeElements)

--- a/src/openrct2/rct2/T6Exporter.cpp
+++ b/src/openrct2/rct2/T6Exporter.cpp
@@ -30,7 +30,7 @@
 
 namespace RCT2
 {
-    T6Exporter::T6Exporter(TrackDesign* trackDesign)
+    T6Exporter::T6Exporter(const TrackDesign& trackDesign)
         : _trackDesign(trackDesign)
     {
     }
@@ -52,73 +52,73 @@ namespace RCT2
     bool T6Exporter::SaveTrack(OpenRCT2::IStream* stream)
     {
         OpenRCT2::MemoryStream tempStream;
-        tempStream.WriteValue<uint8_t>(OpenRCT2RideTypeToRCT2RideType(_trackDesign->trackAndVehicle.rtdIndex));
+        tempStream.WriteValue<uint8_t>(OpenRCT2RideTypeToRCT2RideType(_trackDesign.trackAndVehicle.rtdIndex));
         tempStream.WriteValue<uint8_t>(0);
         tempStream.WriteValue<uint32_t>(0);
-        tempStream.WriteValue<uint8_t>(static_cast<uint8_t>(_trackDesign->operation.rideMode));
-        tempStream.WriteValue<uint8_t>(EnumValue(_trackDesign->appearance.vehicleColourSettings) | (2 << 2));
+        tempStream.WriteValue<uint8_t>(static_cast<uint8_t>(_trackDesign.operation.rideMode));
+        tempStream.WriteValue<uint8_t>(EnumValue(_trackDesign.appearance.vehicleColourSettings) | (2 << 2));
         for (auto i = 0; i < RCT2::Limits::kMaxVehicleColours; i++)
         {
-            tempStream.WriteValue<uint8_t>(_trackDesign->appearance.vehicleColours[i].Body);
-            tempStream.WriteValue<uint8_t>(_trackDesign->appearance.vehicleColours[i].Trim);
+            tempStream.WriteValue<uint8_t>(_trackDesign.appearance.vehicleColours[i].Body);
+            tempStream.WriteValue<uint8_t>(_trackDesign.appearance.vehicleColours[i].Trim);
         }
         tempStream.WriteValue<uint8_t>(0);
-        auto entranceStyle = GetStationStyleFromIdentifier(_trackDesign->appearance.stationObjectIdentifier);
+        auto entranceStyle = GetStationStyleFromIdentifier(_trackDesign.appearance.stationObjectIdentifier);
         tempStream.WriteValue<uint8_t>(entranceStyle);
-        tempStream.WriteValue<uint8_t>(_trackDesign->statistics.totalAirTime);
-        tempStream.WriteValue<uint8_t>(_trackDesign->operation.departFlags);
-        tempStream.WriteValue<uint8_t>(_trackDesign->trackAndVehicle.numberOfTrains);
-        tempStream.WriteValue<uint8_t>(_trackDesign->trackAndVehicle.numberOfCarsPerTrain);
-        tempStream.WriteValue<uint8_t>(_trackDesign->operation.minWaitingTime);
-        tempStream.WriteValue<uint8_t>(_trackDesign->operation.maxWaitingTime);
-        tempStream.WriteValue<uint8_t>(_trackDesign->operation.operationSetting);
-        tempStream.WriteValue<int8_t>(_trackDesign->statistics.maxSpeed);
-        tempStream.WriteValue<int8_t>(_trackDesign->statistics.averageSpeed);
-        tempStream.WriteValue<uint16_t>(_trackDesign->statistics.rideLength);
-        tempStream.WriteValue<uint8_t>(_trackDesign->statistics.maxPositiveVerticalG);
-        tempStream.WriteValue<int8_t>(_trackDesign->statistics.maxNegativeVerticalG);
-        tempStream.WriteValue<uint8_t>(_trackDesign->statistics.maxLateralG);
+        tempStream.WriteValue<uint8_t>(_trackDesign.statistics.totalAirTime);
+        tempStream.WriteValue<uint8_t>(_trackDesign.operation.departFlags);
+        tempStream.WriteValue<uint8_t>(_trackDesign.trackAndVehicle.numberOfTrains);
+        tempStream.WriteValue<uint8_t>(_trackDesign.trackAndVehicle.numberOfCarsPerTrain);
+        tempStream.WriteValue<uint8_t>(_trackDesign.operation.minWaitingTime);
+        tempStream.WriteValue<uint8_t>(_trackDesign.operation.maxWaitingTime);
+        tempStream.WriteValue<uint8_t>(_trackDesign.operation.operationSetting);
+        tempStream.WriteValue<int8_t>(_trackDesign.statistics.maxSpeed);
+        tempStream.WriteValue<int8_t>(_trackDesign.statistics.averageSpeed);
+        tempStream.WriteValue<uint16_t>(_trackDesign.statistics.rideLength);
+        tempStream.WriteValue<uint8_t>(_trackDesign.statistics.maxPositiveVerticalG);
+        tempStream.WriteValue<int8_t>(_trackDesign.statistics.maxNegativeVerticalG);
+        tempStream.WriteValue<uint8_t>(_trackDesign.statistics.maxLateralG);
         // inversions double as hole count for mini golf
-        tempStream.WriteValue<uint8_t>(_trackDesign->statistics.inversions);
-        tempStream.WriteValue<uint8_t>(_trackDesign->statistics.drops);
-        tempStream.WriteValue<uint8_t>(_trackDesign->statistics.highestDropHeight);
-        tempStream.WriteValue<uint8_t>(_trackDesign->statistics.ratings.excitement / kTD46RatingsMultiplier);
-        tempStream.WriteValue<uint8_t>(_trackDesign->statistics.ratings.intensity / kTD46RatingsMultiplier);
-        tempStream.WriteValue<uint8_t>(_trackDesign->statistics.ratings.nausea / kTD46RatingsMultiplier);
-        tempStream.WriteValue<money16>(ToMoney16(_trackDesign->statistics.upkeepCost));
+        tempStream.WriteValue<uint8_t>(_trackDesign.statistics.inversions);
+        tempStream.WriteValue<uint8_t>(_trackDesign.statistics.drops);
+        tempStream.WriteValue<uint8_t>(_trackDesign.statistics.highestDropHeight);
+        tempStream.WriteValue<uint8_t>(_trackDesign.statistics.ratings.excitement / kTD46RatingsMultiplier);
+        tempStream.WriteValue<uint8_t>(_trackDesign.statistics.ratings.intensity / kTD46RatingsMultiplier);
+        tempStream.WriteValue<uint8_t>(_trackDesign.statistics.ratings.nausea / kTD46RatingsMultiplier);
+        tempStream.WriteValue<money16>(ToMoney16(_trackDesign.statistics.upkeepCost));
         for (auto i = 0; i < Limits::kNumColourSchemes; i++)
         {
-            tempStream.WriteValue<uint8_t>(_trackDesign->appearance.trackColours[i].main);
+            tempStream.WriteValue<uint8_t>(_trackDesign.appearance.trackColours[i].main);
         }
         for (auto i = 0; i < Limits::kNumColourSchemes; i++)
         {
-            tempStream.WriteValue<uint8_t>(_trackDesign->appearance.trackColours[i].additional);
+            tempStream.WriteValue<uint8_t>(_trackDesign.appearance.trackColours[i].additional);
         }
         for (auto i = 0; i < Limits::kNumColourSchemes; i++)
         {
-            tempStream.WriteValue<uint8_t>(_trackDesign->appearance.trackColours[i].supports);
+            tempStream.WriteValue<uint8_t>(_trackDesign.appearance.trackColours[i].supports);
         }
         tempStream.WriteValue<uint32_t>(0);
-        tempStream.Write(&_trackDesign->trackAndVehicle.vehicleObject.Entry, sizeof(RCTObjectEntry));
-        tempStream.WriteValue<uint8_t>(_trackDesign->statistics.spaceRequired.x);
-        tempStream.WriteValue<uint8_t>(_trackDesign->statistics.spaceRequired.y);
+        tempStream.Write(&_trackDesign.trackAndVehicle.vehicleObject.Entry, sizeof(RCTObjectEntry));
+        tempStream.WriteValue<uint8_t>(_trackDesign.statistics.spaceRequired.x);
+        tempStream.WriteValue<uint8_t>(_trackDesign.statistics.spaceRequired.y);
         for (auto i = 0; i < RCT2::Limits::kMaxVehicleColours; i++)
         {
-            tempStream.WriteValue<uint8_t>(_trackDesign->appearance.vehicleColours[i].Tertiary);
+            tempStream.WriteValue<uint8_t>(_trackDesign.appearance.vehicleColours[i].Tertiary);
         }
-        tempStream.WriteValue<uint8_t>(_trackDesign->operation.liftHillSpeed | (_trackDesign->operation.numCircuits << 5));
+        tempStream.WriteValue<uint8_t>(_trackDesign.operation.liftHillSpeed | (_trackDesign.operation.numCircuits << 5));
 
-        const auto& rtd = GetRideTypeDescriptor(_trackDesign->trackAndVehicle.rtdIndex);
+        const auto& rtd = GetRideTypeDescriptor(_trackDesign.trackAndVehicle.rtdIndex);
         if (rtd.HasFlag(RIDE_TYPE_FLAG_IS_MAZE))
         {
-            for (const auto& mazeElement : _trackDesign->mazeElements)
+            for (const auto& mazeElement : _trackDesign.mazeElements)
             {
                 tempStream.WriteValue<int8_t>(mazeElement.location.x);
                 tempStream.WriteValue<int8_t>(mazeElement.location.y);
                 tempStream.WriteValue<uint16_t>(mazeElement.mazeEntry);
             }
 
-            for (const auto& entranceElement : _trackDesign->entranceElements)
+            for (const auto& entranceElement : _trackDesign.entranceElements)
             {
                 tempStream.WriteValue<int8_t>(entranceElement.location.x);
                 tempStream.WriteValue<int8_t>(entranceElement.location.y);
@@ -131,7 +131,7 @@ namespace RCT2
         }
         else
         {
-            for (const auto& trackElement : _trackDesign->trackElements)
+            for (const auto& trackElement : _trackDesign.trackElements)
             {
                 auto trackType = OpenRCT2TrackTypeToRCT2(trackElement.type);
                 if (trackType == TrackElemType::MultiDimInvertedUp90ToFlatQuarterLoop)
@@ -145,7 +145,7 @@ namespace RCT2
 
             tempStream.WriteValue<uint8_t>(0xFF);
 
-            for (const auto& entranceElement : _trackDesign->entranceElements)
+            for (const auto& entranceElement : _trackDesign.entranceElements)
             {
                 tempStream.WriteValue<uint8_t>(
                     entranceElement.location.z == -1 ? static_cast<uint8_t>(0x80) : entranceElement.location.z);
@@ -158,7 +158,7 @@ namespace RCT2
             tempStream.WriteValue<uint8_t>(0xFF);
         }
 
-        for (const auto& sceneryElement : _trackDesign->sceneryElements)
+        for (const auto& sceneryElement : _trackDesign.sceneryElements)
         {
             auto flags = sceneryElement.flags;
             if (sceneryElement.sceneryObject.Entry.GetType() == ObjectType::Walls)

--- a/src/openrct2/rct2/T6Exporter.cpp
+++ b/src/openrct2/rct2/T6Exporter.cpp
@@ -82,9 +82,9 @@ namespace RCT2
             _trackDesign->type == RIDE_TYPE_MINI_GOLF ? _trackDesign->statistics.holes : _trackDesign->statistics.inversions);
         tempStream.WriteValue<uint8_t>(_trackDesign->statistics.drops);
         tempStream.WriteValue<uint8_t>(_trackDesign->statistics.highestDropHeight);
-        tempStream.WriteValue<uint8_t>(_trackDesign->statistics.excitement);
-        tempStream.WriteValue<uint8_t>(_trackDesign->statistics.intensity);
-        tempStream.WriteValue<uint8_t>(_trackDesign->statistics.nausea);
+        tempStream.WriteValue<uint8_t>(_trackDesign->statistics.ratings.excitement / kTD46RatingsMultiplier);
+        tempStream.WriteValue<uint8_t>(_trackDesign->statistics.ratings.intensity / kTD46RatingsMultiplier);
+        tempStream.WriteValue<uint8_t>(_trackDesign->statistics.ratings.nausea / kTD46RatingsMultiplier);
         tempStream.WriteValue<money16>(ToMoney16(_trackDesign->statistics.upkeepCost));
         for (auto i = 0; i < Limits::kNumColourSchemes; i++)
         {

--- a/src/openrct2/rct2/T6Exporter.h
+++ b/src/openrct2/rct2/T6Exporter.h
@@ -27,12 +27,12 @@ namespace RCT2
     class T6Exporter final
     {
     public:
-        T6Exporter(TrackDesign* trackDesign);
+        T6Exporter(const TrackDesign& trackDesign);
 
         bool SaveTrack(const utf8* path);
         bool SaveTrack(OpenRCT2::IStream* stream);
 
     private:
-        TrackDesign* _trackDesign;
+        const TrackDesign& _trackDesign;
     };
 } // namespace RCT2

--- a/src/openrct2/rct2/T6Importer.cpp
+++ b/src/openrct2/rct2/T6Importer.cpp
@@ -109,9 +109,9 @@ namespace RCT2
 
             td->statistics.drops = td6.Drops;
             td->statistics.highestDropHeight = td6.HighestDropHeight;
-            td->statistics.excitement = td6.Excitement;
-            td->statistics.intensity = td6.Intensity;
-            td->statistics.nausea = td6.Nausea;
+            td->statistics.ratings.excitement = td6.Excitement * kTD46RatingsMultiplier;
+            td->statistics.ratings.intensity = td6.Intensity * kTD46RatingsMultiplier;
+            td->statistics.ratings.nausea = td6.Nausea * kTD46RatingsMultiplier;
             td->statistics.upkeepCost = ToMoney64(td6.UpkeepCost);
             for (auto i = 0; i < Limits::kNumColourSchemes; ++i)
             {

--- a/src/openrct2/rct2/T6Importer.cpp
+++ b/src/openrct2/rct2/T6Importer.cpp
@@ -82,7 +82,7 @@ namespace RCT2
                 td->appearance.vehicleColours[i].Tertiary = td6.VehicleAdditionalColour[i];
             }
             td->appearance.stationObjectIdentifier = GetStationIdentifierFromStyle(td6.EntranceStyle);
-            td->statistics.totalAirTime = td6.TotalAirTime;
+            td->statistics.totalAirTime = (td6.TotalAirTime * 1024) / 123;
             td->operation.departFlags = td6.DepartFlags;
             td->trackAndVehicle.numberOfTrains = td6.NumberOfTrains;
             td->trackAndVehicle.numberOfCarsPerTrain = td6.NumberOfCarsPerTrain;
@@ -92,20 +92,16 @@ namespace RCT2
             td->statistics.maxSpeed = td6.MaxSpeed;
             td->statistics.averageSpeed = td6.AverageSpeed;
             td->statistics.rideLength = td6.RideLength;
-            td->statistics.maxPositiveVerticalG = td6.MaxPositiveVerticalG;
-            td->statistics.maxNegativeVerticalG = td6.MaxNegativeVerticalG;
-            td->statistics.maxLateralG = td6.MaxLateralG;
+            td->statistics.maxPositiveVerticalG = td6.MaxPositiveVerticalG * kTD46GForcesMultiplier;
+            td->statistics.maxNegativeVerticalG = td6.MaxNegativeVerticalG * kTD46GForcesMultiplier;
+            td->statistics.maxLateralG = td6.MaxLateralG * kTD46GForcesMultiplier;
 
-            if (td->trackAndVehicle.rtdIndex == RIDE_TYPE_MINI_GOLF)
-            {
-                td->statistics.holes = td6.Holes;
-            }
+            if (td6.Type == RIDE_TYPE_MINI_GOLF)
+                td->statistics.holes = td6.Holes & kRCT12InversionAndHoleMask;
             else
-            {
-                td->statistics.inversions = td6.Inversions;
-            }
+                td->statistics.inversions = td6.Inversions & kRCT12InversionAndHoleMask;
 
-            td->statistics.drops = td6.Drops;
+            td->statistics.drops = td6.Drops & kRCT12RideNumDropsMask;
             td->statistics.highestDropHeight = td6.HighestDropHeight;
             td->statistics.ratings.excitement = td6.Excitement * kTD46RatingsMultiplier;
             td->statistics.ratings.intensity = td6.Intensity * kTD46RatingsMultiplier;

--- a/src/openrct2/rct2/T6Importer.cpp
+++ b/src/openrct2/rct2/T6Importer.cpp
@@ -73,9 +73,7 @@ namespace RCT2
 
             td->type = td6.Type; // 0x00
 
-            td->cost = 0.00_GBP;
             td->operation.rideMode = static_cast<RideMode>(td6.RideMode);
-            td->trackFlags = 0;
             td->appearance.vehicleColourSettings = static_cast<VehicleColourSettings>(td6.VersionAndColourScheme & 0x3);
             for (auto i = 0; i < Limits::kMaxVehicleColours; ++i)
             {
@@ -200,7 +198,7 @@ namespace RCT2
                 td->sceneryElements.push_back(std::move(sceneryElement));
             }
 
-            td->name = _name;
+            td->gameStateData.name = _name;
 
             UpdateRideType(td);
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5986,3 +5986,25 @@ ResultWithMessage Ride::ChangeStatusCreateVehicles(bool isApplying, const Coords
 
     return { true };
 }
+
+uint8_t Ride::getNumDrops() const
+{
+    return dropsPoweredLifts & kRideNumDropsMask;
+}
+
+void Ride::setNumDrops(uint8_t newValue)
+{
+    dropsPoweredLifts &= ~kRideNumDropsMask;
+    dropsPoweredLifts |= (newValue & kRideNumDropsMask);
+}
+
+uint8_t Ride::getNumPoweredLifts() const
+{
+    return dropsPoweredLifts >> 6;
+}
+
+void Ride::setPoweredLifts(uint8_t newValue)
+{
+    dropsPoweredLifts &= ~kRideNumPoweredLiftsMask;
+    dropsPoweredLifts |= (newValue << 6);
+}

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4638,7 +4638,7 @@ bool RideHasAnyTrackElements(const Ride& ride)
 void InvalidateTestResults(Ride& ride)
 {
     ride.measurement = {};
-    ride.excitement = kRideRatingUndefined;
+    ride.ratings.setNull();
     ride.lifecycle_flags &= ~RIDE_LIFECYCLE_TESTED;
     ride.lifecycle_flags &= ~RIDE_LIFECYCLE_TEST_IN_PROGRESS;
     if (ride.lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK)
@@ -5439,7 +5439,7 @@ bool RideHasStationShelter(const Ride& ride)
 
 bool RideHasRatings(const Ride& ride)
 {
-    return ride.excitement != kRideRatingUndefined;
+    return !ride.ratings.isNull();
 }
 
 int32_t GetBoosterSpeed(ride_type_t rideType, int32_t rawSpeed)

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -49,6 +49,11 @@ constexpr uint16_t const MAX_STATION_LOCATIONS = OpenRCT2::Limits::kMaxStationsP
 
 constexpr uint16_t const MAZE_CLEARANCE_HEIGHT = 4 * COORDS_Z_STEP;
 
+constexpr uint8_t kRideMaxDropsCount = 63;
+constexpr uint8_t kRideNumDropsMask = 0b00111111;
+constexpr uint8_t kRideMaxNumPoweredLiftsCount = 3;
+constexpr uint8_t kRideNumPoweredLiftsMask = 0b11000000;
+
 struct RideStation
 {
     static constexpr uint8_t kNoTrain = std::numeric_limits<uint8_t>::max();
@@ -176,7 +181,7 @@ struct Ride
     uint16_t turn_count_banked{};
     uint16_t turn_count_sloped{}; // X = number turns > 3 elements
     // Y is number of powered lifts, X is drops
-    uint8_t drops{}; // (YYXX XXXX)
+    uint8_t dropsPoweredLifts{}; // (YYXX XXXX)
     uint8_t start_drop_height{};
     uint8_t highest_drop_height{};
     int32_t sheltered_length{};
@@ -260,7 +265,7 @@ struct Ride
     uint8_t lift_hill_speed{};
     uint32_t guests_favourite{};
     uint32_t lifecycle_flags{};
-    uint16_t total_air_time{};
+    uint16_t totalAirTime{};
     StationIndex current_test_station{ StationIndex::GetNull() };
     uint8_t num_circuits{};
     CoordsXYZ CableLiftLoc{};
@@ -404,6 +409,12 @@ public:
     bool HasStation() const;
 
     bool FindTrackGap(const CoordsXYE& input, CoordsXYE* output) const;
+
+    uint8_t getNumDrops() const;
+    void setNumDrops(uint8_t newValue);
+
+    uint8_t getNumPoweredLifts() const;
+    void setPoweredLifts(uint8_t newValue);
 };
 void UpdateSpiralSlide(Ride& ride);
 void UpdateChairlift(Ride& ride);

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -191,16 +191,7 @@ struct Ride
     uint16_t num_customers[OpenRCT2::Limits::kCustomerHistorySize]{};
     money64 price[RCT2::ObjectLimits::MaxShopItemsPerRideEntry]{};
     TileCoordsXYZ ChairliftBullwheelLocation[2];
-    union
-    {
-        RatingTuple ratings{};
-        struct
-        {
-            ride_rating excitement;
-            ride_rating intensity;
-            ride_rating nausea;
-        };
-    };
+    RatingTuple ratings{};
     money64 value{};
     uint16_t chairlift_bullwheel_rotation{};
     uint8_t satisfaction{};

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -228,11 +228,11 @@ struct RideLegacyBoosterSettings
 
 struct RatingsModifier
 {
-    RatingsModifierType Type;
-    int32_t Threshold;
-    int32_t Excitement;
-    int32_t Intensity;
-    int32_t Nausea;
+    RatingsModifierType type;
+    int32_t threshold;
+    int32_t excitement;
+    int32_t intensity;
+    int32_t nausea;
 };
 
 struct RideRatingsDescriptor

--- a/src/openrct2/ride/RideRatings.h
+++ b/src/openrct2/ride/RideRatings.h
@@ -27,9 +27,12 @@ constexpr ride_rating kRideRatingUndefined = 0xFFFFu;
 // Used for return values, for functions that modify all three.
 struct RatingTuple
 {
-    ride_rating Excitement;
-    ride_rating Intensity;
-    ride_rating Nausea;
+    ride_rating excitement{};
+    ride_rating intensity{};
+    ride_rating nausea{};
+
+    bool isNull() const;
+    void setNull();
 };
 assert_struct_size(RatingTuple, 6);
 

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -149,21 +149,14 @@ ResultWithMessage TrackDesign::CreateTrackDesign(TrackDesignState& tds, const Ri
     statistics.maxSpeed = static_cast<int8_t>(ride.max_speed / 65536);
     statistics.averageSpeed = static_cast<int8_t>(ride.average_speed / 65536);
     statistics.rideLength = ride.GetTotalLength() / 65536;
-    statistics.maxPositiveVerticalG = ride.max_positive_vertical_g / 32;
-    statistics.maxNegativeVerticalG = ride.max_negative_vertical_g / 32;
-    statistics.maxLateralG = ride.max_lateral_g / 32;
-    statistics.holes = ride.holes & 0x1F;
-    statistics.inversions = ride.inversions & 0x1F;
-    statistics.inversions |= (ride.sheltered_eighths << 5);
-    statistics.drops = ride.drops;
+    statistics.maxPositiveVerticalG = ride.max_positive_vertical_g;
+    statistics.maxNegativeVerticalG = ride.max_negative_vertical_g;
+    statistics.maxLateralG = ride.max_lateral_g;
+    statistics.inversions = ride.inversions;
+    statistics.holes = ride.holes;
+    statistics.drops = ride.getNumDrops();
     statistics.highestDropHeight = ride.highest_drop_height;
-
-    uint16_t _totalAirTime = (ride.total_air_time * 123) / 1024;
-    if (_totalAirTime > 255)
-    {
-        _totalAirTime = 0;
-    }
-    statistics.totalAirTime = static_cast<uint8_t>(_totalAirTime);
+    statistics.totalAirTime = ride.totalAirTime;
 
     statistics.ratings = ride.ratings;
     statistics.upkeepCost = ride.upkeep_cost;

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -165,10 +165,7 @@ ResultWithMessage TrackDesign::CreateTrackDesign(TrackDesignState& tds, const Ri
     }
     statistics.totalAirTime = static_cast<uint8_t>(_totalAirTime);
 
-    statistics.excitement = ride.ratings.Excitement / 10;
-    statistics.intensity = ride.ratings.Intensity / 10;
-    statistics.nausea = ride.ratings.Nausea / 10;
-
+    statistics.ratings = ride.ratings;
     statistics.upkeepCost = ride.upkeep_cost;
 
     const auto& rtd = GetRideTypeDescriptor(type);
@@ -583,9 +580,7 @@ void TrackDesign::Serialise(DataSerialiser& stream)
     stream << DS_TAG(statistics.holes);
     stream << DS_TAG(statistics.drops);
     stream << DS_TAG(statistics.highestDropHeight);
-    stream << DS_TAG(statistics.excitement);
-    stream << DS_TAG(statistics.intensity);
-    stream << DS_TAG(statistics.nausea);
+    stream << DS_TAG(statistics.ratings);
     stream << DS_TAG(statistics.upkeepCost);
     stream << DS_TAG(appearance.trackColours);
     stream << DS_TAG(vehicleObject);

--- a/src/openrct2/ride/TrackDesign.h
+++ b/src/openrct2/ride/TrackDesign.h
@@ -15,6 +15,7 @@
 #include "../object/Object.h"
 #include "../ride/RideColour.h"
 #include "../world/Map.h"
+#include "RideRatings.h"
 #include "VehicleColour.h"
 
 #include <memory>
@@ -151,9 +152,7 @@ struct TrackDesignAppearanceSettings
 
 struct TrackDesignStatistics
 {
-    uint8_t excitement{};
-    uint8_t intensity{};
-    uint8_t nausea{};
+    RatingTuple ratings{};
     int8_t maxSpeed{};
     int8_t averageSpeed{};
 

--- a/src/openrct2/ride/TrackDesign.h
+++ b/src/openrct2/ride/TrackDesign.h
@@ -131,6 +131,13 @@ struct TrackDesignMazeElement
 class DataSerialiser;
 enum class RideMode : uint8_t;
 
+enum class TrackDesignGameStateFlag
+{
+    SceneryUnavailable,
+    HasScenery,
+    VehicleUnavailable,
+};
+
 struct TrackDesignOperatingSettings
 {
     RideMode rideMode{};
@@ -175,11 +182,20 @@ struct TrackDesignStatistics
     TileCoordsXY spaceRequired{};
 };
 
+// Not saved in the track design, but calculated when trying to place one.
+struct TrackDesignGameStateData
+{
+    u8string name{};
+    uint8_t flags{};
+    money64 cost = 0.00_GBP;
+
+    bool hasFlag(TrackDesignGameStateFlag flag) const;
+    void setFlag(TrackDesignGameStateFlag flag, bool on);
+};
+
 struct TrackDesign
 {
     uint8_t type;
-    money64 cost;
-    uint8_t trackFlags;
     uint8_t numberOfTrains;
     uint8_t numberOfCarsPerTrain;
     ObjectEntryDescriptor vehicleObject;
@@ -193,7 +209,7 @@ struct TrackDesign
     std::vector<TrackDesignEntranceElement> entranceElements;
     std::vector<TrackDesignSceneryElement> sceneryElements;
 
-    std::string name;
+    TrackDesignGameStateData gameStateData{};
 
 public:
     ResultWithMessage CreateTrackDesign(TrackDesignState& tds, const Ride& ride);
@@ -205,18 +221,6 @@ private:
     ResultWithMessage CreateTrackDesignTrack(TrackDesignState& tds, const Ride& ride);
     ResultWithMessage CreateTrackDesignMaze(TrackDesignState& tds, const Ride& ride);
     CoordsXYE MazeGetFirstElement(const Ride& ride);
-};
-
-enum
-{
-    TDPF_PLACE_SCENERY = 1 << 0,
-};
-
-enum
-{
-    TRACK_DESIGN_FLAG_SCENERY_UNAVAILABLE = (1 << 0),
-    TRACK_DESIGN_FLAG_HAS_SCENERY = (1 << 1),
-    TRACK_DESIGN_FLAG_VEHICLE_UNAVAILABLE = (1 << 2),
 };
 
 extern bool gTrackDesignSceneryToggle;

--- a/src/openrct2/ride/TrackDesign.h
+++ b/src/openrct2/ride/TrackDesign.h
@@ -138,6 +138,14 @@ enum class TrackDesignGameStateFlag
     VehicleUnavailable,
 };
 
+struct TrackDesignTrackAndVehicleSettings
+{
+    ride_type_t rtdIndex{};
+    ObjectEntryDescriptor vehicleObject{};
+    uint8_t numberOfTrains{};
+    uint8_t numberOfCarsPerTrain{};
+};
+
 struct TrackDesignOperatingSettings
 {
     RideMode rideMode{};
@@ -195,11 +203,7 @@ struct TrackDesignGameStateData
 
 struct TrackDesign
 {
-    uint8_t type;
-    uint8_t numberOfTrains;
-    uint8_t numberOfCarsPerTrain;
-    ObjectEntryDescriptor vehicleObject;
-
+    TrackDesignTrackAndVehicleSettings trackAndVehicle{};
     TrackDesignOperatingSettings operation{};
     TrackDesignAppearanceSettings appearance{};
     TrackDesignStatistics statistics{};

--- a/src/openrct2/ride/TrackDesign.h
+++ b/src/openrct2/ride/TrackDesign.h
@@ -237,17 +237,18 @@ extern RideId gTrackDesignSaveRideIndex;
 
 [[nodiscard]] std::unique_ptr<TrackDesign> TrackDesignImport(const utf8* path);
 
-void TrackDesignMirror(TrackDesign* td);
+void TrackDesignMirror(TrackDesign& td);
 
-GameActions::Result TrackDesignPlace(TrackDesign* td, uint32_t flags, bool placeScenery, Ride& ride, const CoordsXYZD& coords);
-void TrackDesignPreviewRemoveGhosts(TrackDesign* td, Ride& ride, const CoordsXYZD& coords);
-void TrackDesignPreviewDrawOutlines(TrackDesignState& tds, TrackDesign* td, Ride& ride, const CoordsXYZD& coords);
-int32_t TrackDesignGetZPlacement(TrackDesign* td, Ride& ride, const CoordsXYZD& coords);
+GameActions::Result TrackDesignPlace(
+    const TrackDesign& td, uint32_t flags, bool placeScenery, Ride& ride, const CoordsXYZD& coords);
+void TrackDesignPreviewRemoveGhosts(const TrackDesign& td, Ride& ride, const CoordsXYZD& coords);
+void TrackDesignPreviewDrawOutlines(TrackDesignState& tds, const TrackDesign& td, Ride& ride, const CoordsXYZD& coords);
+int32_t TrackDesignGetZPlacement(const TrackDesign& td, Ride& ride, const CoordsXYZD& coords);
 
 ///////////////////////////////////////////////////////////////////////////////
 // Track design preview
 ///////////////////////////////////////////////////////////////////////////////
-void TrackDesignDrawPreview(TrackDesign* td, uint8_t* pixels);
+void TrackDesignDrawPreview(TrackDesign& td, uint8_t* pixels);
 
 ///////////////////////////////////////////////////////////////////////////////
 // Track design saving

--- a/src/openrct2/ride/TrackDesign.h
+++ b/src/openrct2/ride/TrackDesign.h
@@ -174,17 +174,14 @@ struct TrackDesignStatistics
     // TODO: move to a struct of its own, together with rideTime, that can be repeated for multiple stations.
     uint16_t rideLength;
 
-    uint8_t maxPositiveVerticalG{};
-    int8_t maxNegativeVerticalG{};
-    uint8_t maxLateralG{};
-    uint8_t totalAirTime{};
+    fixed16_2dp maxPositiveVerticalG{};
+    fixed16_2dp maxNegativeVerticalG{};
+    fixed16_2dp maxLateralG{};
+    uint16_t totalAirTime{};
     uint8_t drops{};
     uint8_t highestDropHeight{};
-    union
-    {
-        uint8_t inversions{};
-        uint8_t holes;
-    };
+    uint8_t inversions{};
+    uint8_t holes;
 
     money64 upkeepCost;
     TileCoordsXY spaceRequired{};

--- a/src/openrct2/ride/TrackDesignRepository.cpp
+++ b/src/openrct2/ride/TrackDesignRepository.cpp
@@ -79,8 +79,8 @@ public:
             TrackRepositoryItem item;
             item.Name = GetNameFromTrackPath(path);
             item.Path = path;
-            item.RideType = td->type;
-            item.ObjectEntry = std::string(td->vehicleObject.Entry.name, 8);
+            item.RideType = td->trackAndVehicle.rtdIndex;
+            item.ObjectEntry = std::string(td->trackAndVehicle.vehicleObject.Entry.name, 8);
             item.Flags = 0;
             if (IsTrackReadOnly(path))
             {

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -870,7 +870,7 @@ void Vehicle::UpdateMeasurements()
             curRide->previous_lateral_g = gForces.LateralG;
             if (gForces.VerticalG <= 0)
             {
-                curRide->total_air_time++;
+                curRide->totalAirTime++;
             }
 
             if (gForces.VerticalG > curRide->max_positive_vertical_g)
@@ -899,9 +899,11 @@ void Vehicle::UpdateMeasurements()
             if (!(curRide->testing_flags & RIDE_TESTING_POWERED_LIFT))
             {
                 curRide->testing_flags |= RIDE_TESTING_POWERED_LIFT;
-                if (curRide->drops + 64 < 0xFF)
+                auto numPoweredLifts = curRide->getNumPoweredLifts();
+                if (numPoweredLifts < kRideMaxNumPoweredLiftsCount)
                 {
-                    curRide->drops += 64;
+                    numPoweredLifts++;
+                    curRide->setPoweredLifts(numPoweredLifts);
                 }
             }
         }
@@ -1031,11 +1033,10 @@ void Vehicle::UpdateMeasurements()
             curRide->testing_flags &= ~RIDE_TESTING_DROP_UP;
             curRide->testing_flags |= RIDE_TESTING_DROP_DOWN;
 
-            uint8_t drops = curRide->drops & 0x3F;
-            if (drops != 0x3F)
+            uint8_t drops = curRide->getNumDrops();
+            if (drops < kRideMaxDropsCount)
                 drops++;
-            curRide->drops &= ~0x3F;
-            curRide->drops |= drops;
+            curRide->setNumDrops(drops);
 
             curRide->start_drop_height = z / COORDS_Z_STEP;
             testingFlags &= ~RIDE_TESTING_DROP_UP;
@@ -1063,11 +1064,10 @@ void Vehicle::UpdateMeasurements()
             curRide->testing_flags &= ~RIDE_TESTING_DROP_DOWN;
             curRide->testing_flags |= RIDE_TESTING_DROP_UP;
 
-            uint8_t drops = curRide->drops & 0x3F;
-            if (drops != 0x3F)
+            auto drops = curRide->getNumDrops();
+            if (drops != kRideMaxDropsCount)
                 drops++;
-            curRide->drops &= ~0x3F;
-            curRide->drops |= drops;
+            curRide->setNumDrops(drops);
 
             curRide->start_drop_height = z / COORDS_Z_STEP;
         }
@@ -2352,7 +2352,7 @@ static void test_reset(Ride& ride, StationIndex curStation)
     ride.inversions = 0;
     ride.holes = 0;
     ride.sheltered_eighths = 0;
-    ride.drops = 0;
+    ride.dropsPoweredLifts = 0;
     ride.sheltered_length = 0;
     ride.var_11C = 0;
     ride.num_sheltered_sections = 0;
@@ -2363,7 +2363,7 @@ static void test_reset(Ride& ride, StationIndex curStation)
         station.SegmentLength = 0;
         station.SegmentTime = 0;
     }
-    ride.total_air_time = 0;
+    ride.totalAirTime = 0;
     ride.current_test_station = curStation;
     WindowInvalidateByNumber(WindowClass::Ride, ride.id.ToUnderlying());
 }

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -659,7 +659,8 @@ ObjectiveStatus Objective::Check10RollerCoasters() const
     BitSet<MAX_RIDE_OBJECTS> type_already_counted;
     for (const auto& ride : GetRideManager())
     {
-        if (ride.status == RideStatus::Open && ride.excitement >= RIDE_RATING(6, 00) && ride.subtype != OBJECT_ENTRY_INDEX_NULL)
+        if (ride.status == RideStatus::Open && ride.ratings.excitement >= RIDE_RATING(6, 00)
+            && ride.subtype != OBJECT_ENTRY_INDEX_NULL)
         {
             auto rideEntry = ride.GetRideEntry();
             if (rideEntry != nullptr)
@@ -760,7 +761,8 @@ ObjectiveStatus Objective::Check10RollerCoastersLength() const
     auto rcs = 0;
     for (const auto& ride : GetRideManager())
     {
-        if (ride.status == RideStatus::Open && ride.excitement >= RIDE_RATING(7, 00) && ride.subtype != OBJECT_ENTRY_INDEX_NULL)
+        if (ride.status == RideStatus::Open && ride.ratings.excitement >= RIDE_RATING(7, 00)
+            && ride.subtype != OBJECT_ENTRY_INDEX_NULL)
         {
             auto rideEntry = ride.GetRideEntry();
             if (rideEntry != nullptr)
@@ -791,7 +793,7 @@ ObjectiveStatus Objective::CheckFinish5RollerCoasters() const
     auto rcs = 0;
     for (const auto& ride : GetRideManager())
     {
-        if (ride.status != RideStatus::Closed && ride.excitement >= MinimumExcitement)
+        if (ride.status != RideStatus::Closed && ride.ratings.excitement >= MinimumExcitement)
         {
             auto rideEntry = ride.GetRideEntry();
             if (rideEntry != nullptr)

--- a/src/openrct2/scripting/bindings/ride/ScRide.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScRide.cpp
@@ -333,7 +333,7 @@ namespace OpenRCT2::Scripting
     int32_t ScRide::excitement_get() const
     {
         auto ride = GetRide();
-        return ride != nullptr ? ride->excitement : 0;
+        return ride != nullptr ? ride->ratings.excitement : 0;
     }
     void ScRide::excitement_set(int32_t value)
     {
@@ -341,14 +341,14 @@ namespace OpenRCT2::Scripting
         auto ride = GetRide();
         if (ride != nullptr)
         {
-            ride->excitement = value;
+            ride->ratings.excitement = value;
         }
     }
 
     int32_t ScRide::intensity_get() const
     {
         auto ride = GetRide();
-        return ride != nullptr ? ride->intensity : 0;
+        return ride != nullptr ? ride->ratings.intensity : 0;
     }
     void ScRide::intensity_set(int32_t value)
     {
@@ -356,14 +356,14 @@ namespace OpenRCT2::Scripting
         auto ride = GetRide();
         if (ride != nullptr)
         {
-            ride->intensity = value;
+            ride->ratings.intensity = value;
         }
     }
 
     int32_t ScRide::nausea_get() const
     {
         auto ride = GetRide();
-        return ride != nullptr ? ride->nausea : 0;
+        return ride != nullptr ? ride->ratings.nausea : 0;
     }
     void ScRide::nausea_set(int32_t value)
     {
@@ -371,7 +371,7 @@ namespace OpenRCT2::Scripting
         auto ride = GetRide();
         if (ride != nullptr)
         {
-            ride->nausea = value;
+            ride->ratings.nausea = value;
         }
     }
 

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -143,7 +143,7 @@ namespace OpenRCT2::Park
                     continue;
                 if (ride.GetStation().SegmentLength < (600 << 16))
                     continue;
-                if (ride.excitement < RIDE_RATING(6, 00))
+                if (ride.ratings.excitement < RIDE_RATING(6, 00))
                     continue;
 
                 // Bonus guests for good ride
@@ -438,8 +438,8 @@ namespace OpenRCT2::Park
                 totalRideUptime += 100 - ride.downtime;
                 if (RideHasRatings(ride))
                 {
-                    totalRideExcitement += ride.excitement / 8;
-                    totalRideIntensity += ride.intensity / 8;
+                    totalRideExcitement += ride.ratings.excitement / 8;
+                    totalRideIntensity += ride.ratings.intensity / 8;
                     excitingRideCount++;
                 }
                 rideCount++;

--- a/test/tests/RideRatings.cpp
+++ b/test/tests/RideRatings.cpp
@@ -48,8 +48,8 @@ protected:
     {
         RatingTuple ratings = ride.ratings;
         std::string line = String::StdFormat(
-            "%s: (%d, %d, %d)", ride.GetRideTypeDescriptor().EnumName, static_cast<int>(ratings.Excitement),
-            static_cast<int>(ratings.Intensity), static_cast<int>(ratings.Nausea));
+            "%s: (%d, %d, %d)", ride.GetRideTypeDescriptor().EnumName, static_cast<int>(ratings.excitement),
+            static_cast<int>(ratings.intensity), static_cast<int>(ratings.nausea));
         return line;
     }
 


### PR DESCRIPTION
This is mostly bringing `TrackDesign` and children more in line with the corresponding fields in `Ride`, rather than whatever TD6 has. There is also some additional refactoring in adjacent areas (might as well make that nicer while we’re at it).