### PR TITLE
Indent window widget definitions

### DIFF
--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -28,64 +28,64 @@ namespace OpenRCT2::Ui::Windows
     static constexpr StringId WINDOW_TITLE = STR_ABOUT;
     static constexpr int32_t TABHEIGHT = 50;
 
+    enum
+    {
+        WINDOW_ABOUT_PAGE_OPENRCT2,
+        WINDOW_ABOUT_PAGE_RCT2,
+    };
+
+    enum WindowAboutWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_PAGE_BACKGROUND,
+        WIDX_TAB_ABOUT_OPENRCT2,
+        WIDX_TAB_ABOUT_RCT2,
+
+        WIDX_PAGE_START,
+
+        // About OpenRCT2
+        WIDX_INTRO = WIDX_PAGE_START,
+        WIDX_OPENRCT2_LOGO,
+        WIDX_VERSION,
+        WIDX_COPY_BUILD_INFO,
+        WIDX_NEW_VERSION,
+        WIDX_CHANGELOG,
+        WIDX_JOIN_DISCORD,
+        WIDX_CONTRIBUTORS_BUTTON,
+    };
+
     // clang-format off
-enum
-{
-    WINDOW_ABOUT_PAGE_OPENRCT2,
-    WINDOW_ABOUT_PAGE_RCT2,
-};
+    #define WIDGETS_MAIN \
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
+        MakeWidget     ({ 0, TABHEIGHT}, {WW, WH - TABHEIGHT}, WindowWidgetType::Frame,  WindowColour::Secondary               ), /* page background */       \
+        MakeRemapWidget({ 3,        17}, {91, TABHEIGHT - 16}, WindowWidgetType::Tab,    WindowColour::Secondary, SPR_TAB_LARGE), /* about OpenRCT2 button */ \
+        MakeRemapWidget({94,        17}, {91, TABHEIGHT - 16}, WindowWidgetType::Tab,    WindowColour::Secondary, SPR_TAB_LARGE)  /* about RCT2 button */ \
 
-enum WindowAboutWidgetIdx {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_PAGE_BACKGROUND,
-    WIDX_TAB_ABOUT_OPENRCT2,
-    WIDX_TAB_ABOUT_RCT2,
-
-    WIDX_PAGE_START,
-
-    // About OpenRCT2
-    WIDX_INTRO = WIDX_PAGE_START,
-    WIDX_OPENRCT2_LOGO,
-    WIDX_VERSION,
-    WIDX_COPY_BUILD_INFO,
-    WIDX_NEW_VERSION,
-    WIDX_CHANGELOG,
-    WIDX_JOIN_DISCORD,
-    WIDX_CONTRIBUTORS_BUTTON,
-};
-
-#define WIDGETS_MAIN \
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
-    MakeWidget     ({ 0, TABHEIGHT}, {WW, WH - TABHEIGHT}, WindowWidgetType::Frame,  WindowColour::Secondary               ), /* page background */       \
-    MakeRemapWidget({ 3,        17}, {91, TABHEIGHT - 16}, WindowWidgetType::Tab,    WindowColour::Secondary, SPR_TAB_LARGE), /* about OpenRCT2 button */ \
-    MakeRemapWidget({94,        17}, {91, TABHEIGHT - 16}, WindowWidgetType::Tab,    WindowColour::Secondary, SPR_TAB_LARGE)  /* about RCT2 button */ \
-
-static Widget _windowAboutOpenRCT2Widgets[] = {
-    WIDGETS_MAIN,
-    MakeWidget({10, 60},        {WW - 20, 20}, WindowWidgetType::LabelCentred, WindowColour::Secondary, STR_ABOUT_OPENRCT2_DESCRIPTION), // Introduction
-    MakeWidget({30, 90},        {128, 128},    WindowWidgetType::Placeholder,  WindowColour::Secondary, STR_NONE), // OpenRCT2 Logo
-    MakeWidget({168, 100},      {173, 24},     WindowWidgetType::Placeholder,  WindowColour::Secondary, STR_NONE), // Build version
-    MakeWidget({344, 100 },     {24, 24},      WindowWidgetType::ImgBtn,       WindowColour::Secondary, ImageId(SPR_G2_COPY), STR_COPY_BUILD_HASH   ), // "Copy build info" button
-    MakeWidget({168, 115 + 20}, {200, 14},     WindowWidgetType::Placeholder,  WindowColour::Secondary, STR_UPDATE_AVAILABLE  ), // "new version" button
-    MakeWidget({168, 115 + 40}, {200, 14},     WindowWidgetType::Button,       WindowColour::Secondary, STR_CHANGELOG_ELLIPSIS), // changelog button
-    MakeWidget({168, 115 + 60}, {200, 14},     WindowWidgetType::Button,       WindowColour::Secondary, STR_JOIN_DISCORD      ), // "join discord" button
-    MakeWidget({168, 115 + 80}, {200, 14},     WindowWidgetType::Button,       WindowColour::Secondary, STR_CONTRIBUTORS_WINDOW_BUTTON), // "contributors" button
-    kWidgetsEnd,
-};
-
-static Widget _windowAboutRCT2Widgets[] = {
-    WIDGETS_MAIN,
-    kWidgetsEnd,
-};
-
-static Widget *_windowAboutPageWidgets[] = {
-    _windowAboutOpenRCT2Widgets,
-    _windowAboutRCT2Widgets,
-};
-
+    static Widget _windowAboutOpenRCT2Widgets[] = {
+        WIDGETS_MAIN,
+        MakeWidget({10, 60},        {WW - 20, 20}, WindowWidgetType::LabelCentred, WindowColour::Secondary, STR_ABOUT_OPENRCT2_DESCRIPTION), // Introduction
+        MakeWidget({30, 90},        {128, 128},    WindowWidgetType::Placeholder,  WindowColour::Secondary, STR_NONE), // OpenRCT2 Logo
+        MakeWidget({168, 100},      {173, 24},     WindowWidgetType::Placeholder,  WindowColour::Secondary, STR_NONE), // Build version
+        MakeWidget({344, 100 },     {24, 24},      WindowWidgetType::ImgBtn,       WindowColour::Secondary, ImageId(SPR_G2_COPY), STR_COPY_BUILD_HASH   ), // "Copy build info" button
+        MakeWidget({168, 115 + 20}, {200, 14},     WindowWidgetType::Placeholder,  WindowColour::Secondary, STR_UPDATE_AVAILABLE  ), // "new version" button
+        MakeWidget({168, 115 + 40}, {200, 14},     WindowWidgetType::Button,       WindowColour::Secondary, STR_CHANGELOG_ELLIPSIS), // changelog button
+        MakeWidget({168, 115 + 60}, {200, 14},     WindowWidgetType::Button,       WindowColour::Secondary, STR_JOIN_DISCORD      ), // "join discord" button
+        MakeWidget({168, 115 + 80}, {200, 14},     WindowWidgetType::Button,       WindowColour::Secondary, STR_CONTRIBUTORS_WINDOW_BUTTON), // "contributors" button
+        kWidgetsEnd,
+    };
     // clang-format on
+
+    static Widget _windowAboutRCT2Widgets[] = {
+        WIDGETS_MAIN,
+        kWidgetsEnd,
+    };
+
+    static Widget* _windowAboutPageWidgets[] = {
+        _windowAboutOpenRCT2Widgets,
+        _windowAboutRCT2Widgets,
+    };
 
     class AboutWindow final : public Window
     {

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -56,13 +56,18 @@ namespace OpenRCT2::Ui::Windows
         WIDX_CONTRIBUTORS_BUTTON,
     };
 
-// clang-format off
-    #define WIDGETS_MAIN \
-        WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
-        MakeWidget     ({ 0, TABHEIGHT}, {WW, WH - TABHEIGHT}, WindowWidgetType::Frame,  WindowColour::Secondary               ), /* page background */       \
-        MakeRemapWidget({ 3,        17}, {91, TABHEIGHT - 16}, WindowWidgetType::Tab,    WindowColour::Secondary, SPR_TAB_LARGE), /* about OpenRCT2 button */ \
-        MakeRemapWidget({94,        17}, {91, TABHEIGHT - 16}, WindowWidgetType::Tab,    WindowColour::Secondary, SPR_TAB_LARGE)  /* about RCT2 button */ \
+#define WIDGETS_MAIN                                                                                                           \
+    WINDOW_SHIM(WINDOW_TITLE, WW, WH),                                                                                         \
+        MakeWidget(                                                                                                            \
+            { 0, TABHEIGHT }, { WW, WH - TABHEIGHT }, WindowWidgetType::Frame, WindowColour::Secondary), /* page background */ \
+        MakeRemapWidget(                                                                                                       \
+            { 3, 17 }, { 91, TABHEIGHT - 16 }, WindowWidgetType::Tab, WindowColour::Secondary,                                 \
+            SPR_TAB_LARGE), /* about OpenRCT2 button */                                                                        \
+        MakeRemapWidget(                                                                                                       \
+            { 94, 17 }, { 91, TABHEIGHT - 16 }, WindowWidgetType::Tab, WindowColour::Secondary,                                \
+            SPR_TAB_LARGE) /* about RCT2 button */
 
+    // clang-format off
     static Widget _windowAboutOpenRCT2Widgets[] = {
         WIDGETS_MAIN,
         MakeWidget({10, 60},        {WW - 20, 20}, WindowWidgetType::LabelCentred, WindowColour::Secondary, STR_ABOUT_OPENRCT2_DESCRIPTION), // Introduction

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -56,7 +56,7 @@ namespace OpenRCT2::Ui::Windows
         WIDX_CONTRIBUTORS_BUTTON,
     };
 
-    // clang-format off
+// clang-format off
     #define WIDGETS_MAIN \
         WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
         MakeWidget     ({ 0, TABHEIGHT}, {WW, WH - TABHEIGHT}, WindowWidgetType::Frame,  WindowColour::Secondary               ), /* page background */       \

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -58,14 +58,9 @@ namespace OpenRCT2::Ui::Windows
 
 #define WIDGETS_MAIN                                                                                                           \
     WINDOW_SHIM(WINDOW_TITLE, WW, WH),                                                                                         \
-        MakeWidget(                                                                                                            \
-            { 0, TABHEIGHT }, { WW, WH - TABHEIGHT }, WindowWidgetType::Frame, WindowColour::Secondary), /* page background */ \
-        MakeRemapWidget(                                                                                                       \
-            { 3, 17 }, { 91, TABHEIGHT - 16 }, WindowWidgetType::Tab, WindowColour::Secondary,                                 \
-            SPR_TAB_LARGE), /* about OpenRCT2 button */                                                                        \
-        MakeRemapWidget(                                                                                                       \
-            { 94, 17 }, { 91, TABHEIGHT - 16 }, WindowWidgetType::Tab, WindowColour::Secondary,                                \
-            SPR_TAB_LARGE) /* about RCT2 button */
+        MakeWidget({ 0, TABHEIGHT }, { WW, WH - TABHEIGHT }, WindowWidgetType::Frame, WindowColour::Secondary),                \
+        MakeRemapWidget({ 3, 17 }, { 91, TABHEIGHT - 16 }, WindowWidgetType::Tab, WindowColour::Secondary, SPR_TAB_LARGE),     \
+        MakeRemapWidget({ 94, 17 }, { 91, TABHEIGHT - 16 }, WindowWidgetType::Tab, WindowColour::Secondary, SPR_TAB_LARGE)
 
     // clang-format off
     static Widget _windowAboutOpenRCT2Widgets[] = {

--- a/src/openrct2-ui/windows/AssetPacks.cpp
+++ b/src/openrct2-ui/windows/AssetPacks.cpp
@@ -26,29 +26,30 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WW = 400;
     static constexpr int32_t WH = 200;
 
-    // clang-format off
-enum WindowAssetPacksWidgetIdx {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_HIGH_LABEL,
-    WIDX_LIST,
-    WIDX_LOW_LABEL,
-    WIDX_MOVE_UP,
-    WIDX_MOVE_DOWN,
-    WIDX_APPLY,
-};
+    enum WindowAssetPacksWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_HIGH_LABEL,
+        WIDX_LIST,
+        WIDX_LOW_LABEL,
+        WIDX_MOVE_UP,
+        WIDX_MOVE_DOWN,
+        WIDX_APPLY,
+    };
 
-static Widget WindowAssetPacksWidgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({ 0, 0 }, { 0,   0 }, WindowWidgetType::LabelCentred,  WindowColour::Secondary, STR_HIGH_PRIORITY),
-    MakeWidget({ 0, 0 }, { 0, 147 }, WindowWidgetType::Scroll,  WindowColour::Secondary, SCROLL_VERTICAL),
-    MakeWidget({ 0, 0 }, { 0,   0 }, WindowWidgetType::LabelCentred,  WindowColour::Secondary, STR_LOW_PRIORITY),
-    MakeWidget({ 0, 0 }, { 0,   0 }, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_ARROW_UP), STR_INCREASE_PRIOTITY_TIP),
-    MakeWidget({ 0, 0 }, { 0,   0 }, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_ARROW_DOWN), STR_DECREASE_PRIOTITY_TIP),
-    MakeWidget({ 0, 0 }, { 0,   0 }, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_RELOAD), STR_RELOAD_ASSET_PACKS_TIP),
-    kWidgetsEnd,
-};
+    // clang-format off
+    static Widget WindowAssetPacksWidgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({ 0, 0 }, { 0,   0 }, WindowWidgetType::LabelCentred,  WindowColour::Secondary, STR_HIGH_PRIORITY),
+        MakeWidget({ 0, 0 }, { 0, 147 }, WindowWidgetType::Scroll,  WindowColour::Secondary, SCROLL_VERTICAL),
+        MakeWidget({ 0, 0 }, { 0,   0 }, WindowWidgetType::LabelCentred,  WindowColour::Secondary, STR_LOW_PRIORITY),
+        MakeWidget({ 0, 0 }, { 0,   0 }, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_ARROW_UP), STR_INCREASE_PRIOTITY_TIP),
+        MakeWidget({ 0, 0 }, { 0,   0 }, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_ARROW_DOWN), STR_DECREASE_PRIOTITY_TIP),
+        MakeWidget({ 0, 0 }, { 0,   0 }, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_RELOAD), STR_RELOAD_ASSET_PACKS_TIP),
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class AssetPacksWindow final : public Window

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -44,14 +44,24 @@ namespace OpenRCT2::Ui::Windows
         WIDX_TEXT_COLOUR_DROPDOWN_BUTTON
     };
 
+    // clang-format off
     static constexpr StringId BannerColouredTextFormats[] = {
-        STR_TEXT_COLOUR_BLACK,     STR_TEXT_COLOUR_GREY,         STR_TEXT_COLOUR_WHITE,    STR_TEXT_COLOUR_RED,
-        STR_TEXT_COLOUR_GREEN,     STR_TEXT_COLOUR_YELLOW,       STR_TEXT_COLOUR_TOPAZ,    STR_TEXT_COLOUR_CELADON,
-        STR_TEXT_COLOUR_BABYBLUE,  STR_TEXT_COLOUR_PALELAVENDER, STR_TEXT_COLOUR_PALEGOLD, STR_TEXT_COLOUR_LIGHTPINK,
-        STR_TEXT_COLOUR_PEARLAQUA, STR_TEXT_COLOUR_PALESILVER,
+        STR_TEXT_COLOUR_BLACK,
+        STR_TEXT_COLOUR_GREY,
+        STR_TEXT_COLOUR_WHITE,
+        STR_TEXT_COLOUR_RED,
+        STR_TEXT_COLOUR_GREEN,
+        STR_TEXT_COLOUR_YELLOW,
+        STR_TEXT_COLOUR_TOPAZ,
+        STR_TEXT_COLOUR_CELADON,
+        STR_TEXT_COLOUR_BABYBLUE,
+        STR_TEXT_COLOUR_PALELAVENDER,
+        STR_TEXT_COLOUR_PALEGOLD,
+        STR_TEXT_COLOUR_LIGHTPINK,
+        STR_TEXT_COLOUR_PEARLAQUA,
+        STR_TEXT_COLOUR_PALESILVER,
     };
 
-    // clang-format off
     static Widget window_banner_widgets[] = {
         WINDOW_SHIM(WINDOW_TITLE, WW, WH),
         MakeWidget({      3,      17}, {85, 60}, WindowWidgetType::Viewport,  WindowColour::Secondary, 0x0FFFFFFFE                                        ), // tab content panel

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -30,49 +30,39 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WH = 96;
     static constexpr StringId WINDOW_TITLE = STR_BANNER_WINDOW_TITLE;
 
+    enum WindowBannerWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_VIEWPORT,
+        WIDX_BANNER_TEXT,
+        WIDX_BANNER_NO_ENTRY,
+        WIDX_BANNER_DEMOLISH,
+        WIDX_MAIN_COLOUR,
+        WIDX_TEXT_COLOUR_DROPDOWN,
+        WIDX_TEXT_COLOUR_DROPDOWN_BUTTON
+    };
+
+    static constexpr StringId BannerColouredTextFormats[] = {
+        STR_TEXT_COLOUR_BLACK,     STR_TEXT_COLOUR_GREY,         STR_TEXT_COLOUR_WHITE,    STR_TEXT_COLOUR_RED,
+        STR_TEXT_COLOUR_GREEN,     STR_TEXT_COLOUR_YELLOW,       STR_TEXT_COLOUR_TOPAZ,    STR_TEXT_COLOUR_CELADON,
+        STR_TEXT_COLOUR_BABYBLUE,  STR_TEXT_COLOUR_PALELAVENDER, STR_TEXT_COLOUR_PALEGOLD, STR_TEXT_COLOUR_LIGHTPINK,
+        STR_TEXT_COLOUR_PEARLAQUA, STR_TEXT_COLOUR_PALESILVER,
+    };
+
     // clang-format off
-enum WindowBannerWidgetIdx {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_VIEWPORT,
-    WIDX_BANNER_TEXT,
-    WIDX_BANNER_NO_ENTRY,
-    WIDX_BANNER_DEMOLISH,
-    WIDX_MAIN_COLOUR,
-    WIDX_TEXT_COLOUR_DROPDOWN,
-    WIDX_TEXT_COLOUR_DROPDOWN_BUTTON
-};
-
-static constexpr StringId BannerColouredTextFormats[] = {
-    STR_TEXT_COLOUR_BLACK,
-    STR_TEXT_COLOUR_GREY,
-    STR_TEXT_COLOUR_WHITE,
-    STR_TEXT_COLOUR_RED,
-    STR_TEXT_COLOUR_GREEN,
-    STR_TEXT_COLOUR_YELLOW,
-    STR_TEXT_COLOUR_TOPAZ,
-    STR_TEXT_COLOUR_CELADON,
-    STR_TEXT_COLOUR_BABYBLUE,
-    STR_TEXT_COLOUR_PALELAVENDER,
-    STR_TEXT_COLOUR_PALEGOLD,
-    STR_TEXT_COLOUR_LIGHTPINK,
-    STR_TEXT_COLOUR_PEARLAQUA,
-    STR_TEXT_COLOUR_PALESILVER,
-};
-
-static Widget window_banner_widgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({      3,      17}, {85, 60}, WindowWidgetType::Viewport,  WindowColour::Secondary, 0x0FFFFFFFE                                        ), // tab content panel
-    MakeWidget({WW - 25,      19}, {24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_RENAME),         STR_CHANGE_BANNER_TEXT_TIP     ), // change banner button
-    MakeWidget({WW - 25,      43}, {24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_NO_ENTRY),       STR_SET_AS_NO_ENTRY_BANNER_TIP ), // no entry button
-    MakeWidget({WW - 25,      67}, {24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_DEMOLISH),       STR_DEMOLISH_BANNER_TIP        ), // demolish button
-    MakeWidget({      5, WH - 16}, {12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,         STR_SELECT_MAIN_SIGN_COLOUR_TIP), // high money
-    MakeWidget({     43, WH - 16}, {39, 12}, WindowWidgetType::DropdownMenu,  WindowColour::Secondary                                                     ), // high money
-    MakeWidget({     70, WH - 15}, {11, 10}, WindowWidgetType::Button,    WindowColour::Secondary, STR_DROPDOWN_GLYPH, STR_SELECT_TEXT_COLOUR_TIP     ), // high money
-    kWidgetsEnd,
-};
-
+    static Widget window_banner_widgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({      3,      17}, {85, 60}, WindowWidgetType::Viewport,  WindowColour::Secondary, 0x0FFFFFFFE                                        ), // tab content panel
+        MakeWidget({WW - 25,      19}, {24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_RENAME),         STR_CHANGE_BANNER_TEXT_TIP     ), // change banner button
+        MakeWidget({WW - 25,      43}, {24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_NO_ENTRY),       STR_SET_AS_NO_ENTRY_BANNER_TIP ), // no entry button
+        MakeWidget({WW - 25,      67}, {24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_DEMOLISH),       STR_DEMOLISH_BANNER_TIP        ), // demolish button
+        MakeWidget({      5, WH - 16}, {12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,         STR_SELECT_MAIN_SIGN_COLOUR_TIP), // high money
+        MakeWidget({     43, WH - 16}, {39, 12}, WindowWidgetType::DropdownMenu,  WindowColour::Secondary                                                     ), // high money
+        MakeWidget({     70, WH - 15}, {11, 10}, WindowWidgetType::Button,    WindowColour::Secondary, STR_DROPDOWN_GLYPH, STR_SELECT_TEXT_COLOUR_TIP     ), // high money
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class BannerWindow final : public Window

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -26,30 +26,30 @@
 
 namespace OpenRCT2::Ui::Windows
 {
+    enum
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_CONTENT_PANEL,
+        WIDX_SCROLL,
+        WIDX_OPEN_URL,
+    };
+
+    static constexpr int32_t WW = 500;
+    static constexpr int32_t WH = 400;
+    static constexpr StringId WINDOW_TITLE = STR_CHANGELOG_TITLE;
+    constexpr int32_t MIN_WW = 300;
+    constexpr int32_t MIN_WH = 250;
+
     // clang-format off
-enum {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_CONTENT_PANEL,
-    WIDX_SCROLL,
-    WIDX_OPEN_URL,
-};
-
-static constexpr int32_t WW = 500;
-static constexpr int32_t WH = 400;
-static constexpr StringId WINDOW_TITLE = STR_CHANGELOG_TITLE;
-constexpr int32_t MIN_WW = 300;
-constexpr int32_t MIN_WH = 250;
-
-static Widget _windowChangelogWidgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({0,  14}, {500, 382}, WindowWidgetType::Resize,      WindowColour::Secondary                               ), // content panel
-    MakeWidget({3,  16}, {495, 366}, WindowWidgetType::Scroll,      WindowColour::Secondary, SCROLL_BOTH                  ), // scroll area
-    MakeWidget({3, 473}, {300,  14}, WindowWidgetType::Placeholder, WindowColour::Secondary, STR_NEW_RELEASE_DOWNLOAD_PAGE), // changelog button
-    kWidgetsEnd,
-};
-
+    static Widget _windowChangelogWidgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({0,  14}, {500, 382}, WindowWidgetType::Resize,      WindowColour::Secondary                               ), // content panel
+        MakeWidget({3,  16}, {495, 366}, WindowWidgetType::Scroll,      WindowColour::Secondary, SCROLL_BOTH                  ), // scroll area
+        MakeWidget({3, 473}, {300,  14}, WindowWidgetType::Placeholder, WindowColour::Secondary, STR_NEW_RELEASE_DOWNLOAD_PAGE), // changelog button
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class ChangelogWindow final : public Window

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -25,28 +25,28 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WH = 100;
     static constexpr int32_t WW = 400;
 
+    enum WindowCustomCurrencyWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_RATE,
+        WIDX_RATE_UP,
+        WIDX_RATE_DOWN,
+        WIDX_SYMBOL_TEXT,
+        WIDX_AFFIX_DROPDOWN,
+        WIDX_AFFIX_DROPDOWN_BUTTON,
+    };
+
     // clang-format off
-enum WindowCustomCurrencyWidgetIdx {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_RATE,
-    WIDX_RATE_UP,
-    WIDX_RATE_DOWN,
-    WIDX_SYMBOL_TEXT,
-    WIDX_AFFIX_DROPDOWN,
-    WIDX_AFFIX_DROPDOWN_BUTTON,
-};
-
-static Widget window_custom_currency_widgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeSpinnerWidgets({100, 30}, {101, 11}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_CURRENCY_FORMAT), // NB: 3 widgets
-    MakeWidget        ({120, 50}, { 81, 11}, WindowWidgetType::Button,   WindowColour::Secondary, STR_EMPTY          ),
-    MakeWidget        ({220, 50}, {131, 11}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                 ),
-    MakeWidget        ({339, 51}, { 11,  9}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH ),
-    kWidgetsEnd,
-};
-
+    static Widget window_custom_currency_widgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeSpinnerWidgets({100, 30}, {101, 11}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_CURRENCY_FORMAT), // NB: 3 widgets
+        MakeWidget        ({120, 50}, { 81, 11}, WindowWidgetType::Button,   WindowColour::Secondary, STR_EMPTY          ),
+        MakeWidget        ({220, 50}, {131, 11}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                 ),
+        MakeWidget        ({339, 51}, { 11,  9}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH ),
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class CustomCurrencyWindow final : public Window

--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -19,29 +19,29 @@
 
 namespace OpenRCT2::Ui::Windows
 {
+    enum WindowDebugPaintWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TOGGLE_SHOW_WIDE_PATHS,
+        WIDX_TOGGLE_SHOW_BLOCKED_TILES,
+        WIDX_TOGGLE_SHOW_SEGMENT_HEIGHTS,
+        WIDX_TOGGLE_SHOW_BOUND_BOXES,
+        WIDX_TOGGLE_SHOW_DIRTY_VISUALS,
+    };
+
+    constexpr int32_t WINDOW_WIDTH = 200;
+    constexpr int32_t WINDOW_HEIGHT = 8 + 15 + 15 + 15 + 15 + 11 + 8;
+
     // clang-format off
-enum WindowDebugPaintWidgetIdx
-{
-    WIDX_BACKGROUND,
-    WIDX_TOGGLE_SHOW_WIDE_PATHS,
-    WIDX_TOGGLE_SHOW_BLOCKED_TILES,
-    WIDX_TOGGLE_SHOW_SEGMENT_HEIGHTS,
-    WIDX_TOGGLE_SHOW_BOUND_BOXES,
-    WIDX_TOGGLE_SHOW_DIRTY_VISUALS,
-};
-
-constexpr int32_t WINDOW_WIDTH = 200;
-constexpr int32_t WINDOW_HEIGHT = 8 + 15 + 15 + 15 + 15 + 11 + 8;
-
-static Widget window_debug_paint_widgets[] = {
-    MakeWidget({0,          0}, {WINDOW_WIDTH, WINDOW_HEIGHT}, WindowWidgetType::Frame,    WindowColour::Primary                                        ),
-    MakeWidget({8, 8 + 15 * 0}, {         185,            12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_DEBUG_PAINT_SHOW_WIDE_PATHS     ),
-    MakeWidget({8, 8 + 15 * 1}, {         185,            12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_DEBUG_PAINT_SHOW_BLOCKED_TILES  ),
-    MakeWidget({8, 8 + 15 * 2}, {         185,            12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_DEBUG_PAINT_SHOW_SEGMENT_HEIGHTS),
-    MakeWidget({8, 8 + 15 * 3}, {         185,            12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_DEBUG_PAINT_SHOW_BOUND_BOXES    ),
-    MakeWidget({8, 8 + 15 * 4}, {         185,            12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_DEBUG_PAINT_SHOW_DIRTY_VISUALS  ),
-    kWidgetsEnd,
-};
+    static Widget window_debug_paint_widgets[] = {
+        MakeWidget({0,          0}, {WINDOW_WIDTH, WINDOW_HEIGHT}, WindowWidgetType::Frame,    WindowColour::Primary                                        ),
+        MakeWidget({8, 8 + 15 * 0}, {         185,            12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_DEBUG_PAINT_SHOW_WIDE_PATHS     ),
+        MakeWidget({8, 8 + 15 * 1}, {         185,            12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_DEBUG_PAINT_SHOW_BLOCKED_TILES  ),
+        MakeWidget({8, 8 + 15 * 2}, {         185,            12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_DEBUG_PAINT_SHOW_SEGMENT_HEIGHTS),
+        MakeWidget({8, 8 + 15 * 3}, {         185,            12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_DEBUG_PAINT_SHOW_BOUND_BOXES    ),
+        MakeWidget({8, 8 + 15 * 4}, {         185,            12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_DEBUG_PAINT_SHOW_DIRTY_VISUALS  ),
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class DebugPaintWindow final : public Window

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -23,23 +23,23 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WW = 200;
     static constexpr int32_t WH = 100;
 
-    // clang-format off
-enum WindowRideDemolishWidgetIdx
-{
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_DEMOLISH,
-    WIDX_CANCEL
-};
+    enum WindowRideDemolishWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_DEMOLISH,
+        WIDX_CANCEL
+    };
 
-static Widget window_ride_demolish_widgets[] =
-{
-    WINDOW_SHIM_WHITE(STR_DEMOLISH_RIDE, WW, WH),
-    MakeWidget({     10, WH - 22}, {85, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_DEMOLISH          ),
-    MakeWidget({WW - 95, WH - 22}, {85, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_SAVE_PROMPT_CANCEL),
-    kWidgetsEnd,
-};
+    // clang-format off
+    static Widget window_ride_demolish_widgets[] =
+    {
+        WINDOW_SHIM_WHITE(STR_DEMOLISH_RIDE, WW, WH),
+        MakeWidget({     10, WH - 22}, {85, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_DEMOLISH          ),
+        MakeWidget({WW - 95, WH - 22}, {85, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_SAVE_PROMPT_CANCEL),
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class DemolishRidePromptWindow final : public Window

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -29,21 +29,22 @@
 
 namespace OpenRCT2::Ui::Windows
 {
-    // clang-format off
-enum {
-    WIDX_PREVIOUS_IMAGE,        // 1
-    WIDX_PREVIOUS_STEP_BUTTON,  // 2
-    WIDX_NEXT_IMAGE,            // 4
-    WIDX_NEXT_STEP_BUTTON,      // 8
-};
+    enum
+    {
+        WIDX_PREVIOUS_IMAGE,       // 1
+        WIDX_PREVIOUS_STEP_BUTTON, // 2
+        WIDX_NEXT_IMAGE,           // 4
+        WIDX_NEXT_STEP_BUTTON,     // 8
+    };
 
-static Widget _editorBottomToolbarWidgets[] = {
-    MakeWidget({  0, 0}, {200, 34}, WindowWidgetType::ImgBtn,  WindowColour::Primary),
-    MakeWidget({  2, 2}, {196, 30}, WindowWidgetType::FlatBtn, WindowColour::Primary),
-    MakeWidget({440, 0}, {200, 34}, WindowWidgetType::ImgBtn,  WindowColour::Primary),
-    MakeWidget({442, 2}, {196, 30}, WindowWidgetType::FlatBtn, WindowColour::Primary),
-    kWidgetsEnd,
-};
+    // clang-format off
+    static Widget _editorBottomToolbarWidgets[] = {
+        MakeWidget({  0, 0}, {200, 34}, WindowWidgetType::ImgBtn,  WindowColour::Primary),
+        MakeWidget({  2, 2}, {196, 30}, WindowWidgetType::FlatBtn, WindowColour::Primary),
+        MakeWidget({440, 0}, {200, 34}, WindowWidgetType::ImgBtn,  WindowColour::Primary),
+        MakeWidget({442, 2}, {196, 30}, WindowWidgetType::FlatBtn, WindowColour::Primary),
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class EditorBottomToolbarWindow final : public Window

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -35,38 +35,39 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WH = 400;
     static constexpr StringId WINDOW_TITLE = STR_INVENTION_LIST;
 
+    enum
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_RESIZE,
+        WIDX_TAB_1,
+        WIDX_PRE_RESEARCHED_SCROLL,
+        WIDX_RESEARCH_ORDER_SCROLL,
+        WIDX_PREVIEW,
+        WIDX_MOVE_ITEMS_TO_TOP,
+        WIDX_MOVE_ITEMS_TO_BOTTOM,
+        WIDX_RANDOM_SHUFFLE
+    };
+
     // clang-format off
-enum {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_RESIZE,
-    WIDX_TAB_1,
-    WIDX_PRE_RESEARCHED_SCROLL,
-    WIDX_RESEARCH_ORDER_SCROLL,
-    WIDX_PREVIEW,
-    WIDX_MOVE_ITEMS_TO_TOP,
-    WIDX_MOVE_ITEMS_TO_BOTTOM,
-    WIDX_RANDOM_SHUFFLE
-};
+    static Widget _inventionListWidgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({  0,  43}, {600, 357}, WindowWidgetType::Resize,  WindowColour::Secondary                                             ),
+        MakeTab   ({  3,  17}                                                                                               ),
+        MakeWidget({  4,  56}, {368, 161}, WindowWidgetType::Scroll,  WindowColour::Secondary, SCROLL_VERTICAL                            ),
+        MakeWidget({  4, 231}, {368, 157}, WindowWidgetType::Scroll,  WindowColour::Secondary, SCROLL_VERTICAL                            ),
+        MakeWidget({431, 106}, {114, 114}, WindowWidgetType::FlatBtn, WindowColour::Secondary                                             ),
+        MakeWidget({375, 343}, {220,  14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_MOVE_ALL_TOP                           ),
+        MakeWidget({375, 358}, {220,  14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_MOVE_ALL_BOTTOM                        ),
+        MakeWidget({375, 373}, {220,  14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_RANDOM_SHUFFLE,  STR_RANDOM_SHUFFLE_TIP),
+        kWidgetsEnd,
+    };
 
-static Widget _inventionListWidgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({  0,  43}, {600, 357}, WindowWidgetType::Resize,  WindowColour::Secondary                                             ),
-    MakeTab   ({  3,  17}                                                                                               ),
-    MakeWidget({  4,  56}, {368, 161}, WindowWidgetType::Scroll,  WindowColour::Secondary, SCROLL_VERTICAL                            ),
-    MakeWidget({  4, 231}, {368, 157}, WindowWidgetType::Scroll,  WindowColour::Secondary, SCROLL_VERTICAL                            ),
-    MakeWidget({431, 106}, {114, 114}, WindowWidgetType::FlatBtn, WindowColour::Secondary                                             ),
-    MakeWidget({375, 343}, {220,  14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_MOVE_ALL_TOP                           ),
-    MakeWidget({375, 358}, {220,  14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_MOVE_ALL_BOTTOM                        ),
-    MakeWidget({375, 373}, {220,  14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_RANDOM_SHUFFLE,  STR_RANDOM_SHUFFLE_TIP),
-    kWidgetsEnd,
-};
-
-static Widget _inventionListDragWidgets[] = {
-    MakeWidget({0, 0}, {150, 14}, WindowWidgetType::ImgBtn, WindowColour::Primary),
-    kWidgetsEnd,
-};
+    static Widget _inventionListDragWidgets[] = {
+        MakeWidget({0, 0}, {150, 14}, WindowWidgetType::ImgBtn, WindowColour::Primary),
+        kWidgetsEnd,
+    };
     // clang-format on
 
 #pragma endregion

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -61,13 +61,6 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Widgets
 
-    enum
-    {
-        WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN,
-        WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES,
-        WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_COUNT
-    };
-
     static constexpr StringId ObjectiveDropdownOptionNames[] = {
         STR_OBJECTIVE_DROPDOWN_NONE,
         STR_OBJECTIVE_DROPDOWN_NUMBER_OF_GUESTS_AT_A_GIVEN_DATE,
@@ -109,7 +102,14 @@ namespace OpenRCT2::Ui::Windows
         WIDX_RIDES = 6
     };
 
-// clang-format off
+    // clang-format off
+    enum
+    {
+        WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN,
+        WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES,
+        WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_COUNT
+    };
+
     #define MAIN_OBJECTIVE_OPTIONS_WIDGETS \
         WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
         MakeWidget({  0,  43}, {280, 106}, WindowWidgetType::Resize, WindowColour::Secondary), \

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -61,96 +61,98 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Widgets
 
+    enum
+    {
+        WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN,
+        WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES,
+        WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_COUNT
+    };
+
+    static constexpr StringId ObjectiveDropdownOptionNames[] = {
+        STR_OBJECTIVE_DROPDOWN_NONE,
+        STR_OBJECTIVE_DROPDOWN_NUMBER_OF_GUESTS_AT_A_GIVEN_DATE,
+        STR_OBJECTIVE_DROPDOWN_PARK_VALUE_AT_A_GIVEN_DATE,
+        STR_OBJECTIVE_DROPDOWN_HAVE_FUN,
+        STR_OBJECTIVE_DROPDOWN_BUILD_THE_BEST_RIDE_YOU_CAN,
+        STR_OBJECTIVE_DROPDOWN_BUILD_10_ROLLER_COASTERS,
+        STR_OBJECTIVE_DROPDOWN_NUMBER_OF_GUESTS_IN_PARK,
+        STR_OBJECTIVE_DROPDOWN_MONTHLY_INCOME_FROM_RIDE_TICKETS,
+        STR_OBJECTIVE_DROPDOWN_BUILD_10_ROLLER_COASTERS_OF_A_GIVEN_LENGTH,
+        STR_OBJECTIVE_DROPDOWN_FINISH_BUILDING_5_ROLLER_COASTERS,
+        STR_OBJECTIVE_DROPDOWN_REPAY_LOAN_AND_ACHIEVE_A_GIVEN_PARK_VALUE,
+        STR_OBJECTIVE_DROPDOWN_MONTHLY_PROFIT_FROM_FOOD_MERCHANDISE,
+    };
+
+    enum
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_PAGE_BACKGROUND,
+        WIDX_TAB_1,
+        WIDX_TAB_2,
+
+        WIDX_OBJECTIVE = 6,
+        WIDX_OBJECTIVE_DROPDOWN,
+        WIDX_OBJECTIVE_ARG_1,
+        WIDX_OBJECTIVE_ARG_1_INCREASE,
+        WIDX_OBJECTIVE_ARG_1_DECREASE,
+        WIDX_OBJECTIVE_ARG_2,
+        WIDX_OBJECTIVE_ARG_2_INCREASE,
+        WIDX_OBJECTIVE_ARG_2_DECREASE,
+        WIDX_PARK_NAME,
+        WIDX_SCENARIO_NAME,
+        WIDX_CATEGORY,
+        WIDX_CATEGORY_DROPDOWN,
+        WIDX_DETAILS,
+
+        WIDX_RIDES = 6
+    };
+
     // clang-format off
-enum {
-    WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN,
-    WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES,
-    WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_COUNT
-};
+    #define MAIN_OBJECTIVE_OPTIONS_WIDGETS \
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
+        MakeWidget({  0,  43}, {280, 106}, WindowWidgetType::Resize, WindowColour::Secondary), \
+        MakeTab   ({  3,  17}, STR_SELECT_OBJECTIVE_AND_PARK_NAME_TIP         ), \
+        MakeTab   ({ 34,  17}, STR_SELECT_RIDES_TO_BE_PRESERVED_TIP           )
 
-static constexpr StringId ObjectiveDropdownOptionNames[] = {
-    STR_OBJECTIVE_DROPDOWN_NONE,
-    STR_OBJECTIVE_DROPDOWN_NUMBER_OF_GUESTS_AT_A_GIVEN_DATE,
-    STR_OBJECTIVE_DROPDOWN_PARK_VALUE_AT_A_GIVEN_DATE,
-    STR_OBJECTIVE_DROPDOWN_HAVE_FUN,
-    STR_OBJECTIVE_DROPDOWN_BUILD_THE_BEST_RIDE_YOU_CAN,
-    STR_OBJECTIVE_DROPDOWN_BUILD_10_ROLLER_COASTERS,
-    STR_OBJECTIVE_DROPDOWN_NUMBER_OF_GUESTS_IN_PARK,
-    STR_OBJECTIVE_DROPDOWN_MONTHLY_INCOME_FROM_RIDE_TICKETS,
-    STR_OBJECTIVE_DROPDOWN_BUILD_10_ROLLER_COASTERS_OF_A_GIVEN_LENGTH,
-    STR_OBJECTIVE_DROPDOWN_FINISH_BUILDING_5_ROLLER_COASTERS,
-    STR_OBJECTIVE_DROPDOWN_REPAY_LOAN_AND_ACHIEVE_A_GIVEN_PARK_VALUE,
-    STR_OBJECTIVE_DROPDOWN_MONTHLY_PROFIT_FROM_FOOD_MERCHANDISE,
-};
+    static Widget window_editor_objective_options_main_widgets[] = {
+        MAIN_OBJECTIVE_OPTIONS_WIDGETS,
+        MakeWidget        ({ 98,  48}, {344,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_NONE,           STR_SELECT_OBJECTIVE_FOR_THIS_SCENARIO_TIP     ),
+        MakeWidget        ({430,  49}, { 11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH, STR_SELECT_OBJECTIVE_FOR_THIS_SCENARIO_TIP     ),
+        MakeSpinnerWidgets({158,  65}, {120,  12}, WindowWidgetType::Button,   WindowColour::Secondary                                                                     ), // NB: 3 widgets
+        MakeSpinnerWidgets({158,  82}, {120,  12}, WindowWidgetType::Button,   WindowColour::Secondary                                                                     ), // NB: 3 widgets
+        MakeWidget        ({370,  99}, { 75,  12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_CHANGE,         STR_CHANGE_NAME_OF_PARK_TIP                    ),
+        MakeWidget        ({370, 116}, { 75,  12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_CHANGE,         STR_CHANGE_NAME_OF_SCENARIO_TIP                ),
+        MakeWidget        ({ 98, 133}, {180,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_NONE,           STR_SELECT_WHICH_GROUP_THIS_SCENARIO_APPEARS_IN),
+        MakeWidget        ({266, 134}, { 11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH, STR_SELECT_WHICH_GROUP_THIS_SCENARIO_APPEARS_IN),
+        MakeWidget        ({370, 150}, { 75,  12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_CHANGE,         STR_CHANGE_DETAIL_NOTES_ABOUT_PARK_SCENARIO_TIP),
+        kWidgetsEnd,
+    };
 
-enum {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_PAGE_BACKGROUND,
-    WIDX_TAB_1,
-    WIDX_TAB_2,
+    static Widget window_editor_objective_options_rides_widgets[] = {
+        MAIN_OBJECTIVE_OPTIONS_WIDGETS,
+        MakeWidget({  3,  60}, {374, 161}, WindowWidgetType::Scroll, WindowColour::Secondary, SCROLL_VERTICAL),
+        kWidgetsEnd,
+    };
 
-    WIDX_OBJECTIVE = 6,
-    WIDX_OBJECTIVE_DROPDOWN,
-    WIDX_OBJECTIVE_ARG_1,
-    WIDX_OBJECTIVE_ARG_1_INCREASE,
-    WIDX_OBJECTIVE_ARG_1_DECREASE,
-    WIDX_OBJECTIVE_ARG_2,
-    WIDX_OBJECTIVE_ARG_2_INCREASE,
-    WIDX_OBJECTIVE_ARG_2_DECREASE,
-    WIDX_PARK_NAME,
-    WIDX_SCENARIO_NAME,
-    WIDX_CATEGORY,
-    WIDX_CATEGORY_DROPDOWN,
-    WIDX_DETAILS,
-
-    WIDX_RIDES = 6
-};
-
-#define MAIN_OBJECTIVE_OPTIONS_WIDGETS \
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
-    MakeWidget({  0,  43}, {280, 106}, WindowWidgetType::Resize, WindowColour::Secondary), \
-    MakeTab   ({  3,  17}, STR_SELECT_OBJECTIVE_AND_PARK_NAME_TIP         ), \
-    MakeTab   ({ 34,  17}, STR_SELECT_RIDES_TO_BE_PRESERVED_TIP           )
-
-static Widget window_editor_objective_options_main_widgets[] = {
-    MAIN_OBJECTIVE_OPTIONS_WIDGETS,
-    MakeWidget        ({ 98,  48}, {344,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_NONE,           STR_SELECT_OBJECTIVE_FOR_THIS_SCENARIO_TIP     ),
-    MakeWidget        ({430,  49}, { 11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH, STR_SELECT_OBJECTIVE_FOR_THIS_SCENARIO_TIP     ),
-    MakeSpinnerWidgets({158,  65}, {120,  12}, WindowWidgetType::Button,   WindowColour::Secondary                                                                     ), // NB: 3 widgets
-    MakeSpinnerWidgets({158,  82}, {120,  12}, WindowWidgetType::Button,   WindowColour::Secondary                                                                     ), // NB: 3 widgets
-    MakeWidget        ({370,  99}, { 75,  12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_CHANGE,         STR_CHANGE_NAME_OF_PARK_TIP                    ),
-    MakeWidget        ({370, 116}, { 75,  12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_CHANGE,         STR_CHANGE_NAME_OF_SCENARIO_TIP                ),
-    MakeWidget        ({ 98, 133}, {180,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_NONE,           STR_SELECT_WHICH_GROUP_THIS_SCENARIO_APPEARS_IN),
-    MakeWidget        ({266, 134}, { 11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH, STR_SELECT_WHICH_GROUP_THIS_SCENARIO_APPEARS_IN),
-    MakeWidget        ({370, 150}, { 75,  12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_CHANGE,         STR_CHANGE_DETAIL_NOTES_ABOUT_PARK_SCENARIO_TIP),
-    kWidgetsEnd,
-};
-
-static Widget window_editor_objective_options_rides_widgets[] = {
-    MAIN_OBJECTIVE_OPTIONS_WIDGETS,
-    MakeWidget({  3,  60}, {374, 161}, WindowWidgetType::Scroll, WindowColour::Secondary, SCROLL_VERTICAL),
-    kWidgetsEnd,
-};
-
-static Widget *window_editor_objective_options_widgets[] = {
-    window_editor_objective_options_main_widgets,
-    window_editor_objective_options_rides_widgets,
-};
+    static Widget *window_editor_objective_options_widgets[] = {
+        window_editor_objective_options_main_widgets,
+        window_editor_objective_options_rides_widgets,
+    };
 
 #pragma endregion
 
 #pragma region Enabled widgets
 
-static uint64_t window_editor_objective_options_page_hold_down_widgets[] = {
-    (1uLL << WIDX_OBJECTIVE_ARG_1_INCREASE) |
-    (1uLL << WIDX_OBJECTIVE_ARG_1_DECREASE) |
-    (1uLL << WIDX_OBJECTIVE_ARG_2_INCREASE) |
-    (1uLL << WIDX_OBJECTIVE_ARG_2_DECREASE),
+    static uint64_t window_editor_objective_options_page_hold_down_widgets[] = {
+        (1uLL << WIDX_OBJECTIVE_ARG_1_INCREASE) |
+        (1uLL << WIDX_OBJECTIVE_ARG_1_DECREASE) |
+        (1uLL << WIDX_OBJECTIVE_ARG_2_INCREASE) |
+        (1uLL << WIDX_OBJECTIVE_ARG_2_DECREASE),
 
-    0,
-};
+        0,
+    };
     // clang-format on
 
 #pragma endregion

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -83,6 +83,7 @@ namespace OpenRCT2::Ui::Windows
         STR_OBJECTIVE_DROPDOWN_MONTHLY_PROFIT_FROM_FOOD_MERCHANDISE,
     };
 
+    // clang-format off
     enum
     {
         WIDX_BACKGROUND,
@@ -109,13 +110,12 @@ namespace OpenRCT2::Ui::Windows
         WIDX_RIDES = 6
     };
 
-#define MAIN_OBJECTIVE_OPTIONS_WIDGETS \
+    #define MAIN_OBJECTIVE_OPTIONS_WIDGETS \
         WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
         MakeWidget({  0,  43}, {280, 106}, WindowWidgetType::Resize, WindowColour::Secondary), \
         MakeTab   ({  3,  17}, STR_SELECT_OBJECTIVE_AND_PARK_NAME_TIP         ), \
         MakeTab   ({ 34,  17}, STR_SELECT_RIDES_TO_BE_PRESERVED_TIP           )
 
-    // clang-format off
     static Widget window_editor_objective_options_main_widgets[] = {
         MAIN_OBJECTIVE_OPTIONS_WIDGETS,
         MakeWidget        ({ 98,  48}, {344,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_NONE,           STR_SELECT_OBJECTIVE_FOR_THIS_SCENARIO_TIP     ),

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -61,6 +61,13 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Widgets
 
+    enum
+    {
+        WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN,
+        WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES,
+        WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_COUNT
+    };
+
     static constexpr StringId ObjectiveDropdownOptionNames[] = {
         STR_OBJECTIVE_DROPDOWN_NONE,
         STR_OBJECTIVE_DROPDOWN_NUMBER_OF_GUESTS_AT_A_GIVEN_DATE,
@@ -102,20 +109,13 @@ namespace OpenRCT2::Ui::Windows
         WIDX_RIDES = 6
     };
 
-    // clang-format off
-    enum
-    {
-        WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN,
-        WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES,
-        WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_COUNT
-    };
-
-    #define MAIN_OBJECTIVE_OPTIONS_WIDGETS \
+#define MAIN_OBJECTIVE_OPTIONS_WIDGETS \
         WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
         MakeWidget({  0,  43}, {280, 106}, WindowWidgetType::Resize, WindowColour::Secondary), \
         MakeTab   ({  3,  17}, STR_SELECT_OBJECTIVE_AND_PARK_NAME_TIP         ), \
         MakeTab   ({ 34,  17}, STR_SELECT_RIDES_TO_BE_PRESERVED_TIP           )
 
+    // clang-format off
     static Widget window_editor_objective_options_main_widgets[] = {
         MAIN_OBJECTIVE_OPTIONS_WIDGETS,
         MakeWidget        ({ 98,  48}, {344,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_NONE,           STR_SELECT_OBJECTIVE_FOR_THIS_SCENARIO_TIP     ),

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -109,7 +109,7 @@ namespace OpenRCT2::Ui::Windows
         WIDX_RIDES = 6
     };
 
-    // clang-format off
+// clang-format off
     #define MAIN_OBJECTIVE_OPTIONS_WIDGETS \
         WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
         MakeWidget({  0,  43}, {280, 106}, WindowWidgetType::Resize, WindowColour::Secondary), \

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -42,171 +42,173 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Widgets
 
+    enum
+    {
+        WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_FINANCIAL,
+        WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_GUESTS,
+        WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_PARK,
+        WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_COUNT
+    };
+
+    static constexpr StringId ClimateNames[] = {
+        STR_CLIMATE_COOL_AND_WET,
+        STR_CLIMATE_WARM,
+        STR_CLIMATE_HOT_AND_DRY,
+        STR_CLIMATE_COLD,
+    };
+
+    enum
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_PAGE_BACKGROUND,
+        WIDX_TAB_1,
+        WIDX_TAB_2,
+        WIDX_TAB_3,
+        WIDX_PAGE_START,
+
+        // Financial tab
+        WIDX_NO_MONEY = WIDX_PAGE_START,
+        WIDX_INITIAL_CASH,
+        WIDX_INITIAL_CASH_INCREASE,
+        WIDX_INITIAL_CASH_DECREASE,
+        WIDX_INITIAL_LOAN,
+        WIDX_INITIAL_LOAN_INCREASE,
+        WIDX_INITIAL_LOAN_DECREASE,
+        WIDX_MAXIMUM_LOAN,
+        WIDX_MAXIMUM_LOAN_INCREASE,
+        WIDX_MAXIMUM_LOAN_DECREASE,
+        WIDX_INTEREST_RATE,
+        WIDX_INTEREST_RATE_INCREASE,
+        WIDX_INTEREST_RATE_DECREASE,
+        WIDX_FORBID_MARKETING,
+        WIDX_RCT1_INTEREST,
+
+        // Guests tab
+        WIDX_CASH_PER_GUEST = WIDX_PAGE_START,
+        WIDX_CASH_PER_GUEST_INCREASE,
+        WIDX_CASH_PER_GUEST_DECREASE,
+        WIDX_GUEST_INITIAL_HAPPINESS,
+        WIDX_GUEST_INITIAL_HAPPINESS_INCREASE,
+        WIDX_GUEST_INITIAL_HAPPINESS_DECREASE,
+        WIDX_GUEST_INITIAL_HUNGER,
+        WIDX_GUEST_INITIAL_HUNGER_INCREASE,
+        WIDX_GUEST_INITIAL_HUNGER_DECREASE,
+        WIDX_GUEST_INITIAL_THIRST,
+        WIDX_GUEST_INITIAL_THIRST_INCREASE,
+        WIDX_GUEST_INITIAL_THIRST_DECREASE,
+        WIDX_GUEST_PREFER_LESS_INTENSE_RIDES,
+        WIDX_GUEST_PREFER_MORE_INTENSE_RIDES,
+
+        // Park tab
+        WIDX_LAND_COST = WIDX_PAGE_START,
+        WIDX_LAND_COST_INCREASE,
+        WIDX_LAND_COST_DECREASE,
+        WIDX_CONSTRUCTION_RIGHTS_COST,
+        WIDX_CONSTRUCTION_RIGHTS_COST_INCREASE,
+        WIDX_CONSTRUCTION_RIGHTS_COST_DECREASE,
+        WIDX_PAY_FOR_PARK_OR_RIDES,
+        WIDX_PAY_FOR_PARK_OR_RIDES_DROPDOWN,
+        WIDX_ENTRY_PRICE,
+        WIDX_ENTRY_PRICE_INCREASE,
+        WIDX_ENTRY_PRICE_DECREASE,
+        WIDX_CLIMATE,
+        WIDX_CLIMATE_DROPDOWN,
+        WIDX_FORBID_TREE_REMOVAL,
+        WIDX_FORBID_LANDSCAPE_CHANGES,
+        WIDX_FORBID_HIGH_CONSTRUCTION,
+        WIDX_HARD_PARK_RATING,
+        WIDX_HARD_GUEST_GENERATION
+    };
+
     // clang-format off
-enum {
-    WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_FINANCIAL,
-    WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_GUESTS,
-    WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_PARK,
-    WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_COUNT
-};
+    static Widget window_editor_scenario_options_financial_widgets[] = {
+        WINDOW_SHIM(STR_SCENARIO_OPTIONS_FINANCIAL, WW_FINANCIAL, WH_FINANCIAL),
+        MakeWidget        ({  0,  43}, {     WW_FINANCIAL, 106}, WindowWidgetType::Resize,   WindowColour::Secondary                                                            ),
+        MakeTab           ({  3,  17},                                                                                          STR_SCENARIO_OPTIONS_FINANCIAL_TIP),
+        MakeTab           ({ 34,  17},                                                                                          STR_SCENARIO_OPTIONS_GUESTS_TIP   ),
+        MakeTab           ({ 65,  17},                                                                                          STR_SCENARIO_OPTIONS_PARK_TIP     ),
+        MakeWidget        ({  8,  48}, {WW_FINANCIAL - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_MAKE_PARK_NO_MONEY, STR_MAKE_PARK_NO_MONEY_TIP        ),
+        MakeSpinnerWidgets({168,  65}, {              100,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                            ), // NB: 3 widgets
+        MakeSpinnerWidgets({168,  82}, {              100,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                            ), // NB: 3 widgets
+        MakeSpinnerWidgets({168,  99}, {              100,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                            ), // NB: 3 widgets
+        MakeSpinnerWidgets({168, 116}, {               70,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                            ), // NB: 3 widgets
+        MakeWidget        ({  8, 133}, {WW_FINANCIAL - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_FORBID_MARKETING,   STR_FORBID_MARKETING_TIP          ),
+        MakeWidget        ({  8, 116}, {WW_FINANCIAL - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_RCT1_INTEREST,      STR_RCT1_INTEREST_TIP             ),
+        kWidgetsEnd,
+    };
 
-static constexpr StringId ClimateNames[] = {
-    STR_CLIMATE_COOL_AND_WET,
-    STR_CLIMATE_WARM,
-    STR_CLIMATE_HOT_AND_DRY,
-    STR_CLIMATE_COLD,
-};
+    static Widget window_editor_scenario_options_guests_widgets[] = {
+        WINDOW_SHIM(STR_SCENARIO_OPTIONS_GUESTS, WW_GUESTS, WH_GUESTS),
+        MakeWidget        ({  0,  43}, {     WW_GUESTS, 106}, WindowWidgetType::Resize,   WindowColour::Secondary),
+        MakeRemapWidget   ({  3,  17}, {            31,  27}, WindowWidgetType::Tab,      WindowColour::Secondary, SPR_TAB,                              STR_SCENARIO_OPTIONS_FINANCIAL_TIP      ),
+        MakeRemapWidget   ({ 34,  17}, {            31,  30}, WindowWidgetType::Tab,      WindowColour::Secondary, SPR_TAB,                              STR_SCENARIO_OPTIONS_GUESTS_TIP         ),
+        MakeRemapWidget   ({ 65,  17}, {            31,  27}, WindowWidgetType::Tab,      WindowColour::Secondary, SPR_TAB,                              STR_SCENARIO_OPTIONS_PARK_TIP           ),
+        MakeSpinnerWidgets({268,  48}, {            70,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                                                ), // NB: 3 widgets
+        MakeSpinnerWidgets({268,  65}, {            70,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                                                ), // NB: 3 widgets
+        MakeSpinnerWidgets({268,  82}, {            70,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                                                ), // NB: 3 widgets
+        MakeSpinnerWidgets({268,  99}, {            70,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                                                ), // NB: 3 widgets
+        MakeWidget        ({  8, 116}, {WW_GUESTS - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_GUESTS_PREFER_LESS_INTENSE_RIDES, STR_GUESTS_PREFER_LESS_INTENSE_RIDES_TIP),
+        MakeWidget        ({  8, 133}, {WW_GUESTS - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_GUESTS_PREFER_MORE_INTENSE_RIDES, STR_GUESTS_PREFER_MORE_INTENSE_RIDES_TIP),
+        kWidgetsEnd,
+    };
 
-enum {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_PAGE_BACKGROUND,
-    WIDX_TAB_1,
-    WIDX_TAB_2,
-    WIDX_TAB_3,
-    WIDX_PAGE_START,
+    static Widget window_editor_scenario_options_park_widgets[] = {
+        WINDOW_SHIM(STR_SCENARIO_OPTIONS_PARK, WW_PARK, WH_PARK),
+        MakeWidget        ({  0,  43}, {     WW_PARK, 106}, WindowWidgetType::Resize,   WindowColour::Secondary                                                                  ),
+        MakeRemapWidget   ({  3,  17}, {          31,  27}, WindowWidgetType::Tab,      WindowColour::Secondary, SPR_TAB,                      STR_SCENARIO_OPTIONS_FINANCIAL_TIP),
+        MakeRemapWidget   ({ 34,  17}, {          31,  30}, WindowWidgetType::Tab,      WindowColour::Secondary, SPR_TAB,                      STR_SCENARIO_OPTIONS_GUESTS_TIP   ),
+        MakeRemapWidget   ({ 65,  17}, {          31,  27}, WindowWidgetType::Tab,      WindowColour::Secondary, SPR_TAB,                      STR_SCENARIO_OPTIONS_PARK_TIP     ),
+        MakeSpinnerWidgets({188,  48}, {          70,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                                  ), // NB: 3 widgets
+        MakeSpinnerWidgets({188,  65}, {          70,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                                  ), // NB: 3 widgets
+        MakeWidget        ({  8,  82}, {         210,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_NONE,                     STR_PAY_FOR_PARK_PAY_FOR_RIDES_TIP),
+        MakeWidget        ({206,  83}, {          11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH,           STR_PAY_FOR_PARK_PAY_FOR_RIDES_TIP),
+        MakeSpinnerWidgets({328,  82}, {          67,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                                  ), // NB: 3 widgets
+        MakeWidget        ({188,  99}, {         207,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_NONE,                     STR_SELECT_CLIMATE_TIP            ),
+        MakeWidget        ({383, 100}, {          11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH,           STR_SELECT_CLIMATE_TIP            ),
+        MakeWidget        ({  8, 116}, {WW_PARK - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_FORBID_TREE_REMOVAL,      STR_FORBID_TREE_REMOVAL_TIP       ),
+        MakeWidget        ({  8, 133}, {WW_PARK - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_FORBID_LANDSCAPE_CHANGES, STR_FORBID_LANDSCAPE_CHANGES_TIP  ),
+        MakeWidget        ({  8, 150}, {WW_PARK - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_FORBID_HIGH_CONSTRUCTION, STR_FORBID_HIGH_CONSTRUCTION_TIP  ),
+        MakeWidget        ({  8, 167}, {WW_PARK - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_HARD_PARK_RATING,         STR_HARD_PARK_RATING_TIP          ),
+        MakeWidget        ({  8, 184}, {WW_PARK - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_HARD_GUEST_GENERATION,    STR_HARD_GUEST_GENERATION_TIP     ),
+        kWidgetsEnd,
+    };
 
-    // Financial tab
-    WIDX_NO_MONEY = WIDX_PAGE_START,
-    WIDX_INITIAL_CASH,
-    WIDX_INITIAL_CASH_INCREASE,
-    WIDX_INITIAL_CASH_DECREASE,
-    WIDX_INITIAL_LOAN,
-    WIDX_INITIAL_LOAN_INCREASE,
-    WIDX_INITIAL_LOAN_DECREASE,
-    WIDX_MAXIMUM_LOAN,
-    WIDX_MAXIMUM_LOAN_INCREASE,
-    WIDX_MAXIMUM_LOAN_DECREASE,
-    WIDX_INTEREST_RATE,
-    WIDX_INTEREST_RATE_INCREASE,
-    WIDX_INTEREST_RATE_DECREASE,
-    WIDX_FORBID_MARKETING,
-    WIDX_RCT1_INTEREST,
-
-    // Guests tab
-    WIDX_CASH_PER_GUEST = WIDX_PAGE_START,
-    WIDX_CASH_PER_GUEST_INCREASE,
-    WIDX_CASH_PER_GUEST_DECREASE,
-    WIDX_GUEST_INITIAL_HAPPINESS,
-    WIDX_GUEST_INITIAL_HAPPINESS_INCREASE,
-    WIDX_GUEST_INITIAL_HAPPINESS_DECREASE,
-    WIDX_GUEST_INITIAL_HUNGER,
-    WIDX_GUEST_INITIAL_HUNGER_INCREASE,
-    WIDX_GUEST_INITIAL_HUNGER_DECREASE,
-    WIDX_GUEST_INITIAL_THIRST,
-    WIDX_GUEST_INITIAL_THIRST_INCREASE,
-    WIDX_GUEST_INITIAL_THIRST_DECREASE,
-    WIDX_GUEST_PREFER_LESS_INTENSE_RIDES,
-    WIDX_GUEST_PREFER_MORE_INTENSE_RIDES,
-
-    // Park tab
-    WIDX_LAND_COST = WIDX_PAGE_START,
-    WIDX_LAND_COST_INCREASE,
-    WIDX_LAND_COST_DECREASE,
-    WIDX_CONSTRUCTION_RIGHTS_COST,
-    WIDX_CONSTRUCTION_RIGHTS_COST_INCREASE,
-    WIDX_CONSTRUCTION_RIGHTS_COST_DECREASE,
-    WIDX_PAY_FOR_PARK_OR_RIDES,
-    WIDX_PAY_FOR_PARK_OR_RIDES_DROPDOWN,
-    WIDX_ENTRY_PRICE,
-    WIDX_ENTRY_PRICE_INCREASE,
-    WIDX_ENTRY_PRICE_DECREASE,
-    WIDX_CLIMATE,
-    WIDX_CLIMATE_DROPDOWN,
-    WIDX_FORBID_TREE_REMOVAL,
-    WIDX_FORBID_LANDSCAPE_CHANGES,
-    WIDX_FORBID_HIGH_CONSTRUCTION,
-    WIDX_HARD_PARK_RATING,
-    WIDX_HARD_GUEST_GENERATION
-};
-
-static Widget window_editor_scenario_options_financial_widgets[] = {
-    WINDOW_SHIM(STR_SCENARIO_OPTIONS_FINANCIAL, WW_FINANCIAL, WH_FINANCIAL),
-    MakeWidget        ({  0,  43}, {     WW_FINANCIAL, 106}, WindowWidgetType::Resize,   WindowColour::Secondary                                                            ),
-    MakeTab           ({  3,  17},                                                                                          STR_SCENARIO_OPTIONS_FINANCIAL_TIP),
-    MakeTab           ({ 34,  17},                                                                                          STR_SCENARIO_OPTIONS_GUESTS_TIP   ),
-    MakeTab           ({ 65,  17},                                                                                          STR_SCENARIO_OPTIONS_PARK_TIP     ),
-    MakeWidget        ({  8,  48}, {WW_FINANCIAL - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_MAKE_PARK_NO_MONEY, STR_MAKE_PARK_NO_MONEY_TIP        ),
-    MakeSpinnerWidgets({168,  65}, {              100,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                            ), // NB: 3 widgets
-    MakeSpinnerWidgets({168,  82}, {              100,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                            ), // NB: 3 widgets
-    MakeSpinnerWidgets({168,  99}, {              100,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                            ), // NB: 3 widgets
-    MakeSpinnerWidgets({168, 116}, {               70,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                            ), // NB: 3 widgets
-    MakeWidget        ({  8, 133}, {WW_FINANCIAL - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_FORBID_MARKETING,   STR_FORBID_MARKETING_TIP          ),
-    MakeWidget        ({  8, 116}, {WW_FINANCIAL - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_RCT1_INTEREST,      STR_RCT1_INTEREST_TIP             ),
-    kWidgetsEnd,
-};
-
-static Widget window_editor_scenario_options_guests_widgets[] = {
-    WINDOW_SHIM(STR_SCENARIO_OPTIONS_GUESTS, WW_GUESTS, WH_GUESTS),
-    MakeWidget        ({  0,  43}, {     WW_GUESTS, 106}, WindowWidgetType::Resize,   WindowColour::Secondary),
-    MakeRemapWidget   ({  3,  17}, {            31,  27}, WindowWidgetType::Tab,      WindowColour::Secondary, SPR_TAB,                              STR_SCENARIO_OPTIONS_FINANCIAL_TIP      ),
-    MakeRemapWidget   ({ 34,  17}, {            31,  30}, WindowWidgetType::Tab,      WindowColour::Secondary, SPR_TAB,                              STR_SCENARIO_OPTIONS_GUESTS_TIP         ),
-    MakeRemapWidget   ({ 65,  17}, {            31,  27}, WindowWidgetType::Tab,      WindowColour::Secondary, SPR_TAB,                              STR_SCENARIO_OPTIONS_PARK_TIP           ),
-    MakeSpinnerWidgets({268,  48}, {            70,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                                                ), // NB: 3 widgets
-    MakeSpinnerWidgets({268,  65}, {            70,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                                                ), // NB: 3 widgets
-    MakeSpinnerWidgets({268,  82}, {            70,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                                                ), // NB: 3 widgets
-    MakeSpinnerWidgets({268,  99}, {            70,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                                                ), // NB: 3 widgets
-    MakeWidget        ({  8, 116}, {WW_GUESTS - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_GUESTS_PREFER_LESS_INTENSE_RIDES, STR_GUESTS_PREFER_LESS_INTENSE_RIDES_TIP),
-    MakeWidget        ({  8, 133}, {WW_GUESTS - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_GUESTS_PREFER_MORE_INTENSE_RIDES, STR_GUESTS_PREFER_MORE_INTENSE_RIDES_TIP),
-    kWidgetsEnd,
-};
-
-static Widget window_editor_scenario_options_park_widgets[] = {
-    WINDOW_SHIM(STR_SCENARIO_OPTIONS_PARK, WW_PARK, WH_PARK),
-    MakeWidget        ({  0,  43}, {     WW_PARK, 106}, WindowWidgetType::Resize,   WindowColour::Secondary                                                                  ),
-    MakeRemapWidget   ({  3,  17}, {          31,  27}, WindowWidgetType::Tab,      WindowColour::Secondary, SPR_TAB,                      STR_SCENARIO_OPTIONS_FINANCIAL_TIP),
-    MakeRemapWidget   ({ 34,  17}, {          31,  30}, WindowWidgetType::Tab,      WindowColour::Secondary, SPR_TAB,                      STR_SCENARIO_OPTIONS_GUESTS_TIP   ),
-    MakeRemapWidget   ({ 65,  17}, {          31,  27}, WindowWidgetType::Tab,      WindowColour::Secondary, SPR_TAB,                      STR_SCENARIO_OPTIONS_PARK_TIP     ),
-    MakeSpinnerWidgets({188,  48}, {          70,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                                  ), // NB: 3 widgets
-    MakeSpinnerWidgets({188,  65}, {          70,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                                  ), // NB: 3 widgets
-    MakeWidget        ({  8,  82}, {         210,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_NONE,                     STR_PAY_FOR_PARK_PAY_FOR_RIDES_TIP),
-    MakeWidget        ({206,  83}, {          11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH,           STR_PAY_FOR_PARK_PAY_FOR_RIDES_TIP),
-    MakeSpinnerWidgets({328,  82}, {          67,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary                                                                  ), // NB: 3 widgets
-    MakeWidget        ({188,  99}, {         207,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_NONE,                     STR_SELECT_CLIMATE_TIP            ),
-    MakeWidget        ({383, 100}, {          11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH,           STR_SELECT_CLIMATE_TIP            ),
-    MakeWidget        ({  8, 116}, {WW_PARK - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_FORBID_TREE_REMOVAL,      STR_FORBID_TREE_REMOVAL_TIP       ),
-    MakeWidget        ({  8, 133}, {WW_PARK - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_FORBID_LANDSCAPE_CHANGES, STR_FORBID_LANDSCAPE_CHANGES_TIP  ),
-    MakeWidget        ({  8, 150}, {WW_PARK - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_FORBID_HIGH_CONSTRUCTION, STR_FORBID_HIGH_CONSTRUCTION_TIP  ),
-    MakeWidget        ({  8, 167}, {WW_PARK - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_HARD_PARK_RATING,         STR_HARD_PARK_RATING_TIP          ),
-    MakeWidget        ({  8, 184}, {WW_PARK - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_HARD_GUEST_GENERATION,    STR_HARD_GUEST_GENERATION_TIP     ),
-    kWidgetsEnd,
-};
-
-static Widget *window_editor_scenario_options_widgets[] = {
-    window_editor_scenario_options_financial_widgets,
-    window_editor_scenario_options_guests_widgets,
-    window_editor_scenario_options_park_widgets,
-};
+    static Widget *window_editor_scenario_options_widgets[] = {
+        window_editor_scenario_options_financial_widgets,
+        window_editor_scenario_options_guests_widgets,
+        window_editor_scenario_options_park_widgets,
+    };
 
 #pragma endregion
 
 #pragma region Enabled widgets
 
-static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
-    (1uLL << WIDX_INITIAL_CASH_INCREASE) |
-        (1uLL << WIDX_INITIAL_CASH_DECREASE) |
-        (1uLL << WIDX_INITIAL_LOAN_INCREASE) |
-        (1uLL << WIDX_INITIAL_LOAN_DECREASE) |
-        (1uLL << WIDX_MAXIMUM_LOAN_INCREASE) |
-        (1uLL << WIDX_MAXIMUM_LOAN_DECREASE) |
-        (1uLL << WIDX_INTEREST_RATE_INCREASE) |
-        (1uLL << WIDX_INTEREST_RATE_DECREASE),
-    (1uLL << WIDX_CASH_PER_GUEST_INCREASE) |
-        (1uLL << WIDX_CASH_PER_GUEST_DECREASE) |
-        (1uLL << WIDX_GUEST_INITIAL_HAPPINESS_INCREASE) |
-        (1uLL << WIDX_GUEST_INITIAL_HAPPINESS_DECREASE) |
-        (1uLL << WIDX_GUEST_INITIAL_HUNGER_INCREASE) |
-        (1uLL << WIDX_GUEST_INITIAL_HUNGER_DECREASE) |
-        (1uLL << WIDX_GUEST_INITIAL_THIRST_INCREASE) |
-        (1uLL << WIDX_GUEST_INITIAL_THIRST_DECREASE),
-    (1uLL << WIDX_LAND_COST_INCREASE) |
-        (1uLL << WIDX_LAND_COST_DECREASE) |
-        (1uLL << WIDX_CONSTRUCTION_RIGHTS_COST_INCREASE) |
-        (1uLL << WIDX_CONSTRUCTION_RIGHTS_COST_DECREASE) |
-        (1uLL << WIDX_ENTRY_PRICE_INCREASE) |
-        (1uLL << WIDX_ENTRY_PRICE_DECREASE),
-};
+    static uint32_t window_editor_scenario_options_page_hold_down_widgets[] = {
+        (1uLL << WIDX_INITIAL_CASH_INCREASE) |
+            (1uLL << WIDX_INITIAL_CASH_DECREASE) |
+            (1uLL << WIDX_INITIAL_LOAN_INCREASE) |
+            (1uLL << WIDX_INITIAL_LOAN_DECREASE) |
+            (1uLL << WIDX_MAXIMUM_LOAN_INCREASE) |
+            (1uLL << WIDX_MAXIMUM_LOAN_DECREASE) |
+            (1uLL << WIDX_INTEREST_RATE_INCREASE) |
+            (1uLL << WIDX_INTEREST_RATE_DECREASE),
+        (1uLL << WIDX_CASH_PER_GUEST_INCREASE) |
+            (1uLL << WIDX_CASH_PER_GUEST_DECREASE) |
+            (1uLL << WIDX_GUEST_INITIAL_HAPPINESS_INCREASE) |
+            (1uLL << WIDX_GUEST_INITIAL_HAPPINESS_DECREASE) |
+            (1uLL << WIDX_GUEST_INITIAL_HUNGER_INCREASE) |
+            (1uLL << WIDX_GUEST_INITIAL_HUNGER_DECREASE) |
+            (1uLL << WIDX_GUEST_INITIAL_THIRST_INCREASE) |
+            (1uLL << WIDX_GUEST_INITIAL_THIRST_DECREASE),
+        (1uLL << WIDX_LAND_COST_INCREASE) |
+            (1uLL << WIDX_LAND_COST_DECREASE) |
+            (1uLL << WIDX_CONSTRUCTION_RIGHTS_COST_INCREASE) |
+            (1uLL << WIDX_CONSTRUCTION_RIGHTS_COST_DECREASE) |
+            (1uLL << WIDX_ENTRY_PRICE_INCREASE) |
+            (1uLL << WIDX_ENTRY_PRICE_DECREASE),
+    };
     // clang-format on
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -97,17 +97,14 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Widgets
 
-// clang-format off
-    #define MAIN_FINANCES_WIDGETS(TITLE, RSW, RSH, WW, WH) \
-        WINDOW_SHIM(TITLE, WW, WH), \
-        MakeWidget({0, 43}, {RSW, RSH}, WindowWidgetType::Resize, WindowColour::Secondary), \
-        MakeTab({  3, 17}, STR_FINANCES_SHOW_SUMMARY_TAB_TIP      ), \
-        MakeTab({ 34, 17}, STR_FINANCES_SHOW_CASH_TAB_TIP         ), \
-        MakeTab({ 65, 17}, STR_FINANCES_SHOW_PARK_VALUE_TAB_TIP   ), \
-        MakeTab({ 96, 17}, STR_FINANCES_SHOW_WEEKLY_PROFIT_TAB_TIP), \
-        MakeTab({127, 17}, STR_FINANCES_SHOW_MARKETING_TAB_TIP    ), \
-        MakeTab({158, 17}, STR_FINANCES_RESEARCH_TIP              )
+#define MAIN_FINANCES_WIDGETS(TITLE, RSW, RSH, WW, WH)                                                                         \
+    WINDOW_SHIM(TITLE, WW, WH), MakeWidget({ 0, 43 }, { RSW, RSH }, WindowWidgetType::Resize, WindowColour::Secondary),        \
+        MakeTab({ 3, 17 }, STR_FINANCES_SHOW_SUMMARY_TAB_TIP), MakeTab({ 34, 17 }, STR_FINANCES_SHOW_CASH_TAB_TIP),            \
+        MakeTab({ 65, 17 }, STR_FINANCES_SHOW_PARK_VALUE_TAB_TIP),                                                             \
+        MakeTab({ 96, 17 }, STR_FINANCES_SHOW_WEEKLY_PROFIT_TAB_TIP),                                                          \
+        MakeTab({ 127, 17 }, STR_FINANCES_SHOW_MARKETING_TAB_TIP), MakeTab({ 158, 17 }, STR_FINANCES_RESEARCH_TIP)
 
+    // clang-format off
     static Widget _windowFinancesSummaryWidgets[] =
     {
         MAIN_FINANCES_WIDGETS(STR_FINANCIAL_SUMMARY, RSW_OTHER_TABS, RSH_SUMMARY, WW_OTHER_TABS, WH_SUMMARY),

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -95,16 +95,19 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma endregion
 
+    // clang-format off
 #pragma region Widgets
 
-#define MAIN_FINANCES_WIDGETS(TITLE, RSW, RSH, WW, WH)                                                                         \
-    WINDOW_SHIM(TITLE, WW, WH), MakeWidget({ 0, 43 }, { RSW, RSH }, WindowWidgetType::Resize, WindowColour::Secondary),        \
-        MakeTab({ 3, 17 }, STR_FINANCES_SHOW_SUMMARY_TAB_TIP), MakeTab({ 34, 17 }, STR_FINANCES_SHOW_CASH_TAB_TIP),            \
-        MakeTab({ 65, 17 }, STR_FINANCES_SHOW_PARK_VALUE_TAB_TIP),                                                             \
-        MakeTab({ 96, 17 }, STR_FINANCES_SHOW_WEEKLY_PROFIT_TAB_TIP),                                                          \
-        MakeTab({ 127, 17 }, STR_FINANCES_SHOW_MARKETING_TAB_TIP), MakeTab({ 158, 17 }, STR_FINANCES_RESEARCH_TIP)
+#define MAIN_FINANCES_WIDGETS(TITLE, RSW, RSH, WW, WH)                                          \
+    WINDOW_SHIM(TITLE, WW, WH),                                                                 \
+        MakeWidget({ 0, 43 }, { RSW, RSH }, WindowWidgetType::Resize, WindowColour::Secondary), \
+        MakeTab({ 3, 17 }, STR_FINANCES_SHOW_SUMMARY_TAB_TIP),                                  \
+        MakeTab({ 34, 17 }, STR_FINANCES_SHOW_CASH_TAB_TIP),                                    \
+        MakeTab({ 65, 17 }, STR_FINANCES_SHOW_PARK_VALUE_TAB_TIP),                              \
+        MakeTab({ 96, 17 }, STR_FINANCES_SHOW_WEEKLY_PROFIT_TAB_TIP),                           \
+        MakeTab({ 127, 17 }, STR_FINANCES_SHOW_MARKETING_TAB_TIP),                              \
+        MakeTab({ 158, 17 }, STR_FINANCES_RESEARCH_TIP)
 
-    // clang-format off
     static Widget _windowFinancesSummaryWidgets[] =
     {
         MAIN_FINANCES_WIDGETS(STR_FINANCIAL_SUMMARY, RSW_OTHER_TABS, RSH_SUMMARY, WW_OTHER_TABS, WH_SUMMARY),

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -97,7 +97,7 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Widgets
 
-    // clang-format off
+// clang-format off
     #define MAIN_FINANCES_WIDGETS(TITLE, RSW, RSH, WW, WH) \
         WINDOW_SHIM(TITLE, WW, WH), \
         MakeWidget({0, 43}, {RSW, RSH}, WindowWidgetType::Resize, WindowColour::Secondary), \

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -98,72 +98,72 @@ namespace OpenRCT2::Ui::Windows
 #pragma region Widgets
 
     // clang-format off
-#define MAIN_FINANCES_WIDGETS(TITLE, RSW, RSH, WW, WH) \
-    WINDOW_SHIM(TITLE, WW, WH), \
-    MakeWidget({0, 43}, {RSW, RSH}, WindowWidgetType::Resize, WindowColour::Secondary), \
-    MakeTab({  3, 17}, STR_FINANCES_SHOW_SUMMARY_TAB_TIP      ), \
-    MakeTab({ 34, 17}, STR_FINANCES_SHOW_CASH_TAB_TIP         ), \
-    MakeTab({ 65, 17}, STR_FINANCES_SHOW_PARK_VALUE_TAB_TIP   ), \
-    MakeTab({ 96, 17}, STR_FINANCES_SHOW_WEEKLY_PROFIT_TAB_TIP), \
-    MakeTab({127, 17}, STR_FINANCES_SHOW_MARKETING_TAB_TIP    ), \
-    MakeTab({158, 17}, STR_FINANCES_RESEARCH_TIP              )
+    #define MAIN_FINANCES_WIDGETS(TITLE, RSW, RSH, WW, WH) \
+        WINDOW_SHIM(TITLE, WW, WH), \
+        MakeWidget({0, 43}, {RSW, RSH}, WindowWidgetType::Resize, WindowColour::Secondary), \
+        MakeTab({  3, 17}, STR_FINANCES_SHOW_SUMMARY_TAB_TIP      ), \
+        MakeTab({ 34, 17}, STR_FINANCES_SHOW_CASH_TAB_TIP         ), \
+        MakeTab({ 65, 17}, STR_FINANCES_SHOW_PARK_VALUE_TAB_TIP   ), \
+        MakeTab({ 96, 17}, STR_FINANCES_SHOW_WEEKLY_PROFIT_TAB_TIP), \
+        MakeTab({127, 17}, STR_FINANCES_SHOW_MARKETING_TAB_TIP    ), \
+        MakeTab({158, 17}, STR_FINANCES_RESEARCH_TIP              )
 
-static Widget _windowFinancesSummaryWidgets[] =
-{
-    MAIN_FINANCES_WIDGETS(STR_FINANCIAL_SUMMARY, RSW_OTHER_TABS, RSH_SUMMARY, WW_OTHER_TABS, WH_SUMMARY),
-    MakeWidget        ({130,  50}, {391, 211}, WindowWidgetType::Scroll,  WindowColour::Secondary, SCROLL_HORIZONTAL              ),
-    MakeSpinnerWidgets({ 64, 279}, { 97,  14}, WindowWidgetType::Spinner, WindowColour::Secondary, STR_FINANCES_SUMMARY_LOAN_VALUE), // NB: 3 widgets.
-    kWidgetsEnd,
-};
+    static Widget _windowFinancesSummaryWidgets[] =
+    {
+        MAIN_FINANCES_WIDGETS(STR_FINANCIAL_SUMMARY, RSW_OTHER_TABS, RSH_SUMMARY, WW_OTHER_TABS, WH_SUMMARY),
+        MakeWidget        ({130,  50}, {391, 211}, WindowWidgetType::Scroll,  WindowColour::Secondary, SCROLL_HORIZONTAL              ),
+        MakeSpinnerWidgets({ 64, 279}, { 97,  14}, WindowWidgetType::Spinner, WindowColour::Secondary, STR_FINANCES_SUMMARY_LOAN_VALUE), // NB: 3 widgets.
+        kWidgetsEnd,
+    };
 
-static Widget _windowFinancesCashWidgets[] =
-{
-    MAIN_FINANCES_WIDGETS(STR_FINANCIAL_GRAPH, RSW_OTHER_TABS, RSH_OTHER_TABS, WW_OTHER_TABS, WH_OTHER_TABS),
-    kWidgetsEnd,
-};
+    static Widget _windowFinancesCashWidgets[] =
+    {
+        MAIN_FINANCES_WIDGETS(STR_FINANCIAL_GRAPH, RSW_OTHER_TABS, RSH_OTHER_TABS, WW_OTHER_TABS, WH_OTHER_TABS),
+        kWidgetsEnd,
+    };
 
-static Widget _windowFinancesParkValueWidgets[] =
-{
-    MAIN_FINANCES_WIDGETS(STR_PARK_VALUE_GRAPH, RSW_OTHER_TABS, RSH_OTHER_TABS, WW_OTHER_TABS, WH_OTHER_TABS),
-    kWidgetsEnd,
-};
+    static Widget _windowFinancesParkValueWidgets[] =
+    {
+        MAIN_FINANCES_WIDGETS(STR_PARK_VALUE_GRAPH, RSW_OTHER_TABS, RSH_OTHER_TABS, WW_OTHER_TABS, WH_OTHER_TABS),
+        kWidgetsEnd,
+    };
 
-static Widget _windowFinancesProfitWidgets[] =
-{
-    MAIN_FINANCES_WIDGETS(STR_PROFIT_GRAPH, RSW_OTHER_TABS, RSH_OTHER_TABS, WW_OTHER_TABS, WH_OTHER_TABS),
-    kWidgetsEnd,
-};
+    static Widget _windowFinancesProfitWidgets[] =
+    {
+        MAIN_FINANCES_WIDGETS(STR_PROFIT_GRAPH, RSW_OTHER_TABS, RSH_OTHER_TABS, WW_OTHER_TABS, WH_OTHER_TABS),
+        kWidgetsEnd,
+    };
 
-static Widget _windowFinancesMarketingWidgets[] =
-{
-    MAIN_FINANCES_WIDGETS(STR_MARKETING, RSW_OTHER_TABS, RSH_OTHER_TABS, WW_OTHER_TABS, WH_OTHER_TABS),
-    MakeWidget({3, 47}, { WW_OTHER_TABS - 6,  45}, WindowWidgetType::Groupbox, WindowColour::Tertiary , STR_MARKETING_CAMPAIGNS_IN_OPERATION                                   ),
-    MakeWidget({3, 47}, { WW_OTHER_TABS - 6, 206}, WindowWidgetType::Groupbox, WindowColour::Tertiary , STR_MARKETING_CAMPAIGNS_AVAILABLE                                      ),
-    MakeWidget({8,  0}, {WW_OTHER_TABS - 16,  14}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, 0xFFFFFFFF,                           STR_START_THIS_MARKETING_CAMPAIGN),
-    MakeWidget({8,  0}, {WW_OTHER_TABS - 16,  14}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, 0xFFFFFFFF,                           STR_START_THIS_MARKETING_CAMPAIGN),
-    MakeWidget({8,  0}, {WW_OTHER_TABS - 16,  14}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, 0xFFFFFFFF,                           STR_START_THIS_MARKETING_CAMPAIGN),
-    MakeWidget({8,  0}, {WW_OTHER_TABS - 16,  14}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, 0xFFFFFFFF,                           STR_START_THIS_MARKETING_CAMPAIGN),
-    MakeWidget({8,  0}, {WW_OTHER_TABS - 16,  14}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, 0xFFFFFFFF,                           STR_START_THIS_MARKETING_CAMPAIGN),
-    MakeWidget({8,  0}, {WW_OTHER_TABS - 16,  14}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, 0xFFFFFFFF,                           STR_START_THIS_MARKETING_CAMPAIGN),
-    kWidgetsEnd,
-};
+    static Widget _windowFinancesMarketingWidgets[] =
+    {
+        MAIN_FINANCES_WIDGETS(STR_MARKETING, RSW_OTHER_TABS, RSH_OTHER_TABS, WW_OTHER_TABS, WH_OTHER_TABS),
+        MakeWidget({3, 47}, { WW_OTHER_TABS - 6,  45}, WindowWidgetType::Groupbox, WindowColour::Tertiary , STR_MARKETING_CAMPAIGNS_IN_OPERATION                                   ),
+        MakeWidget({3, 47}, { WW_OTHER_TABS - 6, 206}, WindowWidgetType::Groupbox, WindowColour::Tertiary , STR_MARKETING_CAMPAIGNS_AVAILABLE                                      ),
+        MakeWidget({8,  0}, {WW_OTHER_TABS - 16,  14}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, 0xFFFFFFFF,                           STR_START_THIS_MARKETING_CAMPAIGN),
+        MakeWidget({8,  0}, {WW_OTHER_TABS - 16,  14}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, 0xFFFFFFFF,                           STR_START_THIS_MARKETING_CAMPAIGN),
+        MakeWidget({8,  0}, {WW_OTHER_TABS - 16,  14}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, 0xFFFFFFFF,                           STR_START_THIS_MARKETING_CAMPAIGN),
+        MakeWidget({8,  0}, {WW_OTHER_TABS - 16,  14}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, 0xFFFFFFFF,                           STR_START_THIS_MARKETING_CAMPAIGN),
+        MakeWidget({8,  0}, {WW_OTHER_TABS - 16,  14}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, 0xFFFFFFFF,                           STR_START_THIS_MARKETING_CAMPAIGN),
+        MakeWidget({8,  0}, {WW_OTHER_TABS - 16,  14}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, 0xFFFFFFFF,                           STR_START_THIS_MARKETING_CAMPAIGN),
+        kWidgetsEnd,
+    };
 
-static Widget _windowFinancesResearchWidgets[] =
-{
-    MAIN_FINANCES_WIDGETS(STR_RESEARCH_FUNDING, RSW_RESEARCH, RSH_RESEARCH, WW_RESEARCH, WH_RESEARCH),
-    MakeWidget({  3,  47}, { WW_RESEARCH - 6,  45}, WindowWidgetType::Groupbox, WindowColour::Tertiary, STR_RESEARCH_FUNDING_                                                             ),
-    MakeWidget({  8,  59}, {             160,  14}, WindowWidgetType::DropdownMenu, WindowColour::Tertiary, 0xFFFFFFFF,                           STR_SELECT_LEVEL_OF_RESEARCH_AND_DEVELOPMENT),
-    MakeWidget({156,  60}, {              11,  12}, WindowWidgetType::Button,   WindowColour::Tertiary, STR_DROPDOWN_GLYPH,                   STR_SELECT_LEVEL_OF_RESEARCH_AND_DEVELOPMENT),
-    MakeWidget({  3,  96}, { WW_RESEARCH - 6, 107}, WindowWidgetType::Groupbox, WindowColour::Tertiary, STR_RESEARCH_PRIORITIES                                                           ),
-    MakeWidget({  8, 108}, {WW_RESEARCH - 14,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary, STR_RESEARCH_NEW_TRANSPORT_RIDES,     STR_RESEARCH_NEW_TRANSPORT_RIDES_TIP        ),
-    MakeWidget({  8, 121}, {WW_RESEARCH - 14,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary, STR_RESEARCH_NEW_GENTLE_RIDES,        STR_RESEARCH_NEW_GENTLE_RIDES_TIP           ),
-    MakeWidget({  8, 134}, {WW_RESEARCH - 14,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary, STR_RESEARCH_NEW_ROLLER_COASTERS,     STR_RESEARCH_NEW_ROLLER_COASTERS_TIP        ),
-    MakeWidget({  8, 147}, {WW_RESEARCH - 14,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary, STR_RESEARCH_NEW_THRILL_RIDES,        STR_RESEARCH_NEW_THRILL_RIDES_TIP           ),
-    MakeWidget({  8, 160}, {WW_RESEARCH - 14,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary, STR_RESEARCH_NEW_WATER_RIDES,         STR_RESEARCH_NEW_WATER_RIDES_TIP            ),
-    MakeWidget({  8, 173}, {WW_RESEARCH - 14,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary, STR_RESEARCH_NEW_SHOPS_AND_STALLS,    STR_RESEARCH_NEW_SHOPS_AND_STALLS_TIP       ),
-    MakeWidget({  8, 186}, {WW_RESEARCH - 14,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary, STR_RESEARCH_NEW_SCENERY_AND_THEMING, STR_RESEARCH_NEW_SCENERY_AND_THEMING_TIP    ),
-    kWidgetsEnd,
-};
+    static Widget _windowFinancesResearchWidgets[] =
+    {
+        MAIN_FINANCES_WIDGETS(STR_RESEARCH_FUNDING, RSW_RESEARCH, RSH_RESEARCH, WW_RESEARCH, WH_RESEARCH),
+        MakeWidget({  3,  47}, { WW_RESEARCH - 6,  45}, WindowWidgetType::Groupbox, WindowColour::Tertiary, STR_RESEARCH_FUNDING_                                                             ),
+        MakeWidget({  8,  59}, {             160,  14}, WindowWidgetType::DropdownMenu, WindowColour::Tertiary, 0xFFFFFFFF,                           STR_SELECT_LEVEL_OF_RESEARCH_AND_DEVELOPMENT),
+        MakeWidget({156,  60}, {              11,  12}, WindowWidgetType::Button,   WindowColour::Tertiary, STR_DROPDOWN_GLYPH,                   STR_SELECT_LEVEL_OF_RESEARCH_AND_DEVELOPMENT),
+        MakeWidget({  3,  96}, { WW_RESEARCH - 6, 107}, WindowWidgetType::Groupbox, WindowColour::Tertiary, STR_RESEARCH_PRIORITIES                                                           ),
+        MakeWidget({  8, 108}, {WW_RESEARCH - 14,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary, STR_RESEARCH_NEW_TRANSPORT_RIDES,     STR_RESEARCH_NEW_TRANSPORT_RIDES_TIP        ),
+        MakeWidget({  8, 121}, {WW_RESEARCH - 14,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary, STR_RESEARCH_NEW_GENTLE_RIDES,        STR_RESEARCH_NEW_GENTLE_RIDES_TIP           ),
+        MakeWidget({  8, 134}, {WW_RESEARCH - 14,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary, STR_RESEARCH_NEW_ROLLER_COASTERS,     STR_RESEARCH_NEW_ROLLER_COASTERS_TIP        ),
+        MakeWidget({  8, 147}, {WW_RESEARCH - 14,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary, STR_RESEARCH_NEW_THRILL_RIDES,        STR_RESEARCH_NEW_THRILL_RIDES_TIP           ),
+        MakeWidget({  8, 160}, {WW_RESEARCH - 14,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary, STR_RESEARCH_NEW_WATER_RIDES,         STR_RESEARCH_NEW_WATER_RIDES_TIP            ),
+        MakeWidget({  8, 173}, {WW_RESEARCH - 14,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary, STR_RESEARCH_NEW_SHOPS_AND_STALLS,    STR_RESEARCH_NEW_SHOPS_AND_STALLS_TIP       ),
+        MakeWidget({  8, 186}, {WW_RESEARCH - 14,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary, STR_RESEARCH_NEW_SCENERY_AND_THEMING, STR_RESEARCH_NEW_SCENERY_AND_THEMING_TIP    ),
+        kWidgetsEnd,
+    };
     // clang-format on
 
     static Widget* _windowFinancesPageWidgets[] = {

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -40,112 +40,112 @@
 
 namespace OpenRCT2::Ui::Windows
 {
-    // clang-format off
-enum
-{
-    PATH_CONSTRUCTION_MODE_LAND,
-    PATH_CONSTRUCTION_MODE_BRIDGE_OR_TUNNEL_TOOL,
-    PATH_CONSTRUCTION_MODE_BRIDGE_OR_TUNNEL
-};
+    enum
+    {
+        PATH_CONSTRUCTION_MODE_LAND,
+        PATH_CONSTRUCTION_MODE_BRIDGE_OR_TUNNEL_TOOL,
+        PATH_CONSTRUCTION_MODE_BRIDGE_OR_TUNNEL
+    };
 
 #pragma region Measurements
 
-static constexpr StringId WINDOW_TITLE = STR_FOOTPATHS;
-static constexpr int32_t WH_WINDOW = 421;
-static constexpr int32_t WW_WINDOW = 106;
+    static constexpr StringId WINDOW_TITLE = STR_FOOTPATHS;
+    static constexpr int32_t WH_WINDOW = 421;
+    static constexpr int32_t WW_WINDOW = 106;
 
 #pragma endregion
 
 #pragma region Widgets
 
-enum WindowFootpathWidgetIdx : WidgetIndex
-{
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
+    enum WindowFootpathWidgetIdx : WidgetIndex
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
 
-    WIDX_TYPE_GROUP,
-    WIDX_FOOTPATH_TYPE,
-    WIDX_QUEUELINE_TYPE,
-    WIDX_RAILINGS_TYPE,
+        WIDX_TYPE_GROUP,
+        WIDX_FOOTPATH_TYPE,
+        WIDX_QUEUELINE_TYPE,
+        WIDX_RAILINGS_TYPE,
 
-    WIDX_DIRECTION_GROUP,
-    WIDX_DIRECTION_NW,
-    WIDX_DIRECTION_NE,
-    WIDX_DIRECTION_SW,
-    WIDX_DIRECTION_SE,
+        WIDX_DIRECTION_GROUP,
+        WIDX_DIRECTION_NW,
+        WIDX_DIRECTION_NE,
+        WIDX_DIRECTION_SW,
+        WIDX_DIRECTION_SE,
 
-    WIDX_SLOPE_GROUP,
-    WIDX_SLOPEDOWN,
-    WIDX_LEVEL,
-    WIDX_SLOPEUP,
-    WIDX_CONSTRUCT,
-    WIDX_REMOVE,
+        WIDX_SLOPE_GROUP,
+        WIDX_SLOPEDOWN,
+        WIDX_LEVEL,
+        WIDX_SLOPEUP,
+        WIDX_CONSTRUCT,
+        WIDX_REMOVE,
 
-    WIDX_MODE_GROUP,
-    WIDX_CONSTRUCT_ON_LAND,
-    WIDX_CONSTRUCT_BRIDGE_OR_TUNNEL,
-};
+        WIDX_MODE_GROUP,
+        WIDX_CONSTRUCT_ON_LAND,
+        WIDX_CONSTRUCT_BRIDGE_OR_TUNNEL,
+    };
 
-static Widget window_footpath_widgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW_WINDOW, WH_WINDOW),
+    // clang-format off
+    static Widget window_footpath_widgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW_WINDOW, WH_WINDOW),
 
-    // Type group
-    MakeWidget({ 3,  17}, {100, 95}, WindowWidgetType::Groupbox, WindowColour::Primary  , STR_TYPE                                                                          ),
-    MakeWidget({ 6,  30}, { 47, 36}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, 0xFFFFFFFF,                        STR_FOOTPATH_TIP                               ),
-    MakeWidget({53,  30}, { 47, 36}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, 0xFFFFFFFF,                        STR_QUEUE_LINE_PATH_TIP                        ),
-    MakeWidget({29,  69}, { 47, 36}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, 0xFFFFFFFF,                        STR_OBJECT_SELECTION_FOOTPATH_RAILINGS         ),
+        // Type group
+        MakeWidget({ 3,  17}, {100, 95}, WindowWidgetType::Groupbox, WindowColour::Primary  , STR_TYPE                                                                          ),
+        MakeWidget({ 6,  30}, { 47, 36}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, 0xFFFFFFFF,                        STR_FOOTPATH_TIP                               ),
+        MakeWidget({53,  30}, { 47, 36}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, 0xFFFFFFFF,                        STR_QUEUE_LINE_PATH_TIP                        ),
+        MakeWidget({29,  69}, { 47, 36}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, 0xFFFFFFFF,                        STR_OBJECT_SELECTION_FOOTPATH_RAILINGS         ),
 
-    // Direction group
-    MakeWidget({ 3, 115}, {100, 77}, WindowWidgetType::Groupbox, WindowColour::Primary  , STR_DIRECTION                                                                     ),
-    MakeWidget({53, 127}, { 45, 29}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_DIRECTION_NE),     STR_DIRECTION_TIP                              ),
-    MakeWidget({53, 156}, { 45, 29}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_DIRECTION_SE),     STR_DIRECTION_TIP                              ),
-    MakeWidget({ 8, 156}, { 45, 29}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_DIRECTION_SW),     STR_DIRECTION_TIP                              ),
-    MakeWidget({ 8, 127}, { 45, 29}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_DIRECTION_NW),     STR_DIRECTION_TIP                              ),
+        // Direction group
+        MakeWidget({ 3, 115}, {100, 77}, WindowWidgetType::Groupbox, WindowColour::Primary  , STR_DIRECTION                                                                     ),
+        MakeWidget({53, 127}, { 45, 29}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_DIRECTION_NE),     STR_DIRECTION_TIP                              ),
+        MakeWidget({53, 156}, { 45, 29}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_DIRECTION_SE),     STR_DIRECTION_TIP                              ),
+        MakeWidget({ 8, 156}, { 45, 29}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_DIRECTION_SW),     STR_DIRECTION_TIP                              ),
+        MakeWidget({ 8, 127}, { 45, 29}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_DIRECTION_NW),     STR_DIRECTION_TIP                              ),
 
-    // Slope group
-    MakeWidget({ 3, 195}, {100, 41}, WindowWidgetType::Groupbox, WindowColour::Primary  , STR_SLOPE                                                                         ),
-    MakeWidget({17, 207}, { 24, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_DOWN),  STR_SLOPE_DOWN_TIP                             ),
-    MakeWidget({41, 207}, { 24, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_LEVEL), STR_LEVEL_TIP                                  ),
-    MakeWidget({65, 207}, { 24, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_UP),    STR_SLOPE_UP_TIP                               ),
-    MakeWidget({ 8, 242}, { 90, 90}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, 0xFFFFFFFF,                        STR_CONSTRUCT_THE_SELECTED_FOOTPATH_SECTION_TIP),
-    MakeWidget({30, 335}, { 46, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_DEMOLISH_CURRENT_SECTION),      STR_REMOVE_PREVIOUS_FOOTPATH_SECTION_TIP       ),
+        // Slope group
+        MakeWidget({ 3, 195}, {100, 41}, WindowWidgetType::Groupbox, WindowColour::Primary  , STR_SLOPE                                                                         ),
+        MakeWidget({17, 207}, { 24, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_DOWN),  STR_SLOPE_DOWN_TIP                             ),
+        MakeWidget({41, 207}, { 24, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_LEVEL), STR_LEVEL_TIP                                  ),
+        MakeWidget({65, 207}, { 24, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_UP),    STR_SLOPE_UP_TIP                               ),
+        MakeWidget({ 8, 242}, { 90, 90}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, 0xFFFFFFFF,                        STR_CONSTRUCT_THE_SELECTED_FOOTPATH_SECTION_TIP),
+        MakeWidget({30, 335}, { 46, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_DEMOLISH_CURRENT_SECTION),      STR_REMOVE_PREVIOUS_FOOTPATH_SECTION_TIP       ),
 
-    // Mode group
-    MakeWidget({ 3, 361}, {100, 54}, WindowWidgetType::Groupbox, WindowColour::Primary                                                                                      ),
-    MakeWidget({13, 372}, { 36, 36}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_FOOTPATH_LAND),    STR_CONSTRUCT_FOOTPATH_ON_LAND_TIP             ),
-    MakeWidget({57, 372}, { 36, 36}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_FOOTPATH_BRIDGE),  STR_CONSTRUCT_BRIDGE_OR_TUNNEL_FOOTPATH_TIP    ),
-    kWidgetsEnd,
-};
+        // Mode group
+        MakeWidget({ 3, 361}, {100, 54}, WindowWidgetType::Groupbox, WindowColour::Primary                                                                                      ),
+        MakeWidget({13, 372}, { 36, 36}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_FOOTPATH_LAND),    STR_CONSTRUCT_FOOTPATH_ON_LAND_TIP             ),
+        MakeWidget({57, 372}, { 36, 36}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_FOOTPATH_BRIDGE),  STR_CONSTRUCT_BRIDGE_OR_TUNNEL_FOOTPATH_TIP    ),
+        kWidgetsEnd,
+    };
 
 #pragma endregion
 
-/** rct2: 0x0098D8B4 */
-static constexpr uint8_t DefaultPathSlope[] = {
-    0,
-    SLOPE_IS_IRREGULAR_FLAG,
-    SLOPE_IS_IRREGULAR_FLAG,
-    FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | 2,
-    SLOPE_IS_IRREGULAR_FLAG,
-    SLOPE_IS_IRREGULAR_FLAG,
-    FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | 3,
-    RAISE_FOOTPATH_FLAG,
-    SLOPE_IS_IRREGULAR_FLAG,
-    FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | 1,
-    SLOPE_IS_IRREGULAR_FLAG,
-    RAISE_FOOTPATH_FLAG,
-    FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | 0,
-    RAISE_FOOTPATH_FLAG,
-    RAISE_FOOTPATH_FLAG,
-    SLOPE_IS_IRREGULAR_FLAG,
-};
+    /** rct2: 0x0098D8B4 */
+    static constexpr uint8_t DefaultPathSlope[] = {
+        0,
+        SLOPE_IS_IRREGULAR_FLAG,
+        SLOPE_IS_IRREGULAR_FLAG,
+        FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | 2,
+        SLOPE_IS_IRREGULAR_FLAG,
+        SLOPE_IS_IRREGULAR_FLAG,
+        FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | 3,
+        RAISE_FOOTPATH_FLAG,
+        SLOPE_IS_IRREGULAR_FLAG,
+        FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | 1,
+        SLOPE_IS_IRREGULAR_FLAG,
+        RAISE_FOOTPATH_FLAG,
+        FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | 0,
+        RAISE_FOOTPATH_FLAG,
+        RAISE_FOOTPATH_FLAG,
+        SLOPE_IS_IRREGULAR_FLAG,
+    };
 
-/** rct2: 0x0098D7E0 */
-static constexpr uint8_t ConstructionPreviewImages[][4] = {
-    { 5, 10, 5, 10 },   // Flat
-    { 16, 17, 18, 19 }, // Upwards
-    { 18, 19, 16, 17 }, // Downwards
-};
+    /** rct2: 0x0098D7E0 */
+    static constexpr uint8_t ConstructionPreviewImages[][4] = {
+        { 5, 10, 5, 10 },   // Flat
+        { 16, 17, 18, 19 }, // Upwards
+        { 18, 19, 16, 17 }, // Downwards
+    };
     // clang-format on
 
     class FootpathWindow final : public Window

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -32,43 +32,43 @@
 
 namespace OpenRCT2::Ui::Windows
 {
+    enum WindowGameBottomToolbarWidgetIdx
+    {
+        WIDX_LEFT_OUTSET,
+        WIDX_LEFT_INSET,
+        WIDX_MONEY,
+        WIDX_GUESTS,
+        WIDX_PARK_RATING,
+
+        WIDX_MIDDLE_OUTSET,
+        WIDX_MIDDLE_INSET,
+        WIDX_NEWS_SUBJECT,
+        WIDX_NEWS_LOCATE,
+
+        WIDX_RIGHT_OUTSET,
+        WIDX_RIGHT_INSET,
+        WIDX_DATE
+    };
+
     // clang-format off
-enum WindowGameBottomToolbarWidgetIdx
-{
-    WIDX_LEFT_OUTSET,
-    WIDX_LEFT_INSET,
-    WIDX_MONEY,
-    WIDX_GUESTS,
-    WIDX_PARK_RATING,
+    static Widget window_game_bottom_toolbar_widgets[] =
+    {
+        MakeWidget({  0,  0}, {142, 34}, WindowWidgetType::ImgBtn,      WindowColour::Primary                                                     ), // Left outset panel
+        MakeWidget({  2,  2}, {138, 30}, WindowWidgetType::ImgBtn,      WindowColour::Primary                                                     ), // Left inset panel
+        MakeWidget({  2,  1}, {138, 12}, WindowWidgetType::FlatBtn,     WindowColour::Primary , 0xFFFFFFFF, STR_PROFIT_PER_WEEK_AND_PARK_VALUE_TIP), // Money window
+        MakeWidget({  2, 11}, {138, 12}, WindowWidgetType::FlatBtn,     WindowColour::Primary                                                     ), // Guests window
+        MakeWidget({  2, 21}, {138, 11}, WindowWidgetType::FlatBtn,     WindowColour::Primary , 0xFFFFFFFF, STR_PARK_RATING_TIP                   ), // Park rating window
 
-    WIDX_MIDDLE_OUTSET,
-    WIDX_MIDDLE_INSET,
-    WIDX_NEWS_SUBJECT,
-    WIDX_NEWS_LOCATE,
+        MakeWidget({142,  0}, {356, 34}, WindowWidgetType::ImgBtn,      WindowColour::Tertiary                                                    ), // Middle outset panel
+        MakeWidget({144,  2}, {352, 30}, WindowWidgetType::FlatBtn,     WindowColour::Tertiary                                                    ), // Middle inset panel
+        MakeWidget({147,  5}, { 24, 24}, WindowWidgetType::FlatBtn,     WindowColour::Tertiary, 0xFFFFFFFF, STR_SHOW_SUBJECT_TIP                  ), // Associated news item window
+        MakeWidget({469,  5}, { 24, 24}, WindowWidgetType::FlatBtn,     WindowColour::Tertiary, ImageId(SPR_LOCATE), STR_LOCATE_SUBJECT_TIP                ), // Scroll to news item target
 
-    WIDX_RIGHT_OUTSET,
-    WIDX_RIGHT_INSET,
-    WIDX_DATE
-};
-
-static Widget window_game_bottom_toolbar_widgets[] =
-{
-    MakeWidget({  0,  0}, {142, 34}, WindowWidgetType::ImgBtn,      WindowColour::Primary                                                     ), // Left outset panel
-    MakeWidget({  2,  2}, {138, 30}, WindowWidgetType::ImgBtn,      WindowColour::Primary                                                     ), // Left inset panel
-    MakeWidget({  2,  1}, {138, 12}, WindowWidgetType::FlatBtn,     WindowColour::Primary , 0xFFFFFFFF, STR_PROFIT_PER_WEEK_AND_PARK_VALUE_TIP), // Money window
-    MakeWidget({  2, 11}, {138, 12}, WindowWidgetType::FlatBtn,     WindowColour::Primary                                                     ), // Guests window
-    MakeWidget({  2, 21}, {138, 11}, WindowWidgetType::FlatBtn,     WindowColour::Primary , 0xFFFFFFFF, STR_PARK_RATING_TIP                   ), // Park rating window
-
-    MakeWidget({142,  0}, {356, 34}, WindowWidgetType::ImgBtn,      WindowColour::Tertiary                                                    ), // Middle outset panel
-    MakeWidget({144,  2}, {352, 30}, WindowWidgetType::FlatBtn,     WindowColour::Tertiary                                                    ), // Middle inset panel
-    MakeWidget({147,  5}, { 24, 24}, WindowWidgetType::FlatBtn,     WindowColour::Tertiary, 0xFFFFFFFF, STR_SHOW_SUBJECT_TIP                  ), // Associated news item window
-    MakeWidget({469,  5}, { 24, 24}, WindowWidgetType::FlatBtn,     WindowColour::Tertiary, ImageId(SPR_LOCATE), STR_LOCATE_SUBJECT_TIP                ), // Scroll to news item target
-
-    MakeWidget({498,  0}, {142, 34}, WindowWidgetType::ImgBtn,      WindowColour::Primary                                                     ), // Right outset panel
-    MakeWidget({500,  2}, {138, 30}, WindowWidgetType::ImgBtn,      WindowColour::Primary                                                     ), // Right inset panel
-    MakeWidget({500,  2}, {138, 12}, WindowWidgetType::FlatBtn,     WindowColour::Primary                                                     ), // Date
-    kWidgetsEnd,
-};
+        MakeWidget({498,  0}, {142, 34}, WindowWidgetType::ImgBtn,      WindowColour::Primary                                                     ), // Right outset panel
+        MakeWidget({500,  2}, {138, 30}, WindowWidgetType::ImgBtn,      WindowColour::Primary                                                     ), // Right inset panel
+        MakeWidget({500,  2}, {138, 12}, WindowWidgetType::FlatBtn,     WindowColour::Primary                                                     ), // Date
+        kWidgetsEnd,
+    };
     // clang-format on
 
     uint8_t gToolbarDirtyFlags;

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -95,29 +95,29 @@ namespace OpenRCT2::Ui::Windows
 
     static constexpr int32_t TabWidth = 30;
 
-#define MAIN_GUEST_WIDGETS                                                                                                     \
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),                                                                                         \
-        MakeWidget({ 0, 43 }, { 192, 114 }, WindowWidgetType::Resize, WindowColour::Secondary), /* Resize */                   \
-        MakeTab({ 3, 17 }, STR_SHOW_GUEST_VIEW_TIP),                                            /* Tab 1 */                    \
-        MakeTab({ 34, 17 }, STR_SHOW_GUEST_NEEDS_TIP),                                          /* Tab 2 */                    \
-        MakeTab({ 65, 17 }, STR_SHOW_GUEST_VISITED_RIDES_TIP),                                  /* Tab 3 */                    \
-        MakeTab({ 96, 17 }, STR_SHOW_GUEST_FINANCE_TIP),                                        /* Tab 4 */                    \
-        MakeTab({ 127, 17 }, STR_SHOW_GUEST_THOUGHTS_TIP),                                      /* Tab 5 */                    \
-        MakeTab({ 158, 17 }, STR_SHOW_GUEST_ITEMS_TIP),                                         /* Tab 6 */                    \
-        MakeTab({ 189, 17 }, STR_DEBUG_TIP)                                                     /* Tab 7 */
-
     // clang-format off
-static Widget _guestWindowWidgetsOverview[] = {
-    MAIN_GUEST_WIDGETS,
-    MakeWidget({  3,  45}, {164, 12}, WindowWidgetType::LabelCentred, WindowColour::Secondary                                               ), // Label Thought marquee
-    MakeWidget({  3,  57}, {164, 87}, WindowWidgetType::Viewport,      WindowColour::Secondary                                               ), // Viewport
-    MakeWidget({  3, 144}, {164, 11}, WindowWidgetType::LabelCentred, WindowColour::Secondary                                               ), // Label Action
-    MakeWidget({167,  45}, { 24, 24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_PICKUP_BTN), STR_PICKUP_TIP               ), // Pickup Button
-    MakeWidget({167,  69}, { 24, 24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_RENAME),     STR_NAME_GUEST_TIP           ), // Rename Button
-    MakeWidget({167,  93}, { 24, 24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_LOCATE),     STR_LOCATE_SUBJECT_TIP       ), // Locate Button
-    MakeWidget({167, 117}, { 24, 24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_TRACK_PEEP), STR_TOGGLE_GUEST_TRACKING_TIP), // Track Button
-    kWidgetsEnd,
-};
+    #define MAIN_GUEST_WIDGETS                                                                                                     \
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),                                                                                         \
+            MakeWidget({ 0, 43 }, { 192, 114 }, WindowWidgetType::Resize, WindowColour::Secondary), /* Resize */                   \
+            MakeTab({ 3, 17 }, STR_SHOW_GUEST_VIEW_TIP),                                            /* Tab 1 */                    \
+            MakeTab({ 34, 17 }, STR_SHOW_GUEST_NEEDS_TIP),                                          /* Tab 2 */                    \
+            MakeTab({ 65, 17 }, STR_SHOW_GUEST_VISITED_RIDES_TIP),                                  /* Tab 3 */                    \
+            MakeTab({ 96, 17 }, STR_SHOW_GUEST_FINANCE_TIP),                                        /* Tab 4 */                    \
+            MakeTab({ 127, 17 }, STR_SHOW_GUEST_THOUGHTS_TIP),                                      /* Tab 5 */                    \
+            MakeTab({ 158, 17 }, STR_SHOW_GUEST_ITEMS_TIP),                                         /* Tab 6 */                    \
+            MakeTab({ 189, 17 }, STR_DEBUG_TIP)                                                     /* Tab 7 */
+
+    static Widget _guestWindowWidgetsOverview[] = {
+        MAIN_GUEST_WIDGETS,
+        MakeWidget({  3,  45}, {164, 12}, WindowWidgetType::LabelCentred, WindowColour::Secondary                                               ), // Label Thought marquee
+        MakeWidget({  3,  57}, {164, 87}, WindowWidgetType::Viewport,      WindowColour::Secondary                                               ), // Viewport
+        MakeWidget({  3, 144}, {164, 11}, WindowWidgetType::LabelCentred, WindowColour::Secondary                                               ), // Label Action
+        MakeWidget({167,  45}, { 24, 24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_PICKUP_BTN), STR_PICKUP_TIP               ), // Pickup Button
+        MakeWidget({167,  69}, { 24, 24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_RENAME),     STR_NAME_GUEST_TIP           ), // Rename Button
+        MakeWidget({167,  93}, { 24, 24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_LOCATE),     STR_LOCATE_SUBJECT_TIP       ), // Locate Button
+        MakeWidget({167, 117}, { 24, 24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_TRACK_PEEP), STR_TOGGLE_GUEST_TRACKING_TIP), // Track Button
+        kWidgetsEnd,
+    };
     // clang-format on
 
     static Widget _guestWindowWidgetsStats[] = {
@@ -158,16 +158,16 @@ static Widget _guestWindowWidgetsOverview[] = {
     };
 
     // clang-format off
-static constexpr std::array _guestWindowPageWidgets = {
-    _guestWindowWidgetsOverview,
-    _guestWindowWidgetsStats,
-    _guestWindowWidgetsRides,
-    _guestWindowWidgetsFinance,
-    _guestWindowWidgetsThoughts,
-    _guestWindowWidgetsInventory,
-    _guestWindowWidgetsDebug,
-};
-static_assert(_guestWindowPageWidgets.size() == WINDOW_GUEST_PAGE_COUNT);
+    static constexpr std::array _guestWindowPageWidgets = {
+        _guestWindowWidgetsOverview,
+        _guestWindowWidgetsStats,
+        _guestWindowWidgetsRides,
+        _guestWindowWidgetsFinance,
+        _guestWindowWidgetsThoughts,
+        _guestWindowWidgetsInventory,
+        _guestWindowWidgetsDebug,
+    };
+    static_assert(_guestWindowPageWidgets.size() == WINDOW_GUEST_PAGE_COUNT);
     // clang-format on
 
     static constexpr std::array _guestWindowPageSizes = {

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -95,7 +95,7 @@ namespace OpenRCT2::Ui::Windows
 
     static constexpr int32_t TabWidth = 30;
 
-    // clang-format off
+// clang-format off
     #define MAIN_GUEST_WIDGETS                                                                                                     \
         WINDOW_SHIM(WINDOW_TITLE, WW, WH),                                                                                         \
             MakeWidget({ 0, 43 }, { 192, 114 }, WindowWidgetType::Resize, WindowColour::Secondary), /* Resize */                   \

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -95,18 +95,18 @@ namespace OpenRCT2::Ui::Windows
 
     static constexpr int32_t TabWidth = 30;
 
-// clang-format off
-    #define MAIN_GUEST_WIDGETS                                                                                                     \
-        WINDOW_SHIM(WINDOW_TITLE, WW, WH),                                                                                         \
-            MakeWidget({ 0, 43 }, { 192, 114 }, WindowWidgetType::Resize, WindowColour::Secondary), /* Resize */                   \
-            MakeTab({ 3, 17 }, STR_SHOW_GUEST_VIEW_TIP),                                            /* Tab 1 */                    \
-            MakeTab({ 34, 17 }, STR_SHOW_GUEST_NEEDS_TIP),                                          /* Tab 2 */                    \
-            MakeTab({ 65, 17 }, STR_SHOW_GUEST_VISITED_RIDES_TIP),                                  /* Tab 3 */                    \
-            MakeTab({ 96, 17 }, STR_SHOW_GUEST_FINANCE_TIP),                                        /* Tab 4 */                    \
-            MakeTab({ 127, 17 }, STR_SHOW_GUEST_THOUGHTS_TIP),                                      /* Tab 5 */                    \
-            MakeTab({ 158, 17 }, STR_SHOW_GUEST_ITEMS_TIP),                                         /* Tab 6 */                    \
-            MakeTab({ 189, 17 }, STR_DEBUG_TIP)                                                     /* Tab 7 */
+#define MAIN_GUEST_WIDGETS                                                                                                     \
+    WINDOW_SHIM(WINDOW_TITLE, WW, WH),                                                                                         \
+        MakeWidget({ 0, 43 }, { 192, 114 }, WindowWidgetType::Resize, WindowColour::Secondary), /* Resize */                   \
+        MakeTab({ 3, 17 }, STR_SHOW_GUEST_VIEW_TIP),                                            /* Tab 1 */                    \
+        MakeTab({ 34, 17 }, STR_SHOW_GUEST_NEEDS_TIP),                                          /* Tab 2 */                    \
+        MakeTab({ 65, 17 }, STR_SHOW_GUEST_VISITED_RIDES_TIP),                                  /* Tab 3 */                    \
+        MakeTab({ 96, 17 }, STR_SHOW_GUEST_FINANCE_TIP),                                        /* Tab 4 */                    \
+        MakeTab({ 127, 17 }, STR_SHOW_GUEST_THOUGHTS_TIP),                                      /* Tab 5 */                    \
+        MakeTab({ 158, 17 }, STR_SHOW_GUEST_ITEMS_TIP),                                         /* Tab 6 */                    \
+        MakeTab({ 189, 17 }, STR_DEBUG_TIP)                                                     /* Tab 7 */
 
+    // clang-format off
     static Widget _guestWindowWidgetsOverview[] = {
         MAIN_GUEST_WIDGETS,
         MakeWidget({  3,  45}, {164, 12}, WindowWidgetType::LabelCentred, WindowColour::Secondary                                               ), // Label Thought marquee

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -54,21 +54,21 @@ namespace OpenRCT2::Ui::Windows
     };
 
     // clang-format off
-static Widget window_guest_list_widgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({  0, 43}, {350, 287}, WindowWidgetType::Resize,   WindowColour::Secondary                                                   ), // tab content panel
-    MakeWidget({  5, 59}, { 80,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_ARG_4_PAGE_X                                 ), // page dropdown
-    MakeWidget({ 73, 60}, { 11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH                               ), // page dropdown button
-    MakeWidget({120, 59}, {142,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, 0xFFFFFFFF,         STR_INFORMATION_TYPE_TIP     ), // information type dropdown
-    MakeWidget({250, 60}, { 11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH, STR_INFORMATION_TYPE_TIP     ), // information type dropdown button
-    MakeWidget({273, 46}, { 24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_MAP),            STR_SHOW_GUESTS_ON_MAP_TIP   ), // map
-    MakeWidget({297, 46}, { 24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_G2_SEARCH),      STR_GUESTS_FILTER_BY_NAME_TIP), // filter by name
-    MakeWidget({321, 46}, { 24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_TRACK_PEEP),     STR_TRACKED_GUESTS_ONLY_TIP  ), // tracking
-    MakeTab   ({  3, 17},                                                                        STR_INDIVIDUAL_GUESTS_TIP    ), // tab 1
-    MakeTab   ({ 34, 17},                                                                        STR_SUMMARISED_GUESTS_TIP    ), // tab 2
-    MakeWidget({  3, 72}, {344, 255}, WindowWidgetType::Scroll,   WindowColour::Secondary, SCROLL_BOTH                                      ), // guest list
-    kWidgetsEnd,
-};
+    static Widget window_guest_list_widgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({  0, 43}, {350, 287}, WindowWidgetType::Resize,   WindowColour::Secondary                                                   ), // tab content panel
+        MakeWidget({  5, 59}, { 80,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_ARG_4_PAGE_X                                 ), // page dropdown
+        MakeWidget({ 73, 60}, { 11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH                               ), // page dropdown button
+        MakeWidget({120, 59}, {142,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, 0xFFFFFFFF,         STR_INFORMATION_TYPE_TIP     ), // information type dropdown
+        MakeWidget({250, 60}, { 11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH, STR_INFORMATION_TYPE_TIP     ), // information type dropdown button
+        MakeWidget({273, 46}, { 24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_MAP),            STR_SHOW_GUESTS_ON_MAP_TIP   ), // map
+        MakeWidget({297, 46}, { 24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_G2_SEARCH),      STR_GUESTS_FILTER_BY_NAME_TIP), // filter by name
+        MakeWidget({321, 46}, { 24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_TRACK_PEEP),     STR_TRACKED_GUESTS_ONLY_TIP  ), // tracking
+        MakeTab   ({  3, 17},                                                                        STR_INDIVIDUAL_GUESTS_TIP    ), // tab 1
+        MakeTab   ({ 34, 17},                                                                        STR_SUMMARISED_GUESTS_TIP    ), // tab 2
+        MakeWidget({  3, 72}, {344, 255}, WindowWidgetType::Scroll,   WindowColour::Secondary, SCROLL_BOTH                                      ), // guest list
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class GuestListWindow final : public Window

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -31,34 +31,34 @@
 
 namespace OpenRCT2::Ui::Windows
 {
+    enum
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_TRACK_PREVIEW,
+        WIDX_ROTATE,
+        WIDX_TOGGLE_SCENERY,
+        WIDX_INSTALL,
+        WIDX_CANCEL
+    };
+
+    static constexpr StringId WINDOW_TITLE = STR_TRACK_DESIGN_INSTALL_WINDOW_TITLE;
+    static constexpr int32_t WW = 380;
+    static constexpr int32_t WH = 460;
+    constexpr int32_t PREVIEW_BUTTONS_LEFT = WW - 25;
+    constexpr int32_t ACTION_BUTTONS_LEFT = WW - 100;
+
     // clang-format off
-enum {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_TRACK_PREVIEW,
-    WIDX_ROTATE,
-    WIDX_TOGGLE_SCENERY,
-    WIDX_INSTALL,
-    WIDX_CANCEL
-};
-
-static constexpr StringId WINDOW_TITLE = STR_TRACK_DESIGN_INSTALL_WINDOW_TITLE;
-static constexpr int32_t WW = 380;
-static constexpr int32_t WH = 460;
-constexpr int32_t PREVIEW_BUTTONS_LEFT = WW - 25;
-constexpr int32_t ACTION_BUTTONS_LEFT = WW - 100;
-
-static Widget window_install_track_widgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({                   4,  18}, {372, 219}, WindowWidgetType::FlatBtn, WindowColour::Primary                                                              ),
-    MakeWidget({PREVIEW_BUTTONS_LEFT, 422}, { 22,  24}, WindowWidgetType::FlatBtn, WindowColour::Primary, ImageId(SPR_ROTATE_ARROW),                     STR_ROTATE_90_TIP     ),
-    MakeWidget({PREVIEW_BUTTONS_LEFT, 398}, { 22,  24}, WindowWidgetType::FlatBtn, WindowColour::Primary, ImageId(SPR_SCENERY),                          STR_TOGGLE_SCENERY_TIP),
-    MakeWidget({ ACTION_BUTTONS_LEFT, 241}, { 97,  15}, WindowWidgetType::Button,  WindowColour::Primary, STR_INSTALL_NEW_TRACK_DESIGN_INSTALL                        ),
-    MakeWidget({ ACTION_BUTTONS_LEFT, 259}, { 97,  15}, WindowWidgetType::Button,  WindowColour::Primary, STR_INSTALL_NEW_TRACK_DESIGN_CANCEL                         ),
-    kWidgetsEnd,
-};
-
+    static Widget window_install_track_widgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({                   4,  18}, {372, 219}, WindowWidgetType::FlatBtn, WindowColour::Primary                                                              ),
+        MakeWidget({PREVIEW_BUTTONS_LEFT, 422}, { 22,  24}, WindowWidgetType::FlatBtn, WindowColour::Primary, ImageId(SPR_ROTATE_ARROW),                     STR_ROTATE_90_TIP     ),
+        MakeWidget({PREVIEW_BUTTONS_LEFT, 398}, { 22,  24}, WindowWidgetType::FlatBtn, WindowColour::Primary, ImageId(SPR_SCENERY),                          STR_TOGGLE_SCENERY_TIP),
+        MakeWidget({ ACTION_BUTTONS_LEFT, 241}, { 97,  15}, WindowWidgetType::Button,  WindowColour::Primary, STR_INSTALL_NEW_TRACK_DESIGN_INSTALL                        ),
+        MakeWidget({ ACTION_BUTTONS_LEFT, 259}, { 97,  15}, WindowWidgetType::Button,  WindowColour::Primary, STR_INSTALL_NEW_TRACK_DESIGN_CANCEL                         ),
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class InstallTrackWindow final : public Window

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -36,32 +36,32 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WH = 160;
     static constexpr int32_t WW = 98;
 
-    // clang-format off
-enum WindowLandWidgetIdx : WidgetIndex
-{
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_MOUNTAINMODE,
-    WIDX_PAINTMODE,
-    WIDX_PREVIEW,
-    WIDX_DECREMENT,
-    WIDX_INCREMENT,
-    WIDX_FLOOR,
-    WIDX_WALL,
-};
+    enum WindowLandWidgetIdx : WidgetIndex
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_MOUNTAINMODE,
+        WIDX_PAINTMODE,
+        WIDX_PREVIEW,
+        WIDX_DECREMENT,
+        WIDX_INCREMENT,
+        WIDX_FLOOR,
+        WIDX_WALL,
+    };
 
-static Widget window_land_widgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget     ({19,  19}, {24, 24}, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_UP), STR_ENABLE_MOUNTAIN_TOOL_TIP), // mountain mode
-    MakeWidget     ({55,  19}, {24, 24}, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_PAINTBRUSH),                 STR_DISABLE_ELEVATION),        // paint mode
-    MakeWidget     ({27,  48}, {44, 32}, WindowWidgetType::ImgBtn,  WindowColour::Primary  , ImageId(SPR_LAND_TOOL_SIZE_0),           STR_NONE),                     // preview box
-    MakeRemapWidget({28,  49}, {16, 16}, WindowWidgetType::TrnBtn,  WindowColour::Secondary, SPR_LAND_TOOL_DECREASE,         STR_ADJUST_SMALLER_LAND_TIP),  // decrement size
-    MakeRemapWidget({54,  63}, {16, 16}, WindowWidgetType::TrnBtn,  WindowColour::Secondary, SPR_LAND_TOOL_INCREASE,         STR_ADJUST_LARGER_LAND_TIP),   // increment size
-    MakeWidget     ({ 2, 106}, {47, 36}, WindowWidgetType::FlatBtn, WindowColour::Secondary, 0xFFFFFFFF,                     STR_CHANGE_BASE_LAND_TIP),     // floor texture
-    MakeWidget     ({49, 106}, {47, 36}, WindowWidgetType::FlatBtn, WindowColour::Secondary, 0xFFFFFFFF,                     STR_CHANGE_VERTICAL_LAND_TIP), // wall texture
-    kWidgetsEnd,
-};
+    // clang-format off
+    static Widget window_land_widgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget     ({19,  19}, {24, 24}, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_UP), STR_ENABLE_MOUNTAIN_TOOL_TIP), // mountain mode
+        MakeWidget     ({55,  19}, {24, 24}, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_PAINTBRUSH),                 STR_DISABLE_ELEVATION),        // paint mode
+        MakeWidget     ({27,  48}, {44, 32}, WindowWidgetType::ImgBtn,  WindowColour::Primary  , ImageId(SPR_LAND_TOOL_SIZE_0),           STR_NONE),                     // preview box
+        MakeRemapWidget({28,  49}, {16, 16}, WindowWidgetType::TrnBtn,  WindowColour::Secondary, SPR_LAND_TOOL_DECREASE,         STR_ADJUST_SMALLER_LAND_TIP),  // decrement size
+        MakeRemapWidget({54,  63}, {16, 16}, WindowWidgetType::TrnBtn,  WindowColour::Secondary, SPR_LAND_TOOL_INCREASE,         STR_ADJUST_LARGER_LAND_TIP),   // increment size
+        MakeWidget     ({ 2, 106}, {47, 36}, WindowWidgetType::FlatBtn, WindowColour::Secondary, 0xFFFFFFFF,                     STR_CHANGE_BASE_LAND_TIP),     // floor texture
+        MakeWidget     ({49, 106}, {47, 36}, WindowWidgetType::FlatBtn, WindowColour::Secondary, 0xFFFFFFFF,                     STR_CHANGE_VERTICAL_LAND_TIP), // wall texture
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class LandWindow final : public Window

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -35,41 +35,42 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WW = kInGameSize.x;
     static constexpr int32_t WH = kInGameSize.y;
 
+    enum WindowLandRightsWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_PREVIEW,
+        WIDX_DECREMENT,
+        WIDX_INCREMENT,
+
+        // In-game widgets
+        WIDX_BUY_LAND_RIGHTS,
+        WIDX_BUY_CONSTRUCTION_RIGHTS,
+
+        // Editor/sandbox widgets
+        WIDX_UNOWNED_LAND_CHECKBOX,
+        WIDX_LAND_SALE_CHECKBOX,
+        WIDX_LAND_OWNED_CHECKBOX,
+        WIDX_CONSTRUCTION_RIGHTS_SALE_CHECKBOX,
+        WIDX_CONSTRUCTION_RIGHTS_OWNED_CHECKBOX,
+    };
+
     // clang-format off
-enum WindowLandRightsWidgetIdx {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_PREVIEW,
-    WIDX_DECREMENT,
-    WIDX_INCREMENT,
-
-    // In-game widgets
-    WIDX_BUY_LAND_RIGHTS,
-    WIDX_BUY_CONSTRUCTION_RIGHTS,
-
-    // Editor/sandbox widgets
-    WIDX_UNOWNED_LAND_CHECKBOX,
-    WIDX_LAND_SALE_CHECKBOX,
-    WIDX_LAND_OWNED_CHECKBOX,
-    WIDX_CONSTRUCTION_RIGHTS_SALE_CHECKBOX,
-    WIDX_CONSTRUCTION_RIGHTS_OWNED_CHECKBOX,
-};
-
-static Widget window_land_rights_widgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget     ({ 27, 17}, { 44, 32}, WindowWidgetType::ImgBtn, WindowColour::Primary, ImageId(SPR_LAND_TOOL_SIZE_0)                                                   ), // preview box
-    MakeRemapWidget({ 28, 18}, { 16, 16}, WindowWidgetType::TrnBtn, WindowColour::Primary, SPR_LAND_TOOL_DECREASE,          STR_ADJUST_SMALLER_LAND_RIGHTS_TIP             ), // decrement size
-    MakeRemapWidget({ 54, 32}, { 16, 16}, WindowWidgetType::TrnBtn, WindowColour::Primary, SPR_LAND_TOOL_INCREASE,          STR_ADJUST_LARGER_LAND_RIGHTS_TIP              ), // increment size
-    MakeRemapWidget({ 22, 53}, { 24, 24}, WindowWidgetType::ImgBtn, WindowColour::Primary, SPR_BUY_LAND_RIGHTS,             STR_BUY_LAND_RIGHTS_TIP                        ), // land rights
-    MakeRemapWidget({ 52, 53}, { 24, 24}, WindowWidgetType::ImgBtn, WindowColour::Primary, SPR_BUY_CONSTRUCTION_RIGHTS,     STR_BUY_CONSTRUCTION_RIGHTS_TIP                ), // construction rights
-    MakeWidget     ({100, 22}, {170, 12}, WindowWidgetType::Empty,  WindowColour::Primary, STR_LAND_NOT_OWNED,              STR_SET_LAND_TO_BE_NOT_OWNED_TIP               ),
-    MakeWidget     ({100, 38}, {170, 12}, WindowWidgetType::Empty,  WindowColour::Primary, STR_LAND_SALE,                   STR_SET_LAND_TO_BE_AVAILABLE_TIP               ),
-    MakeWidget     ({100, 54}, {170, 12}, WindowWidgetType::Empty,  WindowColour::Primary, STR_LAND_OWNED,                  STR_SET_LAND_TO_BE_OWNED_TIP                   ),
-    MakeWidget     ({100, 70}, {170, 12}, WindowWidgetType::Empty,  WindowColour::Primary, STR_CONSTRUCTION_RIGHTS_SALE,    STR_SET_CONSTRUCTION_RIGHTS_TO_BE_AVAILABLE_TIP),
-    MakeWidget     ({100, 86}, {170, 12}, WindowWidgetType::Empty,  WindowColour::Primary, STR_CONSTRUCTION_RIGHTS_OWNED,   STR_SET_CONSTRUCTION_RIGHTS_TO_BE_OWNED_TIP    ),
-    kWidgetsEnd,
-};
+    static Widget window_land_rights_widgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget     ({ 27, 17}, { 44, 32}, WindowWidgetType::ImgBtn, WindowColour::Primary, ImageId(SPR_LAND_TOOL_SIZE_0)                                                   ), // preview box
+        MakeRemapWidget({ 28, 18}, { 16, 16}, WindowWidgetType::TrnBtn, WindowColour::Primary, SPR_LAND_TOOL_DECREASE,          STR_ADJUST_SMALLER_LAND_RIGHTS_TIP             ), // decrement size
+        MakeRemapWidget({ 54, 32}, { 16, 16}, WindowWidgetType::TrnBtn, WindowColour::Primary, SPR_LAND_TOOL_INCREASE,          STR_ADJUST_LARGER_LAND_RIGHTS_TIP              ), // increment size
+        MakeRemapWidget({ 22, 53}, { 24, 24}, WindowWidgetType::ImgBtn, WindowColour::Primary, SPR_BUY_LAND_RIGHTS,             STR_BUY_LAND_RIGHTS_TIP                        ), // land rights
+        MakeRemapWidget({ 52, 53}, { 24, 24}, WindowWidgetType::ImgBtn, WindowColour::Primary, SPR_BUY_CONSTRUCTION_RIGHTS,     STR_BUY_CONSTRUCTION_RIGHTS_TIP                ), // construction rights
+        MakeWidget     ({100, 22}, {170, 12}, WindowWidgetType::Empty,  WindowColour::Primary, STR_LAND_NOT_OWNED,              STR_SET_LAND_TO_BE_NOT_OWNED_TIP               ),
+        MakeWidget     ({100, 38}, {170, 12}, WindowWidgetType::Empty,  WindowColour::Primary, STR_LAND_SALE,                   STR_SET_LAND_TO_BE_AVAILABLE_TIP               ),
+        MakeWidget     ({100, 54}, {170, 12}, WindowWidgetType::Empty,  WindowColour::Primary, STR_LAND_OWNED,                  STR_SET_LAND_TO_BE_OWNED_TIP                   ),
+        MakeWidget     ({100, 70}, {170, 12}, WindowWidgetType::Empty,  WindowColour::Primary, STR_CONSTRUCTION_RIGHTS_SALE,    STR_SET_CONSTRUCTION_RIGHTS_TO_BE_AVAILABLE_TIP),
+        MakeWidget     ({100, 86}, {170, 12}, WindowWidgetType::Empty,  WindowColour::Primary, STR_CONSTRUCTION_RIGHTS_OWNED,   STR_SET_CONSTRUCTION_RIGHTS_TO_BE_OWNED_TIP    ),
+        kWidgetsEnd,
+    };
     // clang-format on
 
     enum class LandRightsMode : uint8_t

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -67,20 +67,20 @@ namespace OpenRCT2::Ui::Windows
     };
 
     // clang-format off
-static Widget window_loadsave_widgets[] =
-{
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({               0,  WH - 1}, { WW,   1}, WindowWidgetType::Resize,      WindowColour::Secondary                                                             ), // WIDX_RESIZE
-    MakeWidget({               4,      36}, { 84,  14}, WindowWidgetType::Button,      WindowColour::Primary,   STR_LOADSAVE_DEFAULT,              STR_LOADSAVE_DEFAULT_TIP), // WIDX_DEFAULT
-    MakeWidget({              88,      36}, { 84,  14}, WindowWidgetType::Button,      WindowColour::Primary,   STR_FILEBROWSER_ACTION_UP                                  ), // WIDX_UP
-    MakeWidget({             172,      36}, { 87,  14}, WindowWidgetType::Button,      WindowColour::Primary,   STR_FILEBROWSER_ACTION_NEW_FOLDER                          ), // WIDX_NEW_FOLDER
-    MakeWidget({             259,      36}, { 87,  14}, WindowWidgetType::Button,      WindowColour::Primary,   STR_FILEBROWSER_ACTION_NEW_FILE                            ), // WIDX_NEW_FILE
-    MakeWidget({               4,      55}, {170,  14}, WindowWidgetType::TableHeader, WindowColour::Primary                                                               ), // WIDX_SORT_NAME
-    MakeWidget({(WW - 5) / 2 + 1,      55}, {170,  14}, WindowWidgetType::TableHeader, WindowColour::Primary                                                               ), // WIDX_SORT_DATE
-    MakeWidget({               4,      68}, {342, 303}, WindowWidgetType::Scroll,      WindowColour::Primary,   SCROLL_VERTICAL                                            ), // WIDX_SCROLL
-    MakeWidget({               4, WH - 24}, {197,  19}, WindowWidgetType::Button,      WindowColour::Primary,   STR_FILEBROWSER_USE_SYSTEM_WINDOW                          ), // WIDX_BROWSE
-    kWidgetsEnd,
-};
+    static Widget window_loadsave_widgets[] =
+    {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({               0,  WH - 1}, { WW,   1}, WindowWidgetType::Resize,      WindowColour::Secondary                                                             ), // WIDX_RESIZE
+        MakeWidget({               4,      36}, { 84,  14}, WindowWidgetType::Button,      WindowColour::Primary,   STR_LOADSAVE_DEFAULT,              STR_LOADSAVE_DEFAULT_TIP), // WIDX_DEFAULT
+        MakeWidget({              88,      36}, { 84,  14}, WindowWidgetType::Button,      WindowColour::Primary,   STR_FILEBROWSER_ACTION_UP                                  ), // WIDX_UP
+        MakeWidget({             172,      36}, { 87,  14}, WindowWidgetType::Button,      WindowColour::Primary,   STR_FILEBROWSER_ACTION_NEW_FOLDER                          ), // WIDX_NEW_FOLDER
+        MakeWidget({             259,      36}, { 87,  14}, WindowWidgetType::Button,      WindowColour::Primary,   STR_FILEBROWSER_ACTION_NEW_FILE                            ), // WIDX_NEW_FILE
+        MakeWidget({               4,      55}, {170,  14}, WindowWidgetType::TableHeader, WindowColour::Primary                                                               ), // WIDX_SORT_NAME
+        MakeWidget({(WW - 5) / 2 + 1,      55}, {170,  14}, WindowWidgetType::TableHeader, WindowColour::Primary                                                               ), // WIDX_SORT_DATE
+        MakeWidget({               4,      68}, {342, 303}, WindowWidgetType::Scroll,      WindowColour::Primary,   SCROLL_VERTICAL                                            ), // WIDX_SCROLL
+        MakeWidget({               4, WH - 24}, {197,  19}, WindowWidgetType::Button,      WindowColour::Primary,   STR_FILEBROWSER_USE_SYSTEM_WINDOW                          ), // WIDX_BROWSE
+        kWidgetsEnd,
+    };
     // clang-format on
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Main.cpp
+++ b/src/openrct2-ui/windows/Main.cpp
@@ -20,10 +20,10 @@
 namespace OpenRCT2::Ui::Windows
 {
     // clang-format off
-static Widget _mainWidgets[] = {
-    MakeWidget({0, 0}, {0, 0}, WindowWidgetType::Viewport, WindowColour::Primary),
-    kWidgetsEnd,
-};
+    static Widget _mainWidgets[] = {
+        MakeWidget({0, 0}, {0, 0}, WindowWidgetType::Viewport, WindowColour::Primary),
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class MainWindow final : public Window

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -125,66 +125,66 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WH = 273;
 
     // clang-format off
-#define SHARED_WIDGETS \
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH), /* WIDX_BACKGROUND, WIDX_TITLE, WIDX_CLOSE */ \
-    MakeWidget({ 0, 43}, {WW, 229}, WindowWidgetType::Resize, WindowColour::Secondary), /* WIDX_PAGE_BACKGROUND */ \
-    MakeTab   ({ 3, 17}                                                ), /* WIDX_TAB_1 */ \
-    MakeTab   ({34, 17}                                                ), /* WIDX_TAB_2 */ \
-    MakeTab   ({65, 17}                                                ), /* WIDX_TAB_3 */ \
-    MakeTab   ({96, 17}                                                )  /* WIDX_TAB_4 */
+    #define SHARED_WIDGETS \
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH), /* WIDX_BACKGROUND, WIDX_TITLE, WIDX_CLOSE */ \
+        MakeWidget({ 0, 43}, {WW, 229}, WindowWidgetType::Resize, WindowColour::Secondary), /* WIDX_PAGE_BACKGROUND */ \
+        MakeTab   ({ 3, 17}                                                ), /* WIDX_TAB_1 */ \
+        MakeTab   ({34, 17}                                                ), /* WIDX_TAB_2 */ \
+        MakeTab   ({65, 17}                                                ), /* WIDX_TAB_3 */ \
+        MakeTab   ({96, 17}                                                )  /* WIDX_TAB_4 */
 
-static Widget MapWidgets[] = {
-    SHARED_WIDGETS,
-    MakeWidget        ({155, 255}, {90, 14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_MAPGEN_ACTION_GENERATE                                 ),
-    MakeSpinnerWidgets({104,  52}, {50, 12}, WindowWidgetType::Spinner, WindowColour::Secondary, STR_COMMA16                                                ), // NB: 3 widgets
-    MakeWidget        ({155,  52}, {21, 12}, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_LINK_CHAIN),          STR_MAINTAIN_SQUARE_MAP_TOOLTIP),
-    MakeSpinnerWidgets({177,  52}, {50, 12}, WindowWidgetType::Spinner, WindowColour::Secondary, STR_POP16_COMMA16                                          ), // NB: 3 widgets
-    MakeSpinnerWidgets({104,  70}, {95, 12}, WindowWidgetType::Spinner, WindowColour::Secondary                                                             ), // NB: 3 widgets
-    MakeSpinnerWidgets({104,  88}, {95, 12}, WindowWidgetType::Spinner, WindowColour::Secondary                                                             ), // NB: 3 widgets
-    MakeWidget        ({104, 106}, {47, 36}, WindowWidgetType::FlatBtn, WindowColour::Secondary, 0xFFFFFFFF,                 STR_CHANGE_BASE_LAND_TIP       ),
-    MakeWidget        ({151, 106}, {47, 36}, WindowWidgetType::FlatBtn, WindowColour::Secondary, 0xFFFFFFFF,                 STR_CHANGE_VERTICAL_LAND_TIP   ),
-    kWidgetsEnd,
-};
+    static Widget MapWidgets[] = {
+        SHARED_WIDGETS,
+        MakeWidget        ({155, 255}, {90, 14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_MAPGEN_ACTION_GENERATE                                 ),
+        MakeSpinnerWidgets({104,  52}, {50, 12}, WindowWidgetType::Spinner, WindowColour::Secondary, STR_COMMA16                                                ), // NB: 3 widgets
+        MakeWidget        ({155,  52}, {21, 12}, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_LINK_CHAIN),          STR_MAINTAIN_SQUARE_MAP_TOOLTIP),
+        MakeSpinnerWidgets({177,  52}, {50, 12}, WindowWidgetType::Spinner, WindowColour::Secondary, STR_POP16_COMMA16                                          ), // NB: 3 widgets
+        MakeSpinnerWidgets({104,  70}, {95, 12}, WindowWidgetType::Spinner, WindowColour::Secondary                                                             ), // NB: 3 widgets
+        MakeSpinnerWidgets({104,  88}, {95, 12}, WindowWidgetType::Spinner, WindowColour::Secondary                                                             ), // NB: 3 widgets
+        MakeWidget        ({104, 106}, {47, 36}, WindowWidgetType::FlatBtn, WindowColour::Secondary, 0xFFFFFFFF,                 STR_CHANGE_BASE_LAND_TIP       ),
+        MakeWidget        ({151, 106}, {47, 36}, WindowWidgetType::FlatBtn, WindowColour::Secondary, 0xFFFFFFFF,                 STR_CHANGE_VERTICAL_LAND_TIP   ),
+        kWidgetsEnd,
+    };
 
-static Widget RandomWidgets[] = {
-    SHARED_WIDGETS,
-    MakeWidget({155, 255}, { 90, 14}, WindowWidgetType::Button,   WindowColour::Secondary, STR_MAPGEN_ACTION_GENERATE      ),
-    MakeWidget({  4,  52}, {195, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_MAPGEN_OPTION_RANDOM_TERRAIN),
-    MakeWidget({  4,  70}, {195, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_MAPGEN_OPTION_PLACE_TREES   ),
-    kWidgetsEnd,
-};
+    static Widget RandomWidgets[] = {
+        SHARED_WIDGETS,
+        MakeWidget({155, 255}, { 90, 14}, WindowWidgetType::Button,   WindowColour::Secondary, STR_MAPGEN_ACTION_GENERATE      ),
+        MakeWidget({  4,  52}, {195, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_MAPGEN_OPTION_RANDOM_TERRAIN),
+        MakeWidget({  4,  70}, {195, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_MAPGEN_OPTION_PLACE_TREES   ),
+        kWidgetsEnd,
+    };
 
-static Widget SimplexWidgets[] = {
-    SHARED_WIDGETS,
-    MakeWidget        ({155, 255}, { 90, 14}, WindowWidgetType::Button,        WindowColour::Secondary, STR_MAPGEN_ACTION_GENERATE                                       ), // WIDX_SIMPLEX_GENERATE
-    MakeWidget        ({  4,  52}, {195, 12}, WindowWidgetType::LabelCentred,  WindowColour::Secondary, STR_MAPGEN_SIMPLEX_NOISE                                         ), // WIDX_SIMPLEX_LABEL
-    MakeSpinnerWidgets({104,  70}, { 95, 12}, WindowWidgetType::Spinner,       WindowColour::Secondary                                                                   ), // WIDX_SIMPLEX_LOW{,_UP,_DOWN}
-    MakeSpinnerWidgets({104,  88}, { 95, 12}, WindowWidgetType::Spinner,       WindowColour::Secondary                                                                   ), // WIDX_SIMPLEX_HIGH{,_UP,_DOWN}
-    MakeSpinnerWidgets({104, 106}, { 95, 12}, WindowWidgetType::Spinner,       WindowColour::Secondary                                                                   ), // WIDX_SIMPLEX_BASE_FREQ{,_UP,_DOWN}
-    MakeSpinnerWidgets({104, 124}, { 95, 12}, WindowWidgetType::Spinner,       WindowColour::Secondary                                                                   ), // WIDX_SIMPLEX_OCTAVES{,_UP,_DOWN}
-    MakeSpinnerWidgets({104, 148}, { 50, 12}, WindowWidgetType::Spinner,       WindowColour::Secondary, STR_COMMA16                                                      ), // WIDX_SIMPLEX_MAP_SIZE_Y{,_UP,_DOWN}
-    MakeWidget        ({155, 148}, { 21, 12}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_G2_LINK_CHAIN),                STR_MAINTAIN_SQUARE_MAP_TOOLTIP), // WIDX_SIMPLEX_MAP_SIZE_LINK
-    MakeSpinnerWidgets({177, 148}, { 50, 12}, WindowWidgetType::Spinner,       WindowColour::Secondary, STR_POP16_COMMA16                                                ), // WIDX_SIMPLEX_MAP_SIZE_X{,_UP,_DOWN}
-    MakeSpinnerWidgets({104, 166}, { 95, 12}, WindowWidgetType::Spinner,       WindowColour::Secondary                                                                   ), // WIDX_SIMPLEX_WATER_LEVEL{,_UP,_DOWN}
-    MakeWidget        ({104, 190}, { 95, 12}, WindowWidgetType::Checkbox,      WindowColour::Secondary, STR_MAPGEN_OPTION_RANDOM_TERRAIN                                 ), // WIDX_SIMPLEX_RANDOM_TERRAIN_CHECKBOX
-    MakeWidget        ({102, 202}, { 47, 36}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, 0xFFFFFFFF,                       STR_CHANGE_BASE_LAND_TIP       ), // WIDX_SIMPLEX_FLOOR_TEXTURE
-    MakeWidget        ({150, 202}, { 47, 36}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, 0xFFFFFFFF,                       STR_CHANGE_VERTICAL_LAND_TIP   ), // WIDX_SIMPLEX_WALL_TEXTURE
-    MakeWidget        ({104, 239}, { 95, 12}, WindowWidgetType::Checkbox,      WindowColour::Secondary                                                                   ), // WIDX_SIMPLEX_PLACE_TREES_CHECKBOX
-    kWidgetsEnd,
-};
+    static Widget SimplexWidgets[] = {
+        SHARED_WIDGETS,
+        MakeWidget        ({155, 255}, { 90, 14}, WindowWidgetType::Button,        WindowColour::Secondary, STR_MAPGEN_ACTION_GENERATE                                       ), // WIDX_SIMPLEX_GENERATE
+        MakeWidget        ({  4,  52}, {195, 12}, WindowWidgetType::LabelCentred,  WindowColour::Secondary, STR_MAPGEN_SIMPLEX_NOISE                                         ), // WIDX_SIMPLEX_LABEL
+        MakeSpinnerWidgets({104,  70}, { 95, 12}, WindowWidgetType::Spinner,       WindowColour::Secondary                                                                   ), // WIDX_SIMPLEX_LOW{,_UP,_DOWN}
+        MakeSpinnerWidgets({104,  88}, { 95, 12}, WindowWidgetType::Spinner,       WindowColour::Secondary                                                                   ), // WIDX_SIMPLEX_HIGH{,_UP,_DOWN}
+        MakeSpinnerWidgets({104, 106}, { 95, 12}, WindowWidgetType::Spinner,       WindowColour::Secondary                                                                   ), // WIDX_SIMPLEX_BASE_FREQ{,_UP,_DOWN}
+        MakeSpinnerWidgets({104, 124}, { 95, 12}, WindowWidgetType::Spinner,       WindowColour::Secondary                                                                   ), // WIDX_SIMPLEX_OCTAVES{,_UP,_DOWN}
+        MakeSpinnerWidgets({104, 148}, { 50, 12}, WindowWidgetType::Spinner,       WindowColour::Secondary, STR_COMMA16                                                      ), // WIDX_SIMPLEX_MAP_SIZE_Y{,_UP,_DOWN}
+        MakeWidget        ({155, 148}, { 21, 12}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_G2_LINK_CHAIN),                STR_MAINTAIN_SQUARE_MAP_TOOLTIP), // WIDX_SIMPLEX_MAP_SIZE_LINK
+        MakeSpinnerWidgets({177, 148}, { 50, 12}, WindowWidgetType::Spinner,       WindowColour::Secondary, STR_POP16_COMMA16                                                ), // WIDX_SIMPLEX_MAP_SIZE_X{,_UP,_DOWN}
+        MakeSpinnerWidgets({104, 166}, { 95, 12}, WindowWidgetType::Spinner,       WindowColour::Secondary                                                                   ), // WIDX_SIMPLEX_WATER_LEVEL{,_UP,_DOWN}
+        MakeWidget        ({104, 190}, { 95, 12}, WindowWidgetType::Checkbox,      WindowColour::Secondary, STR_MAPGEN_OPTION_RANDOM_TERRAIN                                 ), // WIDX_SIMPLEX_RANDOM_TERRAIN_CHECKBOX
+        MakeWidget        ({102, 202}, { 47, 36}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, 0xFFFFFFFF,                       STR_CHANGE_BASE_LAND_TIP       ), // WIDX_SIMPLEX_FLOOR_TEXTURE
+        MakeWidget        ({150, 202}, { 47, 36}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, 0xFFFFFFFF,                       STR_CHANGE_VERTICAL_LAND_TIP   ), // WIDX_SIMPLEX_WALL_TEXTURE
+        MakeWidget        ({104, 239}, { 95, 12}, WindowWidgetType::Checkbox,      WindowColour::Secondary                                                                   ), // WIDX_SIMPLEX_PLACE_TREES_CHECKBOX
+        kWidgetsEnd,
+    };
 
-static Widget HeightmapWidgets[] = {
-    SHARED_WIDGETS,
-    MakeWidget        ({ 95, 255}, {150, 14}, WindowWidgetType::Button,   WindowColour::Secondary, STR_MAPGEN_SELECT_HEIGHTMAP), // WIDX_HEIGHTMAP_SELECT
-    MakeWidget        ({  4,  52}, {100, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_MAPGEN_SMOOTH_HEIGHTMAP), // WIDX_HEIGHTMAP_SMOOTH_HEIGHTMAP
-    MakeSpinnerWidgets({104,  70}, { 95, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary                             ), // WIDX_HEIGHTMAP_STRENGTH{,_UP,_DOWN}
-    MakeWidget        ({  4,  88}, {100, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_MAPGEN_NORMALIZE       ), // WIDX_HEIGHTMAP_NORMALIZE
-    MakeWidget        ({  4, 106}, {100, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_MAPGEN_SMOOTH_TILE     ), // WIDX_HEIGHTMAP_SMOOTH_TILES
-    MakeSpinnerWidgets({104, 124}, { 95, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary                             ), // WIDX_HEIGHTMAP_LOW{,_UP,_DOWN}
-    MakeSpinnerWidgets({104, 142}, { 95, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary                             ), // WIDX_HEIGHTMAP_HIGH{,_UP,_DOWN}
-    MakeSpinnerWidgets({104, 160}, { 95, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary                             ), // WIDX_HEIGHTMAP_WATER_LEVEL{,_UP,_DOWN}
-    kWidgetsEnd,
-};
+    static Widget HeightmapWidgets[] = {
+        SHARED_WIDGETS,
+        MakeWidget        ({ 95, 255}, {150, 14}, WindowWidgetType::Button,   WindowColour::Secondary, STR_MAPGEN_SELECT_HEIGHTMAP), // WIDX_HEIGHTMAP_SELECT
+        MakeWidget        ({  4,  52}, {100, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_MAPGEN_SMOOTH_HEIGHTMAP), // WIDX_HEIGHTMAP_SMOOTH_HEIGHTMAP
+        MakeSpinnerWidgets({104,  70}, { 95, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary                             ), // WIDX_HEIGHTMAP_STRENGTH{,_UP,_DOWN}
+        MakeWidget        ({  4,  88}, {100, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_MAPGEN_NORMALIZE       ), // WIDX_HEIGHTMAP_NORMALIZE
+        MakeWidget        ({  4, 106}, {100, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_MAPGEN_SMOOTH_TILE     ), // WIDX_HEIGHTMAP_SMOOTH_TILES
+        MakeSpinnerWidgets({104, 124}, { 95, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary                             ), // WIDX_HEIGHTMAP_LOW{,_UP,_DOWN}
+        MakeSpinnerWidgets({104, 142}, { 95, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary                             ), // WIDX_HEIGHTMAP_HIGH{,_UP,_DOWN}
+        MakeSpinnerWidgets({104, 160}, { 95, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary                             ), // WIDX_HEIGHTMAP_WATER_LEVEL{,_UP,_DOWN}
+        kWidgetsEnd,
+    };
     // clang-format on
 
     static Widget* PageWidgets[WINDOW_MAPGEN_PAGE_COUNT] = {
@@ -199,73 +199,73 @@ static Widget HeightmapWidgets[] = {
 #pragma region Widget flags
 
     // clang-format off
-static uint64_t PageDisabledWidgets[WINDOW_MAPGEN_PAGE_COUNT] = {
-    0,
+    static uint64_t PageDisabledWidgets[WINDOW_MAPGEN_PAGE_COUNT] = {
+        0,
 
-    0,
+        0,
 
-    0,
+        0,
 
-    (1uLL << WIDX_HEIGHTMAP_SMOOTH_HEIGHTMAP) |
-    (1uLL << WIDX_HEIGHTMAP_STRENGTH) |
-    (1uLL << WIDX_HEIGHTMAP_STRENGTH_UP) |
-    (1uLL << WIDX_HEIGHTMAP_STRENGTH_DOWN) |
-    (1uLL << WIDX_HEIGHTMAP_NORMALIZE) |
-    (1uLL << WIDX_HEIGHTMAP_SMOOTH_TILES) |
-    (1uLL << WIDX_HEIGHTMAP_HIGH) |
-    (1uLL << WIDX_HEIGHTMAP_HIGH_UP) |
-    (1uLL << WIDX_HEIGHTMAP_HIGH_DOWN) |
-    (1uLL << WIDX_HEIGHTMAP_LOW) |
-    (1uLL << WIDX_HEIGHTMAP_LOW_UP) |
-    (1uLL << WIDX_HEIGHTMAP_LOW_DOWN) |
-    (1uLL << WIDX_HEIGHTMAP_WATER_LEVEL) |
-    (1uLL << WIDX_HEIGHTMAP_WATER_LEVEL_UP) |
-    (1uLL << WIDX_HEIGHTMAP_WATER_LEVEL_DOWN)
-};
+        (1uLL << WIDX_HEIGHTMAP_SMOOTH_HEIGHTMAP) |
+        (1uLL << WIDX_HEIGHTMAP_STRENGTH) |
+        (1uLL << WIDX_HEIGHTMAP_STRENGTH_UP) |
+        (1uLL << WIDX_HEIGHTMAP_STRENGTH_DOWN) |
+        (1uLL << WIDX_HEIGHTMAP_NORMALIZE) |
+        (1uLL << WIDX_HEIGHTMAP_SMOOTH_TILES) |
+        (1uLL << WIDX_HEIGHTMAP_HIGH) |
+        (1uLL << WIDX_HEIGHTMAP_HIGH_UP) |
+        (1uLL << WIDX_HEIGHTMAP_HIGH_DOWN) |
+        (1uLL << WIDX_HEIGHTMAP_LOW) |
+        (1uLL << WIDX_HEIGHTMAP_LOW_UP) |
+        (1uLL << WIDX_HEIGHTMAP_LOW_DOWN) |
+        (1uLL << WIDX_HEIGHTMAP_WATER_LEVEL) |
+        (1uLL << WIDX_HEIGHTMAP_WATER_LEVEL_UP) |
+        (1uLL << WIDX_HEIGHTMAP_WATER_LEVEL_DOWN)
+    };
 
-static uint64_t HoldDownWidgets[WINDOW_MAPGEN_PAGE_COUNT] = {
-    (1uLL << WIDX_MAP_SIZE_Y_UP) |
-    (1uLL << WIDX_MAP_SIZE_Y_DOWN) |
-    (1uLL << WIDX_MAP_SIZE_X_UP) |
-    (1uLL << WIDX_MAP_SIZE_X_DOWN) |
-    (1uLL << WIDX_BASE_HEIGHT_UP) |
-    (1uLL << WIDX_BASE_HEIGHT_DOWN) |
-    (1uLL << WIDX_WATER_LEVEL_UP) |
-    (1uLL << WIDX_WATER_LEVEL_DOWN),
+    static uint64_t HoldDownWidgets[WINDOW_MAPGEN_PAGE_COUNT] = {
+        (1uLL << WIDX_MAP_SIZE_Y_UP) |
+        (1uLL << WIDX_MAP_SIZE_Y_DOWN) |
+        (1uLL << WIDX_MAP_SIZE_X_UP) |
+        (1uLL << WIDX_MAP_SIZE_X_DOWN) |
+        (1uLL << WIDX_BASE_HEIGHT_UP) |
+        (1uLL << WIDX_BASE_HEIGHT_DOWN) |
+        (1uLL << WIDX_WATER_LEVEL_UP) |
+        (1uLL << WIDX_WATER_LEVEL_DOWN),
 
-    0,
+        0,
 
-    (1uLL << WIDX_SIMPLEX_LOW_UP) |
-    (1uLL << WIDX_SIMPLEX_LOW_DOWN) |
-    (1uLL << WIDX_SIMPLEX_HIGH_UP) |
-    (1uLL << WIDX_SIMPLEX_HIGH_DOWN) |
-    (1uLL << WIDX_SIMPLEX_BASE_FREQ_UP) |
-    (1uLL << WIDX_SIMPLEX_BASE_FREQ_DOWN) |
-    (1uLL << WIDX_SIMPLEX_OCTAVES_UP) |
-    (1uLL << WIDX_SIMPLEX_OCTAVES_DOWN) |
-    (1uLL << WIDX_SIMPLEX_MAP_SIZE_Y_UP) |
-    (1uLL << WIDX_SIMPLEX_MAP_SIZE_Y_DOWN) |
-    (1uLL << WIDX_SIMPLEX_MAP_SIZE_X_UP) |
-    (1uLL << WIDX_SIMPLEX_MAP_SIZE_X_DOWN) |
-    (1uLL << WIDX_SIMPLEX_WATER_LEVEL_UP) |
-    (1uLL << WIDX_SIMPLEX_WATER_LEVEL_DOWN),
+        (1uLL << WIDX_SIMPLEX_LOW_UP) |
+        (1uLL << WIDX_SIMPLEX_LOW_DOWN) |
+        (1uLL << WIDX_SIMPLEX_HIGH_UP) |
+        (1uLL << WIDX_SIMPLEX_HIGH_DOWN) |
+        (1uLL << WIDX_SIMPLEX_BASE_FREQ_UP) |
+        (1uLL << WIDX_SIMPLEX_BASE_FREQ_DOWN) |
+        (1uLL << WIDX_SIMPLEX_OCTAVES_UP) |
+        (1uLL << WIDX_SIMPLEX_OCTAVES_DOWN) |
+        (1uLL << WIDX_SIMPLEX_MAP_SIZE_Y_UP) |
+        (1uLL << WIDX_SIMPLEX_MAP_SIZE_Y_DOWN) |
+        (1uLL << WIDX_SIMPLEX_MAP_SIZE_X_UP) |
+        (1uLL << WIDX_SIMPLEX_MAP_SIZE_X_DOWN) |
+        (1uLL << WIDX_SIMPLEX_WATER_LEVEL_UP) |
+        (1uLL << WIDX_SIMPLEX_WATER_LEVEL_DOWN),
 
-    (1uLL << WIDX_HEIGHTMAP_STRENGTH_UP) |
-    (1uLL << WIDX_HEIGHTMAP_STRENGTH_DOWN) |
-    (1uLL << WIDX_HEIGHTMAP_LOW_UP) |
-    (1uLL << WIDX_HEIGHTMAP_LOW_DOWN) |
-    (1uLL << WIDX_HEIGHTMAP_HIGH_UP) |
-    (1uLL << WIDX_HEIGHTMAP_HIGH_DOWN) |
-    (1uLL << WIDX_HEIGHTMAP_WATER_LEVEL_UP) |
-    (1uLL << WIDX_HEIGHTMAP_WATER_LEVEL_DOWN)
-};
+        (1uLL << WIDX_HEIGHTMAP_STRENGTH_UP) |
+        (1uLL << WIDX_HEIGHTMAP_STRENGTH_DOWN) |
+        (1uLL << WIDX_HEIGHTMAP_LOW_UP) |
+        (1uLL << WIDX_HEIGHTMAP_LOW_DOWN) |
+        (1uLL << WIDX_HEIGHTMAP_HIGH_UP) |
+        (1uLL << WIDX_HEIGHTMAP_HIGH_DOWN) |
+        (1uLL << WIDX_HEIGHTMAP_WATER_LEVEL_UP) |
+        (1uLL << WIDX_HEIGHTMAP_WATER_LEVEL_DOWN)
+    };
 
-static uint64_t PressedWidgets[WINDOW_MAPGEN_PAGE_COUNT] = {
-    0,
-    0,
-    0,
-    (1uLL << WIDX_HEIGHTMAP_SMOOTH_TILES)
-};
+    static uint64_t PressedWidgets[WINDOW_MAPGEN_PAGE_COUNT] = {
+        0,
+        0,
+        0,
+        (1uLL << WIDX_HEIGHTMAP_SMOOTH_TILES)
+    };
     // clang-format on
 
 #pragma endregion

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -124,7 +124,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WW = 250;
     static constexpr int32_t WH = 273;
 
-    // clang-format off
+// clang-format off
     #define SHARED_WIDGETS \
         WINDOW_SHIM(WINDOW_TITLE, WW, WH), /* WIDX_BACKGROUND, WIDX_TITLE, WIDX_CLOSE */ \
         MakeWidget({ 0, 43}, {WW, 229}, WindowWidgetType::Resize, WindowColour::Secondary), /* WIDX_PAGE_BACKGROUND */ \

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -124,15 +124,15 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WW = 250;
     static constexpr int32_t WH = 273;
 
-// clang-format off
-    #define SHARED_WIDGETS \
-        WINDOW_SHIM(WINDOW_TITLE, WW, WH), /* WIDX_BACKGROUND, WIDX_TITLE, WIDX_CLOSE */ \
-        MakeWidget({ 0, 43}, {WW, 229}, WindowWidgetType::Resize, WindowColour::Secondary), /* WIDX_PAGE_BACKGROUND */ \
-        MakeTab   ({ 3, 17}                                                ), /* WIDX_TAB_1 */ \
-        MakeTab   ({34, 17}                                                ), /* WIDX_TAB_2 */ \
-        MakeTab   ({65, 17}                                                ), /* WIDX_TAB_3 */ \
-        MakeTab   ({96, 17}                                                )  /* WIDX_TAB_4 */
+#define SHARED_WIDGETS                                                                                                         \
+    WINDOW_SHIM(WINDOW_TITLE, WW, WH), /* WIDX_BACKGROUND, WIDX_TITLE, WIDX_CLOSE */                                           \
+        MakeWidget({ 0, 43 }, { WW, 229 }, WindowWidgetType::Resize, WindowColour::Secondary), /* WIDX_PAGE_BACKGROUND */      \
+        MakeTab({ 3, 17 }),                                                                    /* WIDX_TAB_1 */                \
+        MakeTab({ 34, 17 }),                                                                   /* WIDX_TAB_2 */                \
+        MakeTab({ 65, 17 }),                                                                   /* WIDX_TAB_3 */                \
+        MakeTab({ 96, 17 })                                                                    /* WIDX_TAB_4 */
 
+    // clang-format off
     static Widget MapWidgets[] = {
         SHARED_WIDGETS,
         MakeWidget        ({155, 255}, {90, 14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_MAPGEN_ACTION_GENERATE                                 ),

--- a/src/openrct2-ui/windows/MapTooltip.cpp
+++ b/src/openrct2-ui/windows/MapTooltip.cpp
@@ -20,13 +20,11 @@
 namespace OpenRCT2::Ui::Windows
 {
     // clang-format off
-static Widget window_map_tooltip_widgets[] = {
-    MakeWidget({0, 0}, {200, 30}, WindowWidgetType::ImgBtn, WindowColour::Primary),
-    kWidgetsEnd,
-};
-
-// clang-format on
-#define MAP_TOOLTIP_ARGS
+    static Widget window_map_tooltip_widgets[] = {
+        MakeWidget({0, 0}, {200, 30}, WindowWidgetType::ImgBtn, WindowColour::Primary),
+        kWidgetsEnd,
+    };
+    // clang-format on
 
     static ScreenCoordsXY _lastCursor;
     static int32_t _cursorHoldDuration;

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -35,67 +35,67 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WH = 200;
     static constexpr int32_t WW = 166;
 
+    enum : WidgetIndex
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_MAZE_MODE_GROUPBOX,
+        WIDX_MAZE_BUILD_MODE = 6,
+        WIDX_MAZE_MOVE_MODE,
+        WIDX_MAZE_FILL_MODE,
+        WIDX_MAZE_DIRECTION_GROUPBOX = 25,
+        WIDX_MAZE_DIRECTION_NW,
+        WIDX_MAZE_DIRECTION_NE,
+        WIDX_MAZE_DIRECTION_SW,
+        WIDX_MAZE_DIRECTION_SE,
+        WIDX_MAZE_ENTRANCE = 30,
+        WIDX_MAZE_EXIT,
+    };
+
+    validate_global_widx(WC_MAZE_CONSTRUCTION, WIDX_MAZE_DIRECTION_GROUPBOX);
+    validate_global_widx(WC_MAZE_CONSTRUCTION, WIDX_MAZE_ENTRANCE);
+    validate_global_widx(WC_MAZE_CONSTRUCTION, WIDX_MAZE_EXIT);
+
     // clang-format off
-enum : WidgetIndex
-{
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_MAZE_MODE_GROUPBOX,
-    WIDX_MAZE_BUILD_MODE = 6,
-    WIDX_MAZE_MOVE_MODE,
-    WIDX_MAZE_FILL_MODE,
-    WIDX_MAZE_DIRECTION_GROUPBOX = 25,
-    WIDX_MAZE_DIRECTION_NW,
-    WIDX_MAZE_DIRECTION_NE,
-    WIDX_MAZE_DIRECTION_SW,
-    WIDX_MAZE_DIRECTION_SE,
-    WIDX_MAZE_ENTRANCE = 30,
-    WIDX_MAZE_EXIT,
-};
-
-validate_global_widx(WC_MAZE_CONSTRUCTION, WIDX_MAZE_DIRECTION_GROUPBOX);
-validate_global_widx(WC_MAZE_CONSTRUCTION, WIDX_MAZE_ENTRANCE);
-validate_global_widx(WC_MAZE_CONSTRUCTION, WIDX_MAZE_EXIT);
-
-static Widget window_maze_construction_widgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({ 3,  17}, {160, 55}, WindowWidgetType::Groupbox, WindowColour::Primary  , STR_RIDE_CONSTRUCTION_MODE                                                            ),
-    MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
-    MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
-    MakeWidget({35,  29}, { 32, 32}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_MAZE_CONSTRUCTION_BUILD),    STR_RIDE_CONSTRUCTION_BUILD_MODE                      ),
-    MakeWidget({67,  29}, { 32, 32}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_MAZE_CONSTRUCTION_MOVE),     STR_RIDE_CONSTRUCTION_MOVE_MODE                       ),
-    MakeWidget({99,  29}, { 32, 32}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_MAZE_CONSTRUCTION_FILL_IN),  STR_RIDE_CONSTRUCTION_FILL_IN_MODE                    ),
-    MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
-    MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
-    MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
-    MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
-    MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
-    MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
-    MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
-    MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
-    MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
-    MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
-    MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
-    MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
-    MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
-    MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
-    MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
-    MakeWidget({ 3, 168}, {160, 28}, WindowWidgetType::Groupbox, WindowColour::Primary                                                                                          ),
-    MakeWidget({ 3,  80}, {160, 87}, WindowWidgetType::Groupbox, WindowColour::Primary  , STR_RIDE_CONSTRUCTION_BUILD                                                           ),
-    MakeWidget({83,  96}, { 45, 29}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_DIRECTION_NE),  STR_RIDE_CONSTRUCTION_BUILD_MAZE_IN_THIS_DIRECTION_TIP),
-    MakeWidget({83, 125}, { 45, 29}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_DIRECTION_SE),  STR_RIDE_CONSTRUCTION_BUILD_MAZE_IN_THIS_DIRECTION_TIP),
-    MakeWidget({38, 125}, { 45, 29}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_DIRECTION_SW),  STR_RIDE_CONSTRUCTION_BUILD_MAZE_IN_THIS_DIRECTION_TIP),
-    MakeWidget({38,  96}, { 45, 29}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_DIRECTION_NW),  STR_RIDE_CONSTRUCTION_BUILD_MAZE_IN_THIS_DIRECTION_TIP),
-    MakeWidget({ 9, 178}, { 70, 12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_RIDE_CONSTRUCTION_ENTRANCE, STR_RIDE_CONSTRUCTION_ENTRANCE_TIP                    ),
-    MakeWidget({87, 178}, { 70, 12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_RIDE_CONSTRUCTION_EXIT,     STR_RIDE_CONSTRUCTION_EXIT_TIP                        ),
-    MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
-    MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
-    kWidgetsEnd,
-};
+    static Widget window_maze_construction_widgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({ 3,  17}, {160, 55}, WindowWidgetType::Groupbox, WindowColour::Primary  , STR_RIDE_CONSTRUCTION_MODE                                                            ),
+        MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
+        MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
+        MakeWidget({35,  29}, { 32, 32}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_MAZE_CONSTRUCTION_BUILD),    STR_RIDE_CONSTRUCTION_BUILD_MODE                      ),
+        MakeWidget({67,  29}, { 32, 32}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_MAZE_CONSTRUCTION_MOVE),     STR_RIDE_CONSTRUCTION_MOVE_MODE                       ),
+        MakeWidget({99,  29}, { 32, 32}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_MAZE_CONSTRUCTION_FILL_IN),  STR_RIDE_CONSTRUCTION_FILL_IN_MODE                    ),
+        MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
+        MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
+        MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
+        MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
+        MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
+        MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
+        MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
+        MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
+        MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
+        MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
+        MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
+        MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
+        MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
+        MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
+        MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
+        MakeWidget({ 3, 168}, {160, 28}, WindowWidgetType::Groupbox, WindowColour::Primary                                                                                          ),
+        MakeWidget({ 3,  80}, {160, 87}, WindowWidgetType::Groupbox, WindowColour::Primary  , STR_RIDE_CONSTRUCTION_BUILD                                                           ),
+        MakeWidget({83,  96}, { 45, 29}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_DIRECTION_NE),  STR_RIDE_CONSTRUCTION_BUILD_MAZE_IN_THIS_DIRECTION_TIP),
+        MakeWidget({83, 125}, { 45, 29}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_DIRECTION_SE),  STR_RIDE_CONSTRUCTION_BUILD_MAZE_IN_THIS_DIRECTION_TIP),
+        MakeWidget({38, 125}, { 45, 29}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_DIRECTION_SW),  STR_RIDE_CONSTRUCTION_BUILD_MAZE_IN_THIS_DIRECTION_TIP),
+        MakeWidget({38,  96}, { 45, 29}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION_DIRECTION_NW),  STR_RIDE_CONSTRUCTION_BUILD_MAZE_IN_THIS_DIRECTION_TIP),
+        MakeWidget({ 9, 178}, { 70, 12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_RIDE_CONSTRUCTION_ENTRANCE, STR_RIDE_CONSTRUCTION_ENTRANCE_TIP                    ),
+        MakeWidget({87, 178}, { 70, 12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_RIDE_CONSTRUCTION_EXIT,     STR_RIDE_CONSTRUCTION_EXIT_TIP                        ),
+        MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
+        MakeWidget({ 0,   0}, {  1,  1}, WindowWidgetType::Empty,    WindowColour::Primary                                                                                          ),
+        kWidgetsEnd,
+    };
+    // clang-format on
 
 #pragma endregion
-    // clang-format on
 
     class MazeConstructionWindow final : public Window
     {

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -22,103 +22,106 @@
 
 namespace OpenRCT2::Ui::Windows
 {
+    enum
+    {
+        WINDOW_MULTIPLAYER_PAGE_INFORMATION,
+        WINDOW_MULTIPLAYER_PAGE_PLAYERS,
+        WINDOW_MULTIPLAYER_PAGE_GROUPS,
+        WINDOW_MULTIPLAYER_PAGE_OPTIONS
+    };
+
+    enum WindowMultiplayerWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_CONTENT_PANEL,
+        WIDX_TAB1,
+        WIDX_TAB2,
+        WIDX_TAB3,
+        WIDX_TAB4,
+
+        WIDX_HEADER_PLAYER = 8,
+        WIDX_HEADER_GROUP,
+        WIDX_HEADER_LAST_ACTION,
+        WIDX_HEADER_PING,
+        WIDX_LIST,
+
+        WIDX_DEFAULT_GROUP = 8,
+        WIDX_DEFAULT_GROUP_DROPDOWN,
+        WIDX_ADD_GROUP,
+        WIDX_REMOVE_GROUP,
+        WIDX_RENAME_GROUP,
+        WIDX_SELECTED_GROUP,
+        WIDX_SELECTED_GROUP_DROPDOWN,
+        WIDX_PERMISSIONS_LIST,
+
+        WIDX_LOG_CHAT_CHECKBOX = 8,
+        WIDX_LOG_SERVER_ACTIONS_CHECKBOX,
+        WIDX_KNOWN_KEYS_ONLY_CHECKBOX,
+    };
+
     // clang-format off
-enum {
-    WINDOW_MULTIPLAYER_PAGE_INFORMATION,
-    WINDOW_MULTIPLAYER_PAGE_PLAYERS,
-    WINDOW_MULTIPLAYER_PAGE_GROUPS,
-    WINDOW_MULTIPLAYER_PAGE_OPTIONS
-};
 
-enum WindowMultiplayerWidgetIdx {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_CONTENT_PANEL,
-    WIDX_TAB1,
-    WIDX_TAB2,
-    WIDX_TAB3,
-    WIDX_TAB4,
+    #define MAIN_MULTIPLAYER_WIDGETS \
+        MakeWidget({  0,  0}, {340, 240}, WindowWidgetType::Frame,    WindowColour::Primary                                        ), /* panel / background */ \
+        MakeWidget({  1,  1}, {338,  14}, WindowWidgetType::Caption,  WindowColour::Primary,  STR_NONE,    STR_WINDOW_TITLE_TIP    ), /* title bar */ \
+        MakeWidget({327,  2}, { 11,  12}, WindowWidgetType::CloseBox, WindowColour::Primary,  STR_CLOSE_X, STR_CLOSE_WINDOW_TIP    ), /* close x button */ \
+        MakeWidget({  0, 43}, {340, 197}, WindowWidgetType::Resize,   WindowColour::Secondary                                      ), /* content panel */ \
+        MakeTab   ({  3, 17},                                                                STR_SHOW_SERVER_INFO_TIP), /* tab */ \
+        MakeTab   ({ 34, 17},                                                                STR_PLAYERS_TIP         ), /* tab */ \
+        MakeTab   ({ 65, 17},                                                                STR_GROUPS_TIP          ), /* tab */ \
+        MakeTab   ({ 96, 17},                                                                STR_OPTIONS_TIP         )  /* tab */
 
-    WIDX_HEADER_PLAYER = 8,
-    WIDX_HEADER_GROUP,
-    WIDX_HEADER_LAST_ACTION,
-    WIDX_HEADER_PING,
-    WIDX_LIST,
+    static Widget window_multiplayer_information_widgets[] = {
+        MAIN_MULTIPLAYER_WIDGETS,
+        kWidgetsEnd,
+    };
 
-    WIDX_DEFAULT_GROUP = 8,
-    WIDX_DEFAULT_GROUP_DROPDOWN,
-    WIDX_ADD_GROUP,
-    WIDX_REMOVE_GROUP,
-    WIDX_RENAME_GROUP,
-    WIDX_SELECTED_GROUP,
-    WIDX_SELECTED_GROUP_DROPDOWN,
-    WIDX_PERMISSIONS_LIST,
+    static Widget window_multiplayer_players_widgets[] = {
+        MAIN_MULTIPLAYER_WIDGETS,
+        MakeWidget({  3, 46}, {173,  15}, WindowWidgetType::TableHeader, WindowColour::Primary  , STR_PLAYER     ), // Player name
+        MakeWidget({176, 46}, { 83,  15}, WindowWidgetType::TableHeader, WindowColour::Primary  , STR_GROUP      ), // Player name
+        MakeWidget({259, 46}, {100,  15}, WindowWidgetType::TableHeader, WindowColour::Primary  , STR_LAST_ACTION), // Player name
+        MakeWidget({359, 46}, { 42,  15}, WindowWidgetType::TableHeader, WindowColour::Primary  , STR_PING       ), // Player name
+        MakeWidget({  3, 60}, {334, 177}, WindowWidgetType::Scroll,       WindowColour::Secondary, SCROLL_VERTICAL), // list
+        kWidgetsEnd,
+    };
 
-    WIDX_LOG_CHAT_CHECKBOX = 8,
-    WIDX_LOG_SERVER_ACTIONS_CHECKBOX,
-    WIDX_KNOWN_KEYS_ONLY_CHECKBOX,
-};
+    static Widget window_multiplayer_groups_widgets[] = {
+        MAIN_MULTIPLAYER_WIDGETS,
+        MakeWidget({141, 46}, {175,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                    ), // default group
+        MakeWidget({305, 47}, { 11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH),
+        MakeWidget({ 11, 65}, { 92,  12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_ADD_GROUP     ), // add group button
+        MakeWidget({113, 65}, { 92,  12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_REMOVE_GROUP  ), // remove group button
+        MakeWidget({215, 65}, { 92,  12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_RENAME_GROUP  ), // rename group button
+        MakeWidget({ 72, 80}, {175,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                    ), // selected group
+        MakeWidget({236, 81}, { 11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH),
+        MakeWidget({  3, 94}, {314, 207}, WindowWidgetType::Scroll,   WindowColour::Secondary, SCROLL_VERTICAL   ), // permissions list
+        kWidgetsEnd,
+    };
 
-#define MAIN_MULTIPLAYER_WIDGETS \
-    MakeWidget({  0,  0}, {340, 240}, WindowWidgetType::Frame,    WindowColour::Primary                                        ), /* panel / background */ \
-    MakeWidget({  1,  1}, {338,  14}, WindowWidgetType::Caption,  WindowColour::Primary,  STR_NONE,    STR_WINDOW_TITLE_TIP    ), /* title bar */ \
-    MakeWidget({327,  2}, { 11,  12}, WindowWidgetType::CloseBox, WindowColour::Primary,  STR_CLOSE_X, STR_CLOSE_WINDOW_TIP    ), /* close x button */ \
-    MakeWidget({  0, 43}, {340, 197}, WindowWidgetType::Resize,   WindowColour::Secondary                                      ), /* content panel */ \
-    MakeTab   ({  3, 17},                                                                STR_SHOW_SERVER_INFO_TIP), /* tab */ \
-    MakeTab   ({ 34, 17},                                                                STR_PLAYERS_TIP         ), /* tab */ \
-    MakeTab   ({ 65, 17},                                                                STR_GROUPS_TIP          ), /* tab */ \
-    MakeTab   ({ 96, 17},                                                                STR_OPTIONS_TIP         )  /* tab */
+    static Widget window_multiplayer_options_widgets[] = {
+        MAIN_MULTIPLAYER_WIDGETS,
+        MakeWidget({3, 50}, {295, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_LOG_CHAT,              STR_LOG_CHAT_TIP             ),
+        MakeWidget({3, 64}, {295, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_LOG_SERVER_ACTIONS,    STR_LOG_SERVER_ACTIONS_TIP   ),
+        MakeWidget({3, 78}, {295, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_ALLOW_KNOWN_KEYS_ONLY, STR_ALLOW_KNOWN_KEYS_ONLY_TIP),
+        kWidgetsEnd,
+    };
 
-static Widget window_multiplayer_information_widgets[] = {
-    MAIN_MULTIPLAYER_WIDGETS,
-    kWidgetsEnd,
-};
+    static Widget *window_multiplayer_page_widgets[] = {
+        window_multiplayer_information_widgets,
+        window_multiplayer_players_widgets,
+        window_multiplayer_groups_widgets,
+        window_multiplayer_options_widgets,
+    };
 
-static Widget window_multiplayer_players_widgets[] = {
-    MAIN_MULTIPLAYER_WIDGETS,
-    MakeWidget({  3, 46}, {173,  15}, WindowWidgetType::TableHeader, WindowColour::Primary  , STR_PLAYER     ), // Player name
-    MakeWidget({176, 46}, { 83,  15}, WindowWidgetType::TableHeader, WindowColour::Primary  , STR_GROUP      ), // Player name
-    MakeWidget({259, 46}, {100,  15}, WindowWidgetType::TableHeader, WindowColour::Primary  , STR_LAST_ACTION), // Player name
-    MakeWidget({359, 46}, { 42,  15}, WindowWidgetType::TableHeader, WindowColour::Primary  , STR_PING       ), // Player name
-    MakeWidget({  3, 60}, {334, 177}, WindowWidgetType::Scroll,       WindowColour::Secondary, SCROLL_VERTICAL), // list
-    kWidgetsEnd,
-};
-
-static Widget window_multiplayer_groups_widgets[] = {
-    MAIN_MULTIPLAYER_WIDGETS,
-    MakeWidget({141, 46}, {175,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                    ), // default group
-    MakeWidget({305, 47}, { 11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH),
-    MakeWidget({ 11, 65}, { 92,  12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_ADD_GROUP     ), // add group button
-    MakeWidget({113, 65}, { 92,  12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_REMOVE_GROUP  ), // remove group button
-    MakeWidget({215, 65}, { 92,  12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_RENAME_GROUP  ), // rename group button
-    MakeWidget({ 72, 80}, {175,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                    ), // selected group
-    MakeWidget({236, 81}, { 11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH),
-    MakeWidget({  3, 94}, {314, 207}, WindowWidgetType::Scroll,   WindowColour::Secondary, SCROLL_VERTICAL   ), // permissions list
-    kWidgetsEnd,
-};
-
-static Widget window_multiplayer_options_widgets[] = {
-    MAIN_MULTIPLAYER_WIDGETS,
-    MakeWidget({3, 50}, {295, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_LOG_CHAT,              STR_LOG_CHAT_TIP             ),
-    MakeWidget({3, 64}, {295, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_LOG_SERVER_ACTIONS,    STR_LOG_SERVER_ACTIONS_TIP   ),
-    MakeWidget({3, 78}, {295, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_ALLOW_KNOWN_KEYS_ONLY, STR_ALLOW_KNOWN_KEYS_ONLY_TIP),
-    kWidgetsEnd,
-};
-
-static Widget *window_multiplayer_page_widgets[] = {
-    window_multiplayer_information_widgets,
-    window_multiplayer_players_widgets,
-    window_multiplayer_groups_widgets,
-    window_multiplayer_options_widgets,
-};
-
-static constexpr StringId WindowMultiplayerPageTitles[] = {
-    STR_MULTIPLAYER_INFORMATION_TITLE,
-    STR_MULTIPLAYER_PLAYERS_TITLE,
-    STR_MULTIPLAYER_GROUPS_TITLE,
-    STR_MULTIPLAYER_OPTIONS_TITLE,
-};
+    static constexpr StringId WindowMultiplayerPageTitles[] = {
+        STR_MULTIPLAYER_INFORMATION_TITLE,
+        STR_MULTIPLAYER_PLAYERS_TITLE,
+        STR_MULTIPLAYER_GROUPS_TITLE,
+        STR_MULTIPLAYER_OPTIONS_TITLE,
+    };
 
     // clang-format on
 

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -16,22 +16,23 @@
 
 namespace OpenRCT2::Ui::Windows
 {
+    enum WindowNetworkStatusWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_PASSWORD
+    };
+
     // clang-format off
-enum WindowNetworkStatusWidgetIdx {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_PASSWORD
-};
-
-static Widget window_network_status_widgets[] = {
-    MakeWidget({  0, 0}, {400, 91}, WindowWidgetType::Frame,    WindowColour::Primary                                   ), // panel / background
-    MakeWidget({  1, 1}, {397, 14}, WindowWidgetType::Caption,  WindowColour::Primary, STR_NONE,    STR_WINDOW_TITLE_TIP), // title bar
-    MakeWidget({388, 2}, { 11, 12}, WindowWidgetType::CloseBox, WindowColour::Primary, STR_CLOSE_X, STR_CLOSE_WINDOW_TIP), // close x button
-    kWidgetsEnd,
-};
-
+    static Widget window_network_status_widgets[] = {
+        MakeWidget({  0, 0}, {400, 91}, WindowWidgetType::Frame,    WindowColour::Primary                                   ), // panel / background
+        MakeWidget({  1, 1}, {397, 14}, WindowWidgetType::Caption,  WindowColour::Primary, STR_NONE,    STR_WINDOW_TITLE_TIP), // title bar
+        MakeWidget({388, 2}, { 11, 12}, WindowWidgetType::CloseBox, WindowColour::Primary, STR_CLOSE_X, STR_CLOSE_WINDOW_TIP), // close x button
+        kWidgetsEnd,
+    };
     // clang-format on
+
     class NetworkStatusWindow final : public Window
     {
     public:

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -29,31 +29,32 @@ namespace OpenRCT2::Ui::Windows
 
     constexpr uint16_t SELECTED_ITEM_UNDEFINED = 0xFFFF;
 
-    // clang-format off
-enum WindowNewCampaignWidgetIdx {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_RIDE_LABEL,
-    WIDX_RIDE_DROPDOWN,
-    WIDX_RIDE_DROPDOWN_BUTTON,
-    WIDX_WEEKS_LABEL,
-    WIDX_WEEKS_SPINNER,
-    WIDX_WEEKS_INCREASE_BUTTON,
-    WIDX_WEEKS_DECREASE_BUTTON,
-    WIDX_START_BUTTON
-};
+    enum WindowNewCampaignWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_RIDE_LABEL,
+        WIDX_RIDE_DROPDOWN,
+        WIDX_RIDE_DROPDOWN_BUTTON,
+        WIDX_WEEKS_LABEL,
+        WIDX_WEEKS_SPINNER,
+        WIDX_WEEKS_INCREASE_BUTTON,
+        WIDX_WEEKS_DECREASE_BUTTON,
+        WIDX_START_BUTTON
+    };
 
-static Widget window_new_campaign_widgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget        ({ 14, 24}, {126, 12}, WindowWidgetType::Label,    WindowColour::Primary, STR_EMPTY                                  ), // ride label
-    MakeWidget        ({100, 24}, {242, 12}, WindowWidgetType::DropdownMenu, WindowColour::Primary, STR_EMPTY                                  ), // ride dropdown
-    MakeWidget        ({330, 25}, { 11, 10}, WindowWidgetType::Button,   WindowColour::Primary, STR_DROPDOWN_GLYPH                         ), // ride dropdown button
-    MakeWidget        ({ 14, 41}, {126, 14}, WindowWidgetType::Label,    WindowColour::Primary, STR_LENGTH_OF_TIME                         ), // weeks label
-    MakeSpinnerWidgets({120, 41}, {100, 14}, WindowWidgetType::Spinner,  WindowColour::Primary, STR_EMPTY                                  ), // weeks (3 widgets)
-    MakeWidget        ({ 14, 89}, {322, 14}, WindowWidgetType::Button,   WindowColour::Primary, STR_MARKETING_START_THIS_MARKETING_CAMPAIGN), // start button
-    kWidgetsEnd,
-};
+    // clang-format off
+    static Widget window_new_campaign_widgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget        ({ 14, 24}, {126, 12}, WindowWidgetType::Label,    WindowColour::Primary, STR_EMPTY                                  ), // ride label
+        MakeWidget        ({100, 24}, {242, 12}, WindowWidgetType::DropdownMenu, WindowColour::Primary, STR_EMPTY                                  ), // ride dropdown
+        MakeWidget        ({330, 25}, { 11, 10}, WindowWidgetType::Button,   WindowColour::Primary, STR_DROPDOWN_GLYPH                         ), // ride dropdown button
+        MakeWidget        ({ 14, 41}, {126, 14}, WindowWidgetType::Label,    WindowColour::Primary, STR_LENGTH_OF_TIME                         ), // weeks label
+        MakeSpinnerWidgets({120, 41}, {100, 14}, WindowWidgetType::Spinner,  WindowColour::Primary, STR_EMPTY                                  ), // weeks (3 widgets)
+        MakeWidget        ({ 14, 89}, {322, 14}, WindowWidgetType::Button,   WindowColour::Primary, STR_MARKETING_START_THIS_MARKETING_CAMPAIGN), // start button
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class NewCampaignWindow final : public Window

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -206,26 +206,26 @@ namespace OpenRCT2::Ui::Windows
     static constexpr ScreenSize GroupTrackTypeSize{ GroupByTrackTypeWidth, 14 };
 
     // clang-format off
-static Widget window_new_ride_widgets[] = {
-    WINDOW_SHIM(WindowTitle, WindowWidth, WindowHeight),
-    MakeWidget({  0,  43},             {601, 339},         WindowWidgetType::Resize,   WindowColour::Secondary                                                                ),
-    MakeTab   ({  3,  17},                                                                                      STR_TRANSPORT_RIDES_TIP                                       ),
-    MakeTab   ({ 34,  17},                                                                                      STR_GENTLE_RIDES_TIP                                          ),
-    MakeTab   ({ 65,  17},                                                                                      STR_ROLLER_COASTERS_TIP                                       ),
-    MakeTab   ({ 96,  17},                                                                                      STR_THRILL_RIDES_TIP                                          ),
-    MakeTab   ({127,  17},                                                                                      STR_WATER_RIDES_TIP                                           ),
-    MakeTab   ({158,  17},                                                                                      STR_SHOPS_STALLS_TIP                                          ),
-    MakeTab   ({189,  17},                                                                                      STR_RESEARCH_AND_DEVELOPMENT_TIP                              ),
-    MakeWidget({  3,  62},             {595, 256},         WindowWidgetType::Scroll,   WindowColour::Secondary, SCROLL_VERTICAL                                               ),
-    MakeWidget({  3,  47},             {290,  70},         WindowWidgetType::Groupbox, WindowColour::Tertiary,  STR_CURRENTLY_IN_DEVELOPMENT                                  ),
-    MakeWidget({  3, 124},             {290,  65},         WindowWidgetType::Groupbox, WindowColour::Tertiary,  STR_LAST_DEVELOPMENT                                          ),
-    MakeWidget({265, 161},             { 24,  24},         WindowWidgetType::FlatBtn,  WindowColour::Tertiary,  0xFFFFFFFF,                      STR_RESEARCH_SHOW_DETAILS_TIP),
-    MakeWidget({265,  68},             { 24,  24},         WindowWidgetType::FlatBtn,  WindowColour::Tertiary,  ImageId(SPR_FINANCE),                     STR_FINANCES_RESEARCH_TIP    ),
-    MakeWidget({  4,  46},             {211, 14},          WindowWidgetType::TextBox,  WindowColour::Secondary                          ),
-    MakeWidget({218,  46},             { 70, 14},          WindowWidgetType::Button,   WindowColour::Secondary, STR_OBJECT_SEARCH_CLEAR ),
-    MakeWidget(GroupByTrackTypeOrigin, GroupTrackTypeSize, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_GROUP_BY_TRACK_TYPE,         STR_GROUP_BY_TRACK_TYPE_TIP  ),
-    kWidgetsEnd,
-};
+    static Widget window_new_ride_widgets[] = {
+        WINDOW_SHIM(WindowTitle, WindowWidth, WindowHeight),
+        MakeWidget({  0,  43},             {601, 339},         WindowWidgetType::Resize,   WindowColour::Secondary                                                                ),
+        MakeTab   ({  3,  17},                                                                                      STR_TRANSPORT_RIDES_TIP                                       ),
+        MakeTab   ({ 34,  17},                                                                                      STR_GENTLE_RIDES_TIP                                          ),
+        MakeTab   ({ 65,  17},                                                                                      STR_ROLLER_COASTERS_TIP                                       ),
+        MakeTab   ({ 96,  17},                                                                                      STR_THRILL_RIDES_TIP                                          ),
+        MakeTab   ({127,  17},                                                                                      STR_WATER_RIDES_TIP                                           ),
+        MakeTab   ({158,  17},                                                                                      STR_SHOPS_STALLS_TIP                                          ),
+        MakeTab   ({189,  17},                                                                                      STR_RESEARCH_AND_DEVELOPMENT_TIP                              ),
+        MakeWidget({  3,  62},             {595, 256},         WindowWidgetType::Scroll,   WindowColour::Secondary, SCROLL_VERTICAL                                               ),
+        MakeWidget({  3,  47},             {290,  70},         WindowWidgetType::Groupbox, WindowColour::Tertiary,  STR_CURRENTLY_IN_DEVELOPMENT                                  ),
+        MakeWidget({  3, 124},             {290,  65},         WindowWidgetType::Groupbox, WindowColour::Tertiary,  STR_LAST_DEVELOPMENT                                          ),
+        MakeWidget({265, 161},             { 24,  24},         WindowWidgetType::FlatBtn,  WindowColour::Tertiary,  0xFFFFFFFF,                      STR_RESEARCH_SHOW_DETAILS_TIP),
+        MakeWidget({265,  68},             { 24,  24},         WindowWidgetType::FlatBtn,  WindowColour::Tertiary,  ImageId(SPR_FINANCE),                     STR_FINANCES_RESEARCH_TIP    ),
+        MakeWidget({  4,  46},             {211, 14},          WindowWidgetType::TextBox,  WindowColour::Secondary                          ),
+        MakeWidget({218,  46},             { 70, 14},          WindowWidgetType::Button,   WindowColour::Secondary, STR_OBJECT_SEARCH_CLEAR ),
+        MakeWidget(GroupByTrackTypeOrigin, GroupTrackTypeSize, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_GROUP_BY_TRACK_TYPE,         STR_GROUP_BY_TRACK_TYPE_TIP  ),
+        kWidgetsEnd,
+    };
     // clang-format on
 
 #pragma endregion

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -28,23 +28,22 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WH = 300;
     static constexpr int32_t WW = 400;
 
+    enum WindowNewsWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_SETTINGS,
+        WIDX_SCROLL
+    };
+
     // clang-format off
-enum WindowNewsWidgetIdx {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_SETTINGS,
-    WIDX_SCROLL
-};
-
-
-static Widget window_news_widgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({372, 18}, { 24,  24}, WindowWidgetType::FlatBtn, WindowColour::Primary, ImageId(SPR_TAB_GEARS_0)), // settings
-    MakeWidget({  4, 44}, {392, 252}, WindowWidgetType::Scroll,  WindowColour::Primary, SCROLL_VERTICAL), // scroll
-    kWidgetsEnd,
-};
-
+    static Widget window_news_widgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({372, 18}, { 24,  24}, WindowWidgetType::FlatBtn, WindowColour::Primary, ImageId(SPR_TAB_GEARS_0)), // settings
+        MakeWidget({  4, 44}, {392, 252}, WindowWidgetType::Scroll,  WindowColour::Primary, SCROLL_VERTICAL), // scroll
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class NewsWindow final : public Window

--- a/src/openrct2-ui/windows/NewsOptions.cpp
+++ b/src/openrct2-ui/windows/NewsOptions.cpp
@@ -20,73 +20,75 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WH = 300;
     static constexpr int32_t WW = 400;
 
+    enum
+    {
+        NOTIFICATION_CATEGORY_PARK,
+        NOTIFICATION_CATEGORY_RIDE,
+        NOTIFICATION_CATEGORY_GUEST,
+        NOTIFICATION_CATEGORY_COUNT
+    };
+
+    struct NotificationDef
+    {
+        uint8_t category;
+        StringId caption;
+        size_t config_offset;
+    };
+
     // clang-format off
-enum
-{
-    NOTIFICATION_CATEGORY_PARK,
-    NOTIFICATION_CATEGORY_RIDE,
-    NOTIFICATION_CATEGORY_GUEST,
-    NOTIFICATION_CATEGORY_COUNT
-};
+    static constexpr NotificationDef NewsItemOptionDefinitions[] = {
+        { NOTIFICATION_CATEGORY_PARK,   STR_NOTIFICATION_PARK_AWARD,                        offsetof(Config::Notification, ParkAward)                          },
+        { NOTIFICATION_CATEGORY_PARK,   STR_NOTIFICATION_PARK_MARKETING_CAMPAIGN_FINISHED,  offsetof(Config::Notification, ParkMarketingCampaignFinished)      },
+        { NOTIFICATION_CATEGORY_PARK,   STR_NOTIFICATION_PARK_WARNINGS,                     offsetof(Config::Notification, ParkWarnings)                       },
+        { NOTIFICATION_CATEGORY_PARK,   STR_NOTIFICATION_PARK_RATING_WARNINGS,              offsetof(Config::Notification, ParkRatingWarnings)                 },
+        { NOTIFICATION_CATEGORY_RIDE,   STR_NOTIFICATION_RIDE_BROKEN_DOWN,                  offsetof(Config::Notification, RideBrokenDown)                     },
+        { NOTIFICATION_CATEGORY_RIDE,   STR_NOTIFICATION_RIDE_CRASHED,                      offsetof(Config::Notification, RideCrashed)                        },
+        { NOTIFICATION_CATEGORY_RIDE,   STR_NOTIFICATION_RIDE_CASUALTIES,                   offsetof(Config::Notification, RideCasualties)                     },
+        { NOTIFICATION_CATEGORY_RIDE,   STR_NOTIFICATION_RIDE_WARNINGS,                     offsetof(Config::Notification, RideWarnings)                       },
+        { NOTIFICATION_CATEGORY_RIDE,   STR_NOTIFICATION_RIDE_RESEARCHED,                   offsetof(Config::Notification, RideResearched)                     },
+        { NOTIFICATION_CATEGORY_RIDE,   STR_NOTIFICATION_RIDE_VEHICLE_STALLED,              offsetof(Config::Notification, RideStalledVehicles)                },
+        { NOTIFICATION_CATEGORY_GUEST,  STR_NOTIFICATION_GUEST_WARNINGS,                    offsetof(Config::Notification, GuestWarnings)                      },
+        { NOTIFICATION_CATEGORY_GUEST,  STR_NOTIFICATION_GUEST_LEFT_PARK,                   offsetof(Config::Notification, GuestLeftPark)                      },
+        { NOTIFICATION_CATEGORY_GUEST,  STR_NOTIFICATION_GUEST_QUEUING_FOR_RIDE,            offsetof(Config::Notification, GuestQueuingForRide)                },
+        { NOTIFICATION_CATEGORY_GUEST,  STR_NOTIFICATION_GUEST_ON_RIDE,                     offsetof(Config::Notification, GuestOnRide)                        },
+        { NOTIFICATION_CATEGORY_GUEST,  STR_NOTIFICATION_GUEST_LEFT_RIDE,                   offsetof(Config::Notification, GuestLeftRide)                      },
+        { NOTIFICATION_CATEGORY_GUEST,  STR_NOTIFICATION_GUEST_BOUGHT_ITEM,                 offsetof(Config::Notification, GuestBoughtItem)                    },
+        { NOTIFICATION_CATEGORY_GUEST,  STR_NOTIFICATION_GUEST_USED_FACILITY,               offsetof(Config::Notification, GuestUsedFacility)                  },
+        { NOTIFICATION_CATEGORY_GUEST,  STR_NOTIFICATION_GUEST_DIED,                        offsetof(Config::Notification, GuestDied)                          },
+    };
+    // clang-format on
 
-struct NotificationDef
-{
-    uint8_t category;
-    StringId caption;
-    size_t config_offset;
-};
+    enum WindowNewsOptionsWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_TAB_CONTENT_PANEL,
+        WIDX_FIRST_TAB,
+        WIDX_TAB_PARK = WIDX_FIRST_TAB,
+        WIDX_TAB_RIDE,
+        WIDX_TAB_GUEST,
+        WIDX_CHECKBOX_0
+    };
 
-static constexpr NotificationDef NewsItemOptionDefinitions[] = {
-    { NOTIFICATION_CATEGORY_PARK,   STR_NOTIFICATION_PARK_AWARD,                        offsetof(Config::Notification, ParkAward)                          },
-    { NOTIFICATION_CATEGORY_PARK,   STR_NOTIFICATION_PARK_MARKETING_CAMPAIGN_FINISHED,  offsetof(Config::Notification, ParkMarketingCampaignFinished)      },
-    { NOTIFICATION_CATEGORY_PARK,   STR_NOTIFICATION_PARK_WARNINGS,                     offsetof(Config::Notification, ParkWarnings)                       },
-    { NOTIFICATION_CATEGORY_PARK,   STR_NOTIFICATION_PARK_RATING_WARNINGS,              offsetof(Config::Notification, ParkRatingWarnings)                 },
-    { NOTIFICATION_CATEGORY_RIDE,   STR_NOTIFICATION_RIDE_BROKEN_DOWN,                  offsetof(Config::Notification, RideBrokenDown)                     },
-    { NOTIFICATION_CATEGORY_RIDE,   STR_NOTIFICATION_RIDE_CRASHED,                      offsetof(Config::Notification, RideCrashed)                        },
-    { NOTIFICATION_CATEGORY_RIDE,   STR_NOTIFICATION_RIDE_CASUALTIES,                   offsetof(Config::Notification, RideCasualties)                     },
-    { NOTIFICATION_CATEGORY_RIDE,   STR_NOTIFICATION_RIDE_WARNINGS,                     offsetof(Config::Notification, RideWarnings)                       },
-    { NOTIFICATION_CATEGORY_RIDE,   STR_NOTIFICATION_RIDE_RESEARCHED,                   offsetof(Config::Notification, RideResearched)                     },
-    { NOTIFICATION_CATEGORY_RIDE,   STR_NOTIFICATION_RIDE_VEHICLE_STALLED,              offsetof(Config::Notification, RideStalledVehicles)                },
-    { NOTIFICATION_CATEGORY_GUEST,  STR_NOTIFICATION_GUEST_WARNINGS,                    offsetof(Config::Notification, GuestWarnings)                      },
-    { NOTIFICATION_CATEGORY_GUEST,  STR_NOTIFICATION_GUEST_LEFT_PARK,                   offsetof(Config::Notification, GuestLeftPark)                      },
-    { NOTIFICATION_CATEGORY_GUEST,  STR_NOTIFICATION_GUEST_QUEUING_FOR_RIDE,            offsetof(Config::Notification, GuestQueuingForRide)                },
-    { NOTIFICATION_CATEGORY_GUEST,  STR_NOTIFICATION_GUEST_ON_RIDE,                     offsetof(Config::Notification, GuestOnRide)                        },
-    { NOTIFICATION_CATEGORY_GUEST,  STR_NOTIFICATION_GUEST_LEFT_RIDE,                   offsetof(Config::Notification, GuestLeftRide)                      },
-    { NOTIFICATION_CATEGORY_GUEST,  STR_NOTIFICATION_GUEST_BOUGHT_ITEM,                 offsetof(Config::Notification, GuestBoughtItem)                    },
-    { NOTIFICATION_CATEGORY_GUEST,  STR_NOTIFICATION_GUEST_USED_FACILITY,               offsetof(Config::Notification, GuestUsedFacility)                  },
-    { NOTIFICATION_CATEGORY_GUEST,  STR_NOTIFICATION_GUEST_DIED,                        offsetof(Config::Notification, GuestDied)                          },
-};
-
-enum WindowNewsOptionsWidgetIdx
-{
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_TAB_CONTENT_PANEL,
-    WIDX_FIRST_TAB,
-    WIDX_TAB_PARK = WIDX_FIRST_TAB,
-    WIDX_TAB_RIDE,
-    WIDX_TAB_GUEST,
-    WIDX_CHECKBOX_0
-};
-
-static Widget WindowNewsOptionsWidgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({ 0, 43}, {400, 257}, WindowWidgetType::Resize,   WindowColour::Secondary), // Tab content panel
-    MakeTab   ({ 3, 17}                                                                 ), // Park tab
-    MakeTab   ({34, 17}                                                                 ), // Ride tab
-    MakeTab   ({65, 17}                                                                 ), // Guest tab
-    MakeWidget({ 7, 49}, {343,  14}, WindowWidgetType::Checkbox, WindowColour::Tertiary ),
-    MakeWidget({ 0,  0}, {343,  14}, WindowWidgetType::Checkbox, WindowColour::Tertiary ),
-    MakeWidget({ 0,  0}, {343,  14}, WindowWidgetType::Checkbox, WindowColour::Tertiary ),
-    MakeWidget({ 0,  0}, {343,  14}, WindowWidgetType::Checkbox, WindowColour::Tertiary ),
-    MakeWidget({ 0,  0}, {343,  14}, WindowWidgetType::Checkbox, WindowColour::Tertiary ),
-    MakeWidget({ 0,  0}, {343,  14}, WindowWidgetType::Checkbox, WindowColour::Tertiary ),
-    MakeWidget({ 0,  0}, {343,  14}, WindowWidgetType::Checkbox, WindowColour::Tertiary ),
-    MakeWidget({ 0,  0}, {343,  14}, WindowWidgetType::Checkbox, WindowColour::Tertiary ),
-    MakeWidget({ 0,  0}, {343,  14}, WindowWidgetType::Checkbox, WindowColour::Tertiary ),
-    kWidgetsEnd,
-};
+    // clang-format off
+    static Widget WindowNewsOptionsWidgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({ 0, 43}, {400, 257}, WindowWidgetType::Resize,   WindowColour::Secondary), // Tab content panel
+        MakeTab   ({ 3, 17}                                                                 ), // Park tab
+        MakeTab   ({34, 17}                                                                 ), // Ride tab
+        MakeTab   ({65, 17}                                                                 ), // Guest tab
+        MakeWidget({ 7, 49}, {343,  14}, WindowWidgetType::Checkbox, WindowColour::Tertiary ),
+        MakeWidget({ 0,  0}, {343,  14}, WindowWidgetType::Checkbox, WindowColour::Tertiary ),
+        MakeWidget({ 0,  0}, {343,  14}, WindowWidgetType::Checkbox, WindowColour::Tertiary ),
+        MakeWidget({ 0,  0}, {343,  14}, WindowWidgetType::Checkbox, WindowColour::Tertiary ),
+        MakeWidget({ 0,  0}, {343,  14}, WindowWidgetType::Checkbox, WindowColour::Tertiary ),
+        MakeWidget({ 0,  0}, {343,  14}, WindowWidgetType::Checkbox, WindowColour::Tertiary ),
+        MakeWidget({ 0,  0}, {343,  14}, WindowWidgetType::Checkbox, WindowColour::Tertiary ),
+        MakeWidget({ 0,  0}, {343,  14}, WindowWidgetType::Checkbox, WindowColour::Tertiary ),
+        MakeWidget({ 0,  0}, {343,  14}, WindowWidgetType::Checkbox, WindowColour::Tertiary ),
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class NewsOptionsWindow final : public Window

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -256,41 +256,42 @@ namespace OpenRCT2::Ui::Windows
 
 #endif
 
+    enum WindowObjectLoadErrorWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_COLUMN_OBJECT_NAME,
+        WIDX_COLUMN_OBJECT_SOURCE,
+        WIDX_COLUMN_OBJECT_TYPE,
+        WIDX_SCROLL,
+        WIDX_COPY_CURRENT,
+        WIDX_COPY_ALL,
+        WIDX_DOWNLOAD_ALL
+    };
+
+    static constexpr StringId WINDOW_TITLE = STR_OBJECT_LOAD_ERROR_TITLE;
+    static constexpr int32_t WW = 450;
+    static constexpr int32_t WH = 400;
+    static constexpr int32_t WW_LESS_PADDING = WW - 5;
+    constexpr int32_t NAME_COL_LEFT = 4;
+    constexpr int32_t SOURCE_COL_LEFT = (WW_LESS_PADDING / 4) + 1;
+    constexpr int32_t TYPE_COL_LEFT = 5 * WW_LESS_PADDING / 8 + 1;
+
     // clang-format off
-enum WindowObjectLoadErrorWidgetIdx {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_COLUMN_OBJECT_NAME,
-    WIDX_COLUMN_OBJECT_SOURCE,
-    WIDX_COLUMN_OBJECT_TYPE,
-    WIDX_SCROLL,
-    WIDX_COPY_CURRENT,
-    WIDX_COPY_ALL,
-    WIDX_DOWNLOAD_ALL
-};
-
-static constexpr StringId WINDOW_TITLE = STR_OBJECT_LOAD_ERROR_TITLE;
-static constexpr int32_t WW = 450;
-static constexpr int32_t WH = 400;
-static constexpr int32_t WW_LESS_PADDING = WW - 5;
-constexpr int32_t NAME_COL_LEFT = 4;
-constexpr int32_t SOURCE_COL_LEFT = (WW_LESS_PADDING / 4) + 1;
-constexpr int32_t TYPE_COL_LEFT = 5 * WW_LESS_PADDING / 8 + 1;
-
-static Widget window_object_load_error_widgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({  NAME_COL_LEFT,  57}, {108,  14}, WindowWidgetType::TableHeader, WindowColour::Primary, STR_OBJECT_NAME                                   ), // 'Object name' header
-    MakeWidget({SOURCE_COL_LEFT,  57}, {166,  14}, WindowWidgetType::TableHeader, WindowColour::Primary, STR_OBJECT_SOURCE                                 ), // 'Object source' header
-    MakeWidget({  TYPE_COL_LEFT,  57}, {166,  14}, WindowWidgetType::TableHeader, WindowColour::Primary, STR_OBJECT_TYPE                                   ), // 'Object type' header
-    MakeWidget({  NAME_COL_LEFT,  70}, {442, 298}, WindowWidgetType::Scroll,       WindowColour::Primary, SCROLL_VERTICAL                                   ), // Scrollable list area
-    MakeWidget({  NAME_COL_LEFT, 377}, {145,  14}, WindowWidgetType::Button,       WindowColour::Primary, STR_COPY_SELECTED,           STR_COPY_SELECTED_TIP), // Copy selected button
-    MakeWidget({            152, 377}, {145,  14}, WindowWidgetType::Button,       WindowColour::Primary, STR_COPY_ALL,                STR_COPY_ALL_TIP     ), // Copy all button
-#ifndef DISABLE_HTTP
-    MakeWidget({            300, 377}, {146,  14}, WindowWidgetType::Button,       WindowColour::Primary, STR_DOWNLOAD_ALL,            STR_DOWNLOAD_ALL_TIP ), // Download all button
-#endif
-    kWidgetsEnd,
-};
+    static Widget window_object_load_error_widgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({  NAME_COL_LEFT,  57}, {108,  14}, WindowWidgetType::TableHeader, WindowColour::Primary, STR_OBJECT_NAME                         ), // 'Object name' header
+        MakeWidget({SOURCE_COL_LEFT,  57}, {166,  14}, WindowWidgetType::TableHeader, WindowColour::Primary, STR_OBJECT_SOURCE                       ), // 'Object source' header
+        MakeWidget({  TYPE_COL_LEFT,  57}, {166,  14}, WindowWidgetType::TableHeader, WindowColour::Primary, STR_OBJECT_TYPE                         ), // 'Object type' header
+        MakeWidget({  NAME_COL_LEFT,  70}, {442, 298}, WindowWidgetType::Scroll,      WindowColour::Primary, SCROLL_VERTICAL                         ), // Scrollable list area
+        MakeWidget({  NAME_COL_LEFT, 377}, {145,  14}, WindowWidgetType::Button,      WindowColour::Primary, STR_COPY_SELECTED, STR_COPY_SELECTED_TIP), // Copy selected button
+        MakeWidget({            152, 377}, {145,  14}, WindowWidgetType::Button,      WindowColour::Primary, STR_COPY_ALL,      STR_COPY_ALL_TIP     ), // Copy all button
+    #ifndef DISABLE_HTTP
+        MakeWidget({            300, 377}, {146,  14}, WindowWidgetType::Button,      WindowColour::Primary, STR_DOWNLOAD_ALL,  STR_DOWNLOAD_ALL_TIP ), // Download all button
+    #endif
+        kWidgetsEnd,
+    };
     // clang-format on
 
     /**

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -51,370 +51,372 @@ using namespace OpenRCT2::Audio;
 
 namespace OpenRCT2::Ui::Windows
 {
-    // clang-format off
-enum WindowOptionsPage {
-    WINDOW_OPTIONS_PAGE_DISPLAY,
-    WINDOW_OPTIONS_PAGE_RENDERING,
-    WINDOW_OPTIONS_PAGE_CULTURE,
-    WINDOW_OPTIONS_PAGE_AUDIO,
-    WINDOW_OPTIONS_PAGE_CONTROLS_AND_INTERFACE,
-    WINDOW_OPTIONS_PAGE_MISC,
-    WINDOW_OPTIONS_PAGE_ADVANCED,
-    WINDOW_OPTIONS_PAGE_COUNT
-};
+    enum WindowOptionsPage
+    {
+        WINDOW_OPTIONS_PAGE_DISPLAY,
+        WINDOW_OPTIONS_PAGE_RENDERING,
+        WINDOW_OPTIONS_PAGE_CULTURE,
+        WINDOW_OPTIONS_PAGE_AUDIO,
+        WINDOW_OPTIONS_PAGE_CONTROLS_AND_INTERFACE,
+        WINDOW_OPTIONS_PAGE_MISC,
+        WINDOW_OPTIONS_PAGE_ADVANCED,
+        WINDOW_OPTIONS_PAGE_COUNT
+    };
 
 #pragma region Widgets
 
-enum WindowOptionsWidgetIdx {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_PAGE_BACKGROUND,
-    WIDX_FIRST_TAB,
-    WIDX_TAB_DISPLAY = WIDX_FIRST_TAB,
-    WIDX_TAB_RENDERING,
-    WIDX_TAB_CULTURE,
-    WIDX_TAB_AUDIO,
-    WIDX_TAB_CONTROLS_AND_INTERFACE,
-    WIDX_TAB_MISC,
-    WIDX_TAB_ADVANCED,
+    enum WindowOptionsWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_PAGE_BACKGROUND,
+        WIDX_FIRST_TAB,
+        WIDX_TAB_DISPLAY = WIDX_FIRST_TAB,
+        WIDX_TAB_RENDERING,
+        WIDX_TAB_CULTURE,
+        WIDX_TAB_AUDIO,
+        WIDX_TAB_CONTROLS_AND_INTERFACE,
+        WIDX_TAB_MISC,
+        WIDX_TAB_ADVANCED,
 
-    WIDX_PAGE_START,
+        WIDX_PAGE_START,
 
-    // Display
-    WIDX_HARDWARE_GROUP = WIDX_PAGE_START,
-    WIDX_FULLSCREEN_LABEL,
-    WIDX_FULLSCREEN,
-    WIDX_FULLSCREEN_DROPDOWN,
-    WIDX_RESOLUTION_LABEL,
-    WIDX_RESOLUTION,
-    WIDX_RESOLUTION_DROPDOWN,
-    WIDX_SCALE_LABEL,
-    WIDX_SCALE,
-    WIDX_SCALE_UP,
-    WIDX_SCALE_DOWN,
-    WIDX_DRAWING_ENGINE_LABEL,
-    WIDX_DRAWING_ENGINE,
-    WIDX_DRAWING_ENGINE_DROPDOWN,
-    WIDX_STEAM_OVERLAY_PAUSE,
-    WIDX_UNCAP_FPS_CHECKBOX,
-    WIDX_SHOW_FPS_CHECKBOX,
-    WIDX_MULTITHREADING_CHECKBOX,
-    WIDX_USE_VSYNC_CHECKBOX,
-    WIDX_MINIMIZE_FOCUS_LOSS,
-    WIDX_DISABLE_SCREENSAVER_LOCK,
+        // Display
+        WIDX_HARDWARE_GROUP = WIDX_PAGE_START,
+        WIDX_FULLSCREEN_LABEL,
+        WIDX_FULLSCREEN,
+        WIDX_FULLSCREEN_DROPDOWN,
+        WIDX_RESOLUTION_LABEL,
+        WIDX_RESOLUTION,
+        WIDX_RESOLUTION_DROPDOWN,
+        WIDX_SCALE_LABEL,
+        WIDX_SCALE,
+        WIDX_SCALE_UP,
+        WIDX_SCALE_DOWN,
+        WIDX_DRAWING_ENGINE_LABEL,
+        WIDX_DRAWING_ENGINE,
+        WIDX_DRAWING_ENGINE_DROPDOWN,
+        WIDX_STEAM_OVERLAY_PAUSE,
+        WIDX_UNCAP_FPS_CHECKBOX,
+        WIDX_SHOW_FPS_CHECKBOX,
+        WIDX_MULTITHREADING_CHECKBOX,
+        WIDX_USE_VSYNC_CHECKBOX,
+        WIDX_MINIMIZE_FOCUS_LOSS,
+        WIDX_DISABLE_SCREENSAVER_LOCK,
 
-    // Rendering
-    WIDX_RENDERING_GROUP = WIDX_PAGE_START,
-    WIDX_TILE_SMOOTHING_CHECKBOX,
-    WIDX_GRIDLINES_CHECKBOX,
-    WIDX_UPPER_CASE_BANNERS_CHECKBOX,
-    WIDX_SHOW_GUEST_PURCHASES_CHECKBOX,
-    WIDX_TRANSPARENT_SCREENSHOTS_CHECKBOX,
-    WIDX_VIRTUAL_FLOOR_LABEL,
-    WIDX_VIRTUAL_FLOOR,
-    WIDX_VIRTUAL_FLOOR_DROPDOWN,
-    WIDX_EFFECTS_GROUP,
-    WIDX_DAY_NIGHT_CHECKBOX,
-    WIDX_ENABLE_LIGHT_FX_CHECKBOX,
-    WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX,
-    WIDX_RENDER_WEATHER_EFFECTS_CHECKBOX,
-    WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX,
+        // Rendering
+        WIDX_RENDERING_GROUP = WIDX_PAGE_START,
+        WIDX_TILE_SMOOTHING_CHECKBOX,
+        WIDX_GRIDLINES_CHECKBOX,
+        WIDX_UPPER_CASE_BANNERS_CHECKBOX,
+        WIDX_SHOW_GUEST_PURCHASES_CHECKBOX,
+        WIDX_TRANSPARENT_SCREENSHOTS_CHECKBOX,
+        WIDX_VIRTUAL_FLOOR_LABEL,
+        WIDX_VIRTUAL_FLOOR,
+        WIDX_VIRTUAL_FLOOR_DROPDOWN,
+        WIDX_EFFECTS_GROUP,
+        WIDX_DAY_NIGHT_CHECKBOX,
+        WIDX_ENABLE_LIGHT_FX_CHECKBOX,
+        WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX,
+        WIDX_RENDER_WEATHER_EFFECTS_CHECKBOX,
+        WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX,
 
-    // Culture / Units
-    WIDX_LANGUAGE_LABEL = WIDX_PAGE_START,
-    WIDX_LANGUAGE,
-    WIDX_LANGUAGE_DROPDOWN,
-    WIDX_CURRENCY_LABEL,
-    WIDX_CURRENCY,
-    WIDX_CURRENCY_DROPDOWN,
-    WIDX_DISTANCE_LABEL,
-    WIDX_DISTANCE,
-    WIDX_DISTANCE_DROPDOWN,
-    WIDX_TEMPERATURE_LABEL,
-    WIDX_TEMPERATURE,
-    WIDX_TEMPERATURE_DROPDOWN,
-    WIDX_HEIGHT_LABELS_LABEL,
-    WIDX_HEIGHT_LABELS,
-    WIDX_HEIGHT_LABELS_DROPDOWN,
-    WIDX_DATE_FORMAT_LABEL,
-    WIDX_DATE_FORMAT,
-    WIDX_DATE_FORMAT_DROPDOWN,
+        // Culture / Units
+        WIDX_LANGUAGE_LABEL = WIDX_PAGE_START,
+        WIDX_LANGUAGE,
+        WIDX_LANGUAGE_DROPDOWN,
+        WIDX_CURRENCY_LABEL,
+        WIDX_CURRENCY,
+        WIDX_CURRENCY_DROPDOWN,
+        WIDX_DISTANCE_LABEL,
+        WIDX_DISTANCE,
+        WIDX_DISTANCE_DROPDOWN,
+        WIDX_TEMPERATURE_LABEL,
+        WIDX_TEMPERATURE,
+        WIDX_TEMPERATURE_DROPDOWN,
+        WIDX_HEIGHT_LABELS_LABEL,
+        WIDX_HEIGHT_LABELS,
+        WIDX_HEIGHT_LABELS_DROPDOWN,
+        WIDX_DATE_FORMAT_LABEL,
+        WIDX_DATE_FORMAT,
+        WIDX_DATE_FORMAT_DROPDOWN,
 
-    // Audio
-    WIDX_SOUND = WIDX_PAGE_START,
-    WIDX_SOUND_DROPDOWN,
-    WIDX_MASTER_SOUND_CHECKBOX,
-    WIDX_SOUND_CHECKBOX,
-    WIDX_MUSIC_CHECKBOX,
-    WIDX_AUDIO_FOCUS_CHECKBOX,
-    WIDX_TITLE_MUSIC_LABEL,
-    WIDX_TITLE_MUSIC,
-    WIDX_TITLE_MUSIC_DROPDOWN,
-    WIDX_MASTER_VOLUME,
-    WIDX_SOUND_VOLUME,
-    WIDX_MUSIC_VOLUME,
+        // Audio
+        WIDX_SOUND = WIDX_PAGE_START,
+        WIDX_SOUND_DROPDOWN,
+        WIDX_MASTER_SOUND_CHECKBOX,
+        WIDX_SOUND_CHECKBOX,
+        WIDX_MUSIC_CHECKBOX,
+        WIDX_AUDIO_FOCUS_CHECKBOX,
+        WIDX_TITLE_MUSIC_LABEL,
+        WIDX_TITLE_MUSIC,
+        WIDX_TITLE_MUSIC_DROPDOWN,
+        WIDX_MASTER_VOLUME,
+        WIDX_SOUND_VOLUME,
+        WIDX_MUSIC_VOLUME,
 
-    // Controls and interface
-    WIDX_CONTROLS_GROUP = WIDX_PAGE_START,
-    WIDX_SCREEN_EDGE_SCROLLING,
-    WIDX_TRAP_CURSOR,
-    WIDX_INVERT_DRAG,
-    WIDX_ZOOM_TO_CURSOR,
-    WIDX_WINDOW_BUTTONS_ON_THE_LEFT,
-    WIDX_ENLARGED_UI,
-    WIDX_TOUCH_ENHANCEMENTS,
-    WIDX_HOTKEY_DROPDOWN,
-    WIDX_THEMES_GROUP,
-    WIDX_THEMES_LABEL,
-    WIDX_THEMES,
-    WIDX_THEMES_DROPDOWN,
-    WIDX_THEMES_BUTTON,
-    WIDX_TOOLBAR_BUTTONS_GROUP,
-    WIDX_TOOLBAR_BUTTONS_CENTRED,
-    WIDX_TOOLBAR_BUTTONS_SHOW_FOR_LABEL,
-    WIDX_TOOLBAR_SHOW_FINANCES,
-    WIDX_TOOLBAR_SHOW_RESEARCH,
-    WIDX_TOOLBAR_SHOW_CHEATS,
-    WIDX_TOOLBAR_SHOW_NEWS,
-    WIDX_TOOLBAR_SHOW_MUTE,
-    WIDX_TOOLBAR_SHOW_CHAT,
-    WIDX_TOOLBAR_SHOW_ZOOM,
+        // Controls and interface
+        WIDX_CONTROLS_GROUP = WIDX_PAGE_START,
+        WIDX_SCREEN_EDGE_SCROLLING,
+        WIDX_TRAP_CURSOR,
+        WIDX_INVERT_DRAG,
+        WIDX_ZOOM_TO_CURSOR,
+        WIDX_WINDOW_BUTTONS_ON_THE_LEFT,
+        WIDX_ENLARGED_UI,
+        WIDX_TOUCH_ENHANCEMENTS,
+        WIDX_HOTKEY_DROPDOWN,
+        WIDX_THEMES_GROUP,
+        WIDX_THEMES_LABEL,
+        WIDX_THEMES,
+        WIDX_THEMES_DROPDOWN,
+        WIDX_THEMES_BUTTON,
+        WIDX_TOOLBAR_BUTTONS_GROUP,
+        WIDX_TOOLBAR_BUTTONS_CENTRED,
+        WIDX_TOOLBAR_BUTTONS_SHOW_FOR_LABEL,
+        WIDX_TOOLBAR_SHOW_FINANCES,
+        WIDX_TOOLBAR_SHOW_RESEARCH,
+        WIDX_TOOLBAR_SHOW_CHEATS,
+        WIDX_TOOLBAR_SHOW_NEWS,
+        WIDX_TOOLBAR_SHOW_MUTE,
+        WIDX_TOOLBAR_SHOW_CHAT,
+        WIDX_TOOLBAR_SHOW_ZOOM,
 
-    // Misc
-    WIDX_TITLE_SEQUENCE_GROUP = WIDX_PAGE_START,
-    WIDX_TITLE_SEQUENCE,
-    WIDX_TITLE_SEQUENCE_DROPDOWN,
-    WIDX_SCENARIO_GROUP,
-    WIDX_SCENARIO_GROUPING_LABEL,
-    WIDX_SCENARIO_GROUPING,
-    WIDX_SCENARIO_GROUPING_DROPDOWN,
-    WIDX_SCENARIO_UNLOCKING,
-    WIDX_SCENARIO_OPTIONS_GROUP,
-    WIDX_ALLOW_EARLY_COMPLETION,
-    WIDX_TWEAKS_GROUP,
-    WIDX_REAL_NAME_CHECKBOX,
-    WIDX_AUTO_STAFF_PLACEMENT,
-    WIDX_AUTO_OPEN_SHOPS,
-    WIDX_DEFAULT_INSPECTION_INTERVAL_LABEL,
-    WIDX_DEFAULT_INSPECTION_INTERVAL,
-    WIDX_DEFAULT_INSPECTION_INTERVAL_DROPDOWN,
+        // Misc
+        WIDX_TITLE_SEQUENCE_GROUP = WIDX_PAGE_START,
+        WIDX_TITLE_SEQUENCE,
+        WIDX_TITLE_SEQUENCE_DROPDOWN,
+        WIDX_SCENARIO_GROUP,
+        WIDX_SCENARIO_GROUPING_LABEL,
+        WIDX_SCENARIO_GROUPING,
+        WIDX_SCENARIO_GROUPING_DROPDOWN,
+        WIDX_SCENARIO_UNLOCKING,
+        WIDX_SCENARIO_OPTIONS_GROUP,
+        WIDX_ALLOW_EARLY_COMPLETION,
+        WIDX_TWEAKS_GROUP,
+        WIDX_REAL_NAME_CHECKBOX,
+        WIDX_AUTO_STAFF_PLACEMENT,
+        WIDX_AUTO_OPEN_SHOPS,
+        WIDX_DEFAULT_INSPECTION_INTERVAL_LABEL,
+        WIDX_DEFAULT_INSPECTION_INTERVAL,
+        WIDX_DEFAULT_INSPECTION_INTERVAL_DROPDOWN,
 
-    // Advanced
-    WIDX_DEBUGGING_TOOLS = WIDX_PAGE_START,
-    WIDX_SAVE_PLUGIN_DATA_CHECKBOX,
-    WIDX_STAY_CONNECTED_AFTER_DESYNC,
-    WIDX_ALWAYS_NATIVE_LOADSAVE,
-    WIDX_AUTOSAVE_FREQUENCY_LABEL,
-    WIDX_AUTOSAVE_FREQUENCY,
-    WIDX_AUTOSAVE_FREQUENCY_DROPDOWN,
-    WIDX_AUTOSAVE_AMOUNT_LABEL,
-    WIDX_AUTOSAVE_AMOUNT,
-    WIDX_AUTOSAVE_AMOUNT_UP,
-    WIDX_AUTOSAVE_AMOUNT_DOWN,
-    WIDX_PATH_TO_RCT1_TEXT,
-    WIDX_PATH_TO_RCT1_BUTTON,
-    WIDX_PATH_TO_RCT1_CLEAR,
-    WIDX_ASSET_PACKS,
-};
+        // Advanced
+        WIDX_DEBUGGING_TOOLS = WIDX_PAGE_START,
+        WIDX_SAVE_PLUGIN_DATA_CHECKBOX,
+        WIDX_STAY_CONNECTED_AFTER_DESYNC,
+        WIDX_ALWAYS_NATIVE_LOADSAVE,
+        WIDX_AUTOSAVE_FREQUENCY_LABEL,
+        WIDX_AUTOSAVE_FREQUENCY,
+        WIDX_AUTOSAVE_FREQUENCY_DROPDOWN,
+        WIDX_AUTOSAVE_AMOUNT_LABEL,
+        WIDX_AUTOSAVE_AMOUNT,
+        WIDX_AUTOSAVE_AMOUNT_UP,
+        WIDX_AUTOSAVE_AMOUNT_DOWN,
+        WIDX_PATH_TO_RCT1_TEXT,
+        WIDX_PATH_TO_RCT1_BUTTON,
+        WIDX_PATH_TO_RCT1_CLEAR,
+        WIDX_ASSET_PACKS,
+    };
 
-static constexpr StringId WINDOW_TITLE = STR_OPTIONS_TITLE;
-static constexpr int32_t WW = 310;
-static constexpr int32_t WH = 332;
+    static constexpr StringId WINDOW_TITLE = STR_OPTIONS_TITLE;
+    static constexpr int32_t WW = 310;
+    static constexpr int32_t WH = 332;
 
-#define MAIN_OPTIONS_WIDGETS \
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
-    MakeWidget({  0, 43}, {WW, 289}, WindowWidgetType::Resize, WindowColour::Secondary), \
-    MakeTab   ({  3, 17}, STR_OPTIONS_DISPLAY_TIP                       ), \
-    MakeTab   ({ 34, 17}, STR_OPTIONS_RENDERING_TIP                     ), \
-    MakeTab   ({ 65, 17}, STR_OPTIONS_CULTURE_TIP                       ), \
-    MakeTab   ({ 96, 17}, STR_OPTIONS_AUDIO_TIP                         ), \
-    MakeTab   ({127, 17}, STR_OPTIONS_CONTROLS_AND_INTERFACE_TIP        ), \
-    MakeTab   ({158, 17}, STR_OPTIONS_MISCELLANEOUS_TIP                 ), \
-    MakeTab   ({189, 17}, STR_OPTIONS_ADVANCED                          )
+    // clang-format off
+    #define MAIN_OPTIONS_WIDGETS \
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
+        MakeWidget({  0, 43}, {WW, 289}, WindowWidgetType::Resize, WindowColour::Secondary), \
+        MakeTab   ({  3, 17}, STR_OPTIONS_DISPLAY_TIP                       ), \
+        MakeTab   ({ 34, 17}, STR_OPTIONS_RENDERING_TIP                     ), \
+        MakeTab   ({ 65, 17}, STR_OPTIONS_CULTURE_TIP                       ), \
+        MakeTab   ({ 96, 17}, STR_OPTIONS_AUDIO_TIP                         ), \
+        MakeTab   ({127, 17}, STR_OPTIONS_CONTROLS_AND_INTERFACE_TIP        ), \
+        MakeTab   ({158, 17}, STR_OPTIONS_MISCELLANEOUS_TIP                 ), \
+        MakeTab   ({189, 17}, STR_OPTIONS_ADVANCED                          )
 
-static Widget window_options_display_widgets[] = {
-    MAIN_OPTIONS_WIDGETS,
-    MakeWidget        ({  5,  53}, {300, 170}, WindowWidgetType::Groupbox,     WindowColour::Secondary, STR_HARDWARE_GROUP                                                              ), // Hardware group
-    MakeWidget        ({ 10,  67}, {145,  12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_FULLSCREEN_MODE,                   STR_FULLSCREEN_MODE_TIP                  ), // Fullscreen
-    MakeWidget        ({155,  68}, {145,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                                                  ),
-    MakeWidget        ({288,  69}, { 11,  10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,                    STR_FULLSCREEN_MODE_TIP                  ),
-    MakeWidget        ({ 24,  82}, {145,  12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_DISPLAY_RESOLUTION,                STR_DISPLAY_RESOLUTION_TIP               ), // Resolution
-    MakeWidget        ({155,  83}, {145,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_ARG_16_RESOLUTION_X_BY_Y                                                    ),
-    MakeWidget        ({288,  84}, { 11,  10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,                    STR_DISPLAY_RESOLUTION_TIP               ),
-    MakeWidget        ({ 10,  98}, {145,  12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_UI_SCALING_DESC,                   STR_WINDOW_SCALE_TIP                     ), // Scale
-    MakeSpinnerWidgets({155,  98}, {145,  12}, WindowWidgetType::Spinner,      WindowColour::Secondary, STR_NONE,                              STR_WINDOW_SCALE_TIP                     ), // Scale spinner (3 widgets)
-    MakeWidget        ({ 10, 113}, {145,  12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_DRAWING_ENGINE,                    STR_DRAWING_ENGINE_TIP                   ), // Drawing engine
-    MakeWidget        ({155, 113}, {145,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                                                  ), // Drawing engine
-    MakeWidget        ({288, 114}, { 11,  10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,                    STR_DRAWING_ENGINE_TIP                   ),
-    MakeWidget        ({ 11, 144}, {280,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_STEAM_OVERLAY_PAUSE,               STR_STEAM_OVERLAY_PAUSE_TIP              ), // Pause on steam overlay
-    MakeWidget        ({ 11, 161}, {143,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_UNCAP_FPS,                         STR_UNCAP_FPS_TIP                        ), // Uncap fps
-    MakeWidget        ({155, 161}, {136,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_SHOW_FPS,                          STR_SHOW_FPS_TIP                         ), // Show fps
-    MakeWidget        ({155, 176}, {136,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_MULTITHREADING,                    STR_MULTITHREADING_TIP                   ), // Multithreading
-    MakeWidget        ({ 11, 176}, {143,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_USE_VSYNC,                         STR_USE_VSYNC_TIP                        ), // Use vsync
-    MakeWidget        ({ 11, 191}, {280,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_MINIMISE_FULLSCREEN_ON_FOCUS_LOSS, STR_MINIMISE_FULLSCREEN_ON_FOCUS_LOSS_TIP), // Minimise fullscreen focus loss
-    MakeWidget        ({ 11, 206}, {280,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_DISABLE_SCREENSAVER,               STR_DISABLE_SCREENSAVER_TIP              ), // Disable screensaver
-    kWidgetsEnd,
-};
+    static Widget window_options_display_widgets[] = {
+        MAIN_OPTIONS_WIDGETS,
+        MakeWidget        ({  5,  53}, {300, 170}, WindowWidgetType::Groupbox,     WindowColour::Secondary, STR_HARDWARE_GROUP                                                              ), // Hardware group
+        MakeWidget        ({ 10,  67}, {145,  12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_FULLSCREEN_MODE,                   STR_FULLSCREEN_MODE_TIP                  ), // Fullscreen
+        MakeWidget        ({155,  68}, {145,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                                                  ),
+        MakeWidget        ({288,  69}, { 11,  10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,                    STR_FULLSCREEN_MODE_TIP                  ),
+        MakeWidget        ({ 24,  82}, {145,  12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_DISPLAY_RESOLUTION,                STR_DISPLAY_RESOLUTION_TIP               ), // Resolution
+        MakeWidget        ({155,  83}, {145,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_ARG_16_RESOLUTION_X_BY_Y                                                    ),
+        MakeWidget        ({288,  84}, { 11,  10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,                    STR_DISPLAY_RESOLUTION_TIP               ),
+        MakeWidget        ({ 10,  98}, {145,  12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_UI_SCALING_DESC,                   STR_WINDOW_SCALE_TIP                     ), // Scale
+        MakeSpinnerWidgets({155,  98}, {145,  12}, WindowWidgetType::Spinner,      WindowColour::Secondary, STR_NONE,                              STR_WINDOW_SCALE_TIP                     ), // Scale spinner (3 widgets)
+        MakeWidget        ({ 10, 113}, {145,  12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_DRAWING_ENGINE,                    STR_DRAWING_ENGINE_TIP                   ), // Drawing engine
+        MakeWidget        ({155, 113}, {145,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                                                  ), // Drawing engine
+        MakeWidget        ({288, 114}, { 11,  10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,                    STR_DRAWING_ENGINE_TIP                   ),
+        MakeWidget        ({ 11, 144}, {280,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_STEAM_OVERLAY_PAUSE,               STR_STEAM_OVERLAY_PAUSE_TIP              ), // Pause on steam overlay
+        MakeWidget        ({ 11, 161}, {143,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_UNCAP_FPS,                         STR_UNCAP_FPS_TIP                        ), // Uncap fps
+        MakeWidget        ({155, 161}, {136,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_SHOW_FPS,                          STR_SHOW_FPS_TIP                         ), // Show fps
+        MakeWidget        ({155, 176}, {136,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_MULTITHREADING,                    STR_MULTITHREADING_TIP                   ), // Multithreading
+        MakeWidget        ({ 11, 176}, {143,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_USE_VSYNC,                         STR_USE_VSYNC_TIP                        ), // Use vsync
+        MakeWidget        ({ 11, 191}, {280,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_MINIMISE_FULLSCREEN_ON_FOCUS_LOSS, STR_MINIMISE_FULLSCREEN_ON_FOCUS_LOSS_TIP), // Minimise fullscreen focus loss
+        MakeWidget        ({ 11, 206}, {280,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_DISABLE_SCREENSAVER,               STR_DISABLE_SCREENSAVER_TIP              ), // Disable screensaver
+        kWidgetsEnd,
+    };
 
-constexpr int32_t kFrameRenderingStart = 53;
-constexpr int32_t kFrameEffectStart = 163;
+    constexpr int32_t kFrameRenderingStart = 53;
+    constexpr int32_t kFrameEffectStart = 163;
 
-static Widget window_options_rendering_widgets[] = {
-    MAIN_OPTIONS_WIDGETS,
-    MakeWidget({  5,  kFrameRenderingStart + 0}, {300, 108}, WindowWidgetType::Groupbox,     WindowColour::Secondary, STR_RENDERING_GROUP                                       ), // Rendering group
-    MakeWidget({ 10, kFrameRenderingStart + 15}, {281,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_TILE_SMOOTHING,         STR_TILE_SMOOTHING_TIP        ), // Landscape smoothing
-    MakeWidget({ 10, kFrameRenderingStart + 30}, {281,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_GRIDLINES,              STR_GRIDLINES_TIP             ), // Gridlines
-    MakeWidget({ 10, kFrameRenderingStart + 45}, {281,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_UPPERCASE_BANNERS,      STR_UPPERCASE_BANNERS_TIP     ), // Uppercase banners
-    MakeWidget({ 10, kFrameRenderingStart + 60}, {281,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_SHOW_GUEST_PURCHASES,   STR_SHOW_GUEST_PURCHASES_TIP  ), // Guest purchases
-    MakeWidget({ 10, kFrameRenderingStart + 75}, {281,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_TRANSPARENT_SCREENSHOT, STR_TRANSPARENT_SCREENSHOT_TIP), // Transparent screenshot
-    MakeWidget({ 10, kFrameRenderingStart + 90}, {281,  12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_VIRTUAL_FLOOR_STYLE,    STR_VIRTUAL_FLOOR_STYLE_TIP   ), // Virtual floor
-    MakeWidget({155, kFrameRenderingStart + 90}, {145,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_NONE,                   STR_VIRTUAL_FLOOR_STYLE_TIP   ), // Virtual floor dropdown
-    MakeWidget({288, kFrameRenderingStart + 91}, { 11,  10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,         STR_VIRTUAL_FLOOR_STYLE_TIP   ), // Virtual floor dropdown
+    static Widget window_options_rendering_widgets[] = {
+        MAIN_OPTIONS_WIDGETS,
+        MakeWidget({  5,  kFrameRenderingStart + 0}, {300, 108}, WindowWidgetType::Groupbox,     WindowColour::Secondary, STR_RENDERING_GROUP                                       ), // Rendering group
+        MakeWidget({ 10, kFrameRenderingStart + 15}, {281,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_TILE_SMOOTHING,         STR_TILE_SMOOTHING_TIP        ), // Landscape smoothing
+        MakeWidget({ 10, kFrameRenderingStart + 30}, {281,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_GRIDLINES,              STR_GRIDLINES_TIP             ), // Gridlines
+        MakeWidget({ 10, kFrameRenderingStart + 45}, {281,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_UPPERCASE_BANNERS,      STR_UPPERCASE_BANNERS_TIP     ), // Uppercase banners
+        MakeWidget({ 10, kFrameRenderingStart + 60}, {281,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_SHOW_GUEST_PURCHASES,   STR_SHOW_GUEST_PURCHASES_TIP  ), // Guest purchases
+        MakeWidget({ 10, kFrameRenderingStart + 75}, {281,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_TRANSPARENT_SCREENSHOT, STR_TRANSPARENT_SCREENSHOT_TIP), // Transparent screenshot
+        MakeWidget({ 10, kFrameRenderingStart + 90}, {281,  12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_VIRTUAL_FLOOR_STYLE,    STR_VIRTUAL_FLOOR_STYLE_TIP   ), // Virtual floor
+        MakeWidget({155, kFrameRenderingStart + 90}, {145,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_NONE,                   STR_VIRTUAL_FLOOR_STYLE_TIP   ), // Virtual floor dropdown
+        MakeWidget({288, kFrameRenderingStart + 91}, { 11,  10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,         STR_VIRTUAL_FLOOR_STYLE_TIP   ), // Virtual floor dropdown
 
-    MakeWidget({ 5,  kFrameEffectStart + 0}, {300, 94}, WindowWidgetType::Groupbox, WindowColour::Secondary, STR_EFFECTS_GROUP                                             ), // Rendering group
-    MakeWidget({10, kFrameEffectStart + 15}, {281, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CYCLE_DAY_NIGHT,          STR_CYCLE_DAY_NIGHT_TIP         ), // Cycle day-night
-    MakeWidget({25, kFrameEffectStart + 30}, {266, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_ENABLE_LIGHTING_EFFECTS,  STR_ENABLE_LIGHTING_EFFECTS_TIP ), // Enable light fx
-    MakeWidget({40, kFrameEffectStart + 45}, {251, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_ENABLE_LIGHTING_VEHICLES, STR_ENABLE_LIGHTING_VEHICLES_TIP), // Enable light fx for vehicles
-    MakeWidget({10, kFrameEffectStart + 60}, {281, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_RENDER_WEATHER_EFFECTS,   STR_RENDER_WEATHER_EFFECTS_TIP  ), // Render weather effects
-    MakeWidget({25, kFrameEffectStart + 75}, {266, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_DISABLE_LIGHTNING_EFFECT, STR_DISABLE_LIGHTNING_EFFECT_TIP), // Disable lightning effect
-    kWidgetsEnd,
-};
+        MakeWidget({ 5,  kFrameEffectStart + 0}, {300, 94}, WindowWidgetType::Groupbox, WindowColour::Secondary, STR_EFFECTS_GROUP                                             ), // Rendering group
+        MakeWidget({10, kFrameEffectStart + 15}, {281, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CYCLE_DAY_NIGHT,          STR_CYCLE_DAY_NIGHT_TIP         ), // Cycle day-night
+        MakeWidget({25, kFrameEffectStart + 30}, {266, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_ENABLE_LIGHTING_EFFECTS,  STR_ENABLE_LIGHTING_EFFECTS_TIP ), // Enable light fx
+        MakeWidget({40, kFrameEffectStart + 45}, {251, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_ENABLE_LIGHTING_VEHICLES, STR_ENABLE_LIGHTING_VEHICLES_TIP), // Enable light fx for vehicles
+        MakeWidget({10, kFrameEffectStart + 60}, {281, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_RENDER_WEATHER_EFFECTS,   STR_RENDER_WEATHER_EFFECTS_TIP  ), // Render weather effects
+        MakeWidget({25, kFrameEffectStart + 75}, {266, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_DISABLE_LIGHTNING_EFFECT, STR_DISABLE_LIGHTNING_EFFECT_TIP), // Disable lightning effect
+        kWidgetsEnd,
+    };
 
-static Widget window_options_culture_widgets[] = {
-    MAIN_OPTIONS_WIDGETS,
-    MakeWidget({ 10,  53}, {145, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_OPTIONS_LANGUAGE,   STR_LANGUAGE_TIP           ), // language
-    MakeWidget({155,  53}, {145, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_STRING                                         ),
-    MakeWidget({288,  54}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,     STR_LANGUAGE_TIP           ),
-    MakeWidget({ 10,  68}, {145, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_CURRENCY,           STR_CURRENCY_TIP           ), // Currency
-    MakeWidget({155,  68}, {145, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                     ),
-    MakeWidget({288,  69}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,     STR_CURRENCY_TIP           ),
-    MakeWidget({ 10,  83}, {145, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_DISTANCE_AND_SPEED, STR_DISTANCE_AND_SPEED_TIP ), // Distance and speed
-    MakeWidget({155,  83}, {145, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                     ),
-    MakeWidget({288,  84}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,     STR_DISTANCE_AND_SPEED_TIP ),
-    MakeWidget({ 10,  98}, {145, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_TEMPERATURE,        STR_TEMPERATURE_FORMAT_TIP ), // Temperature
-    MakeWidget({155,  98}, {145, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                     ),
-    MakeWidget({288,  99}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,     STR_TEMPERATURE_FORMAT_TIP ),
-    MakeWidget({ 10, 113}, {145, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_HEIGHT_LABELS,      STR_HEIGHT_LABELS_UNITS_TIP), // Height labels
-    MakeWidget({155, 113}, {145, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                     ),
-    MakeWidget({288, 114}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,     STR_HEIGHT_LABELS_UNITS_TIP),
-    MakeWidget({ 10, 128}, {145, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_DATE_FORMAT,        STR_DATE_FORMAT_TIP        ), // Date format
-    MakeWidget({155, 128}, {145, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                     ),
-    MakeWidget({288, 129}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,     STR_DATE_FORMAT_TIP        ),
-    kWidgetsEnd,
-};
+    static Widget window_options_culture_widgets[] = {
+        MAIN_OPTIONS_WIDGETS,
+        MakeWidget({ 10,  53}, {145, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_OPTIONS_LANGUAGE,   STR_LANGUAGE_TIP           ), // language
+        MakeWidget({155,  53}, {145, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_STRING                                         ),
+        MakeWidget({288,  54}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,     STR_LANGUAGE_TIP           ),
+        MakeWidget({ 10,  68}, {145, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_CURRENCY,           STR_CURRENCY_TIP           ), // Currency
+        MakeWidget({155,  68}, {145, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                     ),
+        MakeWidget({288,  69}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,     STR_CURRENCY_TIP           ),
+        MakeWidget({ 10,  83}, {145, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_DISTANCE_AND_SPEED, STR_DISTANCE_AND_SPEED_TIP ), // Distance and speed
+        MakeWidget({155,  83}, {145, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                     ),
+        MakeWidget({288,  84}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,     STR_DISTANCE_AND_SPEED_TIP ),
+        MakeWidget({ 10,  98}, {145, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_TEMPERATURE,        STR_TEMPERATURE_FORMAT_TIP ), // Temperature
+        MakeWidget({155,  98}, {145, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                     ),
+        MakeWidget({288,  99}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,     STR_TEMPERATURE_FORMAT_TIP ),
+        MakeWidget({ 10, 113}, {145, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_HEIGHT_LABELS,      STR_HEIGHT_LABELS_UNITS_TIP), // Height labels
+        MakeWidget({155, 113}, {145, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                     ),
+        MakeWidget({288, 114}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,     STR_HEIGHT_LABELS_UNITS_TIP),
+        MakeWidget({ 10, 128}, {145, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_DATE_FORMAT,        STR_DATE_FORMAT_TIP        ), // Date format
+        MakeWidget({155, 128}, {145, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                     ),
+        MakeWidget({288, 129}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,     STR_DATE_FORMAT_TIP        ),
+        kWidgetsEnd,
+    };
 
-static Widget window_options_audio_widgets[] = {
-    MAIN_OPTIONS_WIDGETS,
-    MakeWidget({ 10,  53}, {290, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                ), // Audio device
-    MakeWidget({288,  54}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,      STR_AUDIO_DEVICE_TIP ),
-    MakeWidget({ 10,  69}, {220, 12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_MASTER_VOLUME,       STR_MASTER_VOLUME_TIP), // Enable / disable master sound
-    MakeWidget({ 10,  84}, {220, 12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_SOUND_EFFECTS,       STR_SOUND_EFFECTS_TIP), // Enable / disable sound effects
-    MakeWidget({ 10,  99}, {220, 12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_RIDE_MUSIC,          STR_RIDE_MUSIC_TIP   ), // Enable / disable ride music
-    MakeWidget({ 10, 113}, {290, 13}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_AUDIO_FOCUS,         STR_AUDIO_FOCUS_TIP  ), // Enable / disable audio disabled on focus lost
-    MakeWidget({ 10, 128}, {145, 13}, WindowWidgetType::Label,        WindowColour::Secondary, STR_OPTIONS_MUSIC_LABEL, STR_TITLE_MUSIC_TIP  ), // Title music label
-    MakeWidget({155, 127}, {145, 13}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                ), // Title music
-    MakeWidget({288, 128}, { 11, 11}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,      STR_TITLE_MUSIC_TIP  ),
-    MakeWidget({155,  68}, {145, 13}, WindowWidgetType::Scroll,       WindowColour::Secondary, SCROLL_HORIZONTAL                             ), // Master volume
-    MakeWidget({155,  83}, {145, 13}, WindowWidgetType::Scroll,       WindowColour::Secondary, SCROLL_HORIZONTAL                             ), // Sound effect volume
-    MakeWidget({155,  98}, {145, 13}, WindowWidgetType::Scroll,       WindowColour::Secondary, SCROLL_HORIZONTAL                             ), // Music volume
-    kWidgetsEnd,
-};
+    static Widget window_options_audio_widgets[] = {
+        MAIN_OPTIONS_WIDGETS,
+        MakeWidget({ 10,  53}, {290, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                ), // Audio device
+        MakeWidget({288,  54}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,      STR_AUDIO_DEVICE_TIP ),
+        MakeWidget({ 10,  69}, {220, 12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_MASTER_VOLUME,       STR_MASTER_VOLUME_TIP), // Enable / disable master sound
+        MakeWidget({ 10,  84}, {220, 12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_SOUND_EFFECTS,       STR_SOUND_EFFECTS_TIP), // Enable / disable sound effects
+        MakeWidget({ 10,  99}, {220, 12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_RIDE_MUSIC,          STR_RIDE_MUSIC_TIP   ), // Enable / disable ride music
+        MakeWidget({ 10, 113}, {290, 13}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_AUDIO_FOCUS,         STR_AUDIO_FOCUS_TIP  ), // Enable / disable audio disabled on focus lost
+        MakeWidget({ 10, 128}, {145, 13}, WindowWidgetType::Label,        WindowColour::Secondary, STR_OPTIONS_MUSIC_LABEL, STR_TITLE_MUSIC_TIP  ), // Title music label
+        MakeWidget({155, 127}, {145, 13}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                ), // Title music
+        MakeWidget({288, 128}, { 11, 11}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,      STR_TITLE_MUSIC_TIP  ),
+        MakeWidget({155,  68}, {145, 13}, WindowWidgetType::Scroll,       WindowColour::Secondary, SCROLL_HORIZONTAL                             ), // Master volume
+        MakeWidget({155,  83}, {145, 13}, WindowWidgetType::Scroll,       WindowColour::Secondary, SCROLL_HORIZONTAL                             ), // Sound effect volume
+        MakeWidget({155,  98}, {145, 13}, WindowWidgetType::Scroll,       WindowColour::Secondary, SCROLL_HORIZONTAL                             ), // Music volume
+        kWidgetsEnd,
+    };
 
-constexpr int32_t kControlsGroupStart = 53;
-constexpr int32_t kThemesGroupStart = 193;
-constexpr int32_t kToolbarGroupStart = 245;
+    constexpr int32_t kControlsGroupStart = 53;
+    constexpr int32_t kThemesGroupStart = 193;
+    constexpr int32_t kToolbarGroupStart = 245;
 
-static Widget window_options_controls_and_interface_widgets[] = {
-    MAIN_OPTIONS_WIDGETS,
-    MakeWidget({  5, kControlsGroupStart +  0},  {300,137}, WindowWidgetType::Groupbox, WindowColour::Secondary, STR_CONTROLS_GROUP                                                ), // Controls group
-    MakeWidget({ 10, kControlsGroupStart + 13},  {290, 14}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_SCREEN_EDGE_SCROLLING,      STR_SCREEN_EDGE_SCROLLING_TIP     ), // Edge scrolling
-    MakeWidget({ 10, kControlsGroupStart + 30},  {290, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_TRAP_MOUSE,                 STR_TRAP_MOUSE_TIP                ), // Trap mouse
-    MakeWidget({ 10, kControlsGroupStart + 45},  {290, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_INVERT_RIGHT_MOUSE_DRAG,    STR_INVERT_RIGHT_MOUSE_DRAG_TIP   ), // Invert right mouse dragging
-    MakeWidget({ 10, kControlsGroupStart + 60},  {290, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_ZOOM_TO_CURSOR,             STR_ZOOM_TO_CURSOR_TIP            ), // Zoom to cursor
-    MakeWidget({ 10, kControlsGroupStart + 75},  {290, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary,  STR_WINDOW_BUTTONS_ON_THE_LEFT, STR_WINDOW_BUTTONS_ON_THE_LEFT_TIP), // Window buttons on the left
-    MakeWidget({ 10, kControlsGroupStart + 90},  {290, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary,  STR_ENLARGED_UI,                STR_ENLARGED_UI_TIP               ),
-    MakeWidget({ 25, kControlsGroupStart + 105}, {275, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary,  STR_TOUCH_ENHANCEMENTS,         STR_TOUCH_ENHANCEMENTS_TIP        ),
-    MakeWidget({155, kControlsGroupStart + 120}, {145, 13}, WindowWidgetType::Button,   WindowColour::Secondary, STR_HOTKEY,                     STR_HOTKEY_TIP                    ), // Set hotkeys buttons
+    static Widget window_options_controls_and_interface_widgets[] = {
+        MAIN_OPTIONS_WIDGETS,
+        MakeWidget({  5, kControlsGroupStart +  0},  {300,137}, WindowWidgetType::Groupbox, WindowColour::Secondary, STR_CONTROLS_GROUP                                                ), // Controls group
+        MakeWidget({ 10, kControlsGroupStart + 13},  {290, 14}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_SCREEN_EDGE_SCROLLING,      STR_SCREEN_EDGE_SCROLLING_TIP     ), // Edge scrolling
+        MakeWidget({ 10, kControlsGroupStart + 30},  {290, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_TRAP_MOUSE,                 STR_TRAP_MOUSE_TIP                ), // Trap mouse
+        MakeWidget({ 10, kControlsGroupStart + 45},  {290, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_INVERT_RIGHT_MOUSE_DRAG,    STR_INVERT_RIGHT_MOUSE_DRAG_TIP   ), // Invert right mouse dragging
+        MakeWidget({ 10, kControlsGroupStart + 60},  {290, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_ZOOM_TO_CURSOR,             STR_ZOOM_TO_CURSOR_TIP            ), // Zoom to cursor
+        MakeWidget({ 10, kControlsGroupStart + 75},  {290, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary,  STR_WINDOW_BUTTONS_ON_THE_LEFT, STR_WINDOW_BUTTONS_ON_THE_LEFT_TIP), // Window buttons on the left
+        MakeWidget({ 10, kControlsGroupStart + 90},  {290, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary,  STR_ENLARGED_UI,                STR_ENLARGED_UI_TIP               ),
+        MakeWidget({ 25, kControlsGroupStart + 105}, {275, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary,  STR_TOUCH_ENHANCEMENTS,         STR_TOUCH_ENHANCEMENTS_TIP        ),
+        MakeWidget({155, kControlsGroupStart + 120}, {145, 13}, WindowWidgetType::Button,   WindowColour::Secondary, STR_HOTKEY,                     STR_HOTKEY_TIP                    ), // Set hotkeys buttons
 
-    MakeWidget({  5, kThemesGroupStart +  0}, {300, 48}, WindowWidgetType::Groupbox,     WindowColour::Secondary, STR_THEMES_GROUP                                          ), // Themes group
-    MakeWidget({ 10, kThemesGroupStart + 14}, {145, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_THEMES_LABEL_CURRENT_THEME, STR_CURRENT_THEME_TIP     ), // Themes
-    MakeWidget({155, kThemesGroupStart + 14}, {145, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_STRING                                                ),
-    MakeWidget({288, kThemesGroupStart + 15}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,             STR_CURRENT_THEME_TIP     ),
-    MakeWidget({155, kThemesGroupStart + 30}, {145, 13}, WindowWidgetType::Button,       WindowColour::Secondary, STR_EDIT_THEMES_BUTTON,         STR_EDIT_THEMES_BUTTON_TIP), // Themes button
+        MakeWidget({  5, kThemesGroupStart +  0}, {300, 48}, WindowWidgetType::Groupbox,     WindowColour::Secondary, STR_THEMES_GROUP                                          ), // Themes group
+        MakeWidget({ 10, kThemesGroupStart + 14}, {145, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_THEMES_LABEL_CURRENT_THEME, STR_CURRENT_THEME_TIP     ), // Themes
+        MakeWidget({155, kThemesGroupStart + 14}, {145, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_STRING                                                ),
+        MakeWidget({288, kThemesGroupStart + 15}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,             STR_CURRENT_THEME_TIP     ),
+        MakeWidget({155, kThemesGroupStart + 30}, {145, 13}, WindowWidgetType::Button,       WindowColour::Secondary, STR_EDIT_THEMES_BUTTON,         STR_EDIT_THEMES_BUTTON_TIP), // Themes button
 
-    MakeWidget({  5, kToolbarGroupStart +  0}, {300,107}, WindowWidgetType::Groupbox, WindowColour::Secondary, STR_TOOLBAR_BUTTONS_GROUP                                                   ), // Toolbar buttons group
-    MakeWidget({ 10, kToolbarGroupStart + 14}, {280, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary,  STR_OPTIONS_TOOLBAR_BUTTONS_CENTRED, STR_OPTIONS_TOOLBAR_BUTTONS_CENTRED_TIP),
-    MakeWidget({ 10, kToolbarGroupStart + 31}, {280, 12}, WindowWidgetType::Label,    WindowColour::Secondary, STR_SHOW_TOOLBAR_BUTTONS_FOR                                                ),
-    MakeWidget({ 24, kToolbarGroupStart + 46}, {122, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_FINANCES_BUTTON_ON_TOOLBAR,      STR_FINANCES_BUTTON_ON_TOOLBAR_TIP     ), // Finances
-    MakeWidget({ 24, kToolbarGroupStart + 61}, {122, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_RESEARCH_BUTTON_ON_TOOLBAR,      STR_RESEARCH_BUTTON_ON_TOOLBAR_TIP     ), // Research
-    MakeWidget({155, kToolbarGroupStart + 46}, {145, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_CHEATS_BUTTON_ON_TOOLBAR,        STR_CHEATS_BUTTON_ON_TOOLBAR_TIP       ), // Cheats
-    MakeWidget({155, kToolbarGroupStart + 61}, {145, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_SHOW_RECENT_MESSAGES_ON_TOOLBAR, STR_SHOW_RECENT_MESSAGES_ON_TOOLBAR_TIP), // Recent messages
-    MakeWidget({ 24, kToolbarGroupStart + 76}, {162, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_MUTE_BUTTON_ON_TOOLBAR,          STR_MUTE_BUTTON_ON_TOOLBAR_TIP         ), // Mute
-    MakeWidget({155, kToolbarGroupStart + 76}, {145, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_CHAT_BUTTON_ON_TOOLBAR,          STR_CHAT_BUTTON_ON_TOOLBAR_TIP         ), // Chat
-    MakeWidget({ 24, kToolbarGroupStart + 91}, {122, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_ZOOM_BUTTON_ON_TOOLBAR,          STR_ZOOM_BUTTON_ON_TOOLBAR_TIP         ), // Zoom
-    kWidgetsEnd,
-};
+        MakeWidget({  5, kToolbarGroupStart +  0}, {300,107}, WindowWidgetType::Groupbox, WindowColour::Secondary, STR_TOOLBAR_BUTTONS_GROUP                                                   ), // Toolbar buttons group
+        MakeWidget({ 10, kToolbarGroupStart + 14}, {280, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary,  STR_OPTIONS_TOOLBAR_BUTTONS_CENTRED, STR_OPTIONS_TOOLBAR_BUTTONS_CENTRED_TIP),
+        MakeWidget({ 10, kToolbarGroupStart + 31}, {280, 12}, WindowWidgetType::Label,    WindowColour::Secondary, STR_SHOW_TOOLBAR_BUTTONS_FOR                                                ),
+        MakeWidget({ 24, kToolbarGroupStart + 46}, {122, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_FINANCES_BUTTON_ON_TOOLBAR,      STR_FINANCES_BUTTON_ON_TOOLBAR_TIP     ), // Finances
+        MakeWidget({ 24, kToolbarGroupStart + 61}, {122, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_RESEARCH_BUTTON_ON_TOOLBAR,      STR_RESEARCH_BUTTON_ON_TOOLBAR_TIP     ), // Research
+        MakeWidget({155, kToolbarGroupStart + 46}, {145, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_CHEATS_BUTTON_ON_TOOLBAR,        STR_CHEATS_BUTTON_ON_TOOLBAR_TIP       ), // Cheats
+        MakeWidget({155, kToolbarGroupStart + 61}, {145, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_SHOW_RECENT_MESSAGES_ON_TOOLBAR, STR_SHOW_RECENT_MESSAGES_ON_TOOLBAR_TIP), // Recent messages
+        MakeWidget({ 24, kToolbarGroupStart + 76}, {162, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_MUTE_BUTTON_ON_TOOLBAR,          STR_MUTE_BUTTON_ON_TOOLBAR_TIP         ), // Mute
+        MakeWidget({155, kToolbarGroupStart + 76}, {145, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_CHAT_BUTTON_ON_TOOLBAR,          STR_CHAT_BUTTON_ON_TOOLBAR_TIP         ), // Chat
+        MakeWidget({ 24, kToolbarGroupStart + 91}, {122, 12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_ZOOM_BUTTON_ON_TOOLBAR,          STR_ZOOM_BUTTON_ON_TOOLBAR_TIP         ), // Zoom
+        kWidgetsEnd,
+    };
 
-constexpr int32_t kTitleSequenceStart = 53;
-constexpr int32_t kScenarioGroupStart = kTitleSequenceStart + 35;
-constexpr int32_t kScenarioOptionsGroupStart = kScenarioGroupStart + 55;
-constexpr int32_t kTweaksStart = kScenarioOptionsGroupStart + 39;
+    constexpr int32_t kTitleSequenceStart = 53;
+    constexpr int32_t kScenarioGroupStart = kTitleSequenceStart + 35;
+    constexpr int32_t kScenarioOptionsGroupStart = kScenarioGroupStart + 55;
+    constexpr int32_t kTweaksStart = kScenarioOptionsGroupStart + 39;
 
-static Widget window_options_misc_widgets[] = {
-    MAIN_OPTIONS_WIDGETS,
-    MakeWidget(         {  5, kTitleSequenceStart +  0}, {300, 31}, WindowWidgetType::Groupbox,     WindowColour::Secondary, STR_OPTIONS_TITLE_SEQUENCE                        ),
-    MakeDropdownWidgets({ 10, kTitleSequenceStart + 15}, {290, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_STRINGID,               STR_TITLE_SEQUENCE_TIP), // Title sequence dropdown
+    static Widget window_options_misc_widgets[] = {
+        MAIN_OPTIONS_WIDGETS,
+        MakeWidget(         {  5, kTitleSequenceStart +  0}, {300, 31}, WindowWidgetType::Groupbox,     WindowColour::Secondary, STR_OPTIONS_TITLE_SEQUENCE                        ),
+        MakeDropdownWidgets({ 10, kTitleSequenceStart + 15}, {290, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_STRINGID,               STR_TITLE_SEQUENCE_TIP), // Title sequence dropdown
 
-    MakeWidget({  5,  kScenarioGroupStart + 0}, {300, 51}, WindowWidgetType::Groupbox,     WindowColour::Secondary, STR_OPTIONS_SCENARIO_SELECTION                            ),
-    MakeWidget({ 10, kScenarioGroupStart + 16}, {165, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_OPTIONS_SCENARIO_GROUPING,  STR_SCENARIO_GROUPING_TIP ),
-    MakeWidget({175, kScenarioGroupStart + 15}, {125, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                            ), // Scenario select mode
-    MakeWidget({288, kScenarioGroupStart + 16}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,             STR_SCENARIO_GROUPING_TIP ),
-    MakeWidget({ 25, kScenarioGroupStart + 30}, {275, 16}, WindowWidgetType::Checkbox,     WindowColour::Tertiary , STR_OPTIONS_SCENARIO_UNLOCKING, STR_SCENARIO_UNLOCKING_TIP), // Unlocking of scenarios
+        MakeWidget({  5,  kScenarioGroupStart + 0}, {300, 51}, WindowWidgetType::Groupbox,     WindowColour::Secondary, STR_OPTIONS_SCENARIO_SELECTION                            ),
+        MakeWidget({ 10, kScenarioGroupStart + 16}, {165, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_OPTIONS_SCENARIO_GROUPING,  STR_SCENARIO_GROUPING_TIP ),
+        MakeWidget({175, kScenarioGroupStart + 15}, {125, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                            ), // Scenario select mode
+        MakeWidget({288, kScenarioGroupStart + 16}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,             STR_SCENARIO_GROUPING_TIP ),
+        MakeWidget({ 25, kScenarioGroupStart + 30}, {275, 16}, WindowWidgetType::Checkbox,     WindowColour::Tertiary , STR_OPTIONS_SCENARIO_UNLOCKING, STR_SCENARIO_UNLOCKING_TIP), // Unlocking of scenarios
 
-    MakeWidget({ 5,  kScenarioOptionsGroupStart + 0}, {300, 35}, WindowWidgetType::Groupbox, WindowColour::Secondary, STR_SCENARIO_OPTIONS                                ),
-    MakeWidget({10, kScenarioOptionsGroupStart + 15}, {290, 15}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_ALLOW_EARLY_COMPLETION, STR_EARLY_COMPLETION_TIP), // Allow early scenario completion
+        MakeWidget({ 5,  kScenarioOptionsGroupStart + 0}, {300, 35}, WindowWidgetType::Groupbox, WindowColour::Secondary, STR_SCENARIO_OPTIONS                                ),
+        MakeWidget({10, kScenarioOptionsGroupStart + 15}, {290, 15}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_ALLOW_EARLY_COMPLETION, STR_EARLY_COMPLETION_TIP), // Allow early scenario completion
 
-    MakeWidget({  5,  kTweaksStart + 0}, {300, 81}, WindowWidgetType::Groupbox,     WindowColour::Secondary, STR_OPTIONS_TWEAKS                                                  ),
-    MakeWidget({ 10, kTweaksStart + 15}, {290, 15}, WindowWidgetType::Checkbox,     WindowColour::Tertiary , STR_REAL_NAME,            STR_REAL_NAME_TIP                         ), // Show 'real' names of guests
-    MakeWidget({ 10, kTweaksStart + 30}, {290, 15}, WindowWidgetType::Checkbox,     WindowColour::Tertiary , STR_AUTO_STAFF_PLACEMENT, STR_AUTO_STAFF_PLACEMENT_TIP              ), // Auto staff placement
-    MakeWidget({ 10, kTweaksStart + 45}, {290, 15}, WindowWidgetType::Checkbox,     WindowColour::Tertiary , STR_AUTO_OPEN_SHOPS,      STR_AUTO_OPEN_SHOPS_TIP                   ), // Automatically open shops & stalls
-    MakeWidget({ 10, kTweaksStart + 62}, {165, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_DEFAULT_INSPECTION_INTERVAL, STR_DEFAULT_INSPECTION_INTERVAL_TIP),
-    MakeWidget({175, kTweaksStart + 61}, {125, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                                      ), // Default inspection time dropdown
-    MakeWidget({288, kTweaksStart + 62}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,       STR_DEFAULT_INSPECTION_INTERVAL_TIP       ), // Default inspection time dropdown button
-    kWidgetsEnd,
-};
+        MakeWidget({  5,  kTweaksStart + 0}, {300, 81}, WindowWidgetType::Groupbox,     WindowColour::Secondary, STR_OPTIONS_TWEAKS                                                  ),
+        MakeWidget({ 10, kTweaksStart + 15}, {290, 15}, WindowWidgetType::Checkbox,     WindowColour::Tertiary , STR_REAL_NAME,            STR_REAL_NAME_TIP                         ), // Show 'real' names of guests
+        MakeWidget({ 10, kTweaksStart + 30}, {290, 15}, WindowWidgetType::Checkbox,     WindowColour::Tertiary , STR_AUTO_STAFF_PLACEMENT, STR_AUTO_STAFF_PLACEMENT_TIP              ), // Auto staff placement
+        MakeWidget({ 10, kTweaksStart + 45}, {290, 15}, WindowWidgetType::Checkbox,     WindowColour::Tertiary , STR_AUTO_OPEN_SHOPS,      STR_AUTO_OPEN_SHOPS_TIP                   ), // Automatically open shops & stalls
+        MakeWidget({ 10, kTweaksStart + 62}, {165, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_DEFAULT_INSPECTION_INTERVAL, STR_DEFAULT_INSPECTION_INTERVAL_TIP),
+        MakeWidget({175, kTweaksStart + 61}, {125, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                                      ), // Default inspection time dropdown
+        MakeWidget({288, kTweaksStart + 62}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,       STR_DEFAULT_INSPECTION_INTERVAL_TIP       ), // Default inspection time dropdown button
+        kWidgetsEnd,
+    };
 
-static Widget window_options_advanced_widgets[] = {
-    MAIN_OPTIONS_WIDGETS,
-    MakeWidget        ({ 10,  54}, {290, 12}, WindowWidgetType::Checkbox,     WindowColour::Tertiary,  STR_ENABLE_DEBUGGING_TOOLS,                STR_ENABLE_DEBUGGING_TOOLS_TIP               ), // Enable debugging tools
-    MakeWidget        ({ 10,  69}, {290, 12}, WindowWidgetType::Checkbox,     WindowColour::Tertiary,  STR_SAVE_PLUGIN_DATA,                      STR_SAVE_PLUGIN_DATA_TIP                     ), // Export plug-in objects with saved games
-    MakeWidget        ({ 10,  84}, {290, 12}, WindowWidgetType::Checkbox,     WindowColour::Tertiary,  STR_STAY_CONNECTED_AFTER_DESYNC,           STR_STAY_CONNECTED_AFTER_DESYNC_TIP          ), // Do not disconnect after the client desynchronises with the server
-    MakeWidget        ({ 10,  99}, {290, 12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_ALWAYS_NATIVE_LOADSAVE,                STR_ALWAYS_NATIVE_LOADSAVE_TIP               ), // Use native load/save window
-    MakeWidget        ({ 23, 114}, {135, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_OPTIONS_AUTOSAVE_FREQUENCY_LABEL,      STR_AUTOSAVE_FREQUENCY_TIP                   ),
-    MakeWidget        ({165, 113}, {135, 13}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                                                          ), // Autosave dropdown
-    MakeWidget        ({288, 114}, { 11, 11}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,                        STR_AUTOSAVE_FREQUENCY_TIP                   ), // Autosave dropdown button
-    MakeWidget        ({ 23, 130}, {135, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_AUTOSAVE_AMOUNT,                       STR_AUTOSAVE_AMOUNT_TIP                      ),
-    MakeSpinnerWidgets({165, 130}, {135, 12}, WindowWidgetType::Spinner,      WindowColour::Secondary, STR_NONE,                                  STR_AUTOSAVE_AMOUNT_TIP                      ), // Autosave amount spinner
-    MakeWidget        ({ 23, 145}, {276, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_PATH_TO_RCT1,                          STR_PATH_TO_RCT1_TIP                         ), // RCT 1 path text
-    MakeWidget        ({ 24, 160}, {266, 14}, WindowWidgetType::Button,       WindowColour::Secondary, STR_NONE,                                  STR_STRING_TOOLTIP                           ), // RCT 1 path button
-    MakeWidget        ({289, 160}, { 11, 14}, WindowWidgetType::Button,       WindowColour::Secondary, STR_CLOSE_X,                               STR_PATH_TO_RCT1_CLEAR_TIP                   ), // RCT 1 path clear button
-    MakeWidget        ({150, 176}, {150, 14}, WindowWidgetType::Button,       WindowColour::Secondary, STR_EDIT_ASSET_PACKS_BUTTON,               STR_NONE                                     ), // Asset packs
-    kWidgetsEnd,
-};
+    static Widget window_options_advanced_widgets[] = {
+        MAIN_OPTIONS_WIDGETS,
+        MakeWidget        ({ 10,  54}, {290, 12}, WindowWidgetType::Checkbox,     WindowColour::Tertiary,  STR_ENABLE_DEBUGGING_TOOLS,                STR_ENABLE_DEBUGGING_TOOLS_TIP               ), // Enable debugging tools
+        MakeWidget        ({ 10,  69}, {290, 12}, WindowWidgetType::Checkbox,     WindowColour::Tertiary,  STR_SAVE_PLUGIN_DATA,                      STR_SAVE_PLUGIN_DATA_TIP                     ), // Export plug-in objects with saved games
+        MakeWidget        ({ 10,  84}, {290, 12}, WindowWidgetType::Checkbox,     WindowColour::Tertiary,  STR_STAY_CONNECTED_AFTER_DESYNC,           STR_STAY_CONNECTED_AFTER_DESYNC_TIP          ), // Do not disconnect after the client desynchronises with the server
+        MakeWidget        ({ 10,  99}, {290, 12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_ALWAYS_NATIVE_LOADSAVE,                STR_ALWAYS_NATIVE_LOADSAVE_TIP               ), // Use native load/save window
+        MakeWidget        ({ 23, 114}, {135, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_OPTIONS_AUTOSAVE_FREQUENCY_LABEL,      STR_AUTOSAVE_FREQUENCY_TIP                   ),
+        MakeWidget        ({165, 113}, {135, 13}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                                                          ), // Autosave dropdown
+        MakeWidget        ({288, 114}, { 11, 11}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,                        STR_AUTOSAVE_FREQUENCY_TIP                   ), // Autosave dropdown button
+        MakeWidget        ({ 23, 130}, {135, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_AUTOSAVE_AMOUNT,                       STR_AUTOSAVE_AMOUNT_TIP                      ),
+        MakeSpinnerWidgets({165, 130}, {135, 12}, WindowWidgetType::Spinner,      WindowColour::Secondary, STR_NONE,                                  STR_AUTOSAVE_AMOUNT_TIP                      ), // Autosave amount spinner
+        MakeWidget        ({ 23, 145}, {276, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_PATH_TO_RCT1,                          STR_PATH_TO_RCT1_TIP                         ), // RCT 1 path text
+        MakeWidget        ({ 24, 160}, {266, 14}, WindowWidgetType::Button,       WindowColour::Secondary, STR_NONE,                                  STR_STRING_TOOLTIP                           ), // RCT 1 path button
+        MakeWidget        ({289, 160}, { 11, 14}, WindowWidgetType::Button,       WindowColour::Secondary, STR_CLOSE_X,                               STR_PATH_TO_RCT1_CLEAR_TIP                   ), // RCT 1 path clear button
+        MakeWidget        ({150, 176}, {150, 14}, WindowWidgetType::Button,       WindowColour::Secondary, STR_EDIT_ASSET_PACKS_BUTTON,               STR_NONE                                     ), // Asset packs
+        kWidgetsEnd,
+    };
 
-static Widget *window_options_page_widgets[] = {
-    window_options_display_widgets,
-    window_options_rendering_widgets,
-    window_options_culture_widgets,
-    window_options_audio_widgets,
-    window_options_controls_and_interface_widgets,
-    window_options_misc_widgets,
-    window_options_advanced_widgets,
-};
+    static Widget *window_options_page_widgets[] = {
+        window_options_display_widgets,
+        window_options_rendering_widgets,
+        window_options_culture_widgets,
+        window_options_audio_widgets,
+        window_options_controls_and_interface_widgets,
+        window_options_misc_widgets,
+        window_options_advanced_widgets,
+    };
+    // clang-format on
 
 #pragma endregion
-    // clang-format on
 
     class OptionsWindow final : public Window
     {

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -223,7 +223,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WW = 310;
     static constexpr int32_t WH = 332;
 
-    // clang-format off
+// clang-format off
     #define MAIN_OPTIONS_WIDGETS \
         WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
         MakeWidget({  0, 43}, {WW, 289}, WindowWidgetType::Resize, WindowColour::Secondary), \

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -223,18 +223,14 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WW = 310;
     static constexpr int32_t WH = 332;
 
-// clang-format off
-    #define MAIN_OPTIONS_WIDGETS \
-        WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
-        MakeWidget({  0, 43}, {WW, 289}, WindowWidgetType::Resize, WindowColour::Secondary), \
-        MakeTab   ({  3, 17}, STR_OPTIONS_DISPLAY_TIP                       ), \
-        MakeTab   ({ 34, 17}, STR_OPTIONS_RENDERING_TIP                     ), \
-        MakeTab   ({ 65, 17}, STR_OPTIONS_CULTURE_TIP                       ), \
-        MakeTab   ({ 96, 17}, STR_OPTIONS_AUDIO_TIP                         ), \
-        MakeTab   ({127, 17}, STR_OPTIONS_CONTROLS_AND_INTERFACE_TIP        ), \
-        MakeTab   ({158, 17}, STR_OPTIONS_MISCELLANEOUS_TIP                 ), \
-        MakeTab   ({189, 17}, STR_OPTIONS_ADVANCED                          )
+#define MAIN_OPTIONS_WIDGETS                                                                                                   \
+    WINDOW_SHIM(WINDOW_TITLE, WW, WH), MakeWidget({ 0, 43 }, { WW, 289 }, WindowWidgetType::Resize, WindowColour::Secondary),  \
+        MakeTab({ 3, 17 }, STR_OPTIONS_DISPLAY_TIP), MakeTab({ 34, 17 }, STR_OPTIONS_RENDERING_TIP),                           \
+        MakeTab({ 65, 17 }, STR_OPTIONS_CULTURE_TIP), MakeTab({ 96, 17 }, STR_OPTIONS_AUDIO_TIP),                              \
+        MakeTab({ 127, 17 }, STR_OPTIONS_CONTROLS_AND_INTERFACE_TIP), MakeTab({ 158, 17 }, STR_OPTIONS_MISCELLANEOUS_TIP),     \
+        MakeTab({ 189, 17 }, STR_OPTIONS_ADVANCED)
 
+    // clang-format off
     static Widget window_options_display_widgets[] = {
         MAIN_OPTIONS_WIDGETS,
         MakeWidget        ({  5,  53}, {300, 170}, WindowWidgetType::Groupbox,     WindowColour::Secondary, STR_HARDWARE_GROUP                                                              ), // Hardware group

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -219,18 +219,22 @@ namespace OpenRCT2::Ui::Windows
         WIDX_ASSET_PACKS,
     };
 
+    // clang-format off
     static constexpr StringId WINDOW_TITLE = STR_OPTIONS_TITLE;
     static constexpr int32_t WW = 310;
     static constexpr int32_t WH = 332;
 
-#define MAIN_OPTIONS_WIDGETS                                                                                                   \
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH), MakeWidget({ 0, 43 }, { WW, 289 }, WindowWidgetType::Resize, WindowColour::Secondary),  \
-        MakeTab({ 3, 17 }, STR_OPTIONS_DISPLAY_TIP), MakeTab({ 34, 17 }, STR_OPTIONS_RENDERING_TIP),                           \
-        MakeTab({ 65, 17 }, STR_OPTIONS_CULTURE_TIP), MakeTab({ 96, 17 }, STR_OPTIONS_AUDIO_TIP),                              \
-        MakeTab({ 127, 17 }, STR_OPTIONS_CONTROLS_AND_INTERFACE_TIP), MakeTab({ 158, 17 }, STR_OPTIONS_MISCELLANEOUS_TIP),     \
+    #define MAIN_OPTIONS_WIDGETS \
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
+        MakeWidget({ 0, 43 }, { WW, 289 }, WindowWidgetType::Resize, WindowColour::Secondary), \
+        MakeTab({ 3, 17 }, STR_OPTIONS_DISPLAY_TIP), \
+        MakeTab({ 34, 17 }, STR_OPTIONS_RENDERING_TIP), \
+        MakeTab({ 65, 17 }, STR_OPTIONS_CULTURE_TIP), \
+        MakeTab({ 96, 17 }, STR_OPTIONS_AUDIO_TIP), \
+        MakeTab({ 127, 17 }, STR_OPTIONS_CONTROLS_AND_INTERFACE_TIP), \
+        MakeTab({ 158, 17 }, STR_OPTIONS_MISCELLANEOUS_TIP), \
         MakeTab({ 189, 17 }, STR_OPTIONS_ADVANCED)
 
-    // clang-format off
     static Widget window_options_display_widgets[] = {
         MAIN_OPTIONS_WIDGETS,
         MakeWidget        ({  5,  53}, {300, 170}, WindowWidgetType::Groupbox,     WindowColour::Secondary, STR_HARDWARE_GROUP                                                              ), // Hardware group

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -88,7 +88,7 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Widgets
 
-    // clang-format off
+// clang-format off
     #define MAIN_PARK_WIDGETS(WW) \
         WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
         MakeWidget({  0, 43}, {WW, 131}, WindowWidgetType::Resize, WindowColour::Secondary), /* tab content panel */ \

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -43,154 +43,158 @@ namespace OpenRCT2::Ui::Windows
     static constexpr ScreenCoordsXY kGraphBottomRightPadding{ 5, 5 };
     static constexpr uint8_t kGraphNumYLabels = 6;
 
-    // clang-format off
-enum WindowParkPage {
-    WINDOW_PARK_PAGE_ENTRANCE,
-    WINDOW_PARK_PAGE_RATING,
-    WINDOW_PARK_PAGE_GUESTS,
-    WINDOW_PARK_PAGE_PRICE,
-    WINDOW_PARK_PAGE_STATS,
-    WINDOW_PARK_PAGE_OBJECTIVE,
-    WINDOW_PARK_PAGE_AWARDS,
-    WINDOW_PARK_PAGE_COUNT,
-};
+    enum WindowParkPage
+    {
+        WINDOW_PARK_PAGE_ENTRANCE,
+        WINDOW_PARK_PAGE_RATING,
+        WINDOW_PARK_PAGE_GUESTS,
+        WINDOW_PARK_PAGE_PRICE,
+        WINDOW_PARK_PAGE_STATS,
+        WINDOW_PARK_PAGE_OBJECTIVE,
+        WINDOW_PARK_PAGE_AWARDS,
+        WINDOW_PARK_PAGE_COUNT,
+    };
 
-enum WindowParkWidgetIdx {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_PAGE_BACKGROUND,
-    WIDX_TAB_1,
-    WIDX_TAB_2,
-    WIDX_TAB_3,
-    WIDX_TAB_4,
-    WIDX_TAB_5,
-    WIDX_TAB_6,
-    WIDX_TAB_7,
+    enum WindowParkWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_PAGE_BACKGROUND,
+        WIDX_TAB_1,
+        WIDX_TAB_2,
+        WIDX_TAB_3,
+        WIDX_TAB_4,
+        WIDX_TAB_5,
+        WIDX_TAB_6,
+        WIDX_TAB_7,
 
-    WIDX_VIEWPORT = 11,
-    WIDX_STATUS,
-    WIDX_OPEN_OR_CLOSE,
-    WIDX_BUY_LAND_RIGHTS,
-    WIDX_LOCATE,
-    WIDX_RENAME,
-    WIDX_CLOSE_LIGHT,
-    WIDX_OPEN_LIGHT,
+        WIDX_VIEWPORT = 11,
+        WIDX_STATUS,
+        WIDX_OPEN_OR_CLOSE,
+        WIDX_BUY_LAND_RIGHTS,
+        WIDX_LOCATE,
+        WIDX_RENAME,
+        WIDX_CLOSE_LIGHT,
+        WIDX_OPEN_LIGHT,
 
-    WIDX_PRICE_LABEL = 11,
-    WIDX_PRICE,
-    WIDX_INCREASE_PRICE,
-    WIDX_DECREASE_PRICE,
+        WIDX_PRICE_LABEL = 11,
+        WIDX_PRICE,
+        WIDX_INCREASE_PRICE,
+        WIDX_DECREASE_PRICE,
 
-    WIDX_ENTER_NAME = 11
-};
+        WIDX_ENTER_NAME = 11
+    };
 
 #pragma region Widgets
 
-#define MAIN_PARK_WIDGETS(WW) \
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
-    MakeWidget({  0, 43}, {WW, 131}, WindowWidgetType::Resize, WindowColour::Secondary), /* tab content panel */ \
-    MakeTab   ({  3, 17}, STR_PARK_ENTRANCE_TAB_TIP                     ), /* tab 1 */ \
-    MakeTab   ({ 34, 17}, STR_PARK_RATING_TAB_TIP                       ), /* tab 2 */ \
-    MakeTab   ({ 65, 17}, STR_PARK_GUESTS_TAB_TIP                       ), /* tab 3 */ \
-    MakeTab   ({ 96, 17}, STR_PARK_PRICE_TAB_TIP                        ), /* tab 4 */ \
-    MakeTab   ({127, 17}, STR_PARK_STATS_TAB_TIP                        ), /* tab 5 */ \
-    MakeTab   ({158, 17}, STR_PARK_OBJECTIVE_TAB_TIP                    ), /* tab 6 */ \
-    MakeTab   ({189, 17}, STR_PARK_AWARDS_TAB_TIP                       )  /* tab 7 */
+    // clang-format off
+    #define MAIN_PARK_WIDGETS(WW) \
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
+        MakeWidget({  0, 43}, {WW, 131}, WindowWidgetType::Resize, WindowColour::Secondary), /* tab content panel */ \
+        MakeTab   ({  3, 17}, STR_PARK_ENTRANCE_TAB_TIP                     ), /* tab 1 */ \
+        MakeTab   ({ 34, 17}, STR_PARK_RATING_TAB_TIP                       ), /* tab 2 */ \
+        MakeTab   ({ 65, 17}, STR_PARK_GUESTS_TAB_TIP                       ), /* tab 3 */ \
+        MakeTab   ({ 96, 17}, STR_PARK_PRICE_TAB_TIP                        ), /* tab 4 */ \
+        MakeTab   ({127, 17}, STR_PARK_STATS_TAB_TIP                        ), /* tab 5 */ \
+        MakeTab   ({158, 17}, STR_PARK_OBJECTIVE_TAB_TIP                    ), /* tab 6 */ \
+        MakeTab   ({189, 17}, STR_PARK_AWARDS_TAB_TIP                       )  /* tab 7 */
 
-static Widget _entranceWidgets[] = {
-    MAIN_PARK_WIDGETS(230),
-    MakeWidget({  3,  46}, {202, 115}, WindowWidgetType::Viewport,      WindowColour::Secondary                                                                      ), // viewport
-    MakeWidget({  3, 161}, {202,  11}, WindowWidgetType::LabelCentred,  WindowColour::Secondary                                                                      ), // status
-    MakeWidget({205,  49}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, 0xFFFFFFFF,                 STR_OPEN_OR_CLOSE_PARK_TIP              ), // open / close
-    MakeWidget({205,  73}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_BUY_LAND_RIGHTS),        STR_BUY_LAND_AND_CONSTRUCTION_RIGHTS_TIP), // buy land rights
-    MakeWidget({205,  97}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_LOCATE),                 STR_LOCATE_SUBJECT_TIP                  ), // locate
-    MakeWidget({205, 121}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_RENAME),                 STR_NAME_PARK_TIP                       ), // rename
-    MakeWidget({210,  51}, { 14,  15}, WindowWidgetType::ImgBtn,        WindowColour::Secondary, ImageId(SPR_G2_RCT1_CLOSE_BUTTON_0), STR_CLOSE_PARK_TIP                      ),
-    MakeWidget({210,  66}, { 14,  14}, WindowWidgetType::ImgBtn,        WindowColour::Secondary, ImageId(SPR_G2_RCT1_OPEN_BUTTON_0),  STR_OPEN_PARK_TIP                       ),
-    kWidgetsEnd,
-};
+    static Widget _entranceWidgets[] = {
+        MAIN_PARK_WIDGETS(230),
+        MakeWidget({  3,  46}, {202, 115}, WindowWidgetType::Viewport,      WindowColour::Secondary                                                                      ), // viewport
+        MakeWidget({  3, 161}, {202,  11}, WindowWidgetType::LabelCentred,  WindowColour::Secondary                                                                      ), // status
+        MakeWidget({205,  49}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, 0xFFFFFFFF,                 STR_OPEN_OR_CLOSE_PARK_TIP              ), // open / close
+        MakeWidget({205,  73}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_BUY_LAND_RIGHTS),        STR_BUY_LAND_AND_CONSTRUCTION_RIGHTS_TIP), // buy land rights
+        MakeWidget({205,  97}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_LOCATE),                 STR_LOCATE_SUBJECT_TIP                  ), // locate
+        MakeWidget({205, 121}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_RENAME),                 STR_NAME_PARK_TIP                       ), // rename
+        MakeWidget({210,  51}, { 14,  15}, WindowWidgetType::ImgBtn,        WindowColour::Secondary, ImageId(SPR_G2_RCT1_CLOSE_BUTTON_0), STR_CLOSE_PARK_TIP                      ),
+        MakeWidget({210,  66}, { 14,  14}, WindowWidgetType::ImgBtn,        WindowColour::Secondary, ImageId(SPR_G2_RCT1_OPEN_BUTTON_0),  STR_OPEN_PARK_TIP                       ),
+        kWidgetsEnd,
+    };
 
-static Widget _ratingWidgets[] = {
-    MAIN_PARK_WIDGETS(255),
-    kWidgetsEnd,
-};
+    static Widget _ratingWidgets[] = {
+        MAIN_PARK_WIDGETS(255),
+        kWidgetsEnd,
+    };
 
-static Widget _guestsWidgets[] = {
-    MAIN_PARK_WIDGETS(255),
-    kWidgetsEnd,
-};
+    static Widget _guestsWidgets[] = {
+        MAIN_PARK_WIDGETS(255),
+        kWidgetsEnd,
+    };
 
-static Widget _priceWidgets[] = {
-    MAIN_PARK_WIDGETS(230),
-    MakeWidget        ({ 21, 50}, {126, 14}, WindowWidgetType::Label,   WindowColour::Secondary, STR_ADMISSION_PRICE),
-    MakeSpinnerWidgets({147, 50}, { 76, 14}, WindowWidgetType::Spinner, WindowColour::Secondary                     ), // Price (3 widgets)
-    kWidgetsEnd,
-};
+    static Widget _priceWidgets[] = {
+        MAIN_PARK_WIDGETS(230),
+        MakeWidget        ({ 21, 50}, {126, 14}, WindowWidgetType::Label,   WindowColour::Secondary, STR_ADMISSION_PRICE),
+        MakeSpinnerWidgets({147, 50}, { 76, 14}, WindowWidgetType::Spinner, WindowColour::Secondary                     ), // Price (3 widgets)
+        kWidgetsEnd,
+    };
 
-static Widget _statsWidgets[] = {
-    MAIN_PARK_WIDGETS(230),
-    kWidgetsEnd,
-};
+    static Widget _statsWidgets[] = {
+        MAIN_PARK_WIDGETS(230),
+        kWidgetsEnd,
+    };
 
-static Widget _objectiveWidgets[] = {
-    MAIN_PARK_WIDGETS(230),
-    MakeWidget({7, 207}, {216, 14}, WindowWidgetType::Button, WindowColour::Secondary, STR_ENTER_NAME_INTO_SCENARIO_CHART), // enter name
-    kWidgetsEnd,
-};
+    static Widget _objectiveWidgets[] = {
+        MAIN_PARK_WIDGETS(230),
+        MakeWidget({7, 207}, {216, 14}, WindowWidgetType::Button, WindowColour::Secondary, STR_ENTER_NAME_INTO_SCENARIO_CHART), // enter name
+        kWidgetsEnd,
+    };
 
-static Widget _awardsWidgets[] = {
-    MAIN_PARK_WIDGETS(230),
-    kWidgetsEnd,
-};
+    static Widget _awardsWidgets[] = {
+        MAIN_PARK_WIDGETS(230),
+        kWidgetsEnd,
+    };
 
-static std::array<Widget*, WINDOW_PARK_PAGE_COUNT> _pagedWidgets = {
-    _entranceWidgets,
-    _ratingWidgets,
-    _guestsWidgets,
-    _priceWidgets,
-    _statsWidgets,
-    _objectiveWidgets,
-    _awardsWidgets,
-};
+    static std::array<Widget*, WINDOW_PARK_PAGE_COUNT> _pagedWidgets = {
+        _entranceWidgets,
+        _ratingWidgets,
+        _guestsWidgets,
+        _priceWidgets,
+        _statsWidgets,
+        _objectiveWidgets,
+        _awardsWidgets,
+    };
+    // clang-format on
 
 #pragma endregion
 
-static std::array<uint32_t, WINDOW_PARK_PAGE_COUNT> _pagedHoldDownWidgets = {
-    0,
-    0,
-    0,
-    (1uLL << WIDX_INCREASE_PRICE) |
-    (1uLL << WIDX_DECREASE_PRICE),
-    0,
-    0,
-    0,
-};
+    // clang-format off
+    static std::array<uint32_t, WINDOW_PARK_PAGE_COUNT> _pagedHoldDownWidgets = {
+        0,
+        0,
+        0,
+        (1uLL << WIDX_INCREASE_PRICE) |
+        (1uLL << WIDX_DECREASE_PRICE),
+        0,
+        0,
+        0,
+    };
 
-struct WindowParkAward {
-    StringId text;
-    uint32_t sprite;
-};
+    struct WindowParkAward {
+        StringId text;
+        uint32_t sprite;
+    };
 
-static constexpr WindowParkAward _parkAwards[] = {
-    { STR_AWARD_MOST_UNTIDY,                SPR_AWARD_MOST_UNTIDY },
-    { STR_AWARD_MOST_TIDY,                  SPR_AWARD_MOST_TIDY },
-    { STR_AWARD_BEST_ROLLERCOASTERS,        SPR_AWARD_BEST_ROLLERCOASTERS },
-    { STR_AWARD_BEST_VALUE,                 SPR_AWARD_BEST_VALUE },
-    { STR_AWARD_MOST_BEAUTIFUL,             SPR_AWARD_MOST_BEAUTIFUL },
-    { STR_AWARD_WORST_VALUE,                SPR_AWARD_WORST_VALUE },
-    { STR_AWARD_SAFEST,                     SPR_AWARD_SAFEST },
-    { STR_AWARD_BEST_STAFF,                 SPR_AWARD_BEST_STAFF },
-    { STR_AWARD_BEST_FOOD,                  SPR_AWARD_BEST_FOOD },
-    { STR_AWARD_WORST_FOOD,                 SPR_AWARD_WORST_FOOD },
-    { STR_AWARD_BEST_TOILETS,               SPR_AWARD_BEST_TOILETS },
-    { STR_AWARD_MOST_DISAPPOINTING,         SPR_AWARD_MOST_DISAPPOINTING },
-    { STR_AWARD_BEST_WATER_RIDES,           SPR_AWARD_BEST_WATER_RIDES },
-    { STR_AWARD_BEST_CUSTOM_DESIGNED_RIDES, SPR_AWARD_BEST_CUSTOM_DESIGNED_RIDES },
-    { STR_AWARD_MOST_DAZZLING_RIDE_COLOURS, SPR_AWARD_MOST_DAZZLING_RIDE_COLOURS },
-    { STR_AWARD_MOST_CONFUSING_LAYOUT,      SPR_AWARD_MOST_CONFUSING_LAYOUT },
-    { STR_AWARD_BEST_GENTLE_RIDES,          SPR_AWARD_BEST_GENTLE_RIDES },
-};
+    static constexpr WindowParkAward _parkAwards[] = {
+        { STR_AWARD_MOST_UNTIDY,                SPR_AWARD_MOST_UNTIDY },
+        { STR_AWARD_MOST_TIDY,                  SPR_AWARD_MOST_TIDY },
+        { STR_AWARD_BEST_ROLLERCOASTERS,        SPR_AWARD_BEST_ROLLERCOASTERS },
+        { STR_AWARD_BEST_VALUE,                 SPR_AWARD_BEST_VALUE },
+        { STR_AWARD_MOST_BEAUTIFUL,             SPR_AWARD_MOST_BEAUTIFUL },
+        { STR_AWARD_WORST_VALUE,                SPR_AWARD_WORST_VALUE },
+        { STR_AWARD_SAFEST,                     SPR_AWARD_SAFEST },
+        { STR_AWARD_BEST_STAFF,                 SPR_AWARD_BEST_STAFF },
+        { STR_AWARD_BEST_FOOD,                  SPR_AWARD_BEST_FOOD },
+        { STR_AWARD_WORST_FOOD,                 SPR_AWARD_WORST_FOOD },
+        { STR_AWARD_BEST_TOILETS,               SPR_AWARD_BEST_TOILETS },
+        { STR_AWARD_MOST_DISAPPOINTING,         SPR_AWARD_MOST_DISAPPOINTING },
+        { STR_AWARD_BEST_WATER_RIDES,           SPR_AWARD_BEST_WATER_RIDES },
+        { STR_AWARD_BEST_CUSTOM_DESIGNED_RIDES, SPR_AWARD_BEST_CUSTOM_DESIGNED_RIDES },
+        { STR_AWARD_MOST_DAZZLING_RIDE_COLOURS, SPR_AWARD_MOST_DAZZLING_RIDE_COLOURS },
+        { STR_AWARD_MOST_CONFUSING_LAYOUT,      SPR_AWARD_MOST_CONFUSING_LAYOUT },
+        { STR_AWARD_BEST_GENTLE_RIDES,          SPR_AWARD_BEST_GENTLE_RIDES },
+    };
     // clang-format on
 
     class ParkWindow final : public Window

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -88,18 +88,18 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Widgets
 
-// clang-format off
-    #define MAIN_PARK_WIDGETS(WW) \
-        WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
-        MakeWidget({  0, 43}, {WW, 131}, WindowWidgetType::Resize, WindowColour::Secondary), /* tab content panel */ \
-        MakeTab   ({  3, 17}, STR_PARK_ENTRANCE_TAB_TIP                     ), /* tab 1 */ \
-        MakeTab   ({ 34, 17}, STR_PARK_RATING_TAB_TIP                       ), /* tab 2 */ \
-        MakeTab   ({ 65, 17}, STR_PARK_GUESTS_TAB_TIP                       ), /* tab 3 */ \
-        MakeTab   ({ 96, 17}, STR_PARK_PRICE_TAB_TIP                        ), /* tab 4 */ \
-        MakeTab   ({127, 17}, STR_PARK_STATS_TAB_TIP                        ), /* tab 5 */ \
-        MakeTab   ({158, 17}, STR_PARK_OBJECTIVE_TAB_TIP                    ), /* tab 6 */ \
-        MakeTab   ({189, 17}, STR_PARK_AWARDS_TAB_TIP                       )  /* tab 7 */
+#define MAIN_PARK_WIDGETS(WW)                                                                                                  \
+    WINDOW_SHIM(WINDOW_TITLE, WW, WH),                                                                                         \
+        MakeWidget({ 0, 43 }, { WW, 131 }, WindowWidgetType::Resize, WindowColour::Secondary), /* tab content panel */         \
+        MakeTab({ 3, 17 }, STR_PARK_ENTRANCE_TAB_TIP),                                         /* tab 1 */                     \
+        MakeTab({ 34, 17 }, STR_PARK_RATING_TAB_TIP),                                          /* tab 2 */                     \
+        MakeTab({ 65, 17 }, STR_PARK_GUESTS_TAB_TIP),                                          /* tab 3 */                     \
+        MakeTab({ 96, 17 }, STR_PARK_PRICE_TAB_TIP),                                           /* tab 4 */                     \
+        MakeTab({ 127, 17 }, STR_PARK_STATS_TAB_TIP),                                          /* tab 5 */                     \
+        MakeTab({ 158, 17 }, STR_PARK_OBJECTIVE_TAB_TIP),                                      /* tab 6 */                     \
+        MakeTab({ 189, 17 }, STR_PARK_AWARDS_TAB_TIP)                                          /* tab 7 */
 
+    // clang-format off
     static Widget _entranceWidgets[] = {
         MAIN_PARK_WIDGETS(230),
         MakeWidget({  3,  46}, {202, 115}, WindowWidgetType::Viewport,      WindowColour::Secondary                                                                      ), // viewport

--- a/src/openrct2-ui/windows/PatrolArea.cpp
+++ b/src/openrct2-ui/windows/PatrolArea.cpp
@@ -43,13 +43,13 @@ namespace OpenRCT2::Ui::Windows
     };
 
     // clang-format off
-static Widget PatrolAreaWidgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget     ({27, 17}, {44, 32}, WindowWidgetType::ImgBtn,  WindowColour::Primary , ImageId(SPR_LAND_TOOL_SIZE_0)                                           ), // preview box
-    MakeRemapWidget({28, 18}, {16, 16}, WindowWidgetType::TrnBtn,  WindowColour::Tertiary, SPR_LAND_TOOL_DECREASE,      STR_ADJUST_SMALLER_PATROL_AREA_TIP), // decrement size
-    MakeRemapWidget({54, 32}, {16, 16}, WindowWidgetType::TrnBtn,  WindowColour::Tertiary, SPR_LAND_TOOL_INCREASE,      STR_ADJUST_LARGER_PATROL_AREA_TIP ), // increment size
-    kWidgetsEnd,
-};
+    static Widget PatrolAreaWidgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget     ({27, 17}, {44, 32}, WindowWidgetType::ImgBtn,  WindowColour::Primary , ImageId(SPR_LAND_TOOL_SIZE_0)                                  ), // preview box
+        MakeRemapWidget({28, 18}, {16, 16}, WindowWidgetType::TrnBtn,  WindowColour::Tertiary, SPR_LAND_TOOL_DECREASE,      STR_ADJUST_SMALLER_PATROL_AREA_TIP), // decrement size
+        MakeRemapWidget({54, 32}, {16, 16}, WindowWidgetType::TrnBtn,  WindowColour::Tertiary, SPR_LAND_TOOL_INCREASE,      STR_ADJUST_LARGER_PATROL_AREA_TIP ), // increment size
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class PatrolAreaWindow final : public Window

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -25,60 +25,61 @@
 
 namespace OpenRCT2::Ui::Windows
 {
-    // clang-format off
-enum WindowPlayerPage {
-    WINDOW_PLAYER_PAGE_OVERVIEW,
-    WINDOW_PLAYER_PAGE_STATISTICS,
-};
+    enum WindowPlayerPage
+    {
+        WINDOW_PLAYER_PAGE_OVERVIEW,
+        WINDOW_PLAYER_PAGE_STATISTICS,
+    };
 
 #pragma region Widgets
 
-enum WindowPlayerWidgetIdx {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_PAGE_BACKGROUND,
-    WIDX_TAB_1,
-    WIDX_TAB_2,
+    enum WindowPlayerWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_PAGE_BACKGROUND,
+        WIDX_TAB_1,
+        WIDX_TAB_2,
 
-    WIDX_GROUP = 6,
-    WIDX_GROUP_DROPDOWN,
-    WIDX_LOCATE,
-    WIDX_KICK,
-    WIDX_VIEWPORT,
-};
+        WIDX_GROUP = 6,
+        WIDX_GROUP_DROPDOWN,
+        WIDX_LOCATE,
+        WIDX_KICK,
+        WIDX_VIEWPORT,
+    };
 
-#define WINDOW_PLAYER_COMMON_WIDGETS                                                                                                    \
-    MakeWidget({  0,  0}, {192, 157}, WindowWidgetType::Frame,    WindowColour::Primary                                     ), /* Panel / Background */ \
-    MakeWidget({  1,  1}, {190,  14}, WindowWidgetType::Caption,  WindowColour::Primary  , STR_STRING,  STR_WINDOW_TITLE_TIP), /* Title              */ \
-    MakeWidget({179,  2}, { 11,  12}, WindowWidgetType::CloseBox, WindowColour::Primary  , STR_CLOSE_X, STR_CLOSE_WINDOW_TIP), /* Close x button     */ \
-    MakeWidget({  0, 43}, {192, 114}, WindowWidgetType::Resize,   WindowColour::Secondary                                   ), /* Resize             */ \
-    MakeTab   ({  3, 17}                                                                                      ), /* Tab 1              */ \
-    MakeTab   ({ 34, 17}                                                                                      )  /* Tab 2              */
+    // clang-format off
+    #define WINDOW_PLAYER_COMMON_WIDGETS                                                                                                    \
+        MakeWidget({  0,  0}, {192, 157}, WindowWidgetType::Frame,    WindowColour::Primary                                     ), /* Panel / Background */ \
+        MakeWidget({  1,  1}, {190,  14}, WindowWidgetType::Caption,  WindowColour::Primary  , STR_STRING,  STR_WINDOW_TITLE_TIP), /* Title              */ \
+        MakeWidget({179,  2}, { 11,  12}, WindowWidgetType::CloseBox, WindowColour::Primary  , STR_CLOSE_X, STR_CLOSE_WINDOW_TIP), /* Close x button     */ \
+        MakeWidget({  0, 43}, {192, 114}, WindowWidgetType::Resize,   WindowColour::Secondary                                   ), /* Resize             */ \
+        MakeTab   ({  3, 17}                                                                                      ), /* Tab 1              */ \
+        MakeTab   ({ 34, 17}                                                                                      )  /* Tab 2              */
 
-static Widget window_player_overview_widgets[] = {
-    WINDOW_PLAYER_COMMON_WIDGETS,
-    MakeWidget({  3, 46}, {175, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                           ), // Permission group
-    MakeWidget({167, 47}, { 11, 10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH                       ),
-    MakeWidget({179, 45}, { 12, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_LOCATE),         STR_LOCATE_PLAYER_TIP), // Locate button
-    MakeWidget({179, 69}, { 12, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_DEMOLISH),       STR_KICK_PLAYER_TIP  ), // Kick button
-    MakeWidget({  3, 60}, {175, 61}, WindowWidgetType::Viewport, WindowColour::Secondary                                           ), // Viewport
-    kWidgetsEnd,
-};
+    static Widget window_player_overview_widgets[] = {
+        WINDOW_PLAYER_COMMON_WIDGETS,
+        MakeWidget({  3, 46}, {175, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                           ), // Permission group
+        MakeWidget({167, 47}, { 11, 10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH                       ),
+        MakeWidget({179, 45}, { 12, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_LOCATE),         STR_LOCATE_PLAYER_TIP), // Locate button
+        MakeWidget({179, 69}, { 12, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_DEMOLISH),       STR_KICK_PLAYER_TIP  ), // Kick button
+        MakeWidget({  3, 60}, {175, 61}, WindowWidgetType::Viewport, WindowColour::Secondary                                           ), // Viewport
+        kWidgetsEnd,
+    };
 
-static Widget window_player_statistics_widgets[] = {
-    WINDOW_PLAYER_COMMON_WIDGETS,
-    kWidgetsEnd,
-};
+    static Widget window_player_statistics_widgets[] = {
+        WINDOW_PLAYER_COMMON_WIDGETS,
+        kWidgetsEnd,
+    };
 
-static Widget *window_player_page_widgets[] = {
-    window_player_overview_widgets,
-    window_player_statistics_widgets,
-};
+    static Widget *window_player_page_widgets[] = {
+        window_player_overview_widgets,
+        window_player_statistics_widgets,
+    };
+    // clang-format on
 
 #pragma endregion
-
-    // clang-format on
 
     class PlayerWindow final : public Window
     {

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -49,7 +49,7 @@ namespace OpenRCT2::Ui::Windows
         WIDX_VIEWPORT,
     };
 
-    // clang-format off
+// clang-format off
     #define WINDOW_PLAYER_COMMON_WIDGETS                                                                                                    \
         MakeWidget({  0,  0}, {192, 157}, WindowWidgetType::Frame,    WindowColour::Primary                                     ), /* Panel / Background */ \
         MakeWidget({  1,  1}, {190,  14}, WindowWidgetType::Caption,  WindowColour::Primary  , STR_STRING,  STR_WINDOW_TITLE_TIP), /* Title              */ \

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -33,6 +33,7 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Widgets
 
+    // clang-format off
     enum WindowPlayerWidgetIdx
     {
         WIDX_BACKGROUND,
@@ -49,19 +50,14 @@ namespace OpenRCT2::Ui::Windows
         WIDX_VIEWPORT,
     };
 
-#define WINDOW_PLAYER_COMMON_WIDGETS                                                                                           \
-    MakeWidget({ 0, 0 }, { 192, 157 }, WindowWidgetType::Frame, WindowColour::Primary), /* Panel / Background */               \
-        MakeWidget(                                                                                                            \
-            { 1, 1 }, { 190, 14 }, WindowWidgetType::Caption, WindowColour::Primary, STR_STRING,                               \
-            STR_WINDOW_TITLE_TIP), /* Title              */                                                                    \
-        MakeWidget(                                                                                                            \
-            { 179, 2 }, { 11, 12 }, WindowWidgetType::CloseBox, WindowColour::Primary, STR_CLOSE_X,                            \
-            STR_CLOSE_WINDOW_TIP),                                                              /* Close x button     */       \
-        MakeWidget({ 0, 43 }, { 192, 114 }, WindowWidgetType::Resize, WindowColour::Secondary), /* Resize             */       \
-        MakeTab({ 3, 17 }),                                                                     /* Tab 1              */       \
-        MakeTab({ 34, 17 })                                                                     /* Tab 2              */
+#define WINDOW_PLAYER_COMMON_WIDGETS                                                                                              \
+    MakeWidget({ 0, 0 }, { 192, 157 }, WindowWidgetType::Frame, WindowColour::Primary),                                           \
+        MakeWidget({ 1, 1 }, { 190, 14 }, WindowWidgetType::Caption, WindowColour::Primary, STR_STRING, STR_WINDOW_TITLE_TIP),    \
+        MakeWidget({ 179, 2 }, { 11, 12 }, WindowWidgetType::CloseBox, WindowColour::Primary, STR_CLOSE_X, STR_CLOSE_WINDOW_TIP), \
+        MakeWidget({ 0, 43 }, { 192, 114 }, WindowWidgetType::Resize, WindowColour::Secondary),                                   \
+        MakeTab({ 3, 17 }),                                                                                                       \
+        MakeTab({ 34, 17 })
 
-    // clang-format off
     static Widget window_player_overview_widgets[] = {
         WINDOW_PLAYER_COMMON_WIDGETS,
         MakeWidget({  3, 46}, {175, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                           ), // Permission group

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -49,15 +49,19 @@ namespace OpenRCT2::Ui::Windows
         WIDX_VIEWPORT,
     };
 
-// clang-format off
-    #define WINDOW_PLAYER_COMMON_WIDGETS                                                                                                    \
-        MakeWidget({  0,  0}, {192, 157}, WindowWidgetType::Frame,    WindowColour::Primary                                     ), /* Panel / Background */ \
-        MakeWidget({  1,  1}, {190,  14}, WindowWidgetType::Caption,  WindowColour::Primary  , STR_STRING,  STR_WINDOW_TITLE_TIP), /* Title              */ \
-        MakeWidget({179,  2}, { 11,  12}, WindowWidgetType::CloseBox, WindowColour::Primary  , STR_CLOSE_X, STR_CLOSE_WINDOW_TIP), /* Close x button     */ \
-        MakeWidget({  0, 43}, {192, 114}, WindowWidgetType::Resize,   WindowColour::Secondary                                   ), /* Resize             */ \
-        MakeTab   ({  3, 17}                                                                                      ), /* Tab 1              */ \
-        MakeTab   ({ 34, 17}                                                                                      )  /* Tab 2              */
+#define WINDOW_PLAYER_COMMON_WIDGETS                                                                                           \
+    MakeWidget({ 0, 0 }, { 192, 157 }, WindowWidgetType::Frame, WindowColour::Primary), /* Panel / Background */               \
+        MakeWidget(                                                                                                            \
+            { 1, 1 }, { 190, 14 }, WindowWidgetType::Caption, WindowColour::Primary, STR_STRING,                               \
+            STR_WINDOW_TITLE_TIP), /* Title              */                                                                    \
+        MakeWidget(                                                                                                            \
+            { 179, 2 }, { 11, 12 }, WindowWidgetType::CloseBox, WindowColour::Primary, STR_CLOSE_X,                            \
+            STR_CLOSE_WINDOW_TIP),                                                              /* Close x button     */       \
+        MakeWidget({ 0, 43 }, { 192, 114 }, WindowWidgetType::Resize, WindowColour::Secondary), /* Resize             */       \
+        MakeTab({ 3, 17 }),                                                                     /* Tab 1              */       \
+        MakeTab({ 34, 17 })                                                                     /* Tab 2              */
 
+    // clang-format off
     static Widget window_player_overview_widgets[] = {
         WINDOW_PLAYER_COMMON_WIDGETS,
         MakeWidget({  3, 46}, {175, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                           ), // Permission group

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -50,8 +50,8 @@ namespace OpenRCT2::Ui::Windows
         WIDX_VIEWPORT,
     };
 
-#define WINDOW_PLAYER_COMMON_WIDGETS                                                                                              \
-    MakeWidget({ 0, 0 }, { 192, 157 }, WindowWidgetType::Frame, WindowColour::Primary),                                           \
+    #define WINDOW_PLAYER_COMMON_WIDGETS                                                                                              \
+        MakeWidget({ 0, 0 }, { 192, 157 }, WindowWidgetType::Frame, WindowColour::Primary),                                           \
         MakeWidget({ 1, 1 }, { 190, 14 }, WindowWidgetType::Caption, WindowColour::Primary, STR_STRING, STR_WINDOW_TITLE_TIP),    \
         MakeWidget({ 179, 2 }, { 11, 12 }, WindowWidgetType::CloseBox, WindowColour::Primary, STR_CLOSE_X, STR_CLOSE_WINDOW_TIP), \
         MakeWidget({ 0, 43 }, { 192, 114 }, WindowWidgetType::Resize, WindowColour::Secondary),                                   \

--- a/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
@@ -22,23 +22,23 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WW = 200;
     static constexpr int32_t WH = 100;
 
-    // clang-format off
-enum WindowRideRefurbishWidgetIdx
-{
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_REFURBISH,
-    WIDX_CANCEL
-};
+    enum WindowRideRefurbishWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_REFURBISH,
+        WIDX_CANCEL
+    };
 
-static Widget window_ride_refurbish_widgets[] =
-{
-    WINDOW_SHIM_WHITE(STR_REFURBISH_RIDE, WW, WH),
-    MakeWidget({ 10, WH - 22 }, { 85, 14 }, WindowWidgetType::Button, WindowColour::Primary, STR_REFURBISH),
-    MakeWidget({ WW - 95, WH - 22 }, { 85, 14 }, WindowWidgetType::Button, WindowColour::Primary, STR_SAVE_PROMPT_CANCEL),
-    kWidgetsEnd,
-};
+    // clang-format off
+    static Widget window_ride_refurbish_widgets[] =
+    {
+        WINDOW_SHIM_WHITE(STR_REFURBISH_RIDE, WW, WH),
+        MakeWidget({ 10, WH - 22 }, { 85, 14 }, WindowWidgetType::Button, WindowColour::Primary, STR_REFURBISH),
+        MakeWidget({ WW - 95, WH - 22 }, { 85, 14 }, WindowWidgetType::Button, WindowColour::Primary, STR_SAVE_PROMPT_CANCEL),
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class RefurbishRidePromptWindow final : public Window

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -31,78 +31,79 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WH_FUNDING = 207;
     static constexpr int32_t WW_FUNDING = 320;
 
-    // clang-format off
-enum {
-    WINDOW_RESEARCH_PAGE_DEVELOPMENT,
-    WINDOW_RESEARCH_PAGE_FUNDING,
-    WINDOW_RESEARCH_PAGE_COUNT
-};
+    enum
+    {
+        WINDOW_RESEARCH_PAGE_DEVELOPMENT,
+        WINDOW_RESEARCH_PAGE_FUNDING,
+        WINDOW_RESEARCH_PAGE_COUNT
+    };
 
-enum {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_PAGE_BACKGROUND,
-    WIDX_TAB_1,
-    WIDX_TAB_2,
+    enum
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_PAGE_BACKGROUND,
+        WIDX_TAB_1,
+        WIDX_TAB_2,
 
-    WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP,
-    WIDX_LAST_DEVELOPMENT_GROUP,
-    WIDX_LAST_DEVELOPMENT_BUTTON,
+        WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP,
+        WIDX_LAST_DEVELOPMENT_GROUP,
+        WIDX_LAST_DEVELOPMENT_BUTTON,
 
-    WIDX_FUNDING_GROUP = 6,
-    WIDX_RESEARCH_FUNDING,
-    WIDX_RESEARCH_FUNDING_DROPDOWN_BUTTON,
-    WIDX_PRIORITIES_GROUP,
-    WIDX_TRANSPORT_RIDES,
-    WIDX_GENTLE_RIDES,
-    WIDX_ROLLER_COASTERS,
-    WIDX_THRILL_RIDES,
-    WIDX_WATER_RIDES,
-    WIDX_SHOPS_AND_STALLS,
-    WIDX_SCENERY_AND_THEMING,
-};
+        WIDX_FUNDING_GROUP = 6,
+        WIDX_RESEARCH_FUNDING,
+        WIDX_RESEARCH_FUNDING_DROPDOWN_BUTTON,
+        WIDX_PRIORITIES_GROUP,
+        WIDX_TRANSPORT_RIDES,
+        WIDX_GENTLE_RIDES,
+        WIDX_ROLLER_COASTERS,
+        WIDX_THRILL_RIDES,
+        WIDX_WATER_RIDES,
+        WIDX_SHOPS_AND_STALLS,
+        WIDX_SCENERY_AND_THEMING,
+    };
 
 #pragma region Widgets
 
-static Widget window_research_development_widgets[] = {
-    WINDOW_SHIM(STR_RESEARCH_AND_DEVELOPMENT, WW_DEVELOPMENT, WH_DEVELOPMENT),
-    MakeWidget({  0,  43}, {     WW_DEVELOPMENT, 153}, WindowWidgetType::Resize,   WindowColour::Secondary                                                                ),
-    MakeTab   ({  3,  17},                                                                                                  STR_RESEARCH_AND_DEVELOPMENT_TIP),
-    MakeTab   ({ 34,  17},                                                                                                  STR_FINANCES_RESEARCH_TIP       ),
-    MakeWidget({  3,  47}, {WW_DEVELOPMENT - 10,  70}, WindowWidgetType::Groupbox, WindowColour::Tertiary , STR_CURRENTLY_IN_DEVELOPMENT                                  ),
-    MakeWidget({  3, 124}, {WW_DEVELOPMENT - 10,  65}, WindowWidgetType::Groupbox, WindowColour::Tertiary , STR_LAST_DEVELOPMENT                                          ),
-    MakeWidget({265, 161}, {                 24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Tertiary , 0xFFFFFFFF,                   STR_RESEARCH_SHOW_DETAILS_TIP   ),
-    kWidgetsEnd,
-};
+    // clang-format off
+    static Widget window_research_development_widgets[] = {
+        WINDOW_SHIM(STR_RESEARCH_AND_DEVELOPMENT, WW_DEVELOPMENT, WH_DEVELOPMENT),
+        MakeWidget({  0,  43}, {     WW_DEVELOPMENT, 153}, WindowWidgetType::Resize,   WindowColour::Secondary                                                                ),
+        MakeTab   ({  3,  17},                                                                                                  STR_RESEARCH_AND_DEVELOPMENT_TIP),
+        MakeTab   ({ 34,  17},                                                                                                  STR_FINANCES_RESEARCH_TIP       ),
+        MakeWidget({  3,  47}, {WW_DEVELOPMENT - 10,  70}, WindowWidgetType::Groupbox, WindowColour::Tertiary , STR_CURRENTLY_IN_DEVELOPMENT                                  ),
+        MakeWidget({  3, 124}, {WW_DEVELOPMENT - 10,  65}, WindowWidgetType::Groupbox, WindowColour::Tertiary , STR_LAST_DEVELOPMENT                                          ),
+        MakeWidget({265, 161}, {                 24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Tertiary , 0xFFFFFFFF,                   STR_RESEARCH_SHOW_DETAILS_TIP   ),
+        kWidgetsEnd,
+    };
 
-static Widget window_research_funding_widgets[] = {
-    WINDOW_SHIM(STR_RESEARCH_FUNDING, WW_FUNDING, WH_FUNDING),
-    MakeWidget({  0,  43}, {     WW_FUNDING, 164}, WindowWidgetType::Resize,   WindowColour::Secondary                                                                                    ),
-    MakeTab   ({  3,  17},                                                                                                      STR_RESEARCH_AND_DEVELOPMENT_TIP            ),
-    MakeTab   ({ 34,  17},                                                                                                      STR_FINANCES_RESEARCH_TIP                   ),
-    MakeWidget({  3,  47}, { WW_FUNDING - 6,  45}, WindowWidgetType::Groupbox, WindowColour::Tertiary , STR_RESEARCH_FUNDING_                                                             ),
-    MakeWidget({  8,  59}, {            160,  14}, WindowWidgetType::DropdownMenu, WindowColour::Tertiary , 0xFFFFFFFF,                           STR_SELECT_LEVEL_OF_RESEARCH_AND_DEVELOPMENT),
-    MakeWidget({156,  60}, {             11,  12}, WindowWidgetType::Button,   WindowColour::Tertiary , STR_DROPDOWN_GLYPH,                   STR_SELECT_LEVEL_OF_RESEARCH_AND_DEVELOPMENT),
-    MakeWidget({  3,  96}, { WW_FUNDING - 6, 107}, WindowWidgetType::Groupbox, WindowColour::Tertiary , STR_RESEARCH_PRIORITIES                                                           ),
-    MakeWidget({  8, 108}, {WW_FUNDING - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_RESEARCH_NEW_TRANSPORT_RIDES,     STR_RESEARCH_NEW_TRANSPORT_RIDES_TIP        ),
-    MakeWidget({  8, 121}, {WW_FUNDING - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_RESEARCH_NEW_GENTLE_RIDES,        STR_RESEARCH_NEW_GENTLE_RIDES_TIP           ),
-    MakeWidget({  8, 134}, {WW_FUNDING - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_RESEARCH_NEW_ROLLER_COASTERS,     STR_RESEARCH_NEW_ROLLER_COASTERS_TIP        ),
-    MakeWidget({  8, 147}, {WW_FUNDING - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_RESEARCH_NEW_THRILL_RIDES,        STR_RESEARCH_NEW_THRILL_RIDES_TIP           ),
-    MakeWidget({  8, 160}, {WW_FUNDING - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_RESEARCH_NEW_WATER_RIDES,         STR_RESEARCH_NEW_WATER_RIDES_TIP            ),
-    MakeWidget({  8, 173}, {WW_FUNDING - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_RESEARCH_NEW_SHOPS_AND_STALLS,    STR_RESEARCH_NEW_SHOPS_AND_STALLS_TIP       ),
-    MakeWidget({  8, 186}, {WW_FUNDING - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_RESEARCH_NEW_SCENERY_AND_THEMING, STR_RESEARCH_NEW_SCENERY_AND_THEMING_TIP    ),
-    kWidgetsEnd,
-};
+    static Widget window_research_funding_widgets[] = {
+        WINDOW_SHIM(STR_RESEARCH_FUNDING, WW_FUNDING, WH_FUNDING),
+        MakeWidget({  0,  43}, {     WW_FUNDING, 164}, WindowWidgetType::Resize,   WindowColour::Secondary                                                                                    ),
+        MakeTab   ({  3,  17},                                                                                                      STR_RESEARCH_AND_DEVELOPMENT_TIP            ),
+        MakeTab   ({ 34,  17},                                                                                                      STR_FINANCES_RESEARCH_TIP                   ),
+        MakeWidget({  3,  47}, { WW_FUNDING - 6,  45}, WindowWidgetType::Groupbox, WindowColour::Tertiary , STR_RESEARCH_FUNDING_                                                             ),
+        MakeWidget({  8,  59}, {            160,  14}, WindowWidgetType::DropdownMenu, WindowColour::Tertiary , 0xFFFFFFFF,                           STR_SELECT_LEVEL_OF_RESEARCH_AND_DEVELOPMENT),
+        MakeWidget({156,  60}, {             11,  12}, WindowWidgetType::Button,   WindowColour::Tertiary , STR_DROPDOWN_GLYPH,                   STR_SELECT_LEVEL_OF_RESEARCH_AND_DEVELOPMENT),
+        MakeWidget({  3,  96}, { WW_FUNDING - 6, 107}, WindowWidgetType::Groupbox, WindowColour::Tertiary , STR_RESEARCH_PRIORITIES                                                           ),
+        MakeWidget({  8, 108}, {WW_FUNDING - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_RESEARCH_NEW_TRANSPORT_RIDES,     STR_RESEARCH_NEW_TRANSPORT_RIDES_TIP        ),
+        MakeWidget({  8, 121}, {WW_FUNDING - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_RESEARCH_NEW_GENTLE_RIDES,        STR_RESEARCH_NEW_GENTLE_RIDES_TIP           ),
+        MakeWidget({  8, 134}, {WW_FUNDING - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_RESEARCH_NEW_ROLLER_COASTERS,     STR_RESEARCH_NEW_ROLLER_COASTERS_TIP        ),
+        MakeWidget({  8, 147}, {WW_FUNDING - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_RESEARCH_NEW_THRILL_RIDES,        STR_RESEARCH_NEW_THRILL_RIDES_TIP           ),
+        MakeWidget({  8, 160}, {WW_FUNDING - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_RESEARCH_NEW_WATER_RIDES,         STR_RESEARCH_NEW_WATER_RIDES_TIP            ),
+        MakeWidget({  8, 173}, {WW_FUNDING - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_RESEARCH_NEW_SHOPS_AND_STALLS,    STR_RESEARCH_NEW_SHOPS_AND_STALLS_TIP       ),
+        MakeWidget({  8, 186}, {WW_FUNDING - 16,  12}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_RESEARCH_NEW_SCENERY_AND_THEMING, STR_RESEARCH_NEW_SCENERY_AND_THEMING_TIP    ),
+        kWidgetsEnd,
+    };
 
-static Widget *window_research_page_widgets[] = {
-    window_research_development_widgets,
-    window_research_funding_widgets,
-};
+    static Widget *window_research_page_widgets[] = {
+        window_research_development_widgets,
+        window_research_funding_widgets,
+    };
+    // clang-format on
 
 #pragma endregion
-
-    // clang-format on
 
     const int32_t window_research_tab_animation_loops[] = {
         16,

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -231,17 +231,23 @@ namespace OpenRCT2::Ui::Windows
         WIDX_SHOW_GUESTS_QUEUING
     };
 
+    // clang-format off
     constexpr int32_t RCT1_LIGHT_OFFSET = 4;
 
-#define MAIN_RIDE_WIDGETS                                                                                                      \
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH), MakeWidget({ 0, 43 }, { 316, 137 }, WindowWidgetType::Resize, WindowColour::Secondary), \
-        MakeTab({ 3, 17 }, STR_VIEW_OF_RIDE_ATTRACTION_TIP), MakeTab({ 34, 17 }, STR_VEHICLE_DETAILS_AND_OPTIONS_TIP),         \
-        MakeTab({ 65, 17 }, STR_OPERATING_OPTIONS_TIP), MakeTab({ 96, 17 }, STR_MAINTENANCE_OPTIONS_TIP),                      \
-        MakeTab({ 127, 17 }, STR_COLOUR_SCHEME_OPTIONS_TIP), MakeTab({ 158, 17 }, STR_SOUND_AND_MUSIC_OPTIONS_TIP),            \
-        MakeTab({ 189, 17 }, STR_MEASUREMENTS_AND_TEST_DATA_TIP), MakeTab({ 220, 17 }, STR_GRAPHS_TIP),                        \
-        MakeTab({ 251, 17 }, STR_INCOME_AND_COSTS_TIP), MakeTab({ 282, 17 }, STR_CUSTOMER_INFORMATION_TIP)
+    #define MAIN_RIDE_WIDGETS \
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
+        MakeWidget({ 0, 43 }, { 316, 137 }, WindowWidgetType::Resize, WindowColour::Secondary), \
+        MakeTab({ 3, 17 }, STR_VIEW_OF_RIDE_ATTRACTION_TIP), \
+        MakeTab({ 34, 17 }, STR_VEHICLE_DETAILS_AND_OPTIONS_TIP), \
+        MakeTab({ 65, 17 }, STR_OPERATING_OPTIONS_TIP), \
+        MakeTab({ 96, 17 }, STR_MAINTENANCE_OPTIONS_TIP), \
+        MakeTab({ 127, 17 }, STR_COLOUR_SCHEME_OPTIONS_TIP), \
+        MakeTab({ 158, 17 }, STR_SOUND_AND_MUSIC_OPTIONS_TIP), \
+        MakeTab({ 189, 17 }, STR_MEASUREMENTS_AND_TEST_DATA_TIP), \
+        MakeTab({ 220, 17 }, STR_GRAPHS_TIP), \
+        MakeTab({ 251, 17 }, STR_INCOME_AND_COSTS_TIP), \
+        MakeTab({ 282, 17 }, STR_CUSTOMER_INFORMATION_TIP)
 
-    // clang-format off
     // 0x009ADC34
     static Widget _mainWidgets[] = {
         MAIN_RIDE_WIDGETS,

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -233,21 +233,15 @@ namespace OpenRCT2::Ui::Windows
 
     constexpr int32_t RCT1_LIGHT_OFFSET = 4;
 
-// clang-format off
-    #define MAIN_RIDE_WIDGETS \
-        WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
-        MakeWidget({  0, 43}, {316, 137}, WindowWidgetType::Resize, WindowColour::Secondary), \
-        MakeTab   ({  3, 17}, STR_VIEW_OF_RIDE_ATTRACTION_TIP                ), \
-        MakeTab   ({ 34, 17}, STR_VEHICLE_DETAILS_AND_OPTIONS_TIP            ), \
-        MakeTab   ({ 65, 17}, STR_OPERATING_OPTIONS_TIP                      ), \
-        MakeTab   ({ 96, 17}, STR_MAINTENANCE_OPTIONS_TIP                    ), \
-        MakeTab   ({127, 17}, STR_COLOUR_SCHEME_OPTIONS_TIP                  ), \
-        MakeTab   ({158, 17}, STR_SOUND_AND_MUSIC_OPTIONS_TIP                ), \
-        MakeTab   ({189, 17}, STR_MEASUREMENTS_AND_TEST_DATA_TIP             ), \
-        MakeTab   ({220, 17}, STR_GRAPHS_TIP                                 ), \
-        MakeTab   ({251, 17}, STR_INCOME_AND_COSTS_TIP                       ), \
-        MakeTab   ({282, 17}, STR_CUSTOMER_INFORMATION_TIP                   )
+#define MAIN_RIDE_WIDGETS                                                                                                      \
+    WINDOW_SHIM(WINDOW_TITLE, WW, WH), MakeWidget({ 0, 43 }, { 316, 137 }, WindowWidgetType::Resize, WindowColour::Secondary), \
+        MakeTab({ 3, 17 }, STR_VIEW_OF_RIDE_ATTRACTION_TIP), MakeTab({ 34, 17 }, STR_VEHICLE_DETAILS_AND_OPTIONS_TIP),         \
+        MakeTab({ 65, 17 }, STR_OPERATING_OPTIONS_TIP), MakeTab({ 96, 17 }, STR_MAINTENANCE_OPTIONS_TIP),                      \
+        MakeTab({ 127, 17 }, STR_COLOUR_SCHEME_OPTIONS_TIP), MakeTab({ 158, 17 }, STR_SOUND_AND_MUSIC_OPTIONS_TIP),            \
+        MakeTab({ 189, 17 }, STR_MEASUREMENTS_AND_TEST_DATA_TIP), MakeTab({ 220, 17 }, STR_GRAPHS_TIP),                        \
+        MakeTab({ 251, 17 }, STR_INCOME_AND_COSTS_TIP), MakeTab({ 282, 17 }, STR_CUSTOMER_INFORMATION_TIP)
 
+    // clang-format off
     // 0x009ADC34
     static Widget _mainWidgets[] = {
         MAIN_RIDE_WIDGETS,

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -233,7 +233,7 @@ namespace OpenRCT2::Ui::Windows
 
     constexpr int32_t RCT1_LIGHT_OFFSET = 4;
 
-    // clang-format off
+// clang-format off
     #define MAIN_RIDE_WIDGETS \
         WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
         MakeWidget({  0, 43}, {316, 137}, WindowWidgetType::Resize, WindowColour::Secondary), \

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -70,6 +70,7 @@
 #include <vector>
 
 using namespace OpenRCT2::TrackMetaData;
+
 namespace OpenRCT2::Ui::Windows
 {
     static constexpr StringId WINDOW_TITLE = STR_RIDE_WINDOW_TITLE;
@@ -93,352 +94,353 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Widgets
 
+    enum
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_PAGE_BACKGROUND,
+        WIDX_TAB_1,
+        WIDX_TAB_2,
+        WIDX_TAB_3,
+        WIDX_TAB_4,
+        WIDX_TAB_5,
+        WIDX_TAB_6,
+        WIDX_TAB_7,
+        WIDX_TAB_8,
+        WIDX_TAB_9,
+        WIDX_TAB_10,
+
+        WIDX_VIEWPORT = 14,
+        WIDX_VIEW,
+        WIDX_VIEW_DROPDOWN,
+        WIDX_STATUS,
+        WIDX_OPEN,
+        WIDX_CONSTRUCTION,
+        WIDX_RENAME,
+        WIDX_LOCATE,
+        WIDX_DEMOLISH,
+        WIDX_CLOSE_LIGHT,
+        WIDX_SIMULATE_LIGHT,
+        WIDX_TEST_LIGHT,
+        WIDX_OPEN_LIGHT,
+        WIDX_RIDE_TYPE,
+        WIDX_RIDE_TYPE_DROPDOWN,
+
+        WIDX_VEHICLE_TYPE = 14,
+        WIDX_VEHICLE_TYPE_DROPDOWN,
+        WIDX_VEHICLE_REVERSED_TRAINS_CHECKBOX,
+        WIDX_VEHICLE_TRAINS_PREVIEW,
+        WIDX_VEHICLE_TRAINS,
+        WIDX_VEHICLE_TRAINS_INCREASE,
+        WIDX_VEHICLE_TRAINS_DECREASE,
+        WIDX_VEHICLE_CARS_PER_TRAIN,
+        WIDX_VEHICLE_CARS_PER_TRAIN_INCREASE,
+        WIDX_VEHICLE_CARS_PER_TRAIN_DECREASE,
+
+        WIDX_MODE_TWEAK = 14,
+        WIDX_MODE_TWEAK_INCREASE,
+        WIDX_MODE_TWEAK_DECREASE,
+        WIDX_LIFT_HILL_SPEED,
+        WIDX_LIFT_HILL_SPEED_INCREASE,
+        WIDX_LIFT_HILL_SPEED_DECREASE,
+        WIDX_LOAD_CHECKBOX,
+        WIDX_LEAVE_WHEN_ANOTHER_ARRIVES_CHECKBOX,
+        WIDX_MINIMUM_LENGTH_CHECKBOX,
+        WIDX_MINIMUM_LENGTH,
+        WIDX_MINIMUM_LENGTH_INCREASE,
+        WIDX_MINIMUM_LENGTH_DECREASE,
+        WIDX_MAXIMUM_LENGTH_CHECKBOX,
+        WIDX_MAXIMUM_LENGTH,
+        WIDX_MAXIMUM_LENGTH_INCREASE,
+        WIDX_MAXIMUM_LENGTH_DECREASE,
+        WIDX_SYNCHRONISE_WITH_ADJACENT_STATIONS_CHECKBOX,
+        WIDX_MODE_TWEAK_LABEL,
+        WIDX_LIFT_HILL_SPEED_LABEL,
+        WIDX_MODE,
+        WIDX_MODE_DROPDOWN,
+        WIDX_LOAD,
+        WIDX_LOAD_DROPDOWN,
+        WIDX_OPERATE_NUMBER_OF_CIRCUITS_LABEL,
+        WIDX_OPERATE_NUMBER_OF_CIRCUITS,
+        WIDX_OPERATE_NUMBER_OF_CIRCUITS_INCREASE,
+        WIDX_OPERATE_NUMBER_OF_CIRCUITS_DECREASE,
+
+        WIDX_INSPECTION_INTERVAL = 14,
+        WIDX_INSPECTION_INTERVAL_DROPDOWN,
+        WIDX_LOCATE_MECHANIC,
+        WIDX_REFURBISH_RIDE,
+        WIDX_FORCE_BREAKDOWN,
+        WIDX_RELIABILITY_BAR,
+        WIDX_DOWN_TIME_BAR,
+
+        WIDX_TRACK_PREVIEW = 14,
+        WIDX_TRACK_COLOUR_SCHEME,
+        WIDX_TRACK_COLOUR_SCHEME_DROPDOWN,
+        WIDX_TRACK_MAIN_COLOUR,
+        WIDX_TRACK_ADDITIONAL_COLOUR,
+        WIDX_TRACK_SUPPORT_COLOUR,
+        WIDX_MAZE_STYLE,
+        WIDX_MAZE_STYLE_DROPDOWN,
+        WIDX_PAINT_INDIVIDUAL_AREA,
+        WIDX_ENTRANCE_PREVIEW,
+        WIDX_ENTRANCE_STYLE,
+        WIDX_ENTRANCE_STYLE_DROPDOWN,
+        WIDX_VEHICLE_PREVIEW,
+        WIDX_VEHICLE_COLOUR_SCHEME,
+        WIDX_VEHICLE_COLOUR_SCHEME_DROPDOWN,
+        WIDX_VEHICLE_COLOUR_INDEX,
+        WIDX_VEHICLE_COLOUR_INDEX_DROPDOWN,
+        WIDX_VEHICLE_BODY_COLOUR,
+        WIDX_VEHICLE_TRIM_COLOUR,
+        WIDX_VEHICLE_TERTIARY_COLOUR,
+        WIDX_SELL_ITEM_RANDOM_COLOUR_CHECKBOX,
+        WIDX_RANDOMISE_VEHICLE_COLOURS,
+
+        WIDX_PLAY_MUSIC = 14,
+        WIDX_MUSIC,
+        WIDX_MUSIC_DROPDOWN,
+        WIDX_MUSIC_IMAGE,
+        WIDX_MUSIC_DATA,
+
+        WIDX_SAVE_TRACK_DESIGN = 14,
+        WIDX_SELECT_NEARBY_SCENERY,
+        WIDX_RESET_SELECTION,
+        WIDX_SAVE_DESIGN,
+        WIDX_CANCEL_DESIGN,
+
+        WIDX_GRAPH = 14,
+        WIDX_GRAPH_VELOCITY,
+        WIDX_GRAPH_ALTITUDE,
+        WIDX_GRAPH_VERTICAL,
+        WIDX_GRAPH_LATERAL,
+
+        WIDX_PRIMARY_PRICE_LABEL = 14,
+        WIDX_PRIMARY_PRICE,
+        WIDX_PRIMARY_PRICE_INCREASE,
+        WIDX_PRIMARY_PRICE_DECREASE,
+        WIDX_PRIMARY_PRICE_SAME_THROUGHOUT_PARK,
+        WIDX_SECONDARY_PRICE_LABEL,
+        WIDX_SECONDARY_PRICE,
+        WIDX_SECONDARY_PRICE_INCREASE,
+        WIDX_SECONDARY_PRICE_DECREASE,
+        WIDX_SECONDARY_PRICE_SAME_THROUGHOUT_PARK,
+
+        WIDX_SHOW_GUESTS_THOUGHTS = 14,
+        WIDX_SHOW_GUESTS_ON_RIDE,
+        WIDX_SHOW_GUESTS_QUEUING
+    };
+
+    constexpr int32_t RCT1_LIGHT_OFFSET = 4;
+
     // clang-format off
-enum {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_PAGE_BACKGROUND,
-    WIDX_TAB_1,
-    WIDX_TAB_2,
-    WIDX_TAB_3,
-    WIDX_TAB_4,
-    WIDX_TAB_5,
-    WIDX_TAB_6,
-    WIDX_TAB_7,
-    WIDX_TAB_8,
-    WIDX_TAB_9,
-    WIDX_TAB_10,
+    #define MAIN_RIDE_WIDGETS \
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
+        MakeWidget({  0, 43}, {316, 137}, WindowWidgetType::Resize, WindowColour::Secondary), \
+        MakeTab   ({  3, 17}, STR_VIEW_OF_RIDE_ATTRACTION_TIP                ), \
+        MakeTab   ({ 34, 17}, STR_VEHICLE_DETAILS_AND_OPTIONS_TIP            ), \
+        MakeTab   ({ 65, 17}, STR_OPERATING_OPTIONS_TIP                      ), \
+        MakeTab   ({ 96, 17}, STR_MAINTENANCE_OPTIONS_TIP                    ), \
+        MakeTab   ({127, 17}, STR_COLOUR_SCHEME_OPTIONS_TIP                  ), \
+        MakeTab   ({158, 17}, STR_SOUND_AND_MUSIC_OPTIONS_TIP                ), \
+        MakeTab   ({189, 17}, STR_MEASUREMENTS_AND_TEST_DATA_TIP             ), \
+        MakeTab   ({220, 17}, STR_GRAPHS_TIP                                 ), \
+        MakeTab   ({251, 17}, STR_INCOME_AND_COSTS_TIP                       ), \
+        MakeTab   ({282, 17}, STR_CUSTOMER_INFORMATION_TIP                   )
 
-    WIDX_VIEWPORT = 14,
-    WIDX_VIEW,
-    WIDX_VIEW_DROPDOWN,
-    WIDX_STATUS,
-    WIDX_OPEN,
-    WIDX_CONSTRUCTION,
-    WIDX_RENAME,
-    WIDX_LOCATE,
-    WIDX_DEMOLISH,
-    WIDX_CLOSE_LIGHT,
-    WIDX_SIMULATE_LIGHT,
-    WIDX_TEST_LIGHT,
-    WIDX_OPEN_LIGHT,
-    WIDX_RIDE_TYPE,
-    WIDX_RIDE_TYPE_DROPDOWN,
+    // 0x009ADC34
+    static Widget _mainWidgets[] = {
+        MAIN_RIDE_WIDGETS,
+        MakeWidget({  3,  60}, {288, 107}, WindowWidgetType::Viewport,      WindowColour::Secondary                                                                  ),
+        MakeWidget({ 35,  46}, {222,  12}, WindowWidgetType::DropdownMenu,  WindowColour::Secondary, kWidgetContentEmpty,                 STR_VIEW_SELECTION         ),
+        MakeWidget({245,  47}, { 11,  10}, WindowWidgetType::Button,        WindowColour::Secondary, STR_DROPDOWN_GLYPH,                  STR_VIEW_SELECTION         ),
+        MakeWidget({  3, 167}, {288,  11}, WindowWidgetType::LabelCentred,  WindowColour::Secondary                                                                  ),
+        MakeWidget({291,  46}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, kWidgetContentEmpty,                 STR_OPEN_CLOSE_OR_TEST_RIDE),
+        MakeWidget({291,  70}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_CONSTRUCTION),           STR_CONSTRUCTION           ),
+        MakeWidget({291,  94}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_RENAME),                 STR_NAME_RIDE_TIP          ),
+        MakeWidget({291, 118}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_LOCATE),                 STR_LOCATE_SUBJECT_TIP     ),
+        MakeWidget({291, 142}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_DEMOLISH),               STR_DEMOLISH_RIDE_TIP      ),
+        MakeWidget({296,  48}, { 14,  14}, WindowWidgetType::ImgBtn,        WindowColour::Secondary, ImageId(SPR_G2_RCT1_CLOSE_BUTTON_0), STR_CLOSE_RIDE_TIP         ),
+        MakeWidget({296,  62}, { 14,  14}, WindowWidgetType::ImgBtn,        WindowColour::Secondary, ImageId(SPR_G2_RCT1_TEST_BUTTON_0),  STR_SIMULATE_RIDE_TIP      ),
+        MakeWidget({296,  62}, { 14,  14}, WindowWidgetType::ImgBtn,        WindowColour::Secondary, ImageId(SPR_G2_RCT1_TEST_BUTTON_0),  STR_TEST_RIDE_TIP          ),
+        MakeWidget({296,  76}, { 14,  14}, WindowWidgetType::ImgBtn,        WindowColour::Secondary, ImageId(SPR_G2_RCT1_OPEN_BUTTON_0),  STR_OPEN_RIDE_TIP          ),
+        MakeWidget({  3, 180}, {305,  12}, WindowWidgetType::DropdownMenu,      WindowColour::Secondary, STR_ARG_6_STRINGID                                     ),
+        MakeWidget({297, 180}, { 11,  12}, WindowWidgetType::Button,        WindowColour::Secondary, STR_DROPDOWN_GLYPH                                     ),
+        kWidgetsEnd,
+    };
 
-    WIDX_VEHICLE_TYPE = 14,
-    WIDX_VEHICLE_TYPE_DROPDOWN,
-    WIDX_VEHICLE_REVERSED_TRAINS_CHECKBOX,
-    WIDX_VEHICLE_TRAINS_PREVIEW,
-    WIDX_VEHICLE_TRAINS,
-    WIDX_VEHICLE_TRAINS_INCREASE,
-    WIDX_VEHICLE_TRAINS_DECREASE,
-    WIDX_VEHICLE_CARS_PER_TRAIN,
-    WIDX_VEHICLE_CARS_PER_TRAIN_INCREASE,
-    WIDX_VEHICLE_CARS_PER_TRAIN_DECREASE,
+    // 0x009ADDA8
+    static Widget _vehicleWidgets[] = {
+        MAIN_RIDE_WIDGETS,
+        MakeWidget        ({  7,  50}, {302, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                    ),
+        MakeWidget        ({297,  51}, { 11, 10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH                                ),
+        MakeWidget        ({  7, 137}, {302, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_OPTION_REVERSE_TRAINS, STR_OPTION_REVERSE_TRAINS_TIP  ),
+        MakeWidget        ({  7, 154}, {302, 43}, WindowWidgetType::Scroll,   WindowColour::Secondary, STR_EMPTY                                         ),
+        MakeSpinnerWidgets({  7, 203}, {145, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_RIDE_VEHICLE_COUNT, STR_MAX_VEHICLES_TIP      ),
+        MakeSpinnerWidgets({164, 203}, {145, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_1_CAR_PER_TRAIN,    STR_MAX_CARS_PER_TRAIN_TIP),
+        kWidgetsEnd,
+    };
 
-    WIDX_MODE_TWEAK = 14,
-    WIDX_MODE_TWEAK_INCREASE,
-    WIDX_MODE_TWEAK_DECREASE,
-    WIDX_LIFT_HILL_SPEED,
-    WIDX_LIFT_HILL_SPEED_INCREASE,
-    WIDX_LIFT_HILL_SPEED_DECREASE,
-    WIDX_LOAD_CHECKBOX,
-    WIDX_LEAVE_WHEN_ANOTHER_ARRIVES_CHECKBOX,
-    WIDX_MINIMUM_LENGTH_CHECKBOX,
-    WIDX_MINIMUM_LENGTH,
-    WIDX_MINIMUM_LENGTH_INCREASE,
-    WIDX_MINIMUM_LENGTH_DECREASE,
-    WIDX_MAXIMUM_LENGTH_CHECKBOX,
-    WIDX_MAXIMUM_LENGTH,
-    WIDX_MAXIMUM_LENGTH_INCREASE,
-    WIDX_MAXIMUM_LENGTH_DECREASE,
-    WIDX_SYNCHRONISE_WITH_ADJACENT_STATIONS_CHECKBOX,
-    WIDX_MODE_TWEAK_LABEL,
-    WIDX_LIFT_HILL_SPEED_LABEL,
-    WIDX_MODE,
-    WIDX_MODE_DROPDOWN,
-    WIDX_LOAD,
-    WIDX_LOAD_DROPDOWN,
-    WIDX_OPERATE_NUMBER_OF_CIRCUITS_LABEL,
-    WIDX_OPERATE_NUMBER_OF_CIRCUITS,
-    WIDX_OPERATE_NUMBER_OF_CIRCUITS_INCREASE,
-    WIDX_OPERATE_NUMBER_OF_CIRCUITS_DECREASE,
+    // 0x009ADEFC
+    static Widget _operatingWidgets[] = {
+        MAIN_RIDE_WIDGETS,
+        MakeSpinnerWidgets({157,  61}, {152, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_ARG_18_STRINGID                                                                 ), // NB: 3 widgets
+        MakeSpinnerWidgets({157,  75}, {152, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_LIFT_HILL_CHAIN_SPEED_VALUE                                                     ), // NB: 3 widgets
+        MakeWidget        ({  7, 109}, { 80, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_WAIT_FOR,                           STR_WAIT_FOR_PASSENGERS_BEFORE_DEPARTING_TIP),
+        MakeWidget        ({  7, 124}, {302, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary                                                                                      ),
+        MakeWidget        ({  7, 139}, {150, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_MINIMUM_WAITING_TIME,               STR_MINIMUM_LENGTH_BEFORE_DEPARTING_TIP     ),
+        MakeSpinnerWidgets({157, 139}, {152, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_ARG_10_STRINGID                                                                 ), // NB: 3 widgets
+        MakeWidget        ({  7, 154}, {150, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_MAXIMUM_WAITING_TIME,               STR_MAXIMUM_LENGTH_BEFORE_DEPARTING_TIP     ),
+        MakeSpinnerWidgets({157, 154}, {152, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_ARG_14_STRINGID                                                                 ), // NB: 3 widgets
+        MakeWidget        ({  7, 169}, {302, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_SYNCHRONISE_WITH_ADJACENT_STATIONS, STR_SYNCHRONISE_WITH_ADJACENT_STATIONS_TIP  ),
+        MakeWidget        ({ 21,  61}, {129, 12}, WindowWidgetType::Label,    WindowColour::Secondary                                                                                      ),
+        MakeWidget        ({ 21,  75}, {129, 12}, WindowWidgetType::Label,    WindowColour::Secondary, STR_LIFT_HILL_CHAIN_SPEED                                                           ),
+        MakeWidget        ({  7,  47}, {302, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, 0xFFFFFFFF,                             STR_SELECT_OPERATING_MODE                   ),
+        MakeWidget        ({297,  48}, { 11, 10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH,                     STR_SELECT_OPERATING_MODE                   ),
+        MakeWidget        ({ 87, 109}, {222, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                                                      ),
+        MakeWidget        ({297, 110}, { 11, 10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH                                                                  ),
+        MakeWidget        ({ 21,  89}, {129, 12}, WindowWidgetType::Label,    WindowColour::Secondary, STR_NUMBER_OF_CIRCUITS,                 STR_NUMBER_OF_CIRCUITS_TIP                  ),
+        MakeSpinnerWidgets({157,  89}, {152, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_NUMBER_OF_CIRCUITS_VALUE                                                        ), // NB: 3 widgets
+        kWidgetsEnd,
+    };
 
-    WIDX_INSPECTION_INTERVAL = 14,
-    WIDX_INSPECTION_INTERVAL_DROPDOWN,
-    WIDX_LOCATE_MECHANIC,
-    WIDX_REFURBISH_RIDE,
-    WIDX_FORCE_BREAKDOWN,
-    WIDX_RELIABILITY_BAR,
-    WIDX_DOWN_TIME_BAR,
+    // 0x009AE190
+    static Widget _maintenanceWidgets[] = {
+        MAIN_RIDE_WIDGETS,
+        MakeWidget({107,  71}, {202, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_EMPTY,          STR_SELECT_HOW_OFTEN_A_MECHANIC_SHOULD_CHECK_THIS_RIDE),
+        MakeWidget({297,  72}, { 11, 10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH, STR_SELECT_HOW_OFTEN_A_MECHANIC_SHOULD_CHECK_THIS_RIDE),
+        MakeWidget({289, 108}, { 24, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, 0xFFFFFFFF,         STR_LOCATE_NEAREST_AVAILABLE_MECHANIC_TIP             ),
+        MakeWidget({265, 108}, { 24, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION),   STR_REFURBISH_RIDE_TIP                                ),
+        MakeWidget({241, 108}, { 24, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_NO_ENTRY),       STR_DEBUG_FORCE_BREAKDOWN_TIP                         ),
+        MakeProgressBar({107, 47}, { 147, 10}, COLOUR_BRIGHT_GREEN),
+        MakeProgressBar({107, 58}, { 147, 10}, COLOUR_BRIGHT_RED),
+        kWidgetsEnd,
+    };
 
-    WIDX_TRACK_PREVIEW = 14,
-    WIDX_TRACK_COLOUR_SCHEME,
-    WIDX_TRACK_COLOUR_SCHEME_DROPDOWN,
-    WIDX_TRACK_MAIN_COLOUR,
-    WIDX_TRACK_ADDITIONAL_COLOUR,
-    WIDX_TRACK_SUPPORT_COLOUR,
-    WIDX_MAZE_STYLE,
-    WIDX_MAZE_STYLE_DROPDOWN,
-    WIDX_PAINT_INDIVIDUAL_AREA,
-    WIDX_ENTRANCE_PREVIEW,
-    WIDX_ENTRANCE_STYLE,
-    WIDX_ENTRANCE_STYLE_DROPDOWN,
-    WIDX_VEHICLE_PREVIEW,
-    WIDX_VEHICLE_COLOUR_SCHEME,
-    WIDX_VEHICLE_COLOUR_SCHEME_DROPDOWN,
-    WIDX_VEHICLE_COLOUR_INDEX,
-    WIDX_VEHICLE_COLOUR_INDEX_DROPDOWN,
-    WIDX_VEHICLE_BODY_COLOUR,
-    WIDX_VEHICLE_TRIM_COLOUR,
-    WIDX_VEHICLE_TERTIARY_COLOUR,
-    WIDX_SELL_ITEM_RANDOM_COLOUR_CHECKBOX,
-    WIDX_RANDOMISE_VEHICLE_COLOURS,
+    // 0x009AE2A4
+    static Widget _colourWidgets[] = {
+        MAIN_RIDE_WIDGETS,
+        MakeWidget({  3,  47}, { 68, 47}, WindowWidgetType::Spinner,   WindowColour::Secondary                                                                    ),
+        MakeWidget({ 74,  49}, {239, 12}, WindowWidgetType::DropdownMenu,  WindowColour::Secondary, STR_ARG_14_STRINGID                                               ),
+        MakeWidget({301,  50}, { 11, 10}, WindowWidgetType::Button,    WindowColour::Secondary, STR_DROPDOWN_GLYPH,  STR_COLOUR_SCHEME_TO_CHANGE_TIP              ),
+        MakeWidget({ 79,  74}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_MAIN_COLOUR_TIP                   ),
+        MakeWidget({ 99,  74}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_ADDITIONAL_COLOUR_1_TIP           ),
+        MakeWidget({119,  74}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_SUPPORT_STRUCTURE_COLOUR_TIP      ),
+        MakeWidget({ 74,  49}, {239, 12}, WindowWidgetType::DropdownMenu,  WindowColour::Secondary                                                                    ),
+        MakeWidget({301,  50}, { 11, 10}, WindowWidgetType::Button,    WindowColour::Secondary, STR_DROPDOWN_GLYPH                                                ),
+        MakeWidget({289,  68}, { 24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_PAINTBRUSH),      STR_PAINT_INDIVIDUAL_AREA_TIP                ),
+        MakeWidget({245, 101}, { 68, 47}, WindowWidgetType::Spinner,   WindowColour::Secondary                                                                    ),
+        MakeWidget({103, 103}, {139, 12}, WindowWidgetType::DropdownMenu,  WindowColour::Secondary, STR_EMPTY                                                         ),
+        MakeWidget({230, 104}, { 11, 10}, WindowWidgetType::Button,    WindowColour::Secondary, STR_DROPDOWN_GLYPH,  STR_SELECT_STYLE_OF_ENTRANCE_EXIT_STATION_TIP),
+        MakeWidget({  3, 157}, { 68, 47}, WindowWidgetType::Scroll,    WindowColour::Secondary, STR_EMPTY                                                         ),
+        MakeWidget({ 74, 157}, {239, 12}, WindowWidgetType::DropdownMenu,  WindowColour::Secondary, STR_ARG_6_STRINGID                                                ),
+        MakeWidget({301, 158}, { 11, 10}, WindowWidgetType::Button,    WindowColour::Secondary, STR_DROPDOWN_GLYPH,  STR_SELECT_VEHICLE_COLOUR_SCHEME_TIP         ),
+        MakeWidget({ 74, 173}, {239, 12}, WindowWidgetType::DropdownMenu,  WindowColour::Secondary                                                                    ),
+        MakeWidget({301, 174}, { 11, 10}, WindowWidgetType::Button,    WindowColour::Secondary, STR_DROPDOWN_GLYPH,  STR_SELECT_VEHICLE_TO_MODIFY_TIP             ),
+        MakeWidget({ 79, 190}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_MAIN_COLOUR_TIP                   ),
+        MakeWidget({ 99, 190}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_ADDITIONAL_COLOUR_1_TIP           ),
+        MakeWidget({119, 190}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_ADDITIONAL_COLOUR_2_TIP           ),
+        MakeWidget({100,  74}, {239, 12}, WindowWidgetType::Checkbox,  WindowColour::Secondary, STR_RANDOM_COLOUR                                                 ),
+        MakeWidget({139, 190}, {110, 12}, WindowWidgetType::Button,    WindowColour::Secondary, STR_RANDOMISE_VEHICLE_COLOURS, STR_RANDOMISE_VEHICLE_COLOURS_TIP  ),
+        kWidgetsEnd,
+    };
 
-    WIDX_PLAY_MUSIC = 14,
-    WIDX_MUSIC,
-    WIDX_MUSIC_DROPDOWN,
-    WIDX_MUSIC_IMAGE,
-    WIDX_MUSIC_DATA,
+    // 0x009AE4C8
+    static Widget _musicWidgets[] = {
+        MAIN_RIDE_WIDGETS,
+        MakeWidget({  7, 47}, {302,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_PLAY_MUSIC,     STR_SELECT_MUSIC_TIP      ),
+        MakeWidget({  7, 62}, {302,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_EMPTY                                     ),
+        MakeWidget({297, 63}, { 11,  10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH, STR_SELECT_MUSIC_STYLE_TIP),
+        MakeWidget({154, 90}, {114, 114}, WindowWidgetType::FlatBtn,      WindowColour::Secondary                                                ),
+        MakeWidget({  7, 90}, {500, 450}, WindowWidgetType::Scroll,       WindowColour::Secondary, SCROLL_BOTH                                   ),
+        kWidgetsEnd,
+    };
 
-    WIDX_SAVE_TRACK_DESIGN = 14,
-    WIDX_SELECT_NEARBY_SCENERY,
-    WIDX_RESET_SELECTION,
-    WIDX_SAVE_DESIGN,
-    WIDX_CANCEL_DESIGN,
+    // 0x009AE5DC
+    static Widget _measurementWidgets[] = {
+        MAIN_RIDE_WIDGETS,
+        MakeWidget({288, 194}, { 24, 24}, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_FLOPPY),                STR_SAVE_TRACK_DESIGN),
+        MakeWidget({  4, 127}, {154, 14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_SELECT_NEARBY_SCENERY                       ),
+        MakeWidget({158, 127}, {154, 14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_RESET_SELECTION                             ),
+        MakeWidget({  4, 177}, {154, 14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_DESIGN_SAVE                                 ),
+        MakeWidget({158, 177}, {154, 14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_DESIGN_CANCEL                               ),
+        kWidgetsEnd,
+    };
 
-    WIDX_GRAPH = 14,
-    WIDX_GRAPH_VELOCITY,
-    WIDX_GRAPH_ALTITUDE,
-    WIDX_GRAPH_VERTICAL,
-    WIDX_GRAPH_LATERAL,
+    // 0x009AE710
+    static Widget _graphsWidgets[] = {
+        MAIN_RIDE_WIDGETS,
+        MakeWidget({  3,  46}, {306, 112}, WindowWidgetType::Scroll, WindowColour::Secondary, SCROLL_HORIZONTAL,       STR_LOGGING_DATA_FROM_TIP                               ),
+        MakeWidget({  3, 163}, { 73,  14}, WindowWidgetType::Button, WindowColour::Secondary, STR_RIDE_STATS_VELOCITY, STR_SHOW_GRAPH_OF_VELOCITY_AGAINST_TIME_TIP             ),
+        MakeWidget({ 76, 163}, { 73,  14}, WindowWidgetType::Button, WindowColour::Secondary, STR_RIDE_STATS_ALTITUDE, STR_SHOW_GRAPH_OF_ALTITUDE_AGAINST_TIME_TIP             ),
+        MakeWidget({149, 163}, { 73,  14}, WindowWidgetType::Button, WindowColour::Secondary, STR_RIDE_STATS_VERT_G,   STR_SHOW_GRAPH_OF_VERTICAL_ACCELERATION_AGAINST_TIME_TIP),
+        MakeWidget({222, 163}, { 73,  14}, WindowWidgetType::Button, WindowColour::Secondary, STR_RIDE_STATS_LAT_G,    STR_SHOW_GRAPH_OF_LATERAL_ACCELERATION_AGAINST_TIME_TIP ),
+        kWidgetsEnd,
+    };
 
-    WIDX_PRIMARY_PRICE_LABEL = 14,
-    WIDX_PRIMARY_PRICE,
-    WIDX_PRIMARY_PRICE_INCREASE,
-    WIDX_PRIMARY_PRICE_DECREASE,
-    WIDX_PRIMARY_PRICE_SAME_THROUGHOUT_PARK,
-    WIDX_SECONDARY_PRICE_LABEL,
-    WIDX_SECONDARY_PRICE,
-    WIDX_SECONDARY_PRICE_INCREASE,
-    WIDX_SECONDARY_PRICE_DECREASE,
-    WIDX_SECONDARY_PRICE_SAME_THROUGHOUT_PARK,
+    // 0x009AE844
+    static Widget _incomeWidgets[] = {
+        MAIN_RIDE_WIDGETS,
+        MakeWidget        ({ 19,  50}, {126, 14}, WindowWidgetType::Label,    WindowColour::Secondary                                                                    ),
+        MakeSpinnerWidgets({147,  50}, {162, 14}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_ARG_6_CURRENCY2DP                                             ), // NB: 3 widgets
+        MakeWidget        ({  5,  62}, {306, 13}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_SAME_PRICE_THROUGHOUT_PARK, STR_SAME_PRICE_THROUGHOUT_PARK_TIP),
+        MakeWidget        ({ 19,  94}, {126, 14}, WindowWidgetType::Label,    WindowColour::Secondary                                                                    ),
+        MakeSpinnerWidgets({147,  94}, {162, 14}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_RIDE_SECONDARY_PRICE_VALUE                                    ), // NB: 3 widgets
+        MakeWidget        ({  5, 106}, {306, 13}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_SAME_PRICE_THROUGHOUT_PARK, STR_SAME_PRICE_THROUGHOUT_PARK_TIP),
+        kWidgetsEnd,
+    };
 
-    WIDX_SHOW_GUESTS_THOUGHTS = 14,
-    WIDX_SHOW_GUESTS_ON_RIDE,
-    WIDX_SHOW_GUESTS_QUEUING
-};
+    // 0x009AE9C8
+    static Widget _customerWidgets[] = {
+        MAIN_RIDE_WIDGETS,
+        MakeWidget({289,  54}, {24, 24}, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_SHOW_GUESTS_THOUGHTS_ABOUT_THIS_RIDE_ATTRACTION), STR_SHOW_GUESTS_THOUGHTS_ABOUT_THIS_RIDE_ATTRACTION_TIP),
+        MakeWidget({289,  78}, {24, 24}, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_SHOW_GUESTS_ON_THIS_RIDE_ATTRACTION),             STR_SHOW_GUESTS_ON_THIS_RIDE_ATTRACTION_TIP            ),
+        MakeWidget({289, 102}, {24, 24}, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_SHOW_GUESTS_QUEUING_FOR_THIS_RIDE_ATTRACTION),    STR_SHOW_GUESTS_QUEUING_FOR_THIS_RIDE_ATTRACTION_TIP   ),
+        kWidgetsEnd,
+    };
 
-constexpr int32_t RCT1_LIGHT_OFFSET = 4;
+    static const std::array PageWidgets = {
+        _mainWidgets,
+        _vehicleWidgets,
+        _operatingWidgets,
+        _maintenanceWidgets,
+        _colourWidgets,
+        _musicWidgets,
+        _measurementWidgets,
+        _graphsWidgets,
+        _incomeWidgets,
+        _customerWidgets,
+    };
+    static_assert(std::size(PageWidgets) == WINDOW_RIDE_PAGE_COUNT);
 
-#define MAIN_RIDE_WIDGETS \
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
-    MakeWidget({  0, 43}, {316, 137}, WindowWidgetType::Resize, WindowColour::Secondary), \
-    MakeTab   ({  3, 17}, STR_VIEW_OF_RIDE_ATTRACTION_TIP                ), \
-    MakeTab   ({ 34, 17}, STR_VEHICLE_DETAILS_AND_OPTIONS_TIP            ), \
-    MakeTab   ({ 65, 17}, STR_OPERATING_OPTIONS_TIP                      ), \
-    MakeTab   ({ 96, 17}, STR_MAINTENANCE_OPTIONS_TIP                    ), \
-    MakeTab   ({127, 17}, STR_COLOUR_SCHEME_OPTIONS_TIP                  ), \
-    MakeTab   ({158, 17}, STR_SOUND_AND_MUSIC_OPTIONS_TIP                ), \
-    MakeTab   ({189, 17}, STR_MEASUREMENTS_AND_TEST_DATA_TIP             ), \
-    MakeTab   ({220, 17}, STR_GRAPHS_TIP                                 ), \
-    MakeTab   ({251, 17}, STR_INCOME_AND_COSTS_TIP                       ), \
-    MakeTab   ({282, 17}, STR_CUSTOMER_INFORMATION_TIP                   )
-
-// 0x009ADC34
-static Widget _mainWidgets[] = {
-    MAIN_RIDE_WIDGETS,
-    MakeWidget({  3,  60}, {288, 107}, WindowWidgetType::Viewport,      WindowColour::Secondary                                                                  ),
-    MakeWidget({ 35,  46}, {222,  12}, WindowWidgetType::DropdownMenu,  WindowColour::Secondary, kWidgetContentEmpty,                 STR_VIEW_SELECTION         ),
-    MakeWidget({245,  47}, { 11,  10}, WindowWidgetType::Button,        WindowColour::Secondary, STR_DROPDOWN_GLYPH,                  STR_VIEW_SELECTION         ),
-    MakeWidget({  3, 167}, {288,  11}, WindowWidgetType::LabelCentred,  WindowColour::Secondary                                                                  ),
-    MakeWidget({291,  46}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, kWidgetContentEmpty,                 STR_OPEN_CLOSE_OR_TEST_RIDE),
-    MakeWidget({291,  70}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_CONSTRUCTION),           STR_CONSTRUCTION           ),
-    MakeWidget({291,  94}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_RENAME),                 STR_NAME_RIDE_TIP          ),
-    MakeWidget({291, 118}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_LOCATE),                 STR_LOCATE_SUBJECT_TIP     ),
-    MakeWidget({291, 142}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_DEMOLISH),               STR_DEMOLISH_RIDE_TIP      ),
-    MakeWidget({296,  48}, { 14,  14}, WindowWidgetType::ImgBtn,        WindowColour::Secondary, ImageId(SPR_G2_RCT1_CLOSE_BUTTON_0), STR_CLOSE_RIDE_TIP         ),
-    MakeWidget({296,  62}, { 14,  14}, WindowWidgetType::ImgBtn,        WindowColour::Secondary, ImageId(SPR_G2_RCT1_TEST_BUTTON_0),  STR_SIMULATE_RIDE_TIP      ),
-    MakeWidget({296,  62}, { 14,  14}, WindowWidgetType::ImgBtn,        WindowColour::Secondary, ImageId(SPR_G2_RCT1_TEST_BUTTON_0),  STR_TEST_RIDE_TIP          ),
-    MakeWidget({296,  76}, { 14,  14}, WindowWidgetType::ImgBtn,        WindowColour::Secondary, ImageId(SPR_G2_RCT1_OPEN_BUTTON_0),  STR_OPEN_RIDE_TIP          ),
-    MakeWidget({  3, 180}, {305,  12}, WindowWidgetType::DropdownMenu,      WindowColour::Secondary, STR_ARG_6_STRINGID                                     ),
-    MakeWidget({297, 180}, { 11,  12}, WindowWidgetType::Button,        WindowColour::Secondary, STR_DROPDOWN_GLYPH                                     ),
-    kWidgetsEnd,
-};
-
-// 0x009ADDA8
-static Widget _vehicleWidgets[] = {
-    MAIN_RIDE_WIDGETS,
-    MakeWidget        ({  7,  50}, {302, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                    ),
-    MakeWidget        ({297,  51}, { 11, 10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH                                ),
-    MakeWidget        ({  7, 137}, {302, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_OPTION_REVERSE_TRAINS, STR_OPTION_REVERSE_TRAINS_TIP  ),
-    MakeWidget        ({  7, 154}, {302, 43}, WindowWidgetType::Scroll,   WindowColour::Secondary, STR_EMPTY                                         ),
-    MakeSpinnerWidgets({  7, 203}, {145, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_RIDE_VEHICLE_COUNT, STR_MAX_VEHICLES_TIP      ),
-    MakeSpinnerWidgets({164, 203}, {145, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_1_CAR_PER_TRAIN,    STR_MAX_CARS_PER_TRAIN_TIP),
-    kWidgetsEnd,
-};
-
-// 0x009ADEFC
-static Widget _operatingWidgets[] = {
-    MAIN_RIDE_WIDGETS,
-    MakeSpinnerWidgets({157,  61}, {152, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_ARG_18_STRINGID                                                                 ), // NB: 3 widgets
-    MakeSpinnerWidgets({157,  75}, {152, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_LIFT_HILL_CHAIN_SPEED_VALUE                                                     ), // NB: 3 widgets
-    MakeWidget        ({  7, 109}, { 80, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_WAIT_FOR,                           STR_WAIT_FOR_PASSENGERS_BEFORE_DEPARTING_TIP),
-    MakeWidget        ({  7, 124}, {302, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary                                                                                      ),
-    MakeWidget        ({  7, 139}, {150, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_MINIMUM_WAITING_TIME,               STR_MINIMUM_LENGTH_BEFORE_DEPARTING_TIP     ),
-    MakeSpinnerWidgets({157, 139}, {152, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_ARG_10_STRINGID                                                                 ), // NB: 3 widgets
-    MakeWidget        ({  7, 154}, {150, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_MAXIMUM_WAITING_TIME,               STR_MAXIMUM_LENGTH_BEFORE_DEPARTING_TIP     ),
-    MakeSpinnerWidgets({157, 154}, {152, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_ARG_14_STRINGID                                                                 ), // NB: 3 widgets
-    MakeWidget        ({  7, 169}, {302, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_SYNCHRONISE_WITH_ADJACENT_STATIONS, STR_SYNCHRONISE_WITH_ADJACENT_STATIONS_TIP  ),
-    MakeWidget        ({ 21,  61}, {129, 12}, WindowWidgetType::Label,    WindowColour::Secondary                                                                                      ),
-    MakeWidget        ({ 21,  75}, {129, 12}, WindowWidgetType::Label,    WindowColour::Secondary, STR_LIFT_HILL_CHAIN_SPEED                                                           ),
-    MakeWidget        ({  7,  47}, {302, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, 0xFFFFFFFF,                             STR_SELECT_OPERATING_MODE                   ),
-    MakeWidget        ({297,  48}, { 11, 10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH,                     STR_SELECT_OPERATING_MODE                   ),
-    MakeWidget        ({ 87, 109}, {222, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                                                      ),
-    MakeWidget        ({297, 110}, { 11, 10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH                                                                  ),
-    MakeWidget        ({ 21,  89}, {129, 12}, WindowWidgetType::Label,    WindowColour::Secondary, STR_NUMBER_OF_CIRCUITS,                 STR_NUMBER_OF_CIRCUITS_TIP                  ),
-    MakeSpinnerWidgets({157,  89}, {152, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_NUMBER_OF_CIRCUITS_VALUE                                                        ), // NB: 3 widgets
-    kWidgetsEnd,
-};
-
-// 0x009AE190
-static Widget _maintenanceWidgets[] = {
-    MAIN_RIDE_WIDGETS,
-    MakeWidget({107,  71}, {202, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_EMPTY,          STR_SELECT_HOW_OFTEN_A_MECHANIC_SHOULD_CHECK_THIS_RIDE),
-    MakeWidget({297,  72}, { 11, 10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH, STR_SELECT_HOW_OFTEN_A_MECHANIC_SHOULD_CHECK_THIS_RIDE),
-    MakeWidget({289, 108}, { 24, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, 0xFFFFFFFF,         STR_LOCATE_NEAREST_AVAILABLE_MECHANIC_TIP             ),
-    MakeWidget({265, 108}, { 24, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CONSTRUCTION),   STR_REFURBISH_RIDE_TIP                                ),
-    MakeWidget({241, 108}, { 24, 24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_NO_ENTRY),       STR_DEBUG_FORCE_BREAKDOWN_TIP                         ),
-    MakeProgressBar({107, 47}, { 147, 10}, COLOUR_BRIGHT_GREEN),
-    MakeProgressBar({107, 58}, { 147, 10}, COLOUR_BRIGHT_RED),
-    kWidgetsEnd,
-};
-
-// 0x009AE2A4
-static Widget _colourWidgets[] = {
-    MAIN_RIDE_WIDGETS,
-    MakeWidget({  3,  47}, { 68, 47}, WindowWidgetType::Spinner,   WindowColour::Secondary                                                                    ),
-    MakeWidget({ 74,  49}, {239, 12}, WindowWidgetType::DropdownMenu,  WindowColour::Secondary, STR_ARG_14_STRINGID                                               ),
-    MakeWidget({301,  50}, { 11, 10}, WindowWidgetType::Button,    WindowColour::Secondary, STR_DROPDOWN_GLYPH,  STR_COLOUR_SCHEME_TO_CHANGE_TIP              ),
-    MakeWidget({ 79,  74}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_MAIN_COLOUR_TIP                   ),
-    MakeWidget({ 99,  74}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_ADDITIONAL_COLOUR_1_TIP           ),
-    MakeWidget({119,  74}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_SUPPORT_STRUCTURE_COLOUR_TIP      ),
-    MakeWidget({ 74,  49}, {239, 12}, WindowWidgetType::DropdownMenu,  WindowColour::Secondary                                                                    ),
-    MakeWidget({301,  50}, { 11, 10}, WindowWidgetType::Button,    WindowColour::Secondary, STR_DROPDOWN_GLYPH                                                ),
-    MakeWidget({289,  68}, { 24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_PAINTBRUSH),      STR_PAINT_INDIVIDUAL_AREA_TIP                ),
-    MakeWidget({245, 101}, { 68, 47}, WindowWidgetType::Spinner,   WindowColour::Secondary                                                                    ),
-    MakeWidget({103, 103}, {139, 12}, WindowWidgetType::DropdownMenu,  WindowColour::Secondary, STR_EMPTY                                                         ),
-    MakeWidget({230, 104}, { 11, 10}, WindowWidgetType::Button,    WindowColour::Secondary, STR_DROPDOWN_GLYPH,  STR_SELECT_STYLE_OF_ENTRANCE_EXIT_STATION_TIP),
-    MakeWidget({  3, 157}, { 68, 47}, WindowWidgetType::Scroll,    WindowColour::Secondary, STR_EMPTY                                                         ),
-    MakeWidget({ 74, 157}, {239, 12}, WindowWidgetType::DropdownMenu,  WindowColour::Secondary, STR_ARG_6_STRINGID                                                ),
-    MakeWidget({301, 158}, { 11, 10}, WindowWidgetType::Button,    WindowColour::Secondary, STR_DROPDOWN_GLYPH,  STR_SELECT_VEHICLE_COLOUR_SCHEME_TIP         ),
-    MakeWidget({ 74, 173}, {239, 12}, WindowWidgetType::DropdownMenu,  WindowColour::Secondary                                                                    ),
-    MakeWidget({301, 174}, { 11, 10}, WindowWidgetType::Button,    WindowColour::Secondary, STR_DROPDOWN_GLYPH,  STR_SELECT_VEHICLE_TO_MODIFY_TIP             ),
-    MakeWidget({ 79, 190}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_MAIN_COLOUR_TIP                   ),
-    MakeWidget({ 99, 190}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_ADDITIONAL_COLOUR_1_TIP           ),
-    MakeWidget({119, 190}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_ADDITIONAL_COLOUR_2_TIP           ),
-    MakeWidget({100,  74}, {239, 12}, WindowWidgetType::Checkbox,  WindowColour::Secondary, STR_RANDOM_COLOUR                                                 ),
-    MakeWidget({139, 190}, {110, 12}, WindowWidgetType::Button,    WindowColour::Secondary, STR_RANDOMISE_VEHICLE_COLOURS, STR_RANDOMISE_VEHICLE_COLOURS_TIP  ),
-    kWidgetsEnd,
-};
-
-// 0x009AE4C8
-static Widget _musicWidgets[] = {
-    MAIN_RIDE_WIDGETS,
-    MakeWidget({  7, 47}, {302,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_PLAY_MUSIC,     STR_SELECT_MUSIC_TIP      ),
-    MakeWidget({  7, 62}, {302,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary, STR_EMPTY                                     ),
-    MakeWidget({297, 63}, { 11,  10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH, STR_SELECT_MUSIC_STYLE_TIP),
-    MakeWidget({154, 90}, {114, 114}, WindowWidgetType::FlatBtn,      WindowColour::Secondary                                                ),
-    MakeWidget({  7, 90}, {500, 450}, WindowWidgetType::Scroll,       WindowColour::Secondary, SCROLL_BOTH                                   ),
-    kWidgetsEnd,
-};
-
-// 0x009AE5DC
-static Widget _measurementWidgets[] = {
-    MAIN_RIDE_WIDGETS,
-    MakeWidget({288, 194}, { 24, 24}, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_FLOPPY),                STR_SAVE_TRACK_DESIGN),
-    MakeWidget({  4, 127}, {154, 14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_SELECT_NEARBY_SCENERY                       ),
-    MakeWidget({158, 127}, {154, 14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_RESET_SELECTION                             ),
-    MakeWidget({  4, 177}, {154, 14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_DESIGN_SAVE                                 ),
-    MakeWidget({158, 177}, {154, 14}, WindowWidgetType::Button,  WindowColour::Secondary, STR_DESIGN_CANCEL                               ),
-    kWidgetsEnd,
-};
-
-// 0x009AE710
-static Widget _graphsWidgets[] = {
-    MAIN_RIDE_WIDGETS,
-    MakeWidget({  3,  46}, {306, 112}, WindowWidgetType::Scroll, WindowColour::Secondary, SCROLL_HORIZONTAL,       STR_LOGGING_DATA_FROM_TIP                               ),
-    MakeWidget({  3, 163}, { 73,  14}, WindowWidgetType::Button, WindowColour::Secondary, STR_RIDE_STATS_VELOCITY, STR_SHOW_GRAPH_OF_VELOCITY_AGAINST_TIME_TIP             ),
-    MakeWidget({ 76, 163}, { 73,  14}, WindowWidgetType::Button, WindowColour::Secondary, STR_RIDE_STATS_ALTITUDE, STR_SHOW_GRAPH_OF_ALTITUDE_AGAINST_TIME_TIP             ),
-    MakeWidget({149, 163}, { 73,  14}, WindowWidgetType::Button, WindowColour::Secondary, STR_RIDE_STATS_VERT_G,   STR_SHOW_GRAPH_OF_VERTICAL_ACCELERATION_AGAINST_TIME_TIP),
-    MakeWidget({222, 163}, { 73,  14}, WindowWidgetType::Button, WindowColour::Secondary, STR_RIDE_STATS_LAT_G,    STR_SHOW_GRAPH_OF_LATERAL_ACCELERATION_AGAINST_TIME_TIP ),
-    kWidgetsEnd,
-};
-
-// 0x009AE844
-static Widget _incomeWidgets[] = {
-    MAIN_RIDE_WIDGETS,
-    MakeWidget        ({ 19,  50}, {126, 14}, WindowWidgetType::Label,    WindowColour::Secondary                                                                    ),
-    MakeSpinnerWidgets({147,  50}, {162, 14}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_ARG_6_CURRENCY2DP                                             ), // NB: 3 widgets
-    MakeWidget        ({  5,  62}, {306, 13}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_SAME_PRICE_THROUGHOUT_PARK, STR_SAME_PRICE_THROUGHOUT_PARK_TIP),
-    MakeWidget        ({ 19,  94}, {126, 14}, WindowWidgetType::Label,    WindowColour::Secondary                                                                    ),
-    MakeSpinnerWidgets({147,  94}, {162, 14}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_RIDE_SECONDARY_PRICE_VALUE                                    ), // NB: 3 widgets
-    MakeWidget        ({  5, 106}, {306, 13}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_SAME_PRICE_THROUGHOUT_PARK, STR_SAME_PRICE_THROUGHOUT_PARK_TIP),
-    kWidgetsEnd,
-};
-
-// 0x009AE9C8
-static Widget _customerWidgets[] = {
-    MAIN_RIDE_WIDGETS,
-    MakeWidget({289,  54}, {24, 24}, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_SHOW_GUESTS_THOUGHTS_ABOUT_THIS_RIDE_ATTRACTION), STR_SHOW_GUESTS_THOUGHTS_ABOUT_THIS_RIDE_ATTRACTION_TIP),
-    MakeWidget({289,  78}, {24, 24}, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_SHOW_GUESTS_ON_THIS_RIDE_ATTRACTION),             STR_SHOW_GUESTS_ON_THIS_RIDE_ATTRACTION_TIP            ),
-    MakeWidget({289, 102}, {24, 24}, WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_SHOW_GUESTS_QUEUING_FOR_THIS_RIDE_ATTRACTION),    STR_SHOW_GUESTS_QUEUING_FOR_THIS_RIDE_ATTRACTION_TIP   ),
-    kWidgetsEnd,
-};
-
-static const std::array PageWidgets = {
-    _mainWidgets,
-    _vehicleWidgets,
-    _operatingWidgets,
-    _maintenanceWidgets,
-    _colourWidgets,
-    _musicWidgets,
-    _measurementWidgets,
-    _graphsWidgets,
-    _incomeWidgets,
-    _customerWidgets,
-};
-static_assert(std::size(PageWidgets) == WINDOW_RIDE_PAGE_COUNT);
-
-static constexpr std::array PageHoldDownWidgets = {
-    0uLL,
-    (1uLL << WIDX_VEHICLE_TRAINS_INCREASE) |
-        (1uLL << WIDX_VEHICLE_TRAINS_DECREASE) |
-        (1uLL << WIDX_VEHICLE_CARS_PER_TRAIN_INCREASE) |
-        (1uLL << WIDX_VEHICLE_CARS_PER_TRAIN_DECREASE),
-    (1uLL << WIDX_MODE_TWEAK_INCREASE) |
-        (1uLL << WIDX_MODE_TWEAK_DECREASE) |
-        (1uLL << WIDX_LIFT_HILL_SPEED_INCREASE) |
-        (1uLL << WIDX_LIFT_HILL_SPEED_DECREASE) |
-        (1uLL << WIDX_MINIMUM_LENGTH_INCREASE) |
-        (1uLL << WIDX_MINIMUM_LENGTH_DECREASE) |
-        (1uLL << WIDX_MAXIMUM_LENGTH_INCREASE) |
-        (1uLL << WIDX_MAXIMUM_LENGTH_DECREASE) |
-        (1uLL << WIDX_OPERATE_NUMBER_OF_CIRCUITS_INCREASE) |
-        (1uLL << WIDX_OPERATE_NUMBER_OF_CIRCUITS_DECREASE),
-    0uLL,
-    0uLL,
-    0uLL,
-    0uLL,
-    0uLL,
-    (1uLL << WIDX_PRIMARY_PRICE_INCREASE) |
-        (1uLL << WIDX_PRIMARY_PRICE_DECREASE) |
-        (1uLL << WIDX_SECONDARY_PRICE_INCREASE) |
-        (1uLL << WIDX_SECONDARY_PRICE_DECREASE),
-    0uLL,
-};
-static_assert(std::size(PageHoldDownWidgets) == WINDOW_RIDE_PAGE_COUNT);
+    static constexpr std::array PageHoldDownWidgets = {
+        0uLL,
+        (1uLL << WIDX_VEHICLE_TRAINS_INCREASE) |
+            (1uLL << WIDX_VEHICLE_TRAINS_DECREASE) |
+            (1uLL << WIDX_VEHICLE_CARS_PER_TRAIN_INCREASE) |
+            (1uLL << WIDX_VEHICLE_CARS_PER_TRAIN_DECREASE),
+        (1uLL << WIDX_MODE_TWEAK_INCREASE) |
+            (1uLL << WIDX_MODE_TWEAK_DECREASE) |
+            (1uLL << WIDX_LIFT_HILL_SPEED_INCREASE) |
+            (1uLL << WIDX_LIFT_HILL_SPEED_DECREASE) |
+            (1uLL << WIDX_MINIMUM_LENGTH_INCREASE) |
+            (1uLL << WIDX_MINIMUM_LENGTH_DECREASE) |
+            (1uLL << WIDX_MAXIMUM_LENGTH_INCREASE) |
+            (1uLL << WIDX_MAXIMUM_LENGTH_DECREASE) |
+            (1uLL << WIDX_OPERATE_NUMBER_OF_CIRCUITS_INCREASE) |
+            (1uLL << WIDX_OPERATE_NUMBER_OF_CIRCUITS_DECREASE),
+        0uLL,
+        0uLL,
+        0uLL,
+        0uLL,
+        0uLL,
+        (1uLL << WIDX_PRIMARY_PRICE_INCREASE) |
+            (1uLL << WIDX_PRIMARY_PRICE_DECREASE) |
+            (1uLL << WIDX_SECONDARY_PRICE_INCREASE) |
+            (1uLL << WIDX_SECONDARY_PRICE_DECREASE),
+        0uLL,
+    };
+    static_assert(std::size(PageHoldDownWidgets) == WINDOW_RIDE_PAGE_COUNT);
     // clang-format on
 
 #pragma endregion
@@ -489,26 +491,26 @@ static_assert(std::size(PageHoldDownWidgets) == WINDOW_RIDE_PAGE_COUNT);
     static_assert(std::size(PageTabAnimationNumFrames) == WINDOW_RIDE_PAGE_COUNT);
 
     // clang-format off
-static constexpr std::array RatingNames = {
-    static_cast<StringId>(STR_RATING_LOW),
-    static_cast<StringId>(STR_RATING_MEDIUM),
-    static_cast<StringId>(STR_RATING_HIGH),
-    static_cast<StringId>(STR_RATING_VERY_HIGH),
-    static_cast<StringId>(STR_RATING_EXTREME),
-    static_cast<StringId>(STR_RATING_ULTRA_EXTREME),
-};
-static_assert(std::size(RatingNames) == 6);
+    static constexpr std::array RatingNames = {
+        STR_RATING_LOW,
+        STR_RATING_MEDIUM,
+        STR_RATING_HIGH,
+        STR_RATING_VERY_HIGH,
+        STR_RATING_EXTREME,
+        STR_RATING_ULTRA_EXTREME,
+    };
+    static_assert(std::size(RatingNames) == 6);
     // clang-format on
 
     static constexpr std::array RideBreakdownReasonNames = {
-        static_cast<StringId>(STR_RIDE_BREAKDOWN_SAFETY_CUT_OUT),          // BREAKDOWN_SAFETY_CUT_OUT
-        static_cast<StringId>(STR_RIDE_BREAKDOWN_RESTRAINTS_STUCK_CLOSED), // BREAKDOWN_RESTRAINTS_STUCK_CLOSED
-        static_cast<StringId>(STR_RIDE_BREAKDOWN_RESTRAINTS_STUCK_OPEN),   // BREAKDOWN_RESTRAINTS_STUCK_OPEN
-        static_cast<StringId>(STR_RIDE_BREAKDOWN_DOORS_STUCK_CLOSED),      // BREAKDOWN_DOORS_STUCK_CLOSED
-        static_cast<StringId>(STR_RIDE_BREAKDOWN_DOORS_STUCK_OPEN),        // BREAKDOWN_DOORS_STUCK_OPEN
-        static_cast<StringId>(STR_RIDE_BREAKDOWN_VEHICLE_MALFUNCTION),     // BREAKDOWN_VEHICLE_MALFUNCTION
-        static_cast<StringId>(STR_RIDE_BREAKDOWN_BRAKES_FAILURE),          // BREAKDOWN_BRAKES_FAILURE
-        static_cast<StringId>(STR_RIDE_BREAKDOWN_CONTROL_FAILURE),         // BREAKDOWN_CONTROL_FAILURE
+        STR_RIDE_BREAKDOWN_SAFETY_CUT_OUT,          // BREAKDOWN_SAFETY_CUT_OUT
+        STR_RIDE_BREAKDOWN_RESTRAINTS_STUCK_CLOSED, // BREAKDOWN_RESTRAINTS_STUCK_CLOSED
+        STR_RIDE_BREAKDOWN_RESTRAINTS_STUCK_OPEN,   // BREAKDOWN_RESTRAINTS_STUCK_OPEN
+        STR_RIDE_BREAKDOWN_DOORS_STUCK_CLOSED,      // BREAKDOWN_DOORS_STUCK_CLOSED
+        STR_RIDE_BREAKDOWN_DOORS_STUCK_OPEN,        // BREAKDOWN_DOORS_STUCK_OPEN
+        STR_RIDE_BREAKDOWN_VEHICLE_MALFUNCTION,     // BREAKDOWN_VEHICLE_MALFUNCTION
+        STR_RIDE_BREAKDOWN_BRAKES_FAILURE,          // BREAKDOWN_BRAKES_FAILURE
+        STR_RIDE_BREAKDOWN_CONTROL_FAILURE,         // BREAKDOWN_CONTROL_FAILURE
     };
     static_assert(std::size(RideBreakdownReasonNames) == BREAKDOWN_COUNT);
 
@@ -522,64 +524,64 @@ static_assert(std::size(RatingNames) == 6);
     static_assert(std::size(ColourSchemeNames) == kNumRideColourSchemes);
 
     static constexpr std::array VehicleLoadNames = {
-        static_cast<StringId>(STR_QUARTER_LOAD),       //  WAIT_FOR_LOAD_QUARTER
-        static_cast<StringId>(STR_HALF_LOAD),          //  WAIT_FOR_LOAD_HALF
-        static_cast<StringId>(STR_THREE_QUARTER_LOAD), //  WAIT_FOR_LOAD_THREE_QUARTER
-        static_cast<StringId>(STR_FULL_LOAD),          //  WAIT_FOR_LOAD_FULL
-        static_cast<StringId>(STR_ANY_LOAD),           //  WAIT_FOR_LOAD_ANY
+        STR_QUARTER_LOAD,       //  WAIT_FOR_LOAD_QUARTER
+        STR_HALF_LOAD,          //  WAIT_FOR_LOAD_HALF
+        STR_THREE_QUARTER_LOAD, //  WAIT_FOR_LOAD_THREE_QUARTER
+        STR_FULL_LOAD,          //  WAIT_FOR_LOAD_FULL
+        STR_ANY_LOAD,           //  WAIT_FOR_LOAD_ANY
     };
     static_assert(std::size(VehicleLoadNames) == WAIT_FOR_LOAD_COUNT);
 
     static constexpr std::array VehicleColourSchemeNames = {
-        static_cast<StringId>(STR_ALL_VEHICLES_IN_SAME_COLOURS),  // VehicleColourSettings::same,
-        static_cast<StringId>(STR_DIFFERENT_COLOURS_PER),         // VehicleColourSettings::perTrain,
-        static_cast<StringId>(STR_DIFFERENT_COLOURS_PER_VEHICLE), // VehicleColourSettings::perCar,
+        STR_ALL_VEHICLES_IN_SAME_COLOURS,  // VehicleColourSettings::same,
+        STR_DIFFERENT_COLOURS_PER,         // VehicleColourSettings::perTrain,
+        STR_DIFFERENT_COLOURS_PER_VEHICLE, // VehicleColourSettings::perCar,
     };
     static_assert(std::size(VehicleColourSchemeNames) == kNumVehicleColourSettings);
 
     static constexpr std::array VehicleStatusNames = {
-        static_cast<StringId>(STR_MOVING_TO_END_OF),          // Vehicle::Status::MovingToEndOfStation
-        static_cast<StringId>(STR_WAITING_FOR_PASSENGERS_AT), // Vehicle::Status::WaitingForPassengers
-        static_cast<StringId>(STR_WAITING_TO_DEPART),         // Vehicle::Status::WaitingToDepart
-        static_cast<StringId>(STR_DEPARTING),                 // Vehicle::Status::Departing
-        static_cast<StringId>(STR_TRAVELLING_AT_0),           // Vehicle::Status::Travelling
-        static_cast<StringId>(STR_ARRIVING_AT),               // Vehicle::Status::Arriving
-        static_cast<StringId>(STR_UNLOADING_PASSENGERS_AT),   // Vehicle::Status::UnloadingPassengers
-        static_cast<StringId>(STR_TRAVELLING_AT_1),           // Vehicle::Status::TravellingBoat
-        static_cast<StringId>(STR_CRASHING),                  // Vehicle::Status::Crashing
-        static_cast<StringId>(STR_CRASHED_0),                 // Vehicle::Status::Crashed
-        static_cast<StringId>(STR_TRAVELLING_AT_2),           // Vehicle::Status::TravellingDodgems
-        static_cast<StringId>(STR_SWINGING),                  // Vehicle::Status::Swinging
-        static_cast<StringId>(STR_ROTATING_0),                // Vehicle::Status::Rotating
-        static_cast<StringId>(STR_ROTATING_1),                // Vehicle::Status::FerrisWheelRotating
-        static_cast<StringId>(STR_OPERATING_0),               // Vehicle::Status::SimulatorOperating
-        static_cast<StringId>(STR_SHOWING_FILM),              // Vehicle::Status::ShowingFilm
-        static_cast<StringId>(STR_ROTATING_2),                // Vehicle::Status::SpaceRingsOperating
-        static_cast<StringId>(STR_OPERATING_1),               // Vehicle::Status::TopSpinOperating
-        static_cast<StringId>(STR_OPERATING_2),               // Vehicle::Status::HauntedHouseOperating
-        static_cast<StringId>(STR_DOING_CIRCUS_SHOW),         // Vehicle::Status::DoingCircusShow
-        static_cast<StringId>(STR_OPERATING_3),               // Vehicle::Status::CrookedHouseOperating
-        static_cast<StringId>(STR_WAITING_FOR_CABLE_LIFT),    // Vehicle::Status::WaitingForCableLift
-        static_cast<StringId>(STR_TRAVELLING_AT_3),           // Vehicle::Status::TravellingCableLift
-        static_cast<StringId>(STR_STOPPING_0),                // Vehicle::Status::Stopping
-        static_cast<StringId>(STR_WAITING_FOR_PASSENGERS),    // Vehicle::Status::WaitingForPassengers17
-        static_cast<StringId>(STR_WAITING_TO_START),          // Vehicle::Status::WaitingToStart
-        static_cast<StringId>(STR_STARTING),                  // Vehicle::Status::Starting
-        static_cast<StringId>(STR_OPERATING),                 // Vehicle::Status::Operating1A
-        static_cast<StringId>(STR_STOPPING_1),                // Vehicle::Status::Stopping1B
-        static_cast<StringId>(STR_UNLOADING_PASSENGERS),      // Vehicle::Status::UnloadingPassengers1C
-        static_cast<StringId>(STR_STOPPED_BY_BLOCK_BRAKES),   // Vehicle::Status::StoppedByBlockBrakes
+        STR_MOVING_TO_END_OF,          // Vehicle::Status::MovingToEndOfStation
+        STR_WAITING_FOR_PASSENGERS_AT, // Vehicle::Status::WaitingForPassengers
+        STR_WAITING_TO_DEPART,         // Vehicle::Status::WaitingToDepart
+        STR_DEPARTING,                 // Vehicle::Status::Departing
+        STR_TRAVELLING_AT_0,           // Vehicle::Status::Travelling
+        STR_ARRIVING_AT,               // Vehicle::Status::Arriving
+        STR_UNLOADING_PASSENGERS_AT,   // Vehicle::Status::UnloadingPassengers
+        STR_TRAVELLING_AT_1,           // Vehicle::Status::TravellingBoat
+        STR_CRASHING,                  // Vehicle::Status::Crashing
+        STR_CRASHED_0,                 // Vehicle::Status::Crashed
+        STR_TRAVELLING_AT_2,           // Vehicle::Status::TravellingDodgems
+        STR_SWINGING,                  // Vehicle::Status::Swinging
+        STR_ROTATING_0,                // Vehicle::Status::Rotating
+        STR_ROTATING_1,                // Vehicle::Status::FerrisWheelRotating
+        STR_OPERATING_0,               // Vehicle::Status::SimulatorOperating
+        STR_SHOWING_FILM,              // Vehicle::Status::ShowingFilm
+        STR_ROTATING_2,                // Vehicle::Status::SpaceRingsOperating
+        STR_OPERATING_1,               // Vehicle::Status::TopSpinOperating
+        STR_OPERATING_2,               // Vehicle::Status::HauntedHouseOperating
+        STR_DOING_CIRCUS_SHOW,         // Vehicle::Status::DoingCircusShow
+        STR_OPERATING_3,               // Vehicle::Status::CrookedHouseOperating
+        STR_WAITING_FOR_CABLE_LIFT,    // Vehicle::Status::WaitingForCableLift
+        STR_TRAVELLING_AT_3,           // Vehicle::Status::TravellingCableLift
+        STR_STOPPING_0,                // Vehicle::Status::Stopping
+        STR_WAITING_FOR_PASSENGERS,    // Vehicle::Status::WaitingForPassengers17
+        STR_WAITING_TO_START,          // Vehicle::Status::WaitingToStart
+        STR_STARTING,                  // Vehicle::Status::Starting
+        STR_OPERATING,                 // Vehicle::Status::Operating1A
+        STR_STOPPING_1,                // Vehicle::Status::Stopping1B
+        STR_UNLOADING_PASSENGERS,      // Vehicle::Status::UnloadingPassengers1C
+        STR_STOPPED_BY_BLOCK_BRAKES,   // Vehicle::Status::StoppedByBlockBrakes
     };
     static_assert(std::size(VehicleStatusNames) == 31);
 
     static constexpr std::array SingleSessionVehicleStatusNames = {
-        static_cast<StringId>(STR_STOPPING_0),             // Vehicle::Status::MovingToEndOfStation
-        static_cast<StringId>(STR_WAITING_FOR_PASSENGERS), // Vehicle::Status::WaitingForPassengers
-        static_cast<StringId>(STR_WAITING_TO_START),       // Vehicle::Status::WaitingToDepart
-        static_cast<StringId>(STR_STARTING),               // Vehicle::Status::Departing
-        static_cast<StringId>(STR_OPERATING),              // Vehicle::Status::Travelling
-        static_cast<StringId>(STR_STOPPING_1),             // Vehicle::Status::Arriving
-        static_cast<StringId>(STR_UNLOADING_PASSENGERS),   // Vehicle::Status::UnloadingPassengers
+        STR_STOPPING_0,             // Vehicle::Status::MovingToEndOfStation
+        STR_WAITING_FOR_PASSENGERS, // Vehicle::Status::WaitingForPassengers
+        STR_WAITING_TO_START,       // Vehicle::Status::WaitingToDepart
+        STR_STARTING,               // Vehicle::Status::Departing
+        STR_OPERATING,              // Vehicle::Status::Travelling
+        STR_STOPPING_1,             // Vehicle::Status::Arriving
+        STR_UNLOADING_PASSENGERS,   // Vehicle::Status::UnloadingPassengers
     };
     static_assert(std::size(SingleSessionVehicleStatusNames) == 7);
 

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -53,6 +53,7 @@ constexpr int8_t kDefaultSpeedIncrement = 2;
 constexpr int8_t kDefaultMinimumSpeed = 2;
 
 using namespace OpenRCT2::TrackMetaData;
+
 namespace OpenRCT2::Ui::Windows
 {
     static constexpr StringId WINDOW_TITLE = STR_RIDE_CONSTRUCTION_WINDOW_TITLE;
@@ -119,45 +120,45 @@ namespace OpenRCT2::Ui::Windows
     validate_global_widx(WC_RIDE_CONSTRUCTION, WIDX_ROTATE);
 
     // clang-format off
-static Widget _rideConstructionWidgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget        ({  3,  17}, {     GW,  57}, WindowWidgetType::Groupbox, WindowColour::Primary  , STR_RIDE_CONSTRUCTION_DIRECTION                                                                       ),
-    MakeWidget        ({  3,  76}, {     GW,  41}, WindowWidgetType::Groupbox, WindowColour::Primary  , STR_RIDE_CONSTRUCTION_SLOPE                                                                           ),
-    MakeWidget        ({  3, 120}, {     GW,  41}, WindowWidgetType::Groupbox, WindowColour::Primary  , STR_RIDE_CONSTRUCTION_ROLL_BANKING                                                                    ),
-    MakeWidget        ({  6,  29}, {     22,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_LEFT_CURVE_SMALL),  STR_RIDE_CONSTRUCTION_LEFT_CURVE_VERY_SMALL_TIP     ),
-    MakeWidget        ({ 28,  29}, {     22,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_G2_ICON_MEDIUM_CURVE_LEFT),           STR_RIDE_CONSTRUCTION_LEFT_CURVE_SMALL_TIP          ),
-    MakeWidget        ({ 50,  29}, {     22,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_LEFT_CURVE),        STR_RIDE_CONSTRUCTION_LEFT_CURVE_TIP                ),
-    MakeWidget        ({ 72,  29}, {     22,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_LEFT_CURVE_LARGE),  STR_RIDE_CONSTRUCTION_LEFT_CURVE_LARGE_TIP          ),
-    MakeWidget        ({ 94,  29}, {     22,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_STRAIGHT),          STR_RIDE_CONSTRUCTION_STRAIGHT_TIP                  ),
-    MakeWidget        ({116,  29}, {     22,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_RIGHT_CURVE_LARGE), STR_RIDE_CONSTRUCTION_RIGHT_CURVE_LARGE_TIP         ),
-    MakeWidget        ({138,  29}, {     22,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_RIGHT_CURVE),       STR_RIDE_CONSTRUCTION_RIGHT_CURVE_TIP               ),
-    MakeWidget        ({160,  29}, {     22,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_G2_ICON_MEDIUM_CURVE_RIGHT),          STR_RIDE_CONSTRUCTION_RIGHT_CURVE_SMALL_TIP         ),
-    MakeWidget        ({182,  29}, {     22,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_RIGHT_CURVE_SMALL), STR_RIDE_CONSTRUCTION_RIGHT_CURVE_VERY_SMALL_TIP    ),
-    MakeWidget        ({  6,  55}, { GW - 6,  14}, WindowWidgetType::Button,   WindowColour::Secondary, STR_YELLOW_STRING,                                STR_RIDE_CONSTRUCTION_OTHER_TRACK_CONFIGURATIONS_TIP),
-    MakeWidget        ({ 45,  88}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_DOWN_STEEP),  STR_RIDE_CONSTRUCTION_STEEP_SLOPE_DOWN_TIP          ),
-    MakeWidget        ({ 69,  88}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_DOWN),        STR_RIDE_CONSTRUCTION_SLOPE_DOWN_TIP                ),
-    MakeWidget        ({ 93,  88}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_LEVEL),       STR_RIDE_CONSTRUCTION_LEVEL_TIP                     ),
-    MakeWidget        ({117,  88}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_UP),          STR_RIDE_CONSTRUCTION_SLOPE_UP_TIP                  ),
-    MakeWidget        ({141,  88}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_UP_STEEP),    STR_RIDE_CONSTRUCTION_STEEP_SLOPE_UP_TIP            ),
-    MakeWidget        ({178,  88}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CHAIN_LIFT),                          STR_RIDE_CONSTRUCTION_CHAIN_LIFT_TIP                ),
-    MakeWidget        ({ 69, 132}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_LEFT_BANK),         STR_RIDE_CONSTRUCTION_ROLL_FOR_LEFT_CURVE_TIP       ),
-    MakeWidget        ({ 93, 132}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_NO_BANK),           STR_RIDE_CONSTRUCTION_NO_ROLL_TIP                   ),
-    MakeWidget        ({117, 132}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_RIGHT_BANK),        STR_RIDE_CONSTRUCTION_ROLL_FOR_RIGHT_CURVE_TIP      ),
-    MakeWidget        ({  3, 164}, {     GW, 170}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, 0xFFFFFFFF,                                       STR_RIDE_CONSTRUCTION_CONSTRUCT_SELECTED_SECTION_TIP),
-    MakeWidget        ({ 82, 338}, {     46,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_DEMOLISH_CURRENT_SECTION),            STR_RIDE_CONSTRUCTION_REMOVE_HIGHLIGHTED_SECTION_TIP),
-    MakeWidget        ({ 52, 338}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_PREVIOUS),                            STR_RIDE_CONSTRUCTION_MOVE_TO_PREVIOUS_SECTION_TIP  ),
-    MakeWidget        ({134, 338}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_NEXT),                                STR_RIDE_CONSTRUCTION_MOVE_TO_NEXT_SECTION_TIP      ),
-    MakeWidget        ({  3, 362}, {     GW,  28}, WindowWidgetType::Groupbox, WindowColour::Primary                                                                                                          ),
-    MakeWidget        ({ 31, 372}, {     70,  12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_RIDE_CONSTRUCTION_ENTRANCE,                   STR_RIDE_CONSTRUCTION_ENTRANCE_TIP                  ),
-    MakeWidget        ({109, 372}, {     70,  12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_RIDE_CONSTRUCTION_EXIT,                       STR_RIDE_CONSTRUCTION_EXIT_TIP                      ),
-    MakeWidget        ({ 94, 338}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_ROTATE_ARROW),                        STR_ROTATE_90_TIP                                   ),
-    MakeWidget        ({ 41, 132}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_U_SHAPED_TRACK),    STR_RIDE_CONSTRUCTION_U_SHAPED_OPEN_TRACK_TIP       ),
-    MakeWidget        ({144, 132}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_O_SHAPED_TRACK),    STR_RIDE_CONSTRUCTION_O_SHAPED_ENCLOSED_TRACK_TIP   ),
-    MakeWidget        ({118, 120}, {     89,  41}, WindowWidgetType::Groupbox, WindowColour::Primary  , STR_RIDE_CONSTRUCTION_SEAT_ROT                                                                        ),
-    MakeSpinnerWidgets({123, 138}, {     58,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary, 0,                                                STR_RIDE_CONSTRUCTION_SELECT_SEAT_ROTATION_ANGLE_TIP),
-    MakeWidget        ({161, 338}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_G2_SIMULATE),                         STR_SIMULATE_RIDE_TIP                               ),
-    kWidgetsEnd,
-};
+    static Widget _rideConstructionWidgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget        ({  3,  17}, {     GW,  57}, WindowWidgetType::Groupbox, WindowColour::Primary  , STR_RIDE_CONSTRUCTION_DIRECTION                                                                       ),
+        MakeWidget        ({  3,  76}, {     GW,  41}, WindowWidgetType::Groupbox, WindowColour::Primary  , STR_RIDE_CONSTRUCTION_SLOPE                                                                           ),
+        MakeWidget        ({  3, 120}, {     GW,  41}, WindowWidgetType::Groupbox, WindowColour::Primary  , STR_RIDE_CONSTRUCTION_ROLL_BANKING                                                                    ),
+        MakeWidget        ({  6,  29}, {     22,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_LEFT_CURVE_SMALL),  STR_RIDE_CONSTRUCTION_LEFT_CURVE_VERY_SMALL_TIP     ),
+        MakeWidget        ({ 28,  29}, {     22,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_G2_ICON_MEDIUM_CURVE_LEFT),           STR_RIDE_CONSTRUCTION_LEFT_CURVE_SMALL_TIP          ),
+        MakeWidget        ({ 50,  29}, {     22,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_LEFT_CURVE),        STR_RIDE_CONSTRUCTION_LEFT_CURVE_TIP                ),
+        MakeWidget        ({ 72,  29}, {     22,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_LEFT_CURVE_LARGE),  STR_RIDE_CONSTRUCTION_LEFT_CURVE_LARGE_TIP          ),
+        MakeWidget        ({ 94,  29}, {     22,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_STRAIGHT),          STR_RIDE_CONSTRUCTION_STRAIGHT_TIP                  ),
+        MakeWidget        ({116,  29}, {     22,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_RIGHT_CURVE_LARGE), STR_RIDE_CONSTRUCTION_RIGHT_CURVE_LARGE_TIP         ),
+        MakeWidget        ({138,  29}, {     22,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_RIGHT_CURVE),       STR_RIDE_CONSTRUCTION_RIGHT_CURVE_TIP               ),
+        MakeWidget        ({160,  29}, {     22,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_G2_ICON_MEDIUM_CURVE_RIGHT),          STR_RIDE_CONSTRUCTION_RIGHT_CURVE_SMALL_TIP         ),
+        MakeWidget        ({182,  29}, {     22,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_RIGHT_CURVE_SMALL), STR_RIDE_CONSTRUCTION_RIGHT_CURVE_VERY_SMALL_TIP    ),
+        MakeWidget        ({  6,  55}, { GW - 6,  14}, WindowWidgetType::Button,   WindowColour::Secondary, STR_YELLOW_STRING,                                STR_RIDE_CONSTRUCTION_OTHER_TRACK_CONFIGURATIONS_TIP),
+        MakeWidget        ({ 45,  88}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_DOWN_STEEP),  STR_RIDE_CONSTRUCTION_STEEP_SLOPE_DOWN_TIP          ),
+        MakeWidget        ({ 69,  88}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_DOWN),        STR_RIDE_CONSTRUCTION_SLOPE_DOWN_TIP                ),
+        MakeWidget        ({ 93,  88}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_LEVEL),       STR_RIDE_CONSTRUCTION_LEVEL_TIP                     ),
+        MakeWidget        ({117,  88}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_UP),          STR_RIDE_CONSTRUCTION_SLOPE_UP_TIP                  ),
+        MakeWidget        ({141,  88}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_UP_STEEP),    STR_RIDE_CONSTRUCTION_STEEP_SLOPE_UP_TIP            ),
+        MakeWidget        ({178,  88}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_CHAIN_LIFT),                          STR_RIDE_CONSTRUCTION_CHAIN_LIFT_TIP                ),
+        MakeWidget        ({ 69, 132}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_LEFT_BANK),         STR_RIDE_CONSTRUCTION_ROLL_FOR_LEFT_CURVE_TIP       ),
+        MakeWidget        ({ 93, 132}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_NO_BANK),           STR_RIDE_CONSTRUCTION_NO_ROLL_TIP                   ),
+        MakeWidget        ({117, 132}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_RIGHT_BANK),        STR_RIDE_CONSTRUCTION_ROLL_FOR_RIGHT_CURVE_TIP      ),
+        MakeWidget        ({  3, 164}, {     GW, 170}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, 0xFFFFFFFF,                                       STR_RIDE_CONSTRUCTION_CONSTRUCT_SELECTED_SECTION_TIP),
+        MakeWidget        ({ 82, 338}, {     46,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_DEMOLISH_CURRENT_SECTION),            STR_RIDE_CONSTRUCTION_REMOVE_HIGHLIGHTED_SECTION_TIP),
+        MakeWidget        ({ 52, 338}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_PREVIOUS),                            STR_RIDE_CONSTRUCTION_MOVE_TO_PREVIOUS_SECTION_TIP  ),
+        MakeWidget        ({134, 338}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_NEXT),                                STR_RIDE_CONSTRUCTION_MOVE_TO_NEXT_SECTION_TIP      ),
+        MakeWidget        ({  3, 362}, {     GW,  28}, WindowWidgetType::Groupbox, WindowColour::Primary                                                                                                          ),
+        MakeWidget        ({ 31, 372}, {     70,  12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_RIDE_CONSTRUCTION_ENTRANCE,                   STR_RIDE_CONSTRUCTION_ENTRANCE_TIP                  ),
+        MakeWidget        ({109, 372}, {     70,  12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_RIDE_CONSTRUCTION_EXIT,                       STR_RIDE_CONSTRUCTION_EXIT_TIP                      ),
+        MakeWidget        ({ 94, 338}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_ROTATE_ARROW),                        STR_ROTATE_90_TIP                                   ),
+        MakeWidget        ({ 41, 132}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_U_SHAPED_TRACK),    STR_RIDE_CONSTRUCTION_U_SHAPED_OPEN_TRACK_TIP       ),
+        MakeWidget        ({144, 132}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_RIDE_CONSTRUCTION_O_SHAPED_TRACK),    STR_RIDE_CONSTRUCTION_O_SHAPED_ENCLOSED_TRACK_TIP   ),
+        MakeWidget        ({118, 120}, {     89,  41}, WindowWidgetType::Groupbox, WindowColour::Primary  , STR_RIDE_CONSTRUCTION_SEAT_ROT                                                                        ),
+        MakeSpinnerWidgets({123, 138}, {     58,  12}, WindowWidgetType::Spinner,  WindowColour::Secondary, 0,                                                STR_RIDE_CONSTRUCTION_SELECT_SEAT_ROTATION_ANGLE_TIP),
+        MakeWidget        ({161, 338}, {     24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_G2_SIMULATE),                         STR_SIMULATE_RIDE_TIP                               ),
+        kWidgetsEnd,
+    };
     // clang-format on
 
 #pragma endregion

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -62,22 +62,22 @@ namespace OpenRCT2::Ui::Windows
     };
 
     // clang-format off
-static Widget _rideListWidgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({  0, 43}, {340, 197}, WindowWidgetType::Resize,   WindowColour::Secondary                                                                ), // tab page background
-    MakeWidget({315, 60}, { 24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_TOGGLE_OPEN_CLOSE),      STR_OPEN_OR_CLOSE_ALL_RIDES       ), // open / close all toggle
-    MakeWidget({150, 46}, {124,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                                ), // current information type
-    MakeWidget({262, 47}, { 11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH,         STR_RIDE_LIST_INFORMATION_TYPE_TIP), // information type dropdown button
-    MakeWidget({280, 46}, { 54,  12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_SORT,                   STR_RIDE_LIST_SORT_TIP            ), // sort button
-    MakeTab   ({  3, 17},                                                                                STR_LIST_RIDES_TIP                ), // tab 1
-    MakeTab   ({ 34, 17},                                                                                STR_LIST_SHOPS_AND_STALLS_TIP     ), // tab 2
-    MakeTab   ({ 65, 17},                                                                                STR_LIST_KIOSKS_AND_FACILITIES_TIP), // tab 3
-    MakeWidget({  3, 60}, {334, 177}, WindowWidgetType::Scroll,   WindowColour::Secondary, SCROLL_VERTICAL                                               ), // list
-    MakeWidget({320, 62}, { 14,  14}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, ImageId(SPR_G2_RCT1_CLOSE_BUTTON_0)                                    ),
-    MakeWidget({320, 76}, { 14,  14}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, ImageId(SPR_G2_RCT1_OPEN_BUTTON_0)                                     ),
-    MakeWidget({315, 90}, { 24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_DEMOLISH),               STR_QUICK_DEMOLISH_RIDE           ),
-    kWidgetsEnd,
-};
+    static Widget _rideListWidgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({  0, 43}, {340, 197}, WindowWidgetType::Resize,   WindowColour::Secondary                                                                ), // tab page background
+        MakeWidget({315, 60}, { 24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_TOGGLE_OPEN_CLOSE),      STR_OPEN_OR_CLOSE_ALL_RIDES       ), // open / close all toggle
+        MakeWidget({150, 46}, {124,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                                ), // current information type
+        MakeWidget({262, 47}, { 11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH,         STR_RIDE_LIST_INFORMATION_TYPE_TIP), // information type dropdown button
+        MakeWidget({280, 46}, { 54,  12}, WindowWidgetType::Button,   WindowColour::Secondary, STR_SORT,                   STR_RIDE_LIST_SORT_TIP            ), // sort button
+        MakeTab   ({  3, 17},                                                                                STR_LIST_RIDES_TIP                ), // tab 1
+        MakeTab   ({ 34, 17},                                                                                STR_LIST_SHOPS_AND_STALLS_TIP     ), // tab 2
+        MakeTab   ({ 65, 17},                                                                                STR_LIST_KIOSKS_AND_FACILITIES_TIP), // tab 3
+        MakeWidget({  3, 60}, {334, 177}, WindowWidgetType::Scroll,   WindowColour::Secondary, SCROLL_VERTICAL                                               ), // list
+        MakeWidget({320, 62}, { 14,  14}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, ImageId(SPR_G2_RCT1_CLOSE_BUTTON_0)                                    ),
+        MakeWidget({320, 76}, { 14,  14}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, ImageId(SPR_G2_RCT1_OPEN_BUTTON_0)                                     ),
+        MakeWidget({315, 90}, { 24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, ImageId(SPR_DEMOLISH),               STR_QUICK_DEMOLISH_RIDE           ),
+        kWidgetsEnd,
+    };
     // clang-format on
 
     enum

--- a/src/openrct2-ui/windows/SavePrompt.cpp
+++ b/src/openrct2-ui/windows/SavePrompt.cpp
@@ -28,48 +28,52 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WH_QUIT = 38;
     static constexpr int32_t WW_QUIT = 177;
 
+    enum WindowSavePromptWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_LABEL,
+        WIDX_SAVE,
+        WIDX_DONT_SAVE,
+        WIDX_CANCEL
+    };
+
     // clang-format off
-enum WindowSavePromptWidgetIdx {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_LABEL,
-    WIDX_SAVE,
-    WIDX_DONT_SAVE,
-    WIDX_CANCEL
-};
-
-static Widget _savePromptWidgets[] = {
-    WINDOW_SHIM_WHITE(STR_NONE, WW_SAVE, WH_SAVE),
-    MakeWidget({  2, 19}, {256, 12}, WindowWidgetType::LabelCentred, WindowColour::Primary, STR_EMPTY                ), // question/label
-    MakeWidget({  8, 35}, { 78, 14}, WindowWidgetType::Button,        WindowColour::Primary, STR_SAVE_PROMPT_SAVE     ), // save
-    MakeWidget({ 91, 35}, { 78, 14}, WindowWidgetType::Button,        WindowColour::Primary, STR_SAVE_PROMPT_DONT_SAVE), // don't save
-    MakeWidget({174, 35}, { 78, 14}, WindowWidgetType::Button,        WindowColour::Primary, STR_SAVE_PROMPT_CANCEL   ), // cancel
-    kWidgetsEnd,
-};
-
-enum WindowQuitPromptWidgetIdx {
-    WQIDX_BACKGROUND,
-    WQIDX_TITLE,
-    WQIDX_CLOSE,
-    WQIDX_OK,
-    WQIDX_CANCEL
-};
-
-static Widget _quitPromptWidgets[] = {
-    WINDOW_SHIM_WHITE(STR_QUIT_GAME_PROMPT_TITLE, WW_QUIT, WH_QUIT),
-    MakeWidget({ 8, 19}, {78, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_OK    ), // ok
-    MakeWidget({91, 19}, {78, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_CANCEL), // cancel
-    kWidgetsEnd,
-};
-
-static constexpr StringId window_save_prompt_labels[][2] = {
-    { STR_LOAD_GAME_PROMPT_TITLE,   STR_SAVE_BEFORE_LOADING },
-    { STR_QUIT_GAME_PROMPT_TITLE,   STR_SAVE_BEFORE_QUITTING },
-    { STR_QUIT_GAME_2_PROMPT_TITLE, STR_SAVE_BEFORE_QUITTING_2 },
-    { STR_NEW_GAME,                 STR_SAVE_BEFORE_QUITTING },
-};
+    static Widget _savePromptWidgets[] = {
+        WINDOW_SHIM_WHITE(STR_NONE, WW_SAVE, WH_SAVE),
+        MakeWidget({  2, 19}, {256, 12}, WindowWidgetType::LabelCentred, WindowColour::Primary, STR_EMPTY                ), // question/label
+        MakeWidget({  8, 35}, { 78, 14}, WindowWidgetType::Button,        WindowColour::Primary, STR_SAVE_PROMPT_SAVE     ), // save
+        MakeWidget({ 91, 35}, { 78, 14}, WindowWidgetType::Button,        WindowColour::Primary, STR_SAVE_PROMPT_DONT_SAVE), // don't save
+        MakeWidget({174, 35}, { 78, 14}, WindowWidgetType::Button,        WindowColour::Primary, STR_SAVE_PROMPT_CANCEL   ), // cancel
+        kWidgetsEnd,
+    };
     // clang-format on
+
+    enum WindowQuitPromptWidgetIdx
+    {
+        WQIDX_BACKGROUND,
+        WQIDX_TITLE,
+        WQIDX_CLOSE,
+        WQIDX_OK,
+        WQIDX_CANCEL
+    };
+
+    // clang-format off
+    static Widget _quitPromptWidgets[] = {
+        WINDOW_SHIM_WHITE(STR_QUIT_GAME_PROMPT_TITLE, WW_QUIT, WH_QUIT),
+        MakeWidget({ 8, 19}, {78, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_OK    ), // ok
+        MakeWidget({91, 19}, {78, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_CANCEL), // cancel
+        kWidgetsEnd,
+    };
+    // clang-format on
+
+    static constexpr StringId window_save_prompt_labels[][2] = {
+        { STR_LOAD_GAME_PROMPT_TITLE, STR_SAVE_BEFORE_LOADING },
+        { STR_QUIT_GAME_PROMPT_TITLE, STR_SAVE_BEFORE_QUITTING },
+        { STR_QUIT_GAME_2_PROMPT_TITLE, STR_SAVE_BEFORE_QUITTING_2 },
+        { STR_NEW_GAME, STR_SAVE_BEFORE_QUITTING },
+    };
 
     static void WindowSavePromptCallback(int32_t result, const utf8* path)
     {

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -92,22 +92,22 @@ namespace OpenRCT2::Ui::Windows
     };
 
     // clang-format off
-static Widget _scenarioSelectWidgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({ TabWidth + 1, WidgetsStart }, { WW, 284 }, WindowWidgetType::Resize, WindowColour::Secondary), // tab content panel
-    MakeRemapWidget({ 3, TabsStart + (TabHeight * 0) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 01
-    MakeRemapWidget({ 3, TabsStart + (TabHeight * 1) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 02
-    MakeRemapWidget({ 3, TabsStart + (TabHeight * 2) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 03
-    MakeRemapWidget({ 3, TabsStart + (TabHeight * 3) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 04
-    MakeRemapWidget({ 3, TabsStart + (TabHeight * 4) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 05
-    MakeRemapWidget({ 3, TabsStart + (TabHeight * 5) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 06
-    MakeRemapWidget({ 3, TabsStart + (TabHeight * 6) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 07
-    MakeRemapWidget({ 3, TabsStart + (TabHeight * 7) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 08
-    MakeRemapWidget({ 3, TabsStart + (TabHeight * 8) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 09
-    MakeRemapWidget({ 3, TabsStart + (TabHeight * 8) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 10
-    MakeWidget({ TabWidth + 3, WidgetsStart + 1 }, { WW - SidebarWidth, 362 }, WindowWidgetType::Scroll, WindowColour::Secondary, SCROLL_VERTICAL), // level list
-    kWidgetsEnd,
-};
+    static Widget _scenarioSelectWidgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({ TabWidth + 1, WidgetsStart }, { WW, 284 }, WindowWidgetType::Resize, WindowColour::Secondary), // tab content panel
+        MakeRemapWidget({ 3, TabsStart + (TabHeight * 0) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 01
+        MakeRemapWidget({ 3, TabsStart + (TabHeight * 1) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 02
+        MakeRemapWidget({ 3, TabsStart + (TabHeight * 2) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 03
+        MakeRemapWidget({ 3, TabsStart + (TabHeight * 3) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 04
+        MakeRemapWidget({ 3, TabsStart + (TabHeight * 4) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 05
+        MakeRemapWidget({ 3, TabsStart + (TabHeight * 5) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 06
+        MakeRemapWidget({ 3, TabsStart + (TabHeight * 6) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 07
+        MakeRemapWidget({ 3, TabsStart + (TabHeight * 7) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 08
+        MakeRemapWidget({ 3, TabsStart + (TabHeight * 8) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 09
+        MakeRemapWidget({ 3, TabsStart + (TabHeight * 8) }, { TabWidth, TabHeight}, WindowWidgetType::Tab, WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB), // tab 10
+        MakeWidget({ TabWidth + 3, WidgetsStart + 1 }, { WW - SidebarWidth, 362 }, WindowWidgetType::Scroll, WindowColour::Secondary, SCROLL_VERTICAL), // level list
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class ScenarioSelectWindow final : public Window

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -93,22 +93,22 @@ namespace OpenRCT2::Ui::Windows
     validate_global_widx(WC_SCENERY, WIDX_SCENERY_EYEDROPPER_BUTTON);
 
     // clang-format off
-static Widget WindowSceneryBaseWidgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WINDOW_SCENERY_MIN_WIDTH, WINDOW_SCENERY_MIN_HEIGHT),
-    MakeWidget     ({  0,  43}, {634, 99}, WindowWidgetType::Resize,    WindowColour::Secondary                                                  ), // 8         0x009DE2C8
-    MakeWidget     ({  2,  62}, {607, 80}, WindowWidgetType::Scroll,    WindowColour::Secondary, SCROLL_VERTICAL                                 ), // 1000000   0x009DE418
-    MakeWidget     ({609,  59}, { 24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_ROTATE_ARROW),    STR_ROTATE_OBJECTS_90      ), // 2000000   0x009DE428
-    MakeWidget     ({609,  83}, { 24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_PAINTBRUSH),      STR_SCENERY_PAINTBRUSH_TIP ), // 4000000   0x009DE438
-    MakeWidget     ({615,  108}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_COLOUR          ), // 8000000   0x009DE448
-    MakeWidget     ({615, 120}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_SECONDARY_COLOUR), // 10000000  0x009DE458
-    MakeWidget     ({615, 132}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_TERTIARY_COLOUR  ), // 20000000  0x009DE468
-    MakeWidget     ({609, 145}, { 24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_G2_EYEDROPPER),   STR_SCENERY_EYEDROPPER_TIP ), // 40000000  0x009DE478
-    MakeWidget     ({609, 169}, { 24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_SCENERY_CLUSTER), STR_SCENERY_CLUSTER_TIP    ), // 40000000  0x009DE478
-    MakeWidget     ({  4,  46}, {211, 14}, WindowWidgetType::TextBox,   WindowColour::Secondary                          ),
-    MakeWidget     ({218,  46}, { 70, 14}, WindowWidgetType::Button,    WindowColour::Secondary, STR_OBJECT_SEARCH_CLEAR ),
-    MakeWidget     ({539,  46}, { 70, 14}, WindowWidgetType::Button,    WindowColour::Secondary, STR_RESTRICT_SCENERY,   STR_RESTRICT_SCENERY_TIP ),
-    kWidgetsEnd,
-};
+    static Widget WindowSceneryBaseWidgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WINDOW_SCENERY_MIN_WIDTH, WINDOW_SCENERY_MIN_HEIGHT),
+        MakeWidget     ({  0,  43}, {634, 99}, WindowWidgetType::Resize,    WindowColour::Secondary                                                  ), // 8         0x009DE2C8
+        MakeWidget     ({  2,  62}, {607, 80}, WindowWidgetType::Scroll,    WindowColour::Secondary, SCROLL_VERTICAL                                 ), // 1000000   0x009DE418
+        MakeWidget     ({609,  59}, { 24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_ROTATE_ARROW),    STR_ROTATE_OBJECTS_90      ), // 2000000   0x009DE428
+        MakeWidget     ({609,  83}, { 24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_PAINTBRUSH),      STR_SCENERY_PAINTBRUSH_TIP ), // 4000000   0x009DE438
+        MakeWidget     ({615,  108}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_COLOUR          ), // 8000000   0x009DE448
+        MakeWidget     ({615, 120}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_SECONDARY_COLOUR), // 10000000  0x009DE458
+        MakeWidget     ({615, 132}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_TERTIARY_COLOUR  ), // 20000000  0x009DE468
+        MakeWidget     ({609, 145}, { 24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_G2_EYEDROPPER),   STR_SCENERY_EYEDROPPER_TIP ), // 40000000  0x009DE478
+        MakeWidget     ({609, 169}, { 24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_SCENERY_CLUSTER), STR_SCENERY_CLUSTER_TIP    ), // 40000000  0x009DE478
+        MakeWidget     ({  4,  46}, {211, 14}, WindowWidgetType::TextBox,   WindowColour::Secondary                          ),
+        MakeWidget     ({218,  46}, { 70, 14}, WindowWidgetType::Button,    WindowColour::Secondary, STR_OBJECT_SEARCH_CLEAR ),
+        MakeWidget     ({539,  46}, { 70, 14}, WindowWidgetType::Button,    WindowColour::Secondary, STR_RESTRICT_SCENERY,   STR_RESTRICT_SCENERY_TIP ),
+        kWidgetsEnd,
+    };
     // clang-format on
 
     // Persistent between window instances

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -38,21 +38,21 @@ namespace OpenRCT2::Ui::Windows
     ScatterToolDensity gWindowSceneryScatterDensity;
 
     // clang-format off
-static Widget _sceneryScatterWidgets[] = {
-    MakeWidget     ({ 0,  0}, {86, 100}, WindowWidgetType::Frame,    WindowColour::Secondary                                                                ), // panel / background
-    MakeWidget     ({ 1,  1}, {84,  14}, WindowWidgetType::Caption,  WindowColour::Primary  , STR_SCENERY_SCATTER,           STR_WINDOW_TITLE_TIP           ), // title bar
-    MakeWidget     ({73,  2}, {11,  12}, WindowWidgetType::CloseBox, WindowColour::Primary  , STR_CLOSE_X,                   STR_CLOSE_WINDOW_TIP           ), // close x button
+    static Widget _sceneryScatterWidgets[] = {
+        MakeWidget     ({ 0,  0}, {86, 100}, WindowWidgetType::Frame,    WindowColour::Secondary                                                                ), // panel / background
+        MakeWidget     ({ 1,  1}, {84,  14}, WindowWidgetType::Caption,  WindowColour::Primary  , STR_SCENERY_SCATTER,           STR_WINDOW_TITLE_TIP           ), // title bar
+        MakeWidget     ({73,  2}, {11,  12}, WindowWidgetType::CloseBox, WindowColour::Primary  , STR_CLOSE_X,                   STR_CLOSE_WINDOW_TIP           ), // close x button
 
-    MakeWidget     ({20, 17}, {44,  32}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, ImageId(SPR_LAND_TOOL_SIZE_0)                                          ), // preview box
-    MakeRemapWidget({21, 18}, {16,  16}, WindowWidgetType::TrnBtn,   WindowColour::Secondary, SPR_LAND_TOOL_DECREASE,        STR_ADJUST_SMALLER_LAND_TIP    ), // decrement size
-    MakeRemapWidget({47, 32}, {16,  16}, WindowWidgetType::TrnBtn,   WindowColour::Secondary, SPR_LAND_TOOL_INCREASE,        STR_ADJUST_LARGER_LAND_TIP     ), // increment size
+        MakeWidget     ({20, 17}, {44,  32}, WindowWidgetType::ImgBtn,   WindowColour::Secondary, ImageId(SPR_LAND_TOOL_SIZE_0)                                 ), // preview box
+        MakeRemapWidget({21, 18}, {16,  16}, WindowWidgetType::TrnBtn,   WindowColour::Secondary, SPR_LAND_TOOL_DECREASE,        STR_ADJUST_SMALLER_LAND_TIP    ), // decrement size
+        MakeRemapWidget({47, 32}, {16,  16}, WindowWidgetType::TrnBtn,   WindowColour::Secondary, SPR_LAND_TOOL_INCREASE,        STR_ADJUST_LARGER_LAND_TIP     ), // increment size
 
-    MakeWidget     ({ 3, 55}, {80,  42}, WindowWidgetType::Groupbox, WindowColour::Secondary, STR_SCATTER_TOOL_DENSITY                                      ),
-    MakeRemapWidget({ 7, 68}, {24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, SPR_G2_SCENERY_SCATTER_LOW,    STR_SCATTER_TOOL_DENSITY_LOW   ), // low amount
-    MakeRemapWidget({31, 68}, {24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, SPR_G2_SCENERY_SCATTER_MEDIUM, STR_SCATTER_TOOL_DENSITY_MEDIUM), // medium amount
-    MakeRemapWidget({55, 68}, {24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, SPR_G2_SCENERY_SCATTER_HIGH,   STR_SCATTER_TOOL_DENSITY_HIGH  ), // high amount
-    kWidgetsEnd,
-};
+        MakeWidget     ({ 3, 55}, {80,  42}, WindowWidgetType::Groupbox, WindowColour::Secondary, STR_SCATTER_TOOL_DENSITY                                      ),
+        MakeRemapWidget({ 7, 68}, {24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, SPR_G2_SCENERY_SCATTER_LOW,    STR_SCATTER_TOOL_DENSITY_LOW   ), // low amount
+        MakeRemapWidget({31, 68}, {24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, SPR_G2_SCENERY_SCATTER_MEDIUM, STR_SCATTER_TOOL_DENSITY_MEDIUM), // medium amount
+        MakeRemapWidget({55, 68}, {24,  24}, WindowWidgetType::FlatBtn,  WindowColour::Secondary, SPR_G2_SCENERY_SCATTER_HIGH,   STR_SCATTER_TOOL_DENSITY_HIGH  ), // high amount
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class SceneryScatterWindow final : public Window

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -63,17 +63,17 @@ namespace OpenRCT2::Ui::Windows
     };
 
     // clang-format off
-static Widget _serverListWidgets[] = {
-    MakeWidget({  0,  0}, {341,  91}, WindowWidgetType::Frame,    WindowColour::Primary                                           ), // panel / background
-    MakeWidget({  1,  1}, {338,  14}, WindowWidgetType::Caption,  WindowColour::Primary,   STR_SERVER_LIST,   STR_WINDOW_TITLE_TIP), // title bar
-    MakeWidget({327,  2}, { 11,  12}, WindowWidgetType::CloseBox, WindowColour::Primary,   STR_CLOSE_X,       STR_CLOSE_WINDOW_TIP), // close x button
-    MakeWidget({100, 20}, {245,  12}, WindowWidgetType::TextBox,  WindowColour::Secondary                                         ), // player name text box
-    MakeWidget({  6, 37}, {489, 226}, WindowWidgetType::Scroll,   WindowColour::Secondary                                         ), // server list
-    MakeWidget({  6, 53}, {101,  14}, WindowWidgetType::Button,   WindowColour::Secondary, STR_FETCH_SERVERS                      ), // fetch servers button
-    MakeWidget({112, 53}, {101,  14}, WindowWidgetType::Button,   WindowColour::Secondary, STR_ADD_SERVER                         ), // add server button
-    MakeWidget({218, 53}, {101,  14}, WindowWidgetType::Button,   WindowColour::Secondary, STR_START_SERVER                       ), // start server button
-    kWidgetsEnd,
-};
+    static Widget _serverListWidgets[] = {
+        MakeWidget({  0,  0}, {341,  91}, WindowWidgetType::Frame,    WindowColour::Primary                                           ), // panel / background
+        MakeWidget({  1,  1}, {338,  14}, WindowWidgetType::Caption,  WindowColour::Primary,   STR_SERVER_LIST,   STR_WINDOW_TITLE_TIP), // title bar
+        MakeWidget({327,  2}, { 11,  12}, WindowWidgetType::CloseBox, WindowColour::Primary,   STR_CLOSE_X,       STR_CLOSE_WINDOW_TIP), // close x button
+        MakeWidget({100, 20}, {245,  12}, WindowWidgetType::TextBox,  WindowColour::Secondary                                         ), // player name text box
+        MakeWidget({  6, 37}, {489, 226}, WindowWidgetType::Scroll,   WindowColour::Secondary                                         ), // server list
+        MakeWidget({  6, 53}, {101,  14}, WindowWidgetType::Button,   WindowColour::Secondary, STR_FETCH_SERVERS                      ), // fetch servers button
+        MakeWidget({112, 53}, {101,  14}, WindowWidgetType::Button,   WindowColour::Secondary, STR_ADD_SERVER                         ), // add server button
+        MakeWidget({218, 53}, {101,  14}, WindowWidgetType::Button,   WindowColour::Secondary, STR_START_SERVER                       ), // start server button
+        kWidgetsEnd,
+    };
     // clang-format on
 
     void JoinServer(std::string address);

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -23,43 +23,45 @@
 
 namespace OpenRCT2::Ui::Windows
 {
+    enum
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_PORT_INPUT,
+        WIDX_NAME_INPUT,
+        WIDX_DESCRIPTION_INPUT,
+        WIDX_GREETING_INPUT,
+        WIDX_PASSWORD_INPUT,
+        WIDX_MAXPLAYERS,
+        WIDX_MAXPLAYERS_INCREASE,
+        WIDX_MAXPLAYERS_DECREASE,
+        WIDX_ADVERTISE_CHECKBOX,
+        WIDX_START_SERVER,
+        WIDX_LOAD_SERVER
+    };
+
+    static constexpr int32_t WW = 300;
+    static constexpr int32_t WH = 154;
+
     // clang-format off
-enum {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_PORT_INPUT,
-    WIDX_NAME_INPUT,
-    WIDX_DESCRIPTION_INPUT,
-    WIDX_GREETING_INPUT,
-    WIDX_PASSWORD_INPUT,
-    WIDX_MAXPLAYERS,
-    WIDX_MAXPLAYERS_INCREASE,
-    WIDX_MAXPLAYERS_DECREASE,
-    WIDX_ADVERTISE_CHECKBOX,
-    WIDX_START_SERVER,
-    WIDX_LOAD_SERVER
-};
-
-static constexpr int32_t WW = 300;
-static constexpr int32_t WH = 154;
-
-static Widget _windowServerStartWidgets[] = {
-    MakeWidget({ 0, 0 }, { WW, WH }, WindowWidgetType::Frame, WindowColour::Primary), // panel / background
-    MakeWidget({ 1, 1 }, { 298, 14 }, WindowWidgetType::Caption, WindowColour::Primary, STR_START_SERVER,STR_WINDOW_TITLE_TIP), // title bar
-    MakeWidget({ WW - 13, 2 }, { 11, 12 }, WindowWidgetType::CloseBox, WindowColour::Primary, STR_CLOSE_X,STR_CLOSE_WINDOW_TIP), // close x button
-    MakeWidget({ 120, 20 }, { 173, 13 }, WindowWidgetType::TextBox, WindowColour::Secondary), // port text box
-    MakeWidget({ 120, 36 }, { 173, 13 }, WindowWidgetType::TextBox, WindowColour::Secondary), // name text box
-    MakeWidget({ 120, 52 }, { 173, 13 }, WindowWidgetType::TextBox, WindowColour::Secondary), // description text box
-    MakeWidget({ 120, 68 }, { 173, 13 }, WindowWidgetType::TextBox, WindowColour::Secondary), // greeting text box
-    MakeWidget({ 120, 84 }, { 173, 13 }, WindowWidgetType::TextBox, WindowColour::Secondary), // password text box
-    MakeSpinnerWidgets({ 120, 100 }, { 173, 12 }, WindowWidgetType::Spinner, WindowColour::Secondary,STR_SERVER_MAX_PLAYERS_VALUE), // max players (3 widgets)
-    MakeWidget({ 6, 117 }, { 287, 14 }, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_ADVERTISE,STR_ADVERTISE_SERVER_TIP), // advertise checkbox
-    MakeWidget({ 6, WH - 6 - 13 }, { 101, 14 }, WindowWidgetType::Button, WindowColour::Secondary,STR_NEW_GAME), // start server button
-    MakeWidget({ 112, WH - 6 - 13 }, { 101, 14 }, WindowWidgetType::Button, WindowColour::Secondary, STR_LOAD_GAME), // None
-    kWidgetsEnd,
-};
+    static Widget _windowServerStartWidgets[] = {
+        MakeWidget({ 0, 0 }, { WW, WH }, WindowWidgetType::Frame, WindowColour::Primary), // panel / background
+        MakeWidget({ 1, 1 }, { 298, 14 }, WindowWidgetType::Caption, WindowColour::Primary, STR_START_SERVER,STR_WINDOW_TITLE_TIP), // title bar
+        MakeWidget({ WW - 13, 2 }, { 11, 12 }, WindowWidgetType::CloseBox, WindowColour::Primary, STR_CLOSE_X,STR_CLOSE_WINDOW_TIP), // close x button
+        MakeWidget({ 120, 20 }, { 173, 13 }, WindowWidgetType::TextBox, WindowColour::Secondary), // port text box
+        MakeWidget({ 120, 36 }, { 173, 13 }, WindowWidgetType::TextBox, WindowColour::Secondary), // name text box
+        MakeWidget({ 120, 52 }, { 173, 13 }, WindowWidgetType::TextBox, WindowColour::Secondary), // description text box
+        MakeWidget({ 120, 68 }, { 173, 13 }, WindowWidgetType::TextBox, WindowColour::Secondary), // greeting text box
+        MakeWidget({ 120, 84 }, { 173, 13 }, WindowWidgetType::TextBox, WindowColour::Secondary), // password text box
+        MakeSpinnerWidgets({ 120, 100 }, { 173, 12 }, WindowWidgetType::Spinner, WindowColour::Secondary,STR_SERVER_MAX_PLAYERS_VALUE), // max players (3 widgets)
+        MakeWidget({ 6, 117 }, { 287, 14 }, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_ADVERTISE,STR_ADVERTISE_SERVER_TIP), // advertise checkbox
+        MakeWidget({ 6, WH - 6 - 13 }, { 101, 14 }, WindowWidgetType::Button, WindowColour::Secondary,STR_NEW_GAME), // start server button
+        MakeWidget({ 112, WH - 6 - 13 }, { 101, 14 }, WindowWidgetType::Button, WindowColour::Secondary, STR_LOAD_GAME), // None
+        kWidgetsEnd,
+    };
     // clang-format on
+
     class ServerStartWindow final : public Window
     {
     public:

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -41,13 +41,13 @@ namespace OpenRCT2::Ui::Windows
     };
 
     // clang-format off
-static Widget _shortcutWidgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({0,    43}, {350, 287}, WindowWidgetType::Resize, WindowColour::Secondary),
-    MakeWidget({4,    47}, {412, 215}, WindowWidgetType::Scroll, WindowColour::Primary, SCROLL_VERTICAL,           STR_SHORTCUT_LIST_TIP        ),
-    MakeWidget({4, WH-15}, {150,  12}, WindowWidgetType::Button, WindowColour::Primary, STR_SHORTCUT_ACTION_RESET, STR_SHORTCUT_ACTION_RESET_TIP),
-    kWidgetsEnd,
-};
+    static Widget _shortcutWidgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({0,    43}, {350, 287}, WindowWidgetType::Resize, WindowColour::Secondary),
+        MakeWidget({4,    47}, {412, 215}, WindowWidgetType::Scroll, WindowColour::Primary, SCROLL_VERTICAL,           STR_SHORTCUT_LIST_TIP        ),
+        MakeWidget({4, WH-15}, {150,  12}, WindowWidgetType::Button, WindowColour::Primary, STR_SHORTCUT_ACTION_RESET, STR_SHORTCUT_ACTION_RESET_TIP),
+        kWidgetsEnd,
+    };
     // clang-format on
 
     static constexpr StringId CHANGE_WINDOW_TITLE = STR_SHORTCUT_CHANGE_TITLE;
@@ -60,11 +60,11 @@ static Widget _shortcutWidgets[] = {
     };
 
     // clang-format off
-static Widget window_shortcut_change_widgets[] = {
-    WINDOW_SHIM(CHANGE_WINDOW_TITLE, CHANGE_WW, CHANGE_WH),
-    MakeWidget({ 75, 56 }, { 100, 14 }, WindowWidgetType::Button, WindowColour::Primary, STR_SHORTCUT_REMOVE, STR_SHORTCUT_REMOVE_TIP),
-    kWidgetsEnd,
-};
+    static Widget window_shortcut_change_widgets[] = {
+        WINDOW_SHIM(CHANGE_WINDOW_TITLE, CHANGE_WW, CHANGE_WH),
+        MakeWidget({ 75, 56 }, { 100, 14 }, WindowWidgetType::Button, WindowColour::Primary, STR_SHORTCUT_REMOVE, STR_SHORTCUT_REMOVE_TIP),
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class ChangeShortcutWindow final : public Window

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -33,29 +33,29 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WW = 113;
     static constexpr int32_t WH = 96;
 
+    enum WindowSignWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_VIEWPORT,
+        WIDX_SIGN_TEXT,
+        WIDX_SIGN_DEMOLISH,
+        WIDX_MAIN_COLOUR,
+        WIDX_TEXT_COLOUR
+    };
+
     // clang-format off
-enum WindowSignWidgetIdx {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_VIEWPORT,
-    WIDX_SIGN_TEXT,
-    WIDX_SIGN_DEMOLISH,
-    WIDX_MAIN_COLOUR,
-    WIDX_TEXT_COLOUR
-};
-
-// 0x9AEE00
-static Widget _signWidgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({      3,      17}, {85, 60}, WindowWidgetType::Viewport,  WindowColour::Secondary                                                        ), // Viewport
-    MakeWidget({WW - 25,      19}, {24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_RENAME),   STR_CHANGE_SIGN_TEXT_TIP       ), // change sign button
-    MakeWidget({WW - 25,      67}, {24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_DEMOLISH), STR_DEMOLISH_SIGN_TIP          ), // demolish button
-    MakeWidget({      5, WH - 16}, {12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, kWidgetContentEmpty,   STR_SELECT_MAIN_SIGN_COLOUR_TIP), // Main colour
-    MakeWidget({     17, WH - 16}, {12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, kWidgetContentEmpty,   STR_SELECT_TEXT_COLOUR_TIP     ), // Text colour
-    kWidgetsEnd,
-};
-
+    // 0x9AEE00
+    static Widget _signWidgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({      3,      17}, {85, 60}, WindowWidgetType::Viewport,  WindowColour::Secondary                                                        ), // Viewport
+        MakeWidget({WW - 25,      19}, {24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_RENAME),   STR_CHANGE_SIGN_TEXT_TIP       ), // change sign button
+        MakeWidget({WW - 25,      67}, {24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_DEMOLISH), STR_DEMOLISH_SIGN_TIP          ), // demolish button
+        MakeWidget({      5, WH - 16}, {12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, kWidgetContentEmpty,   STR_SELECT_MAIN_SIGN_COLOUR_TIP), // Main colour
+        MakeWidget({     17, WH - 16}, {12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, kWidgetContentEmpty,   STR_SELECT_TEXT_COLOUR_TIP     ), // Text colour
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class SignWindow final : public Window

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -80,14 +80,14 @@ namespace OpenRCT2::Ui::Windows
     validate_global_widx(WC_PEEP, WIDX_PATROL);
     validate_global_widx(WC_STAFF, WIDX_PICKUP);
 
-// clang-format off
-    #define MAIN_STAFF_WIDGETS \
+#define MAIN_STAFF_WIDGETS \
         WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
         MakeWidget({ 0, 43}, {190, 137}, WindowWidgetType::Resize, WindowColour::Secondary), /* Resize */ \
         MakeTab   ({ 3, 17}, STR_STAFF_OVERVIEW_TIP                         ), /* Tab 1 */ \
         MakeTab   ({34, 17}, STR_STAFF_OPTIONS_TIP                          ), /* Tab 2 */ \
         MakeTab   ({65, 17}, STR_STAFF_STATS_TIP                            )  /* Tab 3 */
 
+    // clang-format off
     static Widget _staffOverviewWidgets[] = {
         MAIN_STAFF_WIDGETS,
         MakeWidget     ({      3,      47}, {162, 120}, WindowWidgetType::Viewport,      WindowColour::Secondary                                        ), // Viewport

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -80,7 +80,7 @@ namespace OpenRCT2::Ui::Windows
     validate_global_widx(WC_PEEP, WIDX_PATROL);
     validate_global_widx(WC_STAFF, WIDX_PICKUP);
 
-    // clang-format off
+// clang-format off
     #define MAIN_STAFF_WIDGETS \
         WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
         MakeWidget({ 0, 43}, {190, 137}, WindowWidgetType::Resize, WindowColour::Secondary), /* Resize */ \

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -81,36 +81,36 @@ namespace OpenRCT2::Ui::Windows
     validate_global_widx(WC_STAFF, WIDX_PICKUP);
 
     // clang-format off
-#define MAIN_STAFF_WIDGETS \
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
-    MakeWidget({ 0, 43}, {190, 137}, WindowWidgetType::Resize, WindowColour::Secondary), /* Resize */ \
-    MakeTab   ({ 3, 17}, STR_STAFF_OVERVIEW_TIP                         ), /* Tab 1 */ \
-    MakeTab   ({34, 17}, STR_STAFF_OPTIONS_TIP                          ), /* Tab 2 */ \
-    MakeTab   ({65, 17}, STR_STAFF_STATS_TIP                            )  /* Tab 3 */
+    #define MAIN_STAFF_WIDGETS \
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
+        MakeWidget({ 0, 43}, {190, 137}, WindowWidgetType::Resize, WindowColour::Secondary), /* Resize */ \
+        MakeTab   ({ 3, 17}, STR_STAFF_OVERVIEW_TIP                         ), /* Tab 1 */ \
+        MakeTab   ({34, 17}, STR_STAFF_OPTIONS_TIP                          ), /* Tab 2 */ \
+        MakeTab   ({65, 17}, STR_STAFF_STATS_TIP                            )  /* Tab 3 */
 
-static Widget _staffOverviewWidgets[] = {
-    MAIN_STAFF_WIDGETS,
-    MakeWidget     ({      3,      47}, {162, 120}, WindowWidgetType::Viewport,      WindowColour::Secondary                                        ), // Viewport
-    MakeWidget     ({      3, WH - 13}, {162,  11}, WindowWidgetType::LabelCentred, WindowColour::Secondary                                        ), // Label at bottom of viewport
-    MakeWidget     ({WW - 25,      45}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_PICKUP_BTN), STR_PICKUP_TIP        ), // Pickup Button
-    MakeWidget     ({WW - 25,      69}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_PATROL_BTN), STR_SET_PATROL_TIP    ), // Patrol Button
-    MakeWidget     ({WW - 25,      93}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_RENAME),     STR_NAME_STAFF_TIP    ), // Rename Button
-    MakeWidget     ({WW - 25,     117}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_LOCATE),     STR_LOCATE_SUBJECT_TIP), // Locate Button
-    MakeWidget     ({WW - 25,     141}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_DEMOLISH),   STR_FIRE_STAFF_TIP    ), // Fire Button
-    kWidgetsEnd,
-};
+    static Widget _staffOverviewWidgets[] = {
+        MAIN_STAFF_WIDGETS,
+        MakeWidget     ({      3,      47}, {162, 120}, WindowWidgetType::Viewport,      WindowColour::Secondary                                        ), // Viewport
+        MakeWidget     ({      3, WH - 13}, {162,  11}, WindowWidgetType::LabelCentred, WindowColour::Secondary                                        ), // Label at bottom of viewport
+        MakeWidget     ({WW - 25,      45}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_PICKUP_BTN), STR_PICKUP_TIP        ), // Pickup Button
+        MakeWidget     ({WW - 25,      69}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_PATROL_BTN), STR_SET_PATROL_TIP    ), // Patrol Button
+        MakeWidget     ({WW - 25,      93}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_RENAME),     STR_NAME_STAFF_TIP    ), // Rename Button
+        MakeWidget     ({WW - 25,     117}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_LOCATE),     STR_LOCATE_SUBJECT_TIP), // Locate Button
+        MakeWidget     ({WW - 25,     141}, { 24,  24}, WindowWidgetType::FlatBtn,       WindowColour::Secondary, ImageId(SPR_DEMOLISH),   STR_FIRE_STAFF_TIP    ), // Fire Button
+        kWidgetsEnd,
+    };
 
-//0x9AF910
-static Widget _staffOptionsWidgets[] = {
-    MAIN_STAFF_WIDGETS,
-    MakeWidget     ({      5,  50}, {180,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary                                            ), // Checkbox 1
-    MakeWidget     ({      5,  67}, {180,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary                                            ), // Checkbox 2
-    MakeWidget     ({      5,  84}, {180,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary                                            ), // Checkbox 3
-    MakeWidget     ({      5, 101}, {180,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary                                            ), // Checkbox 4
-    MakeWidget     ({      5,  50}, {180,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                            ), // Costume Dropdown
-    MakeWidget     ({WW - 17,  51}, { 11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH, STR_SELECT_COSTUME_TIP), // Costume Dropdown Button
-    kWidgetsEnd,
-};
+    //0x9AF910
+    static Widget _staffOptionsWidgets[] = {
+        MAIN_STAFF_WIDGETS,
+        MakeWidget     ({      5,  50}, {180,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary                                            ), // Checkbox 1
+        MakeWidget     ({      5,  67}, {180,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary                                            ), // Checkbox 2
+        MakeWidget     ({      5,  84}, {180,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary                                            ), // Checkbox 3
+        MakeWidget     ({      5, 101}, {180,  12}, WindowWidgetType::Checkbox, WindowColour::Secondary                                            ), // Checkbox 4
+        MakeWidget     ({      5,  50}, {180,  12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                            ), // Costume Dropdown
+        MakeWidget     ({WW - 17,  51}, { 11,  10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH, STR_SELECT_COSTUME_TIP), // Costume Dropdown Button
+        kWidgetsEnd,
+    };
     // clang-format on
 
     // 0x9AF9F4

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -80,12 +80,12 @@ namespace OpenRCT2::Ui::Windows
     validate_global_widx(WC_PEEP, WIDX_PATROL);
     validate_global_widx(WC_STAFF, WIDX_PICKUP);
 
-#define MAIN_STAFF_WIDGETS \
-        WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
-        MakeWidget({ 0, 43}, {190, 137}, WindowWidgetType::Resize, WindowColour::Secondary), /* Resize */ \
-        MakeTab   ({ 3, 17}, STR_STAFF_OVERVIEW_TIP                         ), /* Tab 1 */ \
-        MakeTab   ({34, 17}, STR_STAFF_OPTIONS_TIP                          ), /* Tab 2 */ \
-        MakeTab   ({65, 17}, STR_STAFF_STATS_TIP                            )  /* Tab 3 */
+#define MAIN_STAFF_WIDGETS                                                                                                     \
+    WINDOW_SHIM(WINDOW_TITLE, WW, WH),                                                                                         \
+        MakeWidget({ 0, 43 }, { 190, 137 }, WindowWidgetType::Resize, WindowColour::Secondary), /* Resize */                   \
+        MakeTab({ 3, 17 }, STR_STAFF_OVERVIEW_TIP),                                             /* Tab 1 */                    \
+        MakeTab({ 34, 17 }, STR_STAFF_OPTIONS_TIP),                                             /* Tab 2 */                    \
+        MakeTab({ 65, 17 }, STR_STAFF_STATS_TIP)                                                /* Tab 3 */
 
     // clang-format off
     static Widget _staffOverviewWidgets[] = {

--- a/src/openrct2-ui/windows/StaffFirePrompt.cpp
+++ b/src/openrct2-ui/windows/StaffFirePrompt.cpp
@@ -23,23 +23,23 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WW = 200;
     static constexpr int32_t WH = 100;
 
+    enum WindowStaffFireWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_YES,
+        WIDX_CANCEL
+    };
+
     // clang-format off
-enum WindowStaffFireWidgetIdx {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_YES,
-    WIDX_CANCEL
-};
-
-// 0x9AFB4C
-static Widget _staffFireWidgets[] = {
-    WINDOW_SHIM_WHITE(WINDOW_TITLE, WW, WH),
-    MakeWidget({     10, WH - 20}, {85, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_YES               ),
-    MakeWidget({WW - 95, WH - 20}, {85, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_SAVE_PROMPT_CANCEL),
-    kWidgetsEnd,
-};
-
+    // 0x9AFB4C
+    static Widget _staffFireWidgets[] = {
+        WINDOW_SHIM_WHITE(WINDOW_TITLE, WW, WH),
+        MakeWidget({     10, WH - 20}, {85, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_YES               ),
+        MakeWidget({WW - 95, WH - 20}, {85, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_SAVE_PROMPT_CANCEL),
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class StaffFirePromptWindow final : public Window

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -74,21 +74,21 @@ namespace OpenRCT2::Ui::Windows
     constexpr int32_t MAX_WH = 450;
 
     // clang-format off
-static Widget _staffListWidgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({  0, 43}, {    WW, WH - 43}, WindowWidgetType::Resize,    WindowColour::Secondary                                                 ), // tab content panel
-    MakeTab   ({  3, 17},                                                                             STR_STAFF_HANDYMEN_TAB_TIP    ), // handymen tab
-    MakeTab   ({ 34, 17},                                                                             STR_STAFF_MECHANICS_TAB_TIP   ), // mechanics tab
-    MakeTab   ({ 65, 17},                                                                             STR_STAFF_SECURITY_TAB_TIP    ), // security guards tab
-    MakeTab   ({ 96, 17},                                                                             STR_STAFF_ENTERTAINERS_TAB_TIP), // entertainers tab
-    MakeWidget({  3, 72}, {WW - 6,     195}, WindowWidgetType::Scroll,    WindowColour::Secondary, SCROLL_VERTICAL                                ), // staff list
-    MakeWidget({130, 58}, {    12,      12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, STR_NONE,        STR_UNIFORM_COLOUR_TIP        ), // uniform colour picker
-    MakeWidget({165, 17}, {   145,      13}, WindowWidgetType::Button,    WindowColour::Primary  , STR_NONE,        STR_HIRE_STAFF_TIP            ), // hire button
-    MakeWidget({243, 46}, {    24,      24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_DEMOLISH),    STR_QUICK_FIRE_STAFF          ), // quick fire staff
-    MakeWidget({267, 46}, {    24,      24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_PATROL_BTN),  STR_SHOW_PATROL_AREA_TIP      ), // show staff patrol area tool
-    MakeWidget({291, 46}, {    24,      24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_MAP),         STR_SHOW_STAFF_ON_MAP_TIP     ), // show staff on map button
-    kWidgetsEnd,
-};
+    static Widget _staffListWidgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({  0, 43}, {    WW, WH - 43}, WindowWidgetType::Resize,    WindowColour::Secondary                                                     ), // tab content panel
+        MakeTab   ({  3, 17},                                                                          STR_STAFF_HANDYMEN_TAB_TIP                         ), // handymen tab
+        MakeTab   ({ 34, 17},                                                                          STR_STAFF_MECHANICS_TAB_TIP                        ), // mechanics tab
+        MakeTab   ({ 65, 17},                                                                          STR_STAFF_SECURITY_TAB_TIP                         ), // security guards tab
+        MakeTab   ({ 96, 17},                                                                          STR_STAFF_ENTERTAINERS_TAB_TIP                     ), // entertainers tab
+        MakeWidget({  3, 72}, {WW - 6,     195}, WindowWidgetType::Scroll,    WindowColour::Secondary, SCROLL_VERTICAL                                    ), // staff list
+        MakeWidget({130, 58}, {    12,      12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, STR_NONE,        STR_UNIFORM_COLOUR_TIP            ), // uniform colour picker
+        MakeWidget({165, 17}, {   145,      13}, WindowWidgetType::Button,    WindowColour::Primary  , STR_NONE,        STR_HIRE_STAFF_TIP                ), // hire button
+        MakeWidget({243, 46}, {    24,      24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_DEMOLISH),    STR_QUICK_FIRE_STAFF     ), // quick fire staff
+        MakeWidget({267, 46}, {    24,      24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_PATROL_BTN),  STR_SHOW_PATROL_AREA_TIP ), // show staff patrol area tool
+        MakeWidget({291, 46}, {    24,      24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_MAP),         STR_SHOW_STAFF_ON_MAP_TIP), // show staff on map button
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class StaffListWindow final : public Window

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -72,157 +72,159 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WH = 107;
 
     // clang-format off
-static Widget _themesWidgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({  0, 43}, {320,  64}, WindowWidgetType::Resize,       WindowColour::Secondary                                                                                     ), // tab content panel
-    MakeTab   ({  3, 17},                                                                                                        STR_THEMES_TAB_SETTINGS_TIP        ), // settings tab
-    MakeTab   ({ 34, 17},                                                                                                        STR_THEMES_TAB_MAIN_TIP            ), // main ui tab
-    MakeTab   ({ 65, 17},                                                                                                        STR_THEMES_TAB_PARK_TIP            ), // park tab
-    MakeTab   ({ 96, 17},                                                                                                        STR_THEMES_TAB_TOOLS_TIP           ), // tools tab
-    MakeTab   ({127, 17},                                                                                                        STR_THEMES_TAB_RIDES_AND_GUESTS_TIP), // rides and peeps tab
-    MakeTab   ({158, 17},                                                                                                        STR_THEMES_TAB_EDITORS_TIP         ), // editors tab
-    MakeTab   ({189, 17},                                                                                                        STR_THEMES_TAB_MISC_TIP            ), // misc tab
-    MakeTab   ({220, 17},                                                                                                        STR_THEMES_TAB_PROMPTS_TIP         ), // prompts tab
-    MakeTab   ({251, 17},                                                                                                        STR_THEMES_TAB_FEATURES_TIP        ), // features tab
-    MakeWidget({  5, 46}, {214,  15}, WindowWidgetType::TableHeader, WindowColour::Secondary, STR_THEMES_HEADER_WINDOW                                                           ), // Window header
-    MakeWidget({219, 46}, { 97,  15}, WindowWidgetType::TableHeader, WindowColour::Secondary, STR_THEMES_HEADER_PALETTE                                                          ), // Palette header
-    MakeWidget({125, 60}, {175,  12}, WindowWidgetType::DropdownMenu,     WindowColour::Secondary                                                                                     ), // Preset colour schemes
-    MakeWidget({288, 61}, { 11,  10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH                                                                 ),
-    MakeWidget({ 10, 82}, { 91,  12}, WindowWidgetType::Button,       WindowColour::Secondary, STR_THEMES_ACTION_DUPLICATE,                    STR_THEMES_ACTION_DUPLICATE_TIP    ), // Duplicate button
-    MakeWidget({110, 82}, { 91,  12}, WindowWidgetType::Button,       WindowColour::Secondary, STR_TRACK_MANAGE_DELETE,                        STR_THEMES_ACTION_DELETE_TIP       ), // Delete button
-    MakeWidget({210, 82}, { 91,  12}, WindowWidgetType::Button,       WindowColour::Secondary, STR_TRACK_MANAGE_RENAME,                        STR_THEMES_ACTION_RENAME_TIP       ), // Rename button
-    MakeWidget({  0,  0}, {  1,   1}, WindowWidgetType::ColourBtn,    WindowColour::Secondary                                                                                     ), // colour button mask
-    MakeWidget({  3, 60}, {314,  44}, WindowWidgetType::Scroll,       WindowColour::Secondary, SCROLL_VERTICAL                                                                    ), // staff list
-    MakeWidget({ 10, 54}, {290,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_THEMES_OPTION_RCT1_RIDE_CONTROLS                                               ), // rct1 ride lights
-    MakeWidget({ 10, 69}, {290,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_THEMES_OPTION_RCT1_PARK_CONTROLS                                               ), // rct1 park lights
-    MakeWidget({ 10, 84}, {290,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_THEMES_OPTION_RCT1_SCENARIO_SELECTION_FONT                                     ), // rct1 scenario font
-    MakeWidget({ 10, 99}, {290,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_THEMES_OPTION_RCT1_BOTTOM_TOOLBAR                                              ), // rct1 bottom toolbar
-    kWidgetsEnd,
-};
+    static Widget _themesWidgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({  0, 43}, {320,  64}, WindowWidgetType::Resize,       WindowColour::Secondary                                                                                     ), // tab content panel
+        MakeTab   ({  3, 17},                                                                                                        STR_THEMES_TAB_SETTINGS_TIP        ), // settings tab
+        MakeTab   ({ 34, 17},                                                                                                        STR_THEMES_TAB_MAIN_TIP            ), // main ui tab
+        MakeTab   ({ 65, 17},                                                                                                        STR_THEMES_TAB_PARK_TIP            ), // park tab
+        MakeTab   ({ 96, 17},                                                                                                        STR_THEMES_TAB_TOOLS_TIP           ), // tools tab
+        MakeTab   ({127, 17},                                                                                                        STR_THEMES_TAB_RIDES_AND_GUESTS_TIP), // rides and peeps tab
+        MakeTab   ({158, 17},                                                                                                        STR_THEMES_TAB_EDITORS_TIP         ), // editors tab
+        MakeTab   ({189, 17},                                                                                                        STR_THEMES_TAB_MISC_TIP            ), // misc tab
+        MakeTab   ({220, 17},                                                                                                        STR_THEMES_TAB_PROMPTS_TIP         ), // prompts tab
+        MakeTab   ({251, 17},                                                                                                        STR_THEMES_TAB_FEATURES_TIP        ), // features tab
+        MakeWidget({  5, 46}, {214,  15}, WindowWidgetType::TableHeader, WindowColour::Secondary, STR_THEMES_HEADER_WINDOW                                                           ), // Window header
+        MakeWidget({219, 46}, { 97,  15}, WindowWidgetType::TableHeader, WindowColour::Secondary, STR_THEMES_HEADER_PALETTE                                                          ), // Palette header
+        MakeWidget({125, 60}, {175,  12}, WindowWidgetType::DropdownMenu,     WindowColour::Secondary                                                                                     ), // Preset colour schemes
+        MakeWidget({288, 61}, { 11,  10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH                                                                 ),
+        MakeWidget({ 10, 82}, { 91,  12}, WindowWidgetType::Button,       WindowColour::Secondary, STR_THEMES_ACTION_DUPLICATE,                    STR_THEMES_ACTION_DUPLICATE_TIP    ), // Duplicate button
+        MakeWidget({110, 82}, { 91,  12}, WindowWidgetType::Button,       WindowColour::Secondary, STR_TRACK_MANAGE_DELETE,                        STR_THEMES_ACTION_DELETE_TIP       ), // Delete button
+        MakeWidget({210, 82}, { 91,  12}, WindowWidgetType::Button,       WindowColour::Secondary, STR_TRACK_MANAGE_RENAME,                        STR_THEMES_ACTION_RENAME_TIP       ), // Rename button
+        MakeWidget({  0,  0}, {  1,   1}, WindowWidgetType::ColourBtn,    WindowColour::Secondary                                                                                     ), // colour button mask
+        MakeWidget({  3, 60}, {314,  44}, WindowWidgetType::Scroll,       WindowColour::Secondary, SCROLL_VERTICAL                                                                    ), // staff list
+        MakeWidget({ 10, 54}, {290,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_THEMES_OPTION_RCT1_RIDE_CONTROLS                                               ), // rct1 ride lights
+        MakeWidget({ 10, 69}, {290,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_THEMES_OPTION_RCT1_PARK_CONTROLS                                               ), // rct1 park lights
+        MakeWidget({ 10, 84}, {290,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_THEMES_OPTION_RCT1_SCENARIO_SELECTION_FONT                                     ), // rct1 scenario font
+        MakeWidget({ 10, 99}, {290,  12}, WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_THEMES_OPTION_RCT1_BOTTOM_TOOLBAR                                              ), // rct1 bottom toolbar
+        kWidgetsEnd,
+    };
+    // clang-format on
 
 #pragma region Tabs
 
-static int32_t window_themes_tab_animation_loops[] = {
-    32,
-    32,
-    1,
-    1,
-    64,
-    32,
-    8,
-    14,
-    38,
-};
-static int32_t window_themes_tab_animation_divisor[] = {
-    4,
-    4,
-    1,
-    1,
-    4,
-    2,
-    2,
-    2,
-    2,
-};
-static int32_t window_themes_tab_sprites[] = {
-    SPR_TAB_PAINT_0,
-    SPR_TAB_KIOSKS_AND_FACILITIES_0,
-    SPR_TAB_PARK_ENTRANCE,
-    SPR_G2_TAB_LAND,
-    SPR_TAB_RIDE_0,
-    SPR_TAB_WRENCH_0,
-    SPR_TAB_GEARS_0,
-    SPR_TAB_STAFF_OPTIONS_0,
-    SPR_TAB_FINANCES_MARKETING_0,
-};
+    // clang-format off
+    static int32_t window_themes_tab_animation_loops[] = {
+        32,
+        32,
+        1,
+        1,
+        64,
+        32,
+        8,
+        14,
+        38,
+    };
+    static int32_t window_themes_tab_animation_divisor[] = {
+        4,
+        4,
+        1,
+        1,
+        4,
+        2,
+        2,
+        2,
+        2,
+    };
+    static int32_t window_themes_tab_sprites[] = {
+        SPR_TAB_PAINT_0,
+        SPR_TAB_KIOSKS_AND_FACILITIES_0,
+        SPR_TAB_PARK_ENTRANCE,
+        SPR_G2_TAB_LAND,
+        SPR_TAB_RIDE_0,
+        SPR_TAB_WRENCH_0,
+        SPR_TAB_GEARS_0,
+        SPR_TAB_STAFF_OPTIONS_0,
+        SPR_TAB_FINANCES_MARKETING_0,
+    };
 
-static WindowClass window_themes_tab_1_classes[] = {
-    WindowClass::TopToolbar,
-    WindowClass::BottomToolbar,
-    WindowClass::EditorScenarioBottomToolbar,
-    WindowClass::EditorTrackBottomToolbar,
-    WindowClass::TitleMenu,
-    WindowClass::TitleExit,
-    WindowClass::TitleOptions,
-    WindowClass::ScenarioSelect,
-};
+    static WindowClass window_themes_tab_1_classes[] = {
+        WindowClass::TopToolbar,
+        WindowClass::BottomToolbar,
+        WindowClass::EditorScenarioBottomToolbar,
+        WindowClass::EditorTrackBottomToolbar,
+        WindowClass::TitleMenu,
+        WindowClass::TitleExit,
+        WindowClass::TitleOptions,
+        WindowClass::ScenarioSelect,
+    };
 
-static WindowClass window_themes_tab_2_classes[] = {
-    WindowClass::ParkInformation,
-    WindowClass::EditorParkEntrance,
-    WindowClass::Finances,
-    WindowClass::NewCampaign,
-    WindowClass::Research,
-    WindowClass::Map,
-    WindowClass::Viewport,
-    WindowClass::RecentNews,
-};
+    static WindowClass window_themes_tab_2_classes[] = {
+        WindowClass::ParkInformation,
+        WindowClass::EditorParkEntrance,
+        WindowClass::Finances,
+        WindowClass::NewCampaign,
+        WindowClass::Research,
+        WindowClass::Map,
+        WindowClass::Viewport,
+        WindowClass::RecentNews,
+    };
 
-static WindowClass window_themes_tab_3_classes[] = {
-    WindowClass::Land,
-    WindowClass::Water,
-    WindowClass::ClearScenery,
-    WindowClass::LandRights,
-    WindowClass::Scenery,
-    WindowClass::SceneryScatter,
-    WindowClass::Footpath,
-    WindowClass::RideConstruction,
-    WindowClass::TrackDesignPlace,
-    WindowClass::ConstructRide,
-    WindowClass::TrackDesignList,
-    WindowClass::PatrolArea,
-};
+    static WindowClass window_themes_tab_3_classes[] = {
+        WindowClass::Land,
+        WindowClass::Water,
+        WindowClass::ClearScenery,
+        WindowClass::LandRights,
+        WindowClass::Scenery,
+        WindowClass::SceneryScatter,
+        WindowClass::Footpath,
+        WindowClass::RideConstruction,
+        WindowClass::TrackDesignPlace,
+        WindowClass::ConstructRide,
+        WindowClass::TrackDesignList,
+        WindowClass::PatrolArea,
+    };
 
-static WindowClass window_themes_tab_4_classes[] = {
-    WindowClass::Ride,
-    WindowClass::RideList,
-    WindowClass::Peep,
-    WindowClass::GuestList,
-    WindowClass::Staff,
-    WindowClass::StaffList,
-    WindowClass::Banner,
-};
+    static WindowClass window_themes_tab_4_classes[] = {
+        WindowClass::Ride,
+        WindowClass::RideList,
+        WindowClass::Peep,
+        WindowClass::GuestList,
+        WindowClass::Staff,
+        WindowClass::StaffList,
+        WindowClass::Banner,
+    };
 
-static WindowClass window_themes_tab_5_classes[] = {
-    WindowClass::EditorObjectSelection,
-    WindowClass::EditorInventionList,
-    WindowClass::EditorScenarioOptions,
-    WindowClass::EditorObjectiveOptions,
-    WindowClass::Mapgen,
-    WindowClass::ManageTrackDesign,
-    WindowClass::InstallTrack,
-};
+    static WindowClass window_themes_tab_5_classes[] = {
+        WindowClass::EditorObjectSelection,
+        WindowClass::EditorInventionList,
+        WindowClass::EditorScenarioOptions,
+        WindowClass::EditorObjectiveOptions,
+        WindowClass::Mapgen,
+        WindowClass::ManageTrackDesign,
+        WindowClass::InstallTrack,
+    };
 
-static WindowClass window_themes_tab_6_classes[] = {
-    WindowClass::Cheats,
-    WindowClass::TileInspector,
-    WindowClass::ViewClipping,
-    WindowClass::Transparency,
-    WindowClass::Themes,
-    WindowClass::Options,
-    WindowClass::KeyboardShortcutList,
-    WindowClass::ChangeKeyboardShortcut,
-    WindowClass::AssetPacks,
-    WindowClass::Loadsave,
-    WindowClass::About,
-    WindowClass::Changelog,
-    WindowClass::ServerList,
-    WindowClass::Multiplayer,
-    WindowClass::Player,
-    WindowClass::Chat,
-    WindowClass::Console,
-};
+    static WindowClass window_themes_tab_6_classes[] = {
+        WindowClass::Cheats,
+        WindowClass::TileInspector,
+        WindowClass::ViewClipping,
+        WindowClass::Transparency,
+        WindowClass::Themes,
+        WindowClass::Options,
+        WindowClass::KeyboardShortcutList,
+        WindowClass::ChangeKeyboardShortcut,
+        WindowClass::AssetPacks,
+        WindowClass::Loadsave,
+        WindowClass::About,
+        WindowClass::Changelog,
+        WindowClass::ServerList,
+        WindowClass::Multiplayer,
+        WindowClass::Player,
+        WindowClass::Chat,
+        WindowClass::Console,
+    };
 
-static WindowClass window_themes_tab_7_classes[] = {
-    WindowClass::Error,
-    WindowClass::SavePrompt,
-    WindowClass::DemolishRidePrompt,
-    WindowClass::FirePrompt,
-    WindowClass::TrackDeletePrompt,
-    WindowClass::LoadsaveOverwritePrompt,
-    WindowClass::ProgressWindow,
-    WindowClass::NetworkStatus,
-};
+    static WindowClass window_themes_tab_7_classes[] = {
+        WindowClass::Error,
+        WindowClass::SavePrompt,
+        WindowClass::DemolishRidePrompt,
+        WindowClass::FirePrompt,
+        WindowClass::TrackDeletePrompt,
+        WindowClass::LoadsaveOverwritePrompt,
+        WindowClass::ProgressWindow,
+        WindowClass::NetworkStatus,
+    };
 
     static WindowClass* window_themes_tab_classes[] = {
         nullptr,

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -244,7 +244,7 @@ namespace OpenRCT2::Ui::Windows
         return anchorPoint + ScreenCoordsXY{ 14 * horizontalMultiplier, 7 * verticalMultiplier };
     }
 
-    // clang-format off
+// clang-format off
     // Macros for easily obtaining the top and bottom of a widget inside a properties group box
     #define GBBT(GROUPTOP, row)     ((GROUPTOP) + 14 + row * (PropertyButtonSize.height + VERTICAL_GROUPBOX_PADDING))
     #define GBBB(GROUPTOP, row)     (GBBT((GROUPTOP), row) + PropertyButtonSize.height)

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -245,172 +245,172 @@ namespace OpenRCT2::Ui::Windows
     }
 
     // clang-format off
-// Macros for easily obtaining the top and bottom of a widget inside a properties group box
-#define GBBT(GROUPTOP, row)     ((GROUPTOP) + 14 + row * (PropertyButtonSize.height + VERTICAL_GROUPBOX_PADDING))
-#define GBBB(GROUPTOP, row)     (GBBT((GROUPTOP), row) + PropertyButtonSize.height)
+    // Macros for easily obtaining the top and bottom of a widget inside a properties group box
+    #define GBBT(GROUPTOP, row)     ((GROUPTOP) + 14 + row * (PropertyButtonSize.height + VERTICAL_GROUPBOX_PADDING))
+    #define GBBB(GROUPTOP, row)     (GBBT((GROUPTOP), row) + PropertyButtonSize.height)
 
-#define MAIN_TILE_INSPECTOR_WIDGETS \
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
-    MakeWidget({3, 57}, {WW - 6, WH - PADDING_BOTTOM - 58}, WindowWidgetType::Scroll, WindowColour::Secondary, SCROLL_VERTICAL), /* Element list */ \
-    /* X and Y spinners */ \
-    MakeSpinnerWidgets({20, 23}, {51, 12}, WindowWidgetType::Spinner, WindowColour::Secondary), /* Spinner X (3 widgets) */ \
-    MakeSpinnerWidgets({90, 23}, {51, 12}, WindowWidgetType::Spinner, WindowColour::Secondary), /* Spinner Y (3 widgets) */ \
-    /* Top buttons */ \
-    MakeWidget(ToolbarButtonAnchor + ToolbarButtonOffsetX * 0,                     ToolbarButtonSize,     WindowWidgetType::FlatBtn,     WindowColour::Secondary, ImageId(SPR_DEMOLISH),     STR_REMOVE_SELECTED_ELEMENT_TIP ),    /* Remove button */         \
-    MakeWidget(ToolbarButtonAnchor + ToolbarButtonOffsetX * 1,                     ToolbarButtonHalfSize, WindowWidgetType::Button,      WindowColour::Secondary, STR_UP,           STR_MOVE_SELECTED_ELEMENT_UP_TIP),    /* Move up */               \
-    MakeWidget(ToolbarButtonAnchor + ToolbarButtonOffsetX * 1 + ScreenSize{0, 12}, ToolbarButtonHalfSize, WindowWidgetType::Button,      WindowColour::Secondary, STR_DOWN,         STR_MOVE_SELECTED_ELEMENT_DOWN_TIP),  /* Move down */             \
-    MakeWidget(ToolbarButtonAnchor + ToolbarButtonOffsetX * 2,                     ToolbarButtonSize,     WindowWidgetType::FlatBtn,     WindowColour::Secondary, ImageId(SPR_ROTATE_ARROW), STR_ROTATE_SELECTED_ELEMENT_TIP),     /* Rotate button */         \
-    MakeWidget(ToolbarButtonAnchor + ToolbarButtonOffsetX * 3,                     ToolbarButtonSize,     WindowWidgetType::FlatBtn,     WindowColour::Secondary, ImageId(SPR_G2_SORT),      STR_TILE_INSPECTOR_SORT_TIP),         /* Sort button */           \
-    MakeWidget(ToolbarButtonAnchor + ToolbarButtonOffsetX * 4,                     ToolbarButtonSize,     WindowWidgetType::FlatBtn,     WindowColour::Secondary, ImageId(SPR_G2_PASTE),     STR_TILE_INSPECTOR_PASTE_TIP),        /* Paste button */          \
-    MakeWidget(ToolbarButtonAnchor + ToolbarButtonOffsetX * 5,                     ToolbarButtonSize,     WindowWidgetType::FlatBtn,     WindowColour::Secondary, ImageId(SPR_G2_COPY),      STR_TILE_INSPECTOR_COPY_TIP),         /* Copy button */           \
-    /* Column headers */ \
-    MakeWidget(InvisibleFlagColumnXY,   InvisibleFlagColumnSize,   WindowWidgetType::TableHeader, WindowColour::Secondary, STR_TILE_INSPECTOR_INVISIBLE_SHORT,        STR_TILE_INSPECTOR_FLAG_INVISIBLE),   /* Invisible flag */    \
-    MakeWidget(TypeColumnXY,            TypeColumnSize,            WindowWidgetType::TableHeader, WindowColour::Secondary, STR_TILE_INSPECTOR_ELEMENT_TYPE),                                                /* Type */              \
-    MakeWidget(BaseHeightColumnXY,      BaseHeightColumnSize,      WindowWidgetType::TableHeader, WindowColour::Secondary, STR_TILE_INSPECTOR_BASE_HEIGHT_SHORT,      STR_TILE_INSPECTOR_BASE_HEIGHT),      /* Base height */       \
-    MakeWidget(ClearanceHeightColumnXY, ClearanceHeightColumnSize, WindowWidgetType::TableHeader, WindowColour::Secondary, STR_TILE_INSPECTOR_CLEARANGE_HEIGHT_SHORT, STR_TILE_INSPECTOR_CLEARANCE_HEIGHT), /* Clearance height */  \
-    MakeWidget(DirectionColumnXY,       DirectionColumnSize,       WindowWidgetType::TableHeader, WindowColour::Secondary, STR_TILE_INSPECTOR_DIRECTION_SHORT,        STR_TILE_INSPECTOR_DIRECTION),        /* Direction */         \
-    MakeWidget(GhostFlagColumnXY,       GhostFlagColumnSize,       WindowWidgetType::TableHeader, WindowColour::Secondary, STR_TILE_INSPECTOR_FLAG_GHOST_SHORT,       STR_TILE_INSPECTOR_FLAG_GHOST),       /* Ghost flag */        \
-    MakeWidget(LastFlagColumnXY,        LastFlagColumnSize,        WindowWidgetType::TableHeader, WindowColour::Secondary, STR_TILE_INSPECTOR_FLAG_LAST_SHORT,        STR_TILE_INSPECTOR_FLAG_LAST),        /* Last of tile flag */ \
-    /* Group boxes */ \
-    MakeWidget({6, 0},             {WW - 12, 0}, WindowWidgetType::Groupbox,    WindowColour::Secondary, STR_NONE,                               STR_NONE ), /* Details group box */     \
-    MakeWidget({6, 0},             {WW - 12, 0}, WindowWidgetType::Groupbox,    WindowColour::Secondary, STR_TILE_INSPECTOR_GROUPBOX_PROPERTIES, STR_NONE )  /* Properties group box */
+    #define MAIN_TILE_INSPECTOR_WIDGETS \
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
+        MakeWidget({3, 57}, {WW - 6, WH - PADDING_BOTTOM - 58}, WindowWidgetType::Scroll, WindowColour::Secondary, SCROLL_VERTICAL), /* Element list */ \
+        /* X and Y spinners */ \
+        MakeSpinnerWidgets({20, 23}, {51, 12}, WindowWidgetType::Spinner, WindowColour::Secondary), /* Spinner X (3 widgets) */ \
+        MakeSpinnerWidgets({90, 23}, {51, 12}, WindowWidgetType::Spinner, WindowColour::Secondary), /* Spinner Y (3 widgets) */ \
+        /* Top buttons */ \
+        MakeWidget(ToolbarButtonAnchor + ToolbarButtonOffsetX * 0,                     ToolbarButtonSize,     WindowWidgetType::FlatBtn,     WindowColour::Secondary, ImageId(SPR_DEMOLISH),     STR_REMOVE_SELECTED_ELEMENT_TIP ),    /* Remove button */         \
+        MakeWidget(ToolbarButtonAnchor + ToolbarButtonOffsetX * 1,                     ToolbarButtonHalfSize, WindowWidgetType::Button,      WindowColour::Secondary, STR_UP,           STR_MOVE_SELECTED_ELEMENT_UP_TIP),    /* Move up */               \
+        MakeWidget(ToolbarButtonAnchor + ToolbarButtonOffsetX * 1 + ScreenSize{0, 12}, ToolbarButtonHalfSize, WindowWidgetType::Button,      WindowColour::Secondary, STR_DOWN,         STR_MOVE_SELECTED_ELEMENT_DOWN_TIP),  /* Move down */             \
+        MakeWidget(ToolbarButtonAnchor + ToolbarButtonOffsetX * 2,                     ToolbarButtonSize,     WindowWidgetType::FlatBtn,     WindowColour::Secondary, ImageId(SPR_ROTATE_ARROW), STR_ROTATE_SELECTED_ELEMENT_TIP),     /* Rotate button */         \
+        MakeWidget(ToolbarButtonAnchor + ToolbarButtonOffsetX * 3,                     ToolbarButtonSize,     WindowWidgetType::FlatBtn,     WindowColour::Secondary, ImageId(SPR_G2_SORT),      STR_TILE_INSPECTOR_SORT_TIP),         /* Sort button */           \
+        MakeWidget(ToolbarButtonAnchor + ToolbarButtonOffsetX * 4,                     ToolbarButtonSize,     WindowWidgetType::FlatBtn,     WindowColour::Secondary, ImageId(SPR_G2_PASTE),     STR_TILE_INSPECTOR_PASTE_TIP),        /* Paste button */          \
+        MakeWidget(ToolbarButtonAnchor + ToolbarButtonOffsetX * 5,                     ToolbarButtonSize,     WindowWidgetType::FlatBtn,     WindowColour::Secondary, ImageId(SPR_G2_COPY),      STR_TILE_INSPECTOR_COPY_TIP),         /* Copy button */           \
+        /* Column headers */ \
+        MakeWidget(InvisibleFlagColumnXY,   InvisibleFlagColumnSize,   WindowWidgetType::TableHeader, WindowColour::Secondary, STR_TILE_INSPECTOR_INVISIBLE_SHORT,        STR_TILE_INSPECTOR_FLAG_INVISIBLE),   /* Invisible flag */    \
+        MakeWidget(TypeColumnXY,            TypeColumnSize,            WindowWidgetType::TableHeader, WindowColour::Secondary, STR_TILE_INSPECTOR_ELEMENT_TYPE),                                                /* Type */              \
+        MakeWidget(BaseHeightColumnXY,      BaseHeightColumnSize,      WindowWidgetType::TableHeader, WindowColour::Secondary, STR_TILE_INSPECTOR_BASE_HEIGHT_SHORT,      STR_TILE_INSPECTOR_BASE_HEIGHT),      /* Base height */       \
+        MakeWidget(ClearanceHeightColumnXY, ClearanceHeightColumnSize, WindowWidgetType::TableHeader, WindowColour::Secondary, STR_TILE_INSPECTOR_CLEARANGE_HEIGHT_SHORT, STR_TILE_INSPECTOR_CLEARANCE_HEIGHT), /* Clearance height */  \
+        MakeWidget(DirectionColumnXY,       DirectionColumnSize,       WindowWidgetType::TableHeader, WindowColour::Secondary, STR_TILE_INSPECTOR_DIRECTION_SHORT,        STR_TILE_INSPECTOR_DIRECTION),        /* Direction */         \
+        MakeWidget(GhostFlagColumnXY,       GhostFlagColumnSize,       WindowWidgetType::TableHeader, WindowColour::Secondary, STR_TILE_INSPECTOR_FLAG_GHOST_SHORT,       STR_TILE_INSPECTOR_FLAG_GHOST),       /* Ghost flag */        \
+        MakeWidget(LastFlagColumnXY,        LastFlagColumnSize,        WindowWidgetType::TableHeader, WindowColour::Secondary, STR_TILE_INSPECTOR_FLAG_LAST_SHORT,        STR_TILE_INSPECTOR_FLAG_LAST),        /* Last of tile flag */ \
+        /* Group boxes */ \
+        MakeWidget({6, 0},             {WW - 12, 0}, WindowWidgetType::Groupbox,    WindowColour::Secondary, STR_NONE,                               STR_NONE ), /* Details group box */     \
+        MakeWidget({6, 0},             {WW - 12, 0}, WindowWidgetType::Groupbox,    WindowColour::Secondary, STR_TILE_INSPECTOR_GROUPBOX_PROPERTIES, STR_NONE )  /* Properties group box */
 
-static Widget DefaultWidgets[] = {
-    MAIN_TILE_INSPECTOR_WIDGETS,
-    kWidgetsEnd,
-};
+    static Widget DefaultWidgets[] = {
+        MAIN_TILE_INSPECTOR_WIDGETS,
+        kWidgetsEnd,
+    };
 
-constexpr int32_t NumSurfaceProperties = 4;
-constexpr int32_t NumSurfaceDetails = 4;
-constexpr int32_t SurfacePropertiesHeight = 16 + NumSurfaceProperties * 21;
-constexpr int32_t SurfaceDetailsHeight = 20 + NumSurfaceDetails * 11;
-static Widget SurfaceWidgets[] = {
-    MAIN_TILE_INSPECTOR_WIDGETS,
-    MakeSpinnerWidgets(PropertyRowCol({ 12, 0 }, 0, 1), PropertyButtonSize, WindowWidgetType::Spinner, WindowColour::Secondary), // WIDX_SURFACE_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
-    MakeWidget(PropertyRowCol({ 12, 0 }, 1, 0),         PropertyButtonSize, WindowWidgetType::Button,  WindowColour::Secondary, STR_TILE_INSPECTOR_SURFACE_REMOVE_FENCES), // WIDX_SURFACE_BUTTON_REMOVE_FENCES
-    MakeWidget(PropertyRowCol({ 12, 0 }, 1, 1),         PropertyButtonSize, WindowWidgetType::Button,  WindowColour::Secondary, STR_TILE_INSPECTOR_SURFACE_RESTORE_FENCES), // WIDX_SURFACE_BUTTON_RESTORE_FENCES
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 3, 1), 1, 0), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SURFACE_CHECK_CORNER_N
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 3, 1), 2, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SURFACE_CHECK_CORNER_E
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 3, 1), 1, 2), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SURFACE_CHECK_CORNER_S
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 3, 1), 0, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SURFACE_CHECK_CORNER_W
-    MakeWidget(PropertyRowCol({ 12, 0 }, 4, 0), PropertyFullWidth, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_TILE_INSPECTOR_SURFACE_DIAGONAL), // WIDX_SURFACE_CHECK_DIAGONAL
-    kWidgetsEnd,
-};
+    constexpr int32_t NumSurfaceProperties = 4;
+    constexpr int32_t NumSurfaceDetails = 4;
+    constexpr int32_t SurfacePropertiesHeight = 16 + NumSurfaceProperties * 21;
+    constexpr int32_t SurfaceDetailsHeight = 20 + NumSurfaceDetails * 11;
+    static Widget SurfaceWidgets[] = {
+        MAIN_TILE_INSPECTOR_WIDGETS,
+        MakeSpinnerWidgets(PropertyRowCol({ 12, 0 }, 0, 1), PropertyButtonSize, WindowWidgetType::Spinner, WindowColour::Secondary), // WIDX_SURFACE_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
+        MakeWidget(PropertyRowCol({ 12, 0 }, 1, 0),         PropertyButtonSize, WindowWidgetType::Button,  WindowColour::Secondary, STR_TILE_INSPECTOR_SURFACE_REMOVE_FENCES), // WIDX_SURFACE_BUTTON_REMOVE_FENCES
+        MakeWidget(PropertyRowCol({ 12, 0 }, 1, 1),         PropertyButtonSize, WindowWidgetType::Button,  WindowColour::Secondary, STR_TILE_INSPECTOR_SURFACE_RESTORE_FENCES), // WIDX_SURFACE_BUTTON_RESTORE_FENCES
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 3, 1), 1, 0), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SURFACE_CHECK_CORNER_N
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 3, 1), 2, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SURFACE_CHECK_CORNER_E
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 3, 1), 1, 2), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SURFACE_CHECK_CORNER_S
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 3, 1), 0, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SURFACE_CHECK_CORNER_W
+        MakeWidget(PropertyRowCol({ 12, 0 }, 4, 0), PropertyFullWidth, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_TILE_INSPECTOR_SURFACE_DIAGONAL), // WIDX_SURFACE_CHECK_DIAGONAL
+        kWidgetsEnd,
+    };
 
-constexpr int32_t NumPathProperties = 6;
-constexpr int32_t NumPathDetails = 3;
-constexpr int32_t PathPropertiesHeight = 16 + NumPathProperties * 21;
-constexpr int32_t PathDetailsHeight = 20 + NumPathDetails * 11;
-static Widget PathWidgets[] = {
-    MAIN_TILE_INSPECTOR_WIDGETS,
-    MakeSpinnerWidgets(PropertyRowCol({ 12, 0 }, 0, 1), PropertyButtonSize, WindowWidgetType::Spinner, WindowColour::Secondary), // WIDX_PATH_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
-    MakeWidget(PropertyRowCol({ 12, 0 }, 1, 0), PropertyFullWidth, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_TILE_INSPECTOR_PATH_BROKEN), // WIDX_PATH_CHECK_BROKEN
-    MakeWidget(PropertyRowCol({ 12, 0 }, 2, 0), PropertyFullWidth, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_TILE_INSPECTOR_PATH_SLOPED), // WIDX_PATH_CHECK_SLOPED
-    MakeWidget(PropertyRowCol({ 12, 0 }, 3, 0), PropertyFullWidth, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_TILE_INSPECTOR_PATH_JUNCTION_RAILINGS), // WIDX_PATH_CHECK_JUNCTION_RAILINGS
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 3, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_PATH_CHECK_EDGE_NE
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 4, 2), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_PATH_CHECK_EDGE_E
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 3, 3), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_PATH_CHECK_EDGE_SE
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 2, 4), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_PATH_CHECK_EDGE_S
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 1, 3), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_PATH_CHECK_EDGE_SW
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 0, 2), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_PATH_CHECK_EDGE_W
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 1, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_PATH_CHECK_EDGE_NW
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 2, 0), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_PATH_CHECK_EDGE_N
-    kWidgetsEnd,
-};
+    constexpr int32_t NumPathProperties = 6;
+    constexpr int32_t NumPathDetails = 3;
+    constexpr int32_t PathPropertiesHeight = 16 + NumPathProperties * 21;
+    constexpr int32_t PathDetailsHeight = 20 + NumPathDetails * 11;
+    static Widget PathWidgets[] = {
+        MAIN_TILE_INSPECTOR_WIDGETS,
+        MakeSpinnerWidgets(PropertyRowCol({ 12, 0 }, 0, 1), PropertyButtonSize, WindowWidgetType::Spinner, WindowColour::Secondary), // WIDX_PATH_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
+        MakeWidget(PropertyRowCol({ 12, 0 }, 1, 0), PropertyFullWidth, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_TILE_INSPECTOR_PATH_BROKEN), // WIDX_PATH_CHECK_BROKEN
+        MakeWidget(PropertyRowCol({ 12, 0 }, 2, 0), PropertyFullWidth, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_TILE_INSPECTOR_PATH_SLOPED), // WIDX_PATH_CHECK_SLOPED
+        MakeWidget(PropertyRowCol({ 12, 0 }, 3, 0), PropertyFullWidth, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_TILE_INSPECTOR_PATH_JUNCTION_RAILINGS), // WIDX_PATH_CHECK_JUNCTION_RAILINGS
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 3, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_PATH_CHECK_EDGE_NE
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 4, 2), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_PATH_CHECK_EDGE_E
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 3, 3), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_PATH_CHECK_EDGE_SE
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 2, 4), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_PATH_CHECK_EDGE_S
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 1, 3), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_PATH_CHECK_EDGE_SW
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 0, 2), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_PATH_CHECK_EDGE_W
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 1, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_PATH_CHECK_EDGE_NW
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 2, 0), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_PATH_CHECK_EDGE_N
+        kWidgetsEnd,
+    };
 
-constexpr int32_t NumTrackProperties = 5;
-constexpr int32_t NumTrackDetails = 7;
-constexpr int32_t TrackPropertiesHeight = 16 + NumTrackProperties * 21;
-constexpr int32_t TrackDetailsHeight = 20 + NumTrackDetails * 11;
-static Widget TrackWidgets[] = {
-    MAIN_TILE_INSPECTOR_WIDGETS,
-    MakeWidget(PropertyRowCol({ 12, 0}, 0, 0), PropertyFullWidth, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_TILE_INSPECTOR_TRACK_ENTIRE_TRACK_PIECE), // WIDX_TRACK_CHECK_APPLY_TO_ALL
-    MakeSpinnerWidgets(PropertyRowCol({ 12, 0 }, 1, 1), PropertyButtonSize, WindowWidgetType::Spinner, WindowColour::Secondary), // WIDX_TRACK_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
-    MakeWidget(PropertyRowCol({ 12, 0}, 2, 0), PropertyFullWidth, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_TILE_INSPECTOR_TRACK_CHAIN_LIFT), // WIDX_TRACK_CHECK_CHAIN_LIFT
-    MakeWidget(PropertyRowCol({ 12, 0}, 3, 0), PropertyFullWidth, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_TILE_INSPECTOR_TRACK_BRAKE_CLOSED), // WIDX_TRACK_CHECK_BRAKE_CLOSED
-    MakeWidget(PropertyRowCol({ 12, 0}, 4, 0), PropertyFullWidth, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_TILE_INSPECTOR_TRACK_IS_INDESTRUCTIBLE), // WIDX_TRACK_CHECK_IS_INDESTRUCTIBLE
-    kWidgetsEnd,
-};
+    constexpr int32_t NumTrackProperties = 5;
+    constexpr int32_t NumTrackDetails = 7;
+    constexpr int32_t TrackPropertiesHeight = 16 + NumTrackProperties * 21;
+    constexpr int32_t TrackDetailsHeight = 20 + NumTrackDetails * 11;
+    static Widget TrackWidgets[] = {
+        MAIN_TILE_INSPECTOR_WIDGETS,
+        MakeWidget(PropertyRowCol({ 12, 0}, 0, 0), PropertyFullWidth, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_TILE_INSPECTOR_TRACK_ENTIRE_TRACK_PIECE), // WIDX_TRACK_CHECK_APPLY_TO_ALL
+        MakeSpinnerWidgets(PropertyRowCol({ 12, 0 }, 1, 1), PropertyButtonSize, WindowWidgetType::Spinner, WindowColour::Secondary), // WIDX_TRACK_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
+        MakeWidget(PropertyRowCol({ 12, 0}, 2, 0), PropertyFullWidth, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_TILE_INSPECTOR_TRACK_CHAIN_LIFT), // WIDX_TRACK_CHECK_CHAIN_LIFT
+        MakeWidget(PropertyRowCol({ 12, 0}, 3, 0), PropertyFullWidth, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_TILE_INSPECTOR_TRACK_BRAKE_CLOSED), // WIDX_TRACK_CHECK_BRAKE_CLOSED
+        MakeWidget(PropertyRowCol({ 12, 0}, 4, 0), PropertyFullWidth, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_TILE_INSPECTOR_TRACK_IS_INDESTRUCTIBLE), // WIDX_TRACK_CHECK_IS_INDESTRUCTIBLE
+        kWidgetsEnd,
+    };
 
-constexpr int32_t NumSceneryProperties = 4; // The checkbox groups both count for 2 rows
-constexpr int32_t NumSceneryDetails = 3;
-constexpr int32_t SceneryPropertiesHeight = 16 + NumSceneryProperties * 21;
-constexpr int32_t SceneryDetailsHeight = 20 + NumSceneryDetails * 11;
-static Widget SceneryWidgets[] = {
-    MAIN_TILE_INSPECTOR_WIDGETS,
-    MakeSpinnerWidgets(PropertyRowCol({ 12, 0 }, 0, 1), PropertyButtonSize, WindowWidgetType::Spinner, WindowColour::Secondary), // WIDX_SCENERY_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 1, 0), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SCENERY_CHECK_QUARTER_N
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 2, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SCENERY_CHECK_QUARTER_E
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 1, 2), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SCENERY_CHECK_QUARTER_S
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 0, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SCENERY_CHECK_QUARTER_W
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 1, 0), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SCENERY_CHECK_COLLISION_N
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 2, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SCENERY_CHECK_COLLISION_E
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 1, 2), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SCENERY_CHECK_COLLISION_S
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 0, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SCENERY_CHECK_COLLISION_W
-    kWidgetsEnd,
-};
+    constexpr int32_t NumSceneryProperties = 4; // The checkbox groups both count for 2 rows
+    constexpr int32_t NumSceneryDetails = 3;
+    constexpr int32_t SceneryPropertiesHeight = 16 + NumSceneryProperties * 21;
+    constexpr int32_t SceneryDetailsHeight = 20 + NumSceneryDetails * 11;
+    static Widget SceneryWidgets[] = {
+        MAIN_TILE_INSPECTOR_WIDGETS,
+        MakeSpinnerWidgets(PropertyRowCol({ 12, 0 }, 0, 1), PropertyButtonSize, WindowWidgetType::Spinner, WindowColour::Secondary), // WIDX_SCENERY_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 1, 0), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SCENERY_CHECK_QUARTER_N
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 2, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SCENERY_CHECK_QUARTER_E
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 1, 2), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SCENERY_CHECK_QUARTER_S
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 0, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SCENERY_CHECK_QUARTER_W
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 1, 0), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SCENERY_CHECK_COLLISION_N
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 2, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SCENERY_CHECK_COLLISION_E
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 1, 2), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SCENERY_CHECK_COLLISION_S
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 0, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_SCENERY_CHECK_COLLISION_W
+        kWidgetsEnd,
+    };
 
-constexpr int32_t NumEntranceProperties = 2;
-constexpr int32_t NumEntranceDetails = 4;
-constexpr int32_t EntrancePropertiesHeight = 16 + NumEntranceProperties * 21;
-constexpr int32_t EntranceDetailsHeight = 20 + NumEntranceDetails * 11;
-static Widget EntranceWidgets[] = {
-    MAIN_TILE_INSPECTOR_WIDGETS,
-    MakeSpinnerWidgets(PropertyRowCol({ 12, 0 }, 0, 1), PropertyButtonSize, WindowWidgetType::Spinner, WindowColour::Secondary), // WIDX_ENTRANCE_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
-    MakeWidget(PropertyRowCol({ 12, 0 }, 1, 0),         PropertyButtonSize, WindowWidgetType::Button,  WindowColour::Secondary, STR_TILE_INSPECTOR_ENTRANCE_MAKE_USABLE, STR_TILE_INSPECTOR_ENTRANCE_MAKE_USABLE_TIP), // WIDX_ENTRANCE_BUTTON_MAKE_USABLE
-    kWidgetsEnd,
-};
+    constexpr int32_t NumEntranceProperties = 2;
+    constexpr int32_t NumEntranceDetails = 4;
+    constexpr int32_t EntrancePropertiesHeight = 16 + NumEntranceProperties * 21;
+    constexpr int32_t EntranceDetailsHeight = 20 + NumEntranceDetails * 11;
+    static Widget EntranceWidgets[] = {
+        MAIN_TILE_INSPECTOR_WIDGETS,
+        MakeSpinnerWidgets(PropertyRowCol({ 12, 0 }, 0, 1), PropertyButtonSize, WindowWidgetType::Spinner, WindowColour::Secondary), // WIDX_ENTRANCE_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
+        MakeWidget(PropertyRowCol({ 12, 0 }, 1, 0),         PropertyButtonSize, WindowWidgetType::Button,  WindowColour::Secondary, STR_TILE_INSPECTOR_ENTRANCE_MAKE_USABLE, STR_TILE_INSPECTOR_ENTRANCE_MAKE_USABLE_TIP), // WIDX_ENTRANCE_BUTTON_MAKE_USABLE
+        kWidgetsEnd,
+    };
 
-constexpr int32_t NumWallProperties = 4;
-constexpr int32_t NumWallDetails = 2;
-constexpr int32_t WallPropertiesHeight = 16 + NumWallProperties * 21;
-constexpr int32_t WallDetailsHeight = 20 + NumWallDetails * 11;
-static Widget WallWidgets[] = {
-    MAIN_TILE_INSPECTOR_WIDGETS,
-    MakeSpinnerWidgets(PropertyRowCol({ 12, 0 }, 0, 1),                 PropertyButtonSize, WindowWidgetType::Spinner,      WindowColour::Secondary), // WIDX_WALL_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
-    MakeWidget(PropertyRowCol({ 12, 0 }, 1, 1),                         PropertyButtonSize, WindowWidgetType::DropdownMenu, WindowColour::Secondary), // WIDX_WALL_DROPDOWN_SLOPE
-    MakeWidget(PropertyRowCol({ 12 + PropertyButtonSize.width - 12, 0 }, 1, 1), { 11,  12}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH), // WIDX_WALL_DROPDOWN_SLOPE_BUTTON
-    MakeSpinnerWidgets(PropertyRowCol({ 12, 0 }, 2, 1),                 PropertyButtonSize, WindowWidgetType::Spinner,      WindowColour::Secondary), // WIDX_WALL_SPINNER_ANIMATION_FRAME{,_INCREASE,_DECREASE}
-    MakeWidget(PropertyRowCol({ 12, 0 }, 3, 0),                         PropertyFullWidth,  WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_TILE_INSPECTOR_WALL_ANIMATION_IS_BACKWARDS), // WIDX_WALL_ANIMATION_IS_BACKWARDS
-    kWidgetsEnd,
-};
+    constexpr int32_t NumWallProperties = 4;
+    constexpr int32_t NumWallDetails = 2;
+    constexpr int32_t WallPropertiesHeight = 16 + NumWallProperties * 21;
+    constexpr int32_t WallDetailsHeight = 20 + NumWallDetails * 11;
+    static Widget WallWidgets[] = {
+        MAIN_TILE_INSPECTOR_WIDGETS,
+        MakeSpinnerWidgets(PropertyRowCol({ 12, 0 }, 0, 1),                 PropertyButtonSize, WindowWidgetType::Spinner,      WindowColour::Secondary), // WIDX_WALL_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
+        MakeWidget(PropertyRowCol({ 12, 0 }, 1, 1),                         PropertyButtonSize, WindowWidgetType::DropdownMenu, WindowColour::Secondary), // WIDX_WALL_DROPDOWN_SLOPE
+        MakeWidget(PropertyRowCol({ 12 + PropertyButtonSize.width - 12, 0 }, 1, 1), { 11,  12}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH), // WIDX_WALL_DROPDOWN_SLOPE_BUTTON
+        MakeSpinnerWidgets(PropertyRowCol({ 12, 0 }, 2, 1),                 PropertyButtonSize, WindowWidgetType::Spinner,      WindowColour::Secondary), // WIDX_WALL_SPINNER_ANIMATION_FRAME{,_INCREASE,_DECREASE}
+        MakeWidget(PropertyRowCol({ 12, 0 }, 3, 0),                         PropertyFullWidth,  WindowWidgetType::Checkbox,     WindowColour::Secondary, STR_TILE_INSPECTOR_WALL_ANIMATION_IS_BACKWARDS), // WIDX_WALL_ANIMATION_IS_BACKWARDS
+        kWidgetsEnd,
+    };
 
-constexpr int32_t NumLargeSceneryProperties = 1;
-constexpr int32_t NumLargeSceneryDetails = 3;
-constexpr int32_t LargeSceneryPropertiesHeight = 16 + NumLargeSceneryProperties * 21;
-constexpr int32_t LargeSceneryDetailsHeight = 20 + NumLargeSceneryDetails * 11;
-static Widget LargeSceneryWidgets[] = {
-    MAIN_TILE_INSPECTOR_WIDGETS,
-    MakeSpinnerWidgets(PropertyRowCol({ 12, 0 }, 0, 1), PropertyButtonSize, WindowWidgetType::Spinner, WindowColour::Secondary), // WIDX_LARGE_SCENERY_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
-    kWidgetsEnd,
-};
+    constexpr int32_t NumLargeSceneryProperties = 1;
+    constexpr int32_t NumLargeSceneryDetails = 3;
+    constexpr int32_t LargeSceneryPropertiesHeight = 16 + NumLargeSceneryProperties * 21;
+    constexpr int32_t LargeSceneryDetailsHeight = 20 + NumLargeSceneryDetails * 11;
+    static Widget LargeSceneryWidgets[] = {
+        MAIN_TILE_INSPECTOR_WIDGETS,
+        MakeSpinnerWidgets(PropertyRowCol({ 12, 0 }, 0, 1), PropertyButtonSize, WindowWidgetType::Spinner, WindowColour::Secondary), // WIDX_LARGE_SCENERY_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
+        kWidgetsEnd,
+    };
 
-constexpr int32_t NumBannerProperties = 3;
-constexpr int32_t NumBannerDetails = 1;
-constexpr int32_t BannerPropertiesHeight = 16 + NumBannerProperties * 21;
-constexpr int32_t BannerDetailsHeight = 20 + NumBannerDetails * 11;
-static Widget BannerWidgets[] = {
-    MAIN_TILE_INSPECTOR_WIDGETS,
-    MakeSpinnerWidgets(PropertyRowCol({ 12, 0 }, 0, 1), PropertyButtonSize, WindowWidgetType::Spinner, WindowColour::Secondary), // WIDX_BANNER_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 3, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_BANNER_CHECK_BLOCK_NE
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 3, 3), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_BANNER_CHECK_BLOCK_SE
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 1, 3), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_BANNER_CHECK_BLOCK_SW
-    MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 1, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_BANNER_CHECK_BLOCK_NW
+    constexpr int32_t NumBannerProperties = 3;
+    constexpr int32_t NumBannerDetails = 1;
+    constexpr int32_t BannerPropertiesHeight = 16 + NumBannerProperties * 21;
+    constexpr int32_t BannerDetailsHeight = 20 + NumBannerDetails * 11;
+    static Widget BannerWidgets[] = {
+        MAIN_TILE_INSPECTOR_WIDGETS,
+        MakeSpinnerWidgets(PropertyRowCol({ 12, 0 }, 0, 1), PropertyButtonSize, WindowWidgetType::Spinner, WindowColour::Secondary), // WIDX_BANNER_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 3, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_BANNER_CHECK_BLOCK_NE
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 3, 3), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_BANNER_CHECK_BLOCK_SE
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 1, 3), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_BANNER_CHECK_BLOCK_SW
+        MakeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 1, 1), { 12, 12 }, WindowWidgetType::Checkbox, WindowColour::Secondary), // WIDX_BANNER_CHECK_BLOCK_NW
 
-    kWidgetsEnd,
-};
+        kWidgetsEnd,
+    };
 
-static Widget *PageWidgets[] = {
-    DefaultWidgets,
-    SurfaceWidgets,
-    PathWidgets,
-    TrackWidgets,
-    SceneryWidgets,
-    EntranceWidgets,
-    WallWidgets,
-    LargeSceneryWidgets,
-    BannerWidgets,
-};
+    static Widget *PageWidgets[] = {
+        DefaultWidgets,
+        SurfaceWidgets,
+        PathWidgets,
+        TrackWidgets,
+        SceneryWidgets,
+        EntranceWidgets,
+        WallWidgets,
+        LargeSceneryWidgets,
+        BannerWidgets,
+    };
     // clang-format on
 
     struct TileInspectorGroupboxSettings

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -245,7 +245,7 @@ namespace OpenRCT2::Ui::Windows
         return anchorPoint + ScreenCoordsXY{ 14 * horizontalMultiplier, 7 * verticalMultiplier };
     }
 
-// clang-format off
+    // clang-format off
 
     // Macros for easily obtaining the top and bottom of a widget inside a properties group box
     #define GBBT(GROUPTOP, row)     ((GROUPTOP) + 14 + row * (PropertyButtonSize.height + VERTICAL_GROUPBOX_PADDING))

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -229,6 +229,7 @@ namespace OpenRCT2::Ui::Windows
     constexpr int32_t VERTICAL_GROUPBOX_PADDING = 4;
     constexpr auto PropertyButtonSize = ScreenSize{ 130, 18 };
     constexpr auto PropertyFullWidth = ScreenSize{ 370, 18 };
+
 #pragma endregion
 
     constexpr ScreenCoordsXY PropertyRowCol(ScreenCoordsXY anchor, int32_t row, int32_t column)
@@ -245,6 +246,7 @@ namespace OpenRCT2::Ui::Windows
     }
 
 // clang-format off
+
     // Macros for easily obtaining the top and bottom of a widget inside a properties group box
     #define GBBT(GROUPTOP, row)     ((GROUPTOP) + 14 + row * (PropertyButtonSize.height + VERTICAL_GROUPBOX_PADDING))
     #define GBBB(GROUPTOP, row)     (GBBT((GROUPTOP), row) + PropertyButtonSize.height)

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -192,6 +192,7 @@ namespace OpenRCT2::Ui::Windows
 #pragma region MEASUREMENTS
 
     static constexpr StringId WINDOW_TITLE = STR_TILE_INSPECTOR_TITLE;
+
     // Window sizes
     static constexpr int32_t WW = 400;
     static constexpr int32_t WH = 170;
@@ -232,11 +233,11 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma endregion
 
+    // clang-format off
     constexpr ScreenCoordsXY PropertyRowCol(ScreenCoordsXY anchor, int32_t row, int32_t column)
     {
-        return anchor
-            + ScreenCoordsXY{ column * (PropertyButtonSize.width + HORIZONTAL_GROUPBOX_PADDING),
-                              row * (PropertyButtonSize.height + VERTICAL_GROUPBOX_PADDING) };
+        return anchor + ScreenCoordsXY{ column * (PropertyButtonSize.width + HORIZONTAL_GROUPBOX_PADDING),
+                                        row * (PropertyButtonSize.height + VERTICAL_GROUPBOX_PADDING) };
     }
 
     constexpr ScreenCoordsXY CheckboxGroupOffset(
@@ -244,8 +245,6 @@ namespace OpenRCT2::Ui::Windows
     {
         return anchorPoint + ScreenCoordsXY{ 14 * horizontalMultiplier, 7 * verticalMultiplier };
     }
-
-    // clang-format off
 
     // Macros for easily obtaining the top and bottom of a widget inside a properties group box
     #define GBBT(GROUPTOP, row)     ((GROUPTOP) + 14 + row * (PropertyButtonSize.height + VERTICAL_GROUPBOX_PADDING))

--- a/src/openrct2-ui/windows/TitleExit.cpp
+++ b/src/openrct2-ui/windows/TitleExit.cpp
@@ -14,16 +14,15 @@
 
 namespace OpenRCT2::Ui::Windows
 {
-    // clang-format off
-enum WindowTitleExitWidgetIdx {
-    WIDX_EXIT,
-};
+    enum WindowTitleExitWidgetIdx
+    {
+        WIDX_EXIT,
+    };
 
-static Widget _titleExitWidgets[] = {
-    MakeWidget({0, 0}, {40, 64}, WindowWidgetType::ImgBtn, WindowColour::Tertiary, ImageId(SPR_MENU_EXIT), STR_EXIT),
-    kWidgetsEnd,
-};
-    // clang-format on
+    static Widget _titleExitWidgets[] = {
+        MakeWidget({ 0, 0 }, { 40, 64 }, WindowWidgetType::ImgBtn, WindowColour::Tertiary, ImageId(SPR_MENU_EXIT), STR_EXIT),
+        kWidgetsEnd,
+    };
 
     class TitleExitWindow final : public Window
     {

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -23,36 +23,37 @@
 
 namespace OpenRCT2::Ui::Windows
 {
+    enum
+    {
+        WIDX_START_NEW_GAME,
+        WIDX_CONTINUE_SAVED_GAME,
+        WIDX_MULTIPLAYER,
+        WIDX_GAME_TOOLS,
+        WIDX_NEW_VERSION,
+    };
+
+    enum
+    {
+        DDIDX_SCENARIO_EDITOR,
+        DDIDX_CONVERT_SAVED_GAME,
+        DDIDX_TRACK_DESIGNER,
+        DDIDX_TRACK_MANAGER,
+        DDIDX_OPEN_CONTENT_FOLDER,
+        DDIDX_CUSTOM_BEGIN = 6,
+    };
+
+    static constexpr ScreenSize MenuButtonDims = { 82, 82 };
+    static constexpr ScreenSize UpdateButtonDims = { MenuButtonDims.width * 4, 28 };
+
     // clang-format off
-enum {
-    WIDX_START_NEW_GAME,
-    WIDX_CONTINUE_SAVED_GAME,
-    WIDX_MULTIPLAYER,
-    WIDX_GAME_TOOLS,
-    WIDX_NEW_VERSION,
-};
-
-enum
-{
-    DDIDX_SCENARIO_EDITOR,
-    DDIDX_CONVERT_SAVED_GAME,
-    DDIDX_TRACK_DESIGNER,
-    DDIDX_TRACK_MANAGER,
-    DDIDX_OPEN_CONTENT_FOLDER,
-    DDIDX_CUSTOM_BEGIN = 6,
-};
-
-static constexpr ScreenSize MenuButtonDims = { 82, 82 };
-static constexpr ScreenSize UpdateButtonDims = { MenuButtonDims.width * 4, 28 };
-
-static Widget _titleMenuWidgets[] = {
-    MakeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WindowWidgetType::ImgBtn, WindowColour::Tertiary,  ImageId(SPR_MENU_NEW_GAME),       STR_START_NEW_GAME_TIP),
-    MakeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WindowWidgetType::ImgBtn, WindowColour::Tertiary,  ImageId(SPR_MENU_LOAD_GAME),      STR_CONTINUE_SAVED_GAME_TIP),
-    MakeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WindowWidgetType::ImgBtn, WindowColour::Tertiary,  ImageId(SPR_G2_MENU_MULTIPLAYER), STR_SHOW_MULTIPLAYER_TIP),
-    MakeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WindowWidgetType::ImgBtn, WindowColour::Tertiary,  ImageId(SPR_MENU_TOOLBOX),        STR_GAME_TOOLS_TIP),
-    MakeWidget({0,                       0}, UpdateButtonDims, WindowWidgetType::Empty,  WindowColour::Secondary, STR_UPDATE_AVAILABLE),
-    kWidgetsEnd,
-};
+    static Widget _titleMenuWidgets[] = {
+        MakeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WindowWidgetType::ImgBtn, WindowColour::Tertiary,  ImageId(SPR_MENU_NEW_GAME),       STR_START_NEW_GAME_TIP),
+        MakeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WindowWidgetType::ImgBtn, WindowColour::Tertiary,  ImageId(SPR_MENU_LOAD_GAME),      STR_CONTINUE_SAVED_GAME_TIP),
+        MakeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WindowWidgetType::ImgBtn, WindowColour::Tertiary,  ImageId(SPR_G2_MENU_MULTIPLAYER), STR_SHOW_MULTIPLAYER_TIP),
+        MakeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WindowWidgetType::ImgBtn, WindowColour::Tertiary,  ImageId(SPR_MENU_TOOLBOX),        STR_GAME_TOOLS_TIP),
+        MakeWidget({0,                       0}, UpdateButtonDims, WindowWidgetType::Empty,  WindowColour::Secondary, STR_UPDATE_AVAILABLE),
+        kWidgetsEnd,
+    };
     // clang-format on
 
     static void WindowTitleMenuScenarioselectCallback(const utf8* path)

--- a/src/openrct2-ui/windows/TitleOptions.cpp
+++ b/src/openrct2-ui/windows/TitleOptions.cpp
@@ -13,16 +13,15 @@
 
 namespace OpenRCT2::Ui::Windows
 {
-    // clang-format off
-enum WindowTitleOptionsWidgetIdx {
-    WIDX_OPTIONS,
-};
+    enum WindowTitleOptionsWidgetIdx
+    {
+        WIDX_OPTIONS,
+    };
 
-static Widget _windowTitleOptionsWidgets[] = {
-    MakeWidget({0, 0}, {80, 15}, WindowWidgetType::Button, WindowColour::Tertiary, STR_OPTIONS, STR_OPTIONS_TIP),
-    kWidgetsEnd,
-};
-    // clang-format on
+    static Widget _windowTitleOptionsWidgets[] = {
+        MakeWidget({ 0, 0 }, { 80, 15 }, WindowWidgetType::Button, WindowColour::Tertiary, STR_OPTIONS, STR_OPTIONS_TIP),
+        kWidgetsEnd,
+    };
 
     class TitleOptionsWindow final : public Window
     {

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -19,17 +19,15 @@
 
 namespace OpenRCT2::Ui::Windows
 {
-    // clang-format off
-enum {
-    WIDX_BACKGROUND
-};
+    enum
+    {
+        WIDX_BACKGROUND
+    };
 
-static Widget _tooltipWidgets[] = {
-    MakeWidget({0, 0}, {200, 32}, WindowWidgetType::ImgBtn, WindowColour::Primary),
-    kWidgetsEnd,
-};
-
-    // clang-format on
+    static Widget _tooltipWidgets[] = {
+        MakeWidget({ 0, 0 }, { 200, 32 }, WindowWidgetType::ImgBtn, WindowColour::Primary),
+        kWidgetsEnd,
+    };
 
     class TooltipWindow final : public Window
     {

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -27,32 +27,34 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Widgets
 
+    enum
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_RENAME,
+        WIDX_DELETE,
+
+        WIDX_PROMPT_DELETE = 3,
+        WIDX_PROMPT_CANCEL = 4,
+    };
+
     // clang-format off
-enum {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_RENAME,
-    WIDX_DELETE,
+    static Widget _trackManageWidgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({ 10, 24}, {110, 12}, WindowWidgetType::Button, WindowColour::Primary, STR_TRACK_MANAGE_RENAME),
+        MakeWidget({130, 24}, {110, 12}, WindowWidgetType::Button, WindowColour::Primary, STR_TRACK_MANAGE_DELETE),
+        kWidgetsEnd,
+    };
 
-    WIDX_PROMPT_DELETE = 3,
-    WIDX_PROMPT_CANCEL = 4,
-};
+    static Widget _trackDeletePromptWidgets[] = {
+        WINDOW_SHIM(STR_DELETE_FILE, WW_DELETE_PROMPT, WH_DELETE_PROMPT),
+        MakeWidget({ 10, 54}, {110, 12}, WindowWidgetType::Button, WindowColour::Primary, STR_TRACK_MANAGE_DELETE),
+        MakeWidget({130, 54}, {110, 12}, WindowWidgetType::Button, WindowColour::Primary, STR_CANCEL             ),
+        kWidgetsEnd,
+    };
+    // clang-format on
 
-static Widget _trackManageWidgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({ 10, 24}, {110, 12}, WindowWidgetType::Button, WindowColour::Primary, STR_TRACK_MANAGE_RENAME),
-    MakeWidget({130, 24}, {110, 12}, WindowWidgetType::Button, WindowColour::Primary, STR_TRACK_MANAGE_DELETE),
-    kWidgetsEnd,
-};
-
-static Widget _trackDeletePromptWidgets[] = {
-    WINDOW_SHIM(STR_DELETE_FILE, WW_DELETE_PROMPT, WH_DELETE_PROMPT),
-    MakeWidget({ 10, 54}, {110, 12}, WindowWidgetType::Button, WindowColour::Primary, STR_TRACK_MANAGE_DELETE),
-    MakeWidget({130, 54}, {110, 12}, WindowWidgetType::Button, WindowColour::Primary, STR_CANCEL             ),
-    kWidgetsEnd,
-};
-// clang-format on
 #pragma endregion
 
     class TrackDesignManageWindow final : public Window

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -6,6 +6,7 @@
  *
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
+
 #include "../interface/ViewportInteraction.h"
 
 #include <openrct2-ui/interface/Viewport.h>
@@ -50,28 +51,28 @@ namespace OpenRCT2::Ui::Windows
     static constexpr uint8_t _PaletteIndexColourTrack = PALETTE_INDEX_248;   // Grey (dark)
     static constexpr uint8_t _PaletteIndexColourStation = PALETTE_INDEX_252; // Grey (light)
 
+    enum
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_ROTATE,
+        WIDX_MIRROR,
+        WIDX_SELECT_DIFFERENT_DESIGN,
+        WIDX_PRICE
+    };
+
+    validate_global_widx(WC_TRACK_DESIGN_PLACE, WIDX_ROTATE);
+
     // clang-format off
-enum {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_ROTATE,
-    WIDX_MIRROR,
-    WIDX_SELECT_DIFFERENT_DESIGN,
-    WIDX_PRICE
-};
-
-validate_global_widx(WC_TRACK_DESIGN_PLACE, WIDX_ROTATE);
-
-static Widget _trackPlaceWidgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({173,  83}, { 24, 24}, WindowWidgetType::FlatBtn, WindowColour::Primary, ImageId(SPR_ROTATE_ARROW),              STR_ROTATE_90_TIP                         ),
-    MakeWidget({173,  59}, { 24, 24}, WindowWidgetType::FlatBtn, WindowColour::Primary, ImageId(SPR_MIRROR_ARROW),              STR_MIRROR_IMAGE_TIP                      ),
-    MakeWidget({  4, 109}, {192, 12}, WindowWidgetType::Button,  WindowColour::Primary, STR_SELECT_A_DIFFERENT_DESIGN, STR_GO_BACK_TO_DESIGN_SELECTION_WINDOW_TIP),
-    MakeWidget({  0,   0}, {  1,  1}, WindowWidgetType::Empty,   WindowColour::Primary),
-    kWidgetsEnd,
-};
-
+    static Widget _trackPlaceWidgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({173,  83}, { 24, 24}, WindowWidgetType::FlatBtn, WindowColour::Primary, ImageId(SPR_ROTATE_ARROW),              STR_ROTATE_90_TIP                         ),
+        MakeWidget({173,  59}, { 24, 24}, WindowWidgetType::FlatBtn, WindowColour::Primary, ImageId(SPR_MIRROR_ARROW),              STR_MIRROR_IMAGE_TIP                      ),
+        MakeWidget({  4, 109}, {192, 12}, WindowWidgetType::Button,  WindowColour::Primary, STR_SELECT_A_DIFFERENT_DESIGN, STR_GO_BACK_TO_DESIGN_SELECTION_WINDOW_TIP),
+        MakeWidget({  0,   0}, {  1,  1}, WindowWidgetType::Empty,   WindowColour::Primary),
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class TrackDesignPlaceWindow final : public Window

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -35,34 +35,34 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t ROTATE_AND_SCENERY_BUTTON_SIZE = 24;
     static constexpr int32_t WINDOW_PADDING = 5;
 
+    enum
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_BACK,
+        WIDX_FILTER_STRING,
+        WIDX_FILTER_CLEAR,
+        WIDX_TRACK_LIST,
+        WIDX_TRACK_PREVIEW,
+        WIDX_ROTATE,
+        WIDX_TOGGLE_SCENERY,
+    };
+
+    validate_global_widx(WC_TRACK_DESIGN_LIST, WIDX_ROTATE);
+
     // clang-format off
-enum {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_BACK,
-    WIDX_FILTER_STRING,
-    WIDX_FILTER_CLEAR,
-    WIDX_TRACK_LIST,
-    WIDX_TRACK_PREVIEW,
-    WIDX_ROTATE,
-    WIDX_TOGGLE_SCENERY,
-};
-
-validate_global_widx(WC_TRACK_DESIGN_LIST, WIDX_ROTATE);
-
-static Widget _trackListWidgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({  4,  18}, {218,  13}, WindowWidgetType::TableHeader, WindowColour::Primary  , STR_SELECT_OTHER_RIDE                                       ),
-    MakeWidget({  4,  32}, {124,  13}, WindowWidgetType::TextBox,     WindowColour::Secondary                                                              ),
-    MakeWidget({130,  32}, { 92,  13}, WindowWidgetType::Button,       WindowColour::Primary  , STR_OBJECT_SEARCH_CLEAR                                     ),
-    MakeWidget({  4,  46}, {218, 381}, WindowWidgetType::Scroll,       WindowColour::Primary  , SCROLL_VERTICAL,         STR_CLICK_ON_DESIGN_TO_BUILD_IT_TIP),
-    MakeWidget({224,  18}, {372, 219}, WindowWidgetType::FlatBtn,      WindowColour::Primary                                                                ),
-    MakeWidget({572, 405}, { ROTATE_AND_SCENERY_BUTTON_SIZE, ROTATE_AND_SCENERY_BUTTON_SIZE}, WindowWidgetType::FlatBtn,      WindowColour::Primary  , ImageId(SPR_ROTATE_ARROW),        STR_ROTATE_90_TIP                  ),
-    MakeWidget({572, 381}, { ROTATE_AND_SCENERY_BUTTON_SIZE, ROTATE_AND_SCENERY_BUTTON_SIZE}, WindowWidgetType::FlatBtn,      WindowColour::Primary  , ImageId(SPR_SCENERY),             STR_TOGGLE_SCENERY_TIP             ),
-    kWidgetsEnd,
-};
-
+    static Widget _trackListWidgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({  4,  18}, {218,  13}, WindowWidgetType::TableHeader,  WindowColour::Primary, STR_SELECT_OTHER_RIDE                                       ),
+        MakeWidget({  4,  32}, {124,  13}, WindowWidgetType::TextBox,      WindowColour::Secondary                                                            ),
+        MakeWidget({130,  32}, { 92,  13}, WindowWidgetType::Button,       WindowColour::Primary, STR_OBJECT_SEARCH_CLEAR                                     ),
+        MakeWidget({  4,  46}, {218, 381}, WindowWidgetType::Scroll,       WindowColour::Primary, SCROLL_VERTICAL,         STR_CLICK_ON_DESIGN_TO_BUILD_IT_TIP),
+        MakeWidget({224,  18}, {372, 219}, WindowWidgetType::FlatBtn,      WindowColour::Primary                                                              ),
+        MakeWidget({572, 405}, { ROTATE_AND_SCENERY_BUTTON_SIZE, ROTATE_AND_SCENERY_BUTTON_SIZE}, WindowWidgetType::FlatBtn,      WindowColour::Primary, ImageId(SPR_ROTATE_ARROW),        STR_ROTATE_90_TIP                  ),
+        MakeWidget({572, 381}, { ROTATE_AND_SCENERY_BUTTON_SIZE, ROTATE_AND_SCENERY_BUTTON_SIZE}, WindowWidgetType::FlatBtn,      WindowColour::Primary, ImageId(SPR_SCENERY),             STR_TOGGLE_SCENERY_TIP             ),
+        kWidgetsEnd,
+    };
     // clang-format on
 
     constexpr uint16_t TRACK_DESIGN_INDEX_UNLOADED = UINT16_MAX;

--- a/src/openrct2-ui/windows/Transparency.cpp
+++ b/src/openrct2-ui/windows/Transparency.cpp
@@ -31,61 +31,61 @@
 
 namespace OpenRCT2::Ui::Windows
 {
-    // clang-format off
-enum WINDOW_TRANSPARENCY_WIDGET_IDX
-{
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
+    enum WINDOW_TRANSPARENCY_WIDGET_IDX
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
 
-    WIDX_HIDE_VEGETATION,
-    WIDX_HIDE_SCENERY,
-    WIDX_HIDE_PATHS,
-    WIDX_HIDE_RIDES,
-    WIDX_HIDE_VEHICLES,
-    WIDX_HIDE_SUPPORTS,
-    WIDX_HIDE_GUESTS,
-    WIDX_HIDE_STAFF,
-    WIDX_INVISIBLE_VEGETATION,
-    WIDX_INVISIBLE_SCENERY,
-    WIDX_INVISIBLE_PATHS,
-    WIDX_INVISIBLE_RIDES,
-    WIDX_INVISIBLE_VEHICLES,
-    WIDX_INVISIBLE_SUPPORTS,
-};
+        WIDX_HIDE_VEGETATION,
+        WIDX_HIDE_SCENERY,
+        WIDX_HIDE_PATHS,
+        WIDX_HIDE_RIDES,
+        WIDX_HIDE_VEHICLES,
+        WIDX_HIDE_SUPPORTS,
+        WIDX_HIDE_GUESTS,
+        WIDX_HIDE_STAFF,
+        WIDX_INVISIBLE_VEGETATION,
+        WIDX_INVISIBLE_SCENERY,
+        WIDX_INVISIBLE_PATHS,
+        WIDX_INVISIBLE_RIDES,
+        WIDX_INVISIBLE_VEHICLES,
+        WIDX_INVISIBLE_SUPPORTS,
+    };
 
 #pragma region MEASUREMENTS
 
-static constexpr StringId WINDOW_TITLE = STR_TRANSPARENCY_OPTIONS_TITLE;
-static constexpr int32_t WW = 204;
-static constexpr int32_t WH = 57;
+    static constexpr StringId WINDOW_TITLE = STR_TRANSPARENCY_OPTIONS_TITLE;
+    static constexpr int32_t WW = 204;
+    static constexpr int32_t WH = 57;
 
-static constexpr ScreenSize HIDE_SIZE = {24, 24};
-static constexpr ScreenSize INVISIBLE_SIZE = {24, 12};
+    static constexpr ScreenSize HIDE_SIZE = { 24, 24 };
+    static constexpr ScreenSize INVISIBLE_SIZE = { 24, 12 };
 
 #pragma endregion
 
-static Widget _transparancyWidgets[] =
-{
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({  2, 17}, HIDE_SIZE,      WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_BUTTON_HIDE_VEGETATION),  STR_SEE_THROUGH_VEGETATION),
-    MakeWidget({ 27, 17}, HIDE_SIZE,      WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_BUTTON_HIDE_SCENERY),     STR_SEE_THROUGH_SCENERY),
-    MakeWidget({ 52, 17}, HIDE_SIZE,      WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_BUTTON_FOOTPATH),         STR_SEE_THROUGH_PATHS),
-    MakeWidget({ 77, 17}, HIDE_SIZE,      WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_RIDE),                       STR_SEE_THROUGH_RIDES),
-    MakeWidget({102, 17}, HIDE_SIZE,      WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_BUTTON_HIDE_VEHICLES),    STR_SEE_THROUGH_VEHICLES),
-    MakeWidget({127, 17}, HIDE_SIZE,      WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_BUTTON_HIDE_SUPPORTS),    STR_SEE_THROUGH_SUPPORTS),
-    MakeWidget({152, 17}, HIDE_SIZE,      WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_GUESTS),                     STR_SEE_THROUGH_GUESTS),
-    MakeWidget({177, 17}, HIDE_SIZE,      WindowWidgetType::FlatBtn, WindowColour::Secondary, 0xFFFFFFFF,                     STR_SEE_THROUGH_STAFF),
+    // clang-format off
+    static Widget _transparancyWidgets[] =
+    {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({  2, 17}, HIDE_SIZE,      WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_BUTTON_HIDE_VEGETATION),  STR_SEE_THROUGH_VEGETATION),
+        MakeWidget({ 27, 17}, HIDE_SIZE,      WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_BUTTON_HIDE_SCENERY),     STR_SEE_THROUGH_SCENERY),
+        MakeWidget({ 52, 17}, HIDE_SIZE,      WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_BUTTON_FOOTPATH),         STR_SEE_THROUGH_PATHS),
+        MakeWidget({ 77, 17}, HIDE_SIZE,      WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_RIDE),                       STR_SEE_THROUGH_RIDES),
+        MakeWidget({102, 17}, HIDE_SIZE,      WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_BUTTON_HIDE_VEHICLES),    STR_SEE_THROUGH_VEHICLES),
+        MakeWidget({127, 17}, HIDE_SIZE,      WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_G2_BUTTON_HIDE_SUPPORTS),    STR_SEE_THROUGH_SUPPORTS),
+        MakeWidget({152, 17}, HIDE_SIZE,      WindowWidgetType::FlatBtn, WindowColour::Secondary, ImageId(SPR_GUESTS),                     STR_SEE_THROUGH_GUESTS),
+        MakeWidget({177, 17}, HIDE_SIZE,      WindowWidgetType::FlatBtn, WindowColour::Secondary, 0xFFFFFFFF,                     STR_SEE_THROUGH_STAFF),
 
-    MakeWidget({  2, 42}, INVISIBLE_SIZE, WindowWidgetType::FlatBtn, WindowColour::Tertiary,  STR_NONE,                       STR_INVISIBLE_VEGETATION),
-    MakeWidget({ 27, 42}, INVISIBLE_SIZE, WindowWidgetType::FlatBtn, WindowColour::Tertiary,  STR_NONE,                       STR_INVISIBLE_SCENERY),
-    MakeWidget({ 52, 42}, INVISIBLE_SIZE, WindowWidgetType::FlatBtn, WindowColour::Tertiary,  STR_NONE,                       STR_INVISIBLE_PATHS),
-    MakeWidget({ 77, 42}, INVISIBLE_SIZE, WindowWidgetType::FlatBtn, WindowColour::Tertiary,  STR_NONE,                       STR_INVISIBLE_RIDES),
-    MakeWidget({102, 42}, INVISIBLE_SIZE, WindowWidgetType::FlatBtn, WindowColour::Tertiary,  STR_NONE,                       STR_INVISIBLE_VEHICLES),
-    MakeWidget({127, 42}, INVISIBLE_SIZE, WindowWidgetType::FlatBtn, WindowColour::Tertiary,  STR_NONE,                       STR_INVISIBLE_SUPPORTS),
+        MakeWidget({  2, 42}, INVISIBLE_SIZE, WindowWidgetType::FlatBtn, WindowColour::Tertiary,  STR_NONE,                       STR_INVISIBLE_VEGETATION),
+        MakeWidget({ 27, 42}, INVISIBLE_SIZE, WindowWidgetType::FlatBtn, WindowColour::Tertiary,  STR_NONE,                       STR_INVISIBLE_SCENERY),
+        MakeWidget({ 52, 42}, INVISIBLE_SIZE, WindowWidgetType::FlatBtn, WindowColour::Tertiary,  STR_NONE,                       STR_INVISIBLE_PATHS),
+        MakeWidget({ 77, 42}, INVISIBLE_SIZE, WindowWidgetType::FlatBtn, WindowColour::Tertiary,  STR_NONE,                       STR_INVISIBLE_RIDES),
+        MakeWidget({102, 42}, INVISIBLE_SIZE, WindowWidgetType::FlatBtn, WindowColour::Tertiary,  STR_NONE,                       STR_INVISIBLE_VEHICLES),
+        MakeWidget({127, 42}, INVISIBLE_SIZE, WindowWidgetType::FlatBtn, WindowColour::Tertiary,  STR_NONE,                       STR_INVISIBLE_SUPPORTS),
 
-    { kWidgetsEnd },
-};
+        { kWidgetsEnd },
+    };
     // clang-format on
 
     class TransparencyWindow final : public Window

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -22,49 +22,51 @@
 
 namespace OpenRCT2::Ui::Windows
 {
-    // clang-format off
-enum WindowViewClippingWidgetIdx {
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_CLIP_CHECKBOX_ENABLE,
-    WIDX_GROUPBOX_VERTICAL,
-    WIDX_CLIP_HEIGHT_VALUE,
-    WIDX_CLIP_HEIGHT_INCREASE,
-    WIDX_CLIP_HEIGHT_DECREASE,
-    WIDX_CLIP_HEIGHT_SLIDER,
-    WIDX_GROUPBOX_HORIZONTAL,
-    WIDX_CLIP_SELECTOR,
-    WIDX_CLIP_CLEAR,
-};
+    enum WindowViewClippingWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_CLIP_CHECKBOX_ENABLE,
+        WIDX_GROUPBOX_VERTICAL,
+        WIDX_CLIP_HEIGHT_VALUE,
+        WIDX_CLIP_HEIGHT_INCREASE,
+        WIDX_CLIP_HEIGHT_DECREASE,
+        WIDX_CLIP_HEIGHT_SLIDER,
+        WIDX_GROUPBOX_HORIZONTAL,
+        WIDX_CLIP_SELECTOR,
+        WIDX_CLIP_CLEAR,
+    };
 
-enum class DisplayType {
-    DisplayRaw,
-    DisplayUnits
-};
+    enum class DisplayType
+    {
+        DisplayRaw,
+        DisplayUnits
+    };
 
 #pragma region Widgets
 
-static constexpr StringId WINDOW_TITLE = STR_VIEW_CLIPPING_TITLE;
-static constexpr int32_t WW = 180;
-static constexpr int32_t WH = 155;
+    static constexpr StringId WINDOW_TITLE = STR_VIEW_CLIPPING_TITLE;
+    static constexpr int32_t WW = 180;
+    static constexpr int32_t WH = 155;
 
-static Widget _viewClippingWidgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget        ({     11,  19}, {    159,  11}, WindowWidgetType::Checkbox, WindowColour::Primary, STR_VIEW_CLIPPING_HEIGHT_ENABLE,       STR_VIEW_CLIPPING_HEIGHT_ENABLE_TIP  ), // clip enable/disable check box
-    MakeWidget        ({      5,  36}, {WW - 10,  48}, WindowWidgetType::Groupbox, WindowColour::Primary, STR_VIEW_CLIPPING_VERTICAL_CLIPPING                                         ),
-    MakeSpinnerWidgets({     90,  51}, {     79,  12}, WindowWidgetType::Spinner,  WindowColour::Primary, STR_NONE,                              STR_VIEW_CLIPPING_HEIGHT_VALUE_TOGGLE), // clip height (3 widgets)
-    MakeWidget        ({     11,  66}, {    158,  13}, WindowWidgetType::Scroll,   WindowColour::Primary, SCROLL_HORIZONTAL,                     STR_VIEW_CLIPPING_HEIGHT_SCROLL_TIP  ), // clip height scrollbar
-    MakeWidget        ({      5,  90}, {WW - 10,  60}, WindowWidgetType::Groupbox, WindowColour::Primary, STR_VIEW_CLIPPING_HORIZONTAL_CLIPPING                                       ),
-    MakeWidget        ({     11, 105}, {    158,  17}, WindowWidgetType::Button,   WindowColour::Primary, STR_VIEW_CLIPPING_SELECT_AREA                                               ), // selector
-    MakeWidget        ({     11, 126}, {    158,  18}, WindowWidgetType::Button,   WindowColour::Primary, STR_VIEW_CLIPPING_CLEAR_SELECTION                                           ), // clear
+    // clang-format off
+    static Widget _viewClippingWidgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget        ({     11,  19}, {    159,  11}, WindowWidgetType::Checkbox, WindowColour::Primary, STR_VIEW_CLIPPING_HEIGHT_ENABLE,       STR_VIEW_CLIPPING_HEIGHT_ENABLE_TIP  ), // clip enable/disable check box
+        MakeWidget        ({      5,  36}, {WW - 10,  48}, WindowWidgetType::Groupbox, WindowColour::Primary, STR_VIEW_CLIPPING_VERTICAL_CLIPPING                                         ),
+        MakeSpinnerWidgets({     90,  51}, {     79,  12}, WindowWidgetType::Spinner,  WindowColour::Primary, STR_NONE,                              STR_VIEW_CLIPPING_HEIGHT_VALUE_TOGGLE), // clip height (3 widgets)
+        MakeWidget        ({     11,  66}, {    158,  13}, WindowWidgetType::Scroll,   WindowColour::Primary, SCROLL_HORIZONTAL,                     STR_VIEW_CLIPPING_HEIGHT_SCROLL_TIP  ), // clip height scrollbar
+        MakeWidget        ({      5,  90}, {WW - 10,  60}, WindowWidgetType::Groupbox, WindowColour::Primary, STR_VIEW_CLIPPING_HORIZONTAL_CLIPPING                                       ),
+        MakeWidget        ({     11, 105}, {    158,  17}, WindowWidgetType::Button,   WindowColour::Primary, STR_VIEW_CLIPPING_SELECT_AREA                                               ), // selector
+        MakeWidget        ({     11, 126}, {    158,  18}, WindowWidgetType::Button,   WindowColour::Primary, STR_VIEW_CLIPPING_CLEAR_SELECTION                                           ), // clear
 
-    kWidgetsEnd,
-};
+        kWidgetsEnd,
+    };
+    // clang-format on
 
 #pragma endregion
 
-    // clang-format on
     class ViewClippingWindow final : public Window
     {
     private:

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -38,7 +38,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WW = 200;
     static constexpr int32_t WH = 200;
 
-    static constexpr ScreenSize VIEWPORT_BUTTON = {24, 24};
+    static constexpr ScreenSize VIEWPORT_BUTTON = { 24, 24 };
 
 #pragma endregion
 

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -19,42 +19,41 @@
 
 namespace OpenRCT2::Ui::Windows
 {
-    // clang-format off
-enum WindowViewportWidgetIdx
-{
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_CONTENT_PANEL,
-    WIDX_VIEWPORT,
-    WIDX_ZOOM_IN,
-    WIDX_ZOOM_OUT,
-    WIDX_LOCATE,
-    WIDX_ROTATE,
-};
+    enum WindowViewportWidgetIdx
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_CONTENT_PANEL,
+        WIDX_VIEWPORT,
+        WIDX_ZOOM_IN,
+        WIDX_ZOOM_OUT,
+        WIDX_LOCATE,
+        WIDX_ROTATE,
+    };
 
 #pragma region MEASUREMENTS
 
-static constexpr StringId WINDOW_TITLE = STR_VIEWPORT_NO;
-static constexpr int32_t WW = 200;
-static constexpr int32_t WH = 200;
+    static constexpr StringId WINDOW_TITLE = STR_VIEWPORT_NO;
+    static constexpr int32_t WW = 200;
+    static constexpr int32_t WH = 200;
 
-static constexpr ScreenSize VIEWPORT_BUTTON = {24, 24};
+    static constexpr ScreenSize VIEWPORT_BUTTON = {24, 24};
 
 #pragma endregion
 
-static Widget _viewportWidgets[] =
-{
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget({      0, 14}, { WW - 1, WH - 1}, WindowWidgetType::Resize,   WindowColour::Secondary                                         ), // resize
-    MakeWidget({      3, 17}, {WW - 26, WH - 3}, WindowWidgetType::Viewport, WindowColour::Primary                                           ), // viewport
-    MakeWidget({WW - 25, 17}, VIEWPORT_BUTTON,   WindowWidgetType::FlatBtn,  WindowColour::Primary  , ImageId(SPR_G2_ZOOM_IN),  STR_ZOOM_IN_TIP       ), // zoom in
-    MakeWidget({WW - 25, 41}, VIEWPORT_BUTTON,   WindowWidgetType::FlatBtn,  WindowColour::Primary  , ImageId(SPR_G2_ZOOM_OUT), STR_ZOOM_OUT_TIP      ), // zoom out
-    MakeWidget({WW - 25, 65}, VIEWPORT_BUTTON,   WindowWidgetType::FlatBtn,  WindowColour::Primary  , ImageId(SPR_LOCATE),      STR_LOCATE_SUBJECT_TIP), // locate
-    MakeWidget({WW - 25, 89}, VIEWPORT_BUTTON,   WindowWidgetType::FlatBtn,  WindowColour::Primary  , ImageId(SPR_ROTATE_ARROW),STR_LOCATE_SUBJECT_TIP), // rotate
-    kWidgetsEnd,
-};
-
+    // clang-format off
+    static Widget _viewportWidgets[] =
+    {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget({      0, 14}, { WW - 1, WH - 1}, WindowWidgetType::Resize,   WindowColour::Secondary                                         ), // resize
+        MakeWidget({      3, 17}, {WW - 26, WH - 3}, WindowWidgetType::Viewport, WindowColour::Primary                                           ), // viewport
+        MakeWidget({WW - 25, 17}, VIEWPORT_BUTTON,   WindowWidgetType::FlatBtn,  WindowColour::Primary  , ImageId(SPR_G2_ZOOM_IN),  STR_ZOOM_IN_TIP       ), // zoom in
+        MakeWidget({WW - 25, 41}, VIEWPORT_BUTTON,   WindowWidgetType::FlatBtn,  WindowColour::Primary  , ImageId(SPR_G2_ZOOM_OUT), STR_ZOOM_OUT_TIP      ), // zoom out
+        MakeWidget({WW - 25, 65}, VIEWPORT_BUTTON,   WindowWidgetType::FlatBtn,  WindowColour::Primary  , ImageId(SPR_LOCATE),      STR_LOCATE_SUBJECT_TIP), // locate
+        MakeWidget({WW - 25, 89}, VIEWPORT_BUTTON,   WindowWidgetType::FlatBtn,  WindowColour::Primary  , ImageId(SPR_ROTATE_ARROW),STR_LOCATE_SUBJECT_TIP), // rotate
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class ViewportWindow final : public Window

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -28,24 +28,24 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t WH = 77;
     static constexpr int32_t WW = 76;
 
-    // clang-format off
-enum WindowWaterWidgetIdx : WidgetIndex
-{
-    WIDX_BACKGROUND,
-    WIDX_TITLE,
-    WIDX_CLOSE,
-    WIDX_PREVIEW,
-    WIDX_DECREMENT,
-    WIDX_INCREMENT
-};
+    enum WindowWaterWidgetIdx : WidgetIndex
+    {
+        WIDX_BACKGROUND,
+        WIDX_TITLE,
+        WIDX_CLOSE,
+        WIDX_PREVIEW,
+        WIDX_DECREMENT,
+        WIDX_INCREMENT
+    };
 
-static Widget _waterWidgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    MakeWidget     ({16, 17}, {44, 32}, WindowWidgetType::ImgBtn, WindowColour::Primary , ImageId(SPR_LAND_TOOL_SIZE_0),   STR_NONE),                     // preview box
-    MakeRemapWidget({17, 18}, {16, 16}, WindowWidgetType::TrnBtn, WindowColour::Tertiary, SPR_LAND_TOOL_DECREASE, STR_ADJUST_SMALLER_WATER_TIP), // decrement size
-    MakeRemapWidget({43, 32}, {16, 16}, WindowWidgetType::TrnBtn, WindowColour::Tertiary, SPR_LAND_TOOL_INCREASE, STR_ADJUST_LARGER_WATER_TIP),  // increment size
-    kWidgetsEnd,
-};
+    // clang-format off
+    static Widget _waterWidgets[] = {
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+        MakeWidget     ({16, 17}, {44, 32}, WindowWidgetType::ImgBtn, WindowColour::Primary , ImageId(SPR_LAND_TOOL_SIZE_0),   STR_NONE),            // preview box
+        MakeRemapWidget({17, 18}, {16, 16}, WindowWidgetType::TrnBtn, WindowColour::Tertiary, SPR_LAND_TOOL_DECREASE, STR_ADJUST_SMALLER_WATER_TIP), // decrement size
+        MakeRemapWidget({43, 32}, {16, 16}, WindowWidgetType::TrnBtn, WindowColour::Tertiary, SPR_LAND_TOOL_INCREASE, STR_ADJUST_LARGER_WATER_TIP),  // increment size
+        kWidgetsEnd,
+    };
     // clang-format on
 
     class WaterWindow final : public Window


### PR DESCRIPTION
When the windows were converted, in most cases, their widget definitions were not indented to account for the new namespace. It appears this was the case due to having been wrapped in `clang-format` toggle comments. This PR manually corrects this.

NB: in draft as I'm only halfway through the windows.