### PR TITLE
Use tables for wooden support placement

### DIFF
--- a/src/openrct2/paint/support/WoodenSupports.cpp
+++ b/src/openrct2/paint/support/WoodenSupports.cpp
@@ -10,6 +10,7 @@
 #include "WoodenSupports.h"
 
 #include "../../interface/Viewport.h"
+#include "../../ride/TrackData.h"
 #include "../../sprites.h"
 #include "../../world/Map.h"
 #include "../../world/Surface.h"
@@ -623,4 +624,32 @@ bool PathBoxSupportsPaintSetup(
     }
 
     return hasSupports;
+}
+
+bool DrawSupportForSequenceA(
+    PaintSession& session, WoodenSupportType supportType, track_type_t trackType, uint8_t sequence, Direction direction,
+    int32_t height, ImageId imageTemplate)
+{
+    const auto& ted = OpenRCT2::TrackMetaData::GetTrackElementDescriptor(trackType);
+    const auto& desc = ted.sequenceWoodenSupports[sequence];
+
+    if (desc.subType == WoodenSupportSubType::Null)
+        return false;
+
+    return WoodenASupportsPaintSetupRotated(
+        session, supportType, desc.subType, direction, height, imageTemplate, desc.transitionType);
+}
+
+bool DrawSupportForSequenceB(
+    PaintSession& session, WoodenSupportType supportType, track_type_t trackType, uint8_t sequence, Direction direction,
+    int32_t height, ImageId imageTemplate)
+{
+    const auto& ted = OpenRCT2::TrackMetaData::GetTrackElementDescriptor(trackType);
+    const auto& desc = ted.sequenceWoodenSupports[sequence];
+
+    if (desc.subType == WoodenSupportSubType::Null)
+        return false;
+
+    return WoodenBSupportsPaintSetupRotated(
+        session, supportType, desc.subType, direction, height, imageTemplate, desc.transitionType);
 }

--- a/src/openrct2/paint/support/WoodenSupports.h
+++ b/src/openrct2/paint/support/WoodenSupports.h
@@ -14,6 +14,8 @@
 
 #include <cstdint>
 
+using track_type_t = uint16_t;
+
 enum class WoodenSupportType : uint8_t
 {
     Truss = 0,
@@ -75,3 +77,9 @@ bool WoodenBSupportsPaintSetupRotated(
 bool PathBoxSupportsPaintSetup(
     PaintSession& session, WoodenSupportSubType supportType, bool isSloped, Direction slopeRotation, int32_t height,
     ImageId imageTemplate, const FootpathPaintInfo& pathPaintInfo);
+bool DrawSupportForSequenceA(
+    PaintSession& session, WoodenSupportType supportType, track_type_t trackType, uint8_t sequence, Direction direction,
+    int32_t height, ImageId imageTemplate);
+bool DrawSupportForSequenceB(
+    PaintSession& session, WoodenSupportType supportType, track_type_t trackType, uint8_t sequence, Direction direction,
+    int32_t height, ImageId imageTemplate);

--- a/src/openrct2/paint/support/WoodenSupports.hpp
+++ b/src/openrct2/paint/support/WoodenSupports.hpp
@@ -1,0 +1,42 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2024 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include "../../ride/TrackData.h"
+
+template<track_type_t trackType>
+bool DrawSupportForSequenceA(
+    PaintSession& session, WoodenSupportType supportType, uint8_t sequence, Direction direction, int32_t height,
+    ImageId imageTemplate)
+{
+    const auto& ted = OpenRCT2::TrackMetaData::GetTrackElementDescriptor(trackType);
+    const auto& desc = ted.sequenceWoodenSupports[sequence];
+
+    if (desc.subType == WoodenSupportSubType::Null)
+        return false;
+
+    return WoodenASupportsPaintSetupRotated(
+        session, supportType, desc.subType, direction, height, imageTemplate, desc.transitionType);
+}
+
+template<track_type_t trackType>
+bool DrawSupportForSequenceB(
+    PaintSession& session, WoodenSupportType supportType, uint8_t sequence, Direction direction, int32_t height,
+    ImageId imageTemplate)
+{
+    const auto& ted = OpenRCT2::TrackMetaData::GetTrackElementDescriptor(trackType);
+    const auto& desc = ted.sequenceWoodenSupports[sequence];
+
+    if (desc.subType == WoodenSupportSubType::Null)
+        return false;
+
+    return WoodenBSupportsPaintSetupRotated(
+        session, supportType, desc.subType, direction, height, imageTemplate, desc.transitionType);
+}

--- a/src/openrct2/paint/track/coaster/AirPoweredVerticalCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/AirPoweredVerticalCoaster.cpp
@@ -16,6 +16,7 @@
 #include "../../../world/Map.h"
 #include "../../Paint.h"
 #include "../../support/WoodenSupports.h"
+#include "../../support/WoodenSupports.hpp"
 #include "../../tile_element/Paint.TileElement.h"
 #include "../../tile_element/Segment.h"
 #include "../../track/Segment.h"
@@ -186,8 +187,8 @@ static void AirPoweredVerticalRCTrackFlat(
     auto imageId = session.TrackColours.WithIndex(imageIds[direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { { 0, 6, height }, { 32, 20, 1 } });
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours);
+    DrawSupportForSequenceA<TrackElemType::Flat>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     PaintUtilPushTunnelRotated(session, direction, height, TunnelType::SquareFlat);
 
@@ -213,8 +214,8 @@ static void AirPoweredVerticalRCTrackStation(
         session, direction, session.TrackColours.WithIndex(imageIds[direction][0]), { 0, 0, height },
         { { 0, 6, height }, { 32, 20, 1 } });
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours);
+    DrawSupportForSequenceA<TrackElemType::EndStation>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     TrackPaintUtilDrawNarrowStationPlatform(session, ride, direction, height, 5, trackElement);
 
@@ -350,8 +351,8 @@ static void AirPoweredVerticalRCTrackFlatToLeftBank(
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { { 0, 27, height }, { 32, 1, 26 } });
     }
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours);
+    DrawSupportForSequenceA<TrackElemType::FlatToLeftBank>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     PaintUtilPushTunnelRotated(session, direction, height, TunnelType::SquareFlat);
 
