### PR TITLE
Prefer using passed game state in save import classes

### DIFF
--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -33,11 +33,16 @@ using namespace OpenRCT2::Scripting;
 
 namespace OpenRCT2
 {
-    static GameState_t _gameState{};
+    static auto _gameState = std::make_unique<GameState_t>();
 
     GameState_t& GetGameState()
     {
-        return _gameState;
+        return *_gameState;
+    }
+
+    void SwapGameState(std::unique_ptr<GameState_t>& otherState)
+    {
+        _gameState.swap(otherState);
     }
 
     /**

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -149,6 +149,7 @@ namespace OpenRCT2
     };
 
     GameState_t& GetGameState();
+    void SwapGameState(std::unique_ptr<GameState_t>& otherState);
 
     void gameStateInitAll(GameState_t& gameState, const TileCoordsXY& mapSize);
     void gameStateTick();

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1071,7 +1071,7 @@ namespace OpenRCT2
                         std::vector<TileElement> tileElements;
                         tileElements.resize(numElements);
                         cs.Read(tileElements.data(), tileElements.size() * sizeof(TileElement));
-                        SetTileElements(std::move(tileElements));
+                        SetTileElements(gameState, std::move(tileElements));
                         {
                             TileElementIterator it;
                             TileElementIteratorBegin(&it);

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -182,7 +182,7 @@ namespace OpenRCT2::RCT1
             ImportRides();
             ImportRideMeasurements();
             ImportEntities();
-            ImportTileElements();
+            ImportTileElements(gameState);
             ImportPeepSpawns();
             ImportFinance(gameState);
             ImportResearch(gameState);
@@ -1517,7 +1517,7 @@ namespace OpenRCT2::RCT1
             return result;
         }
 
-        void ImportTileElements()
+        void ImportTileElements(GameState_t& gameState)
         {
             // Build tile pointer cache (needed to get the first element at a certain location)
             auto tilePointerIndex = TilePointerIndex<RCT12TileElement>(
@@ -1565,7 +1565,7 @@ namespace OpenRCT2::RCT1
                 }
             }
 
-            SetTileElements(std::move(tileElements));
+            SetTileElements(gameState, std::move(tileElements));
             FixEntrancePositions();
         }
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1565,7 +1565,7 @@ namespace OpenRCT2::RCT1
             }
 
             SetTileElements(gameState, std::move(tileElements));
-            FixEntrancePositions();
+            FixEntrancePositions(gameState);
         }
 
         size_t ImportTileElement(TileElement* dst, const RCT12TileElement* src)
@@ -2438,9 +2438,8 @@ namespace OpenRCT2::RCT1
             dst->position.y = src->y;
         }
 
-        void FixEntrancePositions()
+        void FixEntrancePositions(GameState_t& gameState)
         {
-            auto& gameState = GetGameState();
             gameState.Park.Entrances.clear();
             TileElementIterator it;
             TileElementIteratorBegin(&it);

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -183,7 +183,7 @@ namespace OpenRCT2::RCT1
             ImportRideMeasurements();
             ImportEntities();
             ImportTileElements(gameState);
-            ImportPeepSpawns();
+            ImportPeepSpawns(gameState);
             ImportFinance(gameState);
             ImportResearch(gameState);
             ImportParkName(gameState);
@@ -1405,9 +1405,8 @@ namespace OpenRCT2::RCT1
             dst->z = src->z;
         }
 
-        void ImportPeepSpawns()
+        void ImportPeepSpawns(GameState_t& gameState)
         {
-            auto& gameState = GetGameState();
             gameState.PeepSpawns.clear();
             for (size_t i = 0; i < Limits::kMaxPeepSpawns; i++)
             {

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -186,12 +186,12 @@ namespace OpenRCT2::RCT1
             ImportPeepSpawns();
             ImportFinance(gameState);
             ImportResearch(gameState);
-            ImportParkName();
+            ImportParkName(gameState);
             ImportParkFlags(gameState);
             ImportClimate(gameState);
             ImportScenarioNameDetails(gameState);
             ImportScenarioObjective(gameState);
-            ImportSavedView();
+            ImportSavedView(gameState);
 
             RCT12::FetchAndApplyScenarioPatch(_s4Path, _isScenario);
             FixNextGuestNumber(gameState);
@@ -2121,7 +2121,7 @@ namespace OpenRCT2::RCT1
             }
         }
 
-        void ImportParkName()
+        void ImportParkName(GameState_t& gameState)
         {
             std::string parkName = std::string(_s4.ScenarioName);
             if (IsUserStringID(static_cast<StringId>(_s4.ParkNameStringIndex)))
@@ -2133,7 +2133,7 @@ namespace OpenRCT2::RCT1
                 }
             }
 
-            auto& park = GetGameState().Park;
+            auto& park = gameState.Park;
             park.Name = std::move(parkName);
         }
 
@@ -2371,9 +2371,8 @@ namespace OpenRCT2::RCT1
                 gameState.ScenarioObjective.RideId = GetBuildTheBestRideId();
         }
 
-        void ImportSavedView()
+        void ImportSavedView(GameState_t& gameState)
         {
-            auto& gameState = GetGameState();
             gameState.SavedView = ScreenCoordsXY{ _s4.ViewX, _s4.ViewY };
             gameState.SavedViewZoom = ZoomLevel{ static_cast<int8_t>(_s4.ViewZoom) };
             gameState.SavedViewRotation = _s4.ViewRotation;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -352,7 +352,7 @@ namespace OpenRCT2::RCT2
             // Pad013573EE
             // rct1_park_entrance_z
 
-            ImportPeepSpawns();
+            ImportPeepSpawns(gameState);
 
             gameState.GuestChangeModifier = _s6.GuestCountChangeModifier;
             gameState.ResearchFundingLevel = _s6.CurrentResearchLevel;
@@ -1098,7 +1098,7 @@ namespace OpenRCT2::RCT2
          * Imports guest entry points.
          * Includes fixes for incorrectly set guest entry points in some scenarios.
          */
-        void ImportPeepSpawns()
+        void ImportPeepSpawns(GameState_t& gameState)
         {
             // Many WW and TT have scenario_filename fields containing an incorrect filename. Check for both this filename
             // and the corrected filename.
@@ -1129,7 +1129,6 @@ namespace OpenRCT2::RCT2
                 _s6.PeepSpawns[0].z = 7;
             }
 
-            auto& gameState = GetGameState();
             gameState.PeepSpawns.clear();
             for (size_t i = 0; i < Limits::kMaxPeepSpawns; i++)
             {

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -329,7 +329,7 @@ namespace OpenRCT2::RCT2
             ScenarioRandSeed(_s6.ScenarioSrand0, _s6.ScenarioSrand1);
 
             DetermineFlatRideStatus();
-            ImportTileElements();
+            ImportTileElements(gameState);
             ImportEntities();
 
             gameState.InitialCash = ToMoney64(_s6.InitialCash);
@@ -1162,7 +1162,7 @@ namespace OpenRCT2::RCT2
             dst->num_riders = numRiders;
         }
 
-        void ImportTileElements()
+        void ImportTileElements(GameState_t& gameState)
         {
             // Build tile pointer cache (needed to get the first element at a certain location)
             auto tilePointerIndex = TilePointerIndex<RCT12TileElement>(
@@ -1232,7 +1232,7 @@ namespace OpenRCT2::RCT2
                     }
                 }
             }
-            SetTileElements(std::move(tileElements));
+            SetTileElements(gameState, std::move(tileElements));
         }
 
         void ImportTileElement(TileElement* dst, const RCT12TileElement* src, bool invisible)

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -2152,7 +2152,8 @@ static void TrackDesignPreviewClearMap()
 {
     auto numTiles = kMaximumMapSizeTechnical * kMaximumMapSizeTechnical;
 
-    GetGameState().MapSize = TRACK_DESIGN_PREVIEW_MAP_SIZE;
+    auto& gameState = GetGameState();
+    gameState.MapSize = TRACK_DESIGN_PREVIEW_MAP_SIZE;
 
     // Reserve ~8 elements per tile
     std::vector<TileElement> tileElements;
@@ -2171,7 +2172,8 @@ static void TrackDesignPreviewClearMap()
         element->AsSurface()->SetOwnership(OWNERSHIP_OWNED);
         element->AsSurface()->SetParkFences(0);
     }
-    SetTileElements(std::move(tileElements));
+
+    SetTileElements(gameState, std::move(tileElements));
 }
 
 bool TrackDesignAreEntranceAndExitPlaced()

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -111,9 +111,14 @@ extern uint32_t gLandRemainingConstructionSales;
 
 extern bool gMapLandRightsUpdateSuccess;
 
+namespace OpenRCT2
+{
+    struct GameState_t;
+}
+
 void ReorganiseTileElements();
 const std::vector<TileElement>& GetTileElements();
-void SetTileElements(std::vector<TileElement>&& tileElements);
+void SetTileElements(OpenRCT2::GameState_t& gameState, std::vector<TileElement>&& tileElements);
 void StashMap();
 void UnstashMap();
 std::vector<TileElement> GetReorganisedTileElementsWithoutGhosts();


### PR DESCRIPTION
This PR changes the save import classes such that they use the game state passed to `Import` further down the call chain. Split off from #22646.

NB: This is early work, still. More work will be required for importing e.g. rides and entities independently from globals. Additionally, tile iterators currently work on globals, which needs changing as well.