### PR TITLE
Close windows before loading another save

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Fix: [#22921] Wooden RollerCoaster flat to steep railings appear in front of track in front of them.
 - Fix: [#22962] Fuzzy horizontal-to-vertical line transitions in charts.
 - Fix: [#23009] Scenarios from RCT Classic (.sea files) are not included in the scenario index.
+- Fix: [#23015] Crash when loading a save game when the construction window is still open.
 
 0.4.15 (2024-10-06)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -267,6 +267,11 @@ namespace OpenRCT2::Ui::Windows
         char pathBuffer[MAX_PATH];
         SafeStrCpy(pathBuffer, path, sizeof(pathBuffer));
 
+        // Closing this will cause a Ride window to pop up, so we have to do this to ensure that
+        // no windows are open (besides the toolbars and LoadSave window).
+        WindowCloseByClass(WindowClass::RideConstruction);
+        WindowCloseAllExceptClass(WindowClass::Loadsave);
+
         auto& gameState = GetGameState();
 
         switch (_type & 0x0F)


### PR DESCRIPTION
This will hopefully put a stopper on all those `std::_Narrow_char_traits` crashes we have seen, all of which seem to involve loading up another game when having certain windows open. The construction window seems to be involved rather often. It appears as if the game is trying to draw strings that no longer exist. So just close the windows early, we won’t need them in the new save anyway.