@@ -380,8 +381,8 @@ static void AirPoweredVerticalRCTrackFlatToRightBank(
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { { 0, 27, height }, { 32, 1, 26 } });
     }
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours);
+    DrawSupportForSequenceA<TrackElemType::FlatToRightBank>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     PaintUtilPushTunnelRotated(session, direction, height, TunnelType::SquareFlat);
 
@@ -543,8 +544,8 @@ static void AirPoweredVerticalRCTrackLeftBank(
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
     }
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours);
+    DrawSupportForSequenceA<TrackElemType::LeftBank>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     PaintUtilPushTunnelRotated(session, direction, height, TunnelType::SquareFlat);
 
@@ -573,8 +574,8 @@ static void AirPoweredVerticalRCTrackBrakes(
     auto imageId = session.TrackColours.WithIndex(imageIds[direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { { 0, 6, height }, { 32, 20, 1 } });
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours);
+    DrawSupportForSequenceA<TrackElemType::Brakes>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     PaintUtilPushTunnelRotated(session, direction, height, TunnelType::SquareFlat);
 
@@ -987,8 +988,8 @@ static void AirPoweredVerticalRCTrackBooster(
         PaintUtilPushTunnelLeft(session, height, TunnelType::SquareFlat);
     }
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours);
+    DrawSupportForSequenceA<TrackElemType::Booster>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
 }
@@ -1007,8 +1008,8 @@ static void AirPoweredVerticalRCTrackOnridePhoto(
     auto imageId = session.TrackColours.WithIndex(imageIds[direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height }, { { 0, 6, height }, { 32, 20, 1 } });
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours);
+    DrawSupportForSequenceA<TrackElemType::OnRidePhoto>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     TrackPaintUtilOnridePhotoPaint(session, direction, height + 3, trackElement);
     PaintUtilPushTunnelRotated(session, direction, height, TunnelType::SquareFlat);

--- a/src/openrct2/paint/track/coaster/HeartlineTwisterCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/HeartlineTwisterCoaster.cpp
@@ -16,6 +16,7 @@
 #include "../../../world/Map.h"
 #include "../../Paint.h"
 #include "../../support/WoodenSupports.h"
+#include "../../support/WoodenSupports.hpp"
 #include "../../tile_element/Paint.TileElement.h"
 #include "../../tile_element/Segment.h"
 #include "../../track/Segment.h"
@@ -93,8 +94,8 @@ static void HeartlineTwisterRCTrackFlat(
         }
     }
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours);
+    DrawSupportForSequenceA<TrackElemType::Flat>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     PaintUtilPushTunnelRotated(session, direction, height, TunnelType::StandardFlat);
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
@@ -207,9 +208,8 @@ static void HeartlineTwisterRCTrack25DegUp(
         }
     }
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours,
-        WoodenSupportTransitionType::Up25Deg);
+    DrawSupportForSequenceA<TrackElemType::Up25>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     if (direction == 0 || direction == 3)
     {
@@ -305,9 +305,8 @@ static void HeartlineTwisterRCTrack60DegUp(
         }
     }
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours,
-        WoodenSupportTransitionType::Up60Deg);
+    DrawSupportForSequenceA<TrackElemType::Up60>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     if (direction == 0 || direction == 3)
     {
@@ -403,9 +402,8 @@ static void HeartlineTwisterRCTrackFlatTo25DegUp(
         }
     }
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours,
-        WoodenSupportTransitionType::FlatToUp25Deg);
+    DrawSupportForSequenceA<TrackElemType::FlatToUp25>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     if (direction == 0 || direction == 3)
     {
@@ -501,9 +499,8 @@ static void HeartlineTwisterRCTrack25DegUpTo60DegUp(
         }
     }
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours,
-        WoodenSupportTransitionType::Up25DegToUp60Deg);
+    DrawSupportForSequenceA<TrackElemType::Up25ToUp60>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     if (direction == 0 || direction == 3)
     {
@@ -599,9 +596,8 @@ static void HeartlineTwisterRCTrack60DegUpTo25DegUp(
         }
     }
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours,
-        WoodenSupportTransitionType::Up60DegToUp25Deg);
+    DrawSupportForSequenceA<TrackElemType::Up60ToUp25>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     if (direction == 0 || direction == 3)
     {
@@ -697,9 +693,8 @@ static void HeartlineTwisterRCTrack25DegUpToFlat(
         }
     }
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours,
-        WoodenSupportTransitionType::Up25DegToFlat);
+    DrawSupportForSequenceA<TrackElemType::Up25ToFlat>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     if (direction == 0 || direction == 3)
     {
@@ -805,9 +800,8 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                     break;
             }
 
