### PR TITLE
Simplify landscape (save) loading in scenario editor

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Feature: [OpenMusic#54] Added Progressive ride music style (feat. Approaching Nirvana).
 - Change: [#22230] The plugin/script engine is now initialised off the main thread.
 - Change: [#22251] Hide author info in the scenery window unless debug tools are active.
+- Change: [#22309] The scenario editor now supports loading landscapes from .sea save files.
 - Fix: [#19210] The load/save window executes the loading code twice, resulting in a slowdown.
 - Fix: [#22056] Potential crash upon exiting the game.
 - Fix: [#22208] Cursor may fail to register hits in some cases (original bug).

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -60,8 +60,6 @@ namespace Editor
     static void ConvertSaveToScenarioCallback(int32_t result, const utf8* path);
     static void SetAllLandOwned();
     static void FinaliseMainView();
-    static bool ReadS4OrS6(const char* path);
-    static bool ReadPark(const char* path);
     static void ClearMapForEditing(bool fromSave);
 
     static void ObjectListLoad()
@@ -226,31 +224,6 @@ namespace Editor
         GameActions::Execute(&landBuyRightsAction);
     }
 
-    /**
-     *
-     *  rct2: 0x006758C0
-     */
-    bool LoadLandscape(const utf8* path)
-    {
-        // #4996: Make sure the object selection window closes here to prevent unload objects
-        //        after we have loaded a new park.
-        WindowCloseAll();
-
-        auto extension = GetFileExtensionType(path);
-        switch (extension)
-        {
-            case FileExtension::SC6:
-            case FileExtension::SV6:
-            case FileExtension::SC4:
-            case FileExtension::SV4:
-                return ReadS4OrS6(path);
-            case FileExtension::PARK:
-                return ReadPark(path);
-            default:
-                return false;
-        }
-    }
-
     static void AfterLoadCleanup(bool loadedFromSave)
     {
         ClearMapForEditing(loadedFromSave);
@@ -267,49 +240,20 @@ namespace Editor
         FinaliseMainView();
     }
 
-    /**
-     *
-     *  rct2: 0x006758FE
-     */
-    static bool ReadS4OrS6(const char* path)
+    bool LoadLandscape(const utf8* path)
     {
-        auto extensionS = Path::GetExtension(path);
-        const char* extension = extensionS.c_str();
-        auto loadedFromSave = false;
-        const auto loadSuccess = GetContext()->LoadParkFromFile(path);
-        if (!loadSuccess)
+        // #4996: Make sure the object selection window closes here to prevent unload objects
+        //        after we have loaded a new park.
+        WindowCloseAll();
+
+        if (!GetContext()->LoadParkFromFile(path))
             return false;
 
-        if (String::IEquals(extension, ".sv4") || String::IEquals(extension, ".sv6") || String::IEquals(extension, ".sv7") == 0)
-        {
-            loadedFromSave = true;
-        }
+        auto extension = Path::GetExtension(path);
+        bool loadedFromSave = !ParkImporter::ExtensionIsScenario(extension);
 
         AfterLoadCleanup(loadedFromSave);
         return true;
-    }
-
-    static bool ReadPark(const char* path)
-    {
-        try
-        {
-            auto context = GetContext();
-            auto& objManager = context->GetObjectManager();
-            auto importer = ParkImporter::CreateParkFile(context->GetObjectRepository());
-            auto loadResult = importer->Load(path);
-            objManager.LoadObjects(loadResult.RequiredObjects);
-
-            // TODO: Have a separate GameState and exchange once loaded.
-            auto& gameState = GetGameState();
-            importer->Import(gameState);
-
-            AfterLoadCleanup(true);
-            return true;
-        }
-        catch (const std::exception&)
-        {
-            return false;
-        }
     }
 
     static void ClearMapForEditing(bool fromSave)


### PR DESCRIPTION
This PR simplifies the landscape loading process in the scenario editor. It was essentially duplicating functionality from `Context::LoadParkFromFile(path)`.

Added bonus is that the scenario editor now supports loading `.sea` files as well. I suppose that warrants a changelog entry.