### PR TITLE
Speed-up wide path recalculation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,9 +80,9 @@ set(OPENMSX_VERSION "1.6")
 set(OPENMSX_URL  "https://github.com/OpenRCT2/OpenMusic/releases/download/v${OPENMSX_VERSION}/openmusic.zip")
 set(OPENMSX_SHA1 "ba170fa6d777b309c15420f4b6eb3fa25082a9d1")
 
-set(REPLAYS_VERSION "0.0.79")
+set(REPLAYS_VERSION "0.0.80")
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
-set(REPLAYS_SHA1 "34457077DBA9448A08FF6AC95E5CB92D65252E0C")
+set(REPLAYS_SHA1 "76C977E1B5CA5A87798E98D489247C766F129D89")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -51,8 +51,8 @@
     <OpenSFXSha1>b1b1f1b241d2cbff63a1889c4dc5a09bdf769bfb</OpenSFXSha1>
     <OpenMSXUrl>https://github.com/OpenRCT2/OpenMusic/releases/download/v1.6/openmusic.zip</OpenMSXUrl>
     <OpenMSXSha1>ba170fa6d777b309c15420f4b6eb3fa25082a9d1</OpenMSXSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.79/replays.zip</ReplaysUrl>
-    <ReplaysSha1>34457077DBA9448A08FF6AC95E5CB92D65252E0C</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.80/replays.zip</ReplaysUrl>
+    <ReplaysSha1>76C977E1B5CA5A87798E98D489247C766F129D89</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -760,6 +760,9 @@ void MapUpdatePathWideFlags()
         return;
     }
 
+    const int32_t kPracticalMapSizeBigX = GetGameState().MapSize.x * kCoordsXYStep;
+    const int32_t kPracticalMapSizeBigY = GetGameState().MapSize.y * kCoordsXYStep;
+
     // Presumably update_path_wide_flags is too computationally expensive to call for every
     // tile every update, so gWidePathTileLoopX and gWidePathTileLoopY store the x and y
     // progress. A maximum of 128 calls is done per update.
@@ -770,11 +773,11 @@ void MapUpdatePathWideFlags()
 
         // Next x, y tile
         loopPosition.x += kCoordsXYStep;
-        if (loopPosition.x >= MAXIMUM_MAP_SIZE_BIG)
+        if (loopPosition.x >= kPracticalMapSizeBigX)
         {
             loopPosition.x = 0;
             loopPosition.y += kCoordsXYStep;
-            if (loopPosition.y >= MAXIMUM_MAP_SIZE_BIG)
+            if (loopPosition.y >= kPracticalMapSizeBigY)
             {
                 loopPosition.y = 0;
             }


### PR DESCRIPTION
I was wondering about the delay in recalculating the wide path flags. It's iterative on purpose, of course, but there was room for a good speed-up.

The loop was iterating over all coordinates in the range from 0 to `MAXIMUM_MAP_SIZE_BIG`. This constant has become much bigger with the introduction of the NSF, meaning the process takes 16 times as long on a regular 256x256 map! The iteration only needs to consider the _actual_ map size, though — and only the actual X and Y size at that. This PR changes that, resulting in a nice speed-up.

Built on top of #22827; to be merged after. Filed as a separate PR as it requires new replays.