### PR TITLE
Move title version info to its own window

### DIFF
--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -129,6 +129,8 @@ public:
                 return TitleMenuOpen();
             case WindowClass::TitleOptions:
                 return TitleOptionsOpen();
+            case WindowClass::TitleVersion:
+                return TitleVersionOpen();
             case WindowClass::TopToolbar:
                 return TopToolbarOpen();
             case WindowClass::ViewClipping:

--- a/src/openrct2-ui/input/Shortcuts.cpp
+++ b/src/openrct2-ui/input/Shortcuts.cpp
@@ -155,7 +155,7 @@ static void ShortcutRemoveTopBottomToolbarToggle()
             WindowCloseByClass(WindowClass::TitleOptions);
             WindowCloseByClass(WindowClass::TitleMenu);
             WindowCloseByClass(WindowClass::TitleExit);
-            TitleSetHideVersionInfo(true);
+            WindowCloseByClass(WindowClass::TitleVersion);
         }
         else
         {

--- a/src/openrct2-ui/libopenrct2ui.vcxproj
+++ b/src/openrct2-ui/libopenrct2ui.vcxproj
@@ -217,6 +217,7 @@
     <ClCompile Include="windows\TitleLogo.cpp" />
     <ClCompile Include="windows\TitleMenu.cpp" />
     <ClCompile Include="windows\TitleOptions.cpp" />
+    <ClCompile Include="windows\TitleVersion.cpp" />
     <ClCompile Include="windows\Tooltip.cpp" />
     <ClCompile Include="windows\TopToolbar.cpp" />
     <ClCompile Include="windows\TrackDesignManage.cpp" />

--- a/src/openrct2-ui/windows/TitleVersion.cpp
+++ b/src/openrct2-ui/windows/TitleVersion.cpp
@@ -1,0 +1,58 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2024 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include <openrct2-ui/interface/Widget.h>
+#include <openrct2-ui/windows/Window.h>
+#include <openrct2/Context.h>
+#include <openrct2/Version.h>
+#include <openrct2/drawing/Drawing.h>
+#include <openrct2/interface/Colour.h>
+
+namespace OpenRCT2::Ui::Windows
+{
+    static constexpr int32_t WW = 500;
+    static constexpr int32_t WH = 30;
+
+    static Widget _widgets[] = {
+        kWidgetsEnd,
+    };
+
+    class TitleVersionWindow final : public Window
+    {
+        void OnOpen() override
+        {
+            widgets = _widgets;
+        }
+
+        void OnDraw(DrawPixelInfo& dpi) override
+        {
+            // Write name and version information
+            const auto whiteOutline = ColourWithFlags{ COLOUR_WHITE }.withFlag(ColourFlag::withOutline, true);
+            DrawText(dpi, windowPos, { whiteOutline }, gVersionInfoFull);
+            width = GfxGetStringWidth(gVersionInfoFull, FontStyle::Medium);
+
+            // Write platform information
+            constexpr const char platformInfo[] = OPENRCT2_PLATFORM " (" OPENRCT2_ARCHITECTURE ")";
+            DrawText(dpi, windowPos + ScreenCoordsXY(0, kListRowHeight), { whiteOutline }, platformInfo);
+            width = std::max<int16_t>(width, GfxGetStringWidth(platformInfo, FontStyle::Medium));
+        }
+    };
+
+    WindowBase* TitleVersionOpen()
+    {
+        auto* window = WindowBringToFrontByClass(WindowClass::TitleVersion);
+        if (window == nullptr)
+        {
+            window = WindowCreate<TitleVersionWindow>(
+                WindowClass::TitleVersion, ScreenCoordsXY(8, ContextGetHeight() - 30), WW, WH,
+                WF_STICK_TO_BACK | WF_TRANSPARENT);
+        }
+        return window;
+    }
+} // namespace OpenRCT2::Ui::Windows

--- a/src/openrct2-ui/windows/Window.h
+++ b/src/openrct2-ui/windows/Window.h
@@ -75,6 +75,7 @@ namespace OpenRCT2::Ui::Windows
     WindowBase* TitleLogoOpen();
     WindowBase* TitleMenuOpen();
     WindowBase* TitleOptionsOpen();
+    WindowBase* TitleVersionOpen();
     WindowBase* ViewportOpen();
     WindowBase* WaterOpen();
     WindowBase* ViewClippingOpen();

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -1389,6 +1389,10 @@ void WindowResizeGui(int32_t width, int32_t height)
         titleWind->windowPos.y = height - 182;
     }
 
