### PR TITLE
Fix calculating wide path status

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Change: [#22740] Add virtual floor to shifted track design placement.
 - Change: [#22795] Replace Giga Coaster and Twister Roller Coaster booster images.
 - Fix: [#2614] The colour tab of the ride window does not hide invisible cars (original bug).
+- Fix: [#7672] Wide path status is set to all 'wide' paths, instead of only a quarter, impeding pathfinding.
 - Fix: [#15406] Tunnels on steep Side-Friction track are drawn too low.
 - Fix: [#21959] “Save this before...?” message does not appear when selecting “New Game”.
 - Fix: [#22231] Invalid object version can cause a crash.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,7 +8,7 @@
 - Change: [#22740] Add virtual floor to shifted track design placement.
 - Change: [#22795] Replace Giga Coaster and Twister Roller Coaster booster images.
 - Fix: [#2614] The colour tab of the ride window does not hide invisible cars (original bug).
-- Fix: [#7672] Wide path status is set to all 'wide' paths, instead of only a quarter, impeding pathfinding.
+- Fix: [#7672] Wide path status is set to all ‘wide’ paths, instead of only a quarter, impeding pathfinding.
 - Fix: [#15406] Tunnels on steep Side-Friction track are drawn too low.
 - Fix: [#21959] “Save this before...?” message does not appear when selecting “New Game”.
 - Fix: [#22231] Invalid object version can cause a crash.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -49,7 +49,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kNetworkStreamVersion = 0;
+constexpr uint8_t kNetworkStreamVersion = 1;
 
 const std::string kNetworkStreamID = std::string(OPENRCT2_VERSION) + "-" + std::to_string(kNetworkStreamVersion);
 

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1596,8 +1596,8 @@ void FootpathUpdatePathWideFlags(const CoordsXY& footpathPos)
     // FootpathClearWide(x, y);
     // y -= 0x20;
 
-    // Check if tile coords are being passed? Why does that even happen?
-    // TODO: Needs adjusting for higher coords (NSF) before this is merged.
+    // Only consider approx. 1/4 of tiles for wide path status
+    // (NB: the other 3/4 do get cleared above!)
     if (!(footpathPos.x & 0xE0) || (!(footpathPos.y & 0xE0)))
         return;
 

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1596,6 +1596,11 @@ void FootpathUpdatePathWideFlags(const CoordsXY& footpathPos)
     // FootpathClearWide(x, y);
     // y -= 0x20;
 
+    // Check if tile coords are being passed? Why does that even happen?
+    // TODO: Needs adjusting for higher coords (NSF) before this is merged.
+    if (!(footpathPos.x & 0xE0) || (!(footpathPos.y & 0xE0)))
+        return;
+
     TileElement* tileElement = MapGetFirstElementAt(footpathPos);
     if (tileElement == nullptr)
         return;

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1596,8 +1596,8 @@ void FootpathUpdatePathWideFlags(const CoordsXY& footpathPos)
     // FootpathClearWide(x, y);
     // y -= 0x20;
 
-    // Only consider approx. 1/4 of tiles for wide path status
-    // (NB: the other 3/4 do get cleared above!)
+    // Only consider approx. 1/8 of tiles for wide path status
+    // (NB: the other 7/8 do get cleared above!)
     if (!(footpathPos.x & 0xE0) || (!(footpathPos.y & 0xE0)))
         return;
 


### PR DESCRIPTION
Effectively reverts 86be86331e53eb7c3a29b6d1d58cc47ab2ada27a. Should fix #22824.

Question remains what this code was originally aiming to _do_. The commit that originally changed the behaviour seems to suggest the function wouldn't run if it had been passed _tile_ coordinates, rather than the world coordinates it expects. That doesn't seem to be the case, though, as it checks against the lower 0xE0 bits having been set, which is the case every 224/32=7 tiles. It seems to be a means to prevent entire lengths of paths being cut off from the pathfinding algorithm.

In OpenRCT2, the check was evidently changed by 86be86331e53eb7c3a29b6d1d58cc47ab2ada27a and eventually removed entirely. This PR restores the behaviour, but the resulting 'wide path' flags do appear more erratic now. Clearly, this makes the pathfinding more flexible, but it warrants some thorough playtesting before this is considered for merging. Oddly enough, our replay tests appear to be fine, though. (Perhaps as a result of players working around the pathfinding oddities in the first place?)

@deurklink @LordMarcel Could you test this PR and report your findings? Builds can be downloaded from the 'Checks' tab, under 'CI'.

Before:
![Test Park 2024-09-26 10-04-54](https://github.com/user-attachments/assets/56b88ed1-3c34-4fce-a1fd-43985a4ddf0c)

After:
![Test Park 2024-09-26 10-05-26](https://github.com/user-attachments/assets/f587df7d-542d-42b5-a40e-c984081d6f88)