### PR TITLE
Rework modifier key state into strong enum

### DIFF
--- a/src/openrct2-ui/input/InputManager.cpp
+++ b/src/openrct2-ui/input/InputManager.cpp
@@ -29,7 +29,7 @@ using namespace OpenRCT2::Ui;
 
 InputManager::InputManager()
 {
-    InputResetModifierKeyState();
+    _modifierKeyState = EnumValue(ModifierKey::none);
 }
 
 void InputManager::QueueInputEvent(const SDL_Event& e)
@@ -131,7 +131,7 @@ void InputManager::HandleViewScrolling()
         if (InputGetState() != InputState::Normal)
             return;
 
-        if (InputIsModifierKeyPressed(ModifierKey::shift) || InputIsModifierKeyPressed(ModifierKey::ctrl))
+        if (IsModifierKeyPressed(ModifierKey::shift) || IsModifierKeyPressed(ModifierKey::ctrl))
             return;
 
         GameHandleEdgeScroll();
@@ -140,34 +140,40 @@ void InputManager::HandleViewScrolling()
 
 void InputManager::HandleModifiers()
 {
-    InputResetModifierKeyState();
+    _modifierKeyState = EnumValue(ModifierKey::none);
+
     auto modifiers = SDL_GetModState();
     if (modifiers & KMOD_SHIFT)
     {
-        InputSetModifierKeyPressed(ModifierKey::shift);
+        _modifierKeyState |= EnumValue(ModifierKey::shift);
     }
     if (modifiers & KMOD_CTRL)
     {
-        InputSetModifierKeyPressed(ModifierKey::ctrl);
+        _modifierKeyState |= EnumValue(ModifierKey::ctrl);
     }
     if (modifiers & KMOD_ALT)
     {
-        InputSetModifierKeyPressed(ModifierKey::alt);
+        _modifierKeyState |= EnumValue(ModifierKey::alt);
     }
 #ifdef __MACOSX__
     if (modifiers & KMOD_GUI)
     {
-        InputSetModifierKeyPressed(ModifierKey::cmd);
+        _modifierKeyState |= EnumValue(ModifierKey::cmd);
     }
 #endif
 
     if (Config::Get().general.VirtualFloorStyle != VirtualFloorStyles::Off)
     {
-        if (InputIsModifierKeyPressed(ModifierKey::ctrl) || InputIsModifierKeyPressed(ModifierKey::shift))
+        if (IsModifierKeyPressed(ModifierKey::ctrl) || IsModifierKeyPressed(ModifierKey::shift))
             VirtualFloorEnable();
         else
             VirtualFloorDisable();
     }
+}
+
+bool InputManager::IsModifierKeyPressed(ModifierKey modifier) const
+{
+    return _modifierKeyState & EnumValue(modifier);
 }
 
 void InputManager::ProcessEvents()

--- a/src/openrct2-ui/input/InputManager.cpp
+++ b/src/openrct2-ui/input/InputManager.cpp
@@ -126,7 +126,7 @@ void InputManager::HandleViewScrolling()
         if (InputGetState() != InputState::Normal)
             return;
 
-        if (gInputPlaceObjectModifier & (PLACE_OBJECT_MODIFIER_SHIFT_Z | PLACE_OBJECT_MODIFIER_COPY_Z))
+        if (InputIsModifierKeyPressed(ModifierKey::shift) || InputIsModifierKeyPressed(ModifierKey::ctrl))
             return;
 
         GameHandleEdgeScroll();
