### PR TITLE
Further refinement to transparency options

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -28,6 +28,7 @@
 - Fix: [#22606] Virtual floor is sometimes drawn above the path when placing paths.
 - Fix: [#22625] Fix compilation with orignal ride ratings.
 - Fix: [#22671] Game default to hide supports on startup.
+- Fix: [#22671] Unchecking invisible option does not uncheck see-through option on transparency options and vice versa.
 
 0.4.13 (2024-08-04)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -27,6 +27,7 @@
 - Fix: [#22593] Memory leak on Android builds when reading zip files.
 - Fix: [#22606] Virtual floor is sometimes drawn above the path when placing paths.
 - Fix: [#22625] Fix compilation with orignal ride ratings.
+- Fix: [#22671] Game default to hide supports on startup.
 
 0.4.13 (2024-08-04)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/Main.cpp
+++ b/src/openrct2-ui/windows/Main.cpp
@@ -36,9 +36,9 @@ static Widget _mainWidgets[] = {
             widgets = _mainWidgets;
 
             ViewportCreate(this, windowPos, width, height, Focus(CoordsXYZ(0x0FFF, 0x0FFF, 0)));
-            if (viewport != nullptr && !(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO))
+            if (viewport != nullptr)
             {
-                SetViewportFlags();
+                SetViewportFlags(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO);
                 viewport->rotation = 0;
             }
             gShowGridLinesRefCount = 0;
@@ -53,9 +53,14 @@ static Widget _mainWidgets[] = {
         }
 
     private:
-        void SetViewportFlags()
+        void SetViewportFlags(bool isTitleWindow)
         {
             viewport->flags |= VIEWPORT_FLAG_SOUND_ON;
+            if (isTitleWindow)
+            {
+                return;
+            }
+
             if (Config::Get().general.InvisibleRides)
             {
                 viewport->flags |= VIEWPORT_FLAG_INVISIBLE_RIDES;

--- a/src/openrct2-ui/windows/Transparency.cpp
+++ b/src/openrct2-ui/windows/Transparency.cpp
@@ -158,12 +158,28 @@ static Widget _transparancyWidgets[] =
         }
 
     private:
+        uint32_t ToggleSeeThrough(uint32_t wflags, uint32_t seeThroughFlag, uint32_t transparencyFlag)
+        {
+            wflags ^= seeThroughFlag;
+            // If see-through is disabled, we also want to disable invisible
+            if (!(wflags & seeThroughFlag))
+            {
+                wflags &= ~transparencyFlag;
+            }
+            SaveInConfig(wflags);
+            return wflags;
+        }
+
         uint32_t ToggleTransparency(uint32_t wflags, uint32_t transparencyFlag, uint32_t seeThroughFlag)
         {
             wflags ^= transparencyFlag;
             if (wflags & transparencyFlag)
             {
                 wflags |= seeThroughFlag;
+            }
+            else
+            {
+                wflags &= ~seeThroughFlag;
             }
             SaveInConfig(wflags);
             return wflags;
@@ -182,22 +198,22 @@ static Widget _transparancyWidgets[] =
             switch (widgetIndex)
             {
                 case WIDX_HIDE_RIDES:
-                    wflags ^= VIEWPORT_FLAG_HIDE_RIDES;
+                    wflags = ToggleSeeThrough(wflags, VIEWPORT_FLAG_HIDE_RIDES, VIEWPORT_FLAG_INVISIBLE_RIDES);
                     break;
                 case WIDX_HIDE_VEHICLES:
-                    wflags ^= VIEWPORT_FLAG_HIDE_VEHICLES;
+                    wflags = ToggleSeeThrough(wflags, VIEWPORT_FLAG_HIDE_VEHICLES, VIEWPORT_FLAG_INVISIBLE_VEHICLES);
                     break;
                 case WIDX_HIDE_SCENERY:
-                    wflags ^= VIEWPORT_FLAG_HIDE_SCENERY;
+                    wflags = ToggleSeeThrough(wflags, VIEWPORT_FLAG_HIDE_SCENERY, VIEWPORT_FLAG_INVISIBLE_SCENERY);
                     break;
                 case WIDX_HIDE_VEGETATION:
-                    wflags ^= VIEWPORT_FLAG_HIDE_VEGETATION;
+                    wflags = ToggleSeeThrough(wflags, VIEWPORT_FLAG_HIDE_VEGETATION, VIEWPORT_FLAG_INVISIBLE_VEGETATION);
                     break;
                 case WIDX_HIDE_PATHS:
-                    wflags ^= VIEWPORT_FLAG_HIDE_PATHS;
+                    wflags = ToggleSeeThrough(wflags, VIEWPORT_FLAG_HIDE_PATHS, VIEWPORT_FLAG_INVISIBLE_PATHS);
                     break;
                 case WIDX_HIDE_SUPPORTS:
-                    wflags ^= VIEWPORT_FLAG_HIDE_SUPPORTS;
+                    wflags = ToggleSeeThrough(wflags, VIEWPORT_FLAG_HIDE_SUPPORTS, VIEWPORT_FLAG_INVISIBLE_SUPPORTS);
                     break;
                 case WIDX_INVISIBLE_RIDES:
                     wflags = ToggleTransparency(wflags, VIEWPORT_FLAG_INVISIBLE_RIDES, VIEWPORT_FLAG_HIDE_RIDES);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -248,7 +248,7 @@ namespace OpenRCT2::Config
             model->InvisibleTrees = reader->GetBoolean("invisible_trees", false);
             model->InvisibleScenery = reader->GetBoolean("invisible_scenery", false);
             model->InvisiblePaths = reader->GetBoolean("invisible_paths", false);
-            model->InvisibleSupports = reader->GetBoolean("invisible_supports", true);
+            model->InvisibleSupports = reader->GetBoolean("invisible_supports", false);
 
             model->LastVersionCheckTime = reader->GetInt64("last_version_check_time", 0);
         }


### PR DESCRIPTION
06302f7 - This undoes 9e1b24d, which apparently @Broxzier pushed by accident 2y ago and no one noticed 🤣 (likely because loading transparency options were broken on startup until #22659 

be1153b - Untoggling the invisible transparency would not untoggle the see-through, even though it might have been the one to set it. So now whenever unchecking the invisible, it also unchecks the see through. Similarly, if you had both see through and invisible checked and unchecked the see-through, it would remain invisible, so when disabling see through, it now disables invisible too.

4d2efa0 - Improves quick fix of #22670 to not affect sound on title scren

I think this makes it for an easier time using the window, but I'm open for suggestions.