### PR TITLE
Fix #22339: Printing ui.tool.cursor in console crashes the game.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Fix: [#22304] Graphs don't draw lines on the left edge of the screen.
 - Fix: [#22318] Water sparkles are missing if transparent water is enabled without RCT1 linked.
 - Fix: [#22333] Tile inspector closes other tool windows.
+- Fix: [#22339] Printing ui.tool.cursor in console crashes the game.
 
 0.4.12 (2024-07-07)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/scripting/CustomMenu.cpp
+++ b/src/openrct2-ui/scripting/CustomMenu.cpp
@@ -86,9 +86,9 @@ namespace OpenRCT2::Scripting
         {
             auto str = CursorNames[value];
             duk_push_lstring(ctx, str.data(), str.size());
-            DukValue::take_from_stack(ctx);
+            return DukValue::take_from_stack(ctx);
         }
-        return {};
+        return ToDuk(ctx, undefined);
     }
 
     template<> CursorID FromDuk(const DukValue& s)


### PR DESCRIPTION
Fixes #22339 

Returning `DukValue{}` seems to be dangerous as it can cause the following exception when encountered by the duktape engine:

```
terminate called after throwing an instance of 'duk_fatal_exception'
  what():  uncaught: 'DukValue is uninitialized'
```

I'm not sure whether the correct thing to do would be to instead return:

`ToDuk(ctx, nullptr);`

or 

`ToDuk(ctx, undefined);`

I went with the latter option since it seems more correct to me in this case, but it looks like a lot of the existing code goes with the first option.