### PR TITLE
Add clamp to map size text input

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Fix: [#23018] Crash when loading a new game when the construction window is still open.
 - Fix: [#23023] Large scenery clearance height interpreted as negative when greater than 127.
 - Fix: [#23044] "remove_unused_objects" command causes blank peep names.
+- Fix: [#23048] Map generator allows map sizes out of range through text input.
 
 0.4.15 (2024-10-06)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -499,11 +499,11 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_MAP_SIZE_Y:
                 case WIDX_MAP_SIZE_X:
                     // The practical size is 2 lower than the technical size
-                    value += 2;
+                    auto technicalSize = std::clamp<uint16_t>(value + 2, kMinimumMapSizeTechnical, kMaximumMapSizeTechnical);
                     if (_resizeDirection == ResizeDirection::Y || _mapWidthAndHeightLinked)
-                        _settings.mapSize.y = value;
+                        _settings.mapSize.y = technicalSize;
                     if (_resizeDirection == ResizeDirection::X || _mapWidthAndHeightLinked)
-                        _settings.mapSize.x = value;
+                        _settings.mapSize.x = technicalSize;
                     break;
             }
 


### PR DESCRIPTION
This prevents the input of map sizes outside the technical limits. These limits were enforced by the +/- button route, but not by manual text input.