### PR TITLE
Increase network timeout, small refactors

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Improved: [#22352] The object selection window now groups relevant object tabs together.
 - Improved: [#22357] Error messages are now themeable and easier to read.
 - Improved: [#22361] Add additional colour preset for the Observation Tower.
+- Improved: [#22433] Increase the network timeout from 7 to 20 seconds, should help slow clients getting disconnected.
 - Change: [#12292] The ‘Toggle visibility of toolbars’ shortcut is no longer assigned by default.
 - Change: [#21494] Display pixel density is now taken into account for the initial window scale setting.
 - Change: [#22230] The plugin/script engine is now initialised off the main thread.

--- a/src/openrct2/network/NetworkConnection.cpp
+++ b/src/openrct2/network/NetworkConnection.cpp
@@ -21,6 +21,7 @@ using namespace OpenRCT2;
 
 static constexpr size_t kNetworkDisconnectReasonBufSize = 256;
 static constexpr size_t kNetworkBufferSize = 1024 * 64; // 64 KiB, maximum packet size.
+static constexpr size_t kNetworkNoDataTimeout = 20;     // Seconds.
 
 NetworkConnection::NetworkConnection() noexcept
 {
@@ -179,7 +180,8 @@ void NetworkConnection::ResetLastPacketTime() noexcept
 bool NetworkConnection::ReceivedPacketRecently() const noexcept
 {
 #    ifndef DEBUG
-    if (Platform::GetTicks() > _lastPacketTime + 7000)
+    constexpr auto kTimeoutMs = kNetworkNoDataTimeout * 1000;
+    if (Platform::GetTicks() > _lastPacketTime + kTimeoutMs)
     {
         return false;
     }

--- a/src/openrct2/network/NetworkConnection.cpp
+++ b/src/openrct2/network/NetworkConnection.cpp
@@ -21,7 +21,9 @@ using namespace OpenRCT2;
 
 static constexpr size_t kNetworkDisconnectReasonBufSize = 256;
 static constexpr size_t kNetworkBufferSize = 1024 * 64; // 64 KiB, maximum packet size.
-static constexpr size_t kNetworkNoDataTimeout = 20;     // Seconds.
+#    ifndef DEBUG
+static constexpr size_t kNetworkNoDataTimeout = 20; // Seconds.
+#    endif
 
 NetworkConnection::NetworkConnection() noexcept
 {

--- a/src/openrct2/network/NetworkConnection.cpp
+++ b/src/openrct2/network/NetworkConnection.cpp
@@ -19,8 +19,8 @@
 
 using namespace OpenRCT2;
 
-constexpr size_t NETWORK_DISCONNECT_REASON_BUFFER_SIZE = 256;
-constexpr size_t NetworkBufferSize = 1024 * 64; // 64 KiB, maximum packet size.
+static constexpr size_t kNetworkDisconnectReasonBufSize = 256;
+static constexpr size_t kNetworkBufferSize = 1024 * 64; // 64 KiB, maximum packet size.
 
 NetworkConnection::NetworkConnection() noexcept
 {
@@ -68,11 +68,11 @@ NetworkReadPacket NetworkConnection::ReadPacket()
         // NOTE: BytesTransfered includes the header length, this will not underflow.
         const size_t missingLength = header.Size - (InboundPacket.BytesTransferred - sizeof(header));
 
-        uint8_t buffer[NetworkBufferSize];
+        uint8_t buffer[kNetworkBufferSize];
 
         if (missingLength > 0)
         {
-            NetworkReadPacket status = Socket->ReceiveData(buffer, std::min(missingLength, NetworkBufferSize), &bytesRead);
+            NetworkReadPacket status = Socket->ReceiveData(buffer, std::min(missingLength, kNetworkBufferSize), &bytesRead);
             if (status != NetworkReadPacket::Success)
             {
                 return status;
@@ -199,8 +199,8 @@ void NetworkConnection::SetLastDisconnectReason(std::string_view src)
 
 void NetworkConnection::SetLastDisconnectReason(const StringId string_id, void* args)
 {
-    char buffer[NETWORK_DISCONNECT_REASON_BUFFER_SIZE];
-    OpenRCT2::FormatStringLegacy(buffer, NETWORK_DISCONNECT_REASON_BUFFER_SIZE, string_id, args);
+    char buffer[kNetworkDisconnectReasonBufSize];
+    OpenRCT2::FormatStringLegacy(buffer, kNetworkDisconnectReasonBufSize, string_id, args);
     SetLastDisconnectReason(buffer);
 }
 


### PR DESCRIPTION
I've noticed that while trying to join a server with a large map and a lot of objects that my game was frozen for quite some time which makes the server think that we disconnected, I've increased the timeout from 7 to 20 seconds which should hopefully cover most cases. I believe some people complained about this before, this time I managed to see it for myself.