### PR TITLE
Remove void* obj from RideEntry

### DIFF
--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1275,19 +1275,19 @@ namespace OpenRCT2::Ui::Windows
             if (GetSelectedObjectType() == ObjectType::Ride)
             {
                 auto* rideObject = reinterpret_cast<RideObject*>(_loadedObject.get());
-                const auto* rideEntry = reinterpret_cast<RideObjectEntry*>(rideObject->GetLegacyData());
-                if (rideEntry->shop_item[0] != ShopItem::None)
+                const auto& rideEntry = rideObject->GetEntry();
+                if (rideEntry.shop_item[0] != ShopItem::None)
                 {
                     std::string sells = "";
-                    for (size_t i = 0; i < std::size(rideEntry->shop_item); i++)
+                    for (size_t i = 0; i < std::size(rideEntry.shop_item); i++)
                     {
-                        if (rideEntry->shop_item[i] == ShopItem::None)
+                        if (rideEntry.shop_item[i] == ShopItem::None)
                             continue;
 
                         if (!sells.empty())
                             sells += ", ";
 
-                        sells += LanguageGetString(GetShopItemDescriptor(rideEntry->shop_item[i]).Naming.Plural);
+                        sells += LanguageGetString(GetShopItemDescriptor(rideEntry.shop_item[i]).Naming.Plural);
                     }
                     auto ft = Formatter();
                     ft.Add<const char*>(sells.c_str());

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -682,22 +682,23 @@ namespace OpenRCT2::Ui::Windows
                     continue;
 
                 // Ride entries
-                const auto* rideEntry = GetRideEntryByIndex(rideEntryIndex);
+                auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
+                auto rideObj = static_cast<const RideObject*>(objMgr.GetLoadedObject(ObjectType::Ride, rideEntryIndex));
 
                 // Skip if the vehicle isn't the preferred vehicle for this generic track type
                 if (!Config::Get().interface.ListRideVehiclesSeparately
                     && !GetRideTypeDescriptor(rideType).HasFlag(RtdFlag::listVehiclesSeparately)
-                    && highestVehiclePriority > rideEntry->BuildMenuPriority)
+                    && highestVehiclePriority > rideObj->GetEntry().BuildMenuPriority)
                 {
                     continue;
                 }
 
-                if (!IsFiltered(*rideEntry))
+                if (!IsFiltered(*rideObj))
                 {
                     continue;
                 }
 
-                highestVehiclePriority = rideEntry->BuildMenuPriority;
+                highestVehiclePriority = rideObj->GetEntry().BuildMenuPriority;
 
                 // Determines how and where to draw a button for this ride type/vehicle.
                 if (Config::Get().interface.ListRideVehiclesSeparately
@@ -729,7 +730,7 @@ namespace OpenRCT2::Ui::Windows
                 else if (allowDrawingOverLastButton)
                 {
                     // Non-separate, draw over previous
-                    if (rideType == rideEntry->ride_type[0])
+                    if (rideType == rideObj->GetEntry().ride_type[0])
                     {
                         nextListItem--;
                         nextListItem->Type = rideType;
@@ -742,13 +743,13 @@ namespace OpenRCT2::Ui::Windows
             return nextListItem;
         }
 
-        bool IsFiltered(const RideObjectEntry& rideEntry)
+        bool IsFiltered(const RideObject& rideObject)
         {
             if (_filter.empty())
                 return true;
 
-            return IsFilterInRideType(rideEntry) || IsFilterInRideName(rideEntry) || IsFilterInIdentifier(rideEntry)
-                || IsFilterInAuthors(rideEntry) || IsFilterInFilename(rideEntry);
+            return IsFilterInRideType(rideObject.GetEntry()) || IsFilterInRideName(rideObject.GetEntry())
+                || IsFilterInIdentifier(rideObject) || IsFilterInAuthors(rideObject) || IsFilterInFilename(rideObject);
         }
 
         bool IsFilterInRideType(const RideObjectEntry& rideEntry)
@@ -763,30 +764,27 @@ namespace OpenRCT2::Ui::Windows
             return String::Contains(u8string_view(LanguageGetString(rideName)), _filter, true);
         }
 
-        bool IsFilterInAuthors(const RideObjectEntry& rideEntry)
+        bool IsFilterInAuthors(const RideObject& rideObject)
         {
-            auto rideObject = static_cast<RideObject*>(rideEntry.obj);
-            auto authors = rideObject->GetAuthors();
+            auto& authors = rideObject.GetAuthors();
 
-            for (auto author : authors)
+            for (auto& author : authors)
                 if (String::Contains(author, _filter, true))
                     return true;
 
             return false;
         }
 
-        bool IsFilterInIdentifier(const RideObjectEntry& rideEntry)
+        bool IsFilterInIdentifier(const RideObject& rideObject)
         {
-            auto rideObject = static_cast<RideObject*>(rideEntry.obj);
-            auto objectName = rideObject->GetObjectEntry().GetName();
+            auto objectName = rideObject.GetObjectEntry().GetName();
 
             return String::Contains(objectName, _filter, true);
         }
 
-        bool IsFilterInFilename(const RideObjectEntry& rideEntry)
+        bool IsFilterInFilename(const RideObject& rideObject)
         {
-            auto rideObject = static_cast<RideObject*>(rideEntry.obj);
-            auto repoItem = ObjectRepositoryFindObjectByEntry(&(rideObject->GetObjectEntry()));
+            auto repoItem = ObjectRepositoryFindObjectByEntry(&(rideObject.GetObjectEntry()));
 
             return String::Contains(repoItem->Path, _filter, true);
         }
@@ -919,8 +917,10 @@ namespace OpenRCT2::Ui::Windows
 
         void DrawRideInformation(DrawPixelInfo& dpi, RideSelection item, const ScreenCoordsXY& screenPos, int32_t textWidth)
         {
-            const auto* rideEntry = GetRideEntryByIndex(item.EntryIndex);
-            RideNaming rideNaming = GetRideNaming(item.Type, *rideEntry);
+            auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
+            auto rideObj = static_cast<const RideObject*>(objMgr.GetLoadedObject(ObjectType::Ride, item.EntryIndex));
+            const auto& rideEntry = rideObj->GetEntry();
+            RideNaming rideNaming = GetRideNaming(item.Type, rideEntry);
             auto ft = Formatter();
 
             UpdateVehicleAvailability(item.Type);
@@ -935,7 +935,7 @@ namespace OpenRCT2::Ui::Windows
                 if (Config::Get().interface.ListRideVehiclesSeparately)
                 {
                     ft = Formatter();
-                    ft.Add<StringId>(rideEntry->naming.Name);
+                    ft.Add<StringId>(rideEntry.naming.Name);
                     DrawTextEllipsised(
                         dpi, screenPos + ScreenCoordsXY{ 0, 39 }, WindowWidth - 2, STR_NEW_RIDE_VEHICLE_NAME, ft);
                 }
@@ -976,8 +976,7 @@ namespace OpenRCT2::Ui::Windows
             // Draw object author(s) if debugging tools are active
             if (Config::Get().general.DebuggingTools)
             {
-                auto rideObject = static_cast<RideObject*>(rideEntry->obj);
-                auto repoItem = ObjectRepositoryFindObjectByEntry(&(rideObject->GetObjectEntry()));
+                auto repoItem = ObjectRepositoryFindObjectByEntry(&(rideObj->GetObjectEntry()));
 
                 StringId authorStringId = repoItem->Authors.size() > 1 ? STR_AUTHORS_STRING : STR_AUTHOR_STRING;
 

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -740,11 +740,9 @@ private:
             if (rideObject == nullptr)
                 continue;
 
-            const auto* entry = static_cast<RideObjectEntry*>(rideObject->GetLegacyData());
-            if (entry == nullptr)
-                continue;
+            const auto& entry = rideObject->GetEntry();
 
-            for (auto rideType : entry->ride_type)
+            for (auto rideType : entry.ride_type)
             {
                 if (rideType < _rideTypeToObjectMap.size())
                 {

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -265,8 +265,6 @@ void RideObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
 
 void RideObject::Load()
 {
-    _legacyType.obj = this;
-
     GetStringTable().Sort();
     _legacyType.naming.Name = LanguageAllocateObjectString(GetName());
     _legacyType.naming.Description = LanguageAllocateObjectString(GetDescription());

--- a/src/openrct2/object/RideObject.h
+++ b/src/openrct2/object/RideObject.h
@@ -30,6 +30,10 @@ public:
     {
         return &_legacyType;
     }
+    const RideObjectEntry& GetEntry() const
+    {
+        return _legacyType;
+    }
 
     void ReadJson(IReadObjectContext* context, json_t& root) override;
     void ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream) override;

--- a/src/openrct2/rct2/T6Importer.cpp
+++ b/src/openrct2/rct2/T6Importer.cpp
@@ -218,12 +218,9 @@ namespace OpenRCT2::RCT2
                 auto rawObject = ObjectRepositoryLoadObject(&td->trackAndVehicle.vehicleObject.Entry);
                 if (rawObject != nullptr)
                 {
-                    const auto* rideEntry = static_cast<const RideObjectEntry*>(
-                        static_cast<RideObject*>(rawObject.get())->GetLegacyData());
-                    if (rideEntry != nullptr)
-                    {
-                        td->trackAndVehicle.rtdIndex = RCT2RideTypeToOpenRCT2RideType(td->trackAndVehicle.rtdIndex, *rideEntry);
-                    }
+                    const auto& rideEntry = static_cast<RideObject*>(rawObject.get())->GetEntry();
+
+                    td->trackAndVehicle.rtdIndex = RCT2RideTypeToOpenRCT2RideType(td->trackAndVehicle.rtdIndex, rideEntry);
                     rawObject->Unload();
                 }
             }

--- a/src/openrct2/ride/RideEntry.h
+++ b/src/openrct2/ride/RideEntry.h
@@ -72,7 +72,6 @@ struct RideObjectEntry
     uint8_t max_height;
     ShopItem shop_item[OpenRCT2::RCT2::ObjectLimits::MaxShopItemsPerRideEntry];
     StringId capacity;
-    void* obj;
     uint8_t Clearance;
 
     const CarEntry* GetCar(size_t id) const

--- a/src/openrct2/scripting/bindings/object/ScObject.hpp
+++ b/src/openrct2/scripting/bindings/object/ScObject.hpp
@@ -488,7 +488,7 @@ namespace OpenRCT2::Scripting
             return 0;
         }
 
-        Object* GetObject() const
+        const RideObject* GetObject() const
         {
             auto& objManager = GetContext()->GetObjectManager();
             return static_cast<RideObject*>(objManager.GetLoadedObject(_objectType, _objectIndex));
@@ -499,7 +499,7 @@ namespace OpenRCT2::Scripting
             auto obj = GetObject();
             if (obj != nullptr)
             {
-                auto rideEntry = static_cast<RideObjectEntry*>(obj->GetLegacyData());
+                auto rideEntry = &obj->GetEntry();
                 if (rideEntry != nullptr && _vehicleIndex < std::size(rideEntry->Cars))
                 {
                     return rideEntry->GetCar(_vehicleIndex);
@@ -567,7 +567,7 @@ namespace OpenRCT2::Scripting
 
         uint32_t firstImageId_get() const
         {
-            auto entry = GetLegacyData();
+            auto entry = GetEntry();
             if (entry != nullptr)
             {
                 return entry->images_offset;
@@ -577,7 +577,7 @@ namespace OpenRCT2::Scripting
 
         uint32_t flags_get() const
         {
-            auto entry = GetLegacyData();
+            auto entry = GetEntry();
             if (entry != nullptr)
             {
                 return entry->flags;
@@ -588,7 +588,7 @@ namespace OpenRCT2::Scripting
         std::vector<uint8_t> rideType_get() const
         {
             std::vector<uint8_t> result;
-            auto entry = GetLegacyData();
+            auto entry = GetEntry();
             if (entry != nullptr)
             {
                 for (auto rideType : entry->ride_type)
@@ -601,7 +601,7 @@ namespace OpenRCT2::Scripting
 
         uint8_t minCarsInTrain_get() const
         {
-            auto entry = GetLegacyData();
+            auto entry = GetEntry();
             if (entry != nullptr)
             {
                 return entry->min_cars_in_train;
@@ -611,7 +611,7 @@ namespace OpenRCT2::Scripting
 
         uint8_t maxCarsInTrain_get() const
         {
-            auto entry = GetLegacyData();
+            auto entry = GetEntry();
             if (entry != nullptr)
             {
                 return entry->max_cars_in_train;
@@ -621,7 +621,7 @@ namespace OpenRCT2::Scripting
 
         uint8_t carsPerFlatRide_get() const
         {
-            auto entry = GetLegacyData();
+            auto entry = GetEntry();
             if (entry != nullptr)
             {
                 return entry->cars_per_flat_ride;
@@ -631,7 +631,7 @@ namespace OpenRCT2::Scripting
 
         uint8_t zeroCars_get() const
         {
-            auto entry = GetLegacyData();
+            auto entry = GetEntry();
             if (entry != nullptr)
             {
                 return entry->zero_cars;
@@ -641,7 +641,7 @@ namespace OpenRCT2::Scripting
 
         uint8_t tabVehicle_get() const
         {
-            auto entry = GetLegacyData();
+            auto entry = GetEntry();
             if (entry != nullptr)
             {
                 return entry->TabCar;
@@ -651,7 +651,7 @@ namespace OpenRCT2::Scripting
 
         uint8_t defaultVehicle_get() const
         {
-            auto entry = GetLegacyData();
+            auto entry = GetEntry();
             if (entry != nullptr)
             {
                 return entry->DefaultCar;
@@ -661,7 +661,7 @@ namespace OpenRCT2::Scripting
 
         uint8_t frontVehicle_get() const
         {
-            auto entry = GetLegacyData();
+            auto entry = GetEntry();
             if (entry != nullptr)
             {
                 return entry->FrontCar;
@@ -671,7 +671,7 @@ namespace OpenRCT2::Scripting
 
         uint8_t secondVehicle_get() const
         {
-            auto entry = GetLegacyData();
+            auto entry = GetEntry();
             if (entry != nullptr)
             {
                 return entry->SecondCar;
@@ -681,7 +681,7 @@ namespace OpenRCT2::Scripting
 
         uint8_t rearVehicle_get() const
         {
-            auto entry = GetLegacyData();
+            auto entry = GetEntry();
             if (entry != nullptr)
             {
                 return entry->RearCar;
@@ -691,7 +691,7 @@ namespace OpenRCT2::Scripting
 
         uint8_t thirdVehicle_get() const
         {
-            auto entry = GetLegacyData();
+            auto entry = GetEntry();
             if (entry != nullptr)
             {
                 return entry->ThirdCar;
@@ -702,7 +702,7 @@ namespace OpenRCT2::Scripting
         std::vector<std::shared_ptr<ScRideObjectVehicle>> vehicles_get() const
         {
             std::vector<std::shared_ptr<ScRideObjectVehicle>> result;
-            auto entry = GetLegacyData();
+            auto entry = GetEntry();
             if (entry != nullptr)
             {
                 for (size_t i = 0; i < std::size(entry->Cars); i++)
@@ -715,7 +715,7 @@ namespace OpenRCT2::Scripting
 
         int8_t excitementMultiplier_get() const
         {
-            auto entry = GetLegacyData();
+            auto entry = GetEntry();
             if (entry != nullptr)
             {
                 return entry->excitement_multiplier;
@@ -725,7 +725,7 @@ namespace OpenRCT2::Scripting
 
         int8_t intensityMultiplier_get() const
         {
-            auto entry = GetLegacyData();
+            auto entry = GetEntry();
             if (entry != nullptr)
             {
                 return entry->intensity_multiplier;
@@ -735,7 +735,7 @@ namespace OpenRCT2::Scripting
 
         int8_t nauseaMultiplier_get() const
         {
-            auto entry = GetLegacyData();
+            auto entry = GetEntry();
             if (entry != nullptr)
             {
                 return entry->nausea_multiplier;
@@ -745,7 +745,7 @@ namespace OpenRCT2::Scripting
 
         uint8_t maxHeight_get() const
         {
-            auto entry = GetLegacyData();
+            auto entry = GetEntry();
             if (entry != nullptr)
             {
                 return entry->max_height;
@@ -755,7 +755,7 @@ namespace OpenRCT2::Scripting
 
         uint8_t shopItem_get() const
         {
-            auto entry = GetLegacyData();
+            auto entry = GetEntry();
             if (entry != nullptr)
             {
                 return EnumValue(entry->shop_item[0]);
@@ -765,7 +765,7 @@ namespace OpenRCT2::Scripting
 
         uint8_t shopItemSecondary_get() const
         {
-            auto entry = GetLegacyData();
+            auto entry = GetEntry();
             if (entry != nullptr)
             {
                 return EnumValue(entry->shop_item[1]);
@@ -779,12 +779,12 @@ namespace OpenRCT2::Scripting
             return static_cast<RideObject*>(ScObject::GetObject());
         }
 
-        const RideObjectEntry* GetLegacyData() const
+        const RideObjectEntry* GetEntry() const
         {
             auto obj = GetObject();
             if (obj != nullptr)
             {
-                return static_cast<RideObjectEntry*>(obj->GetLegacyData());
+                return &obj->GetEntry();
             }
             return nullptr;
         }


### PR DESCRIPTION
The void* obj in the ride entry was used to point to the object but all users were first getting the object to get the entry to then get the object. Better to just get the object if you need the object.

Also added a helper method for getting the entry as part of future work to improve the object interface.