### PR TITLE
Replace some functions from _legacy.cpp with their intents

### DIFF
--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -12,6 +12,7 @@
 #include "../interface/Window.h"
 
 #include <memory>
+#include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
 #include <openrct2/Diagnostic.h>
 #include <openrct2/Game.h>
@@ -24,7 +25,6 @@
 #include <openrct2/core/String.hpp>
 #include <openrct2/entity/EntityRegistry.h>
 #include <openrct2/interface/Viewport.h>
-#include <openrct2/interface/Window.h>
 #include <openrct2/localisation/StringIds.h>
 #include <openrct2/management/NewsItem.h>
 #include <openrct2/object/ObjectManager.h>
@@ -437,7 +437,7 @@ namespace OpenRCT2::Title
             ResetAllSpriteQuadrantPlacements();
             auto intent = Intent(INTENT_ACTION_REFRESH_NEW_RIDES);
             ContextBroadcastIntent(&intent);
-            ScenerySetDefaultPlacementConfiguration();
+            Ui::Windows::WindowScenerySetDefaultPlacementConfiguration();
             News::InitQueue();
             LoadPalette();
             gScreenAge = 0;

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -163,7 +163,7 @@ static Widget _editorBottomToolbarWidgets[] = {
         {
             WindowCloseAll();
             SetAllSceneryItemsInvented();
-            ScenerySetDefaultPlacementConfiguration();
+            WindowScenerySetDefaultPlacementConfiguration();
             GetGameState().EditorStep = EditorStep::LandscapeEditor;
             ContextOpenWindow(WindowClass::Map);
             GfxInvalidateScreen();

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -182,6 +182,7 @@ static Widget _rideConstructionWidgets[] = {
     };
 
     static void WindowRideConstructionMouseUpDemolishNextPiece(const CoordsXYZD& piecePos, int32_t type);
+    static void WindowRideConstructionUpdateActiveElements();
 
     /* move to ride.c */
     static void CloseRideWindowForConstruction(RideId rideId)
@@ -4628,5 +4629,11 @@ static Widget _rideConstructionWidgets[] = {
             }
             WindowRideConstructionUpdateActiveElements();
         }
+    }
+
+    static void WindowRideConstructionUpdateActiveElements()
+    {
+        auto intent = Intent(INTENT_ACTION_RIDE_CONSTRUCTION_UPDATE_ACTIVE_ELEMENTS);
+        ContextBroadcastIntent(&intent);
     }
 } // namespace OpenRCT2::Ui::Windows

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -384,14 +384,13 @@ namespace OpenRCT2::Editor
         windowManager->SetMainView(gameState.SavedView, gameState.SavedViewZoom, gameState.SavedViewRotation);
 
         ResetAllSpriteQuadrantPlacements();
-        ScenerySetDefaultPlacementConfiguration();
 
+        windowManager->BroadcastIntent(Intent(INTENT_ACTION_SET_DEFAULT_SCENERY_CONFIG));
         windowManager->BroadcastIntent(Intent(INTENT_ACTION_REFRESH_NEW_RIDES));
+        windowManager->BroadcastIntent(Intent(INTENT_ACTION_CLEAR_TILE_INSPECTOR_CLIPBOARD));
 
         gWindowUpdateTicks = 0;
         LoadPalette();