+    WindowBase* versionWind = WindowFindByClass(WindowClass::TitleVersion);
+    if (versionWind != nullptr)
+        versionWind->windowPos.y = height - 30;
+
     WindowBase* exitWind = WindowFindByClass(WindowClass::TitleExit);
     if (exitWind != nullptr)
     {

--- a/src/openrct2/interface/WindowClasses.h
+++ b/src/openrct2/interface/WindowClasses.h
@@ -89,6 +89,7 @@ enum class WindowClass : uint8_t
     AssetPacks = 135,
     ResetShortcutKeysPrompt = 136,
     ProgressWindow = 137,
+    TitleVersion = 138,
 
     // Only used for colour schemes
     Staff = 220,

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -56,11 +56,6 @@ void Painter::Paint(IDrawingEngine& de)
         UpdatePaletteEffects();
         _uiContext->Draw(*dpi);
 
-        if ((gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) && !TitleShouldHideVersionInfo())
-        {
-            DrawOpenRCT2(*dpi, { 0, _uiContext->GetHeight() - 20 });
-        }
-
         GfxDrawPickedUpPeep(*dpi);
         GfxInvalidatePickedUpPeep();
 
@@ -106,13 +101,10 @@ void Painter::PaintReplayNotice(DrawPixelInfo& dpi, const char* text)
 
 static bool ShouldShowFPS()
 {
-    if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO && !TitleShouldHideVersionInfo())
+    if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return true;
 
-    if (!WindowFindByClass(WindowClass::TopToolbar))
-        return false;
-
-    return true;
+    return WindowFindByClass(WindowClass::TopToolbar);
 }
 
 void Painter::PaintFPS(DrawPixelInfo& dpi)

--- a/src/openrct2/scenes/title/TitleScene.cpp
+++ b/src/openrct2/scenes/title/TitleScene.cpp
@@ -15,7 +15,6 @@
 #include "../../GameState.h"
 #include "../../Input.h"
 #include "../../OpenRCT2.h"
-#include "../../Version.h"
 #include "../../audio/audio.h"
 #include "../../config/Config.h"
 #include "../../core/Console.hpp"
@@ -89,16 +88,6 @@ void TitleScene::StopPreviewingSequence()
 bool TitleScene::IsPreviewingSequence()
 {
     return _previewingSequence;
-}
-
-bool TitleScene::ShouldHideVersionInfo()
-{
-    return _hideVersionInfo;
-}
-
-void TitleScene::SetHideVersionInfo(bool value)
-{
-    _hideVersionInfo = value;
 }
 
 void TitleScene::Load()
@@ -210,8 +199,8 @@ void TitleScene::CreateWindows()
     ContextOpenWindow(WindowClass::TitleExit);
     ContextOpenWindow(WindowClass::TitleOptions);
     ContextOpenWindow(WindowClass::TitleLogo);
+    ContextOpenWindow(WindowClass::TitleVersion);
     WindowResizeGui(ContextGetWidth(), ContextGetHeight());
-    _hideVersionInfo = false;
 }
 
 void TitleScene::TitleInitialise()
@@ -370,27 +359,6 @@ void TitleSequenceChangePreset(size_t preset)
     }
 }
 
