### PR TITLE
Close #23018: Close windows before loading new game

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#22962] Fuzzy horizontal-to-vertical line transitions in charts.
 - Fix: [#23009] Scenarios from RCT Classic (.sea files) are not included in the scenario index.
 - Fix: [#23015] Crash when loading a save game when the construction window is still open.
+- Fix: [#23018] Crash when loading a new game when the construction window is still open.
 - Fix: [#23023] Large scenery clearance height interpreted as negative when greater than 127.
 
 0.4.15 (2024-10-06)

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -622,7 +622,11 @@ static void GameLoadOrQuitNoSavePromptCallback(int32_t result, const utf8* path)
 
 static void NewGameWindowCallback(const utf8* path)
 {
-    WindowCloseByClass(WindowClass::EditorObjectSelection);
+    // Closing this will cause a Ride window to pop up, so we have to do this to ensure that
+    // no windows are open (besides the toolbars and LoadSave window).
+    WindowCloseByClass(WindowClass::RideConstruction);
+    WindowCloseAllExceptClass(WindowClass::Loadsave);
+
     GameNotifyMapChange();
     GetContext()->LoadParkFromFile(path, false, true);
     GameLoadScripts();


### PR DESCRIPTION
When starting a new game from an existing one, close all windows before loading the new map in order to prevent crashes. Also see #23015.