### PR TITLE
Fix #21908: Errors showing up when placing/moving track design previews

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Feature: [#22414] Finance graphs can be resized.
 - Change: [#21659] Increase the Hybrid Roller Coaster’s maximum lift speed to 17 km/h (11 mph).
 - Change: [#22466] The Clear Scenery tool now uses a bulldozer cursor instead of a generic crosshair.
+- Fix: [#21908] Errors showing up when placing/moving track design previews.
 - Fix: [#22307] Hover tooltips in financial charts are not invalidated properly.
 - Fix: [#22395, #22396] Misaligned tick marks in financial and guest count graphs (original bug).
 

--- a/src/openrct2/actions/TrackDesignAction.cpp
+++ b/src/openrct2/actions/TrackDesignAction.cpp
@@ -171,13 +171,9 @@ GameActions::Result TrackDesignAction::Execute() const
     }
 
     // Query first, this is required again to determine if scenery is available.
-    bool placeScenery = true;
+    uint32_t flags = GetFlags() & ~GAME_COMMAND_FLAG_APPLY;
 
-    uint32_t flags = 0;
-    if (GetFlags() & GAME_COMMAND_FLAG_GHOST)
-        flags |= GAME_COMMAND_FLAG_GHOST;
-    if (GetFlags() & GAME_COMMAND_FLAG_REPLAY)
-        flags |= GAME_COMMAND_FLAG_REPLAY;
+    bool placeScenery = true;
 
     auto queryRes = TrackDesignPlace(_td, flags, placeScenery, *ride, _loc);
     if (_trackDesignPlaceStateSceneryUnavailable)
@@ -225,8 +221,7 @@ GameActions::Result TrackDesignAction::Execute() const
         GameActions::ExecuteNested(&rideSetVehicleAction);
     }
 
-    SetOperatingSettingNested(
-        ride->id, RideSetSetting::Mode, static_cast<uint8_t>(_td.operation.rideMode), GAME_COMMAND_FLAG_APPLY);
+    SetOperatingSettingNested(ride->id, RideSetSetting::Mode, static_cast<uint8_t>(_td.operation.rideMode), flags);
     auto rideSetVehicleAction2 = RideSetVehicleAction(
         ride->id, RideSetVehicleType::NumTrains, _td.trackAndVehicle.numberOfTrains);
     GameActions::ExecuteNested(&rideSetVehicleAction2);
@@ -235,14 +230,14 @@ GameActions::Result TrackDesignAction::Execute() const
         ride->id, RideSetVehicleType::NumCarsPerTrain, _td.trackAndVehicle.numberOfCarsPerTrain);
     GameActions::ExecuteNested(&rideSetVehicleAction3);
 
-    SetOperatingSettingNested(ride->id, RideSetSetting::Departure, _td.operation.departFlags, GAME_COMMAND_FLAG_APPLY);
-    SetOperatingSettingNested(ride->id, RideSetSetting::MinWaitingTime, _td.operation.minWaitingTime, GAME_COMMAND_FLAG_APPLY);
-    SetOperatingSettingNested(ride->id, RideSetSetting::MaxWaitingTime, _td.operation.maxWaitingTime, GAME_COMMAND_FLAG_APPLY);
-    SetOperatingSettingNested(ride->id, RideSetSetting::Operation, _td.operation.operationSetting, GAME_COMMAND_FLAG_APPLY);
-    SetOperatingSettingNested(ride->id, RideSetSetting::LiftHillSpeed, _td.operation.liftHillSpeed, GAME_COMMAND_FLAG_APPLY);
+    SetOperatingSettingNested(ride->id, RideSetSetting::Departure, _td.operation.departFlags, flags);
+    SetOperatingSettingNested(ride->id, RideSetSetting::MinWaitingTime, _td.operation.minWaitingTime, flags);
+    SetOperatingSettingNested(ride->id, RideSetSetting::MaxWaitingTime, _td.operation.maxWaitingTime, flags);
+    SetOperatingSettingNested(ride->id, RideSetSetting::Operation, _td.operation.operationSetting, flags);
+    SetOperatingSettingNested(ride->id, RideSetSetting::LiftHillSpeed, _td.operation.liftHillSpeed, flags);
 
     auto numCircuits = std::max<uint8_t>(1, _td.operation.numCircuits);
-    SetOperatingSettingNested(ride->id, RideSetSetting::NumCircuits, numCircuits, GAME_COMMAND_FLAG_APPLY);
+    SetOperatingSettingNested(ride->id, RideSetSetting::NumCircuits, numCircuits, flags);
     ride->SetToDefaultInspectionInterval();
     ride->lifecycle_flags |= RIDE_LIFECYCLE_NOT_CUSTOM_DESIGN;
     ride->vehicleColourSettings = _td.appearance.vehicleColourSettings;


### PR DESCRIPTION
~~Also took the liberty to correct the console spam~~, game action queries shouldn't really report errors as the name it implies its just a query so its allowed to fail, we should look at the other game actions to also correct this at some point, if it fails in Execute then we should definitely report errors as you are not supposed to call Execute if Query fails.

Closes #21908