### PR TITLE
Introduce isToolActive function as alternative for gCurrentToolWidget global

### DIFF
--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -199,8 +199,7 @@ namespace OpenRCT2::Ui
                          w.windowPos + ScreenCoordsXY{ widget.right, widget.bottom } };
 
         // Check if the button is pressed down
-        uint8_t press = WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex) ? INSET_RECT_FLAG_BORDER_INSET
-                                                                                              : 0;
+        uint8_t press = WidgetIsPressed(w, widgetIndex) || isToolActive(w, widgetIndex) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
         auto colour = w.colours[widget.colour];
 
@@ -288,7 +287,7 @@ namespace OpenRCT2::Ui
         auto colour = w.colours[widget.colour];
 
         // Check if the button is pressed down
-        if (WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex))
+        if (WidgetIsPressed(w, widgetIndex) || isToolActive(w, widgetIndex))
         {
             if (static_cast<int32_t>(widget.image.ToUInt32()) == -2)
             {
@@ -321,8 +320,7 @@ namespace OpenRCT2::Ui
         auto colour = w.colours[widget.colour];
 
         // Border
-        uint8_t press = WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex) ? INSET_RECT_FLAG_BORDER_INSET
-                                                                                              : 0;
+        uint8_t press = WidgetIsPressed(w, widgetIndex) || isToolActive(w, widgetIndex) ? INSET_RECT_FLAG_BORDER_INSET : 0;
         GfxFillRectInset(dpi, rect, colour, press);
 
         // Button caption
@@ -597,7 +595,7 @@ namespace OpenRCT2::Ui
         uint8_t press = 0;
         if (w.flags & WF_10)
             press |= INSET_RECT_FLAG_FILL_MID_LIGHT;
-        if (WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex))
+        if (WidgetIsPressed(w, widgetIndex) || isToolActive(w, widgetIndex))
             press |= INSET_RECT_FLAG_BORDER_INSET;
 
         auto colour = w.colours[widget.colour];
@@ -826,7 +824,7 @@ namespace OpenRCT2::Ui
 
         if (widget.type == WindowWidgetType::ColourBtn || widget.type == WindowWidgetType::TrnBtn
             || widget.type == WindowWidgetType::Tab)
-            if (WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex))
+            if (WidgetIsPressed(w, widgetIndex) || isToolActive(w, widgetIndex))
                 image = image.WithIndexOffset(1);
 
         const auto colour = w.colours[widget.colour].colour;
@@ -915,20 +913,6 @@ namespace OpenRCT2::Ui
             return false;
         if (gHoverWidget.widget_index != widgetIndex)
             return false;
-        return true;
-    }
-
-    bool WidgetIsActiveTool(const WindowBase& w, WidgetIndex widgetIndex)
-    {
-        if (!(InputTestFlag(INPUT_FLAG_TOOL_ACTIVE)))
-            return false;
-        if (gCurrentToolWidget.window_classification != w.classification)
-            return false;
-        if (gCurrentToolWidget.window_number != w.number)
-            return false;
-        if (gCurrentToolWidget.widget_index != widgetIndex)
-            return false;
-
         return true;
     }
 

--- a/src/openrct2-ui/interface/Widget.h
+++ b/src/openrct2-ui/interface/Widget.h
@@ -177,7 +177,6 @@ namespace OpenRCT2::Ui
     bool WidgetIsVisible(const WindowBase& w, WidgetIndex widgetIndex);
     bool WidgetIsPressed(const WindowBase& w, WidgetIndex widgetIndex);
     bool WidgetIsHighlighted(const WindowBase& w, WidgetIndex widgetIndex);
-    bool WidgetIsActiveTool(const WindowBase& w, WidgetIndex widgetIndex);
     void WidgetScrollGetPart(
         WindowBase& w, const Widget* widget, const ScreenCoordsXY& screenCoords, ScreenCoordsXY& retScreenCoords,
         int32_t* output_scroll_area, int32_t* scroll_id);

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -497,7 +497,7 @@ static void WindowInvalidatePressedImageButton(const WindowBase& w)
         if (widget->type != WindowWidgetType::ImgBtn)
             continue;
 
-        if (WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex))
+        if (WidgetIsPressed(w, widgetIndex) || isToolActive(w, widgetIndex))
             GfxSetDirtyBlocks({ w.windowPos, w.windowPos + ScreenCoordsXY{ w.width, w.height } });
     }
 }

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -87,7 +87,7 @@ namespace OpenRCT2::Ui::Windows
 
         void OnClose() override
         {
-            if (ClearSceneryToolIsActive())
+            if (isToolActive(WindowClass::ClearScenery, WIDX_BACKGROUND))
                 ToolCancel();
         }
 
@@ -164,7 +164,7 @@ namespace OpenRCT2::Ui::Windows
         {
             frame_no++;
             // Close window if another tool is open
-            if (!ClearSceneryToolIsActive())
+            if (!isToolActive(WindowClass::ClearScenery, WIDX_BACKGROUND))
                 Close();
         }
 
