### PR TITLE
S4: Replace duplicate call to CreateAvailableObjectMappings()

### DIFF
--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -178,8 +178,6 @@ namespace OpenRCT2::RCT1
         {
             Initialise(gameState);
 
-            CreateAvailableObjectMappings();
-
             ImportRides();
             ImportRideMeasurements();
             ImportEntities();


### PR DESCRIPTION
Already called in LoadParkFromStream()