### PR TITLE
Invalidate finance graphs when hovered over

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -29,6 +29,7 @@
 - Fix: [#22333] Tile inspector closes other tool windows.
 - Fix: [#22339] Printing ui.tool.cursor in console crashes the game.
 - Fix: [#22348] Progress bar screen doesn’t handle window resizing.
+- Fix: [#22409] Search lines in finance graphs aren’t invalidating properly.
 
 0.4.12 (2024-07-07)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -14,6 +14,7 @@
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
 #include <openrct2/GameState.h>
+#include <openrct2/Input.h>
 #include <openrct2/actions/ParkSetLoanAction.h>
 #include <openrct2/actions/ParkSetResearchFundingAction.h>
 #include <openrct2/localisation/Formatter.h>
@@ -242,6 +243,14 @@ static Widget _windowFinancesResearchWidgets[] =
         {
             frame_no++;
             InvalidateWidget(WIDX_TAB_1 + page);
+
+            if (gHoverWidget.window_classification == WindowClass::Finances
+                && (page == WINDOW_FINANCES_PAGE_FINANCIAL_GRAPH || page == WINDOW_FINANCES_PAGE_VALUE_GRAPH
+                    || page == WINDOW_FINANCES_PAGE_PROFIT_GRAPH)
+                && gHoverWidget.widget_index == WIDX_PAGE_BACKGROUND)
+            {
+                InvalidateWidget(WIDX_PAGE_BACKGROUND);
+            }
         }
 
         void OnMouseDown(WidgetIndex widgetIndex) override


### PR DESCRIPTION
The finance graphs has showed search lines and a reference value when hovering over the chart (#10925). This was designed with OpenGL in mind, and therefore needed extra invalidating for the software renderer (#11112).

It seems the invalidation got lost somewhere along the way -- perhaps when the window was converted into a class. This PR reimplements the correct invalidation, such that it only happens when the graph canvas is actually being hovered over.