### PR TITLE
 Create FlagHolder

### DIFF
--- a/src/openrct2/core/FlagHolder.hpp
+++ b/src/openrct2/core/FlagHolder.hpp
@@ -1,0 +1,45 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2024 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+template<typename THolderType, typename TEnumType> struct FlagHolder
+{
+    THolderType holder{};
+
+    constexpr void clearAll()
+    {
+        holder = 0;
+    }
+
+    [[nodiscard]] constexpr bool isEmpty() const
+    {
+        return holder == 0;
+    }
+
+    [[nodiscard]] constexpr bool has(TEnumType flag) const
+    {
+        return (holder & EnumToFlag(flag)) != 0;
+    }
+
+    constexpr void set(TEnumType flag)
+    {
+        holder |= EnumToFlag(flag);
+    }
+
+    constexpr void unset(TEnumType flag)
+    {
+        holder &= ~EnumToFlag(flag);
+    }
+
+    constexpr void flip(TEnumType flag)
+    {
+        holder ^= EnumToFlag(flag);
+    }
+};

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -222,6 +222,7 @@
     <ClInclude Include="core\Range.hpp" />
     <ClInclude Include="core\RTL.h" />
     <ClInclude Include="core\FixedVector.h" />
+    <ClInclude Include="core\FlagHolder.hpp" />
     <ClInclude Include="core\Speed.hpp" />
     <ClInclude Include="core\String.hpp" />
     <ClInclude Include="core\StringBuilder.h" />


### PR DESCRIPTION
Right now, lots of functions implement their own functions for `HasFlag` or empty lots of `EnumValue()` or `static_cast`s to do flag checks.

This introduces a struct that takes an integer of any size and an enum for the flags, which can be applied to any place that needs to hold flags (serialised or not), allowing us to make it all consistent.

The first commit add the structure, the second commit changes over one structure to show how it works in practice.