### PR TITLE
Split off EntranceElement header

### DIFF
--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -53,6 +53,7 @@
 #include <openrct2/world/Scenery.h>
 #include <openrct2/world/Surface.h>
 #include <openrct2/world/Wall.h>
+#include <openrct2/world/tile_element/EntranceElement.h>
 
 using namespace OpenRCT2;
 using namespace OpenRCT2::Ui::Windows;

--- a/src/openrct2-ui/interface/ViewportQuery.cpp
+++ b/src/openrct2-ui/interface/ViewportQuery.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <openrct2/world/Map.h>
 #include <openrct2/world/TileElement.h>
+#include <openrct2/world/tile_element/EntranceElement.h>
 
 namespace OpenRCT2::Ui
 {

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -34,6 +34,7 @@
 #include <openrct2/world/Footpath.h>
 #include <openrct2/world/Scenery.h>
 #include <openrct2/world/Surface.h>
+#include <openrct2/world/tile_element/EntranceElement.h>
 #include <openrct2/world/tile_element/Slope.h>
 #include <vector>
 

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -26,6 +26,7 @@
 #include <openrct2/ride/Track.h>
 #include <openrct2/sprites.h>
 #include <openrct2/windows/Intent.h>
+#include <openrct2/world/tile_element/EntranceElement.h>
 
 namespace OpenRCT2::Ui::Windows
 {

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -64,6 +64,7 @@
 #include <openrct2/sprites.h>
 #include <openrct2/windows/Intent.h>
 #include <openrct2/world/Park.h>
+#include <openrct2/world/tile_element/EntranceElement.h>
 #include <optional>
 #include <string>
 #include <string_view>

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -49,6 +49,7 @@
 #include <openrct2/windows/Intent.h>
 #include <openrct2/world/Entrance.h>
 #include <openrct2/world/Park.h>
+#include <openrct2/world/tile_element/EntranceElement.h>
 
 constexpr int8_t kDefaultSpeedIncrement = 2;
 constexpr int8_t kDefaultMinimumSpeed = 2;

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -41,6 +41,7 @@
 #include <openrct2/world/Scenery.h>
 #include <openrct2/world/Surface.h>
 #include <openrct2/world/TileInspector.h>
+#include <openrct2/world/tile_element/EntranceElement.h>
 #include <openrct2/world/tile_element/Slope.h>
 
 namespace OpenRCT2::Ui::Windows

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -30,6 +30,7 @@
 #include "windows/Intent.h"
 #include "world/Footpath.h"
 #include "world/Scenery.h"
+#include "world/tile_element/EntranceElement.h"
 
 #include <iterator>
 #include <vector>

--- a/src/openrct2/actions/FootpathLayoutPlaceAction.cpp
+++ b/src/openrct2/actions/FootpathLayoutPlaceAction.cpp
@@ -23,6 +23,7 @@
 #include "../world/Park.h"
 #include "../world/Surface.h"
 #include "../world/Wall.h"
+#include "../world/tile_element/EntranceElement.h"
 #include "../world/tile_element/Slope.h"
 
 using namespace OpenRCT2;

--- a/src/openrct2/actions/FootpathPlaceAction.cpp
+++ b/src/openrct2/actions/FootpathPlaceAction.cpp
@@ -29,6 +29,7 @@
 #include "../world/Surface.h"
 #include "../world/TileElementsView.h"
 #include "../world/Wall.h"
+#include "../world/tile_element/EntranceElement.h"
 #include "../world/tile_element/Slope.h"
 
 #include <algorithm>

--- a/src/openrct2/actions/LandSetRightsAction.cpp
+++ b/src/openrct2/actions/LandSetRightsAction.cpp
@@ -25,6 +25,7 @@
 #include "../world/Scenery.h"
 #include "../world/Surface.h"
 #include "../world/TileElementsView.h"
+#include "../world/tile_element/EntranceElement.h"
 
 using namespace OpenRCT2;
 

--- a/src/openrct2/actions/ParkEntrancePlaceAction.cpp
+++ b/src/openrct2/actions/ParkEntrancePlaceAction.cpp
@@ -21,6 +21,7 @@
 #include "../world/MapAnimation.h"
 #include "../world/Park.h"
 #include "../world/Surface.h"
+#include "../world/tile_element/EntranceElement.h"
 
 using namespace OpenRCT2;
 

--- a/src/openrct2/actions/ParkEntranceRemoveAction.cpp
+++ b/src/openrct2/actions/ParkEntranceRemoveAction.cpp
@@ -15,6 +15,7 @@
 #include "../management/Finance.h"
 #include "../world/Entrance.h"
 #include "../world/Park.h"
+#include "../world/tile_element/EntranceElement.h"
 
 using namespace OpenRCT2;
 

--- a/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
+++ b/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
@@ -17,6 +17,7 @@
 #include "../ride/Station.h"
 #include "../world/ConstructionClearance.h"
 #include "../world/MapAnimation.h"
+#include "../world/tile_element/EntranceElement.h"
 
 using namespace OpenRCT2;
 

--- a/src/openrct2/actions/RideEntranceExitRemoveAction.cpp
+++ b/src/openrct2/actions/RideEntranceExitRemoveAction.cpp
@@ -14,6 +14,7 @@
 #include "../ride/Station.h"
 #include "../world/Entrance.h"
 #include "../world/TileElementsView.h"
+#include "../world/tile_element/EntranceElement.h"
 
 using namespace OpenRCT2;
 

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -60,6 +60,7 @@
 #include "../world/Scenery.h"
 #include "../world/Surface.h"
 #include "../world/TileElementsView.h"
+#include "../world/tile_element/EntranceElement.h"
 #include "Peep.h"
 #include "Staff.h"
 

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -56,6 +56,7 @@
 #include "../world/Park.h"
 #include "../world/Scenery.h"
 #include "../world/Surface.h"
+#include "../world/tile_element/EntranceElement.h"
 #include "PatrolArea.h"
 #include "Staff.h"
 

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -43,6 +43,7 @@
 #include "../world/Footpath.h"
 #include "../world/Scenery.h"
 #include "../world/Surface.h"
+#include "../world/tile_element/EntranceElement.h"
 #include "../world/tile_element/Slope.h"
 #include "PatrolArea.h"
 #include "Peep.h"

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -599,6 +599,7 @@
     <ClInclude Include="Version.h" />
     <ClInclude Include="windows\Intent.h" />
     <ClInclude Include="windows\TileInspectorGlobals.h" />
+    <ClInclude Include="world\tile_element\EntranceElement.h" />
     <ClInclude Include="world\tile_element\TileElementType.h" />
     <ClInclude Include="world\tile_element\Slope.h" />
     <ClInclude Include="world\Banner.h" />

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -29,6 +29,7 @@
 #include "../../world/Footpath.h"
 #include "../../world/Park.h"
 #include "../../world/TileInspector.h"
+#include "../../world/tile_element/EntranceElement.h"
 #include "../support/WoodenSupports.h"
 #include "Paint.TileElement.h"
 #include "Segment.h"

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -22,6 +22,7 @@
 #include "../util/Util.h"
 #include "../world/Entrance.h"
 #include "../world/Footpath.h"
+#include "../world/tile_element/EntranceElement.h"
 
 #include <bit>
 #include <bitset>

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -72,6 +72,7 @@
 #include "../world/Surface.h"
 #include "../world/TilePointerIndex.hpp"
 #include "../world/Wall.h"
+#include "../world/tile_element/EntranceElement.h"
 #include "RCT1.h"
 #include "Tables.h"
 

--- a/src/openrct2/rct12/ScenarioPatcher.cpp
+++ b/src/openrct2/rct12/ScenarioPatcher.cpp
@@ -27,6 +27,7 @@
 #include "../world/Location.hpp"
 #include "../world/Map.h"
 #include "../world/Surface.h"
+#include "../world/tile_element/EntranceElement.h"
 #include "../world/tile_element/TileElementType.h"
 
 #ifdef DISABLE_NETWORK

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -77,6 +77,7 @@
 #include "../world/Scenery.h"
 #include "../world/Surface.h"
 #include "../world/TilePointerIndex.hpp"
+#include "../world/tile_element/EntranceElement.h"
 
 #include <cassert>
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -62,6 +62,7 @@
 #include "../world/Park.h"
 #include "../world/Scenery.h"
 #include "../world/TileElementsView.h"
+#include "../world/tile_element/EntranceElement.h"
 #include "CableLift.h"
 #include "RideAudio.h"
 #include "RideConstruction.h"

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -40,6 +40,7 @@
 #include "../world/Park.h"
 #include "../world/Scenery.h"
 #include "../world/TileElementsView.h"
+#include "../world/tile_element/EntranceElement.h"
 #include "Ride.h"
 #include "RideData.h"
 #include "Track.h"

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -58,6 +58,7 @@
 #include "../world/Scenery.h"
 #include "../world/Surface.h"
 #include "../world/Wall.h"
+#include "../world/tile_element/EntranceElement.h"
 #include "../world/tile_element/Slope.h"
 #include "Ride.h"
 #include "RideData.h"

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -26,6 +26,7 @@
 #include "../world/Footpath.h"
 #include "../world/Scenery.h"
 #include "../world/Wall.h"
+#include "../world/tile_element/EntranceElement.h"
 #include "RideData.h"
 #include "Station.h"
 #include "Track.h"

--- a/src/openrct2/scripting/bindings/world/ScTileElement.cpp
+++ b/src/openrct2/scripting/bindings/world/ScTileElement.cpp
@@ -22,6 +22,7 @@
 #    include "../../../world/Footpath.h"
 #    include "../../../world/Scenery.h"
 #    include "../../../world/Surface.h"
+#    include "../../../world/tile_element/EntranceElement.h"
 #    include "../../Duktape.hpp"
 #    include "../../ScriptEngine.h"
 

--- a/src/openrct2/world/ConstructionClearance.cpp
+++ b/src/openrct2/world/ConstructionClearance.cpp
@@ -18,10 +18,11 @@
 #include "../openrct2/Cheats.h"
 #include "../ride/Ride.h"
 #include "../ride/RideData.h"
-#include "../world/tile_element/Slope.h"
 #include "Park.h"
 #include "Scenery.h"
 #include "Surface.h"
+#include "tile_element/EntranceElement.h"
+#include "tile_element/Slope.h"
 
 using namespace OpenRCT2;
 

--- a/src/openrct2/world/Entrance.cpp
+++ b/src/openrct2/world/Entrance.cpp
@@ -30,6 +30,7 @@
 #include "Map.h"
 #include "MapAnimation.h"
 #include "Park.h"
+#include "tile_element/EntranceElement.h"
 
 using namespace OpenRCT2;
 

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -33,12 +33,13 @@
 #include "../ride/Track.h"
 #include "../ride/TrackData.h"
 #include "../util/Util.h"
-#include "../world/tile_element/Slope.h"
 #include "Location.hpp"
 #include "Map.h"
 #include "MapAnimation.h"
 #include "Surface.h"
 #include "TileElement.h"
+#include "tile_element/EntranceElement.h"
+#include "tile_element/Slope.h"
 
 #include <bit>
 #include <iterator>

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -47,7 +47,6 @@
 #include "../util/Util.h"
 #include "../windows/Intent.h"
 #include "../world/TilePointerIndex.hpp"
-#include "../world/tile_element/Slope.h"
 #include "Banner.h"
 #include "Climate.h"
 #include "Entrance.h"
@@ -59,6 +58,8 @@
 #include "TileElementsView.h"
 #include "TileInspector.h"
 #include "Wall.h"
+#include "tile_element/EntranceElement.h"
+#include "tile_element/Slope.h"
 
 #include <iterator>
 #include <memory>

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -29,6 +29,7 @@
 #include "Footpath.h"
 #include "Map.h"
 #include "Scenery.h"
+#include "tile_element/EntranceElement.h"
 
 using namespace OpenRCT2;
 

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -39,6 +39,7 @@
 #include "Entrance.h"
 #include "Map.h"
 #include "Surface.h"
+#include "tile_element/EntranceElement.h"
 
 #include <limits>
 #include <type_traits>

--- a/src/openrct2/world/TileElement.cpp
+++ b/src/openrct2/world/TileElement.cpp
@@ -18,6 +18,7 @@
 #include "Banner.h"
 #include "Location.hpp"
 #include "Scenery.h"
+#include "tile_element/EntranceElement.h"
 #include "tile_element/Slope.h"
 
 using namespace OpenRCT2;
@@ -158,4 +159,14 @@ const QuarterTile QuarterTile::Rotate(uint8_t amount) const
             LOG_ERROR("Tried to rotate QuarterTile invalid amount.");
             return QuarterTile{ 0 };
     }
+}
+
+const EntranceElement* TileElementBase::AsEntrance() const
+{
+    return as<EntranceElement>();
+}
+
+EntranceElement* TileElementBase::AsEntrance()
+{
+    return as<EntranceElement>();
 }

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -35,6 +35,7 @@ using track_type_t = uint16_t;
 
 constexpr uint8_t MAX_ELEMENT_HEIGHT = 255;
 constexpr uint8_t OWNER_MASK = 0b00001111;
+constexpr uint8_t kTileElementSize = 16;
 
 #pragma pack(push, 1)
 
@@ -148,14 +149,8 @@ struct TileElementBase
     {
         return as<WallElement>();
     }
-    const EntranceElement* AsEntrance() const
-    {
-        return as<EntranceElement>();
-    }
-    EntranceElement* AsEntrance()
-    {
-        return as<EntranceElement>();
-    }
+    const EntranceElement* AsEntrance() const;
+    EntranceElement* AsEntrance();
     const BannerElement* AsBanner() const
     {
         return as<BannerElement>();
@@ -548,55 +543,6 @@ public:
 };
 static_assert(sizeof(WallElement) == 16);
 
-struct EntranceElement : TileElementBase
-{
-    static constexpr TileElementType ElementType = TileElementType::Entrance;
-
-private:
-    uint8_t entranceType;        // 5
-    uint8_t SequenceIndex;       // 6. Only uses the lower nibble.
-    StationIndex stationIndex;   // 7
-    ObjectEntryIndex PathType;   // 8
-    RideId rideIndex;            // A
-    uint8_t flags2;              // C
-    ObjectEntryIndex entryIndex; // D
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-private-field"
-    uint8_t Pad0F[1];
-#pragma clang diagnostic pop
-
-public:
-    uint8_t GetEntranceType() const;
-    void SetEntranceType(uint8_t newType);
-
-    RideId GetRideIndex() const;
-    void SetRideIndex(RideId newRideIndex);
-
-    StationIndex GetStationIndex() const;
-    void SetStationIndex(StationIndex newStationIndex);
-
-    uint8_t GetSequenceIndex() const;
-    void SetSequenceIndex(uint8_t newSequenceIndex);
-
-    bool HasLegacyPathEntry() const;
-
-    ObjectEntryIndex GetLegacyPathEntryIndex() const;
-    const FootpathObject* GetLegacyPathEntry() const;
-    void SetLegacyPathEntryIndex(ObjectEntryIndex newPathType);
-
-    ObjectEntryIndex GetSurfaceEntryIndex() const;
-    const FootpathSurfaceObject* GetSurfaceEntry() const;
-    void SetSurfaceEntryIndex(ObjectEntryIndex newIndex);
-
-    const PathSurfaceDescriptor* GetPathSurfaceDescriptor() const;
-
-    int32_t GetDirections() const;
-
-    ObjectEntryIndex getEntryIndex() const;
-    void setEntryIndex(ObjectEntryIndex newIndex);
-};
-static_assert(sizeof(EntranceElement) == 16);
-
 struct BannerElement : TileElementBase
 {
     static constexpr TileElementType ElementType = TileElementType::Banner;
@@ -683,13 +629,6 @@ enum
     TILE_ELEMENT_FLAG_GHOST = (1 << 4),
     TILE_ELEMENT_FLAG_INVISIBLE = (1 << 5),
     TILE_ELEMENT_FLAG_LAST_TILE = (1 << 7)
-};
-
-enum
-{
-    ENTRANCE_TYPE_RIDE_ENTRANCE,
-    ENTRANCE_TYPE_RIDE_EXIT,
-    ENTRANCE_TYPE_PARK_ENTRANCE
 };
 
 enum

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -25,6 +25,7 @@
 #include "Park.h"
 #include "Scenery.h"
 #include "Surface.h"
+#include "tile_element/EntranceElement.h"
 #include "tile_element/Slope.h"
 
 #include <optional>

--- a/src/openrct2/world/tile_element/EntranceElement.cpp
+++ b/src/openrct2/world/tile_element/EntranceElement.cpp
@@ -7,13 +7,14 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#include "EntranceElement.h"
+
 #include "../../Context.h"
 #include "../../object/EntranceObject.h"
 #include "../../object/FootpathObject.h"
 #include "../../object/FootpathSurfaceObject.h"
 #include "../../object/ObjectManager.h"
 #include "../Entrance.h"
-#include "../TileElement.h"
 
 // rct2: 0x0097B974
 static constexpr uint16_t EntranceDirections[] = {

--- a/src/openrct2/world/tile_element/EntranceElement.h
+++ b/src/openrct2/world/tile_element/EntranceElement.h
@@ -1,0 +1,75 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2024 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include "../../Identifiers.h"
+#include "../TileElement.h"
+
+#include <cstdint>
+
+enum
+{
+    ENTRANCE_TYPE_RIDE_ENTRANCE,
+    ENTRANCE_TYPE_RIDE_EXIT,
+    ENTRANCE_TYPE_PARK_ENTRANCE
+};
+
+#pragma pack(push, 1)
+struct EntranceElement;
+
+struct EntranceElement : TileElementBase
+{
+    static constexpr TileElementType ElementType = TileElementType::Entrance;
+
+private:
+    uint8_t entranceType;        // 5
+    uint8_t SequenceIndex;       // 6. Only uses the lower nibble.
+    StationIndex stationIndex;   // 7
+    ObjectEntryIndex PathType;   // 8
+    RideId rideIndex;            // A
+    uint8_t flags2;              // C
+    ObjectEntryIndex entryIndex; // D
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-private-field"
+    uint8_t Pad0F[1];
+#pragma clang diagnostic pop
+
+public:
+    uint8_t GetEntranceType() const;
+    void SetEntranceType(uint8_t newType);
+
+    RideId GetRideIndex() const;
+    void SetRideIndex(RideId newRideIndex);
+
+    StationIndex GetStationIndex() const;
+    void SetStationIndex(StationIndex newStationIndex);
+
+    uint8_t GetSequenceIndex() const;
+    void SetSequenceIndex(uint8_t newSequenceIndex);
+
+    bool HasLegacyPathEntry() const;
+
+    ObjectEntryIndex GetLegacyPathEntryIndex() const;
+    const FootpathObject* GetLegacyPathEntry() const;
+    void SetLegacyPathEntryIndex(ObjectEntryIndex newPathType);
+
+    ObjectEntryIndex GetSurfaceEntryIndex() const;
+    const FootpathSurfaceObject* GetSurfaceEntry() const;
+    void SetSurfaceEntryIndex(ObjectEntryIndex newIndex);
+
+    const PathSurfaceDescriptor* GetPathSurfaceDescriptor() const;
+
+    int32_t GetDirections() const;
+
+    ObjectEntryIndex getEntryIndex() const;
+    void setEntryIndex(ObjectEntryIndex newIndex);
+};
+static_assert(sizeof(EntranceElement) == kTileElementSize);
+#pragma pack(pop)

--- a/test/tests/TileElements.cpp
+++ b/test/tests/TileElements.cpp
@@ -17,6 +17,7 @@
 #include <openrct2/ParkImporter.h>
 #include <openrct2/world/Footpath.h>
 #include <openrct2/world/Map.h>
+#include <openrct2/world/tile_element/EntranceElement.h>
 
 using namespace OpenRCT2;
 

--- a/test/tests/TileElementsView.cpp
+++ b/test/tests/TileElementsView.cpp
@@ -18,6 +18,7 @@
 #include <openrct2/world/Footpath.h>
 #include <openrct2/world/Map.h>
 #include <openrct2/world/TileElementsView.h>
+#include <openrct2/world/tile_element/EntranceElement.h>
 
 using namespace OpenRCT2;
 


### PR DESCRIPTION
Part of #22875. The C++ parts were already split off, so I only had to do the header.

Also introduced a constant for the tile element size (`kTileElementSize`), rather than hardcoding `16` in several files.