### PR TITLE
Update title sequences to v0.4.14 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,9 +60,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
-set(TITLE_SEQUENCE_VERSION "0.4.6")
+set(TITLE_SEQUENCE_VERSION "0.4.13")
 set(TITLE_SEQUENCE_URL  "https://github.com/OpenRCT2/title-sequences/releases/download/v${TITLE_SEQUENCE_VERSION}/title-sequences.zip")
-set(TITLE_SEQUENCE_SHA1 "80fefc6ebbabc42a6f4703412daa5c62f661420d")
+set(TITLE_SEQUENCE_SHA1 "be28b18a250176036e860fcf5cc85ab6c200fd54")
 
 set(OBJECTS_VERSION "1.4.7")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v${OBJECTS_VERSION}/objects.zip")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,9 +60,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
-set(TITLE_SEQUENCE_VERSION "0.4.13")
+set(TITLE_SEQUENCE_VERSION "0.4.14")
 set(TITLE_SEQUENCE_URL  "https://github.com/OpenRCT2/title-sequences/releases/download/v${TITLE_SEQUENCE_VERSION}/title-sequences.zip")
-set(TITLE_SEQUENCE_SHA1 "be28b18a250176036e860fcf5cc85ab6c200fd54")
+set(TITLE_SEQUENCE_SHA1 "54f234cf9ae1e6c0b58e91bf0814371779a68f4f")
 
 set(OBJECTS_VERSION "1.4.7")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v${OBJECTS_VERSION}/objects.zip")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ set(ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
 set(TITLE_SEQUENCE_VERSION "0.4.14")
 set(TITLE_SEQUENCE_URL  "https://github.com/OpenRCT2/title-sequences/releases/download/v${TITLE_SEQUENCE_VERSION}/title-sequences.zip")
