### PR TITLE
Fix #17390: Object selection ride tab uses wrong animations

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Change: [#22230] The plugin/script engine is now initialised off the main thread.
 - Change: [#22251] Hide author info in the scenery window unless debug tools are active.
 - Change: [#22309] The scenario editor now supports loading landscapes from .sea save files.
+- Fix: [#17390] Glitchy animations for the ride type tabs in the object selection window.
 - Fix: [#19210] The load/save window executes the loading code twice, resulting in a slowdown.
 - Fix: [#22056] Potential crash upon exiting the game.
 - Fix: [#22208] Cursor may fail to register hits in some cases (original bug).

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -225,22 +225,20 @@ static std::vector<Widget> _window_editor_object_selection_widgets = {
 #pragma endregion
 
     static constexpr int32_t window_editor_object_selection_animation_loops[] = {
-        20, // All
-        32, // Transport
-        10, // Gentle
-        72, // Coaster
-        24, // Thrill
-        28, // Water
-        16, // Stall
+        20, // Transport
+        32, // Gentle
+        10, // Coaster
+        72, // Thrill
+        24, // Water
+        28, // Stall
     };
     static constexpr int32_t window_editor_object_selection_animation_divisor[] = {
-        4, // All
-        8, // Transport
-        2, // Gentle
-        4, // Coaster
+        4, // Transport
+        8, // Gentle
+        2, // Coaster
         4, // Thrill
         4, // Water
-        2, // Stall
+        4, // Stall
     };
 
     static StringId GetRideTypeStringId(const ObjectRepositoryItem* item);


### PR DESCRIPTION
The ride tab animations in the object selection window were defined incorrectly. The sequence appears to have been copied from the 'New Ride' window, but the definitions for the Research tab appear to not have been taken into account. Instead, there's an 'All' tab, which is compensated for, but everything is still off by one. Compare:

NewRide.cpp:
```cpp
    static constexpr int32_t TabAnimationLoops[] = {
        20, // TRANSPORT_TAB
        32, // GENTLE_TAB
        10, // ROLLER_COASTER_TAB
        72, // THRILL_TAB
        24, // WATER_TAB
        28, // SHOP_TAB
        16, // RESEARCH_TAB
    };
```

EditorObjectSelection.cpp (before this PR):
```cpp
    static constexpr int32_t window_editor_object_selection_animation_loops[] = {
        20, // All
        32, // Transport
        10, // Gentle
        72, // Coaster
        24, // Thrill
        28, // Water
        16, // Stall
    };
```

EditorObjectSelection.cpp (as of this PR):
```cpp
    static constexpr int32_t window_editor_object_selection_animation_loops[] = {
        20, // Transport
        32, // Gentle
        10, // Coaster
        72, // Thrill
        24, // Water
        28, // Stall
    };
```

The `window_editor_object_selection_animation_divisor` array was corrected analogously.