### PR TITLE
Add ctrl/shift modifiers to footpath tool

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Feature: [#22206] Add option to randomise train or vehicle colours.
 - Feature: [#22392] [Plugin] Expose ride vehicle’s spin to the plugin API.
 - Feature: [#22414] Finance graphs can be resized.
+- Feature: [#22569] Footpath placement now respects the construction modifier keys (ctrl/shift).
 - Change: [#21659] Increase the Hybrid Roller Coaster’s maximum lift speed to 17 km/h (11 mph).
 - Change: [#22466] The Clear Scenery tool now uses a bulldozer cursor instead of a generic crosshair.
 - Change: [#22490] The tool to change land and construction rights has been moved out of the Map window.

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -791,6 +791,7 @@ static constexpr uint8_t ConstructionPreviewImages[][4] = {
             else if (!im.IsModifierKeyPressed(ModifierKey::ctrl))
             {
                 _footpathPlaceCtrlState = false;
+                _footpathPlaceCtrlZ = 0;
             }
 
             if (!_footpathPlaceShiftState && im.IsModifierKeyPressed(ModifierKey::shift))
@@ -824,6 +825,7 @@ static constexpr uint8_t ConstructionPreviewImages[][4] = {
             else if (_footpathPlaceShiftState)
             {
                 _footpathPlaceShiftState = false;
+                _footpathPlaceShiftZ = 0;
             }
 
             if (!_footpathPlaceCtrlState)

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -772,66 +772,65 @@ static constexpr uint8_t ConstructionPreviewImages[][4] = {
             {
                 gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE;
                 FootpathProvisionalUpdate();
+                return;
             }
-            else
+
+            // Check for change
+            if ((gProvisionalFootpath.Flags & PROVISIONAL_PATH_FLAG_1)
+                && gProvisionalFootpath.Position == CoordsXYZ{ info.Loc, info.Element->GetBaseZ() })
             {
-                // Check for change
-                if ((gProvisionalFootpath.Flags & PROVISIONAL_PATH_FLAG_1)
-                    && gProvisionalFootpath.Position == CoordsXYZ{ info.Loc, info.Element->GetBaseZ() })
-                {
-                    return;
-                }
-
-                // Set map selection
-                gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE;
-                gMapSelectType = MAP_SELECT_TYPE_FULL;
-                gMapSelectPositionA = info.Loc;
-                gMapSelectPositionB = info.Loc;
-
-                FootpathProvisionalUpdate();
-
-                // Set provisional path
-                int32_t slope = 0;
-                switch (info.SpriteType)
-                {
-                    case ViewportInteractionItem::Terrain:
-                    {
-                        auto surfaceElement = info.Element->AsSurface();
-                        if (surfaceElement != nullptr)
-                        {
-                            slope = DefaultPathSlope[surfaceElement->GetSlope() & kTileSlopeRaisedCornersMask];
-                        }
-                        break;
-                    }
-                    case ViewportInteractionItem::Footpath:
-                    {
-                        auto pathElement = info.Element->AsPath();
-                        if (pathElement != nullptr)
-                        {
-                            slope = pathElement->GetSlopeDirection();
-                            if (pathElement->IsSloped())
-                            {
-                                slope |= FOOTPATH_PROPERTIES_FLAG_IS_SLOPED;
-                            }
-                        }
-                        break;
-                    }
-                    default:
-                        break;
-                }
-                auto z = info.Element->GetBaseZ();
-                if (slope & RAISE_FOOTPATH_FLAG)
-                {
-                    slope &= ~RAISE_FOOTPATH_FLAG;
-                    z += kPathHeightStep;
-                }
-
-                auto pathType = gFootpathSelection.GetSelectedSurface();
-                auto constructFlags = FootpathCreateConstructFlags(pathType);
-                _windowFootpathCost = FootpathProvisionalSet(
-                    pathType, gFootpathSelection.Railings, { info.Loc, z }, slope, constructFlags);
-                WindowInvalidateByClass(WindowClass::Footpath);
+                return;
             }
+
+            // Set map selection
+            gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE;
+            gMapSelectType = MAP_SELECT_TYPE_FULL;
+            gMapSelectPositionA = info.Loc;
+            gMapSelectPositionB = info.Loc;
+
+            FootpathProvisionalUpdate();
+
+            // Set provisional path
+            int32_t slope = 0;
+            switch (info.SpriteType)
+            {
+                case ViewportInteractionItem::Terrain:
+                {
+                    auto surfaceElement = info.Element->AsSurface();
+                    if (surfaceElement != nullptr)
+                    {
+                        slope = DefaultPathSlope[surfaceElement->GetSlope() & kTileSlopeRaisedCornersMask];
+                    }
+                    break;
+                }
+                case ViewportInteractionItem::Footpath:
+                {
+                    auto pathElement = info.Element->AsPath();
+                    if (pathElement != nullptr)
+                    {
+                        slope = pathElement->GetSlopeDirection();
+                        if (pathElement->IsSloped())
+                        {
+                            slope |= FOOTPATH_PROPERTIES_FLAG_IS_SLOPED;
+                        }
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+            auto z = info.Element->GetBaseZ();
+            if (slope & RAISE_FOOTPATH_FLAG)
+            {
+                slope &= ~RAISE_FOOTPATH_FLAG;
+                z += kPathHeightStep;
+            }
+
+            auto pathType = gFootpathSelection.GetSelectedSurface();
+            auto constructFlags = FootpathCreateConstructFlags(pathType);
+            _windowFootpathCost = FootpathProvisionalSet(
+                pathType, gFootpathSelection.Railings, { info.Loc, z }, slope, constructFlags);
+            WindowInvalidateByClass(WindowClass::Footpath);
         }
 
         /**

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -811,7 +811,10 @@ static constexpr uint8_t ConstructionPreviewImages[][4] = {
                 {
                     _footpathPlaceShiftZ = mainWnd->viewport->zoom.ApplyTo(_footpathPlaceShiftZ);
                 }
-                _footpathPlaceShiftZ = Floor2(_footpathPlaceShiftZ, 8);
+
+                const bool allowInvalidHeights = GetGameState().Cheats.AllowTrackPlaceInvalidHeights;
+                const auto heightStep = kCoordsZStep * (!allowInvalidHeights ? 2 : 1);
+                _footpathPlaceShiftZ = Floor2(_footpathPlaceShiftZ, heightStep);
 
                 // Clamp to maximum possible value of BaseHeight can offer.
                 _footpathPlaceShiftZ = std::min<int16_t>(_footpathPlaceShiftZ, maxHeight);

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -787,7 +787,10 @@ static constexpr uint8_t ConstructionPreviewImages[][4] = {
                     auto info = GetMapCoordinatesFromPos(screenCoords, interactionFlags);
                     if (info.SpriteType != ViewportInteractionItem::None)
                     {
-                        _footpathPlaceCtrlZ = info.Element->GetBaseZ();
+                        const bool allowInvalidHeights = GetGameState().Cheats.AllowTrackPlaceInvalidHeights;
+                        const auto heightStep = kCoordsZStep * (!allowInvalidHeights ? 2 : 1);
+
+                        _footpathPlaceCtrlZ = Floor2(info.Element->GetBaseZ(), heightStep);
                         _footpathPlaceCtrlState = true;
                     }
                 }

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -779,7 +779,12 @@ static constexpr uint8_t ConstructionPreviewImages[][4] = {
             {
                 if (im.IsModifierKeyPressed(ModifierKey::ctrl))
                 {
-                    auto info = GetMapCoordinatesFromPos(screenCoords, 0xFCCA);
+                    constexpr auto interactionFlags = EnumsToFlags(
+                        ViewportInteractionItem::Terrain, ViewportInteractionItem::Ride, ViewportInteractionItem::Scenery,
+                        ViewportInteractionItem::Footpath, ViewportInteractionItem::Wall,
+                        ViewportInteractionItem::LargeScenery);
+
+                    auto info = GetMapCoordinatesFromPos(screenCoords, interactionFlags);
                     if (info.SpriteType != ViewportInteractionItem::None)
                     {
                         _footpathPlaceCtrlZ = info.Element->GetBaseZ();

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -834,11 +834,15 @@ static constexpr uint8_t ConstructionPreviewImages[][4] = {
 
             if (!_footpathPlaceCtrlState)
             {
-                mapCoords = ViewportInteractionGetTileStartAtCursor(screenCoords);
-                if (mapCoords.IsNull())
+                auto info = GetMapCoordinatesFromPos(
+                    screenCoords, EnumsToFlags(ViewportInteractionItem::Terrain, ViewportInteractionItem::Footpath));
+
+                if (info.SpriteType == ViewportInteractionItem::None)
                     return std::nullopt;
 
+                mapCoords = info.Loc;
                 _footpathPlaceZ = 0;
+
                 if (_footpathPlaceShiftState)
                 {
                     auto surfaceElement = MapGetSurfaceElementAt(mapCoords);


### PR DESCRIPTION
Various tools in the game allow the use of ctrl/shift modifier keys to adjust the base height of element placement. This PR brings this functionality to the footpath tool.

~~Currently, this is still mostly a prototype. It works, but the code could probably do with a cleanup before this is merged. It also currently allows placing paths at half heights, which it shouldn't.~~

https://github.com/user-attachments/assets/8bede132-315f-4912-baca-41ec57438b73