### PR TITLE
Fix #22056: Stop (and discard) the recording before tearing down the scripting engine

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Feature: [OpenMusic#54] Added Progressive ride music style (feat. Approaching Nirvana).
 - Change: [#22230] The plugin/script engine is now initialised off the main thread.
 - Change: [#22251] Hide author info in the scenery window unless debug tools are active.
+- Fix: [#22056] Potential crash upon exiting the game.
 - Fix: [#22208] Cursor may fail to register hits in some cases.
 
 0.4.12 (2024-07-07)

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -195,6 +195,7 @@ namespace OpenRCT2
 #endif
 
             GameActions::ClearQueue();
+            _replayManager->StopRecording(true);
 #ifndef DISABLE_NETWORK
             _network.Close();
 #endif


### PR DESCRIPTION
Fixes a shutdown crash on tearing down Duktape values inside `ReplayRecordData` after their context has already been destroyed. This was not reproducible in dev builds, because debug recordings are only done by default with Breakpad included in the build.

Fixes #22056

~~I don't think the changelog entry is necessary because most people have the crash prompts in Windows disabled nowadays.~~