-set(TITLE_SEQUENCE_SHA1 "54f234cf9ae1e6c0b58e91bf0814371779a68f4f")
+set(TITLE_SEQUENCE_SHA1 "6c04781b959b468e1f65ec2d2f21f5aaa5e5724d")
 
 set(OBJECTS_VERSION "1.4.7")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v${OBJECTS_VERSION}/objects.zip")

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -36,6 +36,7 @@
 - Feature: [#22213] [Plugin] Allow plugins to focus on textboxes in custom windows.
 - Feature: [#22272] [Plugin] Expose ride vehicle’s current track type via car trackLocation.
 - Feature: [#22301] Loading save games or scenarios now indicates loading progress.
+- Feature: [#22472] New title sequences (https://github.com/OpenRCT2/title-sequences/releases/tag/v0.4.13).
 - Feature: [OpenMusic#54] Added Progressive ride music style (feat. Approaching Nirvana).
 - Improved: [#22352] The object selection window now groups relevant object tabs together.
 - Improved: [#22357] Error messages are now themeable and easier to read.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -36,7 +36,7 @@
 - Feature: [#22213] [Plugin] Allow plugins to focus on textboxes in custom windows.
 - Feature: [#22272] [Plugin] Expose ride vehicle’s current track type via car trackLocation.
 - Feature: [#22301] Loading save games or scenarios now indicates loading progress.
-- Feature: [#22472] New title sequences (https://github.com/OpenRCT2/title-sequences/releases/tag/v0.4.13).
+- Feature: [#22472] New title sequence (see https://github.com/OpenRCT2/title-sequences/releases/tag/v0.4.13 for credits).
 - Feature: [OpenMusic#54] Added Progressive ride music style (feat. Approaching Nirvana).
 - Improved: [#22352] The object selection window now groups relevant object tabs together.
 - Improved: [#22357] Error messages are now themeable and easier to read.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -36,7 +36,7 @@
 - Feature: [#22213] [Plugin] Allow plugins to focus on textboxes in custom windows.
 - Feature: [#22272] [Plugin] Expose ride vehicle’s current track type via car trackLocation.
 - Feature: [#22301] Loading save games or scenarios now indicates loading progress.
-- Feature: [#22472] New title sequence (see https://github.com/OpenRCT2/title-sequences/releases/tag/v0.4.13 for credits).
+- Feature: [#22472] New title sequence (see https://github.com/OpenRCT2/title-sequences/releases/tag/v0.4.14 for credits).
 - Feature: [OpenMusic#54] Added Progressive ride music style (feat. Approaching Nirvana).
 - Improved: [#22352] The object selection window now groups relevant object tabs together.
 - Improved: [#22357] Error messages are now themeable and easier to read.

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -43,8 +43,8 @@
     <LibsSha1 Condition="'$(Platform)'=='x64'">3816671560af3571ada728ffeceec0443471c03b</LibsSha1>
     <LibsUrl Condition="'$(Platform)'=='Win32'">https://github.com/OpenRCT2/Dependencies/releases/download/v36/openrct2-libs-v36-x86-windows-static.zip</LibsUrl>
     <LibsSha1 Condition="'$(Platform)'=='Win32'">d2b8d98a9711cf319e3bd5330e77aef5395820f1</LibsSha1>
-    <TitleSequencesUrl>https://github.com/OpenRCT2/title-sequences/releases/download/v0.4.6/title-sequences.zip</TitleSequencesUrl>
-    <TitleSequencesSha1>80fefc6ebbabc42a6f4703412daa5c62f661420d</TitleSequencesSha1>
+    <TitleSequencesUrl>https://github.com/OpenRCT2/title-sequences/releases/download/v0.4.13/title-sequences.zip</TitleSequencesUrl>
+    <TitleSequencesSha1>be28b18a250176036e860fcf5cc85ab6c200fd54</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.4.7/objects.zip</ObjectsUrl>
     <ObjectsSha1>322de669d4b277fceff0d3f123fbc54785dceb4d</ObjectsSha1>
     <OpenSFXUrl>https://github.com/OpenRCT2/OpenSoundEffects/releases/download/v1.0.5/opensound.zip</OpenSFXUrl>

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -43,7 +43,7 @@
     <LibsSha1 Condition="'$(Platform)'=='x64'">3816671560af3571ada728ffeceec0443471c03b</LibsSha1>
     <LibsUrl Condition="'$(Platform)'=='Win32'">https://github.com/OpenRCT2/Dependencies/releases/download/v36/openrct2-libs-v36-x86-windows-static.zip</LibsUrl>
     <LibsSha1 Condition="'$(Platform)'=='Win32'">d2b8d98a9711cf319e3bd5330e77aef5395820f1</LibsSha1>
-    <TitleSequencesUrl>https://github.com/OpenRCT2/title-sequences/releases/download/v0.4.13/title-sequences.zip</TitleSequencesUrl>
+    <TitleSequencesUrl>https://github.com/OpenRCT2/title-sequences/releases/download/v0.4.14/title-sequences.zip</TitleSequencesUrl>
     <TitleSequencesSha1>be28b18a250176036e860fcf5cc85ab6c200fd54</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.4.7/objects.zip</ObjectsUrl>
     <ObjectsSha1>322de669d4b277fceff0d3f123fbc54785dceb4d</ObjectsSha1>

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -44,7 +44,7 @@
     <LibsUrl Condition="'$(Platform)'=='Win32'">https://github.com/OpenRCT2/Dependencies/releases/download/v36/openrct2-libs-v36-x86-windows-static.zip</LibsUrl>
     <LibsSha1 Condition="'$(Platform)'=='Win32'">d2b8d98a9711cf319e3bd5330e77aef5395820f1</LibsSha1>
     <TitleSequencesUrl>https://github.com/OpenRCT2/title-sequences/releases/download/v0.4.14/title-sequences.zip</TitleSequencesUrl>
-    <TitleSequencesSha1>be28b18a250176036e860fcf5cc85ab6c200fd54</TitleSequencesSha1>
+    <TitleSequencesSha1>6c04781b959b468e1f65ec2d2f21f5aaa5e5724d</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.4.7/objects.zip</ObjectsUrl>
     <ObjectsSha1>322de669d4b277fceff0d3f123fbc54785dceb4d</ObjectsSha1>
     <OpenSFXUrl>https://github.com/OpenRCT2/OpenSoundEffects/releases/download/v1.0.5/opensound.zip</OpenSFXUrl>


### PR DESCRIPTION
Depends on https://github.com/OpenRCT2/title-sequences/pull/13
Depends on https://github.com/OpenRCT2/title-sequences/pull/14

Also create a release (tag) and add title-sequences.zip to the release, so that the links work. The sha1 hash should be correct.