-            WoodenASupportsPaintSetupRotated(
-                session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours,
-                WoodenSupportTransitionType::FlatToUp25Deg);
+            DrawSupportForSequenceA<TrackElemType::HeartLineTransferUp>(
+                session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
             if (direction == 0 || direction == 3)
             {
@@ -881,9 +875,8 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                     break;
             }
 
-            WoodenASupportsPaintSetupRotated(
-                session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours,
-                WoodenSupportTransitionType::Up25DegToFlat);
+            DrawSupportForSequenceA<TrackElemType::HeartLineTransferUp>(
+                session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
             PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48);
@@ -925,8 +918,8 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                     break;
             }
 
-            WoodenASupportsPaintSetupRotated(
-                session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours);
+            DrawSupportForSequenceA<TrackElemType::HeartLineTransferUp>(
+                session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
             PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -1096,9 +1089,8 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                     break;
             }
 
-            WoodenASupportsPaintSetupRotated(
-                session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours,
-                WoodenSupportTransitionType::Up25DegToFlat);
+            DrawSupportForSequenceA<TrackElemType::HeartLineTransferDown>(
+                session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
             PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48);
@@ -1140,8 +1132,8 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                     break;
             }
 
-            WoodenASupportsPaintSetupRotated(
-                session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours);
+            DrawSupportForSequenceA<TrackElemType::HeartLineTransferDown>(
+                session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
             PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -1183,9 +1175,8 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                     break;
             }
 
-            WoodenASupportsPaintSetupRotated(
-                session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours,
-                WoodenSupportTransitionType::FlatToUp25Deg);
+            DrawSupportForSequenceA<TrackElemType::HeartLineTransferDown>(
+                session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
             if (direction == 0 || direction == 3)
             {
@@ -1432,8 +1423,8 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
             break;
     }
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours);
+    DrawSupportForSequenceA<TrackElemType::LeftHeartLineRoll>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     PaintUtilPushTunnelRotated(session, direction, height, TunnelType::StandardFlat);
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
@@ -1671,8 +1662,8 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
             break;
     }
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours);
+    DrawSupportForSequenceA<TrackElemType::RightHeartLineRoll>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     PaintUtilPushTunnelRotated(session, direction, height, TunnelType::StandardFlat);
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);

--- a/src/openrct2/paint/track/coaster/WoodenWildMouse.cpp
+++ b/src/openrct2/paint/track/coaster/WoodenWildMouse.cpp
@@ -15,7 +15,7 @@
 #include "../../../sprites.h"
 #include "../../../world/Map.h"
 #include "../../Paint.h"
-#include "../../support/WoodenSupports.h"
+#include "../../support/WoodenSupports.hpp"
 #include "../../tile_element/Paint.TileElement.h"
 #include "../../tile_element/Segment.h"
 #include "../../track/Segment.h"
