### PR TITLE
Fix UB from unaligned load of RLE line offsets

### DIFF
--- a/src/openrct2/drawing/Drawing.Sprite.RLE.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.RLE.cpp
@@ -15,8 +15,7 @@
 template<DrawBlendOp TBlendOp> static void FASTCALL DrawRLESpriteMagnify(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
 {
     auto& paletteMap = args.PalMap;
-    auto lineOffsets = reinterpret_cast<const uint16_t*>(args.SourceImage.offset);
-    auto src0 = args.SourceImage.offset;
+    auto imgData = args.SourceImage.offset;
     auto dst = args.DestinationBits;
     auto srcX = args.SrcX;
     auto srcY = args.SrcY;
@@ -29,7 +28,9 @@ template<DrawBlendOp TBlendOp> static void FASTCALL DrawRLESpriteMagnify(DrawPix
     {
         uint8_t* nextDst = dst + dstLineWidth;
         const int32_t rowNum = zoom.ApplyTo(srcY + y);
-        const uint8_t* data8 = src0 + lineOffsets[rowNum];
+        uint16_t lineOffset;
+        std::memcpy(&lineOffset, &imgData[rowNum * sizeof(uint16_t)], sizeof(uint16_t));
+        const uint8_t* data8 = imgData + lineOffset;
 
         bool lastDataForLine = false;
         int32_t numPixels = 0;

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1549,11 +1549,11 @@ static bool IsPixelPresentBMP(
 /**
  * rct2: 0x0067933B, 0x00679788, 0x00679C4A, 0x0067A117
  */
-static bool IsPixelPresentRLE(const void* data, const int32_t x, const int32_t y)
+static bool IsPixelPresentRLE(const uint8_t* imgData, const int32_t x, const int32_t y)
 {
-    const uint16_t* data16 = static_cast<const uint16_t*>(data);
-    uint16_t startOffset = data16[y];
-    const uint8_t* data8 = static_cast<const uint8_t*>(data) + startOffset;
+    uint16_t lineOffset;
+    std::memcpy(&lineOffset, &imgData[y * sizeof(uint16_t)], sizeof(uint16_t));
+    const uint8_t* data8 = imgData + lineOffset;
 
     bool lastDataLine = false;
     while (!lastDataLine)


### PR DESCRIPTION
Unfortunately reading a 16 bit value is UB if it's unaligned. I've changed the reads to memcpys which are defined behaviour.

@duncanspumpkin the same would be true for the OpenLoco code that uses this algorithm.