### PR TITLE
Fix #2614: Junior Roller Coaster - Invisible First Vehicle

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.15 (in development)
 ------------------------------------------------------------------------
 - Feature: [#15642] Track design placement can now use contruction modifier keys (ctrl/shift).
+- Fix: [#2614] The colour tab of the ride window does not hide invisible cars (original bug).
 - Fix: [#21959] “Save this before...?” message does not appear when selecting “New Game”.
 - Fix: [#22231] Invalid object version can cause a crash.
 - Fix: [#22653] Add several .parkpatch files for missing water tiles in RCT1 and RCT2 scenarios.

--- a/src/openrct2/ride/CarEntry.cpp
+++ b/src/openrct2/ride/CarEntry.cpp
@@ -138,3 +138,8 @@ void CarEntrySetImageMaxSizes(CarEntry& carEntry, int32_t numImages)
     carEntry.sprite_height_negative = spriteHeightNegative;
     carEntry.sprite_height_positive = spriteHeightPositive;
 }
+
+bool CarEntry::isVisible() const
+{
+    return TabRotationMask != 0;
+}

--- a/src/openrct2/ride/CarEntry.h
+++ b/src/openrct2/ride/CarEntry.h
@@ -226,6 +226,8 @@ struct CarEntry
     bool GroupEnabled(SpriteGroupType rotationType) const;
     uint32_t GroupImageId(SpriteGroupType spriteGroup) const;
     uint32_t SpriteOffset(SpriteGroupType spriteGroup, int32_t imageDirection, uint8_t rankIndex) const;
+
+    bool isVisible() const;
 };
 
 void CarEntrySetImageMaxSizes(CarEntry& carEntry, int32_t numImages);


### PR DESCRIPTION
Tested with:
- Junior RC
- Car Ride
- Splash Boats

Notes for who wants to test this:
- Recolouring trains should still work. Especially make sure that recolouring train 2 actually recolours the second train.
- When selecting a car, check if the dropdown shows the correct number
- When recolouring a car, e.g. car 3, check if the third visible car is indeed recoloured
- Also test this with a vehicle that worked correctly before