-bool TitleShouldHideVersionInfo()
-{
-    auto* context = OpenRCT2::GetContext();
-    auto* titleScene = static_cast<TitleScene*>(context->GetTitleScene());
-    if (titleScene != nullptr)
-    {
-        return titleScene->ShouldHideVersionInfo();
-    }
-    return false;
-}
-
-void TitleSetHideVersionInfo(bool value)
-{
-    auto* context = OpenRCT2::GetContext();
-    auto* titleScene = static_cast<TitleScene*>(context->GetTitleScene());
-    if (titleScene != nullptr)
-    {
-        titleScene->SetHideVersionInfo(value);
-    }
-}
-
 size_t TitleGetConfigSequence()
 {
     return TitleSequenceManagerGetIndexForConfigID(Config::Get().interface.CurrentTitleSequencePreset.c_str());
@@ -437,31 +405,4 @@ bool TitleIsPreviewingSequence()
         return titleScene->IsPreviewingSequence();
     }
     return false;
-}
-
-void DrawOpenRCT2(DrawPixelInfo& dpi, const ScreenCoordsXY& screenCoords)
-{
-    thread_local std::string buffer;
-    buffer.clear();
-    buffer.assign("{OUTLINE}{WHITE}");
-
-    // Write name and version information
-    buffer += gVersionInfoFull;
-
-    DrawText(dpi, screenCoords + ScreenCoordsXY(5, 5 - 13), { COLOUR_BLACK }, buffer.c_str());
-    int16_t width = static_cast<int16_t>(GfxGetStringWidth(buffer, FontStyle::Medium));
-
-    // Write platform information
-    buffer.assign("{OUTLINE}{WHITE}");
-    buffer.append(OPENRCT2_PLATFORM);
-    buffer.append(" (");
-    buffer.append(OPENRCT2_ARCHITECTURE);
-    buffer.append(")");
-
-    DrawText(dpi, screenCoords + ScreenCoordsXY(5, 5), { COLOUR_BLACK }, buffer.c_str());
-    width = std::max(width, static_cast<int16_t>(GfxGetStringWidth(buffer, FontStyle::Medium)));
-
-    // Invalidate screen area
-    GfxSetDirtyBlocks({ screenCoords - ScreenCoordsXY(0, 13),
-                        screenCoords + ScreenCoordsXY{ width + 5, 30 } }); // 30 is an arbitrary height to catch both strings
 }

--- a/src/openrct2/scenes/title/TitleScene.h
+++ b/src/openrct2/scenes/title/TitleScene.h
@@ -26,8 +26,6 @@ namespace OpenRCT2
         bool PreviewSequence(size_t value);
         void StopPreviewingSequence();
         bool IsPreviewingSequence();
-        bool ShouldHideVersionInfo();
-        void SetHideVersionInfo(bool value);
 
         void Load() override;
         void Tick() override;
@@ -39,7 +37,6 @@ namespace OpenRCT2
         ITitleSequencePlayer* _sequencePlayer = nullptr;
         size_t _loadedTitleSequenceId = SIZE_MAX;
         size_t _currentSequence = SIZE_MAX;
-        bool _hideVersionInfo = false;
         bool _previewingSequence = false;
 
         void TitleInitialise();
@@ -53,11 +50,8 @@ extern bool gPreviewingTitleSequenceInGame;
 void TitleCreateWindows();
 void* TitleGetSequencePlayer();
 void TitleSequenceChangePreset(size_t preset);
-bool TitleShouldHideVersionInfo();
-void TitleSetHideVersionInfo(bool value);
 size_t TitleGetConfigSequence();
 size_t TitleGetCurrentSequence();
 bool TitlePreviewSequence(size_t value);
 void TitleStopPreviewingSequence();
 bool TitleIsPreviewingSequence();
-void DrawOpenRCT2(DrawPixelInfo& dpi, const ScreenCoordsXY& screenCoords);


### PR DESCRIPTION
This PR moves the title version info into a window of its own, allowing us to remove some hacky workarounds. Also prevents the version info from showing up while a title sequence is loading (#22301).

NB: no visual changes; it's just like how the title logo has its own borderless window.