### PR TITLE
RideConstruction: move virtual floor to UI counterpart

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -33,6 +33,7 @@
 #include <openrct2/network/network.h>
 #include <openrct2/object/ObjectManager.h>
 #include <openrct2/paint/tile_element/Paint.TileElement.h>
+#include <openrct2/paint/VirtualFloor.h>
 #include <openrct2/platform/Platform.h>
 #include <openrct2/ride/Ride.h>
 #include <openrct2/ride/RideConstruction.h>
@@ -1020,10 +1021,16 @@ static Widget _rideConstructionWidgets[] = {
                     MouseUpDemolish();
                     break;
                 case WIDX_NEXT_SECTION:
+                    VirtualFloorInvalidate();
                     RideSelectNextSection();
+                    if (!SceneryToolIsActive())
+                        VirtualFloorSetHeight(_currentTrackBegin.z);
                     break;
                 case WIDX_PREVIOUS_SECTION:
+                    VirtualFloorInvalidate();
                     RideSelectPreviousSection();
+                    if (!SceneryToolIsActive())
+                        VirtualFloorSetHeight(_currentTrackBegin.z);
                     break;
                 case WIDX_LEFT_CURVE:
                     RideConstructionInvalidateCurrentTrack();
@@ -3127,6 +3134,15 @@ static Widget _rideConstructionWidgets[] = {
                         _currentTrackPrice = PlaceProvisionalTrackPiece(
                             rideIndex, type, direction, liftHillAndAlternativeState, trackPos);
                         WindowRideConstructionUpdateActiveElements();
+
+                        // Invalidate previous track piece (we may not be changing height!)
+                        VirtualFloorInvalidate();
+
+                        if (!SceneryToolIsActive())
+                        {
+                            // Set height to where the next track piece would begin
+                            VirtualFloorSetHeight(_currentTrackBegin.z);
+                        }
                     }
                 }
                 // update flashing arrow

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -32,8 +32,8 @@
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/network/network.h>
 #include <openrct2/object/ObjectManager.h>
-#include <openrct2/paint/tile_element/Paint.TileElement.h>
 #include <openrct2/paint/VirtualFloor.h>
+#include <openrct2/paint/tile_element/Paint.TileElement.h>
 #include <openrct2/platform/Platform.h>
 #include <openrct2/ride/Ride.h>
 #include <openrct2/ride/RideConstruction.h>

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -44,7 +44,6 @@
 #include "../object/ObjectManager.h"
 #include "../object/RideObject.h"
 #include "../object/StationObject.h"
-#include "../paint/VirtualFloor.h"
 #include "../profiling/Profiling.h"
 #include "../rct1/RCT1.h"
 #include "../scenario/Scenario.h"

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -26,7 +26,6 @@
 #include "../localisation/Formatter.h"
 #include "../localisation/Localisation.Date.h"
 #include "../network/network.h"
-#include "../paint/VirtualFloor.h"
 #include "../ui/UiContext.h"
 #include "../ui/WindowManager.h"
 #include "../util/Util.h"
@@ -777,9 +776,6 @@ void RideSelectNextSection()
             return;
         }
 
-        // Invalidate previous track piece (we may not be changing height!)
-        VirtualFloorInvalidate();
-
         CoordsXYE inputElement, outputElement;
         inputElement.x = newCoords->x;
         inputElement.y = newCoords->y;
@@ -789,12 +785,6 @@ void RideSelectNextSection()
             newCoords->x = outputElement.x;
             newCoords->y = outputElement.y;
             tileElement = outputElement.element;
-            if (!SceneryToolIsActive())
-            {
-                // Set next element's height.
-                VirtualFloorSetHeight(tileElement->GetBaseZ());
-            }
-
             _currentTrackBegin = *newCoords;
             _currentTrackPieceDirection = tileElement->GetDirection();
             _currentTrackPieceType = tileElement->AsTrack()->GetTrackType();
@@ -844,9 +834,6 @@ void RideSelectPreviousSection()
             return;
         }
 
-        // Invalidate previous track piece (we may not be changing height!)
-        VirtualFloorInvalidate();
-
         TrackBeginEnd trackBeginEnd;
         if (TrackBlockGetPrevious({ *newCoords, tileElement }, &trackBeginEnd))
         {
@@ -856,11 +843,6 @@ void RideSelectPreviousSection()
             _currentTrackPieceDirection = trackBeginEnd.begin_direction;
             _currentTrackPieceType = trackBeginEnd.begin_element->AsTrack()->GetTrackType();
             _currentTrackSelectionFlags = 0;
-            if (!SceneryToolIsActive())
-            {
-                // Set previous element's height.
-                VirtualFloorSetHeight(trackBeginEnd.begin_element->GetBaseZ());
-            }
             WindowRideConstructionUpdateActiveElements();
         }
         else

--- a/src/openrct2/windows/_legacy.cpp
+++ b/src/openrct2/windows/_legacy.cpp
@@ -18,7 +18,6 @@
 #include "../entity/Staff.h"
 #include "../interface/Viewport.h"
 #include "../network/network.h"
-#include "../paint/VirtualFloor.h"
 #include "../ride/RideConstruction.h"
 #include "../ride/RideData.h"
 #include "../ride/Track.h"
@@ -67,15 +66,6 @@ money64 PlaceProvisionalTrackPiece(
         if (_currentTrackPitchEnd != TrackPitch::None)
             ViewportSetVisibility(ViewportVisibility::TrackHeights);
 
-        // Invalidate previous track piece (we may not be changing height!)
-        VirtualFloorInvalidate();
-
-        if (!SceneryToolIsActive())
-        {
-            // Set new virtual floor height.
-            VirtualFloorSetHeight(trackPos.z);
-        }
-
         return result.Cost;
     }
 
@@ -88,17 +78,12 @@ money64 PlaceProvisionalTrackPiece(
     if (res.Error != GameActions::Status::Ok)
         return kMoney64Undefined;
 
-    int16_t z_begin, z_end;
+    int16_t z_begin{};
     const auto& ted = GetTrackElementDescriptor(trackType);
     const TrackCoordinates& coords = ted.Coordinates;
     if (ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_HAS_TRACK))
     {
         z_begin = coords.z_begin;
-        z_end = coords.z_end;
-    }
-    else
-    {
-        z_end = z_begin = coords.z_begin;
     }
 
     _unkF440C5 = { trackPos.x, trackPos.y, trackPos.z + z_begin, static_cast<Direction>(trackDirection) };
@@ -110,15 +95,6 @@ money64 PlaceProvisionalTrackPiece(
     ViewportSetVisibility(visiblity);
     if (_currentTrackPitchEnd != TrackPitch::None)
         ViewportSetVisibility(ViewportVisibility::TrackHeights);
-
-    // Invalidate previous track piece (we may not be changing height!)
-    VirtualFloorInvalidate();
-
-    if (!SceneryToolIsActive())
-    {
-        // Set height to where the next track piece would begin
-        VirtualFloorSetHeight(trackPos.z - z_begin + z_end);
-    }
 
     return res.Cost;
 }


### PR DESCRIPTION
Just a small cleanup. Hopefully we can move the virtual floor entirely into the UI namespace at some point.