@@ -135,30 +135,30 @@ void InputManager::HandleViewScrolling()
 
 void InputManager::HandleModifiers()
 {
+    InputResetModifierKeyState();
     auto modifiers = SDL_GetModState();
-    gInputPlaceObjectModifier = PLACE_OBJECT_MODIFIER_NONE;
     if (modifiers & KMOD_SHIFT)
     {
-        gInputPlaceObjectModifier |= PLACE_OBJECT_MODIFIER_SHIFT_Z;
+        InputSetModifierKeyPressed(ModifierKey::shift);
     }
     if (modifiers & KMOD_CTRL)
     {
-        gInputPlaceObjectModifier |= PLACE_OBJECT_MODIFIER_COPY_Z;
+        InputSetModifierKeyPressed(ModifierKey::ctrl);
     }
     if (modifiers & KMOD_ALT)
     {
-        gInputPlaceObjectModifier |= 4;
+        InputSetModifierKeyPressed(ModifierKey::alt);
     }
 #ifdef __MACOSX__
     if (modifiers & KMOD_GUI)
     {
-        gInputPlaceObjectModifier |= 8;
+        InputSetModifierKeyPressed(ModifierKey::cmd);
     }
 #endif
 
     if (Config::Get().general.VirtualFloorStyle != VirtualFloorStyles::Off)
     {
-        if (gInputPlaceObjectModifier & (PLACE_OBJECT_MODIFIER_COPY_Z | PLACE_OBJECT_MODIFIER_SHIFT_Z))
+        if (InputIsModifierKeyPressed(ModifierKey::ctrl) || InputIsModifierKeyPressed(ModifierKey::shift))
             VirtualFloorEnable();
         else
             VirtualFloorDisable();

--- a/src/openrct2-ui/input/InputManager.cpp
+++ b/src/openrct2-ui/input/InputManager.cpp
@@ -27,6 +27,11 @@
 
 using namespace OpenRCT2::Ui;
 
+InputManager::InputManager()
+{
+    InputResetModifierKeyState();
+}
+
 void InputManager::QueueInputEvent(const SDL_Event& e)
 {
     switch (e.type)

--- a/src/openrct2-ui/input/InputManager.h
+++ b/src/openrct2-ui/input/InputManager.h
@@ -70,6 +70,8 @@ namespace OpenRCT2::Ui
         bool HasTextInputFocus() const;
 
     public:
+        InputManager();
+
         void QueueInputEvent(const SDL_Event& e);
         void QueueInputEvent(InputEvent&& e);
         void Process();

--- a/src/openrct2-ui/input/InputManager.h
+++ b/src/openrct2-ui/input/InputManager.h
@@ -43,6 +43,15 @@ namespace OpenRCT2::Ui
         InputEventState State;
     };
 
+    enum class ModifierKey : uint8_t
+    {
+        none = 0,
+        shift = 1 << 0,
+        ctrl = 1 << 1,
+        alt = 1 << 2,
+        cmd = 1 << 3,
+    };
+
     class InputManager
     {
     private:
@@ -52,6 +61,7 @@ namespace OpenRCT2::Ui
         ScreenCoordsXY _viewScroll;
         uint32_t _mouseState{};
         std::vector<uint8_t> _keyboardState;
+        uint8_t _modifierKeyState;
 
         void CheckJoysticks();
 
@@ -72,6 +82,7 @@ namespace OpenRCT2::Ui
     public:
         InputManager();
 
+        bool IsModifierKeyPressed(ModifierKey modifier) const;
         void QueueInputEvent(const SDL_Event& e);
         void QueueInputEvent(InputEvent&& e);
         void Process();

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1290,13 +1290,13 @@ void InputStateWidgetPressed(
         if (w->widgets[widgetIndex].type == WindowWidgetType::CloseBox && cursor_w_class == w->classification
             && cursor_w_number == w->number && widgetIndex == cursor_widgetIndex)
         {
-            if (gInputPlaceObjectModifier & PLACE_OBJECT_MODIFIER_SHIFT_Z)
+            if (InputIsModifierKeyPressed(ModifierKey::shift))
             {
                 gLastCloseModifier.window.number = w->number;
                 gLastCloseModifier.window.classification = w->classification;
                 gLastCloseModifier.modifier = CloseWindowModifier::Shift;
             }
-            else if (gInputPlaceObjectModifier & PLACE_OBJECT_MODIFIER_COPY_Z)
+            else if (InputIsModifierKeyPressed(ModifierKey::ctrl))
             {
                 gLastCloseModifier.window.number = w->number;
                 gLastCloseModifier.window.classification = w->classification;
@@ -1643,11 +1643,6 @@ void GameHandleEdgeScroll()
         scrollY = 1;
 
     InputScrollViewport(ScreenCoordsXY(scrollX, scrollY));
-}
-
-bool InputTestPlaceObjectModifier(PLACE_OBJECT_MODIFIER modifier)
-{
-    return gInputPlaceObjectModifier & modifier;
 }
 
 void InputScrollViewport(const ScreenCoordsXY& scrollScreenCoords)

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -10,13 +10,15 @@
 #include "MouseInput.h"
 
 #include "../UiStringIds.h"
-#include "../interface/ViewportInteraction.h"
 
 #include <cassert>
 #include <cmath>
 #include <iterator>
+#include <openrct2-ui/UiContext.h>
+#include <openrct2-ui/input/InputManager.h>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Viewport.h>
+#include <openrct2-ui/interface/ViewportInteraction.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
 #include <openrct2-ui/windows/Window.h>
@@ -1290,13 +1292,14 @@ void InputStateWidgetPressed(
         if (w->widgets[widgetIndex].type == WindowWidgetType::CloseBox && cursor_w_class == w->classification
             && cursor_w_number == w->number && widgetIndex == cursor_widgetIndex)
         {
-            if (InputIsModifierKeyPressed(ModifierKey::shift))
+            auto& im = GetInputManager();
+            if (im.IsModifierKeyPressed(ModifierKey::shift))
             {
                 gLastCloseModifier.window.number = w->number;
                 gLastCloseModifier.window.classification = w->classification;
                 gLastCloseModifier.modifier = CloseWindowModifier::Shift;
             }
-            else if (InputIsModifierKeyPressed(ModifierKey::ctrl))
+            else if (im.IsModifierKeyPressed(ModifierKey::ctrl))
             {
                 gLastCloseModifier.window.number = w->number;
                 gLastCloseModifier.window.classification = w->classification;

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -7,11 +7,12 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include "../interface/Viewport.h"
-
+#include <openrct2-ui/UiContext.h>
+#include <openrct2-ui/input/InputManager.h>
 #include <openrct2-ui/input/MouseInput.h>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/LandTool.h>
+#include <openrct2-ui/interface/Viewport.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
@@ -601,7 +602,7 @@ static Widget window_land_widgets[] = {
          */
         void ToolUpdateLand(const ScreenCoordsXY& screenPos)
         {
-            const bool mapCtrlPressed = InputIsModifierKeyPressed(ModifierKey::ctrl);
+            const bool mapCtrlPressed = GetInputManager().IsModifierKeyPressed(ModifierKey::ctrl);
 
             MapInvalidateSelectionRect();
 

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -601,7 +601,7 @@ static Widget window_land_widgets[] = {
          */
         void ToolUpdateLand(const ScreenCoordsXY& screenPos)
         {
-            const bool mapCtrlPressed = InputTestPlaceObjectModifier(PLACE_OBJECT_MODIFIER_COPY_Z);
+            const bool mapCtrlPressed = InputIsModifierKeyPressed(ModifierKey::ctrl);
 
             MapInvalidateSelectionRect();
 

--- a/src/openrct2-ui/windows/MapTooltip.cpp
+++ b/src/openrct2-ui/windows/MapTooltip.cpp
@@ -97,8 +97,7 @@ static Widget window_map_tooltip_widgets[] = {
         std::memcpy(&stringId, _mapTooltipArgs.Data(), sizeof(StringId));
 
         if (_cursorHoldDuration < 25 || stringId == STR_NONE
-            || InputTestPlaceObjectModifier(
-                static_cast<PLACE_OBJECT_MODIFIER>(PLACE_OBJECT_MODIFIER_COPY_Z | PLACE_OBJECT_MODIFIER_SHIFT_Z))
+            || InputIsModifierKeyPressed(ModifierKey::ctrl) || InputIsModifierKeyPressed(ModifierKey::shift)
             || WindowFindByClass(WindowClass::Error) != nullptr)
         {
             WindowCloseByClass(WindowClass::MapTooltip);

--- a/src/openrct2-ui/windows/MapTooltip.cpp
+++ b/src/openrct2-ui/windows/MapTooltip.cpp
@@ -7,8 +7,9 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include "../interface/Theme.h"
-
+#include <openrct2-ui/UiContext.h>
+#include <openrct2-ui/input/InputManager.h>
+#include <openrct2-ui/interface/Theme.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
@@ -96,8 +97,9 @@ static Widget window_map_tooltip_widgets[] = {
         StringId stringId;
         std::memcpy(&stringId, _mapTooltipArgs.Data(), sizeof(StringId));
 
-        if (_cursorHoldDuration < 25 || stringId == STR_NONE || InputIsModifierKeyPressed(ModifierKey::ctrl)
-            || InputIsModifierKeyPressed(ModifierKey::shift) || WindowFindByClass(WindowClass::Error) != nullptr)
+        auto& im = GetInputManager();
+        if (_cursorHoldDuration < 25 || stringId == STR_NONE || im.IsModifierKeyPressed(ModifierKey::ctrl)
+            || im.IsModifierKeyPressed(ModifierKey::shift) || WindowFindByClass(WindowClass::Error) != nullptr)
         {
             WindowCloseByClass(WindowClass::MapTooltip);
         }

--- a/src/openrct2-ui/windows/MapTooltip.cpp
+++ b/src/openrct2-ui/windows/MapTooltip.cpp
@@ -96,9 +96,8 @@ static Widget window_map_tooltip_widgets[] = {
         StringId stringId;
         std::memcpy(&stringId, _mapTooltipArgs.Data(), sizeof(StringId));
 
-        if (_cursorHoldDuration < 25 || stringId == STR_NONE
-            || InputIsModifierKeyPressed(ModifierKey::ctrl) || InputIsModifierKeyPressed(ModifierKey::shift)
-            || WindowFindByClass(WindowClass::Error) != nullptr)
+        if (_cursorHoldDuration < 25 || stringId == STR_NONE || InputIsModifierKeyPressed(ModifierKey::ctrl)
+            || InputIsModifierKeyPressed(ModifierKey::shift) || WindowFindByClass(WindowClass::Error) != nullptr)
         {
             WindowCloseByClass(WindowClass::MapTooltip);
         }

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2924,7 +2924,7 @@ static Widget _rideConstructionWidgets[] = {
 
         if (!_trackPlaceCtrlState)
         {
-            if (gInputPlaceObjectModifier & PLACE_OBJECT_MODIFIER_COPY_Z)
+            if (InputIsModifierKeyPressed(ModifierKey::ctrl))
             {
                 auto info = GetMapCoordinatesFromPos(screenCoords, 0xFCCA);
                 if (info.SpriteType != ViewportInteractionItem::None)
@@ -2936,7 +2936,7 @@ static Widget _rideConstructionWidgets[] = {
         }
         else
         {
-            if (!(gInputPlaceObjectModifier & PLACE_OBJECT_MODIFIER_COPY_Z))
+            if (!(InputIsModifierKeyPressed(ModifierKey::ctrl)))
             {
                 _trackPlaceCtrlState = false;
             }
@@ -2944,7 +2944,7 @@ static Widget _rideConstructionWidgets[] = {
 
         if (!_trackPlaceShiftState)
         {
-            if (gInputPlaceObjectModifier & PLACE_OBJECT_MODIFIER_SHIFT_Z)
+            if (InputIsModifierKeyPressed(ModifierKey::shift))
             {
                 _trackPlaceShiftState = true;
                 _trackPlaceShiftStart = screenCoords;
@@ -2953,7 +2953,7 @@ static Widget _rideConstructionWidgets[] = {
         }
         else
         {
-            if (gInputPlaceObjectModifier & PLACE_OBJECT_MODIFIER_SHIFT_Z)
+            if (InputIsModifierKeyPressed(ModifierKey::shift))
             {
                 uint16_t maxHeight = ZoomLevel::max().ApplyTo(
                     std::numeric_limits<decltype(TileElement::BaseHeight)>::max() - 32);

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -7,13 +7,14 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include "../interface/ViewportInteraction.h"
-#include "../ride/Construction.h"
-
 #include <limits>
+#include <openrct2-ui/UiContext.h>
+#include <openrct2-ui/input/InputManager.h>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Viewport.h>
+#include <openrct2-ui/interface/ViewportInteraction.h>
 #include <openrct2-ui/interface/Widget.h>
+#include <openrct2-ui/ride/Construction.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Cheats.h>
 #include <openrct2/Context.h>
@@ -2921,10 +2922,11 @@ static Widget _rideConstructionWidgets[] = {
     static std::optional<CoordsXY> RideGetPlacePositionFromScreenPosition(ScreenCoordsXY screenCoords)
     {
         CoordsXY mapCoords;
+        auto& im = GetInputManager();
 
         if (!_trackPlaceCtrlState)
         {
-            if (InputIsModifierKeyPressed(ModifierKey::ctrl))
+            if (im.IsModifierKeyPressed(ModifierKey::ctrl))
             {
                 auto info = GetMapCoordinatesFromPos(screenCoords, 0xFCCA);
                 if (info.SpriteType != ViewportInteractionItem::None)
@@ -2936,7 +2938,7 @@ static Widget _rideConstructionWidgets[] = {
         }
         else
         {
-            if (!(InputIsModifierKeyPressed(ModifierKey::ctrl)))
+            if (!(im.IsModifierKeyPressed(ModifierKey::ctrl)))
             {
                 _trackPlaceCtrlState = false;
             }
@@ -2944,7 +2946,7 @@ static Widget _rideConstructionWidgets[] = {
 
         if (!_trackPlaceShiftState)
         {
-            if (InputIsModifierKeyPressed(ModifierKey::shift))
+            if (im.IsModifierKeyPressed(ModifierKey::shift))
             {
                 _trackPlaceShiftState = true;
                 _trackPlaceShiftStart = screenCoords;
@@ -2953,7 +2955,7 @@ static Widget _rideConstructionWidgets[] = {
         }
         else
         {
-            if (InputIsModifierKeyPressed(ModifierKey::shift))
+            if (im.IsModifierKeyPressed(ModifierKey::shift))
             {
                 uint16_t maxHeight = ZoomLevel::max().ApplyTo(
                     std::numeric_limits<decltype(TileElement::BaseHeight)>::max() - 32);

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -6,11 +6,13 @@
  *
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
-#include "../interface/ViewportInteraction.h"
 
 #include <deque>
+#include <openrct2-ui/UiContext.h>
+#include <openrct2-ui/input/InputManager.h>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Viewport.h>
+#include <openrct2-ui/interface/ViewportInteraction.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
@@ -2359,9 +2361,10 @@ static Widget WindowSceneryBaseWidgets[] = {
             }
             else
             {
+                auto& im = GetInputManager();
                 if (!gSceneryCtrlPressed)
                 {
-                    if (InputIsModifierKeyPressed(ModifierKey::ctrl))
+                    if (im.IsModifierKeyPressed(ModifierKey::ctrl))
                     {
                         // CTRL pressed
                         constexpr auto flag = EnumsToFlags(
@@ -2379,7 +2382,7 @@ static Widget WindowSceneryBaseWidgets[] = {
                 }
                 else
                 {
-                    if (!(InputIsModifierKeyPressed(ModifierKey::ctrl)))
+                    if (!(im.IsModifierKeyPressed(ModifierKey::ctrl)))
                     {
                         // CTRL not pressed
                         gSceneryCtrlPressed = false;
@@ -2388,7 +2391,7 @@ static Widget WindowSceneryBaseWidgets[] = {
 
                 if (!gSceneryShiftPressed)
                 {
-                    if (InputIsModifierKeyPressed(ModifierKey::shift))
+                    if (im.IsModifierKeyPressed(ModifierKey::shift))
                     {
                         // SHIFT pressed
                         gSceneryShiftPressed = true;
@@ -2399,7 +2402,7 @@ static Widget WindowSceneryBaseWidgets[] = {
                 }
                 else
                 {
-                    if (InputIsModifierKeyPressed(ModifierKey::shift))
+                    if (im.IsModifierKeyPressed(ModifierKey::shift))
                     {
                         // SHIFT pressed
                         gSceneryShiftPressZOffset = (gSceneryShiftPressY - screenPos.y + 4);

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -2361,7 +2361,7 @@ static Widget WindowSceneryBaseWidgets[] = {
             {
                 if (!gSceneryCtrlPressed)
                 {
-                    if (InputTestPlaceObjectModifier(PLACE_OBJECT_MODIFIER_COPY_Z))
+                    if (InputIsModifierKeyPressed(ModifierKey::ctrl))
                     {
                         // CTRL pressed
                         constexpr auto flag = EnumsToFlags(
@@ -2379,7 +2379,7 @@ static Widget WindowSceneryBaseWidgets[] = {
                 }
                 else
                 {
-                    if (!(InputTestPlaceObjectModifier(PLACE_OBJECT_MODIFIER_COPY_Z)))
+                    if (!(InputIsModifierKeyPressed(ModifierKey::ctrl)))
                     {
                         // CTRL not pressed
                         gSceneryCtrlPressed = false;
@@ -2388,7 +2388,7 @@ static Widget WindowSceneryBaseWidgets[] = {
 
                 if (!gSceneryShiftPressed)
                 {
-                    if (InputTestPlaceObjectModifier(PLACE_OBJECT_MODIFIER_SHIFT_Z))
+                    if (InputIsModifierKeyPressed(ModifierKey::shift))
                     {
                         // SHIFT pressed
                         gSceneryShiftPressed = true;
@@ -2399,7 +2399,7 @@ static Widget WindowSceneryBaseWidgets[] = {
                 }
                 else
                 {
-                    if (InputTestPlaceObjectModifier(PLACE_OBJECT_MODIFIER_SHIFT_Z))
+                    if (InputIsModifierKeyPressed(ModifierKey::shift))
                     {
                         // SHIFT pressed
                         gSceneryShiftPressZOffset = (gSceneryShiftPressY - screenPos.y + 4);

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -526,7 +526,7 @@ static Widget _staffListWidgets[] = {
         void HireNewMember(StaffType staffType, EntertainerCostume entertainerType)
         {
             bool autoPosition = Config::Get().general.AutoStaffPlacement;
-            if (gInputPlaceObjectModifier & PLACE_OBJECT_MODIFIER_SHIFT_Z)
+            if (InputIsModifierKeyPressed(ModifierKey::shift))
             {
                 autoPosition = autoPosition ^ 1;
             }

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -7,11 +7,12 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include "../interface/ViewportQuery.h"
-
 #include <limits>
+#include <openrct2-ui/UiContext.h>
+#include <openrct2-ui/input/InputManager.h>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Viewport.h>
+#include <openrct2-ui/interface/ViewportQuery.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
@@ -526,7 +527,7 @@ static Widget _staffListWidgets[] = {
         void HireNewMember(StaffType staffType, EntertainerCostume entertainerType)
         {
             bool autoPosition = Config::Get().general.AutoStaffPlacement;
-            if (InputIsModifierKeyPressed(ModifierKey::shift))
+            if (GetInputManager().IsModifierKeyPressed(ModifierKey::shift))
             {
                 autoPosition = autoPosition ^ 1;
             }

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -958,7 +958,7 @@ static uint64_t PageDisabledWidgets[] = {
             CoordsXY mapCoords;
             TileElement* clickedElement = nullptr;
             bool mouseOnViewport = false;
-            if (InputTestPlaceObjectModifier(PLACE_OBJECT_MODIFIER_COPY_Z))
+            if (InputIsModifierKeyPressed(ModifierKey::ctrl))
             {
                 auto info = GetMapCoordinatesFromPos(screenCoords, ViewportInteractionFlags);
                 clickedElement = info.Element;
@@ -1772,7 +1772,7 @@ static uint64_t PageDisabledWidgets[] = {
 
         void UpdateSelectedTile(const ScreenCoordsXY& screenCoords)
         {
-            const bool ctrlIsHeldDown = InputTestPlaceObjectModifier(PLACE_OBJECT_MODIFIER_COPY_Z);
+            const bool ctrlIsHeldDown = InputIsModifierKeyPressed(ModifierKey::ctrl);
             // Mouse hasn't moved
             if (screenCoords.x == _toolMouseX && screenCoords.y == _toolMouseY && _toolCtrlDown == ctrlIsHeldDown)
                 return;

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -7,11 +7,12 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include "../UiStringIds.h"
-#include "../interface/Viewport.h"
-
 #include <iterator>
+#include <openrct2-ui/UiContext.h>
+#include <openrct2-ui/UiStringIds.h>
+#include <openrct2-ui/input/InputManager.h>
 #include <openrct2-ui/interface/Dropdown.h>
+#include <openrct2-ui/interface/Viewport.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Game.h>
@@ -958,7 +959,7 @@ static uint64_t PageDisabledWidgets[] = {
             CoordsXY mapCoords;
             TileElement* clickedElement = nullptr;
             bool mouseOnViewport = false;
-            if (InputIsModifierKeyPressed(ModifierKey::ctrl))
+            if (GetInputManager().IsModifierKeyPressed(ModifierKey::ctrl))
             {
                 auto info = GetMapCoordinatesFromPos(screenCoords, ViewportInteractionFlags);
                 clickedElement = info.Element;
@@ -1772,7 +1773,7 @@ static uint64_t PageDisabledWidgets[] = {
 
         void UpdateSelectedTile(const ScreenCoordsXY& screenCoords)
         {
-            const bool ctrlIsHeldDown = InputIsModifierKeyPressed(ModifierKey::ctrl);
+            const bool ctrlIsHeldDown = GetInputManager().IsModifierKeyPressed(ModifierKey::ctrl);
             // Mouse hasn't moved
             if (screenCoords.x == _toolMouseX && screenCoords.y == _toolMouseY && _toolCtrlDown == ctrlIsHeldDown)
                 return;

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -525,7 +525,7 @@ namespace OpenRCT2
                 LightFXInit();
             }
 
-            InputResetPlaceObjModifier();
+            InputResetModifierKeyState();
             ViewportInitAll();
 
             ContextInit();

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -19,7 +19,6 @@
 #include "Game.h"
 #include "GameState.h"
 #include "GameStateSnapshots.h"
-#include "Input.h"
 #include "OpenRCT2.h"
 #include "ParkImporter.h"
 #include "PlatformEnvironment.h"
@@ -525,7 +524,6 @@ namespace OpenRCT2
                 LightFXInit();
             }
 
-            InputResetModifierKeyState();
             ViewportInitAll();
 
             ContextInit();

--- a/src/openrct2/Input.cpp
+++ b/src/openrct2/Input.cpp
@@ -14,7 +14,8 @@
 
 InputState _inputState;
 uint8_t _inputFlags;
-uint8_t gInputPlaceObjectModifier;
+
+static uint8_t gInputModifierKey;
 
 WidgetRef gHoverWidget;
 WidgetRef gPressedWidget;
@@ -76,7 +77,17 @@ void ResetTooltipNotShown()
     _tooltipNotShownTimeout = gCurrentRealTimeTicks + 50;
 }
 
-void InputResetPlaceObjModifier()
+bool InputIsModifierKeyPressed(ModifierKey modifier)
 {
-    gInputPlaceObjectModifier = PLACE_OBJECT_MODIFIER_NONE;
+    return gInputModifierKey & EnumValue(modifier);
+}
+
+void InputSetModifierKeyPressed(ModifierKey modifier)
+{
+    gInputModifierKey |= EnumValue(modifier);
+}
+
+void InputResetModifierKeyState()
+{
+    gInputModifierKey = EnumValue(ModifierKey::none);
 }

--- a/src/openrct2/Input.cpp
+++ b/src/openrct2/Input.cpp
@@ -15,8 +15,6 @@
 InputState _inputState;
 uint8_t _inputFlags;
 
-static uint8_t gInputModifierKey;
-
 WidgetRef gHoverWidget;
 WidgetRef gPressedWidget;
 
@@ -75,19 +73,4 @@ InputState InputGetState()
 void ResetTooltipNotShown()
 {
     _tooltipNotShownTimeout = gCurrentRealTimeTicks + 50;
-}
-
-bool InputIsModifierKeyPressed(ModifierKey modifier)
-{
-    return gInputModifierKey & EnumValue(modifier);
-}
-
-void InputSetModifierKeyPressed(ModifierKey modifier)
-{
-    gInputModifierKey |= EnumValue(modifier);
-}
-
-void InputResetModifierKeyState()
-{
-    gInputModifierKey = EnumValue(ModifierKey::none);
 }

--- a/src/openrct2/Input.h
+++ b/src/openrct2/Input.h
@@ -50,14 +50,14 @@ enum class InputState
     ScrollRight
 };
 
-enum PLACE_OBJECT_MODIFIER
+enum class ModifierKey : uint8_t
 {
-    PLACE_OBJECT_MODIFIER_NONE = 0,
-    PLACE_OBJECT_MODIFIER_SHIFT_Z = (1 << 0),
-    PLACE_OBJECT_MODIFIER_COPY_Z = (1 << 1),
+    none = 0,
+    shift = 1 << 0,
+    ctrl = 1 << 1,
+    alt = 1 << 2,
+    cmd = 1 << 3,
 };
-
-extern uint8_t gInputPlaceObjectModifier;
 
 extern WidgetRef gHoverWidget;
 extern WidgetRef gPressedWidget;
@@ -78,11 +78,11 @@ void InputSetFlag(INPUT_FLAGS flag, bool on);
 bool InputTestFlag(INPUT_FLAGS flag);
 void InputResetFlags();
 
-bool InputTestPlaceObjectModifier(PLACE_OBJECT_MODIFIER modifier);
+void InputResetModifierKeyState();
+bool InputIsModifierKeyPressed(ModifierKey modifier);
+void InputSetModifierKeyPressed(ModifierKey modifier);
 
 void InputSetState(InputState state);
 InputState InputGetState();
 
 void ResetTooltipNotShown();
-
-void InputResetPlaceObjModifier();

--- a/src/openrct2/Input.h
+++ b/src/openrct2/Input.h
@@ -50,15 +50,6 @@ enum class InputState
     ScrollRight
 };
 
-enum class ModifierKey : uint8_t
-{
-    none = 0,
-    shift = 1 << 0,
-    ctrl = 1 << 1,
-    alt = 1 << 2,
-    cmd = 1 << 3,
-};
-
 extern WidgetRef gHoverWidget;
 extern WidgetRef gPressedWidget;
 
@@ -77,10 +68,6 @@ void GameHandleKeyboardInput();
 void InputSetFlag(INPUT_FLAGS flag, bool on);
 bool InputTestFlag(INPUT_FLAGS flag);
 void InputResetFlags();
-
-void InputResetModifierKeyState();
-bool InputIsModifierKeyPressed(ModifierKey modifier);
-void InputSetModifierKeyPressed(ModifierKey modifier);
 
 void InputSetState(InputState state);
 InputState InputGetState();


### PR DESCRIPTION
This PR reworks the modifier key state into a strong enum class in the UI namespace, and takes the state private in `InputManager`. The function `IsModifierKeyPressed` is exposed on the `InputManager` class to query the state.