### PR TITLE
Fix #22133: Ride time is incorrect for extremely low speeds

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -16,6 +16,7 @@
 - Fix: [#15406] Tunnels on steep Side-Friction track are drawn too low.
 - Fix: [#21959] “Save this before...?” message does not appear when selecting “New Game”.
 - Fix: [#22072] Objective date string and staff tenure date string cannot be reused on agglutinative languages.
+- Fix: [#22133] Ride time is incorrect for extremely slow speeds.
 - Fix: [#22231] Invalid object version can cause a crash.
 - Fix: [#22562] Bottom row of pixels is not always drawn by the OpenGL renderer when zoomed in.
 - Fix: [#22653] Missing water tiles in RCT1 and RCT2 scenarios.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -49,7 +49,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kNetworkStreamVersion = 1;
+constexpr uint8_t kNetworkStreamVersion = 2;
 
 const std::string kNetworkStreamID = std::string(OPENRCT2_VERSION) + "-" + std::to_string(kNetworkStreamVersion);
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -848,12 +848,10 @@ void Vehicle::UpdateMeasurements()
             curRide->max_speed = absVelocity;
         }
 
-        if (curRide->average_speed_test_timeout == 0)
+        if (curRide->average_speed_test_timeout == 0 && absVelocity > 0)
         {
-            if (absVelocity > 0x8000)
-                curRide->average_speed = AddClamp<int32_t>(curRide->average_speed, absVelocity);
-            if (absVelocity > 0)
-                stationForTestSegment.SegmentTime++;
+            curRide->average_speed = AddClamp<int32_t>(curRide->average_speed, absVelocity);
+            stationForTestSegment.SegmentTime++;
         }
 
         int32_t distance = abs(((velocity + acceleration) >> 10) * 42);

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -812,7 +812,6 @@ void RideUpdateMeasurementsSpecialElements_WaterCoaster(Ride& ride, const track_
  *
  *  rct2: 0x006D6D1F
  */
-uint8_t test_speed_timeout = 0;
 void Vehicle::UpdateMeasurements()
 {
     auto curRide = GetRide();

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -812,6 +812,7 @@ void RideUpdateMeasurementsSpecialElements_WaterCoaster(Ride& ride, const track_
  *
  *  rct2: 0x006D6D1F
  */
+uint8_t test_speed_timeout = 0;
 void Vehicle::UpdateMeasurements()
 {
     auto curRide = GetRide();
@@ -851,10 +852,9 @@ void Vehicle::UpdateMeasurements()
         if (curRide->average_speed_test_timeout == 0)
         {
             if (absVelocity > 0x8000)
-            {
-                curRide->average_speed = AddClamp<int32_t>(curRide->average_speed, absVelocity); 
-            }
-            stationForTestSegment.SegmentTime++;
+                curRide->average_speed = AddClamp<int32_t>(curRide->average_speed, absVelocity);
+            if (absVelocity > 0)
+                stationForTestSegment.SegmentTime++;
         }
 
         int32_t distance = abs(((velocity + acceleration) >> 10) * 42);

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -848,9 +848,12 @@ void Vehicle::UpdateMeasurements()
             curRide->max_speed = absVelocity;
         }
 
-        if (curRide->average_speed_test_timeout == 0 && absVelocity > 0x8000)
+        if (curRide->average_speed_test_timeout == 0)
         {
-            curRide->average_speed = AddClamp<int32_t>(curRide->average_speed, absVelocity);
+            if (absVelocity > 0x8000)
+            {
+                curRide->average_speed = AddClamp<int32_t>(curRide->average_speed, absVelocity); 
+            }
             stationForTestSegment.SegmentTime++;
         }
 


### PR DESCRIPTION
Testing Tips: (Ride Vehicle Editor Plugin is required)

1. Build ride with powered vehicle (e.g., Monorail)
2. Test ride once (So it shows up in the plugin)
3. Close the ride
4. Set max speed to 1 in the plugin
5. Invalidate test results by setting and resetting the number of circuits
6. Test ride and set speed to turbo or hyper
7. Check test results

Potential improvements:

- Count the time when a train is completely stationary towards overall ride time, such as when using block breaks. (This would affect existing rides, and differ from the original game)
- Use fixed point integers to represent speeds (Suggested by @ZehMatt). 

Address #22133.