### PR TITLE
[plugin] Add money spend hook to scripting API

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.17 (in development)
 ------------------------------------------------------------------------
+- Feature: [#22715] [Plugin] Add money spend hook that can modify the cost based on expenditure.
 - Feature: [#23166] Add Galician translation.
 - Feature: [#23227] Add Classic Wooden Twister roller coaster, for better compatibility with RCT1.
 - Improved: [#23051] Add large sloped turns and new inversions to the Twister, Vertical Drop, Hyper and Flying Roller Coasters.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -511,6 +511,7 @@ declare global {
         subscribe(hook: "interval.tick", callback: () => void): IDisposable;
         subscribe(hook: "map.change", callback: () => void): IDisposable;
         subscribe(hook: "map.save", callback: () => void): IDisposable;
+        subscribe(hook: "money.spend", callback: (e: MoneySpendEventArgs) => void): IDisposable;
         subscribe(hook: "network.authenticate", callback: (e: NetworkAuthenticateEventArgs) => void): IDisposable;
         subscribe(hook: "network.chat", callback: (e: NetworkChatEventArgs) => void): IDisposable;
         subscribe(hook: "network.join", callback: (e: NetworkEventArgs) => void): IDisposable;
@@ -1373,6 +1374,11 @@ declare global {
 
     interface StaffHireNewActionResult extends GameActionResult {
         readonly peep?: number;
+    }
+
+    interface MoneySpendEventArgs {
+        amount: number;
+        readonly expenditureType: ExpenditureType;
     }
 
     interface NetworkEventArgs {

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -15,6 +15,7 @@
 #include <openrct2/actions/RideDemolishAction.h>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Formatter.h>
+#include <openrct2/scripting/ScriptEngine.h>
 #include <openrct2/windows/Intent.h>
 #include <openrct2/world/Park.h>
 
@@ -51,6 +52,9 @@ namespace OpenRCT2::Ui::Windows
         {
             rideId = currentRide.id;
             _demolishRideCost = -RideGetRefundPrice(currentRide);
+#ifdef ENABLE_SCRIPTING
+            GetContext()->GetScriptEngine().RunMoneySpendHooks(_demolishRideCost, ExpenditureType::RideConstruction);
+#endif
         }
 
         void OnOpen() override

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -33,6 +33,7 @@
 #include <openrct2/ride/RideData.h>
 #include <openrct2/ride/TrackData.h>
 #include <openrct2/ride/TrackDesignRepository.h>
+#include <openrct2/scripting/ScriptEngine.h>
 #include <openrct2/sprites.h>
 #include <openrct2/util/Util.h>
 #include <openrct2/windows/Intent.h>
@@ -964,6 +965,9 @@ namespace OpenRCT2::Ui::Windows
                 const auto& ted = GetTrackElementDescriptor(startPieceId);
                 price *= ted.priceModifier;
                 price = (price >> 16) * GetRideTypeDescriptor(item.Type).BuildCosts.PriceEstimateMultiplier;
+#ifdef ENABLE_SCRIPTING
+                GetContext()->GetScriptEngine().RunMoneySpendHooks(price, ExpenditureType::RideConstruction);
+#endif
 
                 //
                 StringId stringId = STR_NEW_RIDE_COST;

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -47,6 +47,7 @@
 #include <openrct2/object/SmallSceneryEntry.h>
 #include <openrct2/object/WallSceneryEntry.h>
 #include <openrct2/paint/VirtualFloor.h>
+#include <openrct2/scripting/ScriptEngine.h>
 #include <openrct2/sprites.h>
 #include <openrct2/world/ConstructionClearance.h>
 #include <openrct2/world/Footpath.h>
@@ -831,6 +832,9 @@ namespace OpenRCT2::Ui::Windows
             auto [name, price] = GetNameAndPrice(selectedSceneryEntry);
             if (price != kMoney64Undefined && !(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
+#ifdef ENABLE_SCRIPTING
+                GetContext()->GetScriptEngine().RunMoneySpendHooks(price, ExpenditureType::Landscaping);
+#endif
                 auto ft = Formatter();
                 ft.Add<money64>(price);
 

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -31,6 +31,7 @@
 #include <openrct2/management/Finance.h>
 #include <openrct2/network/network.h>
 #include <openrct2/peep/PeepAnimationData.h>
+#include <openrct2/scripting/ScriptEngine.h>
 #include <openrct2/sprites.h>
 #include <openrct2/windows/Intent.h>
 #include <openrct2/world/Footpath.h>
@@ -939,8 +940,12 @@ namespace OpenRCT2::Ui::Windows
 
             if (!(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
+                auto wage = GetStaffWage(staff->AssignedStaffType);
+#ifdef ENABLE_SCRIPTING
+                GetContext()->GetScriptEngine().RunMoneySpendHooks(wage, ExpenditureType::Wages);
+#endif
                 auto ft = Formatter();
-                ft.Add<money64>(GetStaffWage(staff->AssignedStaffType));
+                ft.Add<money64>(wage);
                 DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_WAGES, ft);
                 screenCoords.y += kListRowHeight;
             }

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -32,6 +32,7 @@
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/management/Finance.h>
 #include <openrct2/peep/PeepAnimationData.h>
+#include <openrct2/scripting/ScriptEngine.h>
 #include <openrct2/sprites.h>
 #include <openrct2/util/Util.h>
 #include <openrct2/windows/Intent.h>
@@ -295,8 +296,12 @@ namespace OpenRCT2::Ui::Windows
 
             if (!(GetGameState().Park.Flags & PARK_FLAGS_NO_MONEY))
             {
+                auto wage = GetStaffWage(GetSelectedStaffType());
+#ifdef ENABLE_SCRIPTING
+                GetContext()->GetScriptEngine().RunMoneySpendHooks(wage, ExpenditureType::Wages);
+#endif
                 auto ft = Formatter();
-                ft.Add<money64>(GetStaffWage(GetSelectedStaffType()));
+                ft.Add<money64>(wage);
                 DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ width - 155, 32 }, STR_COST_PER_MONTH, ft);
             }
 

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -211,7 +211,7 @@ namespace OpenRCT2::GameActions
         if (result.Error == GameActions::Status::Ok)
         {
 #ifdef ENABLE_SCRIPTING
-            if (topLevel)
+            if (topLevel && result.Expenditure != ExpenditureType::Count)
                 GetContext()->GetScriptEngine().RunMoneySpendHooks(result.Cost, result.Expenditure);
 #endif
             if (!FinanceCheckAffordability(result.Cost, action->GetFlags()))
@@ -365,7 +365,7 @@ namespace OpenRCT2::GameActions
             if (result.Error == GameActions::Status::Ok)
             {
                 auto& scriptEngine = GetContext()->GetScriptEngine();
-                if (topLevel)
+                if (topLevel && result.Expenditure != ExpenditureType::Count)
                     scriptEngine.RunMoneySpendHooks(result.Cost, result.Expenditure);
                 scriptEngine.RunGameActionHooks(*action, result, true);
                 // Script hooks may now have changed the game action result...

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -210,6 +210,10 @@ namespace OpenRCT2::GameActions
 
         if (result.Error == GameActions::Status::Ok)
         {
+#ifdef ENABLE_SCRIPTING
+            if (topLevel)
+                GetContext()->GetScriptEngine().RunMoneySpendHooks(result.Cost, result.Expenditure);
+#endif
             if (!FinanceCheckAffordability(result.Cost, action->GetFlags()))
             {
                 result.Error = GameActions::Status::InsufficientFunds;
@@ -361,6 +365,8 @@ namespace OpenRCT2::GameActions
             if (result.Error == GameActions::Status::Ok)
             {
                 auto& scriptEngine = GetContext()->GetScriptEngine();
+                if (topLevel)
+                    scriptEngine.RunMoneySpendHooks(result.Cost, result.Expenditure);
                 scriptEngine.RunGameActionHooks(*action, result, true);
                 // Script hooks may now have changed the game action result...
             }

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -2334,14 +2334,16 @@ void Guest::SpendMoney(money64& peep_expend_type, money64 amount, ExpenditureTyp
 
     WindowInvalidateByNumber(WindowClass::Peep, Id);
 
+    amount *= -1;
+
 #ifdef ENABLE_SCRIPTING
     // guest pays original price, player receives modified amount
     GetContext()->GetScriptEngine().RunMoneySpendHooks(amount, expenditure);
 #endif
 
-    FinancePayment(-amount, expenditure);
+    FinancePayment(amount, expenditure);
 
-    MoneyEffect::CreateAt(amount, GetLocation(), true);
+    MoneyEffect::CreateAt(-amount, GetLocation(), true);
 
     OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::Purchase, GetLocation());
 }

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -106,11 +106,11 @@ void FinancePayWages()
 
     for (auto peep : EntityList<Staff>())
     {
-        auto wage = GetStaffWage(peep->AssignedStaffType);
+        auto wage = GetStaffWage(peep->AssignedStaffType) / 4;
 #ifdef ENABLE_SCRIPTING
         GetContext()->GetScriptEngine().RunMoneySpendHooks(wage, ExpenditureType::Wages);
 #endif
-        FinancePayment(wage / 4, ExpenditureType::Wages);
+        FinancePayment(wage, ExpenditureType::Wages);
     }
 }
 
@@ -127,11 +127,11 @@ void FinancePayResearch()
     }
 
     const uint8_t level = gameState.ResearchFundingLevel;
-    auto cost = research_cost_table[level];
+    auto cost = research_cost_table[level] / 4;
 #ifdef ENABLE_SCRIPTING
     GetContext()->GetScriptEngine().RunMoneySpendHooks(cost, ExpenditureType::Research);
 #endif
-    FinancePayment(cost / 4, ExpenditureType::Research);
+    FinancePayment(cost, ExpenditureType::Research);
 }
 
 /**

--- a/src/openrct2/scripting/HookEngine.cpp
+++ b/src/openrct2/scripting/HookEngine.cpp
@@ -35,6 +35,7 @@ static const EnumMap<HOOK_TYPE> HooksLookupTable({
     { "map.changed", HOOK_TYPE::MAP_CHANGED },
     { "map.save", HOOK_TYPE::MAP_SAVE },
     { "park.guest.softcap.calculate", HOOK_TYPE::PARK_CALCULATE_GUEST_CAP },
+    { "money.spend", HOOK_TYPE::MONEY_SPEND },
 });
 
 HOOK_TYPE OpenRCT2::Scripting::GetHookType(const std::string& name)

--- a/src/openrct2/scripting/HookEngine.h
+++ b/src/openrct2/scripting/HookEngine.h
@@ -43,6 +43,7 @@ namespace OpenRCT2::Scripting
         MAP_CHANGED,
         MAP_SAVE,
         PARK_CALCULATE_GUEST_CAP,
+        MONEY_SPEND,
         COUNT,
         UNDEFINED = -1,
     };

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -46,7 +46,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 103;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 104;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;
@@ -255,6 +255,8 @@ namespace OpenRCT2::Scripting
         [[nodiscard]] std::unique_ptr<GameAction> CreateGameAction(
             const std::string& actionid, const DukValue& args, const std::string& pluginName);
         [[nodiscard]] DukValue GameActionResultToDuk(const GameAction& action, const GameActions::Result& result);
+
+        void RunMoneySpendHooks(money64& amount, const ExpenditureType expenditureType);
 
         void SaveSharedStorage();
 


### PR DESCRIPTION
This is an implementation of what has been discussed in #21932.
It provides a hook that is called whenever the player spends or receives money. The hook has two arguments, the cost and the expenditure type. The cost can be modified by the script.