### PR TITLE
Make SoftwareWithHardwareDisplay the default drawing engine

### DIFF
--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -189,7 +189,7 @@ namespace OpenRCT2::Config
             model->WindowWidth = reader->GetInt32("window_width", -1);
             model->DefaultDisplay = reader->GetInt32("default_display", 0);
             model->DrawingEngine = reader->GetEnum<DrawingEngine>(
-                "drawing_engine", DrawingEngine::Software, Enum_DrawingEngine);
+                "drawing_engine", DrawingEngine::SoftwareWithHardwareDisplay, Enum_DrawingEngine);
             model->UncapFPS = reader->GetBoolean("uncap_fps", false);
             model->UseVSync = reader->GetBoolean("use_vsync", true);
             model->VirtualFloorStyle = reader->GetEnum<VirtualFloorStyles>(


### PR DESCRIPTION
The basic software drawing engine does not support all features. For the best player experience, I propose we make the hardware-backed software drawing engine the default. (NB: this change won't affect existing configs.)

With some refactor work, I think the basic software drawing engine could be removed entirely, in favour of the hardware-backed one. SDL could take care of the fallbacks based on GPU features, like we do in OpenLoco.