### PR TITLE
Skip unnecessary steps after map init

### DIFF
--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -462,7 +462,7 @@ void MapInit(const TileCoordsXY& size)
     gameState.WidePathTileLoopPosition = {};
     gameState.MapSize = size;
     MapRemoveOutOfRangeElements();
-    MapAnimationAutoCreate();
+    ClearMapAnimations();
 
     auto intent = Intent(INTENT_ACTION_MAP);
     ContextBroadcastIntent(&intent);

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -601,7 +601,7 @@ const std::vector<MapAnimation>& GetMapAnimations()
     return _mapAnimations;
 }
 
-static void ClearMapAnimations()
+void ClearMapAnimations()
 {
     _mapAnimations.clear();
 }

--- a/src/openrct2/world/MapAnimation.h
+++ b/src/openrct2/world/MapAnimation.h
@@ -44,6 +44,7 @@ enum
 void MapAnimationCreate(int32_t type, const CoordsXYZ& loc);
 void MapAnimationInvalidateAll();
 const std::vector<MapAnimation>& GetMapAnimations();
+void ClearMapAnimations();
 void MapAnimationAutoCreate();
 void MapAnimationAutoCreateAtTileElement(TileCoordsXY coords, TileElement* el);
 void ShiftAllMapAnimations(CoordsXY amount);


### PR DESCRIPTION
If the map is cleared, it will not have any out of range elements - so no need to check - or map animations to create, so no need to create these, just clear the existing list.