### PR TITLE
Improve performance for SawyerChunkReader once again

### DIFF
--- a/src/openrct2/rct12/SawyerChunk.cpp
+++ b/src/openrct2/rct12/SawyerChunk.cpp
@@ -9,10 +9,11 @@
 
 #include "SawyerChunk.h"
 
-#include "../core/Memory.hpp"
 #include "SawyerChunkReader.h"
 
-SawyerChunk::SawyerChunk(SAWYER_ENCODING encoding, std::vector<uint8_t>&& data)
+using namespace OpenRCT2;
+
+SawyerChunk::SawyerChunk(SAWYER_ENCODING encoding, MemoryStream&& data)
     : _data(std::move(data))
     , _encoding(encoding)
 {

--- a/src/openrct2/rct12/SawyerChunk.h
+++ b/src/openrct2/rct12/SawyerChunk.h
@@ -9,8 +9,9 @@
 
 #pragma once
 
-#include <memory>
-#include <vector>
+#include "../core/MemoryStream.h"
+
+#include <cstdint>
 
 /**
  * The type of encoding / compression for a sawyer encoded chunk.
@@ -29,22 +30,22 @@ enum class SAWYER_ENCODING : uint8_t
 class SawyerChunk final
 {
 private:
-    std::vector<uint8_t> _data;
+    OpenRCT2::MemoryStream _data;
     SAWYER_ENCODING _encoding = SAWYER_ENCODING::NONE;
 
 public:
     const void* GetData() const
     {
-        return _data.data();
+        return _data.GetData();
     }
     size_t GetLength() const
     {
-        return _data.size();
+        return _data.GetLength();
     }
     SAWYER_ENCODING GetEncoding() const
     {
         return _encoding;
     }
 
-    SawyerChunk(SAWYER_ENCODING encoding, std::vector<uint8_t>&& data);
+    SawyerChunk(SAWYER_ENCODING encoding, OpenRCT2::MemoryStream&& data);
 };

--- a/src/openrct2/rct12/SawyerChunkReader.cpp
+++ b/src/openrct2/rct12/SawyerChunkReader.cpp
@@ -15,16 +15,6 @@
 
 using namespace OpenRCT2;
 
-// malloc is very slow for large allocations in MSVC debug builds as it allocates
-// memory on a special debug heap and then initialises all the memory to 0xCC.
-#if defined(_WIN32) && defined(DEBUG)
-#    define __USE_HEAP_ALLOC__
-#    ifndef WIN32_LEAN_AND_MEAN
-#        define WIN32_LEAN_AND_MEAN
-#    endif
-#    include <windows.h>
-#endif
-
 // Allow chunks to be uncompressed to a maximum of 16 MiB
 constexpr size_t MAX_UNCOMPRESSED_CHUNK_SIZE = 16 * 1024 * 1024;
 

--- a/src/openrct2/rct12/SawyerChunkReader.h
+++ b/src/openrct2/rct12/SawyerChunkReader.h
@@ -85,11 +85,4 @@ public:
         ReadChunk(&result, sizeof(result));
         return result;
     }
-
-private:
-    static std::vector<uint8_t> DecodeChunk(const void* src, const SawyerCodingChunkHeader& header);
-    static std::vector<uint8_t> DecodeChunkRLERepeat(const void* src, size_t srcLength);
-    static std::vector<uint8_t> DecodeChunkRLE(const void* src, size_t srcLength);
-    static std::vector<uint8_t> DecodeChunkRepeat(const void* src, size_t srcLength);
-    static std::vector<uint8_t> DecodeChunkRotate(const void* src, size_t srcLength);
 };


### PR DESCRIPTION
This drastically improves the load times for debug builds and squeezed a few ms out of release builds.
## Debug
develop:
```
Building object index (7929 items)
Finished building object index in 88.55 seconds.
```
PR:
```
Building object index (7929 items)
Finished building object index in 7.49 seconds.
```

## Release
develop:
```
Building object index (7929 items)
Finished building object index in 0.39 seconds.
```
PR:
```
Building object index (7929 items)
Finished building object index in 0.36 seconds.
```