### PR TITLE
Fix #23044: "remove_unused_objects" command causes blank peep names

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Fix: [#23009] Scenarios from RCT Classic (.sea files) are not included in the scenario index.
 - Fix: [#23015] Crash when loading a save game when the construction window is still open.
 - Fix: [#23023] Large scenery clearance height interpreted as negative when greater than 127.
+- Fix: [#23044] "remove_unused_objects" command causes blank peep names.
 
 0.4.15 (2024-10-06)
 ------------------------------------------------------------------------

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -707,6 +707,10 @@ int32_t EditorRemoveUnusedObjects()
                 if (objectType == ObjectType::Water)
                     continue;
 
+                // Avoid the used peep names object being deleted as no in-use checks are performed.
+                if (objectType == ObjectType::PeepNames)
+                    continue;
+
                 // It’s hard to determine exactly if a scenery group is used, so do not remove these automatically.
                 if (objectType == ObjectType::SceneryGroup)
                     continue;


### PR DESCRIPTION
Fixes #23044.

We don't check if the peep names object is in-use, as game styles differ per person and so do their settings. The UI doesn't allow zero peep name objects, but the console command bypasses this check. This fixes it, as the water check is also done here.

Fix is confirmed to be working using the macOS artifact. 