### PR TITLE
Add missing string includes

### DIFF
--- a/src/openrct2/audio/audio.h
+++ b/src/openrct2/audio/audio.h
@@ -14,6 +14,7 @@
 #include "AudioMixer.h"
 
 #include <memory>
+#include <string>
 #include <string_view>
 #include <vector>
 

--- a/src/openrct2/core/Crypt.h
+++ b/src/openrct2/core/Crypt.h
@@ -11,6 +11,7 @@
 
 #include <array>
 #include <memory>
+#include <string>
 #include <string_view>
 #include <vector>
 

--- a/src/openrct2/localisation/FormatCodes.h
+++ b/src/openrct2/localisation/FormatCodes.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <string>
 #include <string_view>
 
 enum class FormatToken

--- a/src/openrct2/rct12/CSStringConverter.h
+++ b/src/openrct2/rct12/CSStringConverter.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 #include <string_view>
 
 enum class RCT2LanguageId : uint8_t;


### PR DESCRIPTION
@733737 was having issues with a preview release of MSVC which no longer includes `<string>` in `<string_view>`. https://github.com/microsoft/STL/pull/4633