### PR TITLE
Fix Wooden RC flat to steep rails drawing order

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.16 (in development)
 ------------------------------------------------------------------------
+- Fix: [#22921] Wooden RollerCoaster flat to steep railings appear in front of track in front of them.
 
 0.4.15 (2024-10-06)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/WoodenRollerCoaster.cpp
@@ -8216,39 +8216,14 @@ static void WoodenRCTrackFlatTo60DegUpLongBase(
                         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 1:
-                    session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                        session, direction,
-                        WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_G2_WOODEN_RC_FLAT_TO_STEEP + 7),
+                    session.WoodenSupportsPrependTo = WoodenRCTrackPaint<isClassic>(
+                        session, direction, SPR_G2_WOODEN_RC_FLAT_TO_STEEP + 7, SPR_G2_WOODEN_RC_FLAT_TO_STEEP_RAILS + 7,
                         { 0, 0, height }, { { 28, 4, height - 16 }, { 2, 24, 56 } });
-                    session.WoodenSupportsPrependTo = PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(SPR_G2_WOODEN_RC_FLAT_TO_STEEP_RAILS + 7),
-                        { 0, 0, height }, { { 28, 4, height - 16 }, { 2, 24, 56 } });
-                    PaintAddImageAsParentRotated(
-                        session, direction,
-                        WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_G2_WOODEN_RC_FLAT_TO_STEEP_FRONT + 3),
-                        { 0, 0, height }, { { 28, 4, height + 16 }, { 2, 22, 0 } });
-                    PaintAddImageAsChildRotated(
-                        session, direction,
-                        WoodenRCGetRailsColour(session).WithIndex(SPR_G2_WOODEN_RC_FLAT_TO_STEEP_FRONT_RAILS + 3),
-                        { 0, 0, height }, { { 28, 4, height + 16 }, { 2, 22, 0 } });
                     break;
                 case 2:
-                    session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                        session, direction,
-                        WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_G2_WOODEN_RC_FLAT_TO_STEEP + 11),
+                    session.WoodenSupportsPrependTo = WoodenRCTrackPaint<isClassic>(
+                        session, direction, SPR_G2_WOODEN_RC_FLAT_TO_STEEP + 11, SPR_G2_WOODEN_RC_FLAT_TO_STEEP_RAILS + 11,
                         { 0, 0, height }, { { 28, 4, height - 16 }, { 2, 24, 56 } });
-                    session.WoodenSupportsPrependTo = PaintAddImageAsChildRotated(
-                        session, direction,
-                        WoodenRCGetRailsColour(session).WithIndex(SPR_G2_WOODEN_RC_FLAT_TO_STEEP_RAILS + 11), { 0, 0, height },
-                        { { 28, 4, height - 16 }, { 2, 24, 56 } });
-                    PaintAddImageAsParentRotated(
-                        session, direction,
-                        WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_G2_WOODEN_RC_FLAT_TO_STEEP_FRONT + 7),
-                        { 0, 0, height }, { { 28, 4, height + 16 }, { 2, 22, 0 } });
-                    PaintAddImageAsChildRotated(
-                        session, direction,
-                        WoodenRCGetRailsColour(session).WithIndex(SPR_G2_WOODEN_RC_FLAT_TO_STEEP_FRONT_RAILS + 7),
-                        { 0, 0, height }, { { 28, 4, height + 16 }, { 2, 22, 0 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -8300,40 +8275,14 @@ static void WoodenRCTrack60DegUpToFlatLongBase(
                         { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 1:
-                    session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                        session, direction,
-                        WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_G2_WOODEN_RC_FLAT_TO_STEEP + 20),
-                        { 0, 0, height }, { { 28, 4, height - 16 }, { 2, 24, 56 } });
-                    session.WoodenSupportsPrependTo = PaintAddImageAsChildRotated(
-                        session, direction,
-                        WoodenRCGetRailsColour(session).WithIndex(SPR_G2_WOODEN_RC_FLAT_TO_STEEP_RAILS + 20), { 0, 0, height },
-                        { { 28, 4, height - 16 }, { 2, 24, 56 } });
-                    PaintAddImageAsParentRotated(
-                        session, direction,
-                        WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_G2_WOODEN_RC_FLAT_TO_STEEP_FRONT + 8),
-                        { 0, 0, height }, { { 28, 4, height + 16 }, { 2, 22, 0 } });
-                    PaintAddImageAsChildRotated(
-                        session, direction,
-                        WoodenRCGetRailsColour(session).WithIndex(SPR_G2_WOODEN_RC_FLAT_TO_STEEP_FRONT_RAILS + 8),
-                        { 0, 0, height }, { { 28, 4, height + 16 }, { 2, 22, 0 } });
+                    session.WoodenSupportsPrependTo = WoodenRCTrackPaint<isClassic>(
+                        session, direction, SPR_G2_WOODEN_RC_FLAT_TO_STEEP + 20, SPR_G2_WOODEN_RC_FLAT_TO_STEEP_RAILS + 20,
+                        { 0, 0, height }, { { 28, 4, height - 16 }, { 2, 24, 76 } });
                     break;
                 case 2:
-                    session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
-                        session, direction,
-                        WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_G2_WOODEN_RC_FLAT_TO_STEEP + 24),
-                        { 0, 0, height }, { { 28, 4, height - 16 }, { 2, 24, 56 } });
-                    session.WoodenSupportsPrependTo = PaintAddImageAsChildRotated(
-                        session, direction,
-                        WoodenRCGetRailsColour(session).WithIndex(SPR_G2_WOODEN_RC_FLAT_TO_STEEP_RAILS + 24), { 0, 0, height },
-                        { { 28, 4, height - 16 }, { 2, 24, 56 } });
-                    PaintAddImageAsParentRotated(
-                        session, direction,
-                        WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_G2_WOODEN_RC_FLAT_TO_STEEP_FRONT + 12),
-                        { 0, 0, height }, { { 28, 4, height + 16 }, { 2, 22, 0 } });
-                    PaintAddImageAsChildRotated(
-                        session, direction,
-                        WoodenRCGetRailsColour(session).WithIndex(SPR_G2_WOODEN_RC_FLAT_TO_STEEP_FRONT_RAILS + 12),
-                        { 0, 0, height }, { { 28, 4, height + 16 }, { 2, 22, 0 } });
+                    session.WoodenSupportsPrependTo = WoodenRCTrackPaint<isClassic>(
+                        session, direction, SPR_G2_WOODEN_RC_FLAT_TO_STEEP + 24, SPR_G2_WOODEN_RC_FLAT_TO_STEEP_RAILS + 24,
+                        { 0, 0, height }, { { 28, 4, height - 16 }, { 2, 24, 76 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(


### PR DESCRIPTION
This fixes the railing on the wooden flat to steep pieces from drawing in front of track in front of them.

![railsinfront](https://github.com/user-attachments/assets/2f406d49-2de9-4b96-877f-e246f2a62f40)

Unfortunately this doesn't fix this issue with the supports which is related to prepending and also happens with the vanilla pieces that use it.
![supportsinfront](https://github.com/user-attachments/assets/cc796e47-6397-4afd-b7e5-bd520812078b)
