### PR TITLE
Fix progress bar widgets when multiple windows are open

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -22,6 +22,7 @@
 - Fix: [#22222] Staff list may remain invalid when changing tabs.
 - Fix: [#22265] Button for switching covered tracks on slides doesn’t stay pressed.
 - Fix: [#22284] Unrated rides cause high amount of nausea.
+- Fix: [#22292] Progress bar not updating correctly with multiple windows open.
 - Fix: [#22304] Graphs don’t draw lines on the left edge of the screen.
 - Fix: [#22318] Water sparkles are missing if transparent water is enabled without RCT1 linked.
 - Fix: [#22333] Tile inspector closes other tool windows.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -22,7 +22,7 @@
 - Fix: [#22222] Staff list may remain invalid when changing tabs.
 - Fix: [#22265] Button for switching covered tracks on slides doesn’t stay pressed.
 - Fix: [#22284] Unrated rides cause high amount of nausea.
-- Fix: [#22292] Progress bar in guest stats widget and ride maintenance widget not updating correctly.
+- Fix: [#22292] Progress bar widgets in guest and ride windows are not updating correctly.
 - Fix: [#22304] Graphs don’t draw lines on the left edge of the screen.
 - Fix: [#22318] Water sparkles are missing if transparent water is enabled without RCT1 linked.
 - Fix: [#22333] Tile inspector closes other tool windows.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -22,7 +22,7 @@
 - Fix: [#22222] Staff list may remain invalid when changing tabs.
 - Fix: [#22265] Button for switching covered tracks on slides doesn’t stay pressed.
 - Fix: [#22284] Unrated rides cause high amount of nausea.
-- Fix: [#22292] Progress bar not updating correctly with multiple windows open.
+- Fix: [#22292] Progress bar in guest stats widget and ride maintenance widget not updating correctly.
 - Fix: [#22304] Graphs don’t draw lines on the left edge of the screen.
 - Fix: [#22318] Water sparkles are missing if transparent water is enabled without RCT1 linked.
 - Fix: [#22333] Tile inspector closes other tool windows.

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1075,7 +1075,7 @@ static_assert(_guestWindowPageWidgets.size() == WINDOW_GUEST_PAGE_COUNT);
             int32_t energyPercentage = NormalizeGuestStatValue(
                 peep->Energy - kPeepMinEnergy, kPeepMaxEnergy - kPeepMinEnergy, 10);
             WidgetProgressBarSetNewPercentage(widgets[WIDX_ENERGY_BAR], energyPercentage);
-            
+
             int32_t hungerPercentage = NormalizeGuestStatValue(peep->Hunger - 32, 158, 0);
             hungerPercentage = 100 - hungerPercentage; // the bar should be longer when peep->Hunger is low
             WidgetProgressBarSetNewPercentage(widgets[WIDX_HUNGER_BAR], hungerPercentage);

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1062,6 +1062,34 @@ static_assert(_guestWindowPageWidgets.size() == WINDOW_GUEST_PAGE_COUNT);
 
         void OnDrawStats(DrawPixelInfo& dpi)
         {
+            // ebx
+            const auto peep = GetGuest();
+            if (peep == nullptr)
+            {
+                return;
+            }
+
+            int32_t happinessPercentage = NormalizeGuestStatValue(peep->Happiness, kPeepMaxHappiness, 10);
+            WidgetProgressBarSetNewPercentage(widgets[WIDX_HAPPINESS_BAR], happinessPercentage);
+
+            int32_t energyPercentage = NormalizeGuestStatValue(
+                peep->Energy - kPeepMinEnergy, kPeepMaxEnergy - kPeepMinEnergy, 10);
+            WidgetProgressBarSetNewPercentage(widgets[WIDX_ENERGY_BAR], energyPercentage);
+            
+            int32_t hungerPercentage = NormalizeGuestStatValue(peep->Hunger - 32, 158, 0);
+            hungerPercentage = 100 - hungerPercentage; // the bar should be longer when peep->Hunger is low
+            WidgetProgressBarSetNewPercentage(widgets[WIDX_HUNGER_BAR], hungerPercentage);
+
+            int32_t thirstPercentage = NormalizeGuestStatValue(peep->Thirst - 32, 158, 0);
+            thirstPercentage = 100 - thirstPercentage; // the bar should be longer when peep->Thirst is low
+            WidgetProgressBarSetNewPercentage(widgets[WIDX_THIRST_BAR], thirstPercentage);
+
+            int32_t nauseaPercentage = NormalizeGuestStatValue(peep->Nausea - 32, 223, 0);
+            WidgetProgressBarSetNewPercentage(widgets[WIDX_NAUSEA_BAR], nauseaPercentage);
+
+            int32_t toiletPercentage = NormalizeGuestStatValue(peep->Toilet - 64, 178, 0);
+            WidgetProgressBarSetNewPercentage(widgets[WIDX_TOILET_BAR], toiletPercentage);
+
             DrawWidgets(dpi);
             OverviewTabDraw(dpi);
             StatsTabDraw(dpi);
@@ -1071,13 +1099,6 @@ static_assert(_guestWindowPageWidgets.size() == WINDOW_GUEST_PAGE_COUNT);
             InventoryTabDraw(dpi);
             DebugTabDraw(dpi);
 
-            // ebx
-            const auto peep = GetGuest();
-            if (peep == nullptr)
-            {
-                return;
-            }
-
             // Not sure why this is not stats widgets
             // cx dx
             auto screenCoords = windowPos
@@ -1086,46 +1107,25 @@ static_assert(_guestWindowPageWidgets.size() == WINDOW_GUEST_PAGE_COUNT);
             // Happiness
             DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_HAPPINESS_LABEL);
 
-            int32_t happinessPercentage = NormalizeGuestStatValue(peep->Happiness, kPeepMaxHappiness, 10);
-            WidgetProgressBarSetNewPercentage(widgets[WIDX_HAPPINESS_BAR], happinessPercentage);
-
             // Energy
             screenCoords.y += kListRowHeight;
             DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_ENERGY_LABEL);
-
-            int32_t energyPercentage = NormalizeGuestStatValue(
-                peep->Energy - kPeepMinEnergy, kPeepMaxEnergy - kPeepMinEnergy, 10);
-            WidgetProgressBarSetNewPercentage(widgets[WIDX_ENERGY_BAR], energyPercentage);
 
             // Hunger
             screenCoords.y += kListRowHeight;
             DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_HUNGER_LABEL);
 
-            int32_t hungerPercentage = NormalizeGuestStatValue(peep->Hunger - 32, 158, 0);
-            hungerPercentage = 100 - hungerPercentage; // the bar should be longer when peep->Hunger is low
-            WidgetProgressBarSetNewPercentage(widgets[WIDX_HUNGER_BAR], hungerPercentage);
-
             // Thirst
             screenCoords.y += kListRowHeight;
             DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_THIRST_LABEL);
-
-            int32_t thirstPercentage = NormalizeGuestStatValue(peep->Thirst - 32, 158, 0);
-            thirstPercentage = 100 - thirstPercentage; // the bar should be longer when peep->Thirst is low
-            WidgetProgressBarSetNewPercentage(widgets[WIDX_THIRST_BAR], thirstPercentage);
 
             // Nausea
             screenCoords.y += kListRowHeight;
             DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_NAUSEA_LABEL);
 
-            int32_t nauseaPercentage = NormalizeGuestStatValue(peep->Nausea - 32, 223, 0);
-            WidgetProgressBarSetNewPercentage(widgets[WIDX_NAUSEA_BAR], nauseaPercentage);
-
             // Toilet
             screenCoords.y += kListRowHeight;
             DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_TOILET_LABEL);
-
-            int32_t toiletPercentage = NormalizeGuestStatValue(peep->Toilet - 64, 178, 0);
-            WidgetProgressBarSetNewPercentage(widgets[WIDX_TOILET_BAR], toiletPercentage);
 
             // Time in park
             screenCoords.y += kListRowHeight + 1;

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -3965,12 +3965,18 @@ static_assert(std::size(RatingNames) == 6);
 
         void MaintenanceOnDraw(DrawPixelInfo& dpi)
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
-
             auto ride = GetRide(rideId);
             if (ride == nullptr)
                 return;
+
+            uint16_t reliability = ride->reliability_percentage;
+            WidgetProgressBarSetNewPercentage(widgets[WIDX_RELIABILITY_BAR], std::max<uint8_t>(10, reliability));
+
+            uint16_t downTime = ride->downtime;
+            WidgetProgressBarSetNewPercentage(widgets[WIDX_DOWN_TIME_BAR], downTime);
+
+            DrawWidgets(dpi);
+            DrawTabImages(dpi);
 
             // Locate mechanic button image
             Widget* widget = &widgets[WIDX_LOCATE_MECHANIC];
@@ -3987,18 +3993,14 @@ static_assert(std::size(RatingNames) == 6);
             widget = &widgets[WIDX_PAGE_BACKGROUND];
             screenCoords = windowPos + ScreenCoordsXY{ widget->left + 4, widget->top + 4 };
 
-            uint16_t reliability = ride->reliability_percentage;
             auto ft = Formatter();
             ft.Add<uint16_t>(reliability);
             DrawTextBasic(dpi, screenCoords, STR_RELIABILITY_LABEL_1757, ft);
-            WidgetProgressBarSetNewPercentage(widgets[WIDX_RELIABILITY_BAR], std::max<uint8_t>(10, reliability));
             screenCoords.y += 11;
 
-            uint16_t downTime = ride->downtime;
             ft = Formatter();
             ft.Add<uint16_t>(downTime);
             DrawTextBasic(dpi, screenCoords, STR_DOWN_TIME_LABEL_1889, ft);
-            WidgetProgressBarSetNewPercentage(widgets[WIDX_DOWN_TIME_BAR], downTime);
             screenCoords.y += 26;
 
             // Last inspection


### PR DESCRIPTION
The progress bar values were being set after the `DrawWidgets` call where they are displayed. This means that they were always drawn one window after they were supposed to. This appears to be unique for the progress bars widgets. My solution is to re-order the `OnDraw` functions for the specific widgets so that the progress bar information is calculated before `DrawWidgets` is called. This does mean that some code that could end the function early (the `GetRide` call) is called earlier than before but since this will only return a null pointer if the ID is wrong, I figured this was an acceptable tradeoff. Let me know if this is not ok and I can handle the potential of a null pointer differently. 

I also noticed this was happening for the guests also so I fixed that as well.