### PR TITLE
Fix #22333: Tile inspector closes other tool windows

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Fix: [#22284] Unrated rides cause high amount of nausea.
 - Fix: [#22304] Graphs don't draw lines on the left edge of the screen.
 - Fix: [#22318] Water sparkles are missing if transparent water is enabled without RCT1 linked.
+- Fix: [#22333] Tile inspector closes other tool windows.
 
 0.4.12 (2024-07-07)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -721,7 +721,8 @@ static uint64_t PageDisabledWidgets[] = {
 
         void OnClose() override
         {
-            ToolCancel();
+            if (gCurrentToolWidget.window_classification == WindowClass::TileInspector)
+                ToolCancel();
             TileElement* const elem = OpenRCT2::TileInspector::GetSelectedElement();
             if (elem != nullptr)
             {


### PR DESCRIPTION
Fixes #22333 

Caused by the tile inspector closing when another tool has set the current tool to something else, but then clearing the current tool on close.