### PR TITLE
Split off MouseInput.h from Input.h

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -27,6 +27,7 @@
 #include <cstdlib>
 #include <memory>
 #include <openrct2-ui/input/InputManager.h>
+#include <openrct2-ui/input/MouseInput.h>
 #include <openrct2-ui/interface/Window.h>
 #include <openrct2/Context.h>
 #include <openrct2/Diagnostic.h>

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -14,6 +14,7 @@
 #include "windows/Window.h"
 
 #include <openrct2-ui/input/InputManager.h>
+#include <openrct2-ui/input/MouseInput.h>
 #include <openrct2-ui/input/ShortcutManager.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Input.h>

--- a/src/openrct2-ui/input/InputManager.cpp
+++ b/src/openrct2-ui/input/InputManager.cpp
@@ -13,6 +13,7 @@
 
 #include <SDL.h>
 #include <openrct2-ui/UiContext.h>
+#include <openrct2-ui/input/MouseInput.h>
 #include <openrct2-ui/input/ShortcutManager.h>
 #include <openrct2-ui/interface/InGameConsole.h>
 #include <openrct2-ui/windows/Window.h>

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1106,8 +1106,6 @@ static void InputWidgetLeft(const ScreenCoordsXY& screenCoords, WindowBase* w, W
     }
 }
 
-#pragma endregion
-
 /**
  *
  *  rct2: 0x006ED833
@@ -1558,29 +1556,6 @@ static void InputUpdateTooltip(WindowBase* w, WidgetIndex widgetIndex, const Scr
             WindowCloseByClass(WindowClass::Tooltip);
         }
     }
-}
-
-#pragma endregion
-
-#pragma region Keyboard input
-
-/**
- *
- *  rct2: 0x00406CD2
- */
-int32_t GetNextKey()
-{
-    uint8_t* keysPressed = const_cast<uint8_t*>(ContextGetKeysPressed());
-    for (int32_t i = 0; i < 221; i++)
-    {
-        if (keysPressed[i])
-        {
-            keysPressed[i] = 0;
-            return i;
-        }
-    }
-
-    return 0;
 }
 
 #pragma endregion

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -7,6 +7,8 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#include "MouseInput.h"
+
 #include "../UiStringIds.h"
 #include "../interface/ViewportInteraction.h"
 

--- a/src/openrct2-ui/input/MouseInput.h
+++ b/src/openrct2-ui/input/MouseInput.h
@@ -1,0 +1,31 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2024 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <openrct2/interface/Window.h>
+
+enum class MouseState : uint32_t
+{
+    Released,
+    LeftPress,
+    LeftRelease,
+    RightPress,
+    RightRelease
+};
+
+extern ScreenCoordsXY gInputDragLast;
+
+void InputWindowPositionBegin(WindowBase& w, WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords);
+void GameHandleInput();
+void GameHandleEdgeScroll();
+
+void StoreMouseInput(MouseState state, const ScreenCoordsXY& screenCoords);
+
+void InputScrollViewport(const ScreenCoordsXY& screenCoords);

--- a/src/openrct2-ui/libopenrct2ui.vcxproj
+++ b/src/openrct2-ui/libopenrct2ui.vcxproj
@@ -64,6 +64,7 @@
     <ClInclude Include="drawing\engines\opengl\TextureCache.h" />
     <ClInclude Include="drawing\engines\opengl\TransparencyDepth.h" />
     <ClInclude Include="input\InputManager.h" />
+    <ClInclude Include="input\MouseInput.h" />
     <ClInclude Include="input\ShortcutIds.h" />
     <ClInclude Include="input\ShortcutManager.h" />
     <ClInclude Include="interface\Dropdown.h" />

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -8,6 +8,7 @@
  *****************************************************************************/
 
 #include <iterator>
+#include <openrct2-ui/input/MouseInput.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Editor.h>

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -9,6 +9,7 @@
 
 #include "../interface/Viewport.h"
 
+#include <openrct2-ui/input/MouseInput.h>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/LandTool.h>
 #include <openrct2-ui/interface/Widget.h>

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -6,9 +6,10 @@
  *
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
-#include "../interface/Viewport.h"
 
+#include <openrct2-ui/input/MouseInput.h>
 #include <openrct2-ui/interface/LandTool.h>
+#include <openrct2-ui/interface/Viewport.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>

--- a/src/openrct2/Input.h
+++ b/src/openrct2/Input.h
@@ -88,7 +88,6 @@ void TitleHandleKeyboardInput();
 void GameHandleInput();
 void GameHandleKeyboardInput();
 void GameHandleEdgeScroll();
-int32_t GetNextKey();
 
 void StoreMouseInput(MouseState state, const ScreenCoordsXY& screenCoords);
 

--- a/src/openrct2/Input.h
+++ b/src/openrct2/Input.h
@@ -36,15 +36,6 @@ enum INPUT_FLAGS
     INPUT_FLAG_VIEWPORT_SCROLLING = (1 << 7)
 };
 
-enum class MouseState : uint32_t
-{
-    Released,
-    LeftPress,
-    LeftRelease,
-    RightPress,
-    RightRelease
-};
-
 enum class InputState
 {
     Reset,
@@ -68,8 +59,6 @@ enum PLACE_OBJECT_MODIFIER
 
 extern uint8_t gInputPlaceObjectModifier;
 
-extern ScreenCoordsXY gInputDragLast;
-
 extern WidgetRef gHoverWidget;
 extern WidgetRef gPressedWidget;
 
@@ -82,14 +71,8 @@ extern InputState _inputState;
 extern uint8_t _inputFlags;
 extern uint32_t _tooltipNotShownTimeout;
 
-void InputWindowPositionBegin(WindowBase& w, WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords);
-
 void TitleHandleKeyboardInput();
-void GameHandleInput();
 void GameHandleKeyboardInput();
-void GameHandleEdgeScroll();
-
-void StoreMouseInput(MouseState state, const ScreenCoordsXY& screenCoords);
 
 void InputSetFlag(INPUT_FLAGS flag, bool on);
 bool InputTestFlag(INPUT_FLAGS flag);
@@ -103,5 +86,3 @@ InputState InputGetState();
 void ResetTooltipNotShown();
 
 void InputResetPlaceObjModifier();
-
-void InputScrollViewport(const ScreenCoordsXY& screenCoords);


### PR DESCRIPTION
Some functions were defined in `Input.h` (libopenrct2), while their implementation is in `MouseInput.cpp` (openrct2-ui). This rectifies that with a new `MouseInput.h` header.

As a bonus, the unused `GetNextKey` function (keyboard logic!) is removed from `MouseInput.cpp`.