### PR TITLE
Revert "Fix renderer creation for HW display engine"

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -35,7 +35,6 @@
 - Fix: [#22339] Printing ui.tool.cursor in console crashes the game.
 - Fix: [#22348] Progress bar screen doesn’t handle window resizing.
 - Fix: [#22389] Alpine coaster has wrong tunnel entrance type.
-- Fix: [#22445] Crash due to incorrect renderer state.
 
 0.4.12 (2024-07-07)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
@@ -67,16 +67,7 @@ public:
 
     void Initialise() override
     {
-#if SDL_VERSION_ATLEAST(2, 28, 0)
-        // Before creating a new renderer, destroy any possible leftover state, as it will prevent the renderer from being
-        // created.
-        if (SDL_GetWindowSurface(_window) != nullptr)
-        {
-            SDL_DestroyWindowSurface(_window);
-        }
-#endif
         _sdlRenderer = SDL_CreateRenderer(_window, -1, SDL_RENDERER_ACCELERATED | (_useVsync ? SDL_RENDERER_PRESENTVSYNC : 0));
-        Guard::Assert(_sdlRenderer != nullptr, "Failed to create renderer: %s", SDL_GetError());
     }
 
     void SetVSync(bool vsync) override


### PR DESCRIPTION
Unfortunately b1e14c676d0171d72df882305c255f211f369c7f (i.e. #22445) immediately crashes OpenRCT2 on start for me. This is on macOS. The parent commit, b0fbd5e1e5c863060ddc05ae62c843ad29ff5231, works fine. This therefore reverts PR #22445.

Just speculation, but maybe the SDL version we ship in the macOS bundle isn't new enough, while we compile against a newer SDL, or something?

Either way, we should test another attempt thoroughly before it is merged.