### PR TITLE
Fix screenshot URL

### DIFF
--- a/distribution/linux/openrct2.appdata.xml
+++ b/distribution/linux/openrct2.appdata.xml
@@ -37,7 +37,7 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image>https://camo.githubusercontent.com/fdb7e0506eedc4625f2f776f495c1072c520496dba3ee6c07bfdbf907d478afd/68747470733a2f2f692e696d6775722e636f6d2f6537434b3553632e706e67</image>
+      <image>https://camo.githubusercontent.com/f513bc551e2c9e04e292724113ea4789726d23921d286f21dad39a6e955b5a56/68747470733a2f2f692e696d6775722e636f6d2f6537434b3553632e706e67</image>
       <caption>Amusement park featuring an inverted roller coaster, a river rapids ride and custom scenery</caption>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
Fix the screenshot URL for Linux Appdata in order to pass Flathub validation.

I saw openrct2.io has a different screenshot than the readme, I think it would be better to use it in order to have a permalink instead of relying on an external service. I can send a PR to update it if you want.