### PR TITLE
Implement what() for existing exceptions

### DIFF
--- a/src/openrct2/ParkImporter.h
+++ b/src/openrct2/ParkImporter.h
@@ -81,6 +81,11 @@ public:
         : MissingObjects(std::move(missingObjects))
     {
     }
+
+    const char* what() const noexcept override
+    {
+        return "Missing objects";
+    }
 };
 
 class UnsupportedRideTypeException : public std::exception
@@ -91,6 +96,11 @@ public:
     explicit UnsupportedRideTypeException(ObjectEntryIndex type)
         : Type(type)
     {
+    }
+
+    const char* what() const noexcept override
+    {
+        return "Invalid ride type";
     }
 };
 
@@ -104,5 +114,10 @@ public:
         : MinVersion(minVersion)
         , TargetVersion(targetVersion)
     {
+    }
+
+    const char* what() const noexcept override
+    {
+        return "Unexpected version";
     }
 };

--- a/src/openrct2/network/ServerList.cpp
+++ b/src/openrct2/network/ServerList.cpp
@@ -23,6 +23,7 @@
 #    include "../core/Memory.hpp"
 #    include "../core/Path.hpp"
 #    include "../core/String.hpp"
+#    include "../localisation/Language.h"
 #    include "../platform/Platform.h"
 #    include "Socket.h"
 #    include "network.h"
@@ -430,6 +431,12 @@ uint32_t ServerList::GetTotalPlayerCount() const
     return std::accumulate(_serverEntries.begin(), _serverEntries.end(), 0, [](uint32_t acc, const ServerListEntry& entry) {
         return acc + entry.Players;
     });
+}
+
+const char* MasterServerException::what() const noexcept
+{
+    static std::string localisedStatusText = LanguageGetString(StatusText);
+    return localisedStatusText.c_str();
 }
 
 #endif

--- a/src/openrct2/network/ServerList.h
+++ b/src/openrct2/network/ServerList.h
@@ -80,4 +80,6 @@ public:
         : StatusText(statusText)
     {
     }
+
+    const char* what() const noexcept override;
 };


### PR DESCRIPTION
While attempting to help on #22287 I ended up having exceptions thrown and the message shown was not useful. This happened because there was a generic catch block (shown below) using `what()`, but `what()` was not implemented by most of our exceptions,

https://github.com/OpenRCT2/OpenRCT2/blob/c161a3911a9e59a64a2879c15e28948e99e7aef6/src/openrct2/ReplayManager.cpp#L557-L561

Our flows usually handle the actual inherited type of the exception, but I think it doesn't hurt to implement `what()` in case we fall into cases like this one.