### PR TITLE
Revert transparency option fixes that... weren’t

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,6 +13,7 @@
 - Fix: [#22653] Add several .parkpatch files for missing water tiles in RCT1 and RCT2 scenarios.
 - Fix: [#22654] Improve several .parkpatch files to remove misplaced scenario elements in RCT1 and RCT2 scenarios.
 - Fix: [#22655] Fix surface style of Botany Breakers around missing water tiles.
+- Fix: [#22729] Invisibility settings persist after reloading OpenRCT2.
 - Fix: [#22734] Support clearance above steep Side-Friction track is too low.
 
 0.4.14 (2024-09-01)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -32,7 +32,6 @@
 - Change: [#22491] Scrollbars are now hidden if the scrollable widget is not actually overflowing.
 - Change: [#22541] In editor/sandbox mode, tool widgets now appear on the side of the map window, instead of the bottom.
 - Change: [#22592] Cheats have been redistributed along three new tabs: date, staff, and nature/weather.
-- Fix: [#21123] Transparency options are not respected on startup.
 - Fix: [#21189] Additional missing/misplaced land & construction rights tiles in Schneider Shores and Urban Park.
 - Fix: [#21908] Errors showing up when placing/moving track design previews.
 - Fix: [#22307] Hover tooltips in financial charts are not invalidated properly.

--- a/src/openrct2-ui/windows/Main.cpp
+++ b/src/openrct2-ui/windows/Main.cpp
@@ -13,7 +13,6 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
-#include <openrct2/OpenRCT2.h>
 #include <openrct2/config/Config.h>
 #include <openrct2/world/Footpath.h>
 
@@ -36,7 +35,7 @@ namespace OpenRCT2::Ui::Windows
             widgets = _mainWidgets;
 
             ViewportCreate(this, windowPos, width, height, Focus(CoordsXYZ(0x0FFF, 0x0FFF, 0)));
-            if (viewport != nullptr && !(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO))
+            if (viewport != nullptr)
             {
                 SetViewportFlags();
                 viewport->rotation = 0;

--- a/src/openrct2-ui/windows/Main.cpp
+++ b/src/openrct2-ui/windows/Main.cpp
@@ -36,9 +36,9 @@ namespace OpenRCT2::Ui::Windows
             widgets = _mainWidgets;
 
             ViewportCreate(this, windowPos, width, height, Focus(CoordsXYZ(0x0FFF, 0x0FFF, 0)));
-            if (viewport != nullptr)
+            if (viewport != nullptr && !(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO))
             {
-                SetViewportFlags(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO);
+                SetViewportFlags();
                 viewport->rotation = 0;
             }
             gShowGridLinesRefCount = 0;
@@ -53,14 +53,9 @@ namespace OpenRCT2::Ui::Windows
         }
 
     private:
-        void SetViewportFlags(bool isTitleWindow)
+        void SetViewportFlags()
         {
             viewport->flags |= VIEWPORT_FLAG_SOUND_ON;
-            if (isTitleWindow)
-            {
-                return;
-            }
-
             if (Config::Get().general.InvisibleRides)
             {
                 viewport->flags |= VIEWPORT_FLAG_INVISIBLE_RIDES;

--- a/src/openrct2-ui/windows/Main.cpp
+++ b/src/openrct2-ui/windows/Main.cpp
@@ -56,35 +56,17 @@ namespace OpenRCT2::Ui::Windows
         {
             viewport->flags |= VIEWPORT_FLAG_SOUND_ON;
             if (Config::Get().general.InvisibleRides)
-            {
                 viewport->flags |= VIEWPORT_FLAG_INVISIBLE_RIDES;
-                viewport->flags |= VIEWPORT_FLAG_HIDE_RIDES;
-            }
             if (Config::Get().general.InvisibleVehicles)
-            {
                 viewport->flags |= VIEWPORT_FLAG_INVISIBLE_VEHICLES;
-                viewport->flags |= VIEWPORT_FLAG_HIDE_VEHICLES;
-            }
             if (Config::Get().general.InvisibleTrees)
-            {
                 viewport->flags |= VIEWPORT_FLAG_INVISIBLE_VEGETATION;
-                viewport->flags |= VIEWPORT_FLAG_HIDE_VEGETATION;
-            }
             if (Config::Get().general.InvisibleScenery)
-            {
                 viewport->flags |= VIEWPORT_FLAG_INVISIBLE_SCENERY;
-                viewport->flags |= VIEWPORT_FLAG_HIDE_SCENERY;
-            }
             if (Config::Get().general.InvisiblePaths)
-            {
                 viewport->flags |= VIEWPORT_FLAG_INVISIBLE_PATHS;
-                viewport->flags |= VIEWPORT_FLAG_HIDE_PATHS;
-            }
             if (Config::Get().general.InvisibleSupports)
-            {
                 viewport->flags |= VIEWPORT_FLAG_INVISIBLE_SUPPORTS;
-                viewport->flags |= VIEWPORT_FLAG_HIDE_SUPPORTS;
-            }
         }
     };
 

--- a/src/openrct2-ui/windows/Transparency.cpp
+++ b/src/openrct2-ui/windows/Transparency.cpp
@@ -158,28 +158,12 @@ namespace OpenRCT2::Ui::Windows
         }
 
     private:
-        uint32_t ToggleSeeThrough(uint32_t wflags, uint32_t seeThroughFlag, uint32_t transparencyFlag)
-        {
-            wflags ^= seeThroughFlag;
-            // If see-through is disabled, we also want to disable invisible
-            if (!(wflags & seeThroughFlag))
-            {
-                wflags &= ~transparencyFlag;
-            }
-            SaveInConfig(wflags);
-            return wflags;
-        }
-
         uint32_t ToggleTransparency(uint32_t wflags, uint32_t transparencyFlag, uint32_t seeThroughFlag)
         {
             wflags ^= transparencyFlag;
             if (wflags & transparencyFlag)
             {
                 wflags |= seeThroughFlag;
-            }
-            else
-            {
-                wflags &= ~seeThroughFlag;
             }
             SaveInConfig(wflags);
             return wflags;
@@ -198,22 +182,22 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_HIDE_RIDES:
-                    wflags = ToggleSeeThrough(wflags, VIEWPORT_FLAG_HIDE_RIDES, VIEWPORT_FLAG_INVISIBLE_RIDES);
+                    wflags ^= VIEWPORT_FLAG_HIDE_RIDES;
                     break;
                 case WIDX_HIDE_VEHICLES:
-                    wflags = ToggleSeeThrough(wflags, VIEWPORT_FLAG_HIDE_VEHICLES, VIEWPORT_FLAG_INVISIBLE_VEHICLES);
+                    wflags ^= VIEWPORT_FLAG_HIDE_VEHICLES;
                     break;
                 case WIDX_HIDE_SCENERY:
-                    wflags = ToggleSeeThrough(wflags, VIEWPORT_FLAG_HIDE_SCENERY, VIEWPORT_FLAG_INVISIBLE_SCENERY);
+                    wflags ^= VIEWPORT_FLAG_HIDE_SCENERY;
                     break;
                 case WIDX_HIDE_VEGETATION:
-                    wflags = ToggleSeeThrough(wflags, VIEWPORT_FLAG_HIDE_VEGETATION, VIEWPORT_FLAG_INVISIBLE_VEGETATION);
+                    wflags ^= VIEWPORT_FLAG_HIDE_VEGETATION;
                     break;
                 case WIDX_HIDE_PATHS:
-                    wflags = ToggleSeeThrough(wflags, VIEWPORT_FLAG_HIDE_PATHS, VIEWPORT_FLAG_INVISIBLE_PATHS);
+                    wflags ^= VIEWPORT_FLAG_HIDE_PATHS;
                     break;
                 case WIDX_HIDE_SUPPORTS:
-                    wflags = ToggleSeeThrough(wflags, VIEWPORT_FLAG_HIDE_SUPPORTS, VIEWPORT_FLAG_INVISIBLE_SUPPORTS);
+                    wflags ^= VIEWPORT_FLAG_HIDE_SUPPORTS;
                     break;
                 case WIDX_INVISIBLE_RIDES:
                     wflags = ToggleTransparency(wflags, VIEWPORT_FLAG_INVISIBLE_RIDES, VIEWPORT_FLAG_HIDE_RIDES);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -249,7 +249,7 @@ namespace OpenRCT2::Config
             model->InvisibleTrees = reader->GetBoolean("invisible_trees", false);
             model->InvisibleScenery = reader->GetBoolean("invisible_scenery", false);
             model->InvisiblePaths = reader->GetBoolean("invisible_paths", false);
-            model->InvisibleSupports = reader->GetBoolean("invisible_supports", false);
+            model->InvisibleSupports = reader->GetBoolean("invisible_supports", true);
 
             model->LastVersionCheckTime = reader->GetInt64("last_version_check_time", 0);
         }


### PR DESCRIPTION
The saga of the transparency options has more drama than an average episode of EastEnders. It starts with one team member unwittingly laying a trap for another, who years later stumbled over it, and all hell broke loose.

\* DUM, DUM, DUMDUMDUMDUM DUM DUM *

The short of it:
- RCT2 does not allow choosing whether something should be see-through or entirely invisible when you toggle its visibility
- OpenRCT2 introduced options for it a few years ago and saved the choice between see-through and entirely invisible in the config, as a boolean. So the config option `invisible_supports = true` means that supports are entirely invisible when you press the button to hide them, rather than see-through. It was not supposed to mean that the invisibility toggle itself should persist. This is not at all foreshadowing.
- Viewport flags were also added with names like `VIEWPORT_FLAG_INVISIBLE_SUPPORTS`, working in the same way.
- An interface was added which both allowed toggling the visibility and switching between see-through and completely invisibility, if it was toggled.

\* BREAK *

- A few weeks ago, a team member looked through the code, noticed some config options that _appeared_ to save whether visibility was toggled. After all, how else would you interpret  `invisible_supports = true`, if you hadn’t read the section above?
- And so he created a PR with some fixes just before the v0.4.14, which was merged with an approval, according to process, but maybe not scrutinised as much as it would have, had we had more time.
- And so it problems with just about any user, as supports default to completely invisiblity when hidden, meaning that they got hidden on startup for everyone.

Now, I think this shows a few things:
1. Merging near releases is risky. We should have made a better evaluation of whether the bug it purported to fix was worth the risk, or at least give it more scrutiny.
2. Naming is important. The interpretation of the team member in question was perfectly reasonable, even though it turned out to be wrong.
3. Data structures are important. If enums had been used, this would have been much less likely.
4. The layout of the ‘Transparency Options window is very confusing. It duplicates functionality from the View menu button, and uses the same on/off mechanism for toggling between see-through and invisibility, which is not how a player is likely to think of it.

So here is the proposed solution:
1. Revert the ‘fixes’.
2. Use enums for the visibility modes, rather than a `bool`
3. Rename the viewport flags. Something like `SUPPORTS_INVISIBLE_WHEN_HIDDEN` is much less prone to misinterpretation than `INVISIBLE_SUPPORTS`.
4. Remove the duplicate functionality from the Transparency Options window, replace the icons with text and change the layout to a vertical one, with a dropdown for every option. This should make its purpose much clearer.

Point 1 is addressed in this PR, points 2, 3 and 4 can be addressed in another.

\* END CREDITS *