### PR TITLE
Fix #22231: Invalid object version can cause a crash

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.15 (in development)
 ------------------------------------------------------------------------
+- Fix: [#22231] Invalid object version can cause a crash.
 - Fix: [#22653] Add several .parkpatch files for missing water tiles in RCT1 and RCT2 scenarios.
 
 0.4.14 (2024-09-01)

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -405,12 +405,13 @@ ObjectVersion VersionTuple(std::string_view version)
         size_t highestIndex = std::min(nums.size(), VersionNumFields);
         for (size_t i = 0; i < highestIndex; i++)
         {
-            auto value = stoi(nums.at(i));
+            auto value = stoll(nums.at(i));
             constexpr auto maxValue = std::numeric_limits<uint16_t>().max();
             if (value > maxValue)
             {
                 LOG_WARNING(
-                    "Version value too high in version string '%s', version value will be capped to %i.", version, maxValue);
+                    "Version value too high in version string '%.*s', version value will be capped to %i.",
+                    static_cast<int>(version.size()), version.data(), maxValue);
                 value = maxValue;
             }
             versions[i] = value;
@@ -418,7 +419,7 @@ ObjectVersion VersionTuple(std::string_view version)
     }
     catch (const std::exception&)
     {
-        LOG_WARNING("Malformed version string '%s', expected X.Y.Z", version);
+        LOG_WARNING("Malformed version string '%.*s', expected X.Y.Z", static_cast<int>(version.size()), version.data());
     }
 
     return std::make_tuple(versions[0], versions[1], versions[2]);


### PR DESCRIPTION
Fixes #22231 

`version` is a string view and cannot be passed directly to the formatter.