### PR TITLE
[Plugin] Fix off-by-one pixel issue in active widget width and height setters

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -37,6 +37,7 @@
 - Fix: [#22339] Printing ui.tool.cursor in console crashes the game.
 - Fix: [#22348] Progress bar screen doesn’t handle window resizing.
 - Fix: [#22389] Alpine coaster has wrong tunnel entrance type.
+- Fix: [#22435] [Plugin] Off-by-one pixel issue in active widget width and height setters.
 
 0.4.12 (2024-07-07)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/scripting/ScWidget.hpp
+++ b/src/openrct2-ui/scripting/ScWidget.hpp
@@ -207,7 +207,7 @@ namespace OpenRCT2::Scripting
             auto widget = GetWidget();
             if (widget != nullptr)
             {
-                return widget->width();
+                return widget->width() + 1;
             }
             return 0;
         }
@@ -216,7 +216,7 @@ namespace OpenRCT2::Scripting
             auto widget = GetWidget();
             if (widget != nullptr)
             {
-                auto delta = widget->left + value - widget->right;
+                auto delta = widget->left + value - (widget->right + 1);
 
                 Invalidate();
                 widget->right += delta;
@@ -246,7 +246,7 @@ namespace OpenRCT2::Scripting
             auto widget = GetWidget();
             if (widget != nullptr)
             {
-                return widget->height();
+                return widget->height() + 1;
             }
             return 0;
         }
@@ -255,7 +255,7 @@ namespace OpenRCT2::Scripting
             auto widget = GetWidget();
             if (widget != nullptr)
             {
-                auto delta = widget->top + value - widget->bottom;
+                auto delta = widget->top + value - (widget->bottom + 1);
 
                 Invalidate();
                 widget->bottom += delta;


### PR DESCRIPTION
Hey there, 

Setting a widget's `width` and `height` in an opened window will make the widget 1 pixel larger than the size originally set in `ui.openWindow`. It seems during opening the window, one single pixel is subtracted from the right/bottom sides of the widget ([see here](https://github.com/OpenRCT2/OpenRCT2/blob/e782635498b6a3d6f8a66c36eacb6db2e7708a66/src/openrct2-ui/scripting/CustomWindow.cpp#L946-L947)). This single pixel is not subtracted when setting the width and height through the property setters. 

This issue leads to UI inconsistencies in various FlexUI plugins which use these setters to update windows reactively after something has been changed.

Here below on the latest develop, I have one button sized 20x20 pixels. The other two buttons update the width/height of the first button to 20 pixels. Expected behaviour would be that first button stays the same size.

https://github.com/user-attachments/assets/9301747c-8b5c-4ce1-8bb9-689dff8c0d07

When making a screenshot of the first button, paste it in paint and count the pixels, the size will count up to 21 pixels instead of 20 after the spontaneous growth.

With the fixes from this PR, the button size will stay the correct size:

https://github.com/user-attachments/assets/d6d0f6f3-7fb6-40b4-b89c-c19434b3ee5b

<details>
<summary>Click here for the plugin in the video.</summary>

```js
registerPlugin({
	name: "Test widget size",
	version: "1",
	authors: ['Basssiiie'],
	targetApiVersion: 82,
	type: "local",
	licence: "MIT",
	main()
	{
		ui.registerMenuItem("Test widget size", function()
		{
			var window = ui.openWindow({
				classification: "test-widget-size",
				title: "Widget size setters",
				width: 100,
				height: 100,
				widgets: [
					{
						name: "test",
						type: "button",
						text: "X..",
						x: 5,
						y: 20,
						width: 20,
						height: 20,
					},
					{
						type: "button",
						text: "Set width = 20",
						x: 5,
						y: 60,
						width: 90,
						height: 15,
						onClick: function()
						{
							var widget = window.findWidget("test");
							var old = widget.width;
							widget.width = 20;
							console.log("Old = " + old + ", new = " + widget.width);
						}
					},
					{
						type: "button",
						text: "Set height = 20",
						x: 5,
						y: 80,
						width: 90,
						height: 15,
						onClick: function()
						{
							var widget = window.findWidget("test");
							var old = widget.height;
							widget.height = 20;
							console.log("Old = " + old + ", new = " + widget.height);
						}
					},
				]
			})
		})
	}
});
```

</details>

Thank you for your time. 🙂
