### PR TITLE
Variable padding for finance graph Y axis labels

### DIFF
--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -75,8 +75,8 @@ namespace OpenRCT2::Graph
         DrawPixelInfo& dpi, const T value, const int32_t hoverIdx, const ScreenRect& bounds, const int32_t xStep,
         const T minValue, const T maxValue, const_utf8string text, ColourWithFlags textCol)
     {
-        const int32_t screenRange = bounds.GetHeight();
-        const int32_t valueRange = maxValue - minValue;
+        const T screenRange = bounds.GetHeight();
+        const T valueRange = maxValue - minValue;
 
         const int32_t yPosition = bounds.GetBottom() - ((value - minValue) * screenRange) / valueRange;
         ScreenCoordsXY coords = { bounds.GetRight() - hoverIdx * xStep, yPosition };
@@ -103,8 +103,8 @@ namespace OpenRCT2::Graph
         DrawPixelInfo& dpi, const T* series, const int32_t count, const ScreenRect& bounds, const int32_t xStep,
         const T minValue, const T maxValue)
     {
-        const int32_t screenRange = bounds.GetHeight();
-        const int32_t valueRange = maxValue - minValue;
+        const T screenRange = bounds.GetHeight();
+        const T valueRange = maxValue - minValue;
 
         ScreenCoordsXY lastCoords;
         bool lastCoordsValid = false;


### PR DESCRIPTION
https://github.com/OpenRCT2/OpenRCT2/pull/22414#issuecomment-2269946030

Also fixes overflows during plotting and a divide by zero.

Most of the diff is that I moved the maximum finding algorithm to `OnPrepareDraw()` because now it needs to know the maximum to calculate the variable padding from its string width.
