### PR TITLE
Fix #22226: Traffic light shows incorrect sprite

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -47,6 +47,7 @@
 - Fix: [#22152] [Plugin] Negative signed integers are truncated.
 - Fix: [#22161] Using arrow keys in textboxes crashes the game.
 - Fix: [#22174] Cheats are reset when starting a server.
+- Fix: [#22226] Red traffic light shows incorrect sprite when pressed.
 - Fix: [objects#323] Incorrect wall boundaries on large WW/TT scenery objects.
 - Fix: [objects#331] Incorrect hover car capacity string.
 - Fix: [objects#334] Incorrect school bus capacity string.

--- a/resources/g2/sprites.json
+++ b/resources/g2/sprites.json
@@ -60,7 +60,7 @@
         "path": "icons/rct1_close_on.png"
     },
     {
-        "path": "icons/rct1_close_off_pressed.png"
+        "path": "icons/rct1_close_on_pressed.png"
     },
     {
         "path": "icons/rct1_test_off.png"


### PR DESCRIPTION
The correct image was already there, it was just a copy-paste error in sprites.json.