### PR TITLE
Move GetInputManager and GetShortcutManager declarations

### DIFF
--- a/src/openrct2-ui/UiContext.h
+++ b/src/openrct2-ui/UiContext.h
@@ -24,8 +24,11 @@ namespace OpenRCT2
 namespace OpenRCT2::Ui
 {
     struct FileDialogDesc;
-    class InGameConsole;
     struct IUiContext;
+
+    class InGameConsole;
+    class InputManager;
+    class ShortcutManager;
 
     struct IPlatformUiContext
     {
@@ -51,4 +54,6 @@ namespace OpenRCT2::Ui
     [[nodiscard]] std::unique_ptr<IPlatformUiContext> CreatePlatformUiContext();
 
     [[nodiscard]] InGameConsole& GetInGameConsole();
+    [[nodiscard]] InputManager& GetInputManager();
+    [[nodiscard]] ShortcutManager& GetShortcutManager();
 } // namespace OpenRCT2::Ui

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -13,6 +13,7 @@
 #include "ride/VehicleSounds.h"
 #include "windows/Window.h"
 
+#include <openrct2-ui/UiContext.h>
 #include <openrct2-ui/input/InputManager.h>
 #include <openrct2-ui/input/ShortcutManager.h>
 #include <openrct2-ui/windows/Window.h>

--- a/src/openrct2-ui/input/ShortcutManager.h
+++ b/src/openrct2-ui/input/ShortcutManager.h
@@ -147,7 +147,4 @@ namespace OpenRCT2::Ui
 
         static std::string_view GetLegacyShortcutId(size_t index);
     };
-
-    InputManager& GetInputManager();
-    ShortcutManager& GetShortcutManager();
 } // namespace OpenRCT2::Ui

--- a/src/openrct2-ui/scripting/CustomMenu.cpp
+++ b/src/openrct2-ui/scripting/CustomMenu.cpp
@@ -13,6 +13,7 @@
 
 #    include "../interface/Viewport.h"
 
+#    include <openrct2-ui/UiContext.h>
 #    include <openrct2-ui/input/ShortcutManager.h>
 #    include <openrct2/Input.h>
 #    include <openrct2/world/Map.h>

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -7,10 +7,11 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include "../input/ShortcutManager.h"
 #include "Window.h"
 
 #include <algorithm>
+#include <openrct2-ui/UiContext.h>
+#include <openrct2-ui/input/ShortcutManager.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Formatter.h>


### PR DESCRIPTION
This PR moves the declarations for `GetInputManager` and `GetShortcutManager` from `ShortcutManager.h` to `UiContext.h`, as `UiContext.cpp` actually implements them.