### PR TITLE
Reduce casting for objects

### DIFF
--- a/src/openrct2-ui/interface/LandTool.cpp
+++ b/src/openrct2-ui/interface/LandTool.cpp
@@ -60,7 +60,7 @@ void LandTool::ShowSurfaceStyleDropdown(WindowBase* w, Widget* widget, ObjectEnt
     auto itemIndex = 0;
     for (size_t i = 0; i < kMaxTerrainSurfaceObjects; i++)
     {
-        const auto surfaceObj = static_cast<TerrainSurfaceObject*>(objManager.GetLoadedObject(ObjectType::TerrainSurface, i));
+        const auto surfaceObj = objManager.GetLoadedObject<TerrainSurfaceObject>(i);
         // If fallback images are loaded, the RCT1 styles will just look like copies of already existing styles, so hide them.
         if (surfaceObj != nullptr && !surfaceObj->UsesFallbackImages())
         {
@@ -92,7 +92,7 @@ ObjectEntryIndex LandTool::GetSurfaceStyleFromDropdownIndex(size_t index)
     auto itemIndex = 0U;
     for (size_t i = 0; i < kMaxTerrainSurfaceObjects; i++)
     {
-        const auto surfaceObj = static_cast<TerrainSurfaceObject*>(objManager.GetLoadedObject(ObjectType::TerrainSurface, i));
+        const auto surfaceObj = objManager.GetLoadedObject<TerrainSurfaceObject>(i);
         // If fallback images are loaded, the RCT1 styles will just look like copies of already existing styles, so hide them.
         if (surfaceObj != nullptr && !surfaceObj->UsesFallbackImages())
         {
@@ -114,7 +114,7 @@ void LandTool::ShowEdgeStyleDropdown(WindowBase* w, Widget* widget, ObjectEntryI
     auto itemIndex = 0;
     for (size_t i = 0; i < kMaxTerrainEdgeObjects; i++)
     {
-        const auto edgeObj = static_cast<TerrainEdgeObject*>(objManager.GetLoadedObject(ObjectType::TerrainEdge, i));
+        const auto edgeObj = objManager.GetLoadedObject<TerrainEdgeObject>(i);
         // If fallback images are loaded, the RCT1 styles will just look like copies of already existing styles, so hide them.
         if (edgeObj != nullptr && !edgeObj->UsesFallbackImages())
         {
@@ -143,7 +143,7 @@ ObjectEntryIndex LandTool::GetEdgeStyleFromDropdownIndex(size_t index)
     auto itemIndex = 0U;
     for (size_t i = 0; i < kMaxTerrainEdgeObjects; i++)
     {
-        const auto edgeObj = static_cast<TerrainEdgeObject*>(objManager.GetLoadedObject(ObjectType::TerrainEdge, i));
+        const auto edgeObj = objManager.GetLoadedObject<TerrainEdgeObject>(i);
         // If fallback images are loaded, the RCT1 styles will just look like copies of already existing styles, so hide them.
         if (edgeObj != nullptr && !edgeObj->UsesFallbackImages())
         {

--- a/src/openrct2-ui/windows/EditorParkEntrance.cpp
+++ b/src/openrct2-ui/windows/EditorParkEntrance.cpp
@@ -79,7 +79,7 @@ namespace OpenRCT2::Ui::Windows
             for (ObjectEntryIndex objectIndex = 0; objectIndex < kMaxParkEntranceObjects; objectIndex++)
             {
                 auto& objManager = GetContext()->GetObjectManager();
-                auto* object = static_cast<EntranceObject*>(objManager.GetLoadedObject(ObjectType::ParkEntrance, objectIndex));
+                auto* object = objManager.GetLoadedObject<EntranceObject>(objectIndex);
                 if (object != nullptr)
                 {
                     const auto* legacyData = reinterpret_cast<const EntranceEntry*>(object->GetLegacyData());

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -715,7 +715,7 @@ namespace OpenRCT2::Ui::Windows
 
             for (ObjectEntryIndex i = 0; i < kMaxPathObjects; i++)
             {
-                auto* pathObj = static_cast<FootpathObject*>(objManager.GetLoadedObject(ObjectType::Paths, i));
+                auto* pathObj = objManager.GetLoadedObject<FootpathObject>(i);
                 if (pathObj == nullptr)
                 {
                     continue;

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -638,7 +638,7 @@ namespace OpenRCT2::Ui::Windows
         ImageIndex GetRideImage(RideSelection rideSelection)
         {
             auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
-            auto obj = static_cast<RideObject*>(objMgr.GetLoadedObject(ObjectType::Ride, rideSelection.EntryIndex));
+            auto obj = objMgr.GetLoadedObject<RideObject>(rideSelection.EntryIndex);
             return obj == nullptr ? ImageIndexUndefined : obj->GetPreviewImage(rideSelection.Type);
         }
 
@@ -683,7 +683,7 @@ namespace OpenRCT2::Ui::Windows
 
                 // Ride entries
                 auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
-                auto rideObj = static_cast<const RideObject*>(objMgr.GetLoadedObject(ObjectType::Ride, rideEntryIndex));
+                auto* rideObj = objMgr.GetLoadedObject<RideObject>(rideEntryIndex);
 
                 // Skip if the vehicle isn't the preferred vehicle for this generic track type
                 if (!Config::Get().interface.ListRideVehiclesSeparately
@@ -918,7 +918,7 @@ namespace OpenRCT2::Ui::Windows
         void DrawRideInformation(DrawPixelInfo& dpi, RideSelection item, const ScreenCoordsXY& screenPos, int32_t textWidth)
         {
             auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
-            auto rideObj = static_cast<const RideObject*>(objMgr.GetLoadedObject(ObjectType::Ride, item.EntryIndex));
+            const auto* rideObj = objMgr.GetLoadedObject<RideObject>(item.EntryIndex);
             const auto& rideEntry = rideObj->GetEntry();
             RideNaming rideNaming = GetRideNaming(item.Type, rideEntry);
             auto ft = Formatter();

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2113,7 +2113,7 @@ namespace OpenRCT2::Ui::Windows
 
             for (ObjectEntryIndex i = 0; i < kMaxStationObjects; i++)
             {
-                auto stationObj = static_cast<StationObject*>(objManager.GetLoadedObject(ObjectType::Station, i));
+                auto stationObj = objManager.GetLoadedObject<StationObject>(i);
                 if (stationObj != nullptr)
                 {
                     auto name = stationObj->NameStringId;
@@ -5055,7 +5055,7 @@ namespace OpenRCT2::Ui::Windows
         static std::string GetMusicString(ObjectEntryIndex musicObjectIndex)
         {
             auto& objManager = GetContext()->GetObjectManager();
-            auto musicObj = static_cast<MusicObject*>(objManager.GetLoadedObject(ObjectType::Music, musicObjectIndex));
+            auto musicObj = objManager.GetLoadedObject<MusicObject>(musicObjectIndex);
 
             return LanguageGetString(musicObj->NameStringId);
         }
@@ -5080,7 +5080,7 @@ namespace OpenRCT2::Ui::Windows
             auto& objManager = GetContext()->GetObjectManager();
             for (ObjectEntryIndex i = 0; i < kMaxMusicObjects; i++)
             {
-                auto musicObj = static_cast<MusicObject*>(objManager.GetLoadedObject(ObjectType::Music, i));
+                auto musicObj = objManager.GetLoadedObject<MusicObject>(i);
                 if (musicObj != nullptr)
                 {
                     // Hide custom music if the WAV file does not exist
@@ -5119,7 +5119,7 @@ namespace OpenRCT2::Ui::Windows
             auto numItems = musicOrder.size();
             for (size_t i = 0; i < numItems; i++)
             {
-                auto musicObj = static_cast<MusicObject*>(objManager.GetLoadedObject(ObjectType::Music, musicOrder[i]));
+                auto musicObj = objManager.GetLoadedObject<MusicObject>(musicOrder[i]);
                 gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
                 gDropdownItems[i].Args = musicObj->NameStringId;
             }

--- a/src/openrct2/actions/SurfaceSetStyleAction.cpp
+++ b/src/openrct2/actions/SurfaceSetStyleAction.cpp
@@ -67,7 +67,7 @@ GameActions::Result SurfaceSetStyleAction::Query() const
 
     if (_edgeStyle != OBJECT_ENTRY_INDEX_NULL)
     {
-        const auto edgeObj = static_cast<TerrainEdgeObject*>(objManager.GetLoadedObject(ObjectType::TerrainEdge, _edgeStyle));
+        const auto edgeObj = objManager.GetLoadedObject<TerrainEdgeObject>(_edgeStyle);
 
         if (edgeObj == nullptr)
         {

--- a/src/openrct2/localisation/Formatting.cpp
+++ b/src/openrct2/localisation/Formatting.cpp
@@ -292,7 +292,7 @@ namespace OpenRCT2
         if (IsRealNameStringId(id))
         {
             auto& objManager = GetContext()->GetObjectManager();
-            auto* peepNamesObj = static_cast<PeepNamesObject*>(objManager.GetLoadedObject(ObjectType::PeepNames, 0));
+            auto* peepNamesObj = objManager.GetLoadedObject<PeepNamesObject>(0);
             if (peepNamesObj != nullptr)
             {
                 auto realNameIndex = id - kRealNameStart;

--- a/src/openrct2/object/AudioObject.h
+++ b/src/openrct2/object/AudioObject.h
@@ -23,6 +23,8 @@ private:
     AudioSampleTable _loadedSampleTable;
 
 public:
+    static constexpr ObjectType objectType = ObjectType::Audio;
+
     void ReadJson(IReadObjectContext* context, json_t& root) override;
     void Load() override;
     void Unload() override;

--- a/src/openrct2/object/BannerObject.h
+++ b/src/openrct2/object/BannerObject.h
@@ -19,6 +19,8 @@ private:
     BannerSceneryEntry _legacyType = {};
 
 public:
+    static constexpr ObjectType objectType = ObjectType::Banners;
+
     void* GetLegacyData() override
     {
         return &_legacyType;

--- a/src/openrct2/object/EntranceObject.h
+++ b/src/openrct2/object/EntranceObject.h
@@ -20,6 +20,8 @@ private:
     EntranceEntry _legacyType = {};
 
 public:
+    static constexpr ObjectType objectType = ObjectType::ParkEntrance;
+
     void* GetLegacyData() override
     {
         return &_legacyType;

--- a/src/openrct2/object/FootpathObject.h
+++ b/src/openrct2/object/FootpathObject.h
@@ -22,6 +22,8 @@ private:
     PathRailingsDescriptor _pathRailingsDescriptor = {};
 
 public:
+    static constexpr ObjectType objectType = ObjectType::Paths;
+
     void* GetLegacyData() override
     {
         return &_legacyType;

--- a/src/openrct2/object/FootpathRailingsObject.h
+++ b/src/openrct2/object/FootpathRailingsObject.h
@@ -26,6 +26,8 @@ public:
     PathRailingsDescriptor _descriptor = {};
 
 public:
+    static constexpr ObjectType objectType = ObjectType::FootpathRailings;
+
     void ReadJson(IReadObjectContext* context, json_t& root) override;
     void Load() override;
     void Unload() override;

--- a/src/openrct2/object/FootpathSurfaceObject.h
+++ b/src/openrct2/object/FootpathSurfaceObject.h
@@ -22,6 +22,8 @@ public:
     PathSurfaceDescriptor _descriptor = {};
 
 public:
+    static constexpr ObjectType objectType = ObjectType::FootpathSurface;
+
     void ReadJson(IReadObjectContext* context, json_t& root) override;
     void Load() override;
     void Unload() override;

--- a/src/openrct2/object/LargeSceneryObject.h
+++ b/src/openrct2/object/LargeSceneryObject.h
@@ -24,6 +24,8 @@ private:
     std::unique_ptr<LargeSceneryText> _3dFont;
 
 public:
+    static constexpr ObjectType objectType = ObjectType::LargeScenery;
+
     void* GetLegacyData() override
     {
         return &_legacyType;

--- a/src/openrct2/object/MusicObject.h
+++ b/src/openrct2/object/MusicObject.h
@@ -53,6 +53,8 @@ private:
     uint32_t _previewImageId{};
 
 public:
+    static constexpr ObjectType objectType = ObjectType::Music;
+
     StringId NameStringId{};
 
     void ReadJson(IReadObjectContext* context, json_t& root) override;

--- a/src/openrct2/object/ObjectManager.h
+++ b/src/openrct2/object/ObjectManager.h
@@ -26,6 +26,10 @@ struct IObjectManager
     }
 
     virtual Object* GetLoadedObject(ObjectType objectType, size_t index) = 0;
+    template<typename TClass> TClass* GetLoadedObject(size_t index)
+    {
+        return static_cast<TClass*>(GetLoadedObject(TClass::objectType, index));
+    }
     virtual Object* GetLoadedObject(const ObjectEntryDescriptor& entry) = 0;
     virtual ObjectEntryIndex GetLoadedObjectEntryIndex(std::string_view identifier) = 0;
     virtual ObjectEntryIndex GetLoadedObjectEntryIndex(const ObjectEntryDescriptor& descriptor) = 0;

--- a/src/openrct2/object/PathAdditionObject.h
+++ b/src/openrct2/object/PathAdditionObject.h
@@ -18,6 +18,8 @@ private:
     PathAdditionEntry _legacyType = {};
 
 public:
+    static constexpr ObjectType objectType = ObjectType::PathAdditions;
+
     void* GetLegacyData() override
     {
         return &_legacyType;

--- a/src/openrct2/object/PeepNamesObject.h
+++ b/src/openrct2/object/PeepNamesObject.h
@@ -22,6 +22,8 @@ private:
     std::vector<std::string> _surnames;
 
 public:
+    static constexpr ObjectType objectType = ObjectType::PeepNames;
+
     void ReadJson(IReadObjectContext* context, json_t& root) override;
     void Load() override;
     void Unload() override;

--- a/src/openrct2/object/RideObject.h
+++ b/src/openrct2/object/RideObject.h
@@ -26,6 +26,8 @@ private:
     std::vector<std::array<CoordsXY, 3>> _peepLoadingWaypoints[OpenRCT2::RCT2::ObjectLimits::MaxCarTypesPerRideEntry];
 
 public:
+    static constexpr ObjectType objectType = ObjectType::Ride;
+
     void* GetLegacyData() override
     {
         return &_legacyType;

--- a/src/openrct2/object/SceneryGroupObject.h
+++ b/src/openrct2/object/SceneryGroupObject.h
@@ -25,6 +25,8 @@ private:
     std::vector<ObjectEntryDescriptor> _items;
 
 public:
+    static constexpr ObjectType objectType = ObjectType::SceneryGroup;
+
     void* GetLegacyData() override
     {
         return &_legacyType;

--- a/src/openrct2/object/SmallSceneryObject.h
+++ b/src/openrct2/object/SmallSceneryObject.h
@@ -22,6 +22,8 @@ private:
     std::vector<uint8_t> _frameOffsets;
 
 public:
+    static constexpr ObjectType objectType = ObjectType::SmallScenery;
+
     void* GetLegacyData() override
     {
         return &_legacyType;

--- a/src/openrct2/object/StationObject.h
+++ b/src/openrct2/object/StationObject.h
@@ -24,6 +24,8 @@ namespace OpenRCT2::STATION_OBJECT_FLAGS
 class StationObject final : public Object
 {
 public:
+    static constexpr ObjectType objectType = ObjectType::Station;
+
     StringId NameStringId{};
     ImageIndex BaseImageId = ImageIndexUndefined;
     ImageIndex ShelterImageId = ImageIndexUndefined;

--- a/src/openrct2/object/TerrainEdgeObject.h
+++ b/src/openrct2/object/TerrainEdgeObject.h
@@ -15,6 +15,8 @@ class TerrainEdgeObject final : public Object
 {
 private:
 public:
+    static constexpr ObjectType objectType = ObjectType::TerrainEdge;
+
     StringId NameStringId{};
     uint32_t IconImageId{};
     uint32_t BaseImageId{};

--- a/src/openrct2/object/TerrainSurfaceObject.h
+++ b/src/openrct2/object/TerrainSurfaceObject.h
@@ -35,6 +35,8 @@ private:
     static constexpr auto kNumImagesInEntry = 19;
 
 public:
+    static constexpr ObjectType objectType = ObjectType::TerrainSurface;
+
     static constexpr uint8_t kNoValue = 0xFF;
     StringId NameStringId{};
     uint32_t IconImageId{};

--- a/src/openrct2/object/WallObject.h
+++ b/src/openrct2/object/WallObject.h
@@ -18,6 +18,8 @@ private:
     WallSceneryEntry _legacyType = {};
 
 public:
+    static constexpr ObjectType objectType = ObjectType::Walls;
+
     void* GetLegacyData() override
     {
         return &_legacyType;

--- a/src/openrct2/object/WaterObject.h
+++ b/src/openrct2/object/WaterObject.h
@@ -20,6 +20,8 @@ private:
     WaterObjectEntry _legacyType = {};
 
 public:
+    static constexpr ObjectType objectType = ObjectType::Water;
+
     void* GetLegacyData() override
     {
         return &_legacyType;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1981,7 +1981,7 @@ void DefaultMusicUpdate(Ride& ride)
     if (ride.music_tune_id == TUNE_ID_NULL)
     {
         auto& objManager = GetContext()->GetObjectManager();
-        auto musicObj = static_cast<MusicObject*>(objManager.GetLoadedObject(ObjectType::Music, ride.music));
+        auto musicObj = objManager.GetLoadedObject<MusicObject>(ride.music);
         if (musicObj != nullptr)
         {
             auto numTracks = musicObj->GetTrackCount();
@@ -5543,13 +5543,13 @@ int32_t RideGetEntryIndex(int32_t rideType, int32_t rideSubType)
 const StationObject* Ride::GetStationObject() const
 {
     auto& objManager = GetContext()->GetObjectManager();
-    return static_cast<StationObject*>(objManager.GetLoadedObject(ObjectType::Station, entrance_style));
+    return objManager.GetLoadedObject<StationObject>(entrance_style);
 }
 
 const MusicObject* Ride::GetMusicObject() const
 {
     auto& objManager = GetContext()->GetObjectManager();
-    return static_cast<MusicObject*>(objManager.GetLoadedObject(ObjectType::Music, music));
+    return objManager.GetLoadedObject<MusicObject>(music);
 }
 
 // Normally, a station has at most one entrance and one exit, which are at the same height

--- a/src/openrct2/ride/RideAudio.cpp
+++ b/src/openrct2/ride/RideAudio.cpp
@@ -170,7 +170,7 @@ namespace OpenRCT2::RideAudio
     {
         auto& objManager = GetContext()->GetObjectManager();
         auto ride = GetRide(instance.RideId);
-        auto musicObj = static_cast<MusicObject*>(objManager.GetLoadedObject(ObjectType::Music, ride->music));
+        auto musicObj = objManager.GetLoadedObject<MusicObject>(ride->music);
         if (musicObj != nullptr)
         {
             auto shouldLoop = musicObj->GetTrackCount() == 1;
@@ -276,7 +276,7 @@ namespace OpenRCT2::RideAudio
     std::pair<size_t, size_t> RideMusicGetTrackOffsetLength_Default(const Ride& ride)
     {
         auto& objManager = GetContext()->GetObjectManager();
-        auto musicObj = static_cast<MusicObject*>(objManager.GetLoadedObject(ObjectType::Music, ride.music));
+        auto musicObj = objManager.GetLoadedObject<MusicObject>(ride.music);
         if (musicObj != nullptr)
         {
             auto numTracks = musicObj->GetTrackCount();

--- a/src/openrct2/scripting/bindings/object/ScObject.hpp
+++ b/src/openrct2/scripting/bindings/object/ScObject.hpp
@@ -158,14 +158,12 @@ namespace OpenRCT2::Scripting
     class ScRideObjectVehicle
     {
     private:
-        ObjectType _objectType{};
         ObjectEntryIndex _objectIndex{};
         size_t _vehicleIndex{};
 
     public:
-        ScRideObjectVehicle(ObjectType objectType, ObjectEntryIndex objectIndex, size_t vehicleIndex)
-            : _objectType(objectType)
-            , _objectIndex(objectIndex)
+        ScRideObjectVehicle(ObjectEntryIndex objectIndex, size_t vehicleIndex)
+            : _objectIndex(objectIndex)
             , _vehicleIndex(vehicleIndex)
         {
         }
@@ -491,7 +489,7 @@ namespace OpenRCT2::Scripting
         const RideObject* GetObject() const
         {
             auto& objManager = GetContext()->GetObjectManager();
-            return static_cast<RideObject*>(objManager.GetLoadedObject(_objectType, _objectIndex));
+            return objManager.GetLoadedObject<RideObject>(_objectIndex);
         }
 
         const CarEntry* GetEntry() const
@@ -707,7 +705,7 @@ namespace OpenRCT2::Scripting
             {
                 for (size_t i = 0; i < std::size(entry->Cars); i++)
                 {
-                    result.push_back(std::make_shared<ScRideObjectVehicle>(static_cast<ObjectType>(_type), _index, i));
+                    result.push_back(std::make_shared<ScRideObjectVehicle>(_index, i));
                 }
             }
             return result;

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1862,7 +1862,7 @@ static bool FootpathIsLegacyPathEntryOkay(ObjectEntryIndex index)
 {
     bool showEditorPaths = ((gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) || GetGameState().Cheats.SandboxMode);
     auto& objManager = OpenRCT2::GetContext()->GetObjectManager();
-    auto footpathObj = static_cast<FootpathObject*>(objManager.GetLoadedObject(ObjectType::Paths, index));
+    auto footpathObj = objManager.GetLoadedObject<FootpathObject>(index);
     if (footpathObj != nullptr)
     {
         auto pathEntry = reinterpret_cast<FootpathEntry*>(footpathObj->GetLegacyData());

--- a/src/openrct2/world/tile_element/EntranceElement.cpp
+++ b/src/openrct2/world/tile_element/EntranceElement.cpp
@@ -80,7 +80,7 @@ ObjectEntryIndex EntranceElement::GetLegacyPathEntryIndex() const
 const FootpathObject* EntranceElement::GetLegacyPathEntry() const
 {
     auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
-    return static_cast<FootpathObject*>(objMgr.GetLoadedObject(ObjectType::Paths, GetLegacyPathEntryIndex()));
+    return objMgr.GetLoadedObject<FootpathObject>(GetLegacyPathEntryIndex());
 }
 
 void EntranceElement::SetLegacyPathEntryIndex(ObjectEntryIndex newPathType)
@@ -100,7 +100,7 @@ ObjectEntryIndex EntranceElement::GetSurfaceEntryIndex() const
 const FootpathSurfaceObject* EntranceElement::GetSurfaceEntry() const
 {
     auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
-    return static_cast<FootpathSurfaceObject*>(objMgr.GetLoadedObject(ObjectType::FootpathSurface, GetSurfaceEntryIndex()));
+    return objMgr.GetLoadedObject<FootpathSurfaceObject>(GetSurfaceEntryIndex());
 }
 
 void EntranceElement::SetSurfaceEntryIndex(ObjectEntryIndex newIndex)

--- a/src/openrct2/world/tile_element/PathElement.cpp
+++ b/src/openrct2/world/tile_element/PathElement.cpp
@@ -254,7 +254,7 @@ ObjectEntryIndex PathElement::GetSurfaceEntryIndex() const
 const FootpathSurfaceObject* PathElement::GetSurfaceEntry() const
 {
     auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
-    return static_cast<FootpathSurfaceObject*>(objMgr.GetLoadedObject(ObjectType::FootpathSurface, GetSurfaceEntryIndex()));
+    return objMgr.GetLoadedObject<FootpathSurfaceObject>(GetSurfaceEntryIndex());
 }
 
 void PathElement::SetSurfaceEntryIndex(ObjectEntryIndex newIndex)
@@ -274,7 +274,7 @@ ObjectEntryIndex PathElement::GetRailingsEntryIndex() const
 const FootpathRailingsObject* PathElement::GetRailingsEntry() const
 {
     auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
-    return static_cast<FootpathRailingsObject*>(objMgr.GetLoadedObject(ObjectType::FootpathRailings, GetRailingsEntryIndex()));
+    return objMgr.GetLoadedObject<FootpathRailingsObject>(GetRailingsEntryIndex());
 }
 
 void PathElement::SetRailingsEntryIndex(ObjectEntryIndex newEntryIndex)

--- a/src/openrct2/world/tile_element/SurfaceElement.cpp
+++ b/src/openrct2/world/tile_element/SurfaceElement.cpp
@@ -26,7 +26,7 @@ ObjectEntryIndex SurfaceElement::GetSurfaceObjectIndex() const
 TerrainSurfaceObject* SurfaceElement::GetSurfaceObject() const
 {
     auto& objManager = OpenRCT2::GetContext()->GetObjectManager();
-    return static_cast<TerrainSurfaceObject*>(objManager.GetLoadedObject(ObjectType::TerrainSurface, GetSurfaceObjectIndex()));
+    return objManager.GetLoadedObject<TerrainSurfaceObject>(GetSurfaceObjectIndex());
 }
 
 ObjectEntryIndex SurfaceElement::GetEdgeObjectIndex() const
@@ -37,7 +37,7 @@ ObjectEntryIndex SurfaceElement::GetEdgeObjectIndex() const
 TerrainEdgeObject* SurfaceElement::GetEdgeObject() const
 {
     auto& objManager = OpenRCT2::GetContext()->GetObjectManager();
-    return static_cast<TerrainEdgeObject*>(objManager.GetLoadedObject(ObjectType::TerrainEdge, GetEdgeObjectIndex()));
+    return objManager.GetLoadedObject<TerrainEdgeObject>(GetEdgeObjectIndex());
 }
 
 void SurfaceElement::SetSurfaceObjectIndex(ObjectEntryIndex newStyle)


### PR DESCRIPTION
Using a trick I nicked from the tile elements, I was able to massive reduce the need for static casts on retrieving objects.