### PR TITLE
Fix #22222: Staff list may remain invalid when changing tabs.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Fix: [#19210] The load/save window executes the loading code twice, resulting in a slowdown.
 - Fix: [#22056] Potential crash upon exiting the game.
 - Fix: [#22208] Cursor may fail to register hits in some cases (original bug).
+- Fix: [#22222] Staff list may remain invalid when changing tabs.
 - Fix: [#22284] Unrated rides cause high amount of nausea.
 - Fix: [#22304] Graphs don't draw lines on the left edge of the screen.
 - Fix: [#22318] Water sparkles are missing if transparent water is enabled without RCT1 linked.

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -226,6 +226,7 @@ static Widget _staffListWidgets[] = {
                     if (_selectedTab != newSelectedTab)
                     {
                         _selectedTab = static_cast<uint8_t>(newSelectedTab);
+                        RefreshList();
                         Invalidate();
                         scrolls[0].v_top = 0;
                         CancelTools();


### PR DESCRIPTION
Fixes #22222

The bug is most visible when the different tabs all show the same number of staff. Otherwise the scroll widget appears to catch the change in size and update on second frame after the click, which is still a bug but it happens quickly and is harder to notice.