### PR TITLE
Prevent loading saved games twice in LoadSave window callback

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Feature: [OpenMusic#54] Added Progressive ride music style (feat. Approaching Nirvana).
 - Change: [#22230] The plugin/script engine is now initialised off the main thread.
 - Change: [#22251] Hide author info in the scenery window unless debug tools are active.
+- Fix: [#19210] The load/save window executes the loading code twice, resulting in a slowdown.
 - Fix: [#22056] Potential crash upon exiting the game.
 - Fix: [#22208] Cursor may fail to register hits in some cases (original bug).
 

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -616,7 +616,6 @@ static void GameLoadOrQuitNoSavePromptCallback(int32_t result, const utf8* path)
         GameNotifyMapChange();
         GameUnloadScripts();
         WindowCloseByClass(WindowClass::EditorObjectSelection);
-        GetContext()->LoadParkFromFile(path);
         GameLoadScripts();
         GameNotifyMapChanged();
         gIsAutosaveLoaded = gIsAutosave;


### PR DESCRIPTION
When loading a save game through the LoadSave window, the window already invokes `LoadParkFromFile(pathBuffer)`. Then, when closing the window with `MODAL_RESULT_OK`, the `GameLoadOrQuitNoSavePromptCallback` is invoked, which invokes `LoadParkFromFile` _again_. I believe the latter call is simply superfluous, and can be omitted.

Fixes #19210.