### PR TITLE
Fix #21123: Transparency options are not respected on startup

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Change: [#22491] Scrollbars are now hidden if the scrollable widget is not actually overflowing.
 - Change: [#22541] In editor/sandbox mode, tool widgets now appear on the side of the map window, instead of the bottom.
 - Change: [#22592] Cheats have been redistributed along three new tabs: date, staff, and nature/weather.
+- Fix: [#21123] Transparency options are not respected on startup.
 - Fix: [#21189] Additional missing/misplaced land & construction rights tiles in Schneider Shores and Urban Park.
 - Fix: [#21908] Errors showing up when placing/moving track design previews.
 - Fix: [#22307] Hover tooltips in financial charts are not invalidated properly.

--- a/src/openrct2-ui/windows/Main.cpp
+++ b/src/openrct2-ui/windows/Main.cpp
@@ -56,17 +56,35 @@ static Widget _mainWidgets[] = {
         {
             viewport->flags |= VIEWPORT_FLAG_SOUND_ON;
             if (Config::Get().general.InvisibleRides)
+            {
                 viewport->flags |= VIEWPORT_FLAG_INVISIBLE_RIDES;
+                viewport->flags |= VIEWPORT_FLAG_HIDE_RIDES;
+            }
             if (Config::Get().general.InvisibleVehicles)
+            {
                 viewport->flags |= VIEWPORT_FLAG_INVISIBLE_VEHICLES;
+                viewport->flags |= VIEWPORT_FLAG_HIDE_VEHICLES;
+            }
             if (Config::Get().general.InvisibleTrees)
+            {
                 viewport->flags |= VIEWPORT_FLAG_INVISIBLE_VEGETATION;
+                viewport->flags |= VIEWPORT_FLAG_HIDE_VEGETATION;
+            }
             if (Config::Get().general.InvisibleScenery)
+            {
                 viewport->flags |= VIEWPORT_FLAG_INVISIBLE_SCENERY;
+                viewport->flags |= VIEWPORT_FLAG_HIDE_SCENERY;
+            }
             if (Config::Get().general.InvisiblePaths)
+            {
                 viewport->flags |= VIEWPORT_FLAG_INVISIBLE_PATHS;
+                viewport->flags |= VIEWPORT_FLAG_HIDE_PATHS;
+            }
             if (Config::Get().general.InvisibleSupports)
+            {
                 viewport->flags |= VIEWPORT_FLAG_INVISIBLE_SUPPORTS;
+                viewport->flags |= VIEWPORT_FLAG_HIDE_SUPPORTS;
+            }
         }
     };
 


### PR DESCRIPTION
#16797 started saving the invisible flags into the config:

https://github.com/OpenRCT2/OpenRCT2/blob/761f126acf5c142262ba24acf95124089b996150/src/openrct2-ui/windows/Transparency.cpp#L237-L246

It never respected them on startup, though. We check if the `VIEWPORT_FLAG_HIDE_*` is set and only then it switches between `VisibilityKind::Hidden` and `VisibilityKind::Partial` depending on whether the corresponding `VIEWPORT_FLAG_INVISIBLE_*` is set. The problem is that only the `VIEWPORT_FLAG_INVISIBLE_*` flags are saved into the config, and never the `*HIDE*` ones, so it never enters these ifs after startup, example:

https://github.com/OpenRCT2/OpenRCT2/blob/761f126acf5c142262ba24acf95124089b996150/src/openrct2/interface/Viewport.cpp#L1476-L1480

Worth stating that when switching to the `*INVISIBLE*` mode, we also set the correspoding `*HIDE*` flag:

https://github.com/OpenRCT2/OpenRCT2/blob/761f126acf5c142262ba24acf95124089b996150/src/openrct2-ui/windows/Transparency.cpp#L161-L168

So there are two solutions to this problem:

1. Assuming that if the `*INVISIBLE*` flag is set we should also set the `*HIDE*` flag (which will make it go into the if as expected). This has no impact in the config.ini footprint, but it is a bit weird that we save some transparency, but not all transparencies. 
2. Start saving the `*HIDE*` flag as well.

I went with solution 1, but I'm torn on what's best and would love opinions.

PS: This will need a changelog entry.