### PR TITLE
Fix #21221: Improve car sprite fallback on sloped diag banked track

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Improved: [#22967] Add medium and large half loops to the Wooden and Classic Wooden Roller Coasters.
 - Improved: [#23010] Make AppImage compatible with Ubuntu 22.04 and Debian Bookworm again.
+- Fix: [#21221] Trains use unbanked sprites on flat to gentle diagonal banked track pieces.
 - Fix: [#22615] Crash when drawing Space Rings with an invalid ride entry.
 - Fix: [#22633] Crash when drawing loading screen with an outdated g2.dat.
 - Fix: [#22918] Zooming with keyboard moves the view off centre.

--- a/src/openrct2/paint/vehicle/VehiclePaint.cpp
+++ b/src/openrct2/paint/vehicle/VehiclePaint.cpp
@@ -3224,7 +3224,7 @@ static void VehiclePitchUp8BankedLeft45(
     }
     else
     {
-        VehiclePitchUp8Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedLeft45(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -3239,7 +3239,7 @@ static void VehiclePitchUp8BankedRight45(
     }
     else
     {
-        VehiclePitchUp8Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedRight45(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -3304,7 +3304,7 @@ static void VehiclePitchUp16BankedLeft22(
     }
     else
     {
-        VehiclePitchUp16Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchUp25BankedLeft45(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -3319,7 +3319,7 @@ static void VehiclePitchUp16BankedRight22(
     }
     else
     {
-        VehiclePitchUp16Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchUp25BankedRight45(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -3466,7 +3466,7 @@ static void VehiclePitchDown8BankedLeft45(
     }
     else
     {
-        VehiclePitchFlat(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedLeft45(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -3481,7 +3481,7 @@ static void VehiclePitchDown8BankedRight45(
     }
     else
     {
-        VehiclePitchFlat(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedRight45(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -3546,7 +3546,7 @@ static void VehiclePitchDown16BankedLeft22(
     }
     else
     {
-        VehiclePitchDown16Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchDown25BankedLeft45(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -3561,7 +3561,7 @@ static void VehiclePitchDown16BankedRight22(
     }
     else
     {
-        VehiclePitchDown16Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchDown25BankedRight45(session, vehicle, imageDirection, z, carEntry);
     }
 }
 


### PR DESCRIPTION
This improves the fallback for trains that don't have all the sprites for diagonal banked slopes. It uses the nearest banked sprites rather than the unbanked sprites.


https://github.com/user-attachments/assets/7eae4159-d0a7-4c5b-8e40-389138accb8c


https://github.com/user-attachments/assets/6f89ed52-9401-4f07-8f6d-c778ec90e4e9