@@ -141,8 +141,8 @@ static void WoodenWildMouseTrackFlat(
 
     auto imageId = session.TrackColours.WithIndex(imageIds[direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 6, height }, { 32, 20, 1 });
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours);
+    DrawSupportForSequenceA<TrackElemType::Flat>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
     PaintUtilPushTunnelRotated(session, direction, height, TunnelType::StandardFlat);
     PaintUtilSetSegmentSupportHeight(
         session,
@@ -173,8 +173,8 @@ static void WoodenWildMouseTrackStation(
     PaintAddImageAsChildRotated(
         session, direction, session.TrackColours.WithIndex(imageIds[direction][0]), { 0, 6, height },
         { { 0, 0, height }, { 32, 20, 1 } });
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours);
+    DrawSupportForSequenceA<TrackElemType::EndStation>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
     TrackPaintUtilDrawStation(session, ride, direction, height, trackElement);
     PaintUtilPushTunnelRotated(session, direction, height, TunnelType::SquareFlat);
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
@@ -205,9 +205,8 @@ static void WoodenWildMouseTrack25DegUp(
     auto imageId = session.TrackColours.WithIndex(imageIds[isChained][direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 2, height }, { { 0, 3, height }, { 32, 25, 1 } });
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours,
-        WoodenSupportTransitionType::Up25Deg);
+    DrawSupportForSequenceA<TrackElemType::Up25>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     if (direction == 0 || direction == 3)
     {
@@ -254,9 +253,8 @@ static void WoodenWildMouseTrack60DegUp(
             session, direction, imageId, { 0, 6, height }, { { 28, 4, height - 16 }, { 2, 24, 93 } });
     }
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours,
-        WoodenSupportTransitionType::Up60Deg);
+    DrawSupportForSequenceA<TrackElemType::Up60>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     if (direction == 0 || direction == 3)
     {
@@ -295,9 +293,8 @@ static void WoodenWildMouseTrackFlatTo25DegUp(
     auto imageId = session.TrackColours.WithIndex(imageIds[isChained][direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 2, height }, { { 0, 3, height }, { 32, 25, 1 } });
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours,
-        WoodenSupportTransitionType::FlatToUp25Deg);
+    DrawSupportForSequenceA<TrackElemType::FlatToUp25>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     if (direction == 0 || direction == 3)
     {
@@ -348,9 +345,8 @@ static void WoodenWildMouseTrack25DegUpTo60DegUp(
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 6, height }, { { 0, 4, height }, { 32, 2, 43 } });
     }
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours,
-        WoodenSupportTransitionType::Up25DegToUp60Deg);
+    DrawSupportForSequenceA<TrackElemType::Up25ToUp60>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     if (direction == 0 || direction == 3)
     {
@@ -400,9 +396,8 @@ static void WoodenWildMouseTrack60DegTo25DegUp(
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 6, height }, { { 0, 4, height }, { 32, 2, 43 } });
     }
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours,
-        WoodenSupportTransitionType::Up60DegToUp25Deg);
+    DrawSupportForSequenceA<TrackElemType::Up60ToUp25>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     if (direction == 0 || direction == 3)
     {
@@ -441,9 +436,8 @@ static void WoodenWildMouseTrack25DegUpToFlat(
     auto imageId = session.TrackColours.WithIndex(imageIds[isChained][direction]);
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 2, height }, { { 0, 3, height }, { 32, 25, 1 } });
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours,
-        WoodenSupportTransitionType::Up25DegToFlat);
+    DrawSupportForSequenceA<TrackElemType::Up25ToFlat>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     if (direction == 0 || direction == 3)
     {
@@ -536,14 +530,8 @@ static void WoodenWildMouseTrackRightQuarterTurn3(
     TrackPaintUtilRightQuarterTurn3TilesPaint4(session, height, direction, trackSequence, session.TrackColours, imageIds);
     TrackPaintUtilRightQuarterTurn3TilesTunnel(session, height, direction, trackSequence, TunnelType::StandardFlat);
 
-    switch (trackSequence)
-    {
-        case 0:
-        case 3:
-            WoodenASupportsPaintSetupRotated(
-                session, kSupportType, WoodenSupportSubType::Corner2, direction, height, session.SupportColours);
-            break;
-    }
+    DrawSupportForSequenceA<TrackElemType::RightQuarterTurn3Tiles>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     int32_t blockedSegments = 0;
     switch (trackSequence)
@@ -598,8 +586,8 @@ static void WoodenWildMouseTrackLeftQuarterTurn1(
             PaintAddImageAsParent(session, imageId, { 6, 6, height }, { 24, 24, 1 });
             break;
     }
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::Corner3, direction, height, session.SupportColours);
+    DrawSupportForSequenceA<TrackElemType::LeftQuarterTurn1Tile>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
     TrackPaintUtilLeftQuarterTurn1TileTunnel(
         session, direction, height, 0, TunnelType::StandardFlat, 0, TunnelType::StandardFlat);
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
@@ -649,9 +637,8 @@ static void WoodenWildMouseTrackFlatTo60DegUp(
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 6, height }, { { 0, 4, height }, { 32, 2, 43 } });
     }
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours,
-        WoodenSupportTransitionType::FlatToUp60Deg);
+    DrawSupportForSequenceA<TrackElemType::FlatToUp60>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     if (direction == 0 || direction == 3)
     {
@@ -701,9 +688,8 @@ static void WoodenWildMouseTrack60DegUpToFlat(
         PaintAddImageAsParentRotated(session, direction, imageId, { 0, 6, height }, { { 0, 4, height }, { 32, 2, 43 } });
     }
 
-    WoodenASupportsPaintSetupRotated(
-        session, kSupportType, WoodenSupportSubType::NeSw, direction, height, session.SupportColours,
-        WoodenSupportTransitionType::Up60DegToFlat);
+    DrawSupportForSequenceA<TrackElemType::Up60ToFlat>(
+        session, kSupportType, trackSequence, direction, height, session.SupportColours);
 
     if (direction == 0 || direction == 3)
     {

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -708,6 +708,349 @@ namespace OpenRCT2::TrackMetaData
 		/* DiagonalBlockBrakes                   */ { 0 },
 	};
 	static_assert(std::size(TrackSequenceProperties) == TrackElemType::Count);
+
+	using WoodenSupportsBySequence = std::array<SequenceWoodenSupport, kMaxSequencesPerPiece>;
+	static constexpr std::array<WoodenSupportsBySequence, TrackElemType::Count> kTrackSequenceWoodenSupports = { {
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // TrackElemType::Flat
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // TrackElemType::EndStation
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // TrackElemType::BeginStation
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // TrackElemType::MiddleStation
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg } }, // Up25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up60Deg } }, // Up60
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp25Deg } }, // FlatToUp25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25DegToUp60Deg } }, // Up25ToUp60
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up60DegToUp25Deg } }, // Up60ToUp25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25DegToFlat } }, // Up25ToFlat
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg } }, // Down25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up60Deg } }, // Down60
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25DegToFlat } }, // FlatToDown25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up60DegToUp25Deg } }, // Down25ToDown60
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25DegToUp60Deg } }, // Down60ToDown25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp25Deg } }, // Down25ToFlat
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Null }, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Null }, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::NwSe } }, // LeftQuarterTurn5Tiles
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Null }, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Null }, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::NwSe } }, // RightQuarterTurn5Tiles
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // FlatToLeftBank
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // FlatToRightBank
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // LeftBankToFlat
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // RightBankToFlat
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Null }, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Null }, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::NwSe } }, // BankedLeftQuarterTurn5Tiles
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Null }, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Null }, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::NwSe } }, // BankedRightQuarterTurn5Tiles
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp25Deg } }, // LeftBankToUp25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp25Deg } }, // RightBankToUp25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25DegToFlat } }, // Up25ToLeftBank
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25DegToFlat } }, // Up25ToRightBank
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25DegToFlat } }, // LeftBankToDown25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25DegToFlat } }, // RightBankToDown25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25DegToFlat } }, // Down25ToLeftBank
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25DegToFlat } }, // Down25ToRightBank
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // LeftBank
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // RightBank
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg }, {}, { WoodenSupportSubType::Corner3 }, { WoodenSupportSubType::Corner1 }, {}, { WoodenSupportSubType::Corner3 }, { WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg } }, // LeftQuarterTurn5TilesUp25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg }, {}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner0 }, {}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg } }, // RightQuarterTurn5TilesUp25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg }, {}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner0 }, {}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg } }, // LeftQuarterTurn5TilesDown25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg }, {}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner0 }, {}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg } }, // RightQuarterTurn5TilesDown25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, {  WoodenSupportSubType::Corner3 }, { WoodenSupportSubType::Corner1 }, { WoodenSupportSubType::NeSw } }, // SBendLeft
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, {  WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::NeSw } }, // SBendRight
+		{}, // LeftVerticalLoop
+		{}, // RightVerticalLoop
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner3 }, {}, {}, { WoodenSupportSubType::Corner3 } }, // LeftQuarterTurn3Tiles
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner2 }, {}, {}, { WoodenSupportSubType::Corner2 } }, // RightQuarterTurn3Tiles
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner3 }, {}, {}, { WoodenSupportSubType::Corner3 } }, // LeftBankedQuarterTurn3Tiles
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner3 }, {}, {}, { WoodenSupportSubType::Corner3 } }, // RightBankedQuarterTurn3Tiles
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner3 }, {}, {}, { WoodenSupportSubType::Corner3 } }, // LeftQuarterTurn3TilesUp25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner3 }, {}, {}, { WoodenSupportSubType::Corner3 } }, // RightQuarterTurn3TilesUp25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner3 }, {}, {}, { WoodenSupportSubType::Corner3 } }, // LeftQuarterTurn3TilesDown25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner3 }, {}, {}, { WoodenSupportSubType::Corner3 } }, // RightQuarterTurn3TilesDown25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner3 } }, // LeftQuarterTurn1Tile
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner3 } }, // RightQuarterTurn1Tile
+		{}, // LeftTwistDownToUp
+		{}, // RightTwistDownToUp
+		{}, // LeftTwistUpToDown
+		{}, // RightTwistUpToDown
+		{}, // HalfLoopUp
+		{}, // HalfLoopDown
+		{}, // LeftCorkscrewUp
+		{}, // RightCorkscrewUp
+		{}, // LeftCorkscrewDown
+		{}, // RightCorkscrewDown
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp60Deg } }, // FlatToUp60
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up60DegToFlat } }, // Up60ToFlat
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up60DegToFlat } }, // FlatToDown60
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp60Deg } }, // Down60ToFlat
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // TowerBase
+		{}, // TowerSection
+		{}, // FlatCovered
+		{}, // Up25Covered
+		{}, // Up60Covered
+		{}, // FlatToUp25Covered
+		{}, // Up25ToUp60Covered
+		{}, // Up60ToUp25Covered
+		{}, // Up25ToFlatCovered
+		{}, // Down25Covered
+		{}, // Down60Covered
+		{}, // FlatToDown25Covered
+		{}, // Down25ToDown60Covered
+		{}, // Down60ToDown25Covered
+		{}, // Down25ToFlatCovered
+		{}, // LeftQuarterTurn5TilesCovered
+		{}, // RightQuarterTurn5TilesCovered
+		{}, // SBendLeftCovered
+		{}, // SBendRightCovered
+		{}, // LeftQuarterTurn3TilesCovered
+		{}, // RightQuarterTurn3TilesCovered
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner3 }, { WoodenSupportSubType::Corner1 }, {}, { WoodenSupportSubType::Corner3 }, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner0 }, {}, { WoodenSupportSubType::Corner2 } }, // LeftHalfBankedHelixUpSmall
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner0 }, {}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner3 }, { WoodenSupportSubType::Corner1 }, {}, { WoodenSupportSubType::Corner3 } }, // RightHalfBankedHelixUpSmall
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner0 }, {}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner3 }, { WoodenSupportSubType::Corner1 }, {}, { WoodenSupportSubType::Corner3 } }, // LeftHalfBankedHelixDownSmall
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner3 }, { WoodenSupportSubType::Corner1 }, {}, { WoodenSupportSubType::Corner3 }, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner0 }, {}, { WoodenSupportSubType::Corner2 } }, // RightHalfBankedHelixDownSmall
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, {}, { WoodenSupportSubType::Corner3 }, { WoodenSupportSubType::Corner1 }, {}, { WoodenSupportSubType::Corner3 }, { WoodenSupportSubType::NwSe }, { WoodenSupportSubType::NwSe }, {}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner0 }, {}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::NeSw } }, // LeftHalfBankedHelixUpLarge
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, {}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner0 }, {}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::NwSe }, { WoodenSupportSubType::NwSe }, {}, { WoodenSupportSubType::Corner3 }, { WoodenSupportSubType::Corner1 }, {}, { WoodenSupportSubType::Corner3 }, { WoodenSupportSubType::NeSw } }, // RightHalfBankedHelixUpLarge
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, {}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner0 }, {}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::NwSe }, { WoodenSupportSubType::NwSe }, {}, { WoodenSupportSubType::Corner3 }, { WoodenSupportSubType::Corner1 }, {}, { WoodenSupportSubType::Corner3 }, { WoodenSupportSubType::NeSw } }, // LeftHalfBankedHelixDownLarge
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, {}, { WoodenSupportSubType::Corner3 }, { WoodenSupportSubType::Corner1 }, {}, { WoodenSupportSubType::Corner3 }, { WoodenSupportSubType::NwSe }, { WoodenSupportSubType::NwSe }, {}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner0 }, {}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::NeSw } }, // RightHalfBankedHelixDownLarge
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner3 } }, // LeftQuarterTurn1TileUp60
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner2 } }, // RightQuarterTurn1TileUp60
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner2 } }, // LeftQuarterTurn1TileDown60
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner3 } }, // RightQuarterTurn1TileDown60
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // Brakes
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // Booster
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // Maze
+		{}, // LeftQuarterBankedHelixLargeUp
+		{}, // RightQuarterBankedHelixLargeUp
+		{}, // LeftQuarterBankedHelixLargeDown
+		{}, // RightQuarterBankedHelixLargeDown
+		{}, // LeftQuarterHelixLargeUp
+		{}, // RightQuarterHelixLargeUp
+		{}, // LeftQuarterHelixLargeDown
+		{}, // RightQuarterHelixLargeDown
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg } }, // Up25LeftBanked
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg } }, // Up25RightBanked
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // Waterfall
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // Rapids
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // OnRidePhoto
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg } }, // Down25LeftBanked
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg } }, // Down25RightBanked
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // Watersplash
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp60DegLongBaseSeq0 }, SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp60DegLongBaseSeq1 }, SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp60DegLongBaseSeq2 }, SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp60DegLongBaseSeq3 } }, // FlatToUp60LongBase
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up60DegToFlatLongBaseSeq0 }, SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up60DegToFlatLongBaseSeq1 }, SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up60DegToFlatLongBaseSeq2 }, SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up60DegToFlatLongBaseSeq3 } }, // Up60ToFlatLongBase
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // Whirlpool
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp60DegLongBaseSeq0 }, SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp60DegLongBaseSeq1 }, SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp60DegLongBaseSeq2 }, SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp60DegLongBaseSeq3 } }, // Down60ToFlatLongBase
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up60DegToFlatLongBaseSeq0 }, SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up60DegToFlatLongBaseSeq1 }, SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up60DegToFlatLongBaseSeq2 }, SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up60DegToFlatLongBaseSeq3 } }, // FlatToDown60LongBase
+		{}, // CableLiftHill
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // ReverseFreefallSlope
+		{}, // ReverseFreefallVertical
+		{}, // Up90
+		{}, // Down90
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // Up60ToUp90
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // Down90ToDown60
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // Up90ToUp60
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // Down60ToDown90
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // BrakeForDrop
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Corner1 }, { WoodenSupportSubType::Corner3 }, {} }, // LeftEighthToDiag
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // RightEighthToDiag
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // LeftEighthToOrthogonal
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Corner1 }, { WoodenSupportSubType::Corner3 }, {} }, // RightEighthToOrthogonal
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Corner1 }, { WoodenSupportSubType::Corner3 }, {} }, // LeftEighthBankToDiag
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // RightEighthBankToDiag
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // LeftEighthBankToOrthogonal
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Corner1 }, { WoodenSupportSubType::Corner3 }, {} }, // RightEighthBankToOrthogonal
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagFlat
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagUp25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagUp60
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagFlatToUp25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagUp25ToUp60
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagUp60ToUp25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagUp25ToFlat
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagDown25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagDown60
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagFlatToDown25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagDown25ToDown60
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagDown60ToDown25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagDown25ToFlat
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagFlatToUp60
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagUp60ToFlat
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagFlatToDown60
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagDown60ToFlat
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagFlatToLeftBank
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagFlatToRightBank
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagLeftBankToFlat
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagRightBankToFlat
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagLeftBankToUp25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagRightBankToUp25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagUp25ToLeftBank
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagUp25ToRightBank
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagLeftBankToDown25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagRightBankToDown25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagDown25ToLeftBank
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagDown25ToRightBank
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagLeftBank
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagRightBank
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // LogFlumeReverser
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // SpinningTunnel
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // LeftBarrelRollUpToDown
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // RightBarrelRollUpToDown
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // LeftBarrelRollDownToUp
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // RightBarrelRollDownToUp
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner3 }, {}, {}, { WoodenSupportSubType::Corner3 } }, // LeftBankToLeftQuarterTurn3TilesUp25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner2 }, {}, {}, { WoodenSupportSubType::Corner2 } }, // RightBankToRightQuarterTurn3TilesUp25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner3 }, {}, {}, { WoodenSupportSubType::Corner3 } }, // LeftQuarterTurn3TilesDown25ToLeftBank
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner2 }, {}, {}, { WoodenSupportSubType::Corner2 } }, // RightQuarterTurn3TilesDown25ToRightBank
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg } }, // PoweredLift
+		{}, // LeftLargeHalfLoopUp
+		{}, // RightLargeHalfLoopUp
+		{}, // LeftLargeHalfLoopDown
+		{}, // RightLargeHalfLoopDown
+		{}, // LeftFlyerTwistUp
+		{}, // RightFlyerTwistUp
+		{}, // LeftFlyerTwistDown
+		{}, // RightFlyerTwistDown
+		{}, // FlyerHalfLoopUninvertedUp
+		{}, // FlyerHalfLoopInvertedDown
+		{}, // LeftFlyerCorkscrewUp
+		{}, // RightFlyerCorkscrewUp
+		{}, // LeftFlyerCorkscrewDown
+		{}, // RightFlyerCorkscrewDown
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp25Deg }, { WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25DegToFlat }, { WoodenSupportSubType::NeSw }, {} }, // HeartLineTransferUp
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25DegToFlat }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp25Deg } }, // HeartLineTransferDown
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // LeftHeartLineRoll
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // RightHeartLineRoll
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // MinigolfHoleA
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // MinigolfHoleB
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // MinigolfHoleC
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NwSe } }, // MinigolfHoleD
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NwSe } }, // MinigolfHoleE
+		{}, // MultiDimInvertedFlatToDown90QuarterLoop
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // Up90ToInvertedFlatQuarterLoop
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // InvertedFlatToDown90QuarterLoop
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner3 }, {}, {}, { WoodenSupportSubType::Corner3 } }, // LeftCurvedLiftHill
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner3 }, {}, {}, { WoodenSupportSubType::Corner3 } }, // RightCurvedLiftHill
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // LeftReverser
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // RightReverser
+		{}, // AirThrustTopCap
+		{}, // AirThrustVerticalDown
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // AirThrustVerticalDownToLevel
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // BlockBrakes
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner3 }, {}, {}, { WoodenSupportSubType::Corner3 } }, // LeftBankedQuarterTurn3TileUp25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner2 }, {}, {}, { WoodenSupportSubType::Corner2 } }, // RightBankedQuarterTurn3TileUp25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner2 }, {}, {}, { WoodenSupportSubType::Corner2 } }, // LeftBankedQuarterTurn3TileDown25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::Corner3 }, {}, {}, { WoodenSupportSubType::Corner3 } }, // RightBankedQuarterTurn3TileDown25
+        { SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, {}, { WoodenSupportSubType::Corner3 }, { WoodenSupportSubType::Corner1 }, {}, {}, { WoodenSupportSubType::Corner3 }, { WoodenSupportSubType::NeSw } }, // LeftBankedQuarterTurn5TileUp25
+        { SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, {}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner0 }, {}, {}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::NeSw } }, // RightBankedQuarterTurn5TileUp25
+        { SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, {}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner0 }, {}, {}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::NeSw } }, // LeftBankedQuarterTurn5TileDown25
+        { SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, {}, { WoodenSupportSubType::Corner3 }, { WoodenSupportSubType::Corner1 }, {}, {}, { WoodenSupportSubType::Corner3 }, { WoodenSupportSubType::NeSw } }, // RightBankedQuarterTurn5TileDown25
+        {  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg } }, // Up25ToLeftBankedUp25
+        {  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg } }, // Up25ToRightBankedUp25
+        {  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg } }, // LeftBankedUp25ToUp25
+		{  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg } }, // RightBankedUp25ToUp25
+		{  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg } }, // Down25ToLeftBankedDown25
+		{  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg } }, // Down25ToRightBankedDown25
+		{  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg } }, // LeftBankedDown25ToDown25
+		{  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg } }, // RightBankedDown25ToDown25
+		{  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp25Deg } }, // LeftBankedFlatToLeftBankedUp25
+		{  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp25Deg } }, // RightBankedFlatToRightBankedUp25
+		{  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25DegToFlat } }, // LeftBankedUp25ToLeftBankedFlat
+		{  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25DegToFlat } }, // RightBankedUp25ToRightBankedFlat
+		{  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25DegToFlat } }, // LeftBankedFlatToLeftBankedDown25
+		{  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25DegToFlat } }, // RightBankedFlatToRightBankedDown25
+		{  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp25Deg } }, // LeftBankedDown25ToLeftBankedFlat
+		{  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp25Deg } }, // RightBankedDown25ToRightBankedFlat
+		{  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp25Deg } }, // FlatToLeftBankedUp25
+		{  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp25Deg } }, // FlatToRightBankedUp25
+		{  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25DegToFlat } }, // LeftBankedUp25ToFlat
+		{  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25DegToFlat } }, // RightBankedUp25ToFlat
+		{  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25DegToFlat } }, // FlatToLeftBankedDown25
+		{  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25DegToFlat } }, // FlatToRightBankedDown25
+		{  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp25Deg } }, // LeftBankedDown25ToFlat
+		{  SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::FlatToUp25Deg } }, // RightBankedDown25ToFlat
+		{}, // LeftQuarterTurn1TileUp90
+		{}, // RightQuarterTurn1TileUp90
+		{}, // LeftQuarterTurn1TileDown90
+		{}, // RightQuarterTurn1TileDown90
+		{}, // MultiDimUp90ToInvertedFlatQuarterLoop
+		{}, // MultiDimFlatToDown90QuarterLoop
+		{}, // MultiDimInvertedUp90ToFlatQuarterLoop
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // RotationControlToggle
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // FlatTrack1x4A
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // FlatTrack2x2
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // FlatTrack4x4
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // FlatTrack2x4
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // FlatTrack1x5
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // FlatTrack1x1A
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // FlatTrack1x4B
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw } }, // FlatTrack1x1B
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // FlatTrack1x4C
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // FlatTrack3x3
+		{}, // LeftLargeCorkscrewUp
+		{}, // RightLargeCorkscrewUp
+		{}, // LeftLargeCorkscrewDown
+		{}, // RightLargeCorkscrewDown
+		{}, // LeftMediumHalfLoopUp
+		{}, // RightMediumHalfLoopUp
+		{}, // LeftMediumHalfLoopDown
+		{}, // RightMediumHalfLoopDown
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // LeftZeroGRollUp
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // RightZeroGRollUp
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // LeftZeroGRollDown
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // RightZeroGRollDown
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // LeftLargeZeroGRollUp
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // RightLargeZeroGRollUp
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // LeftLargeZeroGRollDown
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // RightLargeZeroGRollDown
+		{}, // LeftFlyerLargeHalfLoopUninvertedUp
+		{}, // RightFlyerLargeHalfLoopUninvertedUp
+		{}, // LeftFlyerLargeHalfLoopInvertedDown
+		{}, // RightFlyerLargeHalfLoopInvertedDown
+		{}, // LeftFlyerLargeHalfLoopInvertedUp
+		{}, // RightFlyerLargeHalfLoopInvertedUp
+		{}, // LeftFlyerLargeHalfLoopUninvertedDown
+		{}, // RightFlyerLargeHalfLoopUninvertedDown
+		{}, // FlyerHalfLoopInvertedUp
+		{}, // FlyerHalfLoopUninvertedDown
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Corner1 }, { WoodenSupportSubType::Corner3 }, {} }, // LeftEighthToDiagUp25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // RightEighthToDiagUp25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Corner1 }, { WoodenSupportSubType::Corner3 }, {} }, // LeftEighthToDiagDown25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // RightEighthToDiagDown25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // LeftEighthToOrthogonalUp25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::NwSe }, { WoodenSupportSubType::NwSe } }, // RightEighthToOrthogonalUp25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // LeftEighthToOrthogonalDown25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Corner1 }, { WoodenSupportSubType::Corner3 }, {} }, // RightEighthToOrthogonalDown25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagUp25ToLeftBankedUp25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagUp25ToRightBankedUp25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagLeftBankedUp25ToUp25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagRightBankedUp25ToUp25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagDown25ToLeftBankedDown25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagDown25ToRightBankedDown25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagLeftBankedDown25ToDown25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagRightBankedDown25ToDown25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagLeftBankedFlatToLeftBankedUp25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagRightBankedFlatToRightBankedUp25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagLeftBankedUp25ToLeftBankedFlat
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagRightBankedUp25ToRightBankedFlat
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagLeftBankedFlatToLeftBankedDown25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagRightBankedFlatToRightBankedDown25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagLeftBankedDown25ToLeftBankedFlat
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagRightBankedDown25ToRightBankedFlat
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagFlatToLeftBankedUp25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagFlatToRightBankedUp25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagLeftBankedUp25ToFlat
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagRightBankedUp25ToFlat
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagFlatToLeftBankedDown25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagFlatToRightBankedDown25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagLeftBankedDown25ToFlat
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagRightBankedDown25ToFlat
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagUp25LeftBanked
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagUp25RightBanked
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagDown25LeftBanked
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagDown25RightBanked
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Corner1 }, { WoodenSupportSubType::Corner3 }, {} }, // LeftEighthBankToDiagUp25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // RightEighthBankToDiagUp25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Corner1 }, { WoodenSupportSubType::Corner3 }, {} }, // LeftEighthBankToDiagDown25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // RightEighthBankToDiagDown25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::NeSw } }, // LeftEighthBankToOrthogonalUp25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, { WoodenSupportSubType::NwSe }, { WoodenSupportSubType::NwSe } }, // RightEighthBankToOrthogonalUp25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // LeftEighthBankToOrthogonalDown25
+		{ SequenceWoodenSupport{ WoodenSupportSubType::NeSw, WoodenSupportTransitionType::Up25Deg }, { WoodenSupportSubType::NeSw }, { WoodenSupportSubType::Corner1 }, { WoodenSupportSubType::Corner3 }, {} }, // RightEighthBankToOrthogonalDown25
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagBrakes
+		{ SequenceWoodenSupport{}, { WoodenSupportSubType::Corner0 }, { WoodenSupportSubType::Corner2 }, {} }, // DiagBlockBrakes
+	} };
 	
 	constexpr PreviewTrack kTrackBlockEnd { 255, 255, 255, 255, 255, {255, 255}, 255 };
 	
@@ -8042,6 +8385,7 @@ namespace OpenRCT2::TrackMetaData
             {
                 desc.sequenceElementAllowedWallEdges[j] = TrackSequenceElementAllowedWallEdges[i][j];
                 desc.sequenceProperties[j] = TrackSequenceProperties[i][j];
+                desc.sequenceWoodenSupports[j] = kTrackSequenceWoodenSupports[i][j];
             }
         }
 

--- a/src/openrct2/ride/TrackData.h
+++ b/src/openrct2/ride/TrackData.h
@@ -9,7 +9,10 @@
 
 #pragma once
 
+#include "../paint/support/WoodenSupports.h"
 #include "Track.h"
+
+using namespace OpenRCT2;
 
 namespace OpenRCT2::TrackMetaData
 {
@@ -72,6 +75,12 @@ namespace OpenRCT2::TrackMetaData
         return { 0, 0, 0, 0 };
     }
 
+    struct SequenceWoodenSupport
+    {
+        WoodenSupportSubType subType = WoodenSupportSubType::Null;
+        WoodenSupportTransitionType transitionType = WoodenSupportTransitionType::None;
+    };
+
     using TrackComputeFunction = int32_t (*)(const int16_t);
     struct TrackElementDescriptor
     {
@@ -91,6 +100,7 @@ namespace OpenRCT2::TrackMetaData
 
         std::array<uint8_t, kMaxSequencesPerPiece> sequenceElementAllowedWallEdges;
         std::array<uint8_t, kMaxSequencesPerPiece> sequenceProperties;
+        std::array<SequenceWoodenSupport, kMaxSequencesPerPiece> sequenceWoodenSupports;
 
         TrackDefinition definition;
         SpinFunction spinFunction;


### PR DESCRIPTION
Rather than hardcoding the wooden support placement in every call, create a table with this data. This is another small step towards generic code.