### PR TITLE
Fix msbuild clean target not clearing dependency cache

### DIFF
--- a/openrct2.proj
+++ b/openrct2.proj
@@ -73,6 +73,7 @@
       <SlnProperties>$(SlnProperties);Configuration=$(Configuration)</SlnProperties>
     </PropertyGroup>
     <Delete Files="@(CleanItems)" />
+    <Delete Files="$(DependenciesCheckFile)" />
     <RemoveDir Directories="$(TargetDir)data" />
     <MSBuild Projects="openrct2.sln" Targets="Clean" Properties="$(SlnProperties)" />
   </Target>


### PR DESCRIPTION
If doing `msbuild openrct2.proj /t:clean /p:platform=x64` the compiler would delete a lot of stuff such as the object files and `data` folder, but not the `.dependencies` file.

Upon building again, the routine to download dependencies would check whether the `SHA` on the dependencies is valid (it would always be, since the file hadn't been touched) and that the file of the dependency existed. For `OpenMSX` and `OpenSFX` since they have multiple folders, we only checked that `data` existed and by the time they ran, the `data` folder would have already been created.

A full fix would also improve the check of the libs upon downloading, but this is enough for now to make sure that after a clean, the build is fully downloaded again.