### PR TITLE
Improve performance on file indexing, fix progress bar flickering bug, refactors

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,6 +13,7 @@
 - Improved: [#22357] Error messages are now themeable and easier to read.
 - Improved: [#22361] Add additional colour preset for the Observation Tower.
 - Improved: [#22433] Increase the network timeout from 7 to 20 seconds, should help slow clients getting disconnected.
+- Improved: [#22437] File indexing now properly uses all CPU power, improving object and scenario indexing.
 - Change: [#12292] The ‘Toggle visibility of toolbars’ shortcut is no longer assigned by default.
 - Change: [#21494] Display pixel density is now taken into account for the initial window scale setting.
 - Change: [#22230] The plugin/script engine is now initialised off the main thread.

--- a/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
@@ -158,6 +158,8 @@ public:
         _screenTextureFormat = SDL_AllocFormat(format);
 
         ConfigureBits(width, height, width);
+
+        _drawingContext->Clear(_bitsDPI, PALETTE_INDEX_10);
     }
 
     void SetPalette(const GamePalette& palette) override

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -245,6 +245,7 @@ public:
         ConfigureBits(width, height, width);
         ConfigureCanvas();
         _drawingContext->Resize(width, height);
+        _drawingContext->Clear(_bitsDPI, PALETTE_INDEX_10);
     }
 
     void SetPalette(const GamePalette& palette) override

--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -291,7 +291,7 @@ namespace OpenRCT2::Title
             if (progress == 0)
                 GetContext()->OpenProgress(STR_LOADING_TITLE_SEQUENCE);
 
-            GetContext()->SetProgress(progress, 100, STR_STRING_M_PERCENT, true);
+            GetContext()->SetProgress(progress, 100, STR_STRING_M_PERCENT);
 
             if (progress == 100)
                 GetContext()->CloseProgress();

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -160,9 +160,7 @@ namespace OpenRCT2
         virtual void DisposeDrawingEngine() = 0;
 
         virtual void OpenProgress(StringId captionStringId) = 0;
-        virtual void SetProgress(
-            uint32_t currentProgress, uint32_t totalCount, StringId format = STR_NONE, bool forceDraw = false)
-            = 0;
+        virtual void SetProgress(uint32_t currentProgress, uint32_t totalCount, StringId format = STR_NONE) = 0;
         virtual void CloseProgress() = 0;
 
         virtual bool LoadParkFromFile(const u8string& path, bool loadTitleScreenOnFail = false, bool asScenario = false) = 0;

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -139,6 +139,7 @@ void X8DrawingEngine::Resize(uint32_t width, uint32_t height)
 {
     uint32_t pitch = width;
     ConfigureBits(width, height, pitch);
+    _drawingContext->Clear(_bitsDPI, PALETTE_INDEX_10);
 }
 
 void X8DrawingEngine::SetPalette([[maybe_unused]] const GamePalette& palette)

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -566,7 +566,7 @@ private:
         constexpr auto kObjectLoadProgressRange = kObjectLoadMaxProgress - kObjectLoadMinProgress;
 
         const auto currentProgress = kObjectLoadMinProgress + (numLoaded * kObjectLoadProgressRange / numRequired);
-        OpenRCT2::GetContext()->SetProgress(static_cast<uint32_t>(currentProgress), 100, STR_STRING_M_PERCENT, true);
+        OpenRCT2::GetContext()->SetProgress(static_cast<uint32_t>(currentProgress), 100, STR_STRING_M_PERCENT);
     }
 
     void LoadObjects(std::vector<ObjectToLoad>& requiredObjects, bool reportProgress)

--- a/src/openrct2/scenes/preloader/PreloaderScene.cpp
+++ b/src/openrct2/scenes/preloader/PreloaderScene.cpp
@@ -15,8 +15,6 @@
 #include "../../GameState.h"
 #include "../../OpenRCT2.h"
 #include "../../audio/audio.h"
-#include "../../drawing/IDrawingContext.h"
-#include "../../drawing/IDrawingEngine.h"
 #include "../../interface/Viewport.h"
 #include "../../interface/Window.h"
 #include "../../localisation/LocalisationService.h"

--- a/src/openrct2/scenes/preloader/PreloaderScene.cpp
+++ b/src/openrct2/scenes/preloader/PreloaderScene.cpp
@@ -52,11 +52,6 @@ void PreloaderScene::Tick()
     ContextHandleInput();
     WindowInvalidateAll();
 
-    // Reset screen
-    auto* engine = GetContext().GetDrawingEngine();
-    auto* drawingContext = engine->GetDrawingContext();
-    drawingContext->Clear(*engine->GetDrawingPixelInfo(), PALETTE_INDEX_10);
-
     gInUpdateCode = false;
 
     if (_jobs.CountPending() == 0 && _jobs.CountProcessing() == 0)


### PR DESCRIPTION
This improves the usage of SetProgress, we can tell if we are on the main thread by keeping track of who the main thread id. Also to not waste too many CPU cycles on drawing it limits it now to 40hz/fps. The file indexing is also refactored to actually use up all of the CPU in where when we batch groups and some of them might finish early so some cores will go idle.

Closes #22432
Closes #22418