### PR TITLE
Let Heavy Snow and Blizzard increase brakes failure chance

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -16,11 +16,12 @@
 - Change: [#21494] Display pixel density is now taken into account for the initial window scale setting.
 - Change: [#22230] The plugin/script engine is now initialised off the main thread.
 - Change: [#22251] Hide author info in the scenery window unless debug tools are active.
+- Change: [#22283] Let heavy snow and blizzard increase chance of brakes failure.
 - Change: [#22309] The scenario editor now supports loading landscapes from .sea save files.
 - Fix: [#17390] Glitchy animations for the ride type tabs in the object selection window.
 - Fix: [#19210] The load/save window executes the loading code twice, resulting in a slowdown.
 - Fix: [#22056] Potential crash upon exiting the game.
-- Fix: [#22101] Wrong tunnel shapes on Log Flume and Giga, Hybrid, Single-Rail and Alpine Coasters. 
+- Fix: [#22101] Wrong tunnel shapes on Log Flume and Giga, Hybrid, Single-Rail and Alpine Coasters.
 - Fix: [#22208] Cursor may fail to register hits in some cases (original bug).
 - Fix: [#22209] Water tool selection may disappear near edge of map.
 - Fix: [#22222] Staff list may remain invalid when changing tabs.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -49,7 +49,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kNetworkStreamVersion = 0;
+constexpr uint8_t kNetworkStreamVersion = 1;
 
 const std::string kNetworkStreamID = std::string(OPENRCT2_VERSION) + "-" + std::to_string(kNetworkStreamVersion);
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1464,8 +1464,8 @@ static void RideBreakdownUpdate(Ride& ride)
  */
 static int32_t RideGetNewBreakdownProblem(const Ride& ride)
 {
-    // Brake failure is more likely when it's raining
-    _breakdownProblemProbabilities[BREAKDOWN_BRAKES_FAILURE] = ClimateIsRaining() ? 20 : 3;
+    // Brake failure is more likely when it's raining or heavily snowing (HeavySnow and Blizzard)
+    _breakdownProblemProbabilities[BREAKDOWN_BRAKES_FAILURE] = (ClimateIsRaining() || ClimateIsSnowingHeavily()) ? 20 : 3;
 
     if (!ride.CanBreakDown())
         return -1;


### PR DESCRIPTION
Adds ClimateIsSnowingHeavily() to tern condition setting ride _breakdownProblemProbabilities[BREAKDOWN_BRAKES_FAILURE].

implements #22269

`bool ClimateIsSnowingHeavily()` checks for both HeavySnow and Blizzard but not "light" Snow as suggested in the issue to be consistent with the recent umbrella changes: #21986

#21986 sets `const bool isPrecipitating = ClimateIsRaining() || ClimateIsSnowingHeavily();` for guest, maybe it would be good for future consistency to add function ClimateIsPrecipitating() or similar in world/Climate?
