### PR TITLE
Allow using construction modifier keys for track design placement

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.15 (in development)
 ------------------------------------------------------------------------
+- Feature: [#15642] Track design placement can now use contruction modifier keys (ctrl/shift).
 - Fix: [#22231] Invalid object version can cause a crash.
 - Fix: [#22653] Add several .parkpatch files for missing water tiles in RCT1 and RCT2 scenarios.
 

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -454,11 +454,23 @@ namespace OpenRCT2::Ui::Windows
 
             if (!_trackPlaceCtrlState && im.IsModifierKeyPressed(ModifierKey::ctrl))
             {
-                _trackPlaceCtrlZ = Floor2(surfaceElement->GetBaseZ(), kCoordsZStep);
+                constexpr auto interactionFlags = EnumsToFlags(
+                    ViewportInteractionItem::Terrain, ViewportInteractionItem::Ride, ViewportInteractionItem::Scenery,
+                    ViewportInteractionItem::Footpath, ViewportInteractionItem::Wall, ViewportInteractionItem::LargeScenery);
 
-                // Increase Z above water
-                if (surfaceElement->GetWaterHeight() > 0)
-                    _trackPlaceCtrlZ = std::max(_trackPlaceCtrlZ, surfaceElement->GetWaterHeight());
+                auto info = GetMapCoordinatesFromPos(screenCoords, interactionFlags);
+                if (info.SpriteType == ViewportInteractionItem::Terrain)
+                {
+                    _trackPlaceCtrlZ = Floor2(surfaceElement->GetBaseZ(), kCoordsZStep);
+
+                    // Increase Z above water
+                    if (surfaceElement->GetWaterHeight() > 0)
+                        _trackPlaceCtrlZ = std::max(_trackPlaceCtrlZ, surfaceElement->GetWaterHeight());
+                }
+                else
+                {
+                    _trackPlaceCtrlZ = Floor2(info.Element->GetBaseZ(), kCoordsZStep);
+                }
 
                 _trackPlaceCtrlState = true;
             }

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -529,35 +529,6 @@ namespace OpenRCT2::Ui::Windows
                        *_trackDesign, RideGetTemporaryForPreview(), { mapCoords, _trackPlaceZ, _currentTrackPieceDirection });
         }
 
-        /*
-        int32_t GetBaseZ(const CoordsXY& loc)
-        {
-            auto surfaceElement = MapGetSurfaceElementAt(loc);
-            if (surfaceElement == nullptr)
-                return 0;
-
-            auto z = surfaceElement->GetBaseZ();
-
-            // Increase Z above slope
-            if (surfaceElement->GetSlope() & kTileSlopeRaisedCornersMask)
-            {
-                z += kCoordsZPerTinyZ;
-
-                // Increase Z above double slope
-                if (surfaceElement->GetSlope() & kTileSlopeDiagonalFlag)
-                    z += kCoordsZPerTinyZ;
-            }
-
-            // Increase Z above water
-            if (surfaceElement->GetWaterHeight() > 0)
-                z = std::max(z, surfaceElement->GetWaterHeight());
-
-            return z
-                + TrackDesignGetZPlacement(
-                       *_trackDesign, RideGetTemporaryForPreview(), { loc, z, _currentTrackPieceDirection });
-        }
-        */
-
         void DrawMiniPreviewEntrances(
             const TrackDesign& td, int32_t pass, const CoordsXY& origin, CoordsXY& min, CoordsXY& max, Direction rotation)
         {

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -419,11 +419,11 @@ namespace OpenRCT2::Ui::Windows
             // Increase Z above slope
             if (surfaceElement->GetSlope() & kTileSlopeRaisedCornersMask)
             {
-                z += 16;
+                z += kCoordsZPerTinyZ;
 
                 // Increase Z above double slope
                 if (surfaceElement->GetSlope() & kTileSlopeDiagonalFlag)
-                    z += 16;
+                    z += kCoordsZPerTinyZ;
             }
 
             // Increase Z above water
@@ -597,7 +597,7 @@ namespace OpenRCT2::Ui::Windows
         GameActions::Result FindValidTrackDesignPlaceHeight(CoordsXYZ& loc, uint32_t newFlags)
         {
             GameActions::Result res;
-            for (int32_t i = 0; i < 7; i++, loc.z += 8)
+            for (int32_t i = 0; i < 7; i++, loc.z += kCoordsZStep)
             {
                 auto tdAction = TrackDesignAction(
                     CoordsXYZD{ loc.x, loc.y, loc.z, _currentTrackPieceDirection }, *_trackDesign);

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -7,9 +7,8 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include "../interface/ViewportInteraction.h"
-
 #include <openrct2-ui/interface/Viewport.h>
+#include <openrct2-ui/interface/ViewportInteraction.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Cheats.h>

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -227,7 +227,7 @@ namespace OpenRCT2::Ui::Windows
             if (res.Error != GameActions::Status::Ok)
             {
                 // Unable to build track
-                OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::Error, trackLoc);
+                Audio::Play3D(Audio::SoundId::Error, trackLoc);
 
                 auto windowManager = GetContext()->GetUiContext()->GetWindowManager();
                 windowManager->ShowError(res.GetErrorTitle(), res.GetErrorMessage());
@@ -238,7 +238,7 @@ namespace OpenRCT2::Ui::Windows
             tdAction.SetCallback([&](const GameAction*, const GameActions::Result* result) {
                 if (result->Error != GameActions::Status::Ok)
                 {
-                    OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::Error, result->Position);
+                    Audio::Play3D(Audio::SoundId::Error, result->Position);
                     return;
                 }
 
@@ -247,7 +247,7 @@ namespace OpenRCT2::Ui::Windows
                 if (getRide != nullptr)
                 {
                     WindowCloseByClass(WindowClass::Error);
-                    OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::PlaceItem, trackLoc);
+                    Audio::Play3D(Audio::SoundId::PlaceItem, trackLoc);
 
                     _currentRideIndex = rideId;
                     if (TrackDesignAreEntranceAndExitPlaced())

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -79,6 +79,16 @@ namespace OpenRCT2::Ui::Windows
     class TrackDesignPlaceWindow final : public Window
     {
     private:
+        std::unique_ptr<TrackDesign> _trackDesign;
+
+        CoordsXY _placementLoc;
+        RideId _placementGhostRideId;
+        bool _hasPlacementGhost;
+        money64 _placementCost;
+        CoordsXYZD _placementGhostLoc;
+
+        std::vector<uint8_t> _miniPreview;
+
         bool _trackPlaceCtrlState = false;
         int32_t _trackPlaceCtrlZ;
 
@@ -409,16 +419,6 @@ namespace OpenRCT2::Ui::Windows
         }
 
     private:
-        std::unique_ptr<TrackDesign> _trackDesign;
-
-        CoordsXY _placementLoc;
-        RideId _placementGhostRideId;
-        bool _hasPlacementGhost;
-        money64 _placementCost;
-        CoordsXYZD _placementGhostLoc;
-
-        std::vector<uint8_t> _miniPreview;
-
         void ClearProvisional()
         {
             if (_hasPlacementGhost)


### PR DESCRIPTION
Having added construction modifier key support to footpath placement (#22569), the next step was to add similar support to track design placement. I was warned that it might not be possible without substantial refactor work, though. Though I grew slightly mad in ironing out some placement bugs, overall, everything went better than expected.

Currently, shifting track designs is limited to above surface. This could probably be extended to work below ground as well, though I'd prefer to leave it as-is for now. Either way, we should probably only go underground if some cheats are enabled.

Of course, these changes require a fair bit of testing, so this is not intended to be merged for v0.4.14.

https://github.com/user-attachments/assets/eab8e80e-64e3-4f79-8621-2de963e98da0