### PR TITLE
Disambiguate calls to UtilBitScanForward

### DIFF
--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -690,7 +690,7 @@ static Widget _scenarioSelectWidgets[] = {
 
         void InitTabs()
         {
-            int32_t showPages = 0;
+            uint32_t showPages = 0;
             size_t numScenarios = ScenarioRepositoryGetCount();
             for (size_t i = 0; i < numScenarios; i++)
             {

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -883,8 +883,7 @@ static Widget _staffOptionsWidgets[] = {
                 return;
             }
 
-            auto staffOrders = staff->StaffOrders;
-
+            uint32_t staffOrders = staff->StaffOrders;
             for (auto index = UtilBitScanForward(staffOrders); index != -1; index = UtilBitScanForward(staffOrders))
             {
                 staffOrders &= ~(1 << index);

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -630,7 +630,7 @@ GameActions::Result TrackPlaceAction::Execute() const
         entranceDirections = std::get<0>(ted.SequenceProperties);
         if (entranceDirections & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH)
         {
-            uint8_t availableDirections = entranceDirections & 0x0F;
+            uint32_t availableDirections = entranceDirections & 0x0F;
             if (availableDirections != 0)
             {
                 if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST) && !GetGameState().Cheats.DisableClearanceChecks)

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -1360,12 +1360,12 @@ void Guest::UpdateSitting()
  * To simplify check of 0x36BA3E0 and 0x11FF78
  * returns false on no food.
  */
-int64_t Guest::GetFoodOrDrinkFlags() const
+uint64_t Guest::GetFoodOrDrinkFlags() const
 {
     return GetItemFlags() & (ShopItemsGetAllFoods() | ShopItemsGetAllDrinks());
 }
 
-int64_t Guest::GetEmptyContainerFlags() const
+uint64_t Guest::GetEmptyContainerFlags() const
 {
     return GetItemFlags() & ShopItemsGetAllContainers();
 }

--- a/src/openrct2/entity/Guest.h
+++ b/src/openrct2/entity/Guest.h
@@ -322,8 +322,8 @@ public:
 
     void UpdateGuest();
     void Tick128UpdateGuest(uint32_t index);
-    int64_t GetFoodOrDrinkFlags() const;
-    int64_t GetEmptyContainerFlags() const;
+    uint64_t GetFoodOrDrinkFlags() const;
+    uint64_t GetEmptyContainerFlags() const;
     bool HasDrink() const;
     bool HasFoodOrDrink() const;
     bool HasEmptyContainer() const;

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -662,7 +662,7 @@ Direction Staff::MechanicDirectionPathRand(uint8_t pathDirections) const
  */
 Direction Staff::MechanicDirectionPath(uint8_t validDirections, PathElement* pathElement)
 {
-    uint8_t pathDirections = pathElement->GetEdges();
+    uint32_t pathDirections = pathElement->GetEdges();
     pathDirections &= validDirections;
 
     if (pathDirections == 0)
@@ -780,7 +780,7 @@ bool Staff::DoMechanicPathFinding()
  */
 Direction Staff::DirectionPath(uint8_t validDirections, PathElement* pathElement) const
 {
-    uint8_t pathDirections = pathElement->GetEdges();
+    uint32_t pathDirections = pathElement->GetEdges();
     if (State != PeepState::Answering && State != PeepState::HeadingToInspection)
     {
         pathDirections &= validDirections;

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -791,15 +791,15 @@ Direction Staff::DirectionPath(uint8_t validDirections, PathElement* pathElement
         return DirectionSurface(ScenarioRand() & 3);
     }
 
-    pathDirections &= ~(1 << DirectionReverse(PeepDirection));
+    pathDirections &= ~(1u << DirectionReverse(PeepDirection));
     if (pathDirections == 0)
     {
-        pathDirections |= (1 << DirectionReverse(PeepDirection));
+        pathDirections |= (1u << DirectionReverse(PeepDirection));
     }
 
     Direction direction = UtilBitScanForward(pathDirections);
     // If this is the only direction they can go, then go
-    if (pathDirections == (1 << direction))
+    if (pathDirections == (1u << direction))
     {
         return direction;
     }
@@ -807,7 +807,7 @@ Direction Staff::DirectionPath(uint8_t validDirections, PathElement* pathElement
     direction = ScenarioRand() & 3;
     for (uint8_t i = 0; i < kNumOrthogonalDirections; ++i, direction = DirectionNext(direction))
     {
-        if (pathDirections & (1 << direction))
+        if (pathDirections & (1u << direction))
             return direction;
     }
 

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -107,7 +107,7 @@ static LegacyAnimationParameters GetDefaultAnimationParameters(uint8_t legacyAni
     return VehicleEntryDefaultAnimation[legacyAnimationType];
 }
 
-static constexpr SpritePrecision PrecisionFromNumFrames(uint8_t numRotationFrames)
+static constexpr SpritePrecision PrecisionFromNumFrames(uint32_t numRotationFrames)
 {
     if (numRotationFrames == 0)
         return SpritePrecision::None;

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -582,7 +582,7 @@ namespace OpenRCT2::PathFinding
     {
         PROFILED_FUNCTION();
 
-        uint8_t edges = path->GetEdges();
+        uint32_t edges = path->GetEdges();
 
         int32_t testEdge = UtilBitScanForward(edges);
         if (testEdge == -1)
@@ -981,7 +981,7 @@ namespace OpenRCT2::PathFinding
 
             /* Get all the permitted_edges of the map element. */
             Guard::Assert(tileElement->AsPath() != nullptr);
-            uint8_t edges = PathGetPermittedEdges(staff != nullptr, tileElement->AsPath());
+            uint32_t edges = PathGetPermittedEdges(staff != nullptr, tileElement->AsPath());
 
             LogPathfinding(
                 &peep, "Path element at %d,%d,%d; Steps: %u; Edges (0123):%d%d%d%d; Reverse: %d", loc.x >> 5, loc.y >> 5, loc.z,
@@ -1279,7 +1279,7 @@ namespace OpenRCT2::PathFinding
             return INVALID_DIRECTION;
 
         permittedEdges &= 0xF;
-        uint8_t edges = permittedEdges;
+        uint32_t edges = permittedEdges;
         if (isThin && peep.PathfindGoal == goal)
         {
             /* Use of peep.PathfindHistory[]:
@@ -1886,7 +1886,7 @@ namespace OpenRCT2::PathFinding
         }
 
         // Because this function is called for guests only, never ignore banners.
-        uint8_t edges = PathGetPermittedEdges(false, pathElement);
+        uint32_t edges = PathGetPermittedEdges(false, pathElement);
 
         if (edges == 0)
         {

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1464,19 +1464,18 @@ static void RideBreakdownUpdate(Ride& ride)
  */
 static int32_t RideGetNewBreakdownProblem(const Ride& ride)
 {
-    int32_t availableBreakdownProblems, totalProbability, randomProbability, problemBits, breakdownProblem;
-
     // Brake failure is more likely when it's raining
     _breakdownProblemProbabilities[BREAKDOWN_BRAKES_FAILURE] = ClimateIsRaining() ? 20 : 3;
 
     if (!ride.CanBreakDown())
         return -1;
 
-    availableBreakdownProblems = ride.GetRideTypeDescriptor().AvailableBreakdowns;
+    int32_t availableBreakdownProblems = ride.GetRideTypeDescriptor().AvailableBreakdowns;
 
     // Calculate the total probability range for all possible breakdown problems
-    totalProbability = 0;
-    problemBits = availableBreakdownProblems;
+    int32_t totalProbability = 0;
+    uint32_t problemBits = availableBreakdownProblems;
+    int32_t breakdownProblem;
     while (problemBits != 0)
     {
         breakdownProblem = UtilBitScanForward(problemBits);
@@ -1487,7 +1486,7 @@ static int32_t RideGetNewBreakdownProblem(const Ride& ride)
         return -1;
 
     // Choose a random number within this range
-    randomProbability = ScenarioRand() % totalProbability;
+    int32_t randomProbability = ScenarioRand() % totalProbability;
 
     // Find which problem range the random number lies
     problemBits = availableBreakdownProblems;

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -885,7 +885,7 @@ static void TrackDesignMirrorMaze(TrackDesign& td)
     {
         maze.location.y = -maze.location.y;
 
-        auto mazeEntry = maze.mazeEntry;
+        uint32_t mazeEntry = maze.mazeEntry;
         uint16_t newEntry = 0;
         for (uint8_t position = UtilBitScanForward(mazeEntry); position != 0xFF; position = UtilBitScanForward(mazeEntry))
         {

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -62,11 +62,11 @@ int32_t MphToDmps(int32_t mph)
     return (mph * 73243) >> 14;
 }
 
-int32_t UtilBitScanForward(int32_t source)
+int32_t UtilBitScanForward(uint32_t source)
 {
 #if defined(_MSC_VER) && (_MSC_VER >= 1400) // Visual Studio 2005
     DWORD i;
-    uint8_t success = _BitScanForward(&i, static_cast<uint32_t>(source));
+    uint8_t success = _BitScanForward(&i, source);
     return success != 0 ? i : -1;
 #elif defined(__GNUC__)
     int32_t success = __builtin_ffs(source);
@@ -84,11 +84,11 @@ int32_t UtilBitScanForward(int32_t source)
 #endif
 }
 
-int32_t UtilBitScanForward(int64_t source)
+int32_t UtilBitScanForward(uint64_t source)
 {
 #if defined(_MSC_VER) && (_MSC_VER >= 1400) && defined(_M_X64) // Visual Studio 2005
     DWORD i;
-    uint8_t success = _BitScanForward64(&i, static_cast<uint64_t>(source));
+    uint8_t success = _BitScanForward64(&i, source);
     return success != 0 ? i : -1;
 #elif defined(__GNUC__)
     int32_t success = __builtin_ffsll(source);

--- a/src/openrct2/util/Util.h
+++ b/src/openrct2/util/Util.h
@@ -24,8 +24,8 @@ int32_t MetresToFeet(int32_t metres);
 int32_t MphToKmph(int32_t mph);
 int32_t MphToDmps(int32_t mph);
 
-int32_t UtilBitScanForward(int32_t source);
-int32_t UtilBitScanForward(int64_t source);
+int32_t UtilBitScanForward(uint32_t source);
+int32_t UtilBitScanForward(uint64_t source);
 int32_t StrLogicalCmp(char const* a, char const* b);
 char* SafeStrCpy(char* destination, const char* source, size_t num);
 char* SafeStrCat(char* destination, const char* source, size_t size);

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -359,7 +359,7 @@ CoordsXY FootpathBridgeGetInfoFromPos(const ScreenCoordsXY& screenCoords, int32_
         && viewport->flags & (VIEWPORT_FLAG_UNDERGROUND_INSIDE | VIEWPORT_FLAG_HIDE_BASE | VIEWPORT_FLAG_HIDE_VERTICAL)
         && (*tileElement)->GetType() == TileElementType::Entrance)
     {
-        int32_t directions = (*tileElement)->AsEntrance()->GetDirections();
+        uint32_t directions = (*tileElement)->AsEntrance()->GetDirections();
         if (directions & 0x0F)
         {
             int32_t bx = UtilBitScanForward(directions);
@@ -376,7 +376,7 @@ CoordsXY FootpathBridgeGetInfoFromPos(const ScreenCoordsXY& screenCoords, int32_
         EnumsToFlags(ViewportInteractionItem::Terrain, ViewportInteractionItem::Footpath, ViewportInteractionItem::Ride));
     if (info.SpriteType == ViewportInteractionItem::Ride && (*tileElement)->GetType() == TileElementType::Entrance)
     {
-        int32_t directions = (*tileElement)->AsEntrance()->GetDirections();
+        uint32_t directions = (*tileElement)->AsEntrance()->GetDirections();
         if (directions & 0x0F)
         {
             int32_t bx = (*tileElement)->GetDirectionWithOffset(UtilBitScanForward(directions));
@@ -1285,7 +1285,7 @@ static void FootpathFixOwnership(const CoordsXY& mapPos)
     GameActions::Execute(&landSetRightsAction);
 }
 
-static bool GetNextDirection(int32_t edges, int32_t* direction)
+static bool GetNextDirection(uint32_t edges, int32_t* direction)
 {
     int32_t index = UtilBitScanForward(edges);
     if (index == -1)


### PR DESCRIPTION
We have two implementations of `UtilBitScanForward`, each of which was taking a _signed_ integer as its parameter. To ensure the sign bit is also taken into account, we should make it take an _unsigned_ integer instead.

To counter warnings as a result of implicit integer casts, I have widened the types for some of the callers to `uint32_t` in a few places. This disambiguates which function they should call, and thereby deals with these warnings.