### PR TITLE
Fix #23023. Large Scenery Clearance

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,8 +8,7 @@
 - Fix: [#22962] Fuzzy horizontal-to-vertical line transitions in charts.
 - Fix: [#23009] Scenarios from RCT Classic (.sea files) are not included in the scenario index.
 - Fix: [#23015] Crash when loading a save game when the construction window is still open.
-- Fix: [#23023] Large scenery clearance height interpreted as negative when
-greater than 127.
+- Fix: [#23023] Large scenery clearance height interpreted as negative when greater than 127.
 
 0.4.15 (2024-10-06)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,8 @@
 - Fix: [#22962] Fuzzy horizontal-to-vertical line transitions in charts.
 - Fix: [#23009] Scenarios from RCT Classic (.sea files) are not included in the scenario index.
 - Fix: [#23015] Crash when loading a save game when the construction window is still open.
+- Fix: [#23023] Large scenery clearance height interpreted as negative when
+greater than 127.
 
 0.4.15 (2024-10-06)
 ------------------------------------------------------------------------

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -49,7 +49,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kNetworkStreamVersion = 7;
+constexpr uint8_t kNetworkStreamVersion = 8;
 
 const std::string kNetworkStreamID = std::string(OPENRCT2_VERSION) + "-" + std::to_string(kNetworkStreamVersion);
 

--- a/src/openrct2/object/LargeSceneryObject.cpp
+++ b/src/openrct2/object/LargeSceneryObject.cpp
@@ -253,7 +253,7 @@ std::vector<LargeSceneryTile> LargeSceneryObject::ReadJsonTiles(json_t& jTiles)
             tile.offset.x = Json::GetNumber<int16_t>(jTile["x"]);
             tile.offset.y = Json::GetNumber<int16_t>(jTile["y"]);
             tile.offset.z = Json::GetNumber<int16_t>(jTile["z"]);
-            tile.zClearance = Json::GetNumber<int8_t>(jTile["clearance"]);
+            tile.zClearance = Json::GetNumber<int16_t>(jTile["clearance"]);
 
             tile.hasSupports = Json::GetBoolean(jTile["hasSupports"]);
             tile.allowSupportsAbove = Json::GetBoolean(jTile["allowSupportsAbove"]);


### PR DESCRIPTION
This has been subtly broken for a long time (probably since json objects added) but hasn't caused issues due to an implicit type conversion. After my tile changes the implicit type conversion no longer happened and that meant any clearance values >127 would be interpreted as a negative number producing odd error messages.