### PR TITLE
Hide scrollbars when there is nothing to scroll

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Feature: [#22414] Finance graphs can be resized.
 - Change: [#21659] Increase the Hybrid Roller Coaster’s maximum lift speed to 17 km/h (11 mph).
 - Change: [#22466] The Clear Scenery tool now uses a bulldozer cursor instead of a generic crosshair.
+- Change: [#22491] Scrollbars are now hidden if the scrollable widget is not actually overflowing.
 - Fix: [#21908] Errors showing up when placing/moving track design previews.
 - Fix: [#22307] Hover tooltips in financial charts are not invalidated properly.
 - Fix: [#22395, #22396] Misaligned tick marks in financial and guest count graphs (original bug).

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -682,23 +682,31 @@ namespace OpenRCT2::Ui
         bottomRight.x--;
         bottomRight.y--;
 
+        auto scrollSize = w.OnScrollGetSize(widgetIndex);
+        bool hScrollNeeded = scrollSize.width > widget.width() && (scroll.flags & HSCROLLBAR_VISIBLE);
+        bool vScrollNeeded = scrollSize.height > widget.height() && (scroll.flags & VSCROLLBAR_VISIBLE);
+
         // Horizontal scrollbar
-        if (scroll.flags & HSCROLLBAR_VISIBLE)
+        if (hScrollNeeded)
+        {
             WidgetHScrollbarDraw(
                 dpi, scroll, topLeft.x, bottomRight.y - kScrollBarWidth,
                 ((scroll.flags & VSCROLLBAR_VISIBLE) ? bottomRight.x - (kScrollBarWidth + 1) : bottomRight.x), bottomRight.y,
                 colour);
+        }
 
         // Vertical scrollbar
-        if (scroll.flags & VSCROLLBAR_VISIBLE)
+        if (vScrollNeeded)
+        {
             WidgetVScrollbarDraw(
                 dpi, scroll, bottomRight.x - kScrollBarWidth, topLeft.y, bottomRight.x,
                 ((scroll.flags & HSCROLLBAR_VISIBLE) ? bottomRight.y - (kScrollBarWidth + 1) : bottomRight.y), colour);
+        }
 
         // Contents
-        if (scroll.flags & HSCROLLBAR_VISIBLE)
+        if (hScrollNeeded)
             bottomRight.y -= (kScrollBarWidth + 1);
-        if (scroll.flags & VSCROLLBAR_VISIBLE)
+        if (vScrollNeeded)
             bottomRight.x -= (kScrollBarWidth + 1);
 
         bottomRight.y++;

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1405,8 +1405,12 @@ static Widget window_map_widgets[] = {
         {
             // The initial mini map size should be able to show a reasonably sized map
             auto initSize = std::clamp(getTechnicalMapSize(), 100, 254) * 2;
-            width = initSize + kReservedHSpace + SCROLLBAR_SIZE;
-            height = initSize + kReservedTopSpace + GetReservedBottomSpace() + SCROLLBAR_SIZE;
+            width = initSize + kReservedHSpace;
+            height = initSize + kReservedTopSpace + GetReservedBottomSpace();
+
+            auto scrollbarSize = getTechnicalMapSize() > 254 ? SCROLLBAR_SIZE : 2;
+            width += scrollbarSize;
+            height += scrollbarSize;
 
             auto maxWindowHeight = ContextGetHeight() - 68;
             width = std::min<int16_t>(width, ContextGetWidth());
@@ -1415,9 +1419,13 @@ static Widget window_map_widgets[] = {
 
         void ResetMaxWindowDimensions()
         {
-            max_width = std::clamp(getMiniMapWidth() + kReservedHSpace + SCROLLBAR_SIZE, WW, ContextGetWidth());
+            max_width = std::clamp(getMiniMapWidth() + kReservedHSpace, WW, ContextGetWidth());
             max_height = std::clamp(
-                getMiniMapWidth() + kReservedTopSpace + GetReservedBottomSpace() + SCROLLBAR_SIZE, WH, ContextGetHeight() - 68);
+                getMiniMapWidth() + kReservedTopSpace + GetReservedBottomSpace(), WH, ContextGetHeight() - 68);
+
+            auto scrollbarSize = getMiniMapWidth() + kReservedHSpace > ContextGetWidth() ? SCROLLBAR_SIZE : 2;
+            max_width += scrollbarSize;
+            max_height += scrollbarSize;
         }
 
         void ResizeMiniMap()

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -82,7 +82,7 @@ namespace OpenRCT2::Ui::Windows
 
     static int32_t getMapOffset(int16_t width)
     {
-        return (width - getMiniMapWidth() - kReservedHSpace - SCROLLBAR_SIZE) / 2;
+        return (width - getMiniMapWidth() - kReservedHSpace - kScrollBarWidth) / 2;
     }
 
     // Some functions manipulate coordinates on the map. These are the coordinates of the pixels in the
@@ -649,7 +649,7 @@ static Widget window_map_widgets[] = {
             auto mapOffset = getMapOffset(width);
             if (mapOffset > 0)
             {
-                adjCoords -= ScreenCoordsXY(mapOffset, mapOffset - SCROLLBAR_SIZE / 2);
+                adjCoords -= ScreenCoordsXY(mapOffset, mapOffset - kScrollBarWidth);
             }
 
             CoordsXY c = ScreenToMap(adjCoords);
@@ -718,7 +718,7 @@ static Widget window_map_widgets[] = {
             auto screenOffset = ScreenCoordsXY(0, 0);
             auto mapOffset = getMapOffset(width);
             if (mapOffset > 0)
-                screenOffset += ScreenCoordsXY(mapOffset, mapOffset - SCROLLBAR_SIZE / 2);
+                screenOffset += ScreenCoordsXY(mapOffset, mapOffset - kScrollBarWidth);
 
             G1Element g1temp = {};
             g1temp.offset = _mapImageData.data();
@@ -1408,7 +1408,7 @@ static Widget window_map_widgets[] = {
             width = initSize + kReservedHSpace;
             height = initSize + kReservedTopSpace + GetReservedBottomSpace();
 
-            auto scrollbarSize = getTechnicalMapSize() > 254 ? SCROLLBAR_SIZE : 2;
+            auto scrollbarSize = getTechnicalMapSize() > 254 ? kScrollBarWidth : 2;
             width += scrollbarSize;
             height += scrollbarSize;
 
@@ -1423,7 +1423,7 @@ static Widget window_map_widgets[] = {
             max_height = std::clamp(
                 getMiniMapWidth() + kReservedTopSpace + GetReservedBottomSpace(), WH, ContextGetHeight() - 68);
 
-            auto scrollbarSize = getMiniMapWidth() + kReservedHSpace > ContextGetWidth() ? SCROLLBAR_SIZE : 2;
+            auto scrollbarSize = getMiniMapWidth() + kReservedHSpace > ContextGetWidth() ? kScrollBarWidth : 2;
             max_width += scrollbarSize;
             max_height += scrollbarSize;
         }

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -5018,46 +5018,8 @@ static_assert(std::size(RatingNames) == 6);
                 newWidth = std::max(newWidth, nameWidth + composerWidth + 24);
             }
 
-            // Do we need a horizontal scrollbar?
-            auto left = newWidth - widgets[WIDX_MUSIC_DATA].width() + kScrollBarWidth;
-            if (left < 0)
-            {
-                scrolls[0].flags &= ~HSCROLLBAR_VISIBLE;
-                left = 0;
-            }
-            else
-            {
-                scrolls[0].flags |= HSCROLLBAR_VISIBLE;
-            }
-
-            // Reset the horizontal scrollbar?
-            if (left < scrolls[0].h_left)
-            {
-                scrolls[0].h_left = left;
-                Invalidate();
-            }
-
             // Compute scroll height based on number of tracks
             const int32_t newHeight = static_cast<int32_t>(musicObj->GetTrackCount()) * kScrollableRowHeight;
-
-            // Do we need a vertical scrollbar?
-            auto top = newHeight - widgets[WIDX_MUSIC_DATA].height() + kScrollBarWidth;
-            if (top < 0)
-            {
-                top = 0;
-                scrolls[0].flags &= ~VSCROLLBAR_VISIBLE;
-            }
-            else
-            {
-                scrolls[0].flags |= VSCROLLBAR_VISIBLE;
-            }
-
-            // Reset the vertical scrollbar?
-            if (top < scrolls[0].v_top)
-            {
-                scrolls[0].v_top = top;
-                Invalidate();
-            }
 
             // Return the computed size
             return { newWidth, newHeight };

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -286,8 +286,6 @@ enum SCROLL_FLAGS
     VSCROLLBAR_DOWN_PRESSED = (1 << 7),
 };
 
-#define SCROLLBAR_SIZE 16
-
 enum
 {
     SCROLL_PART_NONE = -1,


### PR DESCRIPTION
This PR changes the scrollview behaviour such that scrollbars are no longer drawn when the scrollview contents do not overflow the visible area.

To do:
- [x] Map window: don't add padding for invisible scrollbars
- [x] Ride window: remove logic to hide scrollbars manually