### PR TITLE
Fix #22316: Always recreate the window when changing drawing engine

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Change: [#22491] Scrollbars are now hidden if the scrollable widget is not actually overflowing.
 - Fix: [#21908] Errors showing up when placing/moving track design previews.
 - Fix: [#22307] Hover tooltips in financial charts are not invalidated properly.
+- Fix: [#22316] Potential crash when switching the drawing engine while the game is running.
 - Fix: [#22395, #22396] Misaligned tick marks in financial and guest count graphs (original bug).
 
 0.4.13 (2024-08-04)

--- a/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
@@ -62,6 +62,14 @@ public:
 
     ~HardwareDisplayDrawingEngine() override
     {
+        if (_screenTexture != nullptr)
+        {
+            SDL_DestroyTexture(_screenTexture);
+        }
+        if (_scaledScreenTexture != nullptr)
+        {
+            SDL_DestroyTexture(_scaledScreenTexture);
+        }
         SDL_FreeFormat(_screenTextureFormat);
         SDL_DestroyRenderer(_sdlRenderer);
     }

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -714,7 +714,6 @@ static Widget *window_options_page_widgets[] = {
                     break;
                 case WIDX_MINIMIZE_FOCUS_LOSS:
                     Config::Get().general.MinimizeFullscreenFocusLoss ^= 1;
-                    RefreshVideo(false);
                     Config::Save();
                     Invalidate();
                     break;
@@ -853,12 +852,10 @@ static Widget *window_options_page_widgets[] = {
                 case WIDX_DRAWING_ENGINE_DROPDOWN:
                     if (dropdownIndex != EnumValue(Config::Get().general.DrawingEngine))
                     {
-                        DrawingEngine srcEngine = drawing_engine_get_type();
                         DrawingEngine dstEngine = static_cast<DrawingEngine>(dropdownIndex);
 
                         Config::Get().general.DrawingEngine = dstEngine;
-                        bool recreate_window = DrawingEngineRequiresNewWindow(srcEngine, dstEngine);
-                        RefreshVideo(recreate_window);
+                        RefreshVideo();
                         Config::Save();
                         Invalidate();
                     }

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -1124,19 +1124,9 @@ void UpdatePaletteEffects()
     }
 }
 
-void RefreshVideo(bool recreateWindow)
+void RefreshVideo()
 {
-    if (recreateWindow)
-    {
-        ContextRecreateWindow();
-    }
-    else
-    {
-        DrawingEngineDispose();
-        DrawingEngineInit();
-        DrawingEngineResize();
-    }
-
+    ContextRecreateWindow();
     DrawingEngineSetPalette(gPalette);
     GfxInvalidateScreen();
 }

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -630,7 +630,7 @@ std::optional<PaletteMap> GetPaletteMapForColour(colour_t paletteId);
 void UpdatePalette(const uint8_t* colours, int32_t start_index, int32_t num_colours);
 void UpdatePaletteEffects();
 
-void RefreshVideo(bool recreateWindow);
+void RefreshVideo();
 void ToggleWindowedMode();
 
 #include "NewDrawing.h"


### PR DESCRIPTION
We have to always create a new window as SDL has some lingering state left on it even when if we free all SDL related handles. 

Closes #22316