### PR TITLE
Game Action Removal Z Position

### DIFF
--- a/src/openrct2/actions/LargeSceneryRemoveAction.cpp
+++ b/src/openrct2/actions/LargeSceneryRemoveAction.cpp
@@ -54,10 +54,9 @@ GameActions::Result LargeSceneryRemoveAction::Query() const
 
     const uint32_t flags = GetFlags();
 
-    int32_t z = TileElementHeight(_loc);
     res.Position.x = _loc.x + 16;
     res.Position.y = _loc.y + 16;
-    res.Position.z = z;
+    res.Position.z = _loc.z;
     res.Expenditure = ExpenditureType::Landscaping;
     res.Cost = 0;
 
@@ -139,10 +138,9 @@ GameActions::Result LargeSceneryRemoveAction::Execute() const
 {
     auto res = GameActions::Result();
 
-    int32_t z = TileElementHeight(_loc);
     res.Position.x = _loc.x + 16;
     res.Position.y = _loc.y + 16;
-    res.Position.z = z;
+    res.Position.z = _loc.z;
     res.Expenditure = ExpenditureType::Landscaping;
     res.Cost = 0;
 

--- a/src/openrct2/actions/SmallSceneryRemoveAction.cpp
+++ b/src/openrct2/actions/SmallSceneryRemoveAction.cpp
@@ -133,8 +133,6 @@ GameActions::Result SmallSceneryRemoveAction::Execute() const
             GameActions::Status::InvalidParameters, STR_CANT_REMOVE_THIS, STR_INVALID_SELECTION_OF_OBJECTS);
     }
 
-    res.Position.z = TileElementHeight(res.Position);
-
     MapInvalidateTileFull(_loc);
     TileElementRemove(tileElement);
 

--- a/src/openrct2/actions/WallRemoveAction.cpp
+++ b/src/openrct2/actions/WallRemoveAction.cpp
@@ -85,7 +85,7 @@ GameActions::Result WallRemoveAction::Execute() const
 
     res.Position.x = _loc.x + 16;
     res.Position.y = _loc.y + 16;
-    res.Position.z = TileElementHeight(res.Position);
+    res.Position.z = _loc.z;
 
     wallElement->RemoveBannerEntry();
     MapInvalidateTileZoom1({ _loc, wallElement->GetBaseZ(), (wallElement->GetBaseZ()) + 72 });


### PR DESCRIPTION
based on #22840

I'm not sure why these actions weren't using the z coordinate it was being passed to set the location as it has to be valid (unlike create functions).

Checked all remove game actions only special one that doesn't set the true z now is `RideEntranceExitRemoveAction` which doesn't actually specify the z. BUT we could change it to use the z of the entrance/exit that it finds.

These changes will only change where money effects happen and will change what values plugins get if they are hooking the position (which is why this issue was investigated)