@@ -381,27 +381,11 @@ namespace OpenRCT2::Ui::Windows
 
     /**
      *
-     *  rct2: 0x0066D125
-     */
-    bool ClearSceneryToolIsActive()
-    {
-        if (!(InputTestFlag(INPUT_FLAG_TOOL_ACTIVE)))
-            return false;
-        if (gCurrentToolWidget.window_classification != WindowClass::ClearScenery)
-            return false;
-        if (gCurrentToolWidget.widget_index != WIDX_BACKGROUND)
-            return false;
-        return true;
-    }
-
-    /**
-     *
      *  rct2: 0x0066CD0C
      */
     void ToggleClearSceneryWindow()
     {
-        if ((InputTestFlag(INPUT_FLAG_TOOL_ACTIVE) && gCurrentToolWidget.window_classification == WindowClass::ClearScenery
-             && gCurrentToolWidget.widget_index == WIDX_BACKGROUND))
+        if (isToolActive(WindowClass::ClearScenery, WIDX_BACKGROUND))
         {
             ToolCancel();
         }

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -56,7 +56,7 @@ static constexpr int32_t WW_WINDOW = 106;
 
 #pragma region Widgets
 
-enum WindowFootpathWidgetIdx
+enum WindowFootpathWidgetIdx : WidgetIndex
 {
     WIDX_BACKGROUND,
     WIDX_TITLE,
@@ -209,33 +209,13 @@ static constexpr uint8_t ConstructionPreviewImages[][4] = {
             // Check tool
             if (_footpathConstructionMode == PATH_CONSTRUCTION_MODE_LAND)
             {
-                if (!(InputTestFlag(INPUT_FLAG_TOOL_ACTIVE)))
-                {
+                if (!isToolActive(WindowClass::Footpath, WIDX_CONSTRUCT_ON_LAND))
                     Close();
-                }
-                else if (gCurrentToolWidget.window_classification != WindowClass::Footpath)
-                {
-                    Close();
-                }
-                else if (gCurrentToolWidget.widget_index != WIDX_CONSTRUCT_ON_LAND)
-                {
-                    Close();
-                }
             }
             else if (_footpathConstructionMode == PATH_CONSTRUCTION_MODE_BRIDGE_OR_TUNNEL_TOOL)
             {
-                if (!(InputTestFlag(INPUT_FLAG_TOOL_ACTIVE)))
-                {
+                if (!isToolActive(WindowClass::Footpath, WIDX_CONSTRUCT_BRIDGE_OR_TUNNEL))
                     Close();
-                }
-                else if (gCurrentToolWidget.window_classification != WindowClass::Footpath)
-                {
-                    Close();
-                }
-                else if (gCurrentToolWidget.widget_index != WIDX_CONSTRUCT_BRIDGE_OR_TUNNEL)
-                {
-                    Close();
-                }
             }
         }
 

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -214,11 +214,8 @@ static_assert(_guestWindowPageWidgets.size() == WINDOW_GUEST_PAGE_COUNT);
 
         void OnClose() override
         {
-            if (InputTestFlag(INPUT_FLAG_TOOL_ACTIVE))
-            {
-                if (classification == gCurrentToolWidget.window_classification && number == gCurrentToolWidget.window_number)
-                    ToolCancel();
-            }
+            if (isToolActive(classification, number))
+                ToolCancel();
         }
 
         void OnMouseUp(WidgetIndex widx) override
@@ -499,11 +496,9 @@ static_assert(_guestWindowPageWidgets.size() == WINDOW_GUEST_PAGE_COUNT);
 
         void SetPage(int32_t newPage)
         {
-            if (InputTestFlag(INPUT_FLAG_TOOL_ACTIVE))
-            {
-                if (number == gCurrentToolWidget.window_number && classification == gCurrentToolWidget.window_classification)
-                    ToolCancel();
-            }
+            if (isToolActive(classification, number))
+                ToolCancel();
+
             int32_t listen = 0;
             if (newPage == WINDOW_GUEST_OVERVIEW && page == WINDOW_GUEST_OVERVIEW && viewport != nullptr)
             {

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -34,7 +34,8 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WW = 98;
 
     // clang-format off
-enum WindowLandWidgetIdx {
+enum WindowLandWidgetIdx : WidgetIndex
+{
     WIDX_BACKGROUND,
     WIDX_TITLE,
     WIDX_CLOSE,
@@ -100,7 +101,7 @@ static Widget window_land_widgets[] = {
         void OnClose() override
         {
             // If the tool wasn't changed, turn tool off
-            if (LandToolIsActive())
+            if (isToolActive(WindowClass::Land, WIDX_BACKGROUND))
                 ToolCancel();
         }
 
@@ -224,7 +225,7 @@ static Widget window_land_widgets[] = {
 
         void OnUpdate() override
         {
-            if (!LandToolIsActive())
+            if (!isToolActive(WindowClass::Land, WIDX_BACKGROUND))
                 Close();
         }
 
@@ -869,27 +870,11 @@ static Widget window_land_widgets[] = {
 
     /**
      *
-     *  rct2: 0x0066D104
-     */
-    bool LandToolIsActive()
-    {
-        if (!(InputTestFlag(INPUT_FLAG_TOOL_ACTIVE)))
-            return false;
-        if (gCurrentToolWidget.window_classification != WindowClass::Land)
-            return false;
-        if (gCurrentToolWidget.widget_index != WIDX_BACKGROUND)
-            return false;
-        return true;
-    }
-
-    /**
-     *
      *  rct2: 0x0066CD54
      */
     void ToggleLandWindow()
     {
-        if ((InputTestFlag(INPUT_FLAG_TOOL_ACTIVE)) && gCurrentToolWidget.window_classification == WindowClass::Land
-            && gCurrentToolWidget.widget_index == WIDX_BACKGROUND)
+        if (isToolActive(WindowClass::Land, WIDX_BACKGROUND))
         {
             ToolCancel();
         }

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -88,7 +88,7 @@ static Widget window_land_rights_widgets[] = {
             }
 
             // If the tool wasn't changed, turn tool off
-            if (LandRightsToolIsActive())
+            if (isToolActive(WindowClass::LandRights))
                 ToolCancel();
         }
 
@@ -168,7 +168,7 @@ static Widget window_land_rights_widgets[] = {
         {
             frame_no++;
             // Close window if another tool is open
-            if (!LandRightsToolIsActive())
+            if (!isToolActive(WindowClass::LandRights))
                 Close();
         }
 
@@ -396,15 +396,6 @@ static Widget window_land_rights_widgets[] = {
             ft.Add<uint16_t>(kLandToolMinimumSize);
             ft.Add<uint16_t>(kLandToolMaximumSize);
             WindowTextInputOpen(this, WIDX_PREVIEW, STR_SELECTION_SIZE, STR_ENTER_SELECTION_SIZE, ft, STR_NONE, STR_NONE, 3);
-        }
-
-        bool LandRightsToolIsActive()
-        {
-            if (!(InputTestFlag(INPUT_FLAG_TOOL_ACTIVE)))
-                return false;
-            if (gCurrentToolWidget.window_classification != WindowClass::LandRights)
-                return false;
-            return true;
         }
     };
 

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -95,7 +95,7 @@ namespace OpenRCT2::Ui::Windows
         PAGE_RIDES
     };
 
-    enum WindowMapWidgetIdx
+    enum WindowMapWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,
@@ -267,8 +267,8 @@ static Widget window_map_widgets[] = {
         {
             _mapImageData.clear();
             _mapImageData.shrink_to_fit();
-            if ((InputTestFlag(INPUT_FLAG_TOOL_ACTIVE)) && gCurrentToolWidget.window_classification == classification
-                && gCurrentToolWidget.window_number == number)
+
+            if (isToolActive(classification, number))
             {
                 ToolCancel();
             }
@@ -823,29 +823,21 @@ static Widget window_map_widgets[] = {
                 // Always show set land rights button
                 widgets[WIDX_SET_LAND_RIGHTS].type = WindowWidgetType::FlatBtn;
 
-                // If any tool is active
-                if ((InputTestFlag(INPUT_FLAG_TOOL_ACTIVE)) && gCurrentToolWidget.window_classification == WindowClass::Map)
+                if (isToolActive(WindowClass::Map, WIDX_SET_LAND_RIGHTS))
                 {
-                    // if not in set land rights mode: show the default scenario editor buttons
-                    if (gCurrentToolWidget.widget_index != WIDX_SET_LAND_RIGHTS)
-                    {
-                        ShowDefaultScenarioEditorButtons();
-                    }
-                    else
-                    { // if in set land rights mode: show land tool buttons + modes
-                        widgets[WIDX_LAND_TOOL].type = WindowWidgetType::ImgBtn;
-                        widgets[WIDX_LAND_TOOL_SMALLER].type = WindowWidgetType::TrnBtn;
-                        widgets[WIDX_LAND_TOOL_LARGER].type = WindowWidgetType::TrnBtn;
+                    // Show land tool buttons + modes
+                    widgets[WIDX_LAND_TOOL].type = WindowWidgetType::ImgBtn;
+                    widgets[WIDX_LAND_TOOL_SMALLER].type = WindowWidgetType::TrnBtn;
+                    widgets[WIDX_LAND_TOOL_LARGER].type = WindowWidgetType::TrnBtn;
 
-                        for (int32_t i = WIDX_LAND_OWNED_CHECKBOX; i <= WIDX_CONSTRUCTION_RIGHTS_SALE_CHECKBOX; i++)
-                            widgets[i].type = WindowWidgetType::Checkbox;
+                    for (int32_t i = WIDX_LAND_OWNED_CHECKBOX; i <= WIDX_CONSTRUCTION_RIGHTS_SALE_CHECKBOX; i++)
+                        widgets[i].type = WindowWidgetType::Checkbox;
 
-                        widgets[WIDX_LAND_TOOL].image = ImageId(LandTool::SizeToSpriteIndex(_landRightsToolSize));
-                    }
+                    widgets[WIDX_LAND_TOOL].image = ImageId(LandTool::SizeToSpriteIndex(_landRightsToolSize));
                 }
                 else
                 {
-                    // if no tool is active: show the default scenario editor buttons
+                    // Show the default scenario editor buttons
                     ShowDefaultScenarioEditorButtons();
                 }
             }

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -683,7 +683,7 @@ static Widget window_map_widgets[] = {
                     gLandToolTerrainSurface, gLandToolTerrainEdge);
                 GameActions::Execute(&surfaceSetStyleAction);
             }
-            else if (WidgetIsActiveTool(*this, WIDX_SET_LAND_RIGHTS))
+            else if (isToolActive(*this, WIDX_SET_LAND_RIGHTS))
             {
                 // Set land rights
                 int32_t landRightsToolSize = std::max<int32_t>(1, _landRightsToolSize);
@@ -857,7 +857,7 @@ static Widget window_map_widgets[] = {
                 + ScreenCoordsXY{ window_map_widgets[WIDX_LAND_TOOL].midX(), window_map_widgets[WIDX_LAND_TOOL].midY() };
 
             // Draw land tool size
-            if (WidgetIsActiveTool(*this, WIDX_SET_LAND_RIGHTS) && _landRightsToolSize > kLandToolMaximumSizeWithSprite)
+            if (isToolActive(*this, WIDX_SET_LAND_RIGHTS) && _landRightsToolSize > kLandToolMaximumSizeWithSprite)
             {
                 auto ft = Formatter();
                 ft.Add<uint16_t>(_landRightsToolSize);
@@ -898,7 +898,7 @@ static Widget window_map_widgets[] = {
                     }
                 }
             }
-            else if (!WidgetIsActiveTool(*this, WIDX_SET_LAND_RIGHTS))
+            else if (!isToolActive(*this, WIDX_SET_LAND_RIGHTS))
             {
                 DrawTextBasic(
                     dpi, windowPos + ScreenCoordsXY{ 4, widgets[WIDX_MAP_SIZE_SPINNER_Y].top + 1 }, STR_MAP_SIZE, {},

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -663,7 +663,7 @@ static Widget window_map_widgets[] = {
                 WindowScrollToLocation(*mainWindow, { mapCoords, mapZ });
             }
 
-            if (LandToolIsActive())
+            if (isToolActive(WindowClass::Land))
             {
                 // Set land terrain
                 int32_t landToolSize = std::max<int32_t>(1, gLandToolSize);

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -36,7 +36,8 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WW = 166;
 
     // clang-format off
-enum {
+enum : WidgetIndex
+{
     WIDX_BACKGROUND,
     WIDX_TITLE,
     WIDX_CLOSE,
@@ -242,8 +243,7 @@ static Widget window_maze_construction_widgets[] = {
                 case RideConstructionState::Front:
                 case RideConstructionState::Back:
                 case RideConstructionState::Selected:
-                    if ((InputTestFlag(INPUT_FLAG_TOOL_ACTIVE))
-                        && gCurrentToolWidget.window_classification == WindowClass::RideConstruction)
+                    if (isToolActive(WindowClass::RideConstruction))
                     {
                         ToolCancel();
                     }
@@ -358,7 +358,7 @@ static Widget window_maze_construction_widgets[] = {
                 entranceOrExitCoords, DirectionReverse(entranceOrExitCoords.direction), rideIndex,
                 gRideEntranceExitPlaceStationIndex, gRideEntranceExitPlaceType == ENTRANCE_TYPE_RIDE_EXIT);
 
-            rideEntranceExitPlaceAction.SetCallback([=](const GameAction* ga, const GameActions::Result* result) {
+            rideEntranceExitPlaceAction.SetCallback([=, this](const GameAction* ga, const GameActions::Result* result) {
                 if (result->Error != GameActions::Status::Ok)
                     return;
 
@@ -375,9 +375,12 @@ static Widget window_maze_construction_widgets[] = {
                 {
                     gRideEntranceExitPlaceType = gRideEntranceExitPlaceType ^ 1;
                     WindowInvalidateByClass(WindowClass::RideConstruction);
-                    gCurrentToolWidget.widget_index = (gRideEntranceExitPlaceType == ENTRANCE_TYPE_RIDE_ENTRANCE)
-                        ? WIDX_MAZE_ENTRANCE
-                        : WIDX_MAZE_EXIT;
+
+                    auto newToolWidgetIndex = (gRideEntranceExitPlaceType == ENTRANCE_TYPE_RIDE_ENTRANCE) ? WIDX_MAZE_ENTRANCE
+                                                                                                          : WIDX_MAZE_EXIT;
+
+                    ToolCancel();
+                    ToolSet(*this, newToolWidgetIndex, Tool::Crosshair);
 
                     WindowMazeConstructionUpdatePressedWidgets();
                 }
@@ -456,7 +459,7 @@ static Widget window_maze_construction_widgets[] = {
         switch (_rideConstructionState)
         {
             case RideConstructionState::EntranceExit:
-                if (gCurrentToolWidget.widget_index == WIDX_MAZE_ENTRANCE)
+                if (isToolActive(WindowClass::RideConstruction, WIDX_MAZE_ENTRANCE))
                 {
                     pressedWidgets |= EnumToFlag(WIDX_MAZE_ENTRANCE);
                 }

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -221,14 +221,14 @@ static Widget window_maze_construction_widgets[] = {
             switch (_rideConstructionState)
             {
                 case RideConstructionState::Place:
-                    if (!WidgetIsActiveTool(*this, WIDX_MAZE_DIRECTION_GROUPBOX))
+                    if (!isToolActive(*this, WIDX_MAZE_DIRECTION_GROUPBOX))
                     {
                         Close();
                         return;
                     }
                     break;
                 case RideConstructionState::EntranceExit:
-                    if (!WidgetIsActiveTool(*this, WIDX_MAZE_ENTRANCE) && !WidgetIsActiveTool(*this, WIDX_MAZE_EXIT))
+                    if (!isToolActive(*this, WIDX_MAZE_ENTRANCE) && !isToolActive(*this, WIDX_MAZE_EXIT))
                     {
                         _rideConstructionState = gRideEntranceExitPlacePreviousRideConstructionState;
                         WindowMazeConstructionUpdatePressedWidgets();

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -210,8 +210,7 @@ static constexpr WindowParkAward _parkAwards[] = {
 
         void OnClose() override
         {
-            if (InputTestFlag(INPUT_FLAG_TOOL_ACTIVE) && classification == gCurrentToolWidget.window_classification
-                && number == gCurrentToolWidget.window_number)
+            if (isToolActive(classification, number))
             {
                 ToolCancel();
             }
@@ -1201,9 +1200,8 @@ static constexpr WindowParkAward _parkAwards[] = {
 #pragma region Common
         void SetPage(int32_t newPage)
         {
-            if (InputTestFlag(INPUT_FLAG_TOOL_ACTIVE))
-                if (classification == gCurrentToolWidget.window_classification && number == gCurrentToolWidget.window_number)
-                    ToolCancel();
+            if (isToolActive(classification, number))
+                ToolCancel();
 
             // Set listen only to viewport
             bool listen = false;

--- a/src/openrct2-ui/windows/PatrolArea.cpp
+++ b/src/openrct2-ui/windows/PatrolArea.cpp
@@ -267,11 +267,7 @@ static Widget PatrolAreaWidgets[] = {
 
         bool PatrolAreaToolIsActive()
         {
-            if (!(InputTestFlag(INPUT_FLAG_TOOL_ACTIVE)))
-                return false;
-            if (gCurrentToolWidget.window_classification != WindowClass::PatrolArea)
-                return false;
-            return true;
+            return isToolActive(WindowClass::PatrolArea);
         }
 
         bool IsStaffWindowOpen()

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1048,9 +1048,8 @@ static_assert(std::size(RatingNames) == 6);
 
         void SetPage(int32_t newPage)
         {
-            if (InputTestFlag(INPUT_FLAG_TOOL_ACTIVE))
-                if (classification == gCurrentToolWidget.window_classification && number == gCurrentToolWidget.window_number)
-                    ToolCancel();
+            if (isToolActive(classification, number))
+                ToolCancel();
 
             if (newPage == WINDOW_RIDE_PAGE_VEHICLE)
             {
@@ -4134,16 +4133,8 @@ static_assert(std::size(RatingNames) == 6);
 
         void ColourClose()
         {
-            if (!(InputTestFlag(INPUT_FLAG_TOOL_ACTIVE)))
-                return;
-
-            if (gCurrentToolWidget.window_classification != classification)
-                return;
-
-            if (gCurrentToolWidget.window_number != number)
-                return;
-
-            ToolCancel();
+            if (isToolActive(classification, number))
+                ToolCancel();
         }
 
         void ColourOnMouseUp(WidgetIndex widgetIndex)
@@ -6899,12 +6890,9 @@ static_assert(std::size(RatingNames) == 6);
             w->SetViewIndex(0);
         }
 
-        if (InputTestFlag(INPUT_FLAG_TOOL_ACTIVE))
+        if (isToolActive(w->classification, w->number))
         {
-            if (w->classification == gCurrentToolWidget.window_classification && w->number == gCurrentToolWidget.window_number)
-            {
-                ToolCancel();
-            }
+            ToolCancel();
         }
 
         if (w->page != WINDOW_RIDE_PAGE_MAIN)
@@ -6934,8 +6922,7 @@ static_assert(std::size(RatingNames) == 6);
             w = WindowRideOpen(ride);
         }
 
-        if (InputTestFlag(INPUT_FLAG_TOOL_ACTIVE) && gCurrentToolWidget.window_classification == w->classification
-            && gCurrentToolWidget.window_number == w->number)
+        if (isToolActive(w->classification, w->number))
         {
             ToolCancel();
         }
@@ -7024,8 +7011,7 @@ static_assert(std::size(RatingNames) == 6);
         {
             w->Invalidate();
 
-            if (InputTestFlag(INPUT_FLAG_TOOL_ACTIVE) && gCurrentToolWidget.window_classification == w->classification
-                && gCurrentToolWidget.window_number == w->number)
+            if (isToolActive(w->classification, w->number))
             {
                 ToolCancel();
             }

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -935,7 +935,7 @@ static Widget _rideConstructionWidgets[] = {
 
             if (_rideConstructionState == RideConstructionState::Place)
             {
-                if (!WidgetIsActiveTool(*this, WIDX_CONSTRUCT))
+                if (!isToolActive(*this, WIDX_CONSTRUCT))
                 {
                     Close();
                     return;
@@ -944,7 +944,7 @@ static Widget _rideConstructionWidgets[] = {
 
             if (_rideConstructionState == RideConstructionState::EntranceExit)
             {
-                if (!WidgetIsActiveTool(*this, WIDX_ENTRANCE) && !WidgetIsActiveTool(*this, WIDX_EXIT))
+                if (!isToolActive(*this, WIDX_ENTRANCE) && !isToolActive(*this, WIDX_EXIT))
                 {
                     _rideConstructionState = gRideEntranceExitPlacePreviousRideConstructionState;
                     WindowRideConstructionUpdateActiveElements();

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1025,13 +1025,13 @@ static Widget _rideConstructionWidgets[] = {
                 case WIDX_NEXT_SECTION:
                     VirtualFloorInvalidate();
                     RideSelectNextSection();
-                    if (!SceneryToolIsActive())
+                    if (!isToolActive(WindowClass::Scenery))
                         VirtualFloorSetHeight(_currentTrackBegin.z);
                     break;
                 case WIDX_PREVIOUS_SECTION:
                     VirtualFloorInvalidate();
                     RideSelectPreviousSection();
-                    if (!SceneryToolIsActive())
+                    if (!isToolActive(WindowClass::Scenery))
                         VirtualFloorSetHeight(_currentTrackBegin.z);
                     break;
                 case WIDX_LEFT_CURVE:
@@ -2201,7 +2201,7 @@ static Widget _rideConstructionWidgets[] = {
         {
             // If the scenery tool is active, we do not display our tiles as it
             // will conflict with larger scenery objects selecting tiles
-            if (SceneryToolIsActive())
+            if (isToolActive(WindowClass::Scenery))
             {
                 return;
             }
@@ -3140,7 +3140,7 @@ static Widget _rideConstructionWidgets[] = {
                         // Invalidate previous track piece (we may not be changing height!)
                         VirtualFloorInvalidate();
 
-                        if (!SceneryToolIsActive())
+                        if (!isToolActive(WindowClass::Scenery))
                         {
                             // Set height to where the next track piece would begin
                             VirtualFloorSetHeight(_currentTrackBegin.z);

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -259,7 +259,7 @@ static Widget _rideConstructionWidgets[] = {
             // In order to cancel the yellow arrow correctly the
             // selection tool should be cancelled. Don't do a tool cancel if
             // another window has already taken control of tool.
-            if (classification == gCurrentToolWidget.window_classification && number == gCurrentToolWidget.window_number)
+            if (isToolActive(classification, number))
                 ToolCancel();
 
             HideGridlines();
@@ -956,8 +956,7 @@ static Widget _rideConstructionWidgets[] = {
                 case RideConstructionState::Front:
                 case RideConstructionState::Back:
                 case RideConstructionState::Selected:
-                    if ((InputTestFlag(INPUT_FLAG_TOOL_ACTIVE))
-                        && gCurrentToolWidget.window_classification == WindowClass::RideConstruction)
+                    if (isToolActive(WindowClass::RideConstruction))
                     {
                         ToolCancel();
                     }
@@ -2567,7 +2566,7 @@ static Widget _rideConstructionWidgets[] = {
                 entranceOrExitCoords, DirectionReverse(gRideEntranceExitPlaceDirection), gRideEntranceExitPlaceRideIndex,
                 gRideEntranceExitPlaceStationIndex, gRideEntranceExitPlaceType == ENTRANCE_TYPE_RIDE_EXIT);
 
-            rideEntranceExitPlaceAction.SetCallback([=](const GameAction* ga, const GameActions::Result* result) {
+            rideEntranceExitPlaceAction.SetCallback([=, this](const GameAction* ga, const GameActions::Result* result) {
                 if (result->Error != GameActions::Status::Ok)
                     return;
 
@@ -2586,9 +2585,13 @@ static Widget _rideConstructionWidgets[] = {
                 {
                     gRideEntranceExitPlaceType = gRideEntranceExitPlaceType ^ 1;
                     WindowInvalidateByClass(WindowClass::RideConstruction);
-                    gCurrentToolWidget.widget_index = (gRideEntranceExitPlaceType == ENTRANCE_TYPE_RIDE_ENTRANCE)
+
+                    auto newToolWidgetIndex = (gRideEntranceExitPlaceType == ENTRANCE_TYPE_RIDE_ENTRANCE)
                         ? WC_RIDE_CONSTRUCTION__WIDX_ENTRANCE
                         : WC_RIDE_CONSTRUCTION__WIDX_EXIT;
+
+                    ToolCancel();
+                    ToolSet(*this, newToolWidgetIndex, Tool::Crosshair);
                 }
             });
             auto res = GameActions::Execute(&rideEntranceExitPlaceAction);

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -241,7 +241,7 @@ static Widget WindowSceneryBaseWidgets[] = {
             if (gWindowSceneryScatterEnabled)
                 WindowCloseByClass(WindowClass::SceneryScatter);
 
-            if (SceneryToolIsActive())
+            if (isToolActive(WindowClass::Scenery))
                 ToolCancel();
         }
 
@@ -486,7 +486,7 @@ static Widget WindowSceneryBaseWidgets[] = {
 
             Invalidate();
 
-            if (!SceneryToolIsActive())
+            if (!isToolActive(WindowClass::Scenery))
             {
                 Close();
                 return;

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -65,7 +65,7 @@ namespace OpenRCT2::Ui::Windows
 
     constexpr uint8_t SceneryContentScrollIndex = 0;
 
-    enum WindowSceneryListWidgetIdx
+    enum WindowSceneryListWidgetIdx : WidgetIndex
     {
         WIDX_SCENERY_BACKGROUND,
         WIDX_SCENERY_TITLE,
@@ -3266,8 +3266,7 @@ static Widget WindowSceneryBaseWidgets[] = {
 
     void ToggleSceneryWindow()
     {
-        if ((InputTestFlag(INPUT_FLAG_TOOL_ACTIVE)) && gCurrentToolWidget.window_classification == WindowClass::Scenery
-            && gCurrentToolWidget.widget_index == WIDX_SCENERY_BACKGROUND)
+        if (isToolActive(WindowClass::Scenery, WIDX_SCENERY_BACKGROUND))
         {
             ToolCancel();
         }

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1077,11 +1077,8 @@ static Widget _staffOptionsWidgets[] = {
 
         void CancelTools()
         {
-            if (InputTestFlag(INPUT_FLAG_TOOL_ACTIVE))
-            {
-                if (number == gCurrentToolWidget.window_number && classification == gCurrentToolWidget.window_classification)
-                    ToolCancel();
-            }
+            if (isToolActive(classification, number))
+                ToolCancel();
         }
 
         void SetPage(int32_t pageNum)

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -632,13 +632,8 @@ static Widget _staffListWidgets[] = {
 
         void CancelTools()
         {
-            if (InputTestFlag(INPUT_FLAG_TOOL_ACTIVE))
-            {
-                if (classification == gCurrentToolWidget.window_classification && number == gCurrentToolWidget.window_number)
-                {
-                    ToolCancel();
-                }
-            }
+            if (isToolActive(classification, number))
+                ToolCancel();
         }
 
         Peep* GetClosestStaffMemberTo(const ScreenCoordsXY& screenCoords)

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -515,7 +515,8 @@ static uint64_t PageDisabledWidgets[] = {
                     InvalidateWidget(WIDX_LIST);
                 _highlightedIndex = -1;
             }
-            if (gCurrentToolWidget.window_classification != WindowClass::TileInspector)
+
+            if (!isToolActive(WindowClass::TileInspector))
                 Close();
         }
 
@@ -722,8 +723,9 @@ static uint64_t PageDisabledWidgets[] = {
 
         void OnClose() override
         {
-            if (gCurrentToolWidget.window_classification == WindowClass::TileInspector)
+            if (isToolActive(WindowClass::TileInspector))
                 ToolCancel();
+
             TileElement* const elem = OpenRCT2::TileInspector::GetSelectedElement();
             if (elem != nullptr)
             {

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -138,9 +138,8 @@ static Widget _trackPlaceWidgets[] = {
 
         void OnUpdate() override
         {
-            if (!(InputTestFlag(INPUT_FLAG_TOOL_ACTIVE)))
-                if (gCurrentToolWidget.window_classification != WindowClass::TrackDesignPlace)
-                    Close();
+            if (!isToolActive(WindowClass::TrackDesignPlace))
+                Close();
         }
 
         void OnToolUpdate(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords) override

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -129,8 +129,8 @@ static Widget _viewClippingWidgets[] = {
                 case WIDX_CLIP_CLEAR:
                     if (IsActive())
                     {
-                        _toolActive = false;
                         ToolCancel();
+                        _toolActive = false;
                     }
                     gClipSelectionA = { 0, 0 };
                     gClipSelectionB = { MAXIMUM_MAP_SIZE_BIG - 1, MAXIMUM_MAP_SIZE_BIG - 1 };
@@ -394,11 +394,7 @@ static Widget _viewClippingWidgets[] = {
 
         bool IsActive()
         {
-            if (!(InputTestFlag(INPUT_FLAG_TOOL_ACTIVE)))
-                return false;
-            if (gCurrentToolWidget.window_classification != WindowClass::ViewClipping)
-                return false;
-            return _toolActive;
+            return isToolActive(WindowClass::ViewClipping);
         }
     };
 

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -27,7 +27,8 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WW = 76;
 
     // clang-format off
-enum WindowWaterWidgetIdx {
+enum WindowWaterWidgetIdx : WidgetIndex
+{
     WIDX_BACKGROUND,
     WIDX_TITLE,
     WIDX_CLOSE,
@@ -65,7 +66,7 @@ static Widget _waterWidgets[] = {
         void OnClose() override
         {
             // If the tool wasn't changed, turn tool off
-            if (WaterToolIsActive())
+            if (isToolActive(WindowClass::Water, WIDX_BACKGROUND))
             {
                 ToolCancel();
             }
@@ -108,7 +109,7 @@ static Widget _waterWidgets[] = {
         void OnUpdate() override
         {
             // Close window if another tool is open
-            if (!WaterToolIsActive())
+            if (!isToolActive(WindowClass::Water, WIDX_BACKGROUND))
             {
                 Close();
             }
@@ -426,26 +427,11 @@ static Widget _waterWidgets[] = {
 
     /**
      *
-     *  rct2: 0x0066D125
-     */
-    bool WaterToolIsActive()
-    {
-        if (!(InputTestFlag(INPUT_FLAG_TOOL_ACTIVE)))
-            return false;
-        if (gCurrentToolWidget.window_classification != WindowClass::Water)
-            return false;
-        if (gCurrentToolWidget.widget_index != WIDX_BACKGROUND)
-            return false;
-        return true;
-    }
-
-    /**
-     *
      *  rct2: 0x0066CD9C
      */
     void ToggleWaterWindow()
     {
-        if (WaterToolIsActive())
+        if (isToolActive(WindowClass::Water, WIDX_BACKGROUND))
         {
             ToolCancel();
         }

--- a/src/openrct2-ui/windows/Window.h
+++ b/src/openrct2-ui/windows/Window.h
@@ -200,7 +200,6 @@ namespace OpenRCT2::Ui::Windows
     void WindowRideConstructionUpdateEnabledTrackPieces();
 
     WindowBase* TopToolbarOpen();
-    bool LandToolIsActive();
 
     WindowBase* SceneryOpen();
     void WindowScenerySetSelectedItem(

--- a/src/openrct2-ui/windows/Window.h
+++ b/src/openrct2-ui/windows/Window.h
@@ -201,7 +201,6 @@ namespace OpenRCT2::Ui::Windows
 
     WindowBase* TopToolbarOpen();
     bool LandToolIsActive();
-    bool ClearSceneryToolIsActive();
     bool WaterToolIsActive();
 
     WindowBase* SceneryOpen();

--- a/src/openrct2-ui/windows/Window.h
+++ b/src/openrct2-ui/windows/Window.h
@@ -201,7 +201,6 @@ namespace OpenRCT2::Ui::Windows
 
     WindowBase* TopToolbarOpen();
     bool LandToolIsActive();
-    bool WaterToolIsActive();
 
     WindowBase* SceneryOpen();
     void WindowScenerySetSelectedItem(

--- a/src/openrct2/Input.cpp
+++ b/src/openrct2/Input.cpp
@@ -21,9 +21,6 @@ WidgetRef gPressedWidget;
 
 uint32_t _tooltipNotShownTimeout;
 
-Tool gCurrentToolId;
-WidgetRef gCurrentToolWidget;
-
 /**
  *
  *  rct2: 0x006E3B43

--- a/src/openrct2/Input.h
+++ b/src/openrct2/Input.h
@@ -66,13 +66,6 @@ enum PLACE_OBJECT_MODIFIER
     PLACE_OBJECT_MODIFIER_COPY_Z = (1 << 1),
 };
 
-struct WidgetRef
-{
-    WindowClass window_classification;
-    rct_windownumber window_number;
-    WidgetIndex widget_index;
-};
-
 extern uint8_t gInputPlaceObjectModifier;
 
 extern ScreenCoordsXY gInputDragLast;
@@ -83,9 +76,6 @@ extern WidgetRef gPressedWidget;
 extern uint32_t gTooltipCloseTimeout;
 extern WidgetRef gTooltipWidget;
 extern ScreenCoordsXY gTooltipCursor;
-
-extern Tool gCurrentToolId;
-extern WidgetRef gCurrentToolWidget;
 
 // TODO: Move to openrct2-ui and make static again
 extern InputState _inputState;

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -50,6 +50,9 @@ WindowCloseModifier gLastCloseModifier = { { WindowClass::Null, 0 }, CloseWindow
 uint32_t gWindowUpdateTicks;
 colour_t gCurrentWindowColours[3];
 
+Tool gCurrentToolId;
+WidgetRef gCurrentToolWidget;
+
 // converted from uint16_t values at 0x009A41EC - 0x009A4230
 // these are percentage coordinates of the viewport to centre to, if a window is obscuring a location, the next is tried
 // clang-format off
@@ -1101,6 +1104,26 @@ static void WindowDrawSingle(DrawPixelInfo& dpi, WindowBase& w, int32_t left, in
     gCurrentWindowColours[2] = w.colours[2].colour;
 
     w.OnDraw(copy);
+}
+
+bool isToolActive(WindowClass cls)
+{
+    return InputTestFlag(INPUT_FLAG_TOOL_ACTIVE) && gCurrentToolWidget.window_classification == cls;
+}
+
+bool isToolActive(WindowClass cls, rct_windownumber number)
+{
+    return isToolActive(cls) && gCurrentToolWidget.window_number == number;
+}
+
+bool isToolActive(WindowClass cls, WidgetIndex widgetIndex)
+{
+    return isToolActive(cls) && gCurrentToolWidget.widget_index == widgetIndex;
+}
+
+bool isToolActive(WindowClass cls, WidgetIndex widgetIndex, rct_windownumber number)
+{
+    return isToolActive(cls, widgetIndex) && gCurrentToolWidget.window_number == number;
 }
 
 /**

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -1126,6 +1126,11 @@ bool isToolActive(WindowClass cls, WidgetIndex widgetIndex, rct_windownumber num
     return isToolActive(cls, widgetIndex) && gCurrentToolWidget.window_number == number;
 }
 
+bool isToolActive(const WindowBase& w, WidgetIndex widgetIndex)
+{
+    return isToolActive(w.classification, widgetIndex, w.number);
+}
+
 /**
  *
  *  rct2: 0x006EE212

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -576,8 +576,6 @@ void TextinputCancel();
 
 bool WindowIsVisible(WindowBase& w);
 
-bool SceneryToolIsActive();
-
 Viewport* WindowGetPreviousViewport(Viewport* current);
 void WindowResetVisibilities();
 void WindowInitAll();

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -473,6 +473,16 @@ enum class Tool
     Bulldozer = 27,
 };
 
+struct WidgetRef
+{
+    WindowClass window_classification;
+    rct_windownumber window_number;
+    WidgetIndex widget_index;
+};
+
+extern Tool gCurrentToolId;
+extern WidgetRef gCurrentToolWidget;
+
 using modal_callback = void (*)(int32_t result);
 using close_callback = void (*)();
 
@@ -545,6 +555,10 @@ void WindowZoomSet(WindowBase& w, ZoomLevel zoomLevel, bool atCursor);
 void WindowDrawAll(DrawPixelInfo& dpi, int32_t left, int32_t top, int32_t right, int32_t bottom);
 void WindowDraw(DrawPixelInfo& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
 
+bool isToolActive(WindowClass cls);
+bool isToolActive(WindowClass cls, rct_windownumber number);
+bool isToolActive(WindowClass cls, WidgetIndex widgetIndex);
+bool isToolActive(WindowClass cls, WidgetIndex widgetIndex, rct_windownumber number);
 bool ToolSet(const WindowBase& w, WidgetIndex widgetIndex, Tool tool);
 void ToolCancel();
 

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -559,6 +559,7 @@ bool isToolActive(WindowClass cls);
 bool isToolActive(WindowClass cls, rct_windownumber number);
 bool isToolActive(WindowClass cls, WidgetIndex widgetIndex);
 bool isToolActive(WindowClass cls, WidgetIndex widgetIndex, rct_windownumber number);
+bool isToolActive(const WindowBase& w, WidgetIndex widgetIndex);
 bool ToolSet(const WindowBase& w, WidgetIndex widgetIndex, Tool tool);
 void ToolCancel();
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4124,8 +4124,7 @@ ResultWithMessage Ride::Open(bool isApplying)
     // to set the track to its final state and clean up ghosts.
     // We can't just call close as it would cause a stack overflow during shop creation
     // with auto open on.
-    if (WindowClass::RideConstruction == gCurrentToolWidget.window_classification
-        && id.ToUnderlying() == gCurrentToolWidget.window_number && (InputTestFlag(INPUT_FLAG_TOOL_ACTIVE)))
+    if (isToolActive(WindowClass::RideConstruction, static_cast<rct_windownumber>(id.ToUnderlying())))
     {
         WindowCloseByNumber(WindowClass::RideConstruction, id.ToUnderlying());
     }

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -912,8 +912,7 @@ static bool ride_modify_entrance_or_exit(const CoordsXYE& tileElement)
     }
 
     RideConstructionInvalidateCurrentTrack();
-    if (_rideConstructionState != RideConstructionState::EntranceExit || !(InputTestFlag(INPUT_FLAG_TOOL_ACTIVE))
-        || gCurrentToolWidget.window_classification != WindowClass::RideConstruction)
+    if (_rideConstructionState != RideConstructionState::EntranceExit || isToolActive(WindowClass::RideConstruction))
     {
         // Replace entrance / exit
         ToolSet(
@@ -940,10 +939,14 @@ static bool ride_modify_entrance_or_exit(const CoordsXYE& tileElement)
             { tileElement.x, tileElement.y }, rideIndex, stationIndex, entranceType == ENTRANCE_TYPE_RIDE_EXIT);
 
         rideEntranceExitRemove.SetCallback([=](const GameAction* ga, const GameActions::Result* result) {
-            gCurrentToolWidget.widget_index = entranceType == ENTRANCE_TYPE_RIDE_ENTRANCE ? WC_RIDE_CONSTRUCTION__WIDX_ENTRANCE
-                                                                                          : WC_RIDE_CONSTRUCTION__WIDX_EXIT;
             gRideEntranceExitPlaceType = entranceType;
             WindowInvalidateByClass(WindowClass::RideConstruction);
+
+            auto newToolWidgetIndex = (entranceType == ENTRANCE_TYPE_RIDE_ENTRANCE) ? WC_RIDE_CONSTRUCTION__WIDX_ENTRANCE
+                                                                                    : WC_RIDE_CONSTRUCTION__WIDX_EXIT;
+
+            ToolCancel();
+            ToolSet(*constructionWindow, newToolWidgetIndex, Tool::Crosshair);
         });
 
         GameActions::Execute(&rideEntranceExitRemove);

--- a/src/openrct2/windows/_legacy.cpp
+++ b/src/openrct2/windows/_legacy.cpp
@@ -371,20 +371,3 @@ bool WindowRideConstructionUpdateState(
 
     return false;
 }
-
-/**
- *
- *  rct2: 0x0066DB3D
- */
-bool SceneryToolIsActive()
-{
-    auto toolWindowClassification = gCurrentToolWidget.window_classification;
-    WidgetIndex toolWidgetIndex = gCurrentToolWidget.widget_index;
-    if (InputTestFlag(INPUT_FLAG_TOOL_ACTIVE))
-    {
-        if (toolWindowClassification == WindowClass::Scenery && toolWidgetIndex == WC_SCENERY__WIDX_SCENERY_BACKGROUND)
-            return true;
-    }
-
-    return false;
-}

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -165,7 +165,7 @@ money64 FootpathProvisionalSet(
     // Invalidate previous footpath piece.
     VirtualFloorInvalidate();
 
-    if (!SceneryToolIsActive())
+    if (!isToolActive(WindowClass::Scenery))
     {
         if (res.Error != GameActions::Status::Ok)
         {


### PR DESCRIPTION
This PR introduces a new window function, `isToolActive`, as an concise way for querying the `gCurrentToolWidget` global. This new function is now used by all windows, leaving the global exclusively used by `MouseInput` and `Window`.

Needs a bit of testing to verify all tools are still working as expected.