### PR TITLE
Fix clear scenery window closing (again)

### DIFF
--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -305,17 +305,22 @@ namespace OpenRCT2::Ui::Windows
 
     WindowBase* ClearSceneryOpen()
     {
-        auto* w = static_cast<CleanSceneryWindow*>(WindowBringToFrontByClass(WindowClass::ClearScenery));
+        return WindowFocusOrCreate<CleanSceneryWindow>(WindowClass::ClearScenery, ScreenCoordsXY(ContextGetWidth() - WW, 29), WW, WH, 0);
+    }
 
-        if (w != nullptr)
-            return w;
-
-        w = WindowCreate<CleanSceneryWindow>(WindowClass::ClearScenery, ScreenCoordsXY(ContextGetWidth() - WW, 29), WW, WH, 0);
-
-        if (w != nullptr)
-            return w;
-
-        return nullptr;
+    /**
+     *
+     *  rct2: 0x0066D125
+     */
+    bool ClearSceneryToolIsActive()
+    {
+        if (!(InputTestFlag(INPUT_FLAG_TOOL_ACTIVE)))
+            return false;
+        if (gCurrentToolWidget.window_classification != WindowClass::ClearScenery)
+            return false;
+        if (gCurrentToolWidget.widget_index != WIDX_BACKGROUND)
+            return false;
+        return true;
     }
 
     /**

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -20,7 +20,7 @@
 
 namespace OpenRCT2::Ui::Windows
 {
-    enum WindowClearSceneryWidgetIdx
+    enum WindowClearSceneryWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,
@@ -305,7 +305,8 @@ namespace OpenRCT2::Ui::Windows
 
     WindowBase* ClearSceneryOpen()
     {
-        return WindowFocusOrCreate<CleanSceneryWindow>(WindowClass::ClearScenery, ScreenCoordsXY(ContextGetWidth() - WW, 29), WW, WH, 0);
+        return WindowFocusOrCreate<CleanSceneryWindow>(
+            WindowClass::ClearScenery, ScreenCoordsXY(ContextGetWidth() - WW, 29), WW, WH, 0);
     }
 
     /**

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -250,7 +250,7 @@ static Widget window_land_rights_widgets[] = {
                 if (_landRightsCost != kMoney64Undefined)
                 {
                     _landRightsCost = kMoney64Undefined;
-                    WindowInvalidateByClass(WindowClass::ClearScenery);
+                    WindowInvalidateByClass(WindowClass::LandRights);
                 }
                 return;
             }

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1016,21 +1016,6 @@ namespace OpenRCT2::Ui::Windows
         return window;
     }
 
-    /**
-     *
-     *  rct2: 0x0066D125
-     */
-    bool ClearSceneryToolIsActive()
-    {
-        if (!(InputTestFlag(INPUT_FLAG_TOOL_ACTIVE)))
-            return false;
-        if (gCurrentToolWidget.window_classification != WindowClass::ClearScenery)
-            return false;
-        if (gCurrentToolWidget.widget_index != WIDX_CLEAR_SCENERY)
-            return false;
-        return true;
-    }
-
     void TopToolbar::InitViewMenu(Widget& widget)
     {
         using namespace Dropdown;


### PR DESCRIPTION
This fixes the clear scenery closing immediately after opening, and adds a function to actually apply/paint map selection for the tool.

Will fix #22439, a regression from #22411. (Unlike #22442, which missed a bit.)