### PR TITLE
Fix Side-Friction train appearing through slopes

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -28,6 +28,7 @@
 - Fix: [#22729] Invisibility settings persist after reloading OpenRCT2.
 - Fix: [#22734] Support clearance above steep Side-Friction track is too low.
 - Fix: [#22774] Fix entities leaving stale pixels on the screen when the framerate is uncapped.
+- Fix: [#22857] Side-Friction Roller Coaster train clips through slopes.
 - Fix: [objects#346] Invalid refund price for Brick Base Block scenery item.
 
 0.4.14 (2024-09-01)

--- a/src/openrct2/paint/track/coaster/SideFrictionRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/SideFrictionRollerCoaster.cpp
@@ -193,7 +193,7 @@ static void SideFrictionRCTrack25DegUp(
                     { { 0, 2, height }, { 32, 27, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21691), { 0, 0, height },
-                    { { 0, 26, height + 5 }, { 32, 1, 9 } });
+                    { { 0, 26, height + 5 }, { 32, 1, 20 } });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -201,7 +201,7 @@ static void SideFrictionRCTrack25DegUp(
                     { { 0, 2, height }, { 32, 27, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21692), { 0, 0, height },
-                    { { 0, 26, height + 5 }, { 32, 1, 9 } });
+                    { { 0, 26, height + 5 }, { 32, 1, 20 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -231,7 +231,7 @@ static void SideFrictionRCTrack25DegUp(
                     { { 0, 2, height }, { 32, 27, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21635), { 0, 0, height },
-                    { { 0, 26, height + 5 }, { 32, 1, 9 } });
+                    { { 0, 26, height + 5 }, { 32, 1, 20 } });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -239,7 +239,7 @@ static void SideFrictionRCTrack25DegUp(
                     { { 0, 2, height }, { 32, 27, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21636), { 0, 0, height },
-                    { { 0, 26, height + 5 }, { 32, 1, 9 } });
+                    { { 0, 26, height + 5 }, { 32, 1, 20 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -288,7 +288,7 @@ static void SideFrictionRCTrackFlatTo25DegUp(
                     { { 0, 2, height }, { 32, 27, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21683), { 0, 0, height },
-                    { { 0, 26, height + 5 }, { 32, 1, 9 } });
+                    { { 0, 26, height + 5 }, { 32, 1, 16 } });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -296,7 +296,7 @@ static void SideFrictionRCTrackFlatTo25DegUp(
                     { { 0, 2, height }, { 32, 27, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21684), { 0, 0, height },
-                    { { 0, 26, height + 5 }, { 32, 1, 9 } });
+                    { { 0, 26, height + 5 }, { 32, 1, 16 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -326,7 +326,7 @@ static void SideFrictionRCTrackFlatTo25DegUp(
                     { { 0, 2, height }, { 32, 27, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21627), { 0, 0, height },
-                    { { 0, 26, height + 5 }, { 32, 1, 9 } });
+                    { { 0, 26, height + 5 }, { 32, 1, 16 } });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -334,7 +334,7 @@ static void SideFrictionRCTrackFlatTo25DegUp(
                     { { 0, 2, height }, { 32, 27, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21628), { 0, 0, height },
-                    { { 0, 26, height + 5 }, { 32, 1, 9 } });
+                    { { 0, 26, height + 5 }, { 32, 1, 16 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -383,7 +383,7 @@ static void SideFrictionRCTrack25DegUpToFlat(
                     { { 0, 2, height }, { 32, 27, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21687), { 0, 0, height },
-                    { { 0, 26, height + 5 }, { 32, 1, 9 } });
+                    { { 0, 26, height + 5 }, { 32, 1, 16 } });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -391,7 +391,7 @@ static void SideFrictionRCTrack25DegUpToFlat(
                     { { 0, 2, height }, { 32, 27, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21688), { 0, 0, height },
-                    { { 0, 26, height + 5 }, { 32, 1, 9 } });
+                    { { 0, 26, height + 5 }, { 32, 1, 16 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -421,7 +421,7 @@ static void SideFrictionRCTrack25DegUpToFlat(
                     { { 0, 2, height }, { 32, 27, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21631), { 0, 0, height },
-                    { { 0, 26, height + 5 }, { 32, 1, 9 } });
+                    { { 0, 26, height + 5 }, { 32, 1, 16 } });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -429,7 +429,7 @@ static void SideFrictionRCTrack25DegUpToFlat(
                     { { 0, 2, height }, { 32, 27, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21632), { 0, 0, height },
-                    { { 0, 26, height + 5 }, { 32, 1, 9 } });
+                    { { 0, 26, height + 5 }, { 32, 1, 16 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -2594,7 +2594,7 @@ static void SideFrictionRCTrack25DegUpTo60DegUp(
                 { 0, 0, height }, { { 0, 2, height }, { 32, 27, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours.WithIndex(SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_1_B),
-                { 0, 0, height }, { { 0, 26, height + 5 }, { 32, 1, 9 } });
+                { 0, 0, height }, { { 0, 26, height + 5 }, { 32, 1, 40 } });
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -2602,7 +2602,7 @@ static void SideFrictionRCTrack25DegUpTo60DegUp(
                 { 0, 0, height }, { { 0, 2, height }, { 32, 27, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours.WithIndex(SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_2_B),
-                { 0, 0, height }, { { 0, 26, height + 5 }, { 32, 1, 9 } });
+                { 0, 0, height }, { { 0, 26, height + 5 }, { 32, 1, 40 } });
             break;
         case 3:
             PaintAddImageAsParentRotated(
@@ -2655,7 +2655,7 @@ static void SideFrictionRCTrack60DegUpTo25DegUp(
                 { 0, 0, height }, { { 0, 2, height }, { 32, 27, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours.WithIndex(SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_1_B),
-                { 0, 0, height }, { { 0, 26, height + 5 }, { 32, 1, 9 } });
+                { 0, 0, height }, { { 0, 26, height + 5 }, { 32, 1, 36 } });
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -2663,7 +2663,7 @@ static void SideFrictionRCTrack60DegUpTo25DegUp(
                 { 0, 0, height }, { { 0, 2, height }, { 32, 27, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours.WithIndex(SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_2_B),
-                { 0, 0, height }, { { 0, 26, height + 5 }, { 32, 1, 9 } });
+                { 0, 0, height }, { { 0, 26, height + 5 }, { 32, 1, 36 } });
             break;
         case 3:
             PaintAddImageAsParentRotated(


### PR DESCRIPTION
This adds a bit of height to the front bounding boxes of the rear facing slopes on the side friction coaster so that the trains don't appear in front of them.


https://github.com/user-attachments/assets/18c0ba21-0d71-4dbc-a10a-c75bd7b34ca2


https://github.com/user-attachments/assets/6490625a-18b7-4cb6-969b-3e83bc169149

![boundingboxes](https://github.com/user-attachments/assets/389622f8-f139-440b-b05b-006b7315f443)