### PR TITLE
Fix #22457: Potential crash opening the scenario select window

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Fix: [#22307] Hover tooltips in financial charts are not invalidated properly.
 - Fix: [#22316] Potential crash when switching the drawing engine while the game is running.
 - Fix: [#22395, #22396] Misaligned tick marks in financial and guest count graphs (original bug).
+- Fix: [#22457] Potential crash opening the scenario select window.
 
 0.4.13 (2024-08-04)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -126,10 +126,11 @@ static Widget _scenarioSelectWidgets[] = {
 
         void OnOpen() override
         {
+            widgets = _scenarioSelectWidgets;
+
             // Load scenario list
             ScenarioRepositoryScan();
 
-            widgets = _scenarioSelectWidgets;
             _highlightedScenario = nullptr;
             InitTabs();
             InitialiseListItems();

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -214,11 +214,11 @@ static Widget _trackListWidgets[] = {
 
         void OnOpen() override
         {
-            LoadDesignsList(_window_track_list_item);
-
             String::Set(_filterString, sizeof(_filterString), "");
             _trackListWidgets[WIDX_FILTER_STRING].string = _filterString;
             widgets = _trackListWidgets;
+
+            LoadDesignsList(_window_track_list_item);
 
             if (gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)
             {


### PR DESCRIPTION
The reason it crashed is because when the progress bar forces the game to render, in this case `OnOpen` called `ScenarioRepositoryScan` which uses the progress bar and attempts to render the window in where widgets is still nullptr since the call to `ScenarioRepositoryScan` has to yet return.

Closes #22457, there are a bunch more issues but I'll manually close them.