### PR TITLE
CLI: print help if no arguments are provided

### DIFF
--- a/src/openrct2/command_line/RootCommands.cpp
+++ b/src/openrct2/command_line/RootCommands.cpp
@@ -242,14 +242,18 @@ exitcode_t HandleNoCommand(CommandLineArgEnumerator* enumerator)
         return result;
     }
 
+    // Does it look like a park URI was provided?
     const char* parkUri;
     if (enumerator->TryPopString(&parkUri) && parkUri[0] != '-')
     {
         String::Set(gOpenRCT2StartupActionPath, sizeof(gOpenRCT2StartupActionPath), parkUri);
         gOpenRCT2StartupAction = StartupAction::Open;
+        return EXITCODE_CONTINUE;
     }
 
-    return EXITCODE_CONTINUE;
+    // If not, just print the help.
+    CommandLine::PrintHelp(_all);
+    return EXITCODE_OK;
 }
 
 exitcode_t HandleCommandEdit(CommandLineArgEnumerator* enumerator)


### PR DESCRIPTION
Currently, the CLI OpenRCT2 binary launches into the title scene when no command-line arguments are provided. It tries updating the title sequence, which hasn't loaded, as there is nothing to render it on.

This PR changes the logic such that invoking `openrct2-cli` just defaults to printing the help.