### PR TITLE
Fix lighting effects not toggling correctly

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Fix: [#22316] Potential crash when switching the drawing engine while the game is running.
 - Fix: [#22395, #22396] Misaligned tick marks in financial and guest count graphs (original bug).
 - Fix: [#22457] Potential crash opening the scenario select window.
+- Fix: [#22582] Lighting effects are not enabled/disabled correctly, making the game appear frozen.
 
 0.4.13 (2024-08-04)
 ------------------------------------------------------------------------

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -131,12 +131,12 @@ void LightFXSetAvailable(bool available)
 
 bool LightFXIsAvailable()
 {
-    return _lightfxAvailable && Config::Get().general.EnableLightFx != 0;
+    return _lightfxAvailable && Config::Get().general.EnableLightFx;
 }
 
 bool LightFXForVehiclesIsAvailable()
 {
-    return LightFXIsAvailable() && Config::Get().general.EnableLightFxForVehicles != 0;
+    return LightFXIsAvailable() && Config::Get().general.EnableLightFxForVehicles;
 }
 
 void LightFXInit()

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -191,6 +191,7 @@ void X8DrawingEngine::BeginDraw()
         if (_lastLightFXenabled != (Config::Get().general.EnableLightFx != 0))
         {
             Resize(_width, _height);
+            _lastLightFXenabled = Config::Get().general.EnableLightFx;
         }
         _weatherDrawer.Restore(_bitsDPI);
     }

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -121,7 +121,7 @@ X8DrawingEngine::X8DrawingEngine([[maybe_unused]] const std::shared_ptr<Ui::IUiC
     _drawingContext = new X8DrawingContext(this);
     _bitsDPI.DrawingEngine = this;
     LightFXSetAvailable(true);
-    _lastLightFXenabled = (Config::Get().general.EnableLightFx != 0);
+    _lastLightFXenabled = Config::Get().general.EnableLightFx;
 }
 
 X8DrawingEngine::~X8DrawingEngine()
@@ -188,7 +188,7 @@ void X8DrawingEngine::BeginDraw()
     if (!IntroIsPlaying())
     {
         // HACK we need to re-configure the bits if light fx has been enabled / disabled
-        if (_lastLightFXenabled != (Config::Get().general.EnableLightFx != 0))
+        if (_lastLightFXenabled != Config::Get().general.EnableLightFx)
         {
             Resize(_width, _height);
             _lastLightFXenabled = Config::Get().general.EnableLightFx;

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -191,6 +191,7 @@ void X8DrawingEngine::BeginDraw()
         if (_lastLightFXenabled != Config::Get().general.EnableLightFx)
         {
             Resize(_width, _height);
+            GfxInvalidateScreen();
             _lastLightFXenabled = Config::Get().general.EnableLightFx;
         }
         _weatherDrawer.Restore(_bitsDPI);


### PR DESCRIPTION
Enabling or disabling the lighting effects would keep re-instantiating the rendering engine due to _one_ boolean value not being reset properly. This has been an issue with the game since v0.3.0 at least; I haven't gone back further.