### PR TITLE
Small Cyrillic font fixes

### DIFF
--- a/src/openrct2/drawing/Font.cpp
+++ b/src/openrct2/drawing/Font.cpp
@@ -193,12 +193,12 @@ static const std::unordered_map<char32_t, int32_t> codepointOffsetMap = {
     { UnicodeChar::cyrillic_e, SPR_G2_CYRILLIC_E_LOWER - SPR_CHAR_START },
     { UnicodeChar::cyrillic_yu, SPR_G2_CYRILLIC_YU_LOWER - SPR_CHAR_START },
     { UnicodeChar::cyrillic_ya, SPR_G2_CYRILLIC_YA_LOWER - SPR_CHAR_START },
-    { UnicodeChar::cyrillic_io, 235 - CS_SPRITE_FONT_OFFSET },                                   // Looks just like ë
-    { UnicodeChar::cyrillic_ukrainian_ie, SPR_G2_CYRILLIC_UKRAINIAN_IE_LOWER - SPR_CHAR_START }, // Looks just like ë
+    { UnicodeChar::cyrillic_io, 235 - CS_SPRITE_FONT_OFFSET }, // Looks just like ë
+    { UnicodeChar::cyrillic_ukrainian_ie, SPR_G2_CYRILLIC_UKRAINIAN_IE_LOWER - SPR_CHAR_START },
     { UnicodeChar::cyrillic_dze, 's' - CS_SPRITE_FONT_OFFSET },
     { UnicodeChar::cyrillic_dotted_i, 'i' - CS_SPRITE_FONT_OFFSET },
     { UnicodeChar::cyrillic_yi, 239 - CS_SPRITE_FONT_OFFSET }, // Looks just like ï
-    { UnicodeChar::cyrillic_je, 'j' - CS_SPRITE_FONT_OFFSET },
+    { UnicodeChar::cyrillic_je, SPR_G2_J - SPR_CHAR_START },
     { UnicodeChar::cyrillic_ghe_upturn_uc, SPR_G2_CYRILLIC_GHE_UPTURN_UPPER - SPR_CHAR_START },
     { UnicodeChar::cyrillic_ghe_upturn, SPR_G2_CYRILLIC_GHE_UPTURN_LOWER - SPR_CHAR_START },
 


### PR DESCRIPTION
The Cyrillic `ј` was still using the old RCT2 glyph, rather than the new one we added. Also removed a copy-pasted, incorrect comment on `є`.