-
-        windowManager->BroadcastIntent(Intent(INTENT_ACTION_CLEAR_TILE_INSPECTOR_CLIPBOARD));
     }
 
     /**

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -501,7 +501,10 @@ void FinishObjectSelection()
     else
     {
         SetAllSceneryItemsInvented();
-        ScenerySetDefaultPlacementConfiguration();
+
+        auto intent = Intent(INTENT_ACTION_SET_DEFAULT_SCENERY_CONFIG);
+        ContextBroadcastIntent(&intent);
+
         gameState.EditorStep = EditorStep::LandscapeEditor;
         GfxInvalidateScreen();
     }

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -369,10 +369,6 @@ void GameLoadInit()
     }
     ResetEntitySpatialIndices();
     ResetAllSpriteQuadrantPlacements();
-    ScenerySetDefaultPlacementConfiguration();
-
-    auto intent = Intent(INTENT_ACTION_REFRESH_NEW_RIDES);
-    ContextBroadcastIntent(&intent);
 
     gWindowUpdateTicks = 0;
     gCurrentRealTimeTicks = 0;
@@ -381,8 +377,9 @@ void GameLoadInit()
 
     if (!gOpenRCT2Headless)
     {
-        intent = Intent(INTENT_ACTION_CLEAR_TILE_INSPECTOR_CLIPBOARD);
-        ContextBroadcastIntent(&intent);
+        windowManager->BroadcastIntent(Intent(INTENT_ACTION_SET_DEFAULT_SCENERY_CONFIG));
+        windowManager->BroadcastIntent(Intent(INTENT_ACTION_REFRESH_NEW_RIDES));
+        windowManager->BroadcastIntent(Intent(INTENT_ACTION_CLEAR_TILE_INSPECTOR_CLIPBOARD));
     }
 
     gGameSpeed = 1;

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -83,10 +83,12 @@ namespace OpenRCT2
         GetGameState().NextGuestNumber = 1;
 
         ContextInit();
-        ScenerySetDefaultPlacementConfiguration();
 
-        auto intent = Intent(INTENT_ACTION_CLEAR_TILE_INSPECTOR_CLIPBOARD);
-        ContextBroadcastIntent(&intent);
+        auto sceneryIntent = Intent(INTENT_ACTION_SET_DEFAULT_SCENERY_CONFIG);
+        ContextBroadcastIntent(&sceneryIntent);
+
+        auto clipboardIntent = Intent(INTENT_ACTION_CLEAR_TILE_INSPECTOR_CLIPBOARD);
+        ContextBroadcastIntent(&clipboardIntent);
 
         LoadPalette();
 

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1273,10 +1273,12 @@ static int32_t ConsoleCommandLoadObject(InteractiveConsole& console, const argum
             ResearchResetCurrentItem();
             gSilentResearch = false;
         }
-        ScenerySetDefaultPlacementConfiguration();
 
-        auto intent = Intent(INTENT_ACTION_REFRESH_NEW_RIDES);
-        ContextBroadcastIntent(&intent);
+        auto sceneryIntent = Intent(INTENT_ACTION_SET_DEFAULT_SCENERY_CONFIG);
+        ContextBroadcastIntent(&sceneryIntent);
+
+        auto ridesIntent = Intent(INTENT_ACTION_REFRESH_NEW_RIDES);
+        ContextBroadcastIntent(&ridesIntent);
 
         gWindowUpdateTicks = 0;
         GfxInvalidateScreen();

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -9,6 +9,7 @@
 
 #include "Research.h"
 
+#include "../Context.h"
 #include "../Date.h"
 #include "../Diagnostic.h"
 #include "../Game.h"
@@ -34,6 +35,7 @@
 #include "../ride/TrackData.h"
 #include "../scenario/Scenario.h"
 #include "../util/Util.h"
+#include "../windows/Intent.h"
 #include "../world/Park.h"
 #include "../world/Scenery.h"
 #include "Finance.h"
@@ -296,7 +298,9 @@ void ResearchFinishItem(const ResearchItem& researchItem)
             }
 
             ResearchInvalidateRelatedWindows();
-            SceneryInit();
+
+            auto intent = Intent(INTENT_ACTION_INIT_SCENERY);
+            ContextBroadcastIntent(&intent);
         }
     }
 }

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -1046,7 +1046,6 @@ bool TrackBlockGetPreviousFromZero(
 
 void RideGetStartOfTrack(CoordsXYE* output);
 
-void WindowRideConstructionUpdateActiveElements();
 money64 RideEntranceExitPlaceGhost(
     const Ride& ride, const CoordsXY& entranceExitCoords, Direction direction, int32_t placeType, StationIndex stationNum);
 

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -464,6 +464,12 @@ std::optional<CoordsXYZ> GetTrackElementOriginAndApplyChanges(
     return retCoordsXYZ;
 }
 
+static void WindowRideConstructionUpdateActiveElements()
+{
+    auto intent = Intent(INTENT_ACTION_RIDE_CONSTRUCTION_UPDATE_ACTIVE_ELEMENTS);
+    ContextBroadcastIntent(&intent);
+}
+
 void RideRestoreProvisionalTrackPiece()
 {
     if (_currentTrackSelectionFlags & TRACK_SELECTION_FLAG_TRACK)

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -94,7 +94,10 @@ void ScenarioReset(GameState_t& gameState)
     gameState.ScenarioRand.seed(s);
 
     ResearchResetCurrentItem();
-    ScenerySetDefaultPlacementConfiguration();
+
+    auto intent = Intent(INTENT_ACTION_SET_DEFAULT_SCENERY_CONFIG);
+    ContextBroadcastIntent(&intent);
+
     News::InitQueue();
 
     gameState.Park.Rating = Park::CalculateParkRating();

--- a/src/openrct2/windows/_legacy.cpp
+++ b/src/openrct2/windows/_legacy.cpp
@@ -411,12 +411,6 @@ bool SceneryToolIsActive()
     return false;
 }
 
-void SceneryInit()
-{
-    auto intent = Intent(INTENT_ACTION_INIT_SCENERY);
-    ContextBroadcastIntent(&intent);
-}
-
 void ScenerySetDefaultPlacementConfiguration()
 {
     auto intent = Intent(INTENT_ACTION_SET_DEFAULT_SCENERY_CONFIG);

--- a/src/openrct2/windows/_legacy.cpp
+++ b/src/openrct2/windows/_legacy.cpp
@@ -398,16 +398,6 @@ bool WindowRideConstructionUpdateState(
 
 /**
  *
- *  rct2: 0x006C84CE
- */
-void WindowRideConstructionUpdateActiveElements()
-{
-    auto intent = Intent(INTENT_ACTION_RIDE_CONSTRUCTION_UPDATE_ACTIVE_ELEMENTS);
-    ContextBroadcastIntent(&intent);
-}
-
-/**
- *
  *  rct2: 0x0066DB3D
  */
 bool SceneryToolIsActive()

--- a/src/openrct2/windows/_legacy.cpp
+++ b/src/openrct2/windows/_legacy.cpp
@@ -410,9 +410,3 @@ bool SceneryToolIsActive()
 
     return false;
 }
-
-void ScenerySetDefaultPlacementConfiguration()
-{
-    auto intent = Intent(INTENT_ACTION_SET_DEFAULT_SCENERY_CONFIG);
-    ContextBroadcastIntent(&intent);
-}

--- a/src/openrct2/world/Scenery.h
+++ b/src/openrct2/world/Scenery.h
@@ -69,7 +69,6 @@ extern const CoordsXY SceneryQuadrantOffsets[];
 extern money64 gClearSceneryCost;
 
 void SceneryUpdateTile(const CoordsXY& sceneryPos);
-void ScenerySetDefaultPlacementConfiguration();
 void SceneryRemoveGhostToolPlacement();
 
 struct WallSceneryEntry;

--- a/src/openrct2/world/Scenery.h
+++ b/src/openrct2/world/Scenery.h
@@ -68,7 +68,6 @@ extern const CoordsXY SceneryQuadrantOffsets[];
 
 extern money64 gClearSceneryCost;
 
-void SceneryInit();
 void SceneryUpdateTile(const CoordsXY& sceneryPos);
 void ScenerySetDefaultPlacementConfiguration();
 void SceneryRemoveGhostToolPlacement();

--- a/test/tests/PlayTests.cpp
+++ b/test/tests/PlayTests.cpp
@@ -57,7 +57,6 @@ static std::unique_ptr<IContext> localStartGame(const std::string& parkPath)
     ResetEntitySpatialIndices();
 
     ResetAllSpriteQuadrantPlacements();
-    ScenerySetDefaultPlacementConfiguration();
     LoadPalette();
     EntityTweener::Get().Reset();
     MapAnimationAutoCreate();

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -65,7 +65,6 @@ static void GameInit(bool retainSpatialIndices)
         ResetEntitySpatialIndices();
 
     ResetAllSpriteQuadrantPlacements();
-    ScenerySetDefaultPlacementConfiguration();
     LoadPalette();
     EntityTweener::Get().Reset();
     MapAnimationAutoCreate();


### PR DESCRIPTION
Some long-overdue long-hanging fruit.

I have an idea for `SceneryToolIsActive` as well, but that should really be tackled after #22428 has been merged.
Edit: see #22430.