### PR TITLE
Refactor spatial indexing to be its own phase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,9 +80,9 @@ set(OPENMSX_VERSION "1.6")
 set(OPENMSX_URL  "https://github.com/OpenRCT2/OpenMusic/releases/download/v${OPENMSX_VERSION}/openmusic.zip")
 set(OPENMSX_SHA1 "ba170fa6d777b309c15420f4b6eb3fa25082a9d1")
 
-set(REPLAYS_VERSION "0.0.81")
+set(REPLAYS_VERSION "0.0.83")
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
-set(REPLAYS_SHA1 "F698526D1D2DABEF80F350A6363223D67DBC96B1")
+set(REPLAYS_SHA1 "FFC98C36AFEC68DC6A48E863413D4E2364A202B3")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -51,8 +51,8 @@
     <OpenSFXSha1>b1b1f1b241d2cbff63a1889c4dc5a09bdf769bfb</OpenSFXSha1>
     <OpenMSXUrl>https://github.com/OpenRCT2/OpenMusic/releases/download/v1.6/openmusic.zip</OpenMSXUrl>
     <OpenMSXSha1>ba170fa6d777b309c15420f4b6eb3fa25082a9d1</OpenMSXSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.81/replays.zip</ReplaysUrl>
-    <ReplaysSha1>F698526D1D2DABEF80F350A6363223D67DBC96B1</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.83/replays.zip</ReplaysUrl>
+    <ReplaysSha1>FFC98C36AFEC68DC6A48E863413D4E2364A202B3</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -1322,7 +1322,6 @@ namespace OpenRCT2
 
             if (ShouldDraw())
             {
-                UpdateEntitiesSpatialIndex();
                 Draw();
             }
         }
@@ -1358,8 +1357,6 @@ namespace OpenRCT2
             {
                 const float alpha = std::min(_ticksAccumulator / kGameUpdateTimeMS, 1.0f);
                 tweener.Tween(alpha);
-
-                UpdateEntitiesSpatialIndex();
 
                 Draw();
             }

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -1322,6 +1322,7 @@ namespace OpenRCT2
 
             if (ShouldDraw())
             {
+                UpdateEntitiesSpatialIndex();
                 Draw();
             }
         }
@@ -1357,6 +1358,8 @@ namespace OpenRCT2
             {
                 const float alpha = std::min(_ticksAccumulator / kGameUpdateTimeMS, 1.0f);
                 tweener.Tween(alpha);
+
+                UpdateEntitiesSpatialIndex();
 
                 Draw();
             }

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -332,6 +332,8 @@ namespace OpenRCT2
         // Update windows
         // WindowDispatchUpdateAll();
 
+        UpdateEntitiesSpatialIndex();
+
         // Start autosave timer after update
         if (gLastAutoSaveUpdate == kAutosavePause)
         {

--- a/src/openrct2/entity/EntityBase.cpp
+++ b/src/openrct2/entity/EntityBase.cpp
@@ -20,18 +20,6 @@ template<> bool EntityBase::Is<EntityBase>() const
     return true;
 }
 
-CoordsXYZ EntityBase::GetLocation() const
-{
-    return { x, y, z };
-}
-
-void EntityBase::SetLocation(const CoordsXYZ& newLocation)
-{
-    x = newLocation.x;
-    y = newLocation.y;
-    z = newLocation.z;
-}
-
 void EntityBase::Invalidate()
 {
     if (x == kLocationNull)

--- a/src/openrct2/entity/EntityBase.h
+++ b/src/openrct2/entity/EntityBase.h
@@ -44,6 +44,7 @@ struct EntityBase
     EntitySpriteData SpriteData;
     // Used as direction or rotation depending on the entity.
     uint8_t Orientation;
+    uint32_t SpatialIndex;
 
     /**
      * Moves a sprite to a new location, invalidates the current position if valid

--- a/src/openrct2/entity/EntityRegistry.cpp
+++ b/src/openrct2/entity/EntityRegistry.cpp
@@ -443,20 +443,22 @@ static void EntitySpatialRemove(EntityBase* entity)
 
 void UpdateEntitiesSpatialIndex()
 {
-    // TODO: This is not optimal, we should only iterate active entities.
-    for (EntityId::UnderlyingType i = 0; i < MAX_ENTITIES; i++)
+    for (auto& entityList : gEntityLists)
     {
-        auto* entity = GetEntity(EntityId::FromUnderlying(i));
-        if (entity == nullptr || entity->Type == EntityType::Null)
-            continue;
-
-        if (entity->SpatialIndex & kSpatialIndexDirtyMask)
+        for (auto& entityId : entityList)
         {
-            if (entity->SpatialIndex != kInvalidSpatialIndex)
+            auto* entity = GetEntity(entityId);
+            if (entity == nullptr || entity->Type == EntityType::Null)
+                continue;
+
+            if (entity->SpatialIndex & kSpatialIndexDirtyMask)
             {
-                EntitySpatialRemove(entity);
+                if (entity->SpatialIndex != kInvalidSpatialIndex)
+                {
+                    EntitySpatialRemove(entity);
+                }
+                EntitySpatialInsert(entity, { entity->x, entity->y });
             }
-            EntitySpatialInsert(entity, { entity->x, entity->y });
         }
     }
 }

--- a/src/openrct2/entity/EntityRegistry.cpp
+++ b/src/openrct2/entity/EntityRegistry.cpp
@@ -46,26 +46,27 @@ static std::vector<EntityId> _freeIdList;
 
 static bool _entityFlashingList[MAX_ENTITIES];
 
-constexpr const uint32_t SPATIAL_INDEX_SIZE = (kMaximumMapSizeTechnical * kMaximumMapSizeTechnical) + 1;
-constexpr uint32_t SPATIAL_INDEX_LOCATION_NULL = SPATIAL_INDEX_SIZE - 1;
+static constexpr const uint32_t kSpatialIndexSize = (kMaximumMapSizeTechnical * kMaximumMapSizeTechnical) + 1;
+static constexpr uint32_t kSpatialIndexNullBucket = kSpatialIndexSize - 1;
+
 static constexpr uint32_t kInvalidSpatialIndex = 0xFFFFFFFFu;
 static constexpr uint32_t kSpatialIndexDirtyMask = 1u << 31;
 
-static std::array<std::vector<EntityId>, SPATIAL_INDEX_SIZE> gEntitySpatialIndex;
+static std::array<std::vector<EntityId>, kSpatialIndexSize> gEntitySpatialIndex;
 
 static void FreeEntity(EntityBase& entity);
 
 static constexpr uint32_t ComputeSpatialIndex(const CoordsXY& loc)
 {
     if (loc.IsNull())
-        return SPATIAL_INDEX_LOCATION_NULL;
+        return kSpatialIndexNullBucket;
 
     // NOTE: The input coordinate is rotated and can have negative components.
     const auto tileX = std::abs(loc.x) / kCoordsXYStep;
     const auto tileY = std::abs(loc.y) / kCoordsXYStep;
 
     if (tileX >= kMaximumMapSizeTechnical || tileY >= kMaximumMapSizeTechnical)
-        return SPATIAL_INDEX_LOCATION_NULL;
+        return kSpatialIndexNullBucket;
 
     return tileX * kMaximumMapSizeTechnical + tileY;
 }

--- a/src/openrct2/entity/EntityRegistry.cpp
+++ b/src/openrct2/entity/EntityRegistry.cpp
@@ -478,7 +478,6 @@ void EntityBase::MoveTo(const CoordsXYZ& newLocation)
         loc.x = kLocationNull;
     }
 
-    // EntitySpatialMove(this, loc);
     const auto newSpatialIndex = ComputeSpatialIndex(loc);
     if (newSpatialIndex != GetSpatialIndex(this))
     {

--- a/src/openrct2/entity/EntityRegistry.cpp
+++ b/src/openrct2/entity/EntityRegistry.cpp
@@ -464,6 +464,19 @@ void UpdateEntitiesSpatialIndex()
     }
 }
 
+CoordsXYZ EntityBase::GetLocation() const
+{
+    return { x, y, z };
+}
+
+void EntityBase::SetLocation(const CoordsXYZ& newLocation)
+{
+    x = newLocation.x;
+    y = newLocation.y;
+    z = newLocation.z;
+    SpatialIndex |= kSpatialIndexDirtyMask;
+}
+
 void EntityBase::MoveTo(const CoordsXYZ& newLocation)
 {
     if (x != kLocationNull)
@@ -478,17 +491,9 @@ void EntityBase::MoveTo(const CoordsXYZ& newLocation)
         loc.x = kLocationNull;
     }
 
-    const auto newSpatialIndex = ComputeSpatialIndex(loc);
-    if (newSpatialIndex != GetSpatialIndex(this))
-    {
-        SpatialIndex |= kSpatialIndexDirtyMask;
-    }
-
     if (loc.x == kLocationNull)
     {
-        x = loc.x;
-        y = loc.y;
-        z = loc.z;
+        SetLocation(loc);
     }
     else
     {

--- a/src/openrct2/entity/EntityRegistry.h
+++ b/src/openrct2/entity/EntityRegistry.h
@@ -66,6 +66,7 @@ void UpdateMoneyEffect();
 void EntitySetCoordinates(const CoordsXYZ& entityPos, EntityBase* entity);
 void EntityRemove(EntityBase* entity);
 uint16_t RemoveFloatingEntities();
+void UpdateEntitiesSpatialIndex();
 
 #pragma pack(push, 1)
 struct EntitiesChecksum

--- a/src/openrct2/entity/EntityTweener.cpp
+++ b/src/openrct2/entity/EntityTweener.cpp
@@ -97,14 +97,12 @@ void EntityTweener::Tween(float alpha)
         if (posA == posB)
             continue;
 
-        ent->Invalidate();
-        EntitySetCoordinates(
-            { static_cast<int32_t>(std::round(posB.x * alpha + posA.x * inv)),
-              static_cast<int32_t>(std::round(posB.y * alpha + posA.y * inv)),
-              static_cast<int32_t>(std::round(posB.z * alpha + posA.z * inv)) },
-            ent);
-        ent->Invalidate();
+        ent->MoveTo({ static_cast<int32_t>(std::round(posB.x * alpha + posA.x * inv)),
+                      static_cast<int32_t>(std::round(posB.y * alpha + posA.y * inv)),
+                      static_cast<int32_t>(std::round(posB.z * alpha + posA.z * inv)) });
     }
+
+    UpdateEntitiesSpatialIndex();
 }
 
 void EntityTweener::Restore()

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -49,7 +49,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kNetworkStreamVersion = 6;
+constexpr uint8_t kNetworkStreamVersion = 7;
 
 const std::string kNetworkStreamID = std::string(OPENRCT2_VERSION) + "-" + std::to_string(kNetworkStreamVersion);
 


### PR DESCRIPTION
This will allow to update peeps/staff in parallel, here is a test build: https://github.com/ZehMatt/OpenRCT2/actions/runs/11067625470

This makes quite the difference on my test park that has 24k peeps all jammed together.
Here is develop:
![openrct2_2024-09-27_11-59-33de5b10849661bb6e1](https://github.com/user-attachments/assets/f6bccc5d-f999-4082-a985-ed49f9c875f7)

Here it is with peeps being updated in parallel:
![openrct2_2024-09-27_12-00-0158eca102e2ae0b93f](https://github.com/user-attachments/assets/4d68e587-c8fc-4464-aebd-c4c5e3c0e36f)
The cost of rendering them is quite high, if I move out of the view its 100+ where in develop its still only about 14+.

My test build is far from perfect, ride queues will most likely have a race condition, that path finding code has globals, so quite a couple PRs ahead before we can better utilize the CPU to make up for the new limits.