### PR TITLE
Show minimap in scenario list for new .park scenarios

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.21 (in development)
 ------------------------------------------------------------------------
+- Feature: [#22646] New scenario files now contain a minimap image, shown in the scenario selection window.
 - Feature: [#23774] Climates can now be customised using objects.
 - Feature: [#23876] New park save files now contain a preview image, shown in the load/save window.
 - Change: [#23932] The land rights window now checks “Land Owned” by default.


### PR DESCRIPTION
This introduces minimaps to the scenario selection window for new `.park` scenarios, building on the work from #23876. Scenarios without an embedded minimap will be displayed as before; there is currently no placeholder image used.

For older scenarios, we'll have to find a different solution. We're still investigating the best approach, but we'll likely settle on an object-based approach.

<img width="928" alt="Screenshot 2025-03-14 at 15 58 40" src="https://github.com/user-attachments/assets/1eab90f0-08d5-46db-9257-ff34bf236d44" />
