### PR TITLE
change ToolEventArgs.mapCoords from CoordsXYZ to CoordsXY

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -4281,7 +4281,7 @@ declare global {
     interface ToolEventArgs {
         readonly isDown: boolean;
         readonly screenCoords: ScreenCoordsXY;
-        readonly mapCoords?: CoordsXYZ;
+        readonly mapCoords?: CoordsXY;
         readonly tileElementIndex?: number;
         readonly entityId?: number;
     }


### PR DESCRIPTION
Testing showed that the event returns CoordsXY instead of CoordsXYZ. The code can be traced back to InteractionInfo.Loc (Viewport.h), which is CoordsXY.