### PR TITLE
Fix #22304: Graphs don't draw the first line if it is on the left edge of the screen

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Fix: [#19210] The load/save window executes the loading code twice, resulting in a slowdown.
 - Fix: [#22056] Potential crash upon exiting the game.
 - Fix: [#22208] Cursor may fail to register hits in some cases (original bug).
+- Fix: [#22304] Graphs don't draw lines on the left edge of the screen.
 
 0.4.12 (2024-07-07)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -186,7 +186,8 @@ namespace Graph
         DrawPixelInfo& dpi, const money64* history, int32_t count, const ScreenCoordsXY& origCoords, int32_t modifier,
         int32_t offset)
     {
-        auto lastCoords = ScreenCoordsXY{ -1, -1 };
+        ScreenCoordsXY lastCoords;
+        bool lastCoordsValid = false;
         auto coords = origCoords;
         for (int32_t i = count - 1; i >= 0; i--)
         {
@@ -194,7 +195,7 @@ namespace Graph
             {
                 coords.y = origCoords.y + 170 - 6 - ((((history[i] >> modifier) + offset) * 170) / 256);
 
-                if (lastCoords.x != -1)
+                if (lastCoordsValid)
                 {
                     auto leftTop1 = lastCoords + ScreenCoordsXY{ 1, 1 };
                     auto rightBottom1 = coords + ScreenCoordsXY{ 1, 1 };
@@ -207,6 +208,7 @@ namespace Graph
                     GfxFillRect(dpi, { coords, coords + ScreenCoordsXY{ 2, 2 } }, PALETTE_INDEX_10);
 
                 lastCoords = coords;
+                lastCoordsValid = true;
             }
             coords.x += 6;
         }
@@ -216,7 +218,8 @@ namespace Graph
         DrawPixelInfo& dpi, const money64* history, int32_t count, const ScreenCoordsXY& origCoords, int32_t modifier,
         int32_t offset)
     {
-        auto lastCoords = ScreenCoordsXY{ -1, -1 };
+        ScreenCoordsXY lastCoords;
+        bool lastCoordsValid = false;
         auto coords = origCoords;
         for (int32_t i = count - 1; i >= 0; i--)
         {
@@ -224,7 +227,7 @@ namespace Graph
             {
                 coords.y = origCoords.y + 170 - 6 - ((((history[i] >> modifier) + offset) * 170) / 256);
 
-                if (lastCoords.x != -1)
+                if (lastCoordsValid)
                 {
                     auto leftTop = lastCoords;
                     auto rightBottom = coords;
@@ -234,6 +237,7 @@ namespace Graph
                     GfxFillRect(dpi, { coords - ScreenCoordsXY{ 1, 1 }, coords + ScreenCoordsXY{ 1, 1 } }, PALETTE_INDEX_21);
 
                 lastCoords = coords;
+                lastCoordsValid = true;
             }
             coords.x += 6;
         }


### PR DESCRIPTION
Fixes #22304

Simple bug caused by using a coordinate of -1 as a special value to represent validity. 