### PR TITLE
Unify graph functions by templating them

### DIFF
--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -48,6 +48,17 @@ namespace OpenRCT2::Graph
     }
 
     template<typename T>
+    constexpr int32_t GetYCoord(T value, [[maybe_unused]] int32_t modifier, [[maybe_unused]] int32_t offset)
+    {
+        return ((255 - value) * 100) / 256;
+    }
+
+    constexpr int32_t GetYCoord(money64 value, int32_t modifier, int32_t offset)
+    {
+        return 170 - 6 - ((((value >> modifier) + offset) * 170) / 256);
+    }
+
+    template<typename T>
     static const ScreenCoordsXY ScreenCoordsForHistoryIndex(
         const int32_t index, const T* history, const int32_t chartX, const int32_t chartY, const int32_t modifier,
         const int32_t offset)
@@ -114,7 +125,7 @@ namespace OpenRCT2::Graph
         {
             if (history[i] != GraphNullValue())
             {
-                coords.y = origCoords.y + 170 - 6 - ((((history[i] >> modifier) + offset) * 170) / 256);
+                coords.y = origCoords.y + GetYCoord(history[i], modifier, offset);
 
                 if (lastCoordsValid)
                 {
@@ -146,7 +157,7 @@ namespace OpenRCT2::Graph
         {
             if (history[i] != GraphNullValue())
             {
-                coords.y = origCoords.y + 170 - 6 - ((((history[i] >> modifier) + offset) * 170) / 256);
+                coords.y = origCoords.y + GetYCoord(history[i], modifier, offset);
 
                 if (lastCoordsValid)
                 {


### PR DESCRIPTION
Needs some work still, but worth doing. Perhaps, in doing this, we can expand the search lines from the finance window to the other graphs with relative ease as well.

To do:
- [x] Parametrise the graph dimensions. (Finance and Park windows use different ones)
- [x] Fix search line invalidation errors in Finance window charts. -> #22409
- [ ] Try adding search lines to Park window charts as well.