### PR TITLE
Change uploaded binary names and tags for develop builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,14 @@ jobs:
       - name: Git describe
         id: ghd
         run: |
-          TAG=$(git describe --abbrev=0 --tags)
-          DESCRIBE=$(git describe --tags)
+          TAG=$(git describe --abbrev=0)
+          DESCRIBE=$(git describe)
           SHORT_SHA=$(git rev-parse --short HEAD)
           DISTANCE=$(git rev-list --count $TAG..HEAD)
+          echo "tag=$TAG"
+          echo "describe=$DESCRIBE"
+          echo "short-sha=$SHORT_SHA"
+          echo "distance=$DISTANCE"
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "describe=$DESCRIBE" >> $GITHUB_OUTPUT
           echo "short-sha=$SHORT_SHA" >> $GITHUB_OUTPUT
@@ -62,16 +66,19 @@ jobs:
       - name: Set env
         id: setenv
         run: |
-          . scripts/setenv -q
+          . scripts/setenv
+          echo "push=$OPENRCT2_PUSH"
           echo "push=$OPENRCT2_PUSH" >> $GITHUB_OUTPUT
       # Name is very similar to "describe", but skips the "v" prefix
       - name: Get artifact name
         id: artifact-name
         run: |
           if [ ${{ steps.ghd.outputs.distance }} -eq 0 ]; then
+            echo "name=${{ env.OPENRCT2_VERSION }}"
             echo "name=${{ env.OPENRCT2_VERSION }}" >> $GITHUB_OUTPUT
           else
-            echo "name=${{ env.OPENRCT2_VERSION }}-${{ steps.ghd.outputs.distance }}-${{ steps.ghd.outputs.short-sha }}" >> $GITHUB_OUTPUT
+            echo "name=${{ env.OPENRCT2_VERSION }}-${{ steps.ghd.outputs.distance }}-g${{ steps.ghd.outputs.short-sha }}"
+            echo "name=${{ env.OPENRCT2_VERSION }}-${{ steps.ghd.outputs.distance }}-g${{ steps.ghd.outputs.short-sha }}" >> $GITHUB_OUTPUT
           fi
   lint-commit:
     name: Lint Commit Message

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,17 +69,12 @@ jobs:
           . scripts/setenv
           echo "push=$OPENRCT2_PUSH"
           echo "push=$OPENRCT2_PUSH" >> $GITHUB_OUTPUT
-      # Name is very similar to "describe", but skips the "v" prefix
+      # Name now uses the same format as "describe"
       - name: Get artifact name
         id: artifact-name
         run: |
-          if [ ${{ steps.ghd.outputs.distance }} -eq 0 ]; then
-            echo "name=${{ env.OPENRCT2_VERSION }}"
-            echo "name=${{ env.OPENRCT2_VERSION }}" >> $GITHUB_OUTPUT
-          else
-            echo "name=${{ env.OPENRCT2_VERSION }}-${{ steps.ghd.outputs.distance }}-g${{ steps.ghd.outputs.short-sha }}"
-            echo "name=${{ env.OPENRCT2_VERSION }}-${{ steps.ghd.outputs.distance }}-g${{ steps.ghd.outputs.short-sha }}" >> $GITHUB_OUTPUT
-          fi
+          echo "name=${{ steps.ghd.outputs.describe }}"
+          echo "name=${{ steps.ghd.outputs.describe }}" >> $GITHUB_OUTPUT
   lint-commit:
     name: Lint Commit Message
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
This slightly modifies our naming scheme, both for binaries and for tags in https://github.com/OpenRCT2/OpenRCT2-binaries/. This latter is a change requested by @GingerAdonis, as dropping the `v` from tag broke his scripts.

I personally like the `git describe`-compatible names, but they're not strictly required - only the tags are.

I have checked and it should not affect our launcher, as it correctly compares the builds by their publish date: https://github.com/OpenRCT2/OpenLauncher/blob/04c15e8e38fa4ca0fa267e2a0dc965fd7e53dafe/src/IntelOrca.OpenLauncher.Core/Build.cs#L36-L51