### PR TITLE
Use infinity icon in object selection window too

### DIFF
--- a/resources/g2/sprites.json
+++ b/resources/g2/sprites.json
@@ -199,7 +199,9 @@
     },
     {
         "path": "icons/infinity.png",
-        "palette": "keep"
+        "palette": "keep",
+        "x": 2,
+        "y": 6
     },
     {
         "path": "tool/normal_selection_6x6.png",

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1006,7 +1006,7 @@ static std::vector<Widget> _window_editor_object_selection_widgets = {
             }
 
             const int32_t ride_tabs[] = {
-                SPR_TAB_RIDE_16,        SPR_TAB_RIDES_TRANSPORT_0, SPR_TAB_RIDES_GENTLE_0, SPR_TAB_RIDES_ROLLER_COASTERS_0,
+                SPR_G2_INFINITY,        SPR_TAB_RIDES_TRANSPORT_0, SPR_TAB_RIDES_GENTLE_0, SPR_TAB_RIDES_ROLLER_COASTERS_0,
                 SPR_TAB_RIDES_THRILL_0, SPR_TAB_RIDES_WATER_0,     SPR_TAB_RIDES_SHOP_0,   SPR_TAB_FINANCES_RESEARCH_0,
             };
             const int32_t ThrillRidesTabAnimationSequence[] = {

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -1516,7 +1516,7 @@ static Widget WindowSceneryBaseWidgets[] = {
                 if (_tabEntries[tabIndex].IsAll())
                 {
                     auto imageId = ImageId(SPR_G2_INFINITY, FilterPaletteID::PaletteNull);
-                    GfxDrawSprite(dpi, imageId, offset + widgetCoordsXY + ScreenCoordsXY(2, 6));
+                    GfxDrawSprite(dpi, imageId, offset + widgetCoordsXY);
                 }
             }
         }


### PR DESCRIPTION
Last year, in #19341, we introduced an 'all scenery' tab. To make the UI more consistent, this PR proposes we use the same icon in the rides tab in the object selection window as well. 

Before:
![Unnamed park 2024-07-21 19-23-22](https://github.com/user-attachments/assets/d9995309-5829-45e1-8b0c-0f70e2393e18)

After:
![Unnamed park 2024-07-21 19-25-07](https://github.com/user-attachments/assets/a43fcef7-fe44-473b-9029-5540b8c002b1)
