### PR TITLE
Park graphs upgrade

### DIFF
--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -182,15 +182,14 @@ namespace OpenRCT2::Graph
         }
     }
 
-    void DrawRatingGraph(DrawPixelInfo& dpi, const GraphProperties<uint8_t>& p)
+    void DrawRatingGraph(DrawPixelInfo& dpi, const GraphProperties<uint16_t>& p)
     {
-        constexpr uint8_t noValue = ParkRatingHistoryUndefined;
+        constexpr uint16_t noValue = ParkRatingHistoryUndefined;
         const FmtString fmt("{BLACK}{COMMA32}");
-        // Since the park rating rating history is divided by 4, we have to fudge the max number here.
-        DrawYLabels<uint16_t>(dpi, p.internalBounds, p.min, kParkRatingMax, p.numYLabels, p.yLabelStepPx, p.lineCol, fmt);
-        DrawMonths<uint8_t, noValue>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx);
-        DrawLine<uint8_t, noValue, true>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx, p.min, p.max);
-        DrawLine<uint8_t, noValue, false>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx, p.min, p.max);
+        DrawYLabels<uint16_t>(dpi, p.internalBounds, p.min, p.max, p.numYLabels, p.yLabelStepPx, p.lineCol, fmt);
+        DrawMonths<uint16_t, noValue>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx);
+        DrawLine<uint16_t, noValue, true>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx, p.min, p.max);
+        DrawLine<uint16_t, noValue, false>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx, p.min, p.max);
     }
 
     void DrawGuestGraph(DrawPixelInfo& dpi, const GraphProperties<uint32_t>& p)

--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -161,44 +161,40 @@ namespace OpenRCT2::Graph
         }
     }
 
-    void DrawFinanceGraph(DrawPixelInfo& dpi, const GraphProperties<money64>& p)
+    template<typename T, T TkNoValue>
+    static void DrawGraph(
+        DrawPixelInfo& dpi, const GraphProperties<T>& p, const FmtString& labelFmt, const FmtString& tooltipFmt)
     {
-        const FmtString fmt("{BLACK}{CURRENCY2DP}");
-        DrawYLabels<money64>(dpi, p.internalBounds, p.min, p.max, p.numYLabels, p.yLabelStepPx, p.lineCol, fmt);
-        DrawMonths<money64, kMoney64Undefined>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx);
-        DrawLine<money64, kMoney64Undefined, true>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx, p.min, p.max);
-        DrawLine<money64, kMoney64Undefined, false>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx, p.min, p.max);
+        DrawYLabels<T>(dpi, p.internalBounds, p.min, p.max, p.numYLabels, p.yLabelStepPx, p.lineCol, labelFmt);
+        DrawMonths<T, TkNoValue>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx);
+        DrawLine<T, TkNoValue, true>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx, p.min, p.max);
+        DrawLine<T, TkNoValue, false>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx, p.min, p.max);
         if (p.hoverIdx >= 0 && p.hoverIdx < p.numPoints)
         {
-            const money64 value = p.series[p.hoverIdx];
-            if (value != kMoney64Undefined)
+            const T value = p.series[p.hoverIdx];
+            if (value != TkNoValue)
             {
                 char buffer[64]{};
-                FormatStringToBuffer(buffer, sizeof(buffer), "{CURRENCY2DP}", value);
-                DrawHoveredValue<money64>(
+                FormatStringToBuffer(buffer, sizeof(buffer), tooltipFmt, value);
+                DrawHoveredValue<T>(
                     dpi, value, p.hoverIdx, p.internalBounds, p.xStepPx, p.min, p.max, buffer,
                     p.lineCol.withFlag(ColourFlag::withOutline, true));
             }
         }
     }
 
+    void DrawFinanceGraph(DrawPixelInfo& dpi, const GraphProperties<money64>& p)
+    {
+        DrawGraph<money64, kMoney64Undefined>(dpi, p, "{BLACK}{CURRENCY2DP}", "{CURRENCY2DP}");
+    }
+
     void DrawRatingGraph(DrawPixelInfo& dpi, const GraphProperties<uint16_t>& p)
     {
-        constexpr uint16_t noValue = ParkRatingHistoryUndefined;
-        const FmtString fmt("{BLACK}{COMMA32}");
-        DrawYLabels<uint16_t>(dpi, p.internalBounds, p.min, p.max, p.numYLabels, p.yLabelStepPx, p.lineCol, fmt);
-        DrawMonths<uint16_t, noValue>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx);
-        DrawLine<uint16_t, noValue, true>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx, p.min, p.max);
-        DrawLine<uint16_t, noValue, false>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx, p.min, p.max);
+        DrawGraph<uint16_t, ParkRatingHistoryUndefined>(dpi, p, "{BLACK}{COMMA32}", "{COMMA32}");
     }
 
     void DrawGuestGraph(DrawPixelInfo& dpi, const GraphProperties<uint32_t>& p)
     {
-        constexpr uint32_t noValue = GuestsInParkHistoryUndefined;
-        const FmtString fmt("{BLACK}{COMMA32}");
-        DrawYLabels<uint32_t>(dpi, p.internalBounds, p.min, p.max, p.numYLabels, p.yLabelStepPx, p.lineCol, fmt);
-        DrawMonths<uint32_t, noValue>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx);
-        DrawLine<uint32_t, noValue, true>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx, p.min, p.max);
-        DrawLine<uint32_t, noValue, false>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx, p.min, p.max);
+        DrawGraph<uint32_t, GuestsInParkHistoryUndefined>(dpi, p, "{BLACK}{COMMA32}", "{COMMA32}");
     }
 } // namespace OpenRCT2::Graph

--- a/src/openrct2-ui/interface/Graph.h
+++ b/src/openrct2-ui/interface/Graph.h
@@ -17,7 +17,6 @@
 namespace OpenRCT2::Graph
 {
     constexpr int32_t kYTickMarkPadding = 8;
-    constexpr int32_t kParkRatingMax = 1000;
 
     template<typename T> struct GraphProperties
     {
@@ -68,6 +67,6 @@ namespace OpenRCT2::Graph
     };
 
     void DrawFinanceGraph(DrawPixelInfo& dpi, const GraphProperties<money64>& p);
-    void DrawRatingGraph(DrawPixelInfo& dpi, const GraphProperties<uint8_t>& p);
+    void DrawRatingGraph(DrawPixelInfo& dpi, const GraphProperties<uint16_t>& p);
     void DrawGuestGraph(DrawPixelInfo& dpi, const GraphProperties<uint32_t>& p);
 } // namespace OpenRCT2::Graph

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -832,7 +832,7 @@ static Widget _windowFinancesResearchWidgets[] =
             _graphProps.min = centredGraph ? -max : 0.00_GBP;
             _graphProps.max = max;
 
-            // dynamic padding for long axis lables:
+            // dynamic padding for long axis labels:
             char buffer[64]{};
             FormatStringToBuffer(buffer, sizeof(buffer), "{BLACK}{CURRENCY2DP}", centredGraph ? -max : max);
             int32_t maxWidth = GfxGetStringWidth(buffer, FontStyle::Small) + Graph::kYTickMarkPadding + 1;

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -39,8 +39,8 @@ namespace OpenRCT2::Ui::Windows
     static constexpr StringId WINDOW_TITLE = STR_STRINGID;
     static constexpr int32_t WH = 224;
 
-    static constexpr ScreenCoordsXY kGraphTopLeftPadding{ 45, 15 };
-    static constexpr ScreenCoordsXY kGraphBottomRightPadding{ 5, 5 };
+    static constexpr ScreenCoordsXY kGraphTopLeftPadding{ 45, 20 };
+    static constexpr ScreenCoordsXY kGraphBottomRightPadding{ 25, 10 };
     static constexpr uint8_t kGraphNumYLabels = 6;
 
     // clang-format off
@@ -681,13 +681,18 @@ static constexpr WindowParkAward _parkAwards[] = {
 #pragma region Rating page
         void OnResizeRating()
         {
-            WindowSetResize(*this, 255, 182, 255, 182);
+            flags |= WF_RESIZABLE;
+            WindowSetResize(*this, 268, 174 + 9, 2000, 2000);
         }
 
         void OnUpdateRating()
         {
             frame_no++;
             WidgetInvalidate(*this, WIDX_TAB_2);
+            if (_ratingProps.UpdateHoverIndex())
+            {
+                InvalidateWidget(WIDX_BACKGROUND);
+            }
         }
 
         void OnPrepareDrawRating()
@@ -736,6 +741,13 @@ static constexpr WindowParkAward _parkAwards[] = {
 
             // Graph border
             GfxFillRectInset(dpi, _ratingGraphBounds, colours[1], INSET_RECT_F_30);
+            // hide resize widget on graph area
+            constexpr ScreenCoordsXY offset{ 1, 1 };
+            constexpr ScreenCoordsXY bigOffset{ 5, 5 };
+            GfxFillRectInset(
+                dpi, { _ratingGraphBounds.Point2 - bigOffset, _ratingGraphBounds.Point2 - offset }, colours[1],
+                INSET_RECT_FLAG_FILL_DONT_LIGHTEN | INSET_RECT_FLAG_BORDER_NONE);
+
             Graph::DrawRatingGraph(dpi, _ratingProps);
         }
 
@@ -744,7 +756,8 @@ static constexpr WindowParkAward _parkAwards[] = {
 #pragma region Guests page
         void OnResizeGuests()
         {
-            WindowSetResize(*this, 255, 182, 255, 182);
+            flags |= WF_RESIZABLE;
+            WindowSetResize(*this, 268, 174 + 9, 2000, 2000);
         }
 
         void OnUpdateGuests()
@@ -752,6 +765,10 @@ static constexpr WindowParkAward _parkAwards[] = {
             frame_no++;
             _peepAnimationFrame = (_peepAnimationFrame + 1) % 24;
             WidgetInvalidate(*this, WIDX_TAB_3);
+            if (_guestProps.UpdateHoverIndex())
+            {
+                InvalidateWidget(WIDX_BACKGROUND);
+            }
         }
 
         void OnPrepareDrawGuests()
@@ -811,6 +828,13 @@ static constexpr WindowParkAward _parkAwards[] = {
 
             // Graph border
             GfxFillRectInset(dpi, _guestGraphBounds, colours[1], INSET_RECT_F_30);
+            // hide resize widget on graph area
+            constexpr ScreenCoordsXY offset{ 1, 1 };
+            constexpr ScreenCoordsXY bigOffset{ 5, 5 };
+            GfxFillRectInset(
+                dpi, { _guestGraphBounds.Point2 - bigOffset, _guestGraphBounds.Point2 - offset }, colours[1],
+                INSET_RECT_FLAG_FILL_DONT_LIGHTEN | INSET_RECT_FLAG_BORDER_NONE);
+
             Graph::DrawGuestGraph(dpi, _guestProps);
         }
 

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -199,7 +199,7 @@ static constexpr WindowParkAward _parkAwards[] = {
         int32_t _numberOfRides = -1;
         uint8_t _peepAnimationFrame = 0;
 
-        Graph::GraphProperties<uint8_t> _ratingProps{};
+        Graph::GraphProperties<uint16_t> _ratingProps{};
         Graph::GraphProperties<uint32_t> _guestProps{};
 
         ScreenRect _ratingGraphBounds;
@@ -706,14 +706,14 @@ static constexpr WindowParkAward _parkAwards[] = {
             AnchorBorderWidgets();
 
             _ratingProps.min = 0;
-            _ratingProps.max = 250;
+            _ratingProps.max = 1000;
             _ratingProps.series = GetGameState().Park.RatingHistory;
             const Widget* background = &widgets[WIDX_PAGE_BACKGROUND];
             _ratingGraphBounds = { windowPos + ScreenCoordsXY{ background->left + 4, background->top + 15 },
                                    windowPos + ScreenCoordsXY{ background->right - 4, background->bottom - 4 } };
 
             char buffer[64]{};
-            FormatStringToBuffer(buffer, sizeof(buffer), "{BLACK}{COMMA32}", Graph::kParkRatingMax);
+            FormatStringToBuffer(buffer, sizeof(buffer), "{BLACK}{COMMA32}", _ratingProps.max);
             int32_t maxWidth = GfxGetStringWidth(buffer, FontStyle::Small) + Graph::kYTickMarkPadding + 1;
             const ScreenCoordsXY dynamicPadding{ std::max(maxWidth, kGraphTopLeftPadding.x), kGraphTopLeftPadding.y };
 

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -911,10 +911,52 @@ namespace OpenRCT2
                         return true;
                     });
 
-                    cs.ReadWriteArray(gameState.Park.RatingHistory, [&cs](uint8_t& value) {
-                        cs.ReadWrite(value);
-                        return true;
-                    });
+                    if (version <= 36)
+                    {
+                        if (cs.GetMode() == OrcaStream::Mode::READING)
+                        {
+                            uint8_t smallHistory[kParkRatingHistorySize];
+                            cs.ReadWriteArray(smallHistory, [&cs](uint8_t& value) {
+                                cs.ReadWrite(value);
+                                return true;
+                            });
+                            for (int i = 0; i < kParkRatingHistorySize; i++)
+                            {
+                                if (smallHistory[i] == RCT12ParkHistoryUndefined)
+                                    gameState.Park.RatingHistory[i] = ParkRatingHistoryUndefined;
+                                else
+                                {
+                                    gameState.Park.RatingHistory[i] = static_cast<uint16_t>(
+                                        smallHistory[i] * RCT12ParkRatingHistoryFactor);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            uint8_t smallHistory[kParkRatingHistorySize];
+                            for (int i = 0; i < kParkRatingHistorySize; i++)
+                            {
+                                if (gameState.Park.RatingHistory[i] == ParkRatingHistoryUndefined)
+                                    smallHistory[i] = RCT12ParkHistoryUndefined;
+                                else
+                                {
+                                    smallHistory[i] = static_cast<uint8_t>(
+                                        gameState.Park.RatingHistory[i] / RCT12ParkRatingHistoryFactor);
+                                }
+                            }
+                            cs.ReadWriteArray(smallHistory, [&cs](uint8_t& value) {
+                                cs.ReadWrite(value);
+                                return true;
+                            });
+                        }
+                    }
+                    else
+                    {
+                        cs.ReadWriteArray(gameState.Park.RatingHistory, [&cs](uint16_t& value) {
+                            cs.ReadWrite(value);
+                            return true;
+                        });
+                    }
 
                     cs.ReadWriteArray(gameState.GuestsInParkHistory, [&cs](uint32_t& value) {
                         cs.ReadWrite(value);

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -11,7 +11,7 @@ namespace OpenRCT2
     struct GameState_t;
 
     // Current version that is saved.
-    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 36;
+    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 37;
 
     // The minimum version that is forwards compatible with the current version.
     constexpr uint32_t PARK_FILE_MIN_VERSION = 33;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2148,7 +2148,13 @@ namespace OpenRCT2::RCT1
             gameState.Park.Rating = _s4.ParkRating;
 
             Park::ResetHistories(gameState);
-            std::copy(std::begin(_s4.ParkRatingHistory), std::end(_s4.ParkRatingHistory), gameState.Park.RatingHistory);
+            for (size_t i = 0; i < std::size(_s4.ParkRatingHistory); i++)
+            {
+                if (_s4.ParkRatingHistory[i] != RCT12ParkHistoryUndefined)
+                {
+                    gameState.Park.RatingHistory[i] = _s4.ParkRatingHistory[i] * RCT12ParkRatingHistoryFactor;
+                }
+            }
             for (size_t i = 0; i < std::size(_s4.GuestsInParkHistory); i++)
             {
                 if (_s4.GuestsInParkHistory[i] != RCT12ParkHistoryUndefined)

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -71,6 +71,7 @@ constexpr uint16_t RCT12VehicleTrackTypeMask = 0b1111111111111100;
 constexpr uint8_t RCT12PeepThoughtItemNone = std::numeric_limits<uint8_t>::max();
 
 constexpr uint8_t RCT12GuestsInParkHistoryFactor = 20;
+constexpr uint8_t RCT12ParkRatingHistoryFactor = 4;
 constexpr uint8_t RCT12ParkHistoryUndefined = std::numeric_limits<uint8_t>::max();
 
 constexpr uint8_t kTD46RatingsMultiplier = 10;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -380,7 +380,13 @@ namespace OpenRCT2::RCT2
             gameState.Park.Rating = _s6.ParkRating;
 
             Park::ResetHistories(gameState);
-            std::copy(std::begin(_s6.ParkRatingHistory), std::end(_s6.ParkRatingHistory), gameState.Park.RatingHistory);
+            for (size_t i = 0; i < std::size(_s6.ParkRatingHistory); i++)
+            {
+                if (_s6.ParkRatingHistory[i] != RCT12ParkHistoryUndefined)
+                {
+                    gameState.Park.RatingHistory[i] = _s6.ParkRatingHistory[i] * RCT12ParkRatingHistoryFactor;
+                }
+            }
             for (size_t i = 0; i < std::size(_s6.GuestsInParkHistory); i++)
             {
                 if (_s6.GuestsInParkHistory[i] != RCT12ParkHistoryUndefined)

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -587,7 +587,7 @@ namespace OpenRCT2::Park
 
         // Update park rating, guests in park and current cash history
         constexpr auto ratingHistorySize = std::extent_v<decltype(ParkData::RatingHistory)>;
-        HistoryPushRecord<uint8_t, ratingHistorySize>(gameState.Park.RatingHistory, gameState.Park.Rating / 4);
+        HistoryPushRecord<uint16_t, ratingHistorySize>(gameState.Park.RatingHistory, gameState.Park.Rating);
         constexpr auto numGuestsHistorySize = std::extent_v<decltype(GameState_t::GuestsInParkHistory)>;
         HistoryPushRecord<uint32_t, numGuestsHistorySize>(gameState.GuestsInParkHistory, gameState.NumGuestsInPark);
 

--- a/src/openrct2/world/Park.h
+++ b/src/openrct2/world/Park.h
@@ -14,7 +14,7 @@
 
 constexpr auto MAX_ENTRANCE_FEE = 999.00_GBP;
 
-constexpr uint8_t ParkRatingHistoryUndefined = std::numeric_limits<uint8_t>::max();
+constexpr uint16_t ParkRatingHistoryUndefined = std::numeric_limits<uint16_t>::max();
 constexpr uint32_t GuestsInParkHistoryUndefined = std::numeric_limits<uint32_t>::max();
 constexpr uint8_t kParkRatingHistorySize = 32;
 constexpr uint8_t kGuestsInParkHistorySize = 32;
@@ -60,7 +60,7 @@ namespace OpenRCT2
             std::string Name;
             uint64_t Flags;
             uint16_t Rating;
-            uint8_t RatingHistory[kParkRatingHistorySize];
+            uint16_t RatingHistory[kParkRatingHistorySize];
             int16_t RatingCasualtyPenalty;
             money64 EntranceFee;
             std::vector<CoordsXYZD> Entrances;


### PR DESCRIPTION
Closes #22686 and brings the finance graph improvements to park graphs.

This required changing the park history data in the save file from 8 bits to 16 bits. 

I also needed to increase the minimum size of the park graph window in order to accommodate the padding required to prevent tooltips from overflowing. This seems to be a good idea regardless, as the month labels were drawing over each other in Japanese at the original minimum size.

Please let me know if I need to bump `PARK_FILE_MIN_VERSION` in `ParkFile.h`

![image](https://github.com/user-attachments/assets/22e89d4f-57f4-4e21-acb8-bfabe9412577)
