### PR TITLE
Upgrade GitHub Actions CI to macOS 14 ahead of deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,16 +197,16 @@ jobs:
       matrix:
         arch: [x64, arm64]
         include:
-          - arch: x64
-            cache_key: macos-x64
+          - arch: arm64
+            cache_key: macos-arm64
             # Note: only build/run tests on the native architecture of the CI agent
             # GitHub macos-12 agents are all Intel, but as of 2024-04-25 new images, e.g. macos-14 (current macos-latest) are arm64
             # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
-            build_flags: -DARCH="x86_64" -DWITH_TESTS=on
+            build_flags: -DARCH="arm64" -DWITH_TESTS=on
             run_tests: true
-          - arch: arm64
-            cache_key: macos-arm64
-            build_flags: -DARCH="arm64"
+          - arch: x64
+            cache_key: macos-x64
+            build_flags: -DARCH="x86_64"
             run_tests: false
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
           if-no-files-found: error
   macos-cmake:
     name: macOS (${{ matrix.arch }}) using CMake
-    runs-on: macos-12
+    runs-on: macos-14
     needs: check-code-formatting
     strategy:
       fail-fast: false
@@ -249,7 +249,7 @@ jobs:
         if: ${{matrix.run_tests}}
   macos-universal:
     name: macOS universal app bundle
-    runs-on: macos-12
+    runs-on: macos-14
     needs: macos-cmake
     steps:
       - name: Checkout


### PR DESCRIPTION
The macOS 12 image we currently use has been [deprecated](https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/) by GitHub. This moves us to macOS 14 ahead of the upcoming macOS 15 release.

Depends on https://github.com/OpenRCT2/Dependencies/pull/41
Depends on https://github.com/OpenRCT2/Dependencies/pull/42