### PR TITLE
Add Linux searchable paths created by game-data-packager

### DIFF
--- a/src/openrct2/platform/Platform.Linux.cpp
+++ b/src/openrct2/platform/Platform.Linux.cpp
@@ -337,7 +337,7 @@ namespace OpenRCT2::Platform
     {
         return {
             // game-data-packager uses this path when installing game files
-            R"(/usr/share/games/roller-coaster-tycoon)",
+            "/usr/share/games/roller-coaster-tycoon",
         };
     }
 
@@ -345,7 +345,7 @@ namespace OpenRCT2::Platform
     {
         return {
             // game-data-packager uses this path when installing game files
-            R"(/usr/share/games/roller-coaster-tycoon2)",
+            "/usr/share/games/roller-coaster-tycoon2",
         };
     }
 

--- a/src/openrct2/platform/Platform.Linux.cpp
+++ b/src/openrct2/platform/Platform.Linux.cpp
@@ -335,12 +335,18 @@ namespace OpenRCT2::Platform
 
     std::vector<std::string_view> GetSearchablePathsRCT1()
     {
-        return {};
+        return {
+            // game-data-packager uses this path when installing game files
+            R"(/usr/share/games/roller-coaster-tycoon)",
+        };
     }
 
     std::vector<std::string_view> GetSearchablePathsRCT2()
     {
-        return {};
+        return {
+            // game-data-packager uses this path when installing game files
+            R"(/usr/share/games/roller-coaster-tycoon2)",
+        };
     }
 
 #    ifndef NO_TTF


### PR DESCRIPTION
With the changes in #22819, it seems reasonable to add a couple of default searchable paths for Linux that are created by the `game-data-packager` utility, available in Debian and its various derivatives.

Debian packaging has had these additional paths for a while now, and with the refactoring into platform-specific helper functions I think it would be good to get this included upstream.