### PR TITLE
Fix #22796: Mini roller coaster paint code triggers assertion

### DIFF
--- a/src/openrct2/paint/track/coaster/MiniRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/MiniRollerCoaster.cpp
@@ -5282,7 +5282,7 @@ static void MiniRCTrackDiag60DegUp(
                     break;
             }
             MetalBSupportsPaintSetupRotated(
-                session, supportType.metal, MetalSupportPlace::LeftCorner, (direction & 1) ? 42 : 38, direction, height,
+                session, supportType.metal, MetalSupportPlace::LeftCorner, direction, (direction & 1) ? 42 : 38, height,
                 session.SupportColours);
             PaintUtilSetSegmentSupportHeight(
                 session,


### PR DESCRIPTION
A small refactor mistake. The assertions did what they had to here.