### PR TITLE
Fix #22527: Changing an element type to wall via scripting can crash the game

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -23,6 +23,7 @@
 - Fix: [#22395, #22396] Misaligned tick marks in financial and guest count graphs (original bug).
 - Fix: [#22457] Potential crash opening the scenario select window.
 - Fix: [#22520] Virtual floor no longer appears when holding modifier keys during track construction.
+- Fix: [#22527] Forcing an element type to “wall” via scripts can crash the game.
 - Fix: [#22582] Lighting effects are not enabled/disabled correctly, making the game appear frozen.
 - Fix: [#22606] Virtual floor is sometimes drawn above the path when placing paths.
 - Fix: [#22625] Fix compilation with orignal ride ratings.

--- a/src/openrct2/scripting/bindings/world/ScTileElement.cpp
+++ b/src/openrct2/scripting/bindings/world/ScTileElement.cpp
@@ -2216,7 +2216,7 @@ namespace OpenRCT2::Scripting
             case TileElementType::Wall:
             {
                 auto wallEntry = _element->AsWall()->GetEntry();
-                if (wallEntry->scrolling_mode == SCROLLING_MODE_NONE)
+                if (wallEntry == nullptr || wallEntry->scrolling_mode == SCROLLING_MODE_NONE)
                     return;
                 break;
             }


### PR DESCRIPTION
Fixes #22527 

The same sort of guard is applied a few lines down in the same function.