### PR TITLE
Fix virtual floor no longer appearing during track construction

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -18,6 +18,7 @@
 - Fix: [#22316] Potential crash when switching the drawing engine while the game is running.
 - Fix: [#22395, #22396] Misaligned tick marks in financial and guest count graphs (original bug).
 - Fix: [#22457] Potential crash opening the scenario select window.
+- Fix: [#22520] Virtual floor no longer appears when holding modifier keys during track construction.
 - Fix: [#22582] Lighting effects are not enabled/disabled correctly, making the game appear frozen.
 
 0.4.13 (2024-08-04)


### PR DESCRIPTION
Fixes #22520. Reverts part of #22428, which was merged for v0.4.13.