### PR TITLE
Rename ScrollBar struct to ScrollArea and rename its properties

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -210,8 +210,8 @@ static void InputScrollDragContinue(const ScreenCoordsXY& screenCoords, WindowBa
         int16_t size = widget.width() - 1;
         if (scroll.flags & VSCROLLBAR_VISIBLE)
             size -= 11;
-        size = std::max(0, scroll.h_right - size);
-        scroll.h_left = std::min<uint16_t>(std::max(0, scroll.h_left + differentialCoords.x), size);
+        size = std::max(0, scroll.contentWidth - size);
+        scroll.contentOffsetX = std::min<uint16_t>(std::max(0, scroll.contentOffsetX + differentialCoords.x), size);
     }
 
     if (scroll.flags & VSCROLLBAR_VISIBLE)
@@ -219,8 +219,8 @@ static void InputScrollDragContinue(const ScreenCoordsXY& screenCoords, WindowBa
         int16_t size = widget.height() - 1;
         if (scroll.flags & HSCROLLBAR_VISIBLE)
             size -= 11;
-        size = std::max(0, scroll.v_bottom - size);
-        scroll.v_top = std::min<uint16_t>(std::max(0, scroll.v_top + differentialCoords.y), size);
+        size = std::max(0, scroll.contentHeight - size);
+        scroll.contentOffsetY = std::min<uint16_t>(std::max(0, scroll.contentOffsetY + differentialCoords.y), size);
     }
 
     WidgetScrollUpdateThumbs(*w, widgetIndex);
@@ -646,38 +646,38 @@ static void InputScrollBegin(WindowBase& w, WidgetIndex widgetIndex, const Scree
     int32_t widget_width = widg.width() - 1;
     if (scroll.flags & VSCROLLBAR_VISIBLE)
         widget_width -= kScrollBarWidth + 1;
-    int32_t widget_content_width = std::max(scroll.h_right - widget_width, 0);
+    int32_t widget_content_width = std::max(scroll.contentWidth - widget_width, 0);
 
     int32_t widget_height = widg.bottom - widg.top - 1;
     if (scroll.flags & HSCROLLBAR_VISIBLE)
         widget_height -= kScrollBarWidth + 1;
-    int32_t widget_content_height = std::max(scroll.v_bottom - widget_height, 0);
+    int32_t widget_content_height = std::max(scroll.contentHeight - widget_height, 0);
 
     switch (scroll_area)
     {
         case SCROLL_PART_HSCROLLBAR_LEFT:
-            scroll.h_left = std::max(scroll.h_left - 3, 0);
+            scroll.contentOffsetX = std::max(scroll.contentOffsetX - 3, 0);
             break;
         case SCROLL_PART_HSCROLLBAR_RIGHT:
-            scroll.h_left = std::min(scroll.h_left + 3, widget_content_width);
+            scroll.contentOffsetX = std::min(scroll.contentOffsetX + 3, widget_content_width);
             break;
         case SCROLL_PART_HSCROLLBAR_LEFT_TROUGH:
-            scroll.h_left = std::max(scroll.h_left - widget_width, 0);
+            scroll.contentOffsetX = std::max(scroll.contentOffsetX - widget_width, 0);
             break;
         case SCROLL_PART_HSCROLLBAR_RIGHT_TROUGH:
-            scroll.h_left = std::min(scroll.h_left + widget_width, widget_content_width);
+            scroll.contentOffsetX = std::min(scroll.contentOffsetX + widget_width, widget_content_width);
             break;
         case SCROLL_PART_VSCROLLBAR_TOP:
-            scroll.v_top = std::max(scroll.v_top - 3, 0);
+            scroll.contentOffsetY = std::max(scroll.contentOffsetY - 3, 0);
             break;
         case SCROLL_PART_VSCROLLBAR_BOTTOM:
-            scroll.v_top = std::min(scroll.v_top + 3, widget_content_height);
+            scroll.contentOffsetY = std::min(scroll.contentOffsetY + 3, widget_content_height);
             break;
         case SCROLL_PART_VSCROLLBAR_TOP_TROUGH:
-            scroll.v_top = std::max(scroll.v_top - widget_height, 0);
+            scroll.contentOffsetY = std::max(scroll.contentOffsetY - widget_height, 0);
             break;
         case SCROLL_PART_VSCROLLBAR_BOTTOM_TROUGH:
-            scroll.v_top = std::min(scroll.v_top + widget_height, widget_content_height);
+            scroll.contentOffsetY = std::min(scroll.contentOffsetY + widget_height, widget_content_height);
             break;
         default:
             break;
@@ -761,7 +761,7 @@ static void InputScrollPartUpdateHThumb(WindowBase& w, WidgetIndex widgetIndex, 
     if (WindowFindByNumber(w.classification, w.number) != nullptr)
     {
         int32_t newLeft;
-        newLeft = scroll.h_right;
+        newLeft = scroll.contentWidth;
         newLeft *= x;
         x = widget.width() - 21;
         if (scroll.flags & VSCROLLBAR_VISIBLE)
@@ -769,7 +769,7 @@ static void InputScrollPartUpdateHThumb(WindowBase& w, WidgetIndex widgetIndex, 
         newLeft /= x;
         x = newLeft;
         scroll.flags |= HSCROLLBAR_THUMB_PRESSED;
-        newLeft = scroll.h_left;
+        newLeft = scroll.contentOffsetX;
         newLeft += x;
         if (newLeft < 0)
             newLeft = 0;
@@ -777,12 +777,12 @@ static void InputScrollPartUpdateHThumb(WindowBase& w, WidgetIndex widgetIndex, 
         if (scroll.flags & VSCROLLBAR_VISIBLE)
             x -= kScrollBarWidth + 1;
         x *= -1;
-        x += scroll.h_right;
+        x += scroll.contentWidth;
         if (x < 0)
             x = 0;
         if (newLeft > x)
             newLeft = x;
-        scroll.h_left = newLeft;
+        scroll.contentOffsetX = newLeft;
         WidgetScrollUpdateThumbs(w, widgetIndex);
         WidgetInvalidateByNumber(w.classification, w.number, widgetIndex);
     }
@@ -800,7 +800,7 @@ static void InputScrollPartUpdateVThumb(WindowBase& w, WidgetIndex widgetIndex, 
     if (WindowFindByNumber(w.classification, w.number) != nullptr)
     {
         int32_t newTop;
-        newTop = scroll.v_bottom;
+        newTop = scroll.contentHeight;
         newTop *= y;
         y = widget.height() - 21;
         if (scroll.flags & HSCROLLBAR_VISIBLE)
@@ -808,7 +808,7 @@ static void InputScrollPartUpdateVThumb(WindowBase& w, WidgetIndex widgetIndex, 
         newTop /= y;
         y = newTop;
         scroll.flags |= VSCROLLBAR_THUMB_PRESSED;
-        newTop = scroll.v_top;
+        newTop = scroll.contentOffsetY;
         newTop += y;
         if (newTop < 0)
             newTop = 0;
@@ -816,12 +816,12 @@ static void InputScrollPartUpdateVThumb(WindowBase& w, WidgetIndex widgetIndex, 
         if (scroll.flags & HSCROLLBAR_VISIBLE)
             y -= kScrollBarWidth + 1;
         y *= -1;
-        y += scroll.v_bottom;
+        y += scroll.contentHeight;
         if (y < 0)
             y = 0;
         if (newTop > y)
             newTop = y;
-        scroll.v_top = newTop;
+        scroll.contentOffsetY = newTop;
         WidgetScrollUpdateThumbs(w, widgetIndex);
         WidgetInvalidateByNumber(w.classification, w.number, widgetIndex);
     }
@@ -837,8 +837,8 @@ static void InputScrollPartUpdateHLeft(WindowBase& w, WidgetIndex widgetIndex, i
     {
         auto& scroll = w.scrolls[scroll_id];
         scroll.flags |= HSCROLLBAR_LEFT_PRESSED;
-        if (scroll.h_left >= 3)
-            scroll.h_left -= 3;
+        if (scroll.contentOffsetX >= 3)
+            scroll.contentOffsetX -= 3;
         WidgetScrollUpdateThumbs(w, widgetIndex);
         WidgetInvalidateByNumber(w.classification, w.number, widgetIndex);
     }
@@ -855,16 +855,16 @@ static void InputScrollPartUpdateHRight(WindowBase& w, WidgetIndex widgetIndex, 
     {
         auto& scroll = w.scrolls[scroll_id];
         scroll.flags |= HSCROLLBAR_RIGHT_PRESSED;
-        scroll.h_left += 3;
+        scroll.contentOffsetX += 3;
         int32_t newLeft = widget.width() - 1;
         if (scroll.flags & VSCROLLBAR_VISIBLE)
             newLeft -= kScrollBarWidth + 1;
         newLeft *= -1;
-        newLeft += scroll.h_right;
+        newLeft += scroll.contentWidth;
         if (newLeft < 0)
             newLeft = 0;
-        if (scroll.h_left > newLeft)
-            scroll.h_left = newLeft;
+        if (scroll.contentOffsetX > newLeft)
+            scroll.contentOffsetX = newLeft;
         WidgetScrollUpdateThumbs(w, widgetIndex);
         WidgetInvalidateByNumber(w.classification, w.number, widgetIndex);
     }
@@ -880,8 +880,8 @@ static void InputScrollPartUpdateVTop(WindowBase& w, WidgetIndex widgetIndex, in
     {
         auto& scroll = w.scrolls[scroll_id];
         scroll.flags |= VSCROLLBAR_UP_PRESSED;
-        if (scroll.v_top >= 3)
-            scroll.v_top -= 3;
+        if (scroll.contentOffsetY >= 3)
+            scroll.contentOffsetY -= 3;
         WidgetScrollUpdateThumbs(w, widgetIndex);
         WidgetInvalidateByNumber(w.classification, w.number, widgetIndex);
     }
@@ -898,16 +898,16 @@ static void InputScrollPartUpdateVBottom(WindowBase& w, WidgetIndex widgetIndex,
     {
         auto& scroll = w.scrolls[scroll_id];
         scroll.flags |= VSCROLLBAR_DOWN_PRESSED;
-        scroll.v_top += 3;
+        scroll.contentOffsetY += 3;
         int32_t newTop = widget.height() - 1;
         if (scroll.flags & HSCROLLBAR_VISIBLE)
             newTop -= kScrollBarWidth + 1;
         newTop *= -1;
-        newTop += scroll.v_bottom;
+        newTop += scroll.contentHeight;
         if (newTop < 0)
             newTop = 0;
-        if (scroll.v_top > newTop)
-            scroll.v_top = newTop;
+        if (scroll.contentOffsetY > newTop)
+            scroll.contentOffsetY = newTop;
         WidgetScrollUpdateThumbs(w, widgetIndex);
         WidgetInvalidateByNumber(w.classification, w.number, widgetIndex);
     }

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -44,9 +44,9 @@ namespace OpenRCT2::Ui
     static void WidgetCloseboxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
     static void WidgetScrollDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
     static void WidgetHScrollbarDraw(
-        DrawPixelInfo& dpi, const ScrollBar& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour);
+        DrawPixelInfo& dpi, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour);
     static void WidgetVScrollbarDraw(
-        DrawPixelInfo& dpi, const ScrollBar& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour);
+        DrawPixelInfo& dpi, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour);
     static void WidgetDrawImage(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
 
     /**
@@ -682,8 +682,8 @@ namespace OpenRCT2::Ui
         bottomRight.x--;
         bottomRight.y--;
 
-        bool hScrollNeeded = scroll.h_right > widget.width() && (scroll.flags & HSCROLLBAR_VISIBLE);
-        bool vScrollNeeded = scroll.v_bottom > widget.height() && (scroll.flags & VSCROLLBAR_VISIBLE);
+        bool hScrollNeeded = scroll.contentWidth > widget.width() && (scroll.flags & HSCROLLBAR_VISIBLE);
+        bool vScrollNeeded = scroll.contentHeight > widget.height() && (scroll.flags & VSCROLLBAR_VISIBLE);
 
         // Horizontal scrollbar
         if (hScrollNeeded)
@@ -721,8 +721,8 @@ namespace OpenRCT2::Ui
         int32_t cb = std::min<int32_t>(dpi.y + dpi.height, bottomRight.y);
 
         // Set the respective dpi attributes
-        scroll_dpi.x = cl - topLeft.x + scroll.h_left;
-        scroll_dpi.y = ct - topLeft.y + scroll.v_top;
+        scroll_dpi.x = cl - topLeft.x + scroll.contentOffsetX;
+        scroll_dpi.y = ct - topLeft.y + scroll.contentOffsetY;
         scroll_dpi.width = cr - cl;
         scroll_dpi.height = cb - ct;
         scroll_dpi.bits += cl - dpi.x;
@@ -735,7 +735,7 @@ namespace OpenRCT2::Ui
     }
 
     static void WidgetHScrollbarDraw(
-        DrawPixelInfo& dpi, const ScrollBar& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour)
+        DrawPixelInfo& dpi, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour)
     {
         colour.setFlag(ColourFlag::translucent, false);
 
@@ -760,8 +760,8 @@ namespace OpenRCT2::Ui
 
         // Thumb
         {
-            int16_t left = std::max(l + kScrollBarWidth, l + scroll.h_thumb_left - 1);
-            int16_t right = std::min(r - kScrollBarWidth, l + scroll.h_thumb_right - 1);
+            int16_t left = std::max(l + kScrollBarWidth, l + scroll.hThumbLeft - 1);
+            int16_t right = std::min(r - kScrollBarWidth, l + scroll.hThumbRight - 1);
             uint8_t flags = (scroll.flags & HSCROLLBAR_THUMB_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
             GfxFillRectInset(dpi, { { left, t }, { right, b } }, colour, flags);
@@ -777,7 +777,7 @@ namespace OpenRCT2::Ui
     }
 
     static void WidgetVScrollbarDraw(
-        DrawPixelInfo& dpi, const ScrollBar& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour)
+        DrawPixelInfo& dpi, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour)
     {
         colour.setFlag(ColourFlag::translucent, false);
 
@@ -801,8 +801,8 @@ namespace OpenRCT2::Ui
         // Thumb
         GfxFillRectInset(
             dpi,
-            { { l, std::max(t + kScrollBarWidth, t + scroll.v_thumb_top - 1) },
-              { r, std::min(b - kScrollBarWidth, t + scroll.v_thumb_bottom - 1) } },
+            { { l, std::max(t + kScrollBarWidth, t + scroll.vThumbTop - 1) },
+              { r, std::min(b - kScrollBarWidth, t + scroll.vThumbBottom - 1) } },
             { colour }, ((scroll.flags & VSCROLLBAR_THUMB_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
 
         // Down button
@@ -947,7 +947,7 @@ namespace OpenRCT2::Ui
         }
 
         const auto& scroll = w.scrolls[*scroll_id];
-        if ((scroll.flags & HSCROLLBAR_VISIBLE) && scroll.h_right > widget->width()
+        if ((scroll.flags & HSCROLLBAR_VISIBLE) && scroll.contentWidth > widget->width()
             && screenCoords.y >= (w.windowPos.y + widget->bottom - (kScrollBarWidth + 1)))
         {
             // horizontal scrollbar
@@ -971,11 +971,11 @@ namespace OpenRCT2::Ui
             {
                 *output_scroll_area = SCROLL_PART_HSCROLLBAR_RIGHT;
             }
-            else if (screenCoords.x < (widget->left + w.windowPos.x + scroll.h_thumb_left))
+            else if (screenCoords.x < (widget->left + w.windowPos.x + scroll.hThumbLeft))
             {
                 *output_scroll_area = SCROLL_PART_HSCROLLBAR_LEFT_TROUGH;
             }
-            else if (screenCoords.x > (widget->left + w.windowPos.x + scroll.h_thumb_right))
+            else if (screenCoords.x > (widget->left + w.windowPos.x + scroll.hThumbRight))
             {
                 *output_scroll_area = SCROLL_PART_HSCROLLBAR_RIGHT_TROUGH;
             }
@@ -985,7 +985,7 @@ namespace OpenRCT2::Ui
             }
         }
         else if (
-            (scroll.flags & VSCROLLBAR_VISIBLE) && scroll.v_bottom > widget->height()
+            (scroll.flags & VSCROLLBAR_VISIBLE) && scroll.contentHeight > widget->height()
             && (screenCoords.x >= w.windowPos.x + widget->right - (kScrollBarWidth + 1)))
         {
             // vertical scrollbar
@@ -1009,11 +1009,11 @@ namespace OpenRCT2::Ui
             {
                 *output_scroll_area = SCROLL_PART_VSCROLLBAR_BOTTOM;
             }
-            else if (screenCoords.y < (widget->top + w.windowPos.y + scroll.v_thumb_top))
+            else if (screenCoords.y < (widget->top + w.windowPos.y + scroll.vThumbTop))
             {
                 *output_scroll_area = SCROLL_PART_VSCROLLBAR_TOP_TROUGH;
             }
-            else if (screenCoords.y > (widget->top + w.windowPos.y + scroll.v_thumb_bottom))
+            else if (screenCoords.y > (widget->top + w.windowPos.y + scroll.vThumbBottom))
             {
                 *output_scroll_area = SCROLL_PART_VSCROLLBAR_BOTTOM_TROUGH;
             }
@@ -1035,8 +1035,8 @@ namespace OpenRCT2::Ui
             }
             else
             {
-                retScreenCoords.x += scroll.h_left - 1;
-                retScreenCoords.y += scroll.v_top - 1;
+                retScreenCoords.x += scroll.contentOffsetX - 1;
+                retScreenCoords.y += scroll.contentOffsetY - 1;
             }
         }
     }
@@ -1250,27 +1250,27 @@ namespace OpenRCT2::Ui
             int32_t view_size = widget.width() - 21;
             if (scroll.flags & VSCROLLBAR_VISIBLE)
                 view_size -= 11;
-            int32_t x = scroll.h_left * view_size;
-            if (scroll.h_right != 0)
-                x /= scroll.h_right;
-            scroll.h_thumb_left = x + 11;
+            int32_t x = scroll.contentOffsetX * view_size;
+            if (scroll.contentWidth != 0)
+                x /= scroll.contentWidth;
+            scroll.hThumbLeft = x + 11;
 
             x = widget.width() - 2;
             if (scroll.flags & VSCROLLBAR_VISIBLE)
                 x -= 11;
-            x += scroll.h_left;
-            if (scroll.h_right != 0)
-                x = (x * view_size) / scroll.h_right;
+            x += scroll.contentOffsetX;
+            if (scroll.contentWidth != 0)
+                x = (x * view_size) / scroll.contentWidth;
             x += 11;
             view_size += 10;
-            scroll.h_thumb_right = std::min(x, view_size);
+            scroll.hThumbRight = std::min(x, view_size);
 
-            if (scroll.h_thumb_right - scroll.h_thumb_left < 20)
+            if (scroll.hThumbRight - scroll.hThumbLeft < 20)
             {
-                double barPosition = (scroll.h_thumb_right * 1.0) / view_size;
+                double barPosition = (scroll.hThumbRight * 1.0) / view_size;
 
-                scroll.h_thumb_left = static_cast<int32_t>(std::lround(scroll.h_thumb_left - (20 * barPosition)));
-                scroll.h_thumb_right = static_cast<int32_t>(std::lround(scroll.h_thumb_right + (20 * (1 - barPosition))));
+                scroll.hThumbLeft = static_cast<int32_t>(std::lround(scroll.hThumbLeft - (20 * barPosition)));
+                scroll.hThumbRight = static_cast<int32_t>(std::lround(scroll.hThumbRight + (20 * (1 - barPosition))));
             }
         }
 
@@ -1279,27 +1279,27 @@ namespace OpenRCT2::Ui
             int32_t view_size = widget.height() - 21;
             if (scroll.flags & HSCROLLBAR_VISIBLE)
                 view_size -= 11;
-            int32_t y = scroll.v_top * view_size;
-            if (scroll.v_bottom != 0)
-                y /= scroll.v_bottom;
-            scroll.v_thumb_top = y + 11;
+            int32_t y = scroll.contentOffsetY * view_size;
+            if (scroll.contentHeight != 0)
+                y /= scroll.contentHeight;
+            scroll.vThumbTop = y + 11;
 
             y = widget.height() - 2;
             if (scroll.flags & HSCROLLBAR_VISIBLE)
                 y -= 11;
-            y += scroll.v_top;
-            if (scroll.v_bottom != 0)
-                y = (y * view_size) / scroll.v_bottom;
+            y += scroll.contentOffsetY;
+            if (scroll.contentHeight != 0)
+                y = (y * view_size) / scroll.contentHeight;
             y += 11;
             view_size += 10;
-            scroll.v_thumb_bottom = std::min(y, view_size);
+            scroll.vThumbBottom = std::min(y, view_size);
 
-            if (scroll.v_thumb_bottom - scroll.v_thumb_top < 20)
+            if (scroll.vThumbBottom - scroll.vThumbTop < 20)
             {
-                double barPosition = (scroll.v_thumb_bottom * 1.0) / view_size;
+                double barPosition = (scroll.vThumbBottom * 1.0) / view_size;
 
-                scroll.v_thumb_top = static_cast<int32_t>(std::lround(scroll.v_thumb_top - (20 * barPosition)));
-                scroll.v_thumb_bottom = static_cast<int32_t>(std::lround(scroll.v_thumb_bottom + (20 * (1 - barPosition))));
+                scroll.vThumbTop = static_cast<int32_t>(std::lround(scroll.vThumbTop - (20 * barPosition)));
+                scroll.vThumbBottom = static_cast<int32_t>(std::lround(scroll.vThumbBottom + (20 * (1 - barPosition))));
             }
         }
     }

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -268,16 +268,16 @@ static void WindowScrollWheelInput(WindowBase& w, int32_t scrollIndex, int32_t w
         int32_t size = widget->height() - 1;
         if (scroll.flags & HSCROLLBAR_VISIBLE)
             size -= 11;
-        size = std::max(0, scroll.v_bottom - size);
-        scroll.v_top = std::min(std::max(0, scroll.v_top + wheel), size);
+        size = std::max(0, scroll.contentHeight - size);
+        scroll.contentOffsetY = std::min(std::max(0, scroll.contentOffsetY + wheel), size);
     }
     else
     {
         int32_t size = widget->width() - 1;
         if (scroll.flags & VSCROLLBAR_VISIBLE)
             size -= 11;
-        size = std::max(0, scroll.h_right - size);
-        scroll.h_left = std::min(std::max(0, scroll.h_left + wheel), size);
+        size = std::max(0, scroll.contentWidth - size);
+        scroll.contentOffsetX = std::min(std::max(0, scroll.contentOffsetX + wheel), size);
     }
 
     WidgetScrollUpdateThumbs(w, widgetIndex);
@@ -936,8 +936,8 @@ namespace OpenRCT2::Ui::Windows
         // Update scroll widgets
         for (auto& scroll : w.scrolls)
         {
-            scroll.h_right = WINDOW_SCROLL_UNDEFINED;
-            scroll.v_bottom = WINDOW_SCROLL_UNDEFINED;
+            scroll.contentWidth = -1;
+            scroll.contentHeight = -1;
         }
         WindowUpdateScrollWidgets(w);
 
@@ -971,26 +971,26 @@ namespace OpenRCT2::Ui::Windows
 
             if (height == 0)
             {
-                scroll.v_top = 0;
+                scroll.contentOffsetY = 0;
             }
             else if (width == 0)
             {
-                scroll.h_left = 0;
+                scroll.contentOffsetX = 0;
             }
             width++;
             height++;
 
             scrollPositionChanged = 0;
-            if ((widget->content & SCROLL_HORIZONTAL) && width != scroll.h_right)
+            if ((widget->content & SCROLL_HORIZONTAL) && width != scroll.contentWidth)
             {
                 scrollPositionChanged = 1;
-                scroll.h_right = width;
+                scroll.contentWidth = width;
             }
 
-            if ((widget->content & SCROLL_VERTICAL) && height != scroll.v_bottom)
+            if ((widget->content & SCROLL_VERTICAL) && height != scroll.contentHeight)
             {
                 scrollPositionChanged = 1;
-                scroll.v_bottom = height;
+                scroll.contentHeight = height;
             }
 
             if (scrollPositionChanged)
@@ -1023,10 +1023,10 @@ namespace OpenRCT2::Ui::Windows
             auto& scroll = w.scrolls[scroll_index];
             scroll.flags = 0;
             ScreenSize scrollSize = w.OnScrollGetSize(scroll_index);
-            scroll.h_left = 0;
-            scroll.h_right = scrollSize.width + 1;
-            scroll.v_top = 0;
-            scroll.v_bottom = scrollSize.height + 1;
+            scroll.contentOffsetX = 0;
+            scroll.contentWidth = scrollSize.width + 1;
+            scroll.contentOffsetY = 0;
+            scroll.contentHeight = scrollSize.height + 1;
 
             if (widget->content & SCROLL_HORIZONTAL)
                 scroll.flags |= HSCROLLBAR_VISIBLE;

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -433,9 +433,9 @@ ScreenSize CustomListView::GetSize()
         auto left = result.width - widget->right + widget->left + 21;
         if (left < 0)
             left = 0;
-        if (left < scroll.h_left)
+        if (left < scroll.contentOffsetX)
         {
-            scroll.h_left = left;
+            scroll.contentOffsetX = left;
             Invalidate();
         }
 
@@ -443,9 +443,9 @@ ScreenSize CustomListView::GetSize()
         auto top = result.height - widget->bottom + widget->top + 21;
         if (top < 0)
             top = 0;
-        if (top < scroll.v_top)
+        if (top < scroll.contentOffsetY)
         {
-            scroll.v_top = top;
+            scroll.contentOffsetY = top;
             Invalidate();
         }
     }
@@ -549,7 +549,7 @@ void CustomListView::MouseUp(const ScreenCoordsXY& pos)
     }
 }
 
-void CustomListView::Paint(WindowBase* w, DrawPixelInfo& dpi, const ScrollBar* scroll) const
+void CustomListView::Paint(WindowBase* w, DrawPixelInfo& dpi, const ScrollArea* scroll) const
 {
     auto paletteIndex = ColourMapA[w->colours[1].colour].mid_light;
     GfxFillRect(dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width, dpi.y + dpi.height } }, paletteIndex);
@@ -638,7 +638,7 @@ void CustomListView::Paint(WindowBase* w, DrawPixelInfo& dpi, const ScrollBar* s
 
     if (ShowColumnHeaders)
     {
-        y = scroll->v_top;
+        y = scroll->contentOffsetY;
 
         auto bgColour = ColourMapA[w->colours[1].colour].mid_light;
         GfxFillRect(dpi, { { dpi.x, y }, { dpi.x + dpi.width, y + 12 } }, bgColour);
@@ -771,7 +771,7 @@ std::optional<RowColumn> CustomListView::GetItemIndexAt(const ScreenCoordsXY& po
     {
         // Check if we pressed the header
         auto& scroll = ParentWindow->scrolls[ScrollIndex];
-        int32_t absoluteY = pos.y - scroll.v_top;
+        int32_t absoluteY = pos.y - scroll.contentOffsetY;
         if (ShowColumnHeaders && absoluteY >= 0 && absoluteY < kListRowHeight)
         {
             result = RowColumn();

--- a/src/openrct2-ui/scripting/CustomListView.h
+++ b/src/openrct2-ui/scripting/CustomListView.h
@@ -138,7 +138,7 @@ namespace OpenRCT2::Ui::Windows
         void MouseOver(const ScreenCoordsXY& pos, bool isMouseDown);
         void MouseDown(const ScreenCoordsXY& pos);
         void MouseUp(const ScreenCoordsXY& pos);
-        void Paint(WindowBase* w, DrawPixelInfo& dpi, const ScrollBar* scroll) const;
+        void Paint(WindowBase* w, DrawPixelInfo& dpi, const ScrollArea* scroll) const;
 
     private:
         void PaintHeading(

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -406,7 +406,7 @@ namespace OpenRCT2::Ui::Windows
                     VisibleListRefresh();
 
                     selected_list_item = -1;
-                    scrolls[0].v_top = 0;
+                    scrolls[0].contentOffsetY = 0;
                     frame_no = 0;
                     Invalidate();
                     break;
@@ -431,7 +431,7 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_FILTER_CLEAR_BUTTON:
                     std::fill_n(_filter_string, sizeof(_filter_string), 0x00);
                     FilterUpdateCounts();
-                    scrolls->v_top = 0;
+                    scrolls->contentOffsetY = 0;
                     VisibleListRefresh();
                     Invalidate();
                     break;
@@ -566,7 +566,7 @@ namespace OpenRCT2::Ui::Windows
                     Config::Save();
 
                     FilterUpdateCounts();
-                    scrolls->v_top = 0;
+                    scrolls->contentOffsetY = 0;
 
                     VisibleListRefresh();
                     Invalidate();
@@ -829,7 +829,7 @@ namespace OpenRCT2::Ui::Windows
 
             FilterUpdateCounts();
 
-            scrolls->v_top = 0;
+            scrolls->contentOffsetY = 0;
 
             VisibleListRefresh();
             Invalidate();
@@ -1147,7 +1147,7 @@ namespace OpenRCT2::Ui::Windows
             _selectedSubTab = 0;
             _filter_flags |= FILTER_RIDES_ALL;
             selected_list_item = -1;
-            scrolls[0].v_top = 0;
+            scrolls[0].contentOffsetY = 0;
             frame_no = 0;
 
             if (_page == EnumValue(ObjectType::Ride))

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -420,7 +420,7 @@ static Widget _windowFinancesResearchWidgets[] =
             auto screenCoords = ScreenCoordsXY{ 0, kTableCellHeight + 2 };
 
             Widget self = widgets[WIDX_SUMMARY_SCROLL];
-            int32_t row_width = std::max<uint16_t>(scrolls[0].h_right, self.width());
+            int32_t row_width = std::max<uint16_t>(scrolls[0].contentWidth, self.width());
 
             // Expenditure / Income row labels
             for (int32_t i = 0; i < static_cast<int32_t>(ExpenditureType::Count); i++)
@@ -851,7 +851,7 @@ static Widget _windowFinancesResearchWidgets[] =
         void InitialiseScrollPosition(WidgetIndex widgetIndex, int32_t scrollId)
         {
             const auto& widget = this->widgets[widgetIndex];
-            scrolls[scrollId].h_left = std::max(0, scrolls[scrollId].h_right - (widget.width() - 2));
+            scrolls[scrollId].contentOffsetX = std::max(0, scrolls[scrollId].contentWidth - (widget.width() - 2));
 
             WidgetScrollUpdateThumbs(*this, widgetIndex);
         }

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1253,9 +1253,9 @@ static_assert(_guestWindowPageWidgets.size() == WINDOW_GUEST_PAGE_COUNT);
             if (visableHeight < 0)
                 visableHeight = 0;
 
-            if (visableHeight < scrolls[0].v_top)
+            if (visableHeight < scrolls[0].contentOffsetY)
             {
-                scrolls[0].v_top = visableHeight;
+                scrolls[0].contentOffsetY = visableHeight;
                 Invalidate();
             }
             return newSize;

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -290,7 +290,7 @@ static Widget window_guest_list_widgets[] = {
                     _trackingOnly = !_trackingOnly;
                     SetWidgetPressed(WIDX_TRACKING, _trackingOnly);
                     Invalidate();
-                    scrolls[0].v_top = 0;
+                    scrolls[0].contentOffsetY = 0;
                     RefreshList();
                     break;
                 case WIDX_FILTER_BY_NAME:
@@ -340,7 +340,7 @@ static Widget window_guest_list_widgets[] = {
                     _tabAnimationIndex = 0;
                     _selectedFilter = {};
                     Invalidate();
-                    scrolls[0].v_top = 0;
+                    scrolls[0].contentOffsetY = 0;
                     RefreshList();
                     break;
                 }
@@ -528,9 +528,9 @@ static Widget window_guest_list_widgets[] = {
             }
 
             auto i = std::max(0, y - widgets[WIDX_GUEST_LIST].bottom + widgets[WIDX_GUEST_LIST].top + 21);
-            if (i < scrolls[0].v_top)
+            if (i < scrolls[0].contentOffsetY)
             {
-                scrolls[0].v_top = i;
+                scrolls[0].contentOffsetY = i;
                 Invalidate();
             }
 
@@ -583,7 +583,7 @@ static Widget window_guest_list_widgets[] = {
                         widgets[WIDX_TRACKING].type = WindowWidgetType::FlatBtn;
                         Invalidate();
                         widgets[WIDX_FILTER_BY_NAME].type = WindowWidgetType::FlatBtn;
-                        scrolls[0].v_top = 0;
+                        scrolls[0].contentOffsetY = 0;
                         RefreshList();
                     }
                     break;

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -722,8 +722,8 @@ static Widget window_map_widgets[] = {
             cx = std::max(cx - ax, 0);
             dx = std::max(dx - bx, 0);
 
-            bp = scrolls[0].h_right - bp;
-            di = scrolls[0].v_bottom - di;
+            bp = scrolls[0].contentWidth - bp;
+            di = scrolls[0].contentHeight - di;
 
             if (bp < 0 && (bp - cx) < 0)
                 cx = 0;
@@ -731,8 +731,8 @@ static Widget window_map_widgets[] = {
             if (di < 0 && (di - dx) < 0)
                 dx = 0;
 
-            scrolls[0].h_left = cx;
-            scrolls[0].v_top = dx;
+            scrolls[0].contentOffsetX = cx;
+            scrolls[0].contentOffsetY = dx;
             WidgetScrollUpdateThumbs(*this, WIDX_MAP);
         }
 

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -574,9 +574,9 @@ static constexpr StringId WindowMultiplayerPageTitles[] = {
                     + window_multiplayer_players_widgets[WIDX_LIST].top + 21;
                 if (i < 0)
                     i = 0;
-                if (i < scrolls[0].v_top)
+                if (i < scrolls[0].contentOffsetY)
                 {
-                    scrolls[0].v_top = i;
+                    scrolls[0].contentOffsetY = i;
                     Invalidate();
                 }
                 break;
@@ -595,9 +595,9 @@ static constexpr StringId WindowMultiplayerPageTitles[] = {
                     + window_multiplayer_groups_widgets[WIDX_LIST].top + 21;
                 if (i < 0)
                     i = 0;
-                if (i < scrolls[0].v_top)
+                if (i < scrolls[0].contentOffsetY)
                 {
-                    scrolls[0].v_top = i;
+                    scrolls[0].contentOffsetY = i;
                     Invalidate();
                 }
                 break;

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -340,7 +340,7 @@ static Widget window_new_ride_widgets[] = {
 
             if (_currentTab < RESEARCH_TAB)
             {
-                _windowNewRideTabScroll[_currentTab] = scrolls[0].v_top;
+                _windowNewRideTabScroll[_currentTab] = scrolls[0].contentOffsetY;
 
                 // Remove highlight when mouse leaves rides list
                 if (!WidgetIsHighlighted(*this, WIDX_RIDE_LIST))
@@ -374,7 +374,7 @@ static Widget window_new_ride_widgets[] = {
                     break;
                 case WIDX_FILTER_CLEAR_BUTTON:
                     _filter.clear();
-                    scrolls->v_top = 0;
+                    scrolls->contentOffsetY = 0;
                     Invalidate();
                     break;
             }
@@ -523,7 +523,7 @@ static Widget window_new_ride_widgets[] = {
 
             _filter.assign(text);
 
-            scrolls->v_top = 0;
+            scrolls->contentOffsetY = 0;
             Invalidate();
         }
 
@@ -913,7 +913,7 @@ static Widget window_new_ride_widgets[] = {
             // Ensure the current tab scroll is within range
             currentTabScroll = std::min<uint16_t>(currentTabScroll, std::max(0, scrollSize.height - listWidgetHeight));
 
-            scrolls[0].v_top = currentTabScroll;
+            scrolls[0].contentOffsetY = currentTabScroll;
             WidgetScrollUpdateThumbs(*this, WIDX_RIDE_LIST);
         }
 

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -65,7 +65,7 @@ static Widget window_news_widgets[] = {
 
             Widget* widget = &widgets[WIDX_SCROLL];
             ScreenSize scrollSize = OnScrollGetSize(0);
-            scrolls[0].v_top = std::max(0, scrollSize.height - (widget->height() - 1));
+            scrolls[0].contentOffsetY = std::max(0, scrollSize.height - (widget->height() - 1));
             WidgetScrollUpdateThumbs(*this, WIDX_SCROLL);
         }
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -2146,10 +2146,10 @@ static Widget *window_options_page_widgets[] = {
             GfxInvalidateScreen();
         }
 
-        uint8_t GetScrollPercentage(const Widget& widget, const ScrollBar& scroll)
+        uint8_t GetScrollPercentage(const Widget& widget, const ScrollArea& scroll)
         {
             uint8_t w = widget.width() - 1;
-            return static_cast<float>(scroll.h_left) / (scroll.h_right - w) * 100;
+            return static_cast<float>(scroll.contentOffsetX) / (scroll.contentWidth - w) * 100;
         }
 
         void InitializeScrollPosition(WidgetIndex widgetIndex, int32_t scrollId, uint8_t volume)
@@ -2157,8 +2157,8 @@ static Widget *window_options_page_widgets[] = {
             const auto& widget = widgets[widgetIndex];
             auto& scroll = scrolls[scrollId];
 
-            int32_t widgetSize = scroll.h_right - (widget.width() - 1);
-            scroll.h_left = ceil(volume / 100.0f * widgetSize);
+            int32_t widgetSize = scroll.contentWidth - (widget.width() - 1);
+            scroll.contentOffsetX = ceil(volume / 100.0f * widgetSize);
 
             WidgetScrollUpdateThumbs(*this, widgetIndex);
         }

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -5793,7 +5793,7 @@ static_assert(std::size(RatingNames) == 6);
             WidgetInvalidate(*this, WIDX_GRAPH);
 
             widget = &widgets[WIDX_GRAPH];
-            x = scrolls[0].h_left;
+            x = scrolls[0].contentOffsetX;
             if (_autoScrollGraph)
             {
                 auto ride = GetRide(rideId);
@@ -5805,7 +5805,7 @@ static_assert(std::size(RatingNames) == 6);
                 }
             }
 
-            scrolls[0].h_left = std::clamp(x, 0, scrolls[0].h_right - (widget->width() - 2));
+            scrolls[0].contentOffsetX = std::clamp(x, 0, scrolls[0].contentWidth - (widget->width() - 2));
             WidgetScrollUpdateThumbs(*this, WIDX_GRAPH);
         }
 
@@ -5996,7 +5996,7 @@ static_assert(std::size(RatingNames) == 6);
                 auto ft = Formatter();
                 ft.Add<int16_t>(scaled_yUnit);
 
-                DrawTextBasic(dpi, { scrolls[0].h_left + 1, y - 4 }, stringID, ft, { FontStyle::Small });
+                DrawTextBasic(dpi, { scrolls[0].contentOffsetX + 1, y - 4 }, stringID, ft, { FontStyle::Small });
             }
 
             // Time marks

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -395,9 +395,9 @@ static Widget _rideListWidgets[] = {
             auto top = newHeight - widgets[WIDX_LIST].bottom + widgets[WIDX_LIST].top + 21;
             if (top < 0)
                 top = 0;
-            if (top < scrolls[0].v_top)
+            if (top < scrolls[0].contentOffsetY)
             {
-                scrolls[0].v_top = top;
+                scrolls[0].contentOffsetY = top;
                 Invalidate();
             }
 

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -296,7 +296,7 @@ static Widget WindowSceneryBaseWidgets[] = {
                 case WIDX_FILTER_CLEAR_BUTTON:
                     _tabEntries[_activeTabIndex].Filter.clear();
                     ContentUpdateScroll();
-                    scrolls->v_top = 0;
+                    scrolls->contentOffsetY = 0;
                     Invalidate();
                     break;
                 case WIDX_RESTRICT_SCENERY:
@@ -549,7 +549,7 @@ static Widget WindowSceneryBaseWidgets[] = {
             _tabEntries[_activeTabIndex].Filter.assign(text);
             ContentUpdateScroll();
 
-            scrolls->v_top = 0;
+            scrolls->contentOffsetY = 0;
             Invalidate();
         }
 
@@ -1098,9 +1098,9 @@ static Widget WindowSceneryBaseWidgets[] = {
             const int32_t listHeight = height - 14 - widgets[WIDX_SCENERY_LIST].top - 1;
 
             const auto sceneryItem = ContentCountRowsWithSelectedItem(tabIndex);
-            scrolls[SceneryContentScrollIndex].v_bottom = ContentRowsHeight(sceneryItem.allRows) + 1;
+            scrolls[SceneryContentScrollIndex].contentHeight = ContentRowsHeight(sceneryItem.allRows) + 1;
 
-            const int32_t maxTop = std::max(0, scrolls[SceneryContentScrollIndex].v_bottom - listHeight);
+            const int32_t maxTop = std::max(0, scrolls[SceneryContentScrollIndex].contentHeight - listHeight);
             auto rowSelected = CountRows(sceneryItem.selected_item);
             if (sceneryItem.scenerySelection.IsUndefined())
             {
@@ -1127,8 +1127,9 @@ static Widget WindowSceneryBaseWidgets[] = {
                 }
             }
 
-            scrolls[SceneryContentScrollIndex].v_top = ContentRowsHeight(rowSelected);
-            scrolls[SceneryContentScrollIndex].v_top = std::min<int32_t>(maxTop, scrolls[SceneryContentScrollIndex].v_top);
+            scrolls[SceneryContentScrollIndex].contentOffsetY = ContentRowsHeight(rowSelected);
+            scrolls[SceneryContentScrollIndex].contentOffsetY = std::min<int32_t>(
+                maxTop, scrolls[SceneryContentScrollIndex].contentOffsetY);
 
             WidgetScrollUpdateThumbs(*this, WIDX_SCENERY_LIST);
         }

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -237,8 +237,10 @@ static Widget _serverListWidgets[] = {
                 {
                     gDropdownItems[1].Format = STR_ADD_TO_FAVOURITES;
                 }
-                auto dropdownPos = ScreenCoordsXY{ windowPos.x + listWidget.left + screenCoords.x + 2 - scrolls[0].h_left,
-                                                   windowPos.y + listWidget.top + screenCoords.y + 2 - scrolls[0].v_top };
+                auto dropdownPos = ScreenCoordsXY{
+                    windowPos.x + listWidget.left + screenCoords.x + 2 - scrolls[0].contentOffsetX,
+                    windowPos.y + listWidget.top + screenCoords.y + 2 - scrolls[0].contentOffsetY
+                };
                 WindowDropdownShowText(dropdownPos, 0, { COLOUR_GREY }, 0, 2);
             }
         }

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -266,9 +266,9 @@ static Widget window_shortcut_change_widgets[] = {
         {
             auto h = static_cast<int32_t>(_list.size() * kScrollableRowHeight);
             auto bottom = std::max(0, h - widgets[WIDX_SCROLL].bottom + widgets[WIDX_SCROLL].top + 21);
-            if (bottom < scrolls[0].v_top)
+            if (bottom < scrolls[0].contentOffsetY)
             {
-                scrolls[0].v_top = bottom;
+                scrolls[0].contentOffsetY = bottom;
                 Invalidate();
             }
             return { 0, h };

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -230,7 +230,7 @@ static Widget _staffListWidgets[] = {
                         _selectedTab = static_cast<uint8_t>(newSelectedTab);
                         RefreshList();
                         Invalidate();
-                        scrolls[0].v_top = 0;
+                        scrolls[0].contentOffsetY = 0;
                         CancelTools();
                     }
                     break;
@@ -329,9 +329,9 @@ static Widget _staffListWidgets[] = {
             auto i = scrollHeight - widgets[WIDX_STAFF_LIST_LIST].bottom + widgets[WIDX_STAFF_LIST_LIST].top + 21;
             if (i < 0)
                 i = 0;
-            if (i < scrolls[0].v_top)
+            if (i < scrolls[0].contentOffsetY)
             {
-                scrolls[0].v_top = i;
+                scrolls[0].contentOffsetY = i;
                 Invalidate();
             }
 

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -491,7 +491,7 @@ static WindowClass window_themes_tab_7_classes[] = {
                     if (_selected_tab == newSelectedTab)
                         break;
                     _selected_tab = static_cast<uint8_t>(newSelectedTab);
-                    scrolls[0].v_top = 0;
+                    scrolls[0].contentOffsetY = 0;
                     frame_no = 0;
                     OnResize();
                     Invalidate();
@@ -680,9 +680,9 @@ static WindowClass window_themes_tab_7_classes[] = {
             int32_t i = scrollHeight - widgets[WIDX_THEMES_LIST].bottom + widgets[WIDX_THEMES_LIST].top + 21;
             if (i < 0)
                 i = 0;
-            if (i < scrolls[0].v_top)
+            if (i < scrolls[0].contentOffsetY)
             {
-                scrolls[0].v_top = i;
+                scrolls[0].contentOffsetY = i;
                 Invalidate();
             }
 
@@ -714,7 +714,7 @@ static WindowClass window_themes_tab_7_classes[] = {
                             widgets[WIDX_THEMES_COLOURBTN_MASK].left = _button_offset_x + _colour_index_2 * 12
                                 + widgets[WIDX_THEMES_LIST].left;
                             widgets[WIDX_THEMES_COLOURBTN_MASK].top = _colour_index_1 * _row_height + _button_offset_y
-                                - scrolls[0].v_top + widgets[WIDX_THEMES_LIST].top;
+                                - scrolls[0].contentOffsetY + widgets[WIDX_THEMES_LIST].top;
                             widgets[WIDX_THEMES_COLOURBTN_MASK].right = widgets[WIDX_THEMES_COLOURBTN_MASK].left + 12;
                             widgets[WIDX_THEMES_COLOURBTN_MASK].bottom = widgets[WIDX_THEMES_COLOURBTN_MASK].top + 12;
 

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1831,7 +1831,7 @@ static uint64_t PageDisabledWidgets[] = {
         void LoadTile(TileElement* elementToSelect)
         {
             windowTileInspectorSelectedIndex = -1;
-            scrolls[0].v_top = 0;
+            scrolls[0].contentOffsetY = 0;
 
             TileElement* element = MapGetFirstElementAt(_toolMap);
             int16_t numItems = 0;

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -369,7 +369,7 @@ static Widget _trackListWidgets[] = {
 
             FilterList();
 
-            scrolls->v_top = 0;
+            scrolls->contentOffsetY = 0;
 
             Invalidate();
         }

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -165,10 +165,10 @@ static Widget _viewClippingWidgets[] = {
         void OnUpdate() override
         {
             const auto& widget = widgets[WIDX_CLIP_HEIGHT_SLIDER];
-            const ScrollBar* const scroll = &this->scrolls[0];
+            const ScrollArea* const scroll = &this->scrolls[0];
             const int16_t scroll_width = widget.width() - 1;
             const uint8_t clip_height = static_cast<uint8_t>(
-                (static_cast<float>(scroll->h_left) / (scroll->h_right - scroll_width)) * 255);
+                (static_cast<float>(scroll->contentOffsetX) / (scroll->contentWidth - scroll_width)) * 255);
             if (clip_height != gClipHeight)
             {
                 gClipHeight = clip_height;
@@ -388,8 +388,8 @@ static Widget _viewClippingWidgets[] = {
             gClipHeight = clipHeight;
             const auto& widget = widgets[WIDX_CLIP_HEIGHT_SLIDER];
             const float clip_height_ratio = static_cast<float>(gClipHeight) / 255;
-            this->scrolls[0].h_left = static_cast<int16_t>(
-                std::ceil(clip_height_ratio * (this->scrolls[0].h_right - (widget.width() - 1))));
+            this->scrolls[0].contentOffsetX = static_cast<int16_t>(
+                std::ceil(clip_height_ratio * (this->scrolls[0].contentWidth - (widget.width() - 1))));
         }
 
         bool IsActive()

--- a/src/openrct2/interface/ScrollArea.h
+++ b/src/openrct2/interface/ScrollArea.h
@@ -1,0 +1,56 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2024 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+namespace OpenRCT2
+{
+    struct ScrollArea
+    {
+        uint16_t flags{};
+        int32_t contentOffsetX{};
+        int32_t contentWidth{};
+        int32_t hThumbLeft{};
+        int32_t hThumbRight{};
+        int32_t contentOffsetY{};
+        int32_t contentHeight{};
+        int32_t vThumbTop{};
+        int32_t vThumbBottom{};
+    };
+
+    enum SCROLL_FLAGS
+    {
+        HSCROLLBAR_VISIBLE = (1 << 0),
+        HSCROLLBAR_THUMB_PRESSED = (1 << 1),
+        HSCROLLBAR_LEFT_PRESSED = (1 << 2),
+        HSCROLLBAR_RIGHT_PRESSED = (1 << 3),
+        VSCROLLBAR_VISIBLE = (1 << 4),
+        VSCROLLBAR_THUMB_PRESSED = (1 << 5),
+        VSCROLLBAR_UP_PRESSED = (1 << 6),
+        VSCROLLBAR_DOWN_PRESSED = (1 << 7),
+    };
+
+    enum
+    {
+        SCROLL_PART_NONE = -1,
+        SCROLL_PART_VIEW = 0,
+        SCROLL_PART_HSCROLLBAR_LEFT = 1,
+        SCROLL_PART_HSCROLLBAR_RIGHT = 2,
+        SCROLL_PART_HSCROLLBAR_LEFT_TROUGH = 3,
+        SCROLL_PART_HSCROLLBAR_RIGHT_TROUGH = 4,
+        SCROLL_PART_HSCROLLBAR_THUMB = 5,
+        SCROLL_PART_VSCROLLBAR_TOP = 6,
+        SCROLL_PART_VSCROLLBAR_BOTTOM = 7,
+        SCROLL_PART_VSCROLLBAR_TOP_TROUGH = 8,
+        SCROLL_PART_VSCROLLBAR_BOTTOM_TROUGH = 9,
+        SCROLL_PART_VSCROLLBAR_THUMB = 10,
+    };
+} // namespace OpenRCT2

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -181,23 +181,6 @@ struct Viewport
     void Invalidate() const;
 };
 
-/**
- * Scroll structure
- * size: 0x12
- */
-struct ScrollArea
-{
-    uint16_t flags{};
-    int32_t contentOffsetX{};
-    int32_t contentWidth{};
-    int32_t hThumbLeft{};
-    int32_t hThumbRight{};
-    int32_t contentOffsetY{};
-    int32_t contentHeight{};
-    int32_t vThumbTop{};
-    int32_t vThumbBottom{};
-};
-
 struct Focus
 {
     using CoordinateFocus = CoordsXYZ;
@@ -270,34 +253,6 @@ enum WINDOW_FLAGS
     // Create only flags
     WF_AUTO_POSITION = (1 << 16),
     WF_CENTRE_SCREEN = (1 << 17),
-};
-
-enum SCROLL_FLAGS
-{
-    HSCROLLBAR_VISIBLE = (1 << 0),
-    HSCROLLBAR_THUMB_PRESSED = (1 << 1),
-    HSCROLLBAR_LEFT_PRESSED = (1 << 2),
-    HSCROLLBAR_RIGHT_PRESSED = (1 << 3),
-    VSCROLLBAR_VISIBLE = (1 << 4),
-    VSCROLLBAR_THUMB_PRESSED = (1 << 5),
-    VSCROLLBAR_UP_PRESSED = (1 << 6),
-    VSCROLLBAR_DOWN_PRESSED = (1 << 7),
-};
-
-enum
-{
-    SCROLL_PART_NONE = -1,
-    SCROLL_PART_VIEW = 0,
-    SCROLL_PART_HSCROLLBAR_LEFT = 1,
-    SCROLL_PART_HSCROLLBAR_RIGHT = 2,
-    SCROLL_PART_HSCROLLBAR_LEFT_TROUGH = 3,
-    SCROLL_PART_HSCROLLBAR_RIGHT_TROUGH = 4,
-    SCROLL_PART_HSCROLLBAR_THUMB = 5,
-    SCROLL_PART_VSCROLLBAR_TOP = 6,
-    SCROLL_PART_VSCROLLBAR_BOTTOM = 7,
-    SCROLL_PART_VSCROLLBAR_TOP_TROUGH = 8,
-    SCROLL_PART_VSCROLLBAR_BOTTOM_TROUGH = 9,
-    SCROLL_PART_VSCROLLBAR_THUMB = 10,
 };
 
 enum

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -185,20 +185,18 @@ struct Viewport
  * Scroll structure
  * size: 0x12
  */
-struct ScrollBar
+struct ScrollArea
 {
     uint16_t flags{};
-    int32_t h_left{};
-    int32_t h_right{};
-    int32_t h_thumb_left{};
-    int32_t h_thumb_right{};
-    int32_t v_top{};
-    int32_t v_bottom{};
-    int32_t v_thumb_top{};
-    int32_t v_thumb_bottom{};
+    int32_t contentOffsetX{};
+    int32_t contentWidth{};
+    int32_t hThumbLeft{};
+    int32_t hThumbRight{};
+    int32_t contentOffsetY{};
+    int32_t contentHeight{};
+    int32_t vThumbTop{};
+    int32_t vThumbBottom{};
 };
-
-constexpr auto WINDOW_SCROLL_UNDEFINED = std::numeric_limits<int32_t>::max();
 
 struct Focus
 {

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -50,7 +50,7 @@ struct WindowBase
         RideId rideId;
     };
     uint16_t flags{};
-    ScrollBar scrolls[3];
+    ScrollArea scrolls[3];
     uint16_t no_list_items{};     // 0 for no items
     int16_t selected_list_item{}; // -1 for none selected
     std::optional<Focus> focus;

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "Colour.h"
+#include "ScrollArea.h"
 #include "Window.h"
 
 #include <list>
@@ -50,7 +51,7 @@ struct WindowBase
         RideId rideId;
     };
     uint16_t flags{};
-    ScrollArea scrolls[3];
+    OpenRCT2::ScrollArea scrolls[3];
     uint16_t no_list_items{};     // 0 for no items
     int16_t selected_list_item{}; // -1 for none selected
     std::optional<Focus> focus;

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -276,6 +276,7 @@
     <ClInclude Include="interface\Fonts.h" />
     <ClInclude Include="interface\InteractiveConsole.h" />
     <ClInclude Include="interface\Screenshot.h" />
+    <ClInclude Include="interface\ScrollArea.h" />
     <ClInclude Include="interface\Viewport.h" />
     <ClInclude Include="interface\Widget.h" />
     <ClInclude Include="interface\Window.h" />


### PR DESCRIPTION
The `ScrollBar` struct was a bit of a misnomer. This PR changes it to `ScrollArea`, which is also the name we use for OpenLoco, and updates its properties to match OpenLoco's as well.

I had originally meant to move the resulting `ScrollArea.h` file into the UI subproject, but since `Window_internal.h` is still in the library, we can't do that quite yet.