### PR TITLE
Close #17025: Do not change ride type of JSON ride objects

### DIFF
--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -639,7 +639,6 @@ void RideObject::ReadJson(IReadObjectContext* context, json_t& root)
             });
     }
 
-    RideObjectUpdateRideType(_legacyType);
     PopulateTablesFromJson(context, root);
 }
 


### PR DESCRIPTION
`RideObjectUpdateRideType()` is intended for legacy DAT, S6 and TD6 files where some ride types were not split. E.g. Corkscrew vs. Hypercoaster. JSON objects just specify the new type instead, so don’t need this code. (In fact, it may even cause problems, as @spacek531 lined out in #17025.)