### PR TITLE
Fix Y axis label tick marks on park and finance graphs

### DIFF
--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -30,9 +30,17 @@ namespace OpenRCT2::Graph
         const T yLabelStep = (max - min) / (numYLabels - 1);
         for (int32_t i = 0; i < numYLabels; i++)
         {
+            // Draw Y label text
             char buffer[64]{};
             FormatStringToBuffer(buffer, sizeof(buffer), fmt, curLabel);
-            DrawText(dpi, { internalBounds.GetLeft(), curScreenPos }, { FontStyle::Small, TextAlignment::RIGHT }, buffer);
+            DrawText(
+                dpi, { internalBounds.GetLeft() - kYTickMarkPadding, curScreenPos }, { FontStyle::Small, TextAlignment::RIGHT },
+                buffer);
+            // Draw Y label tick mark
+            GfxFillRect(
+                dpi, { { internalBounds.GetLeft() - 5, curScreenPos + 5 }, { internalBounds.GetLeft(), curScreenPos + 5 } },
+                PALETTE_INDEX_10);
+            // Draw horizontal gridline
             GfxFillRectInset(
                 dpi, { { internalBounds.GetLeft(), curScreenPos + 5 }, { internalBounds.GetRight(), curScreenPos + 5 } },
                 lineCol, INSET_RECT_FLAG_BORDER_INSET);
@@ -59,8 +67,7 @@ namespace OpenRCT2::Graph
                 DrawTextBasic(
                     dpi, screenCoords - ScreenCoordsXY{ 0, 14 }, STR_GRAPH_LABEL, ft,
                     { FontStyle::Small, TextAlignment::CENTRE });
-
-                // Draw month mark
+                // Draw month tick mark
                 GfxFillRect(
                     dpi, { screenCoords - ScreenCoordsXY{ 0, 4 }, screenCoords - ScreenCoordsXY{ 0, 1 } }, PALETTE_INDEX_10);
             }
@@ -156,7 +163,7 @@ namespace OpenRCT2::Graph
 
     void DrawFinanceGraph(DrawPixelInfo& dpi, const GraphProperties<money64>& p)
     {
-        const FmtString fmt("{BLACK}{CURRENCY2DP} -");
+        const FmtString fmt("{BLACK}{CURRENCY2DP}");
         DrawYLabels<money64>(dpi, p.internalBounds, p.min, p.max, p.numYLabels, p.yLabelStepPx, p.lineCol, fmt);
         DrawMonths<money64, kMoney64Undefined>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx);
         DrawLine<money64, kMoney64Undefined, true>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx, p.min, p.max);
@@ -178,9 +185,9 @@ namespace OpenRCT2::Graph
     void DrawRatingGraph(DrawPixelInfo& dpi, const GraphProperties<uint8_t>& p)
     {
         constexpr uint8_t noValue = ParkRatingHistoryUndefined;
-        const FmtString fmt("{BLACK}{COMMA32} -");
+        const FmtString fmt("{BLACK}{COMMA32}");
         // Since the park rating rating history is divided by 4, we have to fudge the max number here.
-        DrawYLabels<uint16_t>(dpi, p.internalBounds, p.min, 1000, p.numYLabels, p.yLabelStepPx, p.lineCol, fmt);
+        DrawYLabels<uint16_t>(dpi, p.internalBounds, p.min, kParkRatingMax, p.numYLabels, p.yLabelStepPx, p.lineCol, fmt);
         DrawMonths<uint8_t, noValue>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx);
         DrawLine<uint8_t, noValue, true>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx, p.min, p.max);
         DrawLine<uint8_t, noValue, false>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx, p.min, p.max);
@@ -189,7 +196,7 @@ namespace OpenRCT2::Graph
     void DrawGuestGraph(DrawPixelInfo& dpi, const GraphProperties<uint32_t>& p)
     {
         constexpr uint32_t noValue = GuestsInParkHistoryUndefined;
-        const FmtString fmt("{BLACK}{COMMA32} -");
+        const FmtString fmt("{BLACK}{COMMA32}");
         DrawYLabels<uint32_t>(dpi, p.internalBounds, p.min, p.max, p.numYLabels, p.yLabelStepPx, p.lineCol, fmt);
         DrawMonths<uint32_t, noValue>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx);
         DrawLine<uint32_t, noValue, true>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx, p.min, p.max);

--- a/src/openrct2-ui/interface/Graph.h
+++ b/src/openrct2-ui/interface/Graph.h
@@ -16,6 +16,9 @@
 
 namespace OpenRCT2::Graph
 {
+    constexpr int32_t kYTickMarkPadding = 8;
+    constexpr int32_t kParkRatingMax = 1000;
+
     template<typename T> struct GraphProperties
     {
         ScreenRect internalBounds;

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -834,8 +834,8 @@ static Widget _windowFinancesResearchWidgets[] =
 
             // dynamic padding for long axis lables:
             char buffer[64]{};
-            FormatStringToBuffer(buffer, sizeof(buffer), "{BLACK}{CURRENCY2DP} -", centredGraph ? -max : max);
-            int32_t maxWidth = GfxGetStringWidth(buffer, FontStyle::Small) + 1;
+            FormatStringToBuffer(buffer, sizeof(buffer), "{BLACK}{CURRENCY2DP}", centredGraph ? -max : max);
+            int32_t maxWidth = GfxGetStringWidth(buffer, FontStyle::Small) + Graph::kYTickMarkPadding + 1;
             const ScreenCoordsXY dynamicPadding{ std::max(maxWidth, kGraphTopLeftPadding.x), kGraphTopLeftPadding.y };
 
             _graphBounds = { windowPos + ScreenCoordsXY{ graphPageWidget->left + 4, graphPageWidget->top + 15 },

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -705,11 +705,20 @@ static constexpr WindowParkAward _parkAwards[] = {
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
             AnchorBorderWidgets();
 
+            _ratingProps.min = 0;
+            _ratingProps.max = 250;
+            _ratingProps.series = GetGameState().Park.RatingHistory;
             const Widget* background = &widgets[WIDX_PAGE_BACKGROUND];
             _ratingGraphBounds = { windowPos + ScreenCoordsXY{ background->left + 4, background->top + 15 },
                                    windowPos + ScreenCoordsXY{ background->right - 4, background->bottom - 4 } };
+
+            char buffer[64]{};
+            FormatStringToBuffer(buffer, sizeof(buffer), "{BLACK}{COMMA32}", Graph::kParkRatingMax);
+            int32_t maxWidth = GfxGetStringWidth(buffer, FontStyle::Small) + Graph::kYTickMarkPadding + 1;
+            const ScreenCoordsXY dynamicPadding{ std::max(maxWidth, kGraphTopLeftPadding.x), kGraphTopLeftPadding.y };
+
             _ratingProps.RecalculateLayout(
-                { _ratingGraphBounds.Point1 + kGraphTopLeftPadding, _ratingGraphBounds.Point2 - kGraphBottomRightPadding },
+                { _ratingGraphBounds.Point1 + dynamicPadding, _ratingGraphBounds.Point2 - kGraphBottomRightPadding },
                 kGraphNumYLabels, kParkRatingHistorySize);
         }
 
@@ -719,19 +728,14 @@ static constexpr WindowParkAward _parkAwards[] = {
             DrawTabImages(dpi);
 
             Widget* widget = &widgets[WIDX_PAGE_BACKGROUND];
-            const auto& gameState = OpenRCT2::GetGameState();
 
             // Current value
             Formatter ft;
-            ft.Add<uint16_t>(gameState.Park.Rating);
+            ft.Add<uint16_t>(GetGameState().Park.Rating);
             DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ widget->left + 3, widget->top + 2 }, STR_PARK_RATING_LABEL, ft);
 
             // Graph border
             GfxFillRectInset(dpi, _ratingGraphBounds, colours[1], INSET_RECT_F_30);
-
-            _ratingProps.min = 0;
-            _ratingProps.max = 250;
-            _ratingProps.series = gameState.Park.RatingHistory;
             Graph::DrawRatingGraph(dpi, _ratingProps);
         }
 
@@ -765,29 +769,11 @@ static constexpr WindowParkAward _parkAwards[] = {
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
             AnchorBorderWidgets();
 
+            const auto& gameState = GetGameState();
+            _guestProps.series = gameState.GuestsInParkHistory;
             const Widget* background = &widgets[WIDX_PAGE_BACKGROUND];
             _guestGraphBounds = { windowPos + ScreenCoordsXY{ background->left + 4, background->top + 15 },
                                   windowPos + ScreenCoordsXY{ background->right - 4, background->bottom - 4 } };
-            _guestProps.RecalculateLayout(
-                { _guestGraphBounds.Point1 + kGraphTopLeftPadding, _guestGraphBounds.Point2 - kGraphBottomRightPadding },
-                kGraphNumYLabels, kGuestsInParkHistorySize);
-        }
-
-        void OnDrawGuests(DrawPixelInfo& dpi)
-        {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
-
-            Widget* widget = &widgets[WIDX_PAGE_BACKGROUND];
-            const auto& gameState = OpenRCT2::GetGameState();
-
-            // Current value
-            Formatter ft;
-            ft.Add<uint32_t>(gameState.NumGuestsInPark);
-            DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ widget->left + 3, widget->top + 2 }, STR_GUESTS_IN_PARK_LABEL, ft);
-
-            // Graph border
-            GfxFillRectInset(dpi, _guestGraphBounds, colours[1], INSET_RECT_F_30);
 
             // Calculate Y axis max and min
             _guestProps.min = 0;
@@ -800,7 +786,31 @@ static constexpr WindowParkAward _parkAwards[] = {
                 while (value > _guestProps.max)
                     _guestProps.max += 5000;
             }
-            _guestProps.series = gameState.GuestsInParkHistory;
+
+            char buffer[64]{};
+            FormatStringToBuffer(buffer, sizeof(buffer), "{BLACK}{COMMA32}", _guestProps.max);
+            int32_t maxWidth = GfxGetStringWidth(buffer, FontStyle::Small) + Graph::kYTickMarkPadding + 1;
+            const ScreenCoordsXY dynamicPadding{ std::max(maxWidth, kGraphTopLeftPadding.x), kGraphTopLeftPadding.y };
+
+            _guestProps.RecalculateLayout(
+                { _guestGraphBounds.Point1 + dynamicPadding, _guestGraphBounds.Point2 - kGraphBottomRightPadding },
+                kGraphNumYLabels, kGuestsInParkHistorySize);
+        }
+
+        void OnDrawGuests(DrawPixelInfo& dpi)
+        {
+            DrawWidgets(dpi);
+            DrawTabImages(dpi);
+
+            Widget* widget = &widgets[WIDX_PAGE_BACKGROUND];
+
+            // Current value
+            Formatter ft;
+            ft.Add<uint32_t>(GetGameState().NumGuestsInPark);
+            DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ widget->left + 3, widget->top + 2 }, STR_GUESTS_IN_PARK_LABEL, ft);
+
+            // Graph border
+            GfxFillRectInset(dpi, _guestGraphBounds, colours[1], INSET_RECT_F_30);
             Graph::DrawGuestGraph(dpi, _guestProps);
         }
 


### PR DESCRIPTION
The original code had a hack to draw Y axis tick marks with a hyphen in the label string. This works for the typical sprite fonts but doesn't work for TTF fonts. I have changed it to draw the tick marks in a similar way to the x axis tick marks for months.

In addition, because I don't really have strong guarantees about the width of labels rendered with TTF fonts, I have also added variable padding to park graph Y axis labels (it was already added to the finance graphs on a previous PR). There are also slight issue with vertical positioning but these seem difficult to solve and apply to all TTF rendering so it's out of scope.


Before:
![screenshot-2024-08-17_02:42:59](https://github.com/user-attachments/assets/99efe768-2268-4fb7-9b7d-ea8072b10c54)
After:
![screenshot-2024-08-17_02:35:28](https://github.com/user-attachments/assets/9dabf360-6fdb-471c-b38c-cd2ece1a8cd4)