### PR TITLE
Fix fuzzy horizontal-to-vertical line transitions in charts

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#22918] Zooming with keyboard moves the view off centre.
 - Fix: [#22921] Wooden RollerCoaster flat to steep railings appear in front of track in front of them.
+- Fix: [#22962] Fuzzy horizontal-to-vertical line transitions in charts.
 
 0.4.15 (2024-10-06)
 ------------------------------------------------------------------------

--- a/src/openrct2/drawing/Line.cpp
+++ b/src/openrct2/drawing/Line.cpp
@@ -154,7 +154,7 @@ void GfxDrawLineSoftware(DrawPixelInfo& dpi, const ScreenLine& line, int32_t col
 
             // Reset non vertical line vars
             x_start = x + 1;
-            no_pixels = 1;
+            no_pixels = 0; // NB: will be incremented in next iteration
             y += y_step;
             error += delta_x;
         }

--- a/src/openrct2/drawing/Line.cpp
+++ b/src/openrct2/drawing/Line.cpp
@@ -139,7 +139,7 @@ void GfxDrawLineSoftware(DrawPixelInfo& dpi, const ScreenLine& line, int32_t col
     else
         y_step = -1;
 
-    for (int32_t x = x1, x_start = x1, no_pixels = 1; x < x2; ++x, ++no_pixels)
+    for (int32_t x = x1, x_start = x1, length = 1; x < x2; ++x, ++length)
     {
         // Vertical lines are drawn 1 pixel at a time
         if (steep)
@@ -150,11 +150,11 @@ void GfxDrawLineSoftware(DrawPixelInfo& dpi, const ScreenLine& line, int32_t col
         {
             // Non vertical lines are drawn with as many pixels in a horizontal line as possible
             if (!steep)
-                GfxDrawLineOnBuffer(dpi, colour, { x_start, y }, no_pixels);
+                GfxDrawLineOnBuffer(dpi, colour, { x_start, y }, length);
 
             // Reset non vertical line vars
             x_start = x + 1;
-            no_pixels = 0; // NB: will be incremented in next iteration
+            length = 0; // NB: will be incremented in next iteration
             y += y_step;
             error += delta_x;
         }
@@ -162,7 +162,7 @@ void GfxDrawLineSoftware(DrawPixelInfo& dpi, const ScreenLine& line, int32_t col
         // Catch the case of the last line
         if (x + 1 == x2 && !steep)
         {
-            GfxDrawLineOnBuffer(dpi, colour, { x_start, y }, no_pixels);
+            GfxDrawLineOnBuffer(dpi, colour, { x_start, y }, length);
         }
     }
 }


### PR DESCRIPTION
Before:
![Forest Frontiers 2024-10-12 00-22-12](https://github.com/user-attachments/assets/3f30d75d-4d3c-4d4a-bc4d-c52dfb54c581)

After:
![Forest Frontiers 2024-10-12 00-23-28](https://github.com/user-attachments/assets/dbea5774-9429-4f76-84f8-fdbaedbaa00c)

Issue was discovered while working on https://github.com/OpenLoco/OpenLoco/pull/2646.