### PR TITLE
Fix PatrolArea and AudioSource memory leaks

### DIFF
--- a/src/openrct2-ui/audio/AudioContext.cpp
+++ b/src/openrct2-ui/audio/AudioContext.cpp
@@ -90,6 +90,7 @@ namespace OpenRCT2::Audio
             }
             catch (const std::exception& e)
             {
+                SDL_RWclose(rw);
                 LOG_VERBOSE("Unable to create audio source: %s", e.what());
                 return nullptr;
             }
@@ -119,6 +120,7 @@ namespace OpenRCT2::Audio
             }
             catch (const std::exception& e)
             {
+                SDL_RWclose(rw);
                 LOG_VERBOSE("Unable to create audio source: %s", e.what());
                 return nullptr;
             }

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -685,6 +685,7 @@ void GameLoadOrQuitNoSavePrompt()
         }
         default:
             GameUnloadScripts();
+            ResetAllEntities();
             OpenRCT2Finish();
             break;
     }


### PR DESCRIPTION
This fixes two memory leaks found with the LeakSanitizer:

1. The `PatrolArea` objects are not deleted on game shutdown as the `EntityRegistry` is not cleared. Since it only happens on shutdown, it's quite minor, but I think it's worth fixing to clean up the Sanitizer output.
2. When audio streams fail to load, the `SDL_RW` pointer is left dangling.

There are still two remaining leaks but I don't have much to go off:

```
==58229==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 5184 byte(s) in 4 object(s) allocated from:
    #0 0x7fea56afd891 in malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7fea4edf1321  (/usr/lib/libnvidia-glcore.so.560.35.03+0x9f1321) (BuildId: 9dcacc7a10c4e207f11235357dd8d7cfcd5e1dc2)

Indirect leak of 5216 byte(s) in 2 object(s) allocated from:
    #0 0x7fea56afd1aa in calloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:77
    #1 0x7fea4edf15dd  (/usr/lib/libnvidia-glcore.so.560.35.03+0x9f15dd) (BuildId: 9dcacc7a10c4e207f11235357dd8d7cfcd5e1dc2)

SUMMARY: AddressSanitizer: 10400 byte(s) leaked in 6 allocation(s).

```