### PR TITLE
Add line breaks after template declarations

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,7 +16,6 @@ AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: false
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
@@ -41,6 +40,7 @@ BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeComma
 BreakStringLiterals: true
+BreakTemplateDeclarations: true
 ColumnLimit:     128
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: false

--- a/.clang-format
+++ b/.clang-format
@@ -16,6 +16,7 @@ AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
@@ -40,7 +41,6 @@ BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeComma
 BreakStringLiterals: true
-BreakTemplateDeclarations: true
 ColumnLimit:     128
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: false

--- a/src/openrct2-ui/Ui.cpp
+++ b/src/openrct2-ui/Ui.cpp
@@ -28,7 +28,8 @@ using namespace OpenRCT2;
 using namespace OpenRCT2::Audio;
 using namespace OpenRCT2::Ui;
 
-template<typename T> static std::shared_ptr<T> ToShared(std::unique_ptr<T>&& src)
+template<typename T>
+static std::shared_ptr<T> ToShared(std::unique_ptr<T>&& src)
 {
     return std::shared_ptr<T>(std::move(src));
 }

--- a/src/openrct2-ui/audio/AudioChannel.cpp
+++ b/src/openrct2-ui/audio/AudioChannel.cpp
@@ -18,7 +18,8 @@
 
 namespace OpenRCT2::Audio
 {
-    template<typename AudioSource_ = SDLAudioSource> class AudioChannelImpl final : public ISDLAudioChannel
+    template<typename AudioSource_ = SDLAudioSource>
+    class AudioChannelImpl final : public ISDLAudioChannel
     {
         static_assert(std::is_base_of_v<IAudioSource, AudioSource_>);
 

--- a/src/openrct2-ui/drawing/engines/opengl/DrawCommands.h
+++ b/src/openrct2-ui/drawing/engines/opengl/DrawCommands.h
@@ -16,7 +16,8 @@
 #include <vector>
 namespace OpenRCT2::Ui
 {
-    template<typename T> class CommandBatch
+    template<typename T>
+    class CommandBatch
     {
     private:
         std::vector<T> _instances;

--- a/src/openrct2-ui/drawing/engines/opengl/GLSLTypes.h
+++ b/src/openrct2-ui/drawing/engines/opengl/GLSLTypes.h
@@ -16,7 +16,8 @@ namespace OpenRCT2::Ui
 #pragma pack(push, 1)
     namespace detail
     {
-        template<typename T_> struct Vec2
+        template<typename T_>
+        struct Vec2
         {
             using ValueType = T_;
 
@@ -37,7 +38,8 @@ namespace OpenRCT2::Ui
         template struct Vec2<GLfloat>;
         template struct Vec2<GLint>;
 
-        template<typename T_> struct Vec3
+        template<typename T_>
+        struct Vec3
         {
             using ValueType = T_;
 
@@ -64,7 +66,8 @@ namespace OpenRCT2::Ui
         template struct Vec3<GLfloat>;
         template struct Vec3<GLint>;
 
-        template<typename T_> struct Vec4
+        template<typename T_>
+        struct Vec4
         {
             using ValueType = T_;
 

--- a/src/openrct2-ui/input/ShortcutManager.h
+++ b/src/openrct2-ui/input/ShortcutManager.h
@@ -133,7 +133,8 @@ namespace OpenRCT2::Ui
         void SaveUserBindings();
 
         void RegisterShortcut(RegisteredShortcut&& shortcut);
-        template<typename... Args> void RegisterShortcut(Args&&... args)
+        template<typename... Args>
+        void RegisterShortcut(Args&&... args)
         {
             RegisterShortcut(RegisteredShortcut(std::forward<Args>(args)...));
         }

--- a/src/openrct2-ui/interface/Dropdown.h
+++ b/src/openrct2-ui/interface/Dropdown.h
@@ -119,7 +119,8 @@ namespace OpenRCT2::Dropdown
         return ItemExt(-1, Dropdown::SeparatorString, STR_EMPTY);
     }
 
-    template<int N> void SetItems(const Dropdown::ItemExt (&items)[N])
+    template<int N>
+    void SetItems(const Dropdown::ItemExt (&items)[N])
     {
         for (int i = 0; i < N; ++i)
         {
@@ -129,7 +130,8 @@ namespace OpenRCT2::Dropdown
         }
     }
 
-    template<int N> constexpr bool ItemIDsMatchIndices(const Dropdown::ItemExt (&items)[N])
+    template<int N>
+    constexpr bool ItemIDsMatchIndices(const Dropdown::ItemExt (&items)[N])
     {
         for (int i = 0; i < N; ++i)
         {

--- a/src/openrct2-ui/interface/Graph.h
+++ b/src/openrct2-ui/interface/Graph.h
@@ -18,7 +18,8 @@ namespace OpenRCT2::Graph
 {
     constexpr int32_t kYTickMarkPadding = 8;
 
-    template<typename T> struct GraphProperties
+    template<typename T>
+    struct GraphProperties
     {
         ScreenRect internalBounds;
         const T* series;

--- a/src/openrct2-ui/ride/VehicleSounds.cpp
+++ b/src/openrct2-ui/ride/VehicleSounds.cpp
@@ -22,8 +22,10 @@ namespace OpenRCT2::Audio
 {
     namespace
     {
-        template<typename T> class TrainIterator;
-        template<typename T> class Train
+        template<typename T>
+        class TrainIterator;
+        template<typename T>
+        class Train
         {
         public:
             explicit Train(T* vehicle)
@@ -47,7 +49,8 @@ namespace OpenRCT2::Audio
         private:
             T* FirstCar;
         };
-        template<typename T> class TrainIterator
+        template<typename T>
+        class TrainIterator
         {
         public:
             using iterator = TrainIterator;
@@ -91,7 +94,8 @@ namespace OpenRCT2::Audio
         };
     } // namespace
 
-    template<typename T> int32_t Train<T>::GetMass() const
+    template<typename T>
+    int32_t Train<T>::GetMass() const
     {
         return std::accumulate(
             begin(), end(), 0, [](int32_t totalMass, const Vehicle& vehicle) { return totalMass + vehicle.mass; });
@@ -430,7 +434,8 @@ namespace OpenRCT2::Audio
         OtherNoises, // e.g. Screams
     };
 
-    template<SoundType type> static uint16_t SoundFrequency(const SoundId id, uint16_t baseFrequency)
+    template<SoundType type>
+    static uint16_t SoundFrequency(const SoundId id, uint16_t baseFrequency)
     {
         if constexpr (type == SoundType::TrackNoises)
         {
@@ -450,7 +455,8 @@ namespace OpenRCT2::Audio
         }
     }
 
-    template<SoundType type> static bool ShouldUpdateChannelRate(const SoundId id)
+    template<SoundType type>
+    static bool ShouldUpdateChannelRate(const SoundId id)
     {
         return type == SoundType::TrackNoises || !IsFixedFrequencySound(id);
     }

--- a/src/openrct2-ui/scripting/CustomImages.cpp
+++ b/src/openrct2-ui/scripting/CustomImages.cpp
@@ -341,7 +341,8 @@ namespace OpenRCT2::Scripting
         return imageData;
     }
 
-    template<> PixelDataKind FromDuk(const DukValue& d)
+    template<>
+    PixelDataKind FromDuk(const DukValue& d)
     {
         if (d.type() == DukValue::Type::STRING)
         {
@@ -358,7 +359,8 @@ namespace OpenRCT2::Scripting
         return PixelDataKind::Unknown;
     }
 
-    template<> PixelDataPaletteKind FromDuk(const DukValue& d)
+    template<>
+    PixelDataPaletteKind FromDuk(const DukValue& d)
     {
         if (d.type() == DukValue::Type::STRING)
         {

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -28,7 +28,8 @@ namespace OpenRCT2::Scripting
 {
     constexpr size_t COLUMN_HEADER_HEIGHT = kListRowHeight + 1;
 
-    template<> ColumnSortOrder FromDuk(const DukValue& d)
+    template<>
+    ColumnSortOrder FromDuk(const DukValue& d)
     {
         if (d.type() == DukValue::Type::STRING)
         {
@@ -41,7 +42,8 @@ namespace OpenRCT2::Scripting
         return ColumnSortOrder::None;
     }
 
-    template<> DukValue ToDuk(duk_context* ctx, const ColumnSortOrder& value)
+    template<>
+    DukValue ToDuk(duk_context* ctx, const ColumnSortOrder& value)
     {
         switch (value)
         {
@@ -54,7 +56,8 @@ namespace OpenRCT2::Scripting
         }
     }
 
-    template<> std::optional<int32_t> FromDuk(const DukValue& d)
+    template<>
+    std::optional<int32_t> FromDuk(const DukValue& d)
     {
         if (d.type() == DukValue::Type::NUMBER)
         {
@@ -63,7 +66,8 @@ namespace OpenRCT2::Scripting
         return std::nullopt;
     }
 
-    template<> ListViewColumn FromDuk(const DukValue& d)
+    template<>
+    ListViewColumn FromDuk(const DukValue& d)
     {
         ListViewColumn result;
         result.CanSort = AsOrDefault(d["canSort"], false);
@@ -86,7 +90,8 @@ namespace OpenRCT2::Scripting
         return result;
     }
 
-    template<> DukValue ToDuk(duk_context* ctx, const ListViewColumn& value)
+    template<>
+    DukValue ToDuk(duk_context* ctx, const ListViewColumn& value)
     {
         DukObject obj(ctx);
         obj.Set("canSort", value.CanSort);
@@ -100,7 +105,8 @@ namespace OpenRCT2::Scripting
         return obj.Take();
     }
 
-    template<> ListViewItem FromDuk(const DukValue& d)
+    template<>
+    ListViewItem FromDuk(const DukValue& d)
     {
         ListViewItem result;
         if (d.type() == DukValue::Type::STRING)
@@ -129,7 +135,8 @@ namespace OpenRCT2::Scripting
         return result;
     }
 
-    template<> std::vector<ListViewColumn> FromDuk(const DukValue& d)
+    template<>
+    std::vector<ListViewColumn> FromDuk(const DukValue& d)
     {
         std::vector<ListViewColumn> result;
         if (d.is_array())
@@ -143,7 +150,8 @@ namespace OpenRCT2::Scripting
         return result;
     }
 
-    template<> std::vector<ListViewItem> FromDuk(const DukValue& d)
+    template<>
+    std::vector<ListViewItem> FromDuk(const DukValue& d)
     {
         std::vector<ListViewItem> result;
         if (d.is_array())
@@ -157,7 +165,8 @@ namespace OpenRCT2::Scripting
         return result;
     }
 
-    template<> std::optional<RowColumn> FromDuk(const DukValue& d)
+    template<>
+    std::optional<RowColumn> FromDuk(const DukValue& d)
     {
         if (d.type() == DukValue::Type::OBJECT)
         {
@@ -171,7 +180,8 @@ namespace OpenRCT2::Scripting
         return std::nullopt;
     }
 
-    template<> DukValue ToDuk(duk_context* ctx, const RowColumn& value)
+    template<>
+    DukValue ToDuk(duk_context* ctx, const RowColumn& value)
     {
         DukObject obj(ctx);
         obj.Set("row", value.Row);
@@ -179,7 +189,8 @@ namespace OpenRCT2::Scripting
         return obj.Take();
     }
 
-    template<> ScrollbarType FromDuk(const DukValue& d)
+    template<>
+    ScrollbarType FromDuk(const DukValue& d)
     {
         auto value = AsOrDefault(d, "");
         if (value == "horizontal")
@@ -191,7 +202,8 @@ namespace OpenRCT2::Scripting
         return ScrollbarType::None;
     }
 
-    template<> DukValue ToDuk(duk_context* ctx, const ScrollbarType& value)
+    template<>
+    DukValue ToDuk(duk_context* ctx, const ScrollbarType& value)
     {
         switch (value)
         {

--- a/src/openrct2-ui/scripting/CustomListView.h
+++ b/src/openrct2-ui/scripting/CustomListView.h
@@ -159,17 +159,38 @@ namespace OpenRCT2::Scripting
 {
     using namespace OpenRCT2::Ui::Windows;
 
-    template<> ColumnSortOrder FromDuk(const DukValue& d);
-    template<> std::optional<int32_t> FromDuk(const DukValue& d);
-    template<> ListViewColumn FromDuk(const DukValue& d);
-    template<> ListViewItem FromDuk(const DukValue& d);
-    template<> std::vector<ListViewColumn> FromDuk(const DukValue& d);
-    template<> std::vector<ListViewItem> FromDuk(const DukValue& d);
-    template<> std::optional<RowColumn> FromDuk(const DukValue& d);
-    template<> DukValue ToDuk(duk_context* ctx, const RowColumn& value);
-    template<> DukValue ToDuk(duk_context* ctx, const ListViewColumn& value);
-    template<> ScrollbarType FromDuk(const DukValue& d);
-    template<> DukValue ToDuk(duk_context* ctx, const ScrollbarType& value);
+    template<>
+    ColumnSortOrder FromDuk(const DukValue& d);
+
+    template<>
+    std::optional<int32_t> FromDuk(const DukValue& d);
+
+    template<>
+    ListViewColumn FromDuk(const DukValue& d);
+
+    template<>
+    ListViewItem FromDuk(const DukValue& d);
+
+    template<>
+    std::vector<ListViewColumn> FromDuk(const DukValue& d);
+
+    template<>
+    std::vector<ListViewItem> FromDuk(const DukValue& d);
+
+    template<>
+    std::optional<RowColumn> FromDuk(const DukValue& d);
+
+    template<>
+    DukValue ToDuk(duk_context* ctx, const RowColumn& value);
+
+    template<>
+    DukValue ToDuk(duk_context* ctx, const ListViewColumn& value);
+
+    template<>
+    ScrollbarType FromDuk(const DukValue& d);
+
+    template<>
+    DukValue ToDuk(duk_context* ctx, const ScrollbarType& value);
 } // namespace OpenRCT2::Scripting
 
 #endif

--- a/src/openrct2-ui/scripting/CustomMenu.cpp
+++ b/src/openrct2-ui/scripting/CustomMenu.cpp
@@ -82,7 +82,8 @@ namespace OpenRCT2::Scripting
         { "banner", ViewportInteractionItem::Banner },
     });
 
-    template<> DukValue ToDuk(duk_context* ctx, const CursorID& cursorId)
+    template<>
+    DukValue ToDuk(duk_context* ctx, const CursorID& cursorId)
     {
         auto value = EnumValue(cursorId);
         if (value < std::size(CursorNames))
@@ -94,7 +95,8 @@ namespace OpenRCT2::Scripting
         return ToDuk(ctx, undefined);
     }
 
-    template<> CursorID FromDuk(const DukValue& s)
+    template<>
+    CursorID FromDuk(const DukValue& s)
     {
         if (s.type() == DukValue::Type::STRING)
         {

--- a/src/openrct2-ui/scripting/CustomMenu.h
+++ b/src/openrct2-ui/scripting/CustomMenu.h
@@ -108,8 +108,10 @@ namespace OpenRCT2::Scripting
     void InitialiseCustomMenuItems(ScriptEngine& scriptEngine);
     void InitialiseCustomTool(ScriptEngine& scriptEngine, const DukValue& dukValue);
 
-    template<> DukValue ToDuk(duk_context* ctx, const CursorID& value);
-    template<> CursorID FromDuk(const DukValue& s);
+    template<>
+    DukValue ToDuk(duk_context* ctx, const CursorID& value);
+    template<>
+    CursorID FromDuk(const DukValue& s);
 
 } // namespace OpenRCT2::Scripting
 

--- a/src/openrct2-ui/scripting/ScTitleSequence.hpp
+++ b/src/openrct2-ui/scripting/ScTitleSequence.hpp
@@ -61,12 +61,14 @@ namespace OpenRCT2::Scripting
         { OpenRCT2::Title::EndCommand::ScriptingName, TitleScript::End },
     });
 
-    template<> DukValue ToDuk(duk_context* ctx, const TitleScript& value)
+    template<>
+    DukValue ToDuk(duk_context* ctx, const TitleScript& value)
     {
         return ToDuk(ctx, TitleScriptMap[value]);
     }
 
-    template<> DukValue ToDuk(duk_context* ctx, const OpenRCT2::Title::TitleCommand& value)
+    template<>
+    DukValue ToDuk(duk_context* ctx, const OpenRCT2::Title::TitleCommand& value)
     {
         using namespace OpenRCT2::Title;
         DukObject obj(ctx);
@@ -115,14 +117,16 @@ namespace OpenRCT2::Scripting
         return obj.Take();
     }
 
-    template<> TitleScript FromDuk(const DukValue& value)
+    template<>
+    TitleScript FromDuk(const DukValue& value)
     {
         if (value.type() == DukValue::Type::STRING)
             return TitleScriptMap[value.as_string()];
         throw DukException() << "Invalid title command id";
     }
 
-    template<> OpenRCT2::Title::TitleCommand FromDuk(const DukValue& value)
+    template<>
+    OpenRCT2::Title::TitleCommand FromDuk(const DukValue& value)
     {
         using namespace OpenRCT2::Title;
         auto type = FromDuk<TitleScript>(value["type"]);

--- a/src/openrct2-ui/scripting/ScUi.hpp
+++ b/src/openrct2-ui/scripting/ScUi.hpp
@@ -61,7 +61,8 @@ namespace OpenRCT2::Scripting
         { "other", ScenarioSource::Other },
     });
 
-    template<> inline DukValue ToDuk(duk_context* ctx, const SCENARIO_CATEGORY& value)
+    template<>
+    inline DukValue ToDuk(duk_context* ctx, const SCENARIO_CATEGORY& value)
     {
         const auto& entry = ScenarioCategoryMap.find(value);
         if (entry != ScenarioCategoryMap.end())
@@ -69,7 +70,8 @@ namespace OpenRCT2::Scripting
         return ToDuk(ctx, ScenarioCategoryMap[SCENARIO_CATEGORY_OTHER]);
     }
 
-    template<> inline DukValue ToDuk(duk_context* ctx, const ScenarioSource& value)
+    template<>
+    inline DukValue ToDuk(duk_context* ctx, const ScenarioSource& value)
     {
         const auto& entry = ScenarioSourceMap.find(value);
         if (entry != ScenarioSourceMap.end())

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -933,7 +933,8 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        template<bool TRealNames> static bool CompareGuestItem(const GuestItem& a, const GuestItem& b)
+        template<bool TRealNames>
+        static bool CompareGuestItem(const GuestItem& a, const GuestItem& b)
         {
             const auto* peepA = GetEntity<Peep>(a.Id);
             const auto* peepB = GetEntity<Peep>(b.Id);

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -791,7 +791,8 @@ namespace OpenRCT2::Ui::Windows
          * Used in RefreshList() to handle the sorting of the list.
          * Uses a lambda function (predicate) as exit criteria for the algorithm.
          */
-        template<typename TSortPred> void SortListByPredicate(const TSortPred& pred)
+        template<typename TSortPred>
+        void SortListByPredicate(const TSortPred& pred)
         {
             std::sort(_rideList.begin(), _rideList.end(), [&pred](const auto& lhs, const auto& rhs) {
                 const Ride* rideLhs = GetRide(lhs.Id);

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -1071,7 +1071,8 @@ namespace OpenRCT2::Ui::Windows
             return contentWidth / SCENERY_BUTTON_WIDTH;
         }
 
-        template<typename T> T CountRows(T items) const
+        template<typename T>
+        T CountRows(T items) const
         {
             const auto rows = items / GetNumColumns();
             return rows;

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -783,7 +783,8 @@ namespace OpenRCT2::Ui::Windows
         }
 
         // TODO: look into using std::span
-        template<typename T> uint16_t GetToolbarWidth(T toolbarItems)
+        template<typename T>
+        uint16_t GetToolbarWidth(T toolbarItems)
         {
             bool firstItem = true;
             auto totalWidth = 0;
@@ -803,7 +804,8 @@ namespace OpenRCT2::Ui::Windows
         }
 
         // TODO: look into using std::span
-        template<typename T> void AlignButtons(T toolbarItems, uint16_t xPos)
+        template<typename T>
+        void AlignButtons(T toolbarItems, uint16_t xPos)
         {
             bool firstItem = true;
             for (auto widgetIndex : toolbarItems)

--- a/src/openrct2/AssetPackManager.cpp
+++ b/src/openrct2/AssetPackManager.cpp
@@ -143,7 +143,8 @@ void AssetPackManager::AddAssetPack(const fs::path& path)
     }
 }
 
-template<typename TFunc> static void EnumerateCommaSeparatedList(std::string_view csl, TFunc func)
+template<typename TFunc>
+static void EnumerateCommaSeparatedList(std::string_view csl, TFunc func)
 {
     size_t elStart = 0;
     for (size_t i = 0; i <= csl.size(); i++)

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -66,7 +66,8 @@ void CheatsSet(CheatType cheatType, int64_t param1 /* = 0*/, int64_t param2 /* =
     GameActions::Execute(&cheatSetAction);
 }
 
-template<typename T> static void CheatEntrySerialise(DataSerialiser& ds, CheatType type, const T& value, uint16_t& count)
+template<typename T>
+static void CheatEntrySerialise(DataSerialiser& ds, CheatType type, const T& value, uint16_t& count)
 {
     ds << static_cast<int32_t>(type) << value;
     count++;

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -236,7 +236,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         std::memcpy(&valB, &spriteCmp.field, sizeof(struc::field));                                                            \
         uintptr_t offset = reinterpret_cast<uintptr_t>(&spriteBase.field) - reinterpret_cast<uintptr_t>(&spriteBase);          \
         changeData.diffs.push_back(                                                                                            \
-            GameStateSpriteChange::Diff{ static_cast<size_t>(offset), sizeof(struc::field), #struc, #field, valA, valB });     \
+            GameStateSpriteChange::Diff { static_cast<size_t>(offset), sizeof(struc::field), #struc, #field, valA, valB });    \
     }
 
     void CompareSpriteDataCommon(

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -54,7 +54,8 @@ struct GameStateSnapshot_t
     OpenRCT2::MemoryStream storedSprites;
     OpenRCT2::MemoryStream parkParameters;
 
-    template<typename T> bool EntitySizeCheck(DataSerialiser& ds)
+    template<typename T>
+    bool EntitySizeCheck(DataSerialiser& ds)
     {
         uint32_t size = sizeof(T);
         ds << size;
@@ -64,7 +65,8 @@ struct GameStateSnapshot_t
         }
         return true;
     }
-    template<typename... T> bool EntitiesSizeCheck(DataSerialiser& ds)
+    template<typename... T>
+    bool EntitiesSizeCheck(DataSerialiser& ds)
     {
         return (EntitySizeCheck<T>(ds) && ...);
     }
@@ -234,7 +236,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         std::memcpy(&valB, &spriteCmp.field, sizeof(struc::field));                                                            \
         uintptr_t offset = reinterpret_cast<uintptr_t>(&spriteBase.field) - reinterpret_cast<uintptr_t>(&spriteBase);          \
         changeData.diffs.push_back(                                                                                            \
-            GameStateSpriteChange::Diff { static_cast<size_t>(offset), sizeof(struc::field), #struc, #field, valA, valB });    \
+            GameStateSpriteChange::Diff{ static_cast<size_t>(offset), sizeof(struc::field), #struc, #field, valA, valB });     \
     }
 
     void CompareSpriteDataCommon(

--- a/src/openrct2/actions/GameAction.h
+++ b/src/openrct2/actions/GameAction.h
@@ -87,7 +87,8 @@ public:
         Visit("y2", param.Point2.y);
     }
 
-    template<typename T> void Visit(std::string_view name, T& param)
+    template<typename T>
+    void Visit(std::string_view name, T& param)
     {
         static_assert(std::is_arithmetic_v<T> || std::is_enum_v<T>, "Not an arithmetic type");
         auto value = static_cast<int32_t>(param);
@@ -95,14 +96,16 @@ public:
         param = static_cast<T>(value);
     }
 
-    template<typename T, T TNull, typename TTag> void Visit(std::string_view name, TIdentifier<T, TNull, TTag>& param)
+    template<typename T, T TNull, typename TTag>
+    void Visit(std::string_view name, TIdentifier<T, TNull, TTag>& param)
     {
         auto value = param.ToUnderlying();
         Visit(name, value);
         param = TIdentifier<T, TNull, TTag>::FromUnderlying(value);
     }
 
-    template<typename T, size_t _TypeID> void Visit(std::string_view name, NetworkObjectId<T, _TypeID>& param)
+    template<typename T, size_t _TypeID>
+    void Visit(std::string_view name, NetworkObjectId<T, _TypeID>& param)
     {
         Visit(name, param.id);
     }
@@ -247,11 +250,13 @@ public:
 #    pragma GCC diagnostic pop
 #endif
 
-template<GameCommand TId> struct GameActionNameQuery
+template<GameCommand TId>
+struct GameActionNameQuery
 {
 };
 
-template<GameCommand TType> struct GameActionBase : GameAction
+template<GameCommand TType>
+struct GameActionBase : GameAction
 {
 public:
     static constexpr GameCommand TYPE = TType;

--- a/src/openrct2/actions/GameActionRegistry.cpp
+++ b/src/openrct2/actions/GameActionRegistry.cpp
@@ -117,7 +117,8 @@ namespace OpenRCT2::GameActions
         registry[idx] = { factory, name };
     }
 
-    template<typename T> static constexpr void Register(GameActionRegistry& registry, const char* name)
+    template<typename T>
+    static constexpr void Register(GameActionRegistry& registry, const char* name)
     {
         GameActionFactory factory = []() -> GameAction* { return new T(); };
         Register<T::TYPE>(registry, factory, name);

--- a/src/openrct2/actions/GameActionResult.h
+++ b/src/openrct2/actions/GameActionResult.h
@@ -81,7 +81,8 @@ namespace OpenRCT2::GameActions
 
         // It is recommended to use strong types since a type alias such as 'using MyType = uint32_t'
         // is still just uint32_t, this guarantees the data is associated with the correct type.
-        template<typename T> void SetData(const T&& data)
+        template<typename T>
+        void SetData(const T&& data)
         {
 #ifdef __ANDROID__
             ResultData = std::make_shared<T>(data);
@@ -90,7 +91,8 @@ namespace OpenRCT2::GameActions
 #endif
         }
 
-        template<typename T> T GetData() const
+        template<typename T>
+        T GetData() const
         {
 #ifdef __ANDROID__
             return *static_cast<T*>(ResultData.get());

--- a/src/openrct2/config/ConfigEnum.hpp
+++ b/src/openrct2/config/ConfigEnum.hpp
@@ -15,7 +15,8 @@
 #include <utility>
 #include <vector>
 
-template<typename T> struct ConfigEnumEntry
+template<typename T>
+struct ConfigEnumEntry
 {
     std::string Key;
     T Value;
@@ -27,14 +28,16 @@ template<typename T> struct ConfigEnumEntry
     }
 };
 
-template<typename T> struct IConfigEnum
+template<typename T>
+struct IConfigEnum
 {
     virtual ~IConfigEnum() = default;
     virtual std::string GetName(T value) const = 0;
     virtual T GetValue(const std::string& key, T defaultValue) const = 0;
 };
 
-template<typename T> class ConfigEnum final : public IConfigEnum<T>
+template<typename T>
+class ConfigEnum final : public IConfigEnum<T>
 {
 private:
     const std::vector<ConfigEnumEntry<T>> _entries;

--- a/src/openrct2/config/IniReader.hpp
+++ b/src/openrct2/config/IniReader.hpp
@@ -17,7 +17,8 @@ namespace OpenRCT2
     struct IStream;
 }
 
-template<typename T> struct IConfigEnum;
+template<typename T>
+struct IConfigEnum;
 
 struct IIniReader
 {
@@ -32,7 +33,8 @@ struct IIniReader
     virtual std::string GetString(const std::string& name, const std::string& defaultValue) const = 0;
     virtual bool TryGetString(const std::string& name, std::string* outValue) const = 0;
 
-    template<typename T> T GetEnum(const std::string& name, T defaultValue, const IConfigEnum<T>& configEnum) const
+    template<typename T>
+    T GetEnum(const std::string& name, T defaultValue, const IConfigEnum<T>& configEnum) const
     {
         std::string szValue;
         if (!TryGetString(name, &szValue))

--- a/src/openrct2/config/IniWriter.hpp
+++ b/src/openrct2/config/IniWriter.hpp
@@ -19,7 +19,8 @@ namespace OpenRCT2
     struct IStream;
 }
 
-template<typename T> struct IConfigEnum;
+template<typename T>
+struct IConfigEnum;
 
 struct IIniWriter
 {
@@ -34,7 +35,8 @@ struct IIniWriter
     virtual void WriteString(const std::string& name, const std::string& value) = 0;
     virtual void WriteEnum(const std::string& name, const std::string& key) = 0;
 
-    template<typename T> void WriteEnum(const std::string& name, T value, const IConfigEnum<T>& configEnum)
+    template<typename T>
+    void WriteEnum(const std::string& name, T value, const IConfigEnum<T>& configEnum)
     {
         static_assert(sizeof(T) <= sizeof(int32_t), "Type too large");
 

--- a/src/openrct2/core/BitSet.hpp
+++ b/src/openrct2/core/BitSet.hpp
@@ -25,7 +25,8 @@ namespace OpenRCT2
         {
             static constexpr size_t BitsPerByte = std::numeric_limits<std::underlying_type_t<std::byte>>::digits;
 
-            template<size_t TNumBits> static constexpr size_t ByteAlignBits()
+            template<size_t TNumBits>
+            static constexpr size_t ByteAlignBits()
             {
                 const auto reminder = TNumBits % BitsPerByte;
                 if constexpr (reminder == 0u)
@@ -48,7 +49,8 @@ namespace OpenRCT2
             static_assert(ByteAlignBits<31>() == 32);
 
             // Returns the amount of bytes required for a single block.
-            template<size_t TNumBits> static constexpr size_t ComputeBlockSize()
+            template<size_t TNumBits>
+            static constexpr size_t ComputeBlockSize()
             {
                 constexpr size_t numBits = ByteAlignBits<TNumBits>();
                 if constexpr (numBits >= std::numeric_limits<uintptr_t>::digits)
@@ -67,7 +69,8 @@ namespace OpenRCT2
                 }
             }
 
-            template<size_t TNumBits, size_t TBlockSizeBytes> static constexpr size_t ComputeBlockCount()
+            template<size_t TNumBits, size_t TBlockSizeBytes>
+            static constexpr size_t ComputeBlockCount()
             {
                 size_t numBits = TNumBits;
                 size_t numBlocks = 0;
@@ -90,7 +93,8 @@ namespace OpenRCT2
             static_assert(ComputeBlockSize<33>() == sizeof(uintptr_t));
 
             // TODO: Replace with std::popcount when C++20 is enabled.
-            template<typename T> static constexpr size_t popcount(const T val)
+            template<typename T>
+            static constexpr size_t popcount(const T val)
             {
                 size_t res = 0;
                 auto x = static_cast<std::make_unsigned_t<T>>(val);
@@ -103,36 +107,43 @@ namespace OpenRCT2
                 return res;
             }
 
-            template<size_t TByteSize> struct StorageBlockType;
+            template<size_t TByteSize>
+            struct StorageBlockType;
 
-            template<> struct StorageBlockType<1>
+            template<>
+            struct StorageBlockType<1>
             {
                 using value_type = uint8_t;
             };
 
-            template<> struct StorageBlockType<2>
+            template<>
+            struct StorageBlockType<2>
             {
                 using value_type = uint16_t;
             };
 
-            template<> struct StorageBlockType<4>
+            template<>
+            struct StorageBlockType<4>
             {
                 using value_type = uint32_t;
             };
 
-            template<> struct StorageBlockType<8>
+            template<>
+            struct StorageBlockType<8>
             {
                 using value_type = uint64_t;
             };
 
-            template<size_t TBitSize> struct storage_block_type_aligned
+            template<size_t TBitSize>
+            struct storage_block_type_aligned
             {
                 using value_type = typename StorageBlockType<ComputeBlockSize<TBitSize>()>::value_type;
             };
         } // namespace BitSet
     } // namespace Detail
 
-    template<size_t TBitSize> class BitSet
+    template<size_t TBitSize>
+    class BitSet
     {
         static constexpr size_t ByteAlignedBitSize = Detail::BitSet::ByteAlignBits<TBitSize>();
 
@@ -154,7 +165,8 @@ namespace OpenRCT2
         using Storage = std::array<BlockType, BlockCount>;
 
         // Proxy object to access the bits as single value.
-        template<typename T> class reference_base
+        template<typename T>
+        class reference_base
         {
             T& _storage;
             const size_t _blockIndex;
@@ -196,7 +208,8 @@ namespace OpenRCT2
         using reference = reference_base<Storage>;
         using const_reference = reference_base<const Storage>;
 
-        template<typename T, typename TValue> class iterator_base
+        template<typename T, typename TValue>
+        class iterator_base
         {
             T* _bitset{};
             size_t _pos{};
@@ -275,7 +288,8 @@ namespace OpenRCT2
         {
         }
 
-        template<typename T> constexpr BitSet(const std::initializer_list<T>& indices)
+        template<typename T>
+        constexpr BitSet(const std::initializer_list<T>& indices)
         {
             for (auto idx : indices)
             {

--- a/src/openrct2/core/ChecksumStream.h
+++ b/src/openrct2/core/ChecksumStream.h
@@ -97,7 +97,8 @@ namespace OpenRCT2
             Write<16>(buffer);
         }
 
-        template<size_t N> void Write(const void* buffer)
+        template<size_t N>
+        void Write(const void* buffer)
         {
             Write(buffer, N);
         }

--- a/src/openrct2/core/CircularBuffer.h
+++ b/src/openrct2/core/CircularBuffer.h
@@ -12,7 +12,8 @@
 #include <array>
 #include <cstddef>
 
-template<typename TType, size_t TMax> class CircularBuffer
+template<typename TType, size_t TMax>
+class CircularBuffer
 {
 public:
     using value_type = TType;

--- a/src/openrct2/core/Collections.hpp
+++ b/src/openrct2/core/Collections.hpp
@@ -49,7 +49,8 @@ namespace OpenRCT2::Collections
         return SIZE_MAX;
     }
 
-    template<typename TCollection, typename TPred> static size_t IndexOf(const TCollection& collection, TPred predicate)
+    template<typename TCollection, typename TPred>
+    static size_t IndexOf(const TCollection& collection, TPred predicate)
     {
         size_t index = 0;
         for (const auto& item : collection)
@@ -65,13 +66,15 @@ namespace OpenRCT2::Collections
 
 #pragma region String helpers
 
-    template<typename TCollection> static bool Contains(TCollection& collection, const char* item, bool ignoreCase = false)
+    template<typename TCollection>
+    static bool Contains(TCollection& collection, const char* item, bool ignoreCase = false)
     {
         return Contains(
             collection, item, [ignoreCase](const char* a, const char* b) { return String::Equals(a, b, ignoreCase); });
     }
 
-    template<typename TCollection> static size_t IndexOf(TCollection& collection, const char* item, bool ignoreCase = false)
+    template<typename TCollection>
+    static size_t IndexOf(TCollection& collection, const char* item, bool ignoreCase = false)
     {
         return IndexOf(
             collection, item, [ignoreCase](const char* a, const char* b) { return String::Equals(a, b, ignoreCase); });

--- a/src/openrct2/core/Crypt.CNG.cpp
+++ b/src/openrct2/core/Crypt.CNG.cpp
@@ -52,7 +52,8 @@ static void ThrowBadAllocOnNull(const void* ptr)
     }
 }
 
-template<typename TBase> class CngHashAlgorithm final : public TBase
+template<typename TBase>
+class CngHashAlgorithm final : public TBase
 {
 private:
     const wchar_t* _algName;
@@ -143,14 +144,16 @@ class DerReader
 private:
     ivstream<uint8_t> _stream;
 
-    template<typename T> T Read(std::istream& stream)
+    template<typename T>
+    T Read(std::istream& stream)
     {
         T value;
         stream.read(reinterpret_cast<char*>(&value), sizeof(T));
         return value;
     }
 
-    template<typename T> std::vector<T> Read(std::istream& stream, size_t count)
+    template<typename T>
+    std::vector<T> Read(std::istream& stream, size_t count)
     {
         std::vector<T> values(count);
         stream.read(reinterpret_cast<char*>(values.data()), sizeof(T) * count);

--- a/src/openrct2/core/Crypt.OpenSSL.cpp
+++ b/src/openrct2/core/Crypt.OpenSSL.cpp
@@ -40,7 +40,8 @@ static void OpenSSLInitialise()
     }
 }
 
-template<typename TBase> class OpenSSLHashAlgorithm final : public TBase
+template<typename TBase>
+class OpenSSLHashAlgorithm final : public TBase
 {
 private:
     const EVP_MD* _type;

--- a/src/openrct2/core/Crypt.h
+++ b/src/openrct2/core/Crypt.h
@@ -17,7 +17,8 @@
 
 namespace OpenRCT2::Crypt
 {
-    template<size_t TLength> class HashAlgorithm
+    template<size_t TLength>
+    class HashAlgorithm
     {
     public:
         using Result = std::array<uint8_t, TLength>;

--- a/src/openrct2/core/DataSerialiser.h
+++ b/src/openrct2/core/DataSerialiser.h
@@ -57,7 +57,8 @@ public:
         return _activeStream;
     }
 
-    template<typename T> DataSerialiser& operator<<(const T& data)
+    template<typename T>
+    DataSerialiser& operator<<(const T& data)
     {
         if (!_isLogging)
         {
@@ -74,7 +75,8 @@ public:
         return *this;
     }
 
-    template<typename T> DataSerialiser& operator<<(DataSerialiserTag<T> data)
+    template<typename T>
+    DataSerialiser& operator<<(DataSerialiserTag<T> data)
     {
         if (!_isLogging)
         {

--- a/src/openrct2/core/DataSerialiserTag.h
+++ b/src/openrct2/core/DataSerialiserTag.h
@@ -9,7 +9,8 @@
 
 #pragma once
 
-template<typename T> class DataSerialiserTag
+template<typename T>
+class DataSerialiserTag
 {
 public:
     DataSerialiserTag(const char* name, T& data)
@@ -33,7 +34,8 @@ private:
     T& _data;
 };
 
-template<typename T> inline DataSerialiserTag<T> CreateDataSerialiserTag(const char* name, T& data)
+template<typename T>
+inline DataSerialiserTag<T> CreateDataSerialiserTag(const char* name, T& data)
 {
     DataSerialiserTag<T> r(name, data);
     return r;

--- a/src/openrct2/core/DataSerialiserTraits.h
+++ b/src/openrct2/core/DataSerialiserTraits.h
@@ -30,14 +30,16 @@
 #include <sstream>
 #include <stdexcept>
 
-template<typename T> struct DataSerializerTraitsT
+template<typename T>
+struct DataSerializerTraitsT
 {
     static void encode(OpenRCT2::IStream* stream, const T& v) = delete;
     static void decode(OpenRCT2::IStream* stream, T& val) = delete;
     static void log(OpenRCT2::IStream* stream, const T& val) = delete;
 };
 
-template<typename T> struct DataSerializerTraitsEnum
+template<typename T>
+struct DataSerializerTraitsEnum
 {
     using TUnderlying = std::underlying_type_t<T>;
 
@@ -65,7 +67,8 @@ template<typename T> struct DataSerializerTraitsEnum
 template<typename T>
 using DataSerializerTraits = std::conditional_t<std::is_enum_v<T>, DataSerializerTraitsEnum<T>, DataSerializerTraitsT<T>>;
 
-template<typename T> struct DataSerializerTraitsIntegral
+template<typename T>
+struct DataSerializerTraitsIntegral
 {
     static void encode(OpenRCT2::IStream* stream, const T& val)
     {
@@ -88,7 +91,8 @@ template<typename T> struct DataSerializerTraitsIntegral
     }
 };
 
-template<> struct DataSerializerTraitsT<bool>
+template<>
+struct DataSerializerTraitsT<bool>
 {
     static void encode(OpenRCT2::IStream* stream, const bool& val)
     {
@@ -107,43 +111,53 @@ template<> struct DataSerializerTraitsT<bool>
     }
 };
 
-template<> struct DataSerializerTraitsT<uint8_t> : public DataSerializerTraitsIntegral<uint8_t>
+template<>
+struct DataSerializerTraitsT<uint8_t> : public DataSerializerTraitsIntegral<uint8_t>
 {
 };
 
-template<> struct DataSerializerTraitsT<int8_t> : public DataSerializerTraitsIntegral<int8_t>
+template<>
+struct DataSerializerTraitsT<int8_t> : public DataSerializerTraitsIntegral<int8_t>
 {
 };
 
-template<> struct DataSerializerTraitsT<utf8> : public DataSerializerTraitsIntegral<utf8>
+template<>
+struct DataSerializerTraitsT<utf8> : public DataSerializerTraitsIntegral<utf8>
 {
 };
 
-template<> struct DataSerializerTraitsT<uint16_t> : public DataSerializerTraitsIntegral<uint16_t>
+template<>
+struct DataSerializerTraitsT<uint16_t> : public DataSerializerTraitsIntegral<uint16_t>
 {
 };
 
-template<> struct DataSerializerTraitsT<int16_t> : public DataSerializerTraitsIntegral<int16_t>
+template<>
+struct DataSerializerTraitsT<int16_t> : public DataSerializerTraitsIntegral<int16_t>
 {
 };
 
-template<> struct DataSerializerTraitsT<uint32_t> : public DataSerializerTraitsIntegral<uint32_t>
+template<>
+struct DataSerializerTraitsT<uint32_t> : public DataSerializerTraitsIntegral<uint32_t>
 {
 };
 
-template<> struct DataSerializerTraitsT<int32_t> : public DataSerializerTraitsIntegral<int32_t>
+template<>
+struct DataSerializerTraitsT<int32_t> : public DataSerializerTraitsIntegral<int32_t>
 {
 };
 
-template<> struct DataSerializerTraitsT<uint64_t> : public DataSerializerTraitsIntegral<uint64_t>
+template<>
+struct DataSerializerTraitsT<uint64_t> : public DataSerializerTraitsIntegral<uint64_t>
 {
 };
 
-template<> struct DataSerializerTraitsT<int64_t> : public DataSerializerTraitsIntegral<int64_t>
+template<>
+struct DataSerializerTraitsT<int64_t> : public DataSerializerTraitsIntegral<int64_t>
 {
 };
 
-template<> struct DataSerializerTraitsT<std::string>
+template<>
+struct DataSerializerTraitsT<std::string>
 {
     static void encode(OpenRCT2::IStream* stream, const std::string& str)
     {
@@ -180,7 +194,8 @@ template<> struct DataSerializerTraitsT<std::string>
     }
 };
 
-template<> struct DataSerializerTraitsT<NetworkPlayerId_t>
+template<>
+struct DataSerializerTraitsT<NetworkPlayerId_t>
 {
     static void encode(OpenRCT2::IStream* stream, const NetworkPlayerId_t& val)
     {
@@ -215,7 +230,8 @@ template<> struct DataSerializerTraitsT<NetworkPlayerId_t>
     }
 };
 
-template<typename T> struct DataSerializerTraitsT<DataSerialiserTag<T>>
+template<typename T>
+struct DataSerializerTraitsT<DataSerialiserTag<T>>
 {
     static void encode(OpenRCT2::IStream* stream, const DataSerialiserTag<T>& tag)
     {
@@ -240,7 +256,8 @@ template<typename T> struct DataSerializerTraitsT<DataSerialiserTag<T>>
     }
 };
 
-template<> struct DataSerializerTraitsT<OpenRCT2::MemoryStream>
+template<>
+struct DataSerializerTraitsT<OpenRCT2::MemoryStream>
 {
     static void encode(OpenRCT2::IStream* stream, const OpenRCT2::MemoryStream& val)
     {
@@ -266,7 +283,8 @@ template<> struct DataSerializerTraitsT<OpenRCT2::MemoryStream>
     }
 };
 
-template<typename _Ty, size_t _Size> struct DataSerializerTraitsPODArray
+template<typename _Ty, size_t _Size>
+struct DataSerializerTraitsPODArray
 {
     static void encode(OpenRCT2::IStream* stream, const _Ty (&val)[_Size])
     {
@@ -308,23 +326,28 @@ template<typename _Ty, size_t _Size> struct DataSerializerTraitsPODArray
     }
 };
 
-template<size_t _Size> struct DataSerializerTraitsT<uint8_t[_Size]> : public DataSerializerTraitsPODArray<uint8_t, _Size>
+template<size_t _Size>
+struct DataSerializerTraitsT<uint8_t[_Size]> : public DataSerializerTraitsPODArray<uint8_t, _Size>
 {
 };
 
-template<size_t _Size> struct DataSerializerTraitsT<utf8[_Size]> : public DataSerializerTraitsPODArray<utf8, _Size>
+template<size_t _Size>
+struct DataSerializerTraitsT<utf8[_Size]> : public DataSerializerTraitsPODArray<utf8, _Size>
 {
 };
 
-template<size_t _Size> struct DataSerializerTraitsT<uint16_t[_Size]> : public DataSerializerTraitsPODArray<uint16_t, _Size>
+template<size_t _Size>
+struct DataSerializerTraitsT<uint16_t[_Size]> : public DataSerializerTraitsPODArray<uint16_t, _Size>
 {
 };
 
-template<size_t _Size> struct DataSerializerTraitsT<uint32_t[_Size]> : public DataSerializerTraitsPODArray<uint32_t, _Size>
+template<size_t _Size>
+struct DataSerializerTraitsT<uint32_t[_Size]> : public DataSerializerTraitsPODArray<uint32_t, _Size>
 {
 };
 
-template<size_t _Size> struct DataSerializerTraitsT<uint64_t[_Size]> : public DataSerializerTraitsPODArray<uint64_t, _Size>
+template<size_t _Size>
+struct DataSerializerTraitsT<uint64_t[_Size]> : public DataSerializerTraitsPODArray<uint64_t, _Size>
 {
 };
 
@@ -334,7 +357,8 @@ struct DataSerializerTraitsT<TIdentifier<T, TNullValue, TTag>[_Size]>
 {
 };
 
-template<typename _Ty, size_t _Size> struct DataSerializerTraitsT<std::array<_Ty, _Size>>
+template<typename _Ty, size_t _Size>
+struct DataSerializerTraitsT<std::array<_Ty, _Size>>
 {
     static void encode(OpenRCT2::IStream* stream, const std::array<_Ty, _Size>& val)
     {
@@ -376,7 +400,8 @@ template<typename _Ty, size_t _Size> struct DataSerializerTraitsT<std::array<_Ty
     }
 };
 
-template<typename _Ty> struct DataSerializerTraitsT<std::vector<_Ty>>
+template<typename _Ty>
+struct DataSerializerTraitsT<std::vector<_Ty>>
 {
     static void encode(OpenRCT2::IStream* stream, const std::vector<_Ty>& val)
     {
@@ -417,7 +442,8 @@ template<typename _Ty> struct DataSerializerTraitsT<std::vector<_Ty>>
     }
 };
 
-template<> struct DataSerializerTraitsT<MapRange>
+template<>
+struct DataSerializerTraitsT<MapRange>
 {
     static void encode(OpenRCT2::IStream* stream, const MapRange& v)
     {
@@ -445,7 +471,8 @@ template<> struct DataSerializerTraitsT<MapRange>
     }
 };
 
-template<> struct DataSerializerTraitsT<TileElement>
+template<>
+struct DataSerializerTraitsT<TileElement>
 {
     static void encode(OpenRCT2::IStream* stream, const TileElement& tileElement)
     {
@@ -489,7 +516,8 @@ template<> struct DataSerializerTraitsT<TileElement>
     }
 };
 
-template<> struct DataSerializerTraitsT<TileCoordsXY>
+template<>
+struct DataSerializerTraitsT<TileCoordsXY>
 {
     static void encode(OpenRCT2::IStream* stream, const TileCoordsXY& coords)
     {
@@ -510,7 +538,8 @@ template<> struct DataSerializerTraitsT<TileCoordsXY>
     }
 };
 
-template<> struct DataSerializerTraitsT<CoordsXY>
+template<>
+struct DataSerializerTraitsT<CoordsXY>
 {
     static void encode(OpenRCT2::IStream* stream, const CoordsXY& coords)
     {
@@ -531,7 +560,8 @@ template<> struct DataSerializerTraitsT<CoordsXY>
     }
 };
 
-template<> struct DataSerializerTraitsT<CoordsXYZ>
+template<>
+struct DataSerializerTraitsT<CoordsXYZ>
 {
     static void encode(OpenRCT2::IStream* stream, const CoordsXYZ& coord)
     {
@@ -556,7 +586,8 @@ template<> struct DataSerializerTraitsT<CoordsXYZ>
     }
 };
 
-template<> struct DataSerializerTraitsT<CoordsXYZD>
+template<>
+struct DataSerializerTraitsT<CoordsXYZD>
 {
     static void encode(OpenRCT2::IStream* stream, const CoordsXYZD& coord)
     {
@@ -584,7 +615,8 @@ template<> struct DataSerializerTraitsT<CoordsXYZD>
     }
 };
 
-template<> struct DataSerializerTraitsT<NetworkCheatType_t>
+template<>
+struct DataSerializerTraitsT<NetworkCheatType_t>
 {
     static void encode(OpenRCT2::IStream* stream, const NetworkCheatType_t& val)
     {
@@ -604,7 +636,8 @@ template<> struct DataSerializerTraitsT<NetworkCheatType_t>
     }
 };
 
-template<> struct DataSerializerTraitsT<RCTObjectEntry>
+template<>
+struct DataSerializerTraitsT<RCTObjectEntry>
 {
     static void encode(OpenRCT2::IStream* stream, const RCTObjectEntry& val)
     {
@@ -626,7 +659,8 @@ template<> struct DataSerializerTraitsT<RCTObjectEntry>
     }
 };
 
-template<> struct DataSerializerTraitsT<ObjectEntryDescriptor>
+template<>
+struct DataSerializerTraitsT<ObjectEntryDescriptor>
 {
     static void encode(OpenRCT2::IStream* stream, const ObjectEntryDescriptor& val)
     {
@@ -670,7 +704,8 @@ template<> struct DataSerializerTraitsT<ObjectEntryDescriptor>
     }
 };
 
-template<> struct DataSerializerTraitsT<TrackDesignTrackElement>
+template<>
+struct DataSerializerTraitsT<TrackDesignTrackElement>
 {
     static void encode(OpenRCT2::IStream* stream, const TrackDesignTrackElement& val)
     {
@@ -698,7 +733,8 @@ template<> struct DataSerializerTraitsT<TrackDesignTrackElement>
     }
 };
 
-template<> struct DataSerializerTraitsT<TrackDesignMazeElement>
+template<>
+struct DataSerializerTraitsT<TrackDesignMazeElement>
 {
     static void encode(OpenRCT2::IStream* stream, const TrackDesignMazeElement& val)
     {
@@ -720,7 +756,8 @@ template<> struct DataSerializerTraitsT<TrackDesignMazeElement>
     }
 };
 
-template<> struct DataSerializerTraitsT<TrackDesignEntranceElement>
+template<>
+struct DataSerializerTraitsT<TrackDesignEntranceElement>
 {
     static void encode(OpenRCT2::IStream* stream, const TrackDesignEntranceElement& val)
     {
@@ -742,7 +779,8 @@ template<> struct DataSerializerTraitsT<TrackDesignEntranceElement>
     }
 };
 
-template<> struct DataSerializerTraitsT<TrackDesignSceneryElement>
+template<>
+struct DataSerializerTraitsT<TrackDesignSceneryElement>
 {
     static void encode(OpenRCT2::IStream* stream, const TrackDesignSceneryElement& val)
     {
@@ -778,7 +816,8 @@ template<> struct DataSerializerTraitsT<TrackDesignSceneryElement>
     }
 };
 
-template<> struct DataSerializerTraitsT<TrackColour>
+template<>
+struct DataSerializerTraitsT<TrackColour>
 {
     static void encode(OpenRCT2::IStream* stream, const TrackColour& val)
     {
@@ -801,7 +840,8 @@ template<> struct DataSerializerTraitsT<TrackColour>
     }
 };
 
-template<> struct DataSerializerTraitsT<VehicleColour>
+template<>
+struct DataSerializerTraitsT<VehicleColour>
 {
     static void encode(OpenRCT2::IStream* stream, const VehicleColour& val)
     {
@@ -823,7 +863,8 @@ template<> struct DataSerializerTraitsT<VehicleColour>
     }
 };
 
-template<> struct DataSerializerTraitsT<RatingTuple>
+template<>
+struct DataSerializerTraitsT<RatingTuple>
 {
     static void encode(OpenRCT2::IStream* stream, const RatingTuple& val)
     {
@@ -847,7 +888,8 @@ template<> struct DataSerializerTraitsT<RatingTuple>
     }
 };
 
-template<> struct DataSerializerTraitsT<IntensityRange>
+template<>
+struct DataSerializerTraitsT<IntensityRange>
 {
     static void encode(OpenRCT2::IStream* stream, const IntensityRange& val)
     {
@@ -867,7 +909,8 @@ template<> struct DataSerializerTraitsT<IntensityRange>
     }
 };
 
-template<> struct DataSerializerTraitsT<PeepThought>
+template<>
+struct DataSerializerTraitsT<PeepThought>
 {
     static void encode(OpenRCT2::IStream* stream, const PeepThought& val)
     {
@@ -893,7 +936,8 @@ template<> struct DataSerializerTraitsT<PeepThought>
     }
 };
 
-template<> struct DataSerializerTraitsT<TileCoordsXYZD>
+template<>
+struct DataSerializerTraitsT<TileCoordsXYZD>
 {
     static void encode(OpenRCT2::IStream* stream, const TileCoordsXYZD& coord)
     {
@@ -922,7 +966,8 @@ template<> struct DataSerializerTraitsT<TileCoordsXYZD>
     }
 };
 
-template<typename T, T TNull, typename TTag> struct DataSerializerTraitsT<TIdentifier<T, TNull, TTag>>
+template<typename T, T TNull, typename TTag>
+struct DataSerializerTraitsT<TIdentifier<T, TNull, TTag>>
 {
     static void encode(OpenRCT2::IStream* stream, const TIdentifier<T, TNull, TTag>& id)
     {
@@ -943,7 +988,8 @@ template<typename T, T TNull, typename TTag> struct DataSerializerTraitsT<TIdent
     }
 };
 
-template<> struct DataSerializerTraitsT<Banner>
+template<>
+struct DataSerializerTraitsT<Banner>
 {
     static void encode(OpenRCT2::IStream* stream, const Banner& banner)
     {

--- a/src/openrct2/core/Endianness.h
+++ b/src/openrct2/core/Endianness.h
@@ -13,11 +13,13 @@
 #include <cstring>
 #include <type_traits>
 
-template<size_t size> struct ByteSwapT
+template<size_t size>
+struct ByteSwapT
 {
 };
 
-template<> struct ByteSwapT<1>
+template<>
+struct ByteSwapT<1>
 {
     using UIntType = uint8_t;
     static uint8_t SwapBE(uint8_t value)
@@ -26,7 +28,8 @@ template<> struct ByteSwapT<1>
     }
 };
 
-template<> struct ByteSwapT<2>
+template<>
+struct ByteSwapT<2>
 {
     using UIntType = uint16_t;
     static uint16_t SwapBE(uint16_t value)
@@ -35,7 +38,8 @@ template<> struct ByteSwapT<2>
     }
 };
 
-template<> struct ByteSwapT<4>
+template<>
+struct ByteSwapT<4>
 {
     using UIntType = uint32_t;
     static uint32_t SwapBE(uint32_t value)
@@ -45,7 +49,8 @@ template<> struct ByteSwapT<4>
     }
 };
 
-template<> struct ByteSwapT<8>
+template<>
+struct ByteSwapT<8>
 {
     using UIntType = uint64_t;
     static uint64_t SwapBE(uint64_t value)
@@ -57,7 +62,8 @@ template<> struct ByteSwapT<8>
     }
 };
 
-template<typename T> static T ByteSwapBE(const T& value)
+template<typename T>
+static T ByteSwapBE(const T& value)
 {
     using ByteSwap = ByteSwapT<sizeof(T)>;
     using UIntType = typename ByteSwap::UIntType;

--- a/src/openrct2/core/EnumMap.hpp
+++ b/src/openrct2/core/EnumMap.hpp
@@ -18,7 +18,8 @@
 /**
  * Bi-directional map for converting between strings and enums / numbers.
  */
-template<typename T> class EnumMap
+template<typename T>
+class EnumMap
 {
 private:
     std::vector<std::pair<std::string_view, T>> _map;

--- a/src/openrct2/core/FileIndex.hpp
+++ b/src/openrct2/core/FileIndex.hpp
@@ -26,7 +26,8 @@
 #include <tuple>
 #include <vector>
 
-template<typename TItem> class FileIndex
+template<typename TItem>
+class FileIndex
 {
 private:
     struct DirectoryStats

--- a/src/openrct2/core/FileScanner.cpp
+++ b/src/openrct2/core/FileScanner.cpp
@@ -303,7 +303,9 @@ private:
             // Get the full path of the file
             auto path = Path::Combine(directory, node->d_name);
 
-            struct stat statInfo{};
+            struct stat statInfo
+            {
+            };
             int32_t statRes = stat(path.c_str(), &statInfo);
             if (statRes != -1)
             {

--- a/src/openrct2/core/FileScanner.cpp
+++ b/src/openrct2/core/FileScanner.cpp
@@ -303,9 +303,7 @@ private:
             // Get the full path of the file
             auto path = Path::Combine(directory, node->d_name);
 
-            struct stat statInfo
-            {
-            };
+            struct stat statInfo{};
             int32_t statRes = stat(path.c_str(), &statInfo);
             if (statRes != -1)
             {

--- a/src/openrct2/core/FixedVector.h
+++ b/src/openrct2/core/FixedVector.h
@@ -15,7 +15,8 @@
 #include <array>
 #include <utility>
 
-template<typename T, size_t MAX> class FixedVector
+template<typename T, size_t MAX>
+class FixedVector
 {
 public:
     using container = std::array<T, MAX>;
@@ -127,7 +128,8 @@ public:
         return _data.begin() + offset;
     }
 
-    template<typename... Args> constexpr reference_type emplace_back(Args&&... args)
+    template<typename... Args>
+    constexpr reference_type emplace_back(Args&&... args)
     {
         OpenRCT2::Guard::Assert(_count < MAX);
         reference_type res = _data[_count++];

--- a/src/openrct2/core/FlagHolder.hpp
+++ b/src/openrct2/core/FlagHolder.hpp
@@ -11,7 +11,8 @@
 
 #include "../util/Util.h"
 
-template<typename THolderType, typename TEnumType> struct FlagHolder
+template<typename THolderType, typename TEnumType>
+struct FlagHolder
 {
     THolderType holder{};
 

--- a/src/openrct2/core/GroupVector.hpp
+++ b/src/openrct2/core/GroupVector.hpp
@@ -14,7 +14,8 @@
 #include <cstdio>
 #include <vector>
 
-template<typename Handle, typename V> class GroupVector
+template<typename Handle, typename V>
+class GroupVector
 {
     std::vector<std::vector<V>> _data;
 

--- a/src/openrct2/core/Guard.hpp
+++ b/src/openrct2/core/Guard.hpp
@@ -37,7 +37,8 @@ namespace OpenRCT2::Guard
 
     std::optional<std::string> GetLastAssertMessage();
 
-    template<typename T> static void ArgumentNotNull(T* argument, const char* message = nullptr, ...)
+    template<typename T>
+    static void ArgumentNotNull(T* argument, const char* message = nullptr, ...)
     {
         va_list args;
         va_start(args, message);
@@ -45,7 +46,8 @@ namespace OpenRCT2::Guard
         va_end(args);
     }
 
-    template<typename T> static void ArgumentNotNull(const std::shared_ptr<T>& argument, const char* message = nullptr, ...)
+    template<typename T>
+    static void ArgumentNotNull(const std::shared_ptr<T>& argument, const char* message = nullptr, ...)
     {
         va_list args;
         va_start(args, message);
@@ -53,7 +55,8 @@ namespace OpenRCT2::Guard
         va_end(args);
     }
 
-    template<typename T> static void ArgumentInRange(T argument, T min, T max, const char* message = nullptr, ...)
+    template<typename T>
+    static void ArgumentInRange(T argument, T min, T max, const char* message = nullptr, ...)
     {
         va_list args;
         va_start(args, message);
@@ -61,7 +64,8 @@ namespace OpenRCT2::Guard
         va_end(args);
     }
 
-    template<typename T> static void IndexInRange(size_t index, const T& container)
+    template<typename T>
+    static void IndexInRange(size_t index, const T& container)
     {
         Guard::Assert(index < container.size(), "Index %zu out of bounds (%zu)", index, container.size());
     }

--- a/src/openrct2/core/IStream.hpp
+++ b/src/openrct2/core/IStream.hpp
@@ -112,7 +112,8 @@ namespace OpenRCT2
         /**
          * Reads the size of the given type from the stream directly into the given address.
          */
-        template<typename T> void Read(T* value)
+        template<typename T>
+        void Read(T* value)
         {
             // Selects the best path at compile time
             if constexpr (sizeof(T) == 1)
@@ -144,7 +145,8 @@ namespace OpenRCT2
         /**
          * Writes the size of the given type to the stream directly from the given address.
          */
-        template<typename T> void Write(const T* value)
+        template<typename T>
+        void Write(const T* value)
         {
             // Selects the best path at compile time
             if constexpr (sizeof(T) == 1)
@@ -176,7 +178,8 @@ namespace OpenRCT2
         /**
          * Reads the given type from the stream. Use this only for small types (e.g. int8_t, int64_t, double)
          */
-        template<typename T> T ReadValue()
+        template<typename T>
+        T ReadValue()
         {
             T buffer;
             Read(&buffer);
@@ -186,19 +189,22 @@ namespace OpenRCT2
         /**
          * Writes the given type to the stream. Use this only for small types (e.g. int8_t, int64_t, double)
          */
-        template<typename T> void WriteValue(const T value)
+        template<typename T>
+        void WriteValue(const T value)
         {
             Write(&value);
         }
 
-        template<typename T> [[nodiscard]] std::unique_ptr<T[]> ReadArray(size_t count)
+        template<typename T>
+        [[nodiscard]] std::unique_ptr<T[]> ReadArray(size_t count)
         {
             auto buffer = std::make_unique<T[]>(count);
             Read(buffer.get(), sizeof(T) * count);
             return buffer;
         }
 
-        template<typename T> void WriteArray(T* buffer, size_t count)
+        template<typename T>
+        void WriteArray(T* buffer, size_t count)
         {
             Write(buffer, sizeof(T) * count);
         }
@@ -224,7 +230,8 @@ public:
     }
 };
 
-template<typename T> class ivstream : public std::istream
+template<typename T>
+class ivstream : public std::istream
 {
 private:
     class vector_streambuf : public std::basic_streambuf<char, std::char_traits<char>>

--- a/src/openrct2/core/Identifier.hpp
+++ b/src/openrct2/core/Identifier.hpp
@@ -12,7 +12,8 @@
 #include <cstdint>
 #include <cstdio>
 
-template<typename T, T TNullValue, typename TTag> class TIdentifier
+template<typename T, T TNullValue, typename TTag>
+class TIdentifier
 {
     enum class ValueType : T
     {

--- a/src/openrct2/core/Json.hpp
+++ b/src/openrct2/core/Json.hpp
@@ -66,7 +66,8 @@ namespace OpenRCT2::Json
      * @param defaultValue Default value to return if the JSON object is not a number type
      * @return Copy of the JSON value converted to the given type
      */
-    template<typename T> T GetNumber(const json_t& jsonObj, T defaultValue = 0)
+    template<typename T>
+    T GetNumber(const json_t& jsonObj, T defaultValue = 0)
     {
         static_assert(std::is_arithmetic<T>::value, "GetNumber template parameter must be arithmetic");
 
@@ -80,7 +81,8 @@ namespace OpenRCT2::Json
      * @param defaultValue Default value to return if the JSON object is not an enum type
      * @return Copy of the JSON value converted to the given enum type
      */
-    template<typename T> T GetEnum(const json_t& jsonObj, T defaultValue)
+    template<typename T>
+    T GetEnum(const json_t& jsonObj, T defaultValue)
     {
         static_assert(std::is_enum<T>::value, "GetEnum template parameter must be an enum");
 
@@ -124,7 +126,8 @@ namespace OpenRCT2::Json
      * @param list List of pairs of keys and bits to enable if that key in the object is true
      * @return Value with relevant bits flipped
      */
-    template<typename T> T GetFlags(const json_t& jsonObj, std::initializer_list<std::pair<std::string, T>> list)
+    template<typename T>
+    T GetFlags(const json_t& jsonObj, std::initializer_list<std::pair<std::string, T>> list)
     {
         static_assert(std::is_convertible<T, int>::value, "GetFlags template parameter must be integral or a weak enum");
 
@@ -158,7 +161,8 @@ namespace OpenRCT2::Json
      * @return Value with relevant bits flipped
      * @note FLAG_NORMAL behaves like the other GetFlags function, but FLAG_INVERTED will turn the flag on when false
      */
-    template<typename T> T GetFlags(const json_t& jsonObj, std::initializer_list<std::tuple<std::string, T, FlagType>> list)
+    template<typename T>
+    T GetFlags(const json_t& jsonObj, std::initializer_list<std::tuple<std::string, T, FlagType>> list)
     {
         static_assert(std::is_convertible<T, int>::value, "GetFlags template parameter must be integral or a weak enum");
 

--- a/src/openrct2/core/Memory.hpp
+++ b/src/openrct2/core/Memory.hpp
@@ -20,21 +20,24 @@
  */
 namespace OpenRCT2::Memory
 {
-    template<typename T> static T* Allocate()
+    template<typename T>
+    static T* Allocate()
     {
         T* result = static_cast<T*>(malloc(sizeof(T)));
         Guard::ArgumentNotNull(result, "Failed to allocate %zu bytes for %s", sizeof(T), typeid(T).name());
         return result;
     }
 
-    template<typename T> static T* Allocate(size_t size)
+    template<typename T>
+    static T* Allocate(size_t size)
     {
         T* result = static_cast<T*>(malloc(size));
         Guard::ArgumentNotNull(result, "Failed to allocate %zu bytes for %s", size, typeid(T).name());
         return result;
     }
 
-    template<typename T> static T* Reallocate(T* ptr, size_t size)
+    template<typename T>
+    static T* Reallocate(T* ptr, size_t size)
     {
         T* result;
         if (ptr == nullptr)
@@ -49,7 +52,8 @@ namespace OpenRCT2::Memory
         return result;
     }
 
-    template<typename T> static void Free(T* ptr)
+    template<typename T>
+    static void Free(T* ptr)
     {
         free(const_cast<void*>(reinterpret_cast<const void*>(ptr)));
     }

--- a/src/openrct2/core/MemoryStream.h
+++ b/src/openrct2/core/MemoryStream.h
@@ -67,7 +67,8 @@ namespace OpenRCT2
         void Read8(void* buffer) override;
         void Read16(void* buffer) override;
 
-        template<size_t N> void Read(void* buffer)
+        template<size_t N>
+        void Read(void* buffer)
         {
             uint64_t position = GetPosition();
             if (position + N > _dataSize)
@@ -86,7 +87,8 @@ namespace OpenRCT2
         void Write8(const void* buffer) override;
         void Write16(const void* buffer) override;
 
-        template<size_t N> void Write(const void* buffer)
+        template<size_t N>
+        void Write(const void* buffer)
         {
             uint64_t position = GetPosition();
             uint64_t nextPosition = position + N;

--- a/src/openrct2/core/Meta.hpp
+++ b/src/openrct2/core/Meta.hpp
@@ -16,7 +16,8 @@ namespace OpenRCT2::Meta
     /**
      * Meta function for checking that all Conditions are true types.
      */
-    template<typename... TConditions> struct all : std::true_type
+    template<typename... TConditions>
+    struct all : std::true_type
     {
     };
 
@@ -25,6 +26,7 @@ namespace OpenRCT2::Meta
     {
     };
 
-    template<typename TType, typename... TTypes> using all_convertible = all<std::is_convertible<TTypes, TType>...>;
+    template<typename TType, typename... TTypes>
+    using all_convertible = all<std::is_convertible<TTypes, TType>...>;
 
 } // namespace OpenRCT2::Meta

--- a/src/openrct2/core/Numerics.hpp
+++ b/src/openrct2/core/Numerics.hpp
@@ -23,7 +23,8 @@ namespace OpenRCT2::Numerics
      * @param shift positions to shift
      * @return rotated value
      */
-    template<typename _UIntType> static constexpr _UIntType rol(_UIntType x, size_t shift)
+    template<typename _UIntType>
+    static constexpr _UIntType rol(_UIntType x, size_t shift)
     {
         static_assert(std::is_unsigned<_UIntType>::value, "result_type must be an unsigned integral type");
         using limits = typename std::numeric_limits<_UIntType>;
@@ -49,7 +50,8 @@ namespace OpenRCT2::Numerics
      * @param shift positions to shift
      * @return rotated value
      */
-    template<typename _UIntType> static constexpr _UIntType ror(_UIntType x, size_t shift)
+    template<typename _UIntType>
+    static constexpr _UIntType ror(_UIntType x, size_t shift)
     {
         static_assert(std::is_unsigned<_UIntType>::value, "result_type must be an unsigned integral type");
         using limits = std::numeric_limits<_UIntType>;

--- a/src/openrct2/core/OrcaStream.hpp
+++ b/src/openrct2/core/OrcaStream.hpp
@@ -181,7 +181,8 @@ namespace OpenRCT2
             return _header;
         }
 
-        template<typename TFunc> bool ReadWriteChunk(const uint32_t chunkId, TFunc f)
+        template<typename TFunc>
+        bool ReadWriteChunk(const uint32_t chunkId, TFunc f)
         {
             if (_mode == Mode::READING)
             {
@@ -287,7 +288,8 @@ namespace OpenRCT2
                 }
             }
 
-            template<typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true> void ReadWrite(T& v)
+            template<typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
+            void ReadWrite(T& v)
             {
                 if (_mode == Mode::READING)
                 {
@@ -299,7 +301,8 @@ namespace OpenRCT2
                 }
             }
 
-            template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true> void ReadWrite(T& v)
+            template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true>
+            void ReadWrite(T& v)
             {
                 using underlying = typename std::underlying_type<T>::type;
                 if (_mode == Mode::READING)
@@ -312,7 +315,8 @@ namespace OpenRCT2
                 }
             }
 
-            template<typename T, T TNullValue, typename TTag> void ReadWrite(TIdentifier<T, TNullValue, TTag>& value)
+            template<typename T, T TNullValue, typename TTag>
+            void ReadWrite(TIdentifier<T, TNullValue, TTag>& value)
             {
                 if (_mode == Mode::READING)
                 {
@@ -376,7 +380,8 @@ namespace OpenRCT2
                 ReadWrite(coords.direction);
             }
 
-            template<typename T, typename = std::enable_if<std::is_integral<T>::value>> T Read()
+            template<typename T, typename = std::enable_if<std::is_integral<T>::value>>
+            T Read()
             {
                 T v{};
                 ReadWrite(v);
@@ -395,7 +400,8 @@ namespace OpenRCT2
                 }
             }
 
-            template<typename T, typename = std::enable_if<std::is_integral<T>::value>> void Write(T v)
+            template<typename T, typename = std::enable_if<std::is_integral<T>::value>>
+            void Write(T v)
             {
                 if (_mode == Mode::READING)
                 {
@@ -434,7 +440,8 @@ namespace OpenRCT2
                 Write(std::string_view(v));
             }
 
-            template<typename TVec, typename TFunc> void ReadWriteVector(TVec& vec, TFunc f)
+            template<typename TVec, typename TFunc>
+            void ReadWriteVector(TVec& vec, TFunc f)
             {
                 if (_mode == Mode::READING)
                 {
@@ -460,7 +467,8 @@ namespace OpenRCT2
                 }
             }
 
-            template<typename TArr, size_t TArrSize, typename TFunc> void ReadWriteArray(TArr (&arr)[TArrSize], TFunc f)
+            template<typename TArr, size_t TArrSize, typename TFunc>
+            void ReadWriteArray(TArr (&arr)[TArrSize], TFunc f)
             {
                 auto& arr2 = *(reinterpret_cast<std::array<TArr, TArrSize>*>(arr));
                 ReadWriteArray(arr2, f);
@@ -500,7 +508,8 @@ namespace OpenRCT2
                 }
             }
 
-            template<typename T> void Ignore()
+            template<typename T>
+            void Ignore()
             {
                 T value{};
                 ReadWrite(value);
@@ -517,7 +526,8 @@ namespace OpenRCT2
                 _buffer.Write(buffer, len);
             }
 
-            template<typename T, typename = std::enable_if<std::is_integral<T>::value>> T ReadInteger()
+            template<typename T, typename = std::enable_if<std::is_integral<T>::value>>
+            T ReadInteger()
             {
                 if constexpr (sizeof(T) > 4)
                 {
@@ -559,7 +569,8 @@ namespace OpenRCT2
                 }
             }
 
-            template<typename T, typename = std::enable_if<std::is_integral<T>::value>> void WriteInteger(const T value)
+            template<typename T, typename = std::enable_if<std::is_integral<T>::value>>
+            void WriteInteger(const T value)
             {
                 if constexpr (sizeof(T) > 4)
                 {

--- a/src/openrct2/core/Path.hpp
+++ b/src/openrct2/core/Path.hpp
@@ -15,7 +15,8 @@ namespace OpenRCT2::Path
 {
     [[nodiscard]] u8string Combine(u8string_view a, u8string_view b);
 
-    template<typename... Args> static u8string Combine(u8string_view a, u8string_view b, Args... args)
+    template<typename... Args>
+    static u8string Combine(u8string_view a, u8string_view b, Args... args)
     {
         return Combine(a, Combine(b, args...));
     }

--- a/src/openrct2/core/Random.hpp
+++ b/src/openrct2/core/Random.hpp
@@ -27,7 +27,8 @@ namespace OpenRCT2::Random
     /**
      * FixedSeedSequence adheres to the _Named Requirement_ `SeedSequence`.
      */
-    template<size_t TNum = 0> class FixedSeedSequence
+    template<size_t TNum = 0>
+    class FixedSeedSequence
     {
     public:
         using result_type = uint32_t;
@@ -60,7 +61,8 @@ namespace OpenRCT2::Random
         {
         }
 
-        template<typename TIt> void generate(TIt begin, TIt end) const
+        template<typename TIt>
+        void generate(TIt begin, TIt end) const
         {
             std::copy_n(v.begin(), std::min(static_cast<size_t>(end - begin), N), begin);
         }
@@ -70,7 +72,8 @@ namespace OpenRCT2::Random
             return N;
         }
 
-        template<typename TIt> constexpr void param(TIt ob) const
+        template<typename TIt>
+        constexpr void param(TIt ob) const
         {
             std::copy(v.begin(), v.end(), ob);
         }
@@ -79,7 +82,8 @@ namespace OpenRCT2::Random
         std::array<result_type, N> v;
     };
 
-    template<typename TUIntType> struct RotateEngineState
+    template<typename TUIntType>
+    struct RotateEngineState
     {
         using value_type = TUIntType;
 
@@ -143,7 +147,8 @@ namespace OpenRCT2::Random
             s1 = s;
         }
 
-        template<typename TSseq> typename std::enable_if<std::is_class<TSseq>::value, void>::type seed(TSseq& seed_seq)
+        template<typename TSseq>
+        typename std::enable_if<std::is_class<TSseq>::value, void>::type seed(TSseq& seed_seq)
         {
             std::array<result_type, 2> s;
             seed_seq.generate(s.begin(), s.end());

--- a/src/openrct2/core/Range.hpp
+++ b/src/openrct2/core/Range.hpp
@@ -12,7 +12,8 @@
 #include <cmath>
 #include <type_traits>
 
-template<typename T> struct Range
+template<typename T>
+struct Range
 {
     static_assert(std::is_integral<T>(), "type must be integral");
 

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -150,7 +150,8 @@ namespace OpenRCT2::String
         return strcmp(a, b);
     }
 
-    template<typename TString> static bool EqualsImpl(TString&& lhs, TString&& rhs, bool ignoreCase)
+    template<typename TString>
+    static bool EqualsImpl(TString&& lhs, TString&& rhs, bool ignoreCase)
     {
         return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), [ignoreCase](auto a, auto b) {
             const auto first = static_cast<unsigned char>(a);

--- a/src/openrct2/core/String.hpp
+++ b/src/openrct2/core/String.hpp
@@ -98,7 +98,8 @@ namespace OpenRCT2::String
      */
     std::string ToUpper(std::string_view src);
 
-    template<typename T> std::optional<T> Parse(std::string_view input)
+    template<typename T>
+    std::optional<T> Parse(std::string_view input)
     {
         if (input.size() == 0)
             return std::nullopt;
@@ -130,7 +131,8 @@ namespace OpenRCT2::String
     /**
      * Returns string representation of a hexadecimal input, such as SHA256 hash
      */
-    template<typename T> std::string StringFromHex(T input)
+    template<typename T>
+    std::string StringFromHex(T input)
     {
         std::string result;
         result.reserve(input.size() * 2);

--- a/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
@@ -9,7 +9,8 @@
 
 #include "Drawing.h"
 
-template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSpriteMagnify(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
+template<DrawBlendOp TBlendOp>
+static void FASTCALL DrawBMPSpriteMagnify(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
 {
     auto& paletteMap = args.PalMap;
     auto src0 = args.SourceImage.offset;
@@ -34,7 +35,8 @@ template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSpriteMagnify(DrawPix
     }
 }
 
-template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSpriteMinify(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
+template<DrawBlendOp TBlendOp>
+static void FASTCALL DrawBMPSpriteMinify(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
 {
     auto& g1 = args.SourceImage;
     auto src = g1.offset + ((static_cast<size_t>(g1.width) * args.SrcY) + args.SrcX);
@@ -59,7 +61,8 @@ template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSpriteMinify(DrawPixe
     }
 }
 
-template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSprite(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
+template<DrawBlendOp TBlendOp>
+static void FASTCALL DrawBMPSprite(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
 {
     if (dpi.zoom_level < ZoomLevel{ 0 })
     {

--- a/src/openrct2/drawing/Drawing.Sprite.RLE.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.RLE.cpp
@@ -12,7 +12,8 @@
 #include <cassert>
 #include <cstring>
 
-template<DrawBlendOp TBlendOp> static void FASTCALL DrawRLESpriteMagnify(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
+template<DrawBlendOp TBlendOp>
+static void FASTCALL DrawRLESpriteMagnify(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
 {
     auto& paletteMap = args.PalMap;
     auto imgData = args.SourceImage.offset;
@@ -151,7 +152,8 @@ static void FASTCALL DrawRLESpriteMinify(DrawPixelInfo& dpi, const DrawSpriteArg
     }
 }
 
-template<DrawBlendOp TBlendOp> static void FASTCALL DrawRLESprite(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
+template<DrawBlendOp TBlendOp>
+static void FASTCALL DrawRLESprite(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
 {
     auto zoom_level = static_cast<int8_t>(dpi.zoom_level);
     switch (zoom_level)

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -451,7 +451,8 @@ struct DrawSpriteArgs
     }
 };
 
-template<DrawBlendOp TBlendOp> bool FASTCALL BlitPixel(const uint8_t* src, uint8_t* dst, const PaletteMap& paletteMap)
+template<DrawBlendOp TBlendOp>
+bool FASTCALL BlitPixel(const uint8_t* src, uint8_t* dst, const PaletteMap& paletteMap)
 {
     if constexpr (TBlendOp & BLEND_TRANSPARENT)
     {

--- a/src/openrct2/drawing/DrawingLock.hpp
+++ b/src/openrct2/drawing/DrawingLock.hpp
@@ -13,7 +13,8 @@
 
 using namespace OpenRCT2;
 
-template<typename T> class DrawingUniqueLock
+template<typename T>
+class DrawingUniqueLock
 {
     T& _mutex;
     const bool _enabled;
@@ -33,7 +34,8 @@ public:
     }
 };
 
-template<typename T> class DrawingSharedLock
+template<typename T>
+class DrawingSharedLock
 {
     T& _mutex;
     const bool _enabled;

--- a/src/openrct2/entity/Balloon.cpp
+++ b/src/openrct2/entity/Balloon.cpp
@@ -20,7 +20,8 @@
 #include "../world/tile_element/TrackElement.h"
 #include "EntityRegistry.h"
 
-template<> bool EntityBase::Is<Balloon>() const
+template<>
+bool EntityBase::Is<Balloon>() const
 {
     return Type == EntityType::Balloon;
 }

--- a/src/openrct2/entity/Duck.cpp
+++ b/src/openrct2/entity/Duck.cpp
@@ -71,7 +71,8 @@ static constexpr const uint8_t * kDuckAnimations[] =
 };
 // clang-format on
 
-template<> bool EntityBase::Is<Duck>() const
+template<>
+bool EntityBase::Is<Duck>() const
 {
     return Type == EntityType::Duck;
 }

--- a/src/openrct2/entity/EntityBase.cpp
+++ b/src/openrct2/entity/EntityBase.cpp
@@ -15,7 +15,8 @@
 using namespace OpenRCT2;
 
 // Required for GetEntity to return a default
-template<> bool EntityBase::Is<EntityBase>() const
+template<>
+bool EntityBase::Is<EntityBase>() const
 {
     return true;
 }

--- a/src/openrct2/entity/EntityBase.h
+++ b/src/openrct2/entity/EntityBase.h
@@ -65,12 +65,15 @@ struct EntityBase
     CoordsXYZ GetLocation() const;
 
     void Invalidate();
-    template<typename T> bool Is() const;
-    template<typename T> T* As()
+    template<typename T>
+    bool Is() const;
+    template<typename T>
+    T* As()
     {
         return Is<T>() ? reinterpret_cast<T*>(this) : nullptr;
     }
-    template<typename T> const T* As() const
+    template<typename T>
+    const T* As() const
     {
         return Is<T>() ? reinterpret_cast<const T*>(this) : nullptr;
     }

--- a/src/openrct2/entity/EntityList.h
+++ b/src/openrct2/entity/EntityList.h
@@ -24,7 +24,8 @@ uint16_t GetMiscEntityCount();
 uint16_t GetNumFreeEntities();
 const std::vector<EntityId>& GetEntityTileList(const CoordsXY& spritePos);
 
-template<typename T> class EntityTileIterator
+template<typename T>
+class EntityTileIterator
 {
 private:
     std::vector<EntityId>::const_iterator iter;
@@ -75,7 +76,8 @@ public:
     using iterator_category = std::forward_iterator_tag;
 };
 
-template<typename T = EntityBase> class EntityTileList
+template<typename T = EntityBase>
+class EntityTileList
 {
 private:
     const std::vector<EntityId>& vec;
@@ -96,7 +98,8 @@ public:
     }
 };
 
-template<typename T> class EntityListIterator
+template<typename T>
+class EntityListIterator
 {
 private:
     std::list<EntityId>::const_iterator iter;
@@ -147,7 +150,8 @@ public:
     using iterator_category = std::forward_iterator_tag;
 };
 
-template<typename T = EntityBase> class EntityList
+template<typename T = EntityBase>
+class EntityList
 {
 private:
     using EntityListIterator_t = EntityListIterator<T>;

--- a/src/openrct2/entity/EntityRegistry.cpp
+++ b/src/openrct2/entity/EntityRegistry.cpp
@@ -222,7 +222,8 @@ void ResetEntitySpatialIndices()
 
 #ifndef DISABLE_NETWORK
 
-template<typename T> void NetworkSerialseEntityType(DataSerialiser& ds)
+template<typename T>
+void NetworkSerialseEntityType(DataSerialiser& ds)
 {
     for (auto* ent : EntityList<T>())
     {
@@ -230,7 +231,8 @@ template<typename T> void NetworkSerialseEntityType(DataSerialiser& ds)
     }
 }
 
-template<typename... T> void NetworkSerialiseEntityTypes(DataSerialiser& ds)
+template<typename... T>
+void NetworkSerialiseEntityTypes(DataSerialiser& ds)
 {
     (NetworkSerialseEntityType<T>(ds), ...);
 }
@@ -380,7 +382,8 @@ EntityBase* CreateEntityAt(const EntityId index, const EntityType type)
     return entity;
 }
 
-template<typename T> void MiscUpdateAllType()
+template<typename T>
+void MiscUpdateAllType()
 {
     for (auto misc : EntityList<T>())
     {
@@ -388,7 +391,8 @@ template<typename T> void MiscUpdateAllType()
     }
 }
 
-template<typename... T> void MiscUpdateAllTypes()
+template<typename... T>
+void MiscUpdateAllTypes()
 {
     (MiscUpdateAllType<T>(), ...);
 }

--- a/src/openrct2/entity/EntityRegistry.h
+++ b/src/openrct2/entity/EntityRegistry.h
@@ -30,7 +30,8 @@ constexpr uint16_t MAX_ENTITIES = 65535;
 
 EntityBase* GetEntity(EntityId sprite_idx);
 
-template<typename T> T* GetEntity(EntityId sprite_idx)
+template<typename T>
+T* GetEntity(EntityId sprite_idx)
 {
     auto spr = GetEntity(sprite_idx);
     return spr != nullptr ? spr->As<T>() : nullptr;
@@ -38,7 +39,8 @@ template<typename T> T* GetEntity(EntityId sprite_idx)
 
 EntityBase* TryGetEntity(EntityId spriteIndex);
 
-template<typename T> T* TryGetEntity(EntityId sprite_idx)
+template<typename T>
+T* TryGetEntity(EntityId sprite_idx)
 {
     auto spr = TryGetEntity(sprite_idx);
     return spr != nullptr ? spr->As<T>() : nullptr;
@@ -46,7 +48,8 @@ template<typename T> T* TryGetEntity(EntityId sprite_idx)
 
 EntityBase* CreateEntity(EntityType type);
 
-template<typename T> T* CreateEntity()
+template<typename T>
+T* CreateEntity()
 {
     return static_cast<T*>(CreateEntity(T::cEntityType));
 }
@@ -54,7 +57,8 @@ template<typename T> T* CreateEntity()
 // Use only with imports that must happen at a specified index
 EntityBase* CreateEntityAt(const EntityId index, const EntityType type);
 // Use only with imports that must happen at a specified index
-template<typename T> T* CreateEntityAt(const EntityId index)
+template<typename T>
+T* CreateEntityAt(const EntityId index)
 {
     return static_cast<T*>(CreateEntityAt(index, T::cEntityType));
 }

--- a/src/openrct2/entity/Fountain.cpp
+++ b/src/openrct2/entity/Fountain.cpp
@@ -83,7 +83,8 @@ const uint8_t _fountainPatternFlags[] = {
     FOUNTAIN_FLAG::FAST,                                                   // FAST_RANDOM_CHASERS
 };
 
-template<> bool EntityBase::Is<JumpingFountain>() const
+template<>
+bool EntityBase::Is<JumpingFountain>() const
 {
     return Type == EntityType::JumpingFountain;
 }

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -454,7 +454,8 @@ static void PeepLeavePark(Guest* peep);
 static void PeepHeadForNearestRideWithFlag(Guest* peep, bool considerOnlyCloseRides, RtdFlag rtdFlag);
 bool Loc690FD0(Peep* peep, RideId* rideToView, uint8_t* rideSeatToView, TileElement* tileElement);
 
-template<> bool EntityBase::Is<Guest>() const
+template<>
+bool EntityBase::Is<Guest>() const
 {
     return Type == EntityType::Guest;
 }
@@ -472,7 +473,8 @@ static bool IsValidLocation(const CoordsXYZ& coords)
     return false;
 }
 
-template<void (Guest::*EasterEggFunc)(Guest*), bool applyToSelf> static void ApplyEasterEggToNearbyGuests(Guest* guest)
+template<void (Guest::*EasterEggFunc)(Guest*), bool applyToSelf>
+static void ApplyEasterEggToNearbyGuests(Guest* guest)
 {
     const auto guestLoc = guest->GetLocation();
     if (!IsValidLocation(guestLoc))
@@ -3140,7 +3142,8 @@ static void PeepLeavePark(Guest* peep)
     WindowInvalidateByNumber(WindowClass::Peep, peep->Id);
 }
 
-template<typename T> static void PeepHeadForNearestRide(Guest* peep, bool considerOnlyCloseRides, T predicate)
+template<typename T>
+static void PeepHeadForNearestRide(Guest* peep, bool considerOnlyCloseRides, T predicate)
 {
     if (peep->State != PeepState::Sitting && peep->State != PeepState::Watching && peep->State != PeepState::Walking)
     {

--- a/src/openrct2/entity/Litter.cpp
+++ b/src/openrct2/entity/Litter.cpp
@@ -15,7 +15,8 @@
 
 using namespace OpenRCT2;
 
-template<> bool EntityBase::Is<Litter>() const
+template<>
+bool EntityBase::Is<Litter>() const
 {
     return Type == EntityType::Litter;
 }

--- a/src/openrct2/entity/MoneyEffect.cpp
+++ b/src/openrct2/entity/MoneyEffect.cpp
@@ -32,7 +32,8 @@ static constexpr CoordsXY _moneyEffectMoveOffset[] = {
     { -1, -1 },
 };
 
-template<> bool EntityBase::Is<MoneyEffect>() const
+template<>
+bool EntityBase::Is<MoneyEffect>() const
 {
     return Type == EntityType::MoneyEffect;
 }

--- a/src/openrct2/entity/Particle.cpp
+++ b/src/openrct2/entity/Particle.cpp
@@ -24,27 +24,32 @@ static constexpr uint32_t _VehicleCrashParticleSprites[kCrashedVehicleParticleNu
     22577, 22589, 22601, 22613, 22625,
 };
 
-template<> bool EntityBase::Is<SteamParticle>() const
+template<>
+bool EntityBase::Is<SteamParticle>() const
 {
     return Type == EntityType::SteamParticle;
 }
 
-template<> bool EntityBase::Is<ExplosionFlare>() const
+template<>
+bool EntityBase::Is<ExplosionFlare>() const
 {
     return Type == EntityType::ExplosionFlare;
 }
 
-template<> bool EntityBase::Is<ExplosionCloud>() const
+template<>
+bool EntityBase::Is<ExplosionCloud>() const
 {
     return Type == EntityType::ExplosionCloud;
 }
 
-template<> bool EntityBase::Is<VehicleCrashParticle>() const
+template<>
+bool EntityBase::Is<VehicleCrashParticle>() const
 {
     return Type == EntityType::CrashedVehicleParticle;
 }
 
-template<> bool EntityBase::Is<CrashSplashParticle>() const
+template<>
+bool EntityBase::Is<CrashSplashParticle>() const
 {
     return Type == EntityType::CrashSplash;
 }

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -125,7 +125,8 @@ const bool gAnimationGroupToSlowWalkMap[] = {
     true,  true,  true,  true,  true,  true,  false, true,  false, true,  true,  true, true,  true,  true,  true,
 };
 
-template<> bool EntityBase::Is<Peep>() const
+template<>
+bool EntityBase::Is<Peep>() const
 {
     return Type == EntityType::Guest || Type == EntityType::Staff;
 }

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -75,7 +75,8 @@ const StringId StaffCostumeNames[] = {
 // Maximum manhattan distance that litter can be for a handyman to seek to it
 const uint16_t MAX_LITTER_DISTANCE = 3 * kCoordsXYStep;
 
-template<> bool EntityBase::Is<Staff>() const
+template<>
+bool EntityBase::Is<Staff>() const
 {
     return Type == EntityType::Staff;
 }

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -708,7 +708,7 @@ void ViewportUpdateFollowSprite(WindowBase* window)
 
         if (!(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO))
         {
-            int32_t height = (TileElementHeight({ sprite->x, sprite->y }))-16;
+            int32_t height = (TileElementHeight({ sprite->x, sprite->y })) - 16;
             int32_t underground = sprite->z < height;
             ViewportSetUndergroundFlag(underground, window, window->viewport);
         }

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -708,7 +708,7 @@ void ViewportUpdateFollowSprite(WindowBase* window)
 
         if (!(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO))
         {
-            int32_t height = (TileElementHeight({ sprite->x, sprite->y })) - 16;
+            int32_t height = (TileElementHeight({ sprite->x, sprite->y }))-16;
             int32_t underground = sprite->z < height;
             ViewportSetUndergroundFlag(underground, window, window->viewport);
         }

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -244,7 +244,8 @@ void WindowFlushDead()
     g_window_list.remove_if([](auto&& w) -> bool { return w->flags & WF_DEAD; });
 }
 
-template<typename TPred> static void WindowCloseByCondition(TPred pred, uint32_t flags = WindowCloseFlags::None)
+template<typename TPred>
+static void WindowCloseByCondition(TPred pred, uint32_t flags = WindowCloseFlags::None)
 {
     for (auto it = g_window_list.rbegin(); it != g_window_list.rend(); ++it)
     {
@@ -476,7 +477,8 @@ WidgetIndex WindowFindWidgetFromPoint(WindowBase& w, const ScreenCoordsXY& scree
  *
  * @param window The window to invalidate (esi).
  */
-template<typename TPred> static void WindowInvalidateByCondition(TPred pred)
+template<typename TPred>
+static void WindowInvalidateByCondition(TPred pred)
 {
     WindowVisitEach([pred](WindowBase* w) {
         if (pred(w))
@@ -541,7 +543,8 @@ void WidgetInvalidate(WindowBase& w, WidgetIndex widgetIndex)
                         { w.windowPos + ScreenCoordsXY{ widget.right + 1, widget.bottom + 1 } } });
 }
 
-template<typename TPred> static void widget_invalidate_by_condition(TPred pred)
+template<typename TPred>
+static void widget_invalidate_by_condition(TPred pred)
 {
     WindowVisitEach([pred](WindowBase* w) {
         if (pred(w))

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -198,7 +198,8 @@ struct Focus
     ZoomLevel zoom{};
     std::variant<CoordinateFocus, EntityFocus> data;
 
-    template<typename T> constexpr explicit Focus(T newValue, ZoomLevel newZoom = {})
+    template<typename T>
+    constexpr explicit Focus(T newValue, ZoomLevel newZoom = {})
     {
         data = newValue;
         zoom = newZoom;

--- a/src/openrct2/interface/ZoomLevel.h
+++ b/src/openrct2/interface/ZoomLevel.h
@@ -53,7 +53,8 @@ public:
     friend constexpr bool operator>(const ZoomLevel& lhs, const ZoomLevel& rhs);
     friend constexpr bool operator<(const ZoomLevel& lhs, const ZoomLevel& rhs);
 
-    template<typename T> constexpr T ApplyTo(const T& lhs) const
+    template<typename T>
+    constexpr T ApplyTo(const T& lhs) const
     {
         if (_level < 0)
             return lhs >> -_level;
@@ -61,7 +62,8 @@ public:
         return lhs << _level;
     }
 
-    template<typename T> constexpr T ApplyInversedTo(const T& lhs) const
+    template<typename T>
+    constexpr T ApplyInversedTo(const T& lhs) const
     {
         if (_level < 0)
             return lhs << -_level;

--- a/src/openrct2/localisation/Formatter.h
+++ b/src/openrct2/localisation/Formatter.h
@@ -79,7 +79,8 @@ public:
         return CurrentBuf - StartBuf;
     }
 
-    template<typename TSpecified, typename TDeduced> Formatter& Add(TDeduced value)
+    template<typename TSpecified, typename TDeduced>
+    Formatter& Add(TDeduced value)
     {
         static_assert(sizeof(TSpecified) <= sizeof(uint64_t), "Type too large");
         static_assert(sizeof(TDeduced) <= sizeof(uint64_t), "Type too large");

--- a/src/openrct2/localisation/Formatting.cpp
+++ b/src/openrct2/localisation/Formatting.cpp
@@ -317,7 +317,8 @@ namespace OpenRCT2
         }
     }
 
-    template<size_t TDecimalPlace, bool TDigitSep, typename T> void FormatNumber(FormatBuffer& ss, T value)
+    template<size_t TDecimalPlace, bool TDigitSep, typename T>
+    void FormatNumber(FormatBuffer& ss, T value)
     {
         char buffer[32];
         size_t i = 0;
@@ -395,7 +396,8 @@ namespace OpenRCT2
         }
     }
 
-    template<size_t TDecimalPlace, bool TDigitSep, typename T> void FormatCurrency(FormatBuffer& ss, T rawValue)
+    template<size_t TDecimalPlace, bool TDigitSep, typename T>
+    void FormatCurrency(FormatBuffer& ss, T rawValue)
     {
         auto currencyDesc = &CurrencyDescriptors[EnumValue(Config::Get().general.CurrencyFormat)];
         auto value = static_cast<int64_t>(rawValue) * currencyDesc->rate;
@@ -450,7 +452,8 @@ namespace OpenRCT2
         }
     }
 
-    template<typename T> static void FormatMinutesSeconds(FormatBuffer& ss, T value)
+    template<typename T>
+    static void FormatMinutesSeconds(FormatBuffer& ss, T value)
     {
         static constexpr StringId Formats[][2] = {
             { STR_DURATION_SEC, STR_DURATION_SECS },
@@ -472,7 +475,8 @@ namespace OpenRCT2
         }
     }
 
-    template<typename T> static void FormatHoursMinutes(FormatBuffer& ss, T value)
+    template<typename T>
+    static void FormatHoursMinutes(FormatBuffer& ss, T value)
     {
         static constexpr StringId Formats[][2] = {
             { STR_REALTIME_MIN, STR_REALTIME_MINS },
@@ -494,7 +498,8 @@ namespace OpenRCT2
         }
     }
 
-    template<typename T> void FormatArgument(FormatBuffer& ss, FormatToken token, T arg)
+    template<typename T>
+    void FormatArgument(FormatBuffer& ss, FormatToken token, T arg)
     {
         switch (token)
         {
@@ -777,7 +782,8 @@ namespace OpenRCT2
         return CopyStringStreamToBuffer(buffer, bufferLen, ss);
     }
 
-    template<typename T> static T ReadFromArgs(const void*& args)
+    template<typename T>
+    static T ReadFromArgs(const void*& args)
     {
         T value;
         std::memcpy(&value, args, sizeof(T));

--- a/src/openrct2/localisation/Formatting.h
+++ b/src/openrct2/localisation/Formatting.h
@@ -26,7 +26,8 @@ namespace OpenRCT2
     // TODO: find a better spot for this (RCT12.h?)
     constexpr size_t kUserStringMaxLength = 32;
 
-    template<typename T, size_t StackSize = 256, typename TTraits = std::char_traits<T>> class FormatBufferBase
+    template<typename T, size_t StackSize = 256, typename TTraits = std::char_traits<T>>
+    class FormatBufferBase
     {
         T _storage[StackSize];
         T* _buffer;
@@ -79,7 +80,8 @@ namespace OpenRCT2
             return _buffer;
         }
 
-        template<size_t N> auto& operator<<(T const (&v)[N])
+        template<size_t N>
+        auto& operator<<(T const (&v)[N])
         {
             append(v, N);
             return *this;
@@ -200,7 +202,8 @@ namespace OpenRCT2
         std::string WithoutFormatTokens() const;
     };
 
-    template<typename T> void FormatArgument(FormatBuffer& ss, FormatToken token, T arg);
+    template<typename T>
+    void FormatArgument(FormatBuffer& ss, FormatToken token, T arg);
 
     bool IsRealNameStringId(StringId id);
     void FormatRealName(FormatBuffer& ss, StringId id);
@@ -264,14 +267,16 @@ namespace OpenRCT2
         }
     }
 
-    template<typename... TArgs> static void FormatString(FormatBuffer& ss, const FmtString& fmt, TArgs&&... argN)
+    template<typename... TArgs>
+    static void FormatString(FormatBuffer& ss, const FmtString& fmt, TArgs&&... argN)
     {
         std::stack<FmtString::iterator> stack;
         stack.push(fmt.begin());
         FormatString(ss, stack, argN...);
     }
 
-    template<typename... TArgs> std::string FormatString(const FmtString& fmt, TArgs&&... argN)
+    template<typename... TArgs>
+    std::string FormatString(const FmtString& fmt, TArgs&&... argN)
     {
         auto& ss = GetThreadFormatStream();
         FormatString(ss, fmt, argN...);
@@ -286,19 +291,22 @@ namespace OpenRCT2
         return CopyStringStreamToBuffer(buffer, bufferLen, ss);
     }
 
-    template<typename... TArgs> static void FormatStringID(FormatBuffer& ss, StringId id, TArgs&&... argN)
+    template<typename... TArgs>
+    static void FormatStringID(FormatBuffer& ss, StringId id, TArgs&&... argN)
     {
         auto fmt = GetFmtStringById(id);
         FormatString(ss, fmt, argN...);
     }
 
-    template<typename... TArgs> std::string FormatStringID(StringId id, TArgs&&... argN)
+    template<typename... TArgs>
+    std::string FormatStringID(StringId id, TArgs&&... argN)
     {
         auto fmt = GetFmtStringById(id);
         return FormatString(fmt, argN...);
     }
 
-    template<typename... TArgs> size_t FormatStringID(char* buffer, size_t bufferLen, StringId id, TArgs&&... argN)
+    template<typename... TArgs>
+    size_t FormatStringID(char* buffer, size_t bufferLen, StringId id, TArgs&&... argN)
     {
         auto& ss = GetThreadFormatStream();
         FormatStringID(ss, id, argN...);

--- a/src/openrct2/management/NewsItem.h
+++ b/src/openrct2/management/NewsItem.h
@@ -120,7 +120,8 @@ namespace OpenRCT2::News
     constexpr int32_t MaxItemsArchive = 50;
     constexpr int32_t MaxItems = News::ItemHistoryStart + News::MaxItemsArchive;
 
-    template<std::size_t N> class ItemQueue
+    template<std::size_t N>
+    class ItemQueue
     {
     public:
         static_assert(N > 0, "Cannot instantiate News::ItemQueue with size=0");
@@ -264,7 +265,8 @@ namespace OpenRCT2::News
             return Archived;
         }
 
-        template<typename Predicate> void ForeachRecentNews(Predicate&& p)
+        template<typename Predicate>
+        void ForeachRecentNews(Predicate&& p)
         {
             for (auto& newsItem : Recent)
             {
@@ -272,7 +274,8 @@ namespace OpenRCT2::News
             }
         }
 
-        template<typename Predicate> void ForeachArchivedNews(Predicate&& p)
+        template<typename Predicate>
+        void ForeachArchivedNews(Predicate&& p)
         {
             for (auto& newsItem : Archived)
             {

--- a/src/openrct2/network/NetworkPacket.h
+++ b/src/openrct2/network/NetworkPacket.h
@@ -43,7 +43,8 @@ struct NetworkPacket final
     void Write(const void* bytes, size_t size);
     void WriteString(std::string_view s);
 
-    template<typename T> NetworkPacket& operator>>(T& value)
+    template<typename T>
+    NetworkPacket& operator>>(T& value)
     {
         if (BytesRead + sizeof(value) > Header.Size)
         {
@@ -59,7 +60,8 @@ struct NetworkPacket final
         return *this;
     }
 
-    template<typename T> NetworkPacket& operator<<(T value)
+    template<typename T>
+    NetworkPacket& operator<<(T value)
     {
         T swapped = ByteSwapBE(value);
         Write(&swapped, sizeof(T));

--- a/src/openrct2/network/NetworkTypes.h
+++ b/src/openrct2/network/NetworkTypes.h
@@ -108,7 +108,8 @@ struct NetworkServerState
 // this structure can be used in combination with DataSerialiser
 // to provide extra details with template specialization.
 #pragma pack(push, 1)
-template<typename T, size_t _TypeID> struct NetworkObjectId
+template<typename T, size_t _TypeID>
+struct NetworkObjectId
 {
     NetworkObjectId(T v)
         : id(v)

--- a/src/openrct2/network/Socket.cpp
+++ b/src/openrct2/network/Socket.cpp
@@ -368,9 +368,7 @@ public:
         {
             throw std::runtime_error("Socket not listening.");
         }
-        struct sockaddr_storage client_addr
-        {
-        };
+        struct sockaddr_storage client_addr{};
         socklen_t client_len = sizeof(struct sockaddr_storage);
 
         std::unique_ptr<ITcpSocket> tcpSocket;

--- a/src/openrct2/network/Socket.cpp
+++ b/src/openrct2/network/Socket.cpp
@@ -368,7 +368,9 @@ public:
         {
             throw std::runtime_error("Socket not listening.");
         }
-        struct sockaddr_storage client_addr{};
+        struct sockaddr_storage client_addr
+        {
+        };
         socklen_t client_len = sizeof(struct sockaddr_storage);
 
         std::unique_ptr<ITcpSocket> tcpSocket;

--- a/src/openrct2/object/ObjectAsset.h
+++ b/src/openrct2/object/ObjectAsset.h
@@ -48,7 +48,8 @@ public:
     friend bool operator==(const ObjectAsset& l, const ObjectAsset& r);
 };
 
-template<> struct std::hash<ObjectAsset>
+template<>
+struct std::hash<ObjectAsset>
 {
     std::size_t operator()(const ObjectAsset& asset) const noexcept
     {

--- a/src/openrct2/object/ObjectEntryManager.h
+++ b/src/openrct2/object/ObjectEntryManager.h
@@ -15,7 +15,8 @@ namespace OpenRCT2::ObjectManager
 {
     const void* GetObjectEntry(ObjectType type, ObjectEntryIndex idx);
 
-    template<typename T> const T* GetObjectEntry(ObjectEntryIndex idx)
+    template<typename T>
+    const T* GetObjectEntry(ObjectEntryIndex idx)
     {
         return reinterpret_cast<const T*>(GetObjectEntry(T::kObjectType, idx));
     }

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -472,7 +472,8 @@ private:
         LOG_VERBOSE("%u / %u objects unloaded", numObjectsUnloaded, totalObjectsLoaded);
     }
 
-    template<typename T> void UpdateSceneryGroupIndexes(ObjectType type)
+    template<typename T>
+    void UpdateSceneryGroupIndexes(ObjectType type)
     {
         auto& list = GetObjectList(type);
         for (auto* loadedObject : list)

--- a/src/openrct2/object/ObjectManager.h
+++ b/src/openrct2/object/ObjectManager.h
@@ -26,7 +26,8 @@ struct IObjectManager
     }
 
     virtual Object* GetLoadedObject(ObjectType objectType, size_t index) = 0;
-    template<typename TClass> TClass* GetLoadedObject(size_t index)
+    template<typename TClass>
+    TClass* GetLoadedObject(size_t index)
     {
         return static_cast<TClass*>(GetLoadedObject(TClass::kObjectType, index));
     }

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -216,7 +216,8 @@ static PaintStruct* CreateNormalPaintStruct(
     return ps;
 }
 
-template<uint8_t direction> void PaintSessionGenerateRotate(PaintSession& session)
+template<uint8_t direction>
+void PaintSessionGenerateRotate(PaintSession& session)
 {
     // Optimised modified version of ViewportPosToMapPos
     ScreenCoordsXY screenCoord = { Floor2(session.DPI.WorldX(), 32), Floor2((session.DPI.WorldY() - 16), 32) };
@@ -400,7 +401,8 @@ static std::pair<PaintStruct*, PaintStruct*> PaintStructsGetNextPending(PaintStr
 
 // Re-orders all nodes after the specified child node and marks the child node as traversed. The resulting
 // order of the children is the depth based on rotation and dimensions of the bounding box.
-template<uint8_t TRotation> static void PaintStructsSortQuadrant(PaintStruct* parent, PaintStruct* child)
+template<uint8_t TRotation>
+static void PaintStructsSortQuadrant(PaintStruct* parent, PaintStruct* child)
 {
     // Mark visited.
     child->SortFlags &= ~PaintSortFlags::PendingVisit;
@@ -493,7 +495,8 @@ static void PaintStructsLinkQuadrants(PaintSessionCore& session, PaintStruct& ps
     } while (++quadrantIndex <= session.QuadrantFrontIndex);
 }
 
-template<int TRotation> static void PaintSessionArrangeImpl(PaintSessionCore& session)
+template<int TRotation>
+static void PaintSessionArrangeImpl(PaintSessionCore& session)
 {
     uint32_t quadrantIndex = session.QuadrantBackIndex;
     if (quadrantIndex == UINT32_MAX)

--- a/src/openrct2/paint/track/coaster/JuniorRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/JuniorRollerCoaster.cpp
@@ -1851,7 +1851,8 @@ static constexpr const uint32_t junior_rc_track_pieces_diag_blockbrakes[2][4] = 
     },
 };
 
-template<JuniorRCSubType TSubType> constexpr uint8_t JuniorRCGetSubTypeOffset(const TrackElement& trackElement)
+template<JuniorRCSubType TSubType>
+constexpr uint8_t JuniorRCGetSubTypeOffset(const TrackElement& trackElement)
 {
     return trackElement.HasChain() ? EnumValue(TSubType) : 0;
 }
@@ -5799,7 +5800,8 @@ static void JuniorRCTrackOnRidePhoto(
 }
 
 /* 0x008AAA0C */
-template<JuniorRCSubType TSubType> TRACK_PAINT_FUNCTION GetTrackPaintFunctionJuniorRCTemplate(OpenRCT2::TrackElemType trackType)
+template<JuniorRCSubType TSubType>
+TRACK_PAINT_FUNCTION GetTrackPaintFunctionJuniorRCTemplate(OpenRCT2::TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/WoodenRollerCoaster.cpp
@@ -17628,7 +17628,8 @@ static void WoodenRCTrackRightLargeHalfLoopDown(
     WoodenRCTrackLeftLargeHalfLoopUp<isClassic>(session, ride, 6 - trackSequence, direction, height, trackElement, supportType);
 }
 
-template<bool isClassic> TRACK_PAINT_FUNCTION GetTrackPaintFunctionWoodenAndClassicWoodenRC(OpenRCT2::TrackElemType trackType)
+template<bool isClassic>
+TRACK_PAINT_FUNCTION GetTrackPaintFunctionWoodenAndClassicWoodenRC(OpenRCT2::TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/WoodenRollerCoaster.h
+++ b/src/openrct2/paint/track/coaster/WoodenRollerCoaster.h
@@ -40,7 +40,8 @@ static constexpr const WoodenSupportSubType WoodenRCDiagonalSupports[4][kNumOrth
       WoodenSupportSubType::Null } // sequence 3
 };
 
-template<bool isClassic> ImageId WoodenRCGetTrackColour(const PaintSession& session)
+template<bool isClassic>
+ImageId WoodenRCGetTrackColour(const PaintSession& session)
 {
     if (isClassic)
         return session.TrackColours;
@@ -62,7 +63,8 @@ PaintStruct* WoodenRCTrackPaint(
     return PaintAddImageAsChildRotated(session, direction, railsImageId, offset, boundBox);
 }
 
-template<bool isClassic> void WoodenRCTrackPaintBb(PaintSession& session, const SpriteBoundBox2* bb, int16_t height)
+template<bool isClassic>
+void WoodenRCTrackPaintBb(PaintSession& session, const SpriteBoundBox2* bb, int16_t height)
 {
     if (bb->ImageIdA == 0)
         return;

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1640,7 +1640,8 @@ namespace OpenRCT2
             }
         }
 
-        template<typename T> static void ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, T& entity);
+        template<typename T>
+        static void ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, T& entity);
 
         static void ReadWriteEntityCommon(OrcaStream::ChunkStream& cs, EntityBase& entity)
         {
@@ -2035,12 +2036,16 @@ namespace OpenRCT2
             }
         }
 
-        template<typename T> void WriteEntitiesOfType(OrcaStream& os, OrcaStream::ChunkStream& cs);
-        template<typename... T> void WriteEntitiesOfTypes(OrcaStream& os, OrcaStream::ChunkStream& cs);
+        template<typename T>
+        void WriteEntitiesOfType(OrcaStream& os, OrcaStream::ChunkStream& cs);
+        template<typename... T>
+        void WriteEntitiesOfTypes(OrcaStream& os, OrcaStream::ChunkStream& cs);
 
-        template<typename T> void ReadEntitiesOfType(OrcaStream& os, OrcaStream::ChunkStream& cs);
+        template<typename T>
+        void ReadEntitiesOfType(OrcaStream& os, OrcaStream::ChunkStream& cs);
 
-        template<typename... T> void ReadEntitiesOfTypes(OrcaStream& os, OrcaStream::ChunkStream& cs);
+        template<typename... T>
+        void ReadEntitiesOfTypes(OrcaStream& os, OrcaStream::ChunkStream& cs);
 
         void ReadWriteEntitiesChunk(GameState_t& gameState, OrcaStream& os);
 
@@ -2076,7 +2081,8 @@ namespace OpenRCT2
         }
     };
 
-    template<> void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, Vehicle& entity)
+    template<>
+    void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, Vehicle& entity)
     {
         ReadWriteEntityCommon(cs, entity);
         cs.ReadWrite(entity.SubType);
@@ -2192,7 +2198,8 @@ namespace OpenRCT2
         }
     }
 
-    template<> void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, Guest& guest)
+    template<>
+    void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, Guest& guest)
     {
         ReadWritePeep(os, cs, guest);
         auto version = os.GetHeader().TargetVersion;
@@ -2364,7 +2371,8 @@ namespace OpenRCT2
         cs.ReadWrite(guest.ItemFlags);
     }
 
-    template<> void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, Staff& entity)
+    template<>
+    void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, Staff& entity)
     {
         ReadWritePeep(os, cs, entity);
 
@@ -2410,14 +2418,16 @@ namespace OpenRCT2
         cs.ReadWrite(entity.StaffBinsEmptied);
     }
 
-    template<> void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, SteamParticle& steamParticle)
+    template<>
+    void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, SteamParticle& steamParticle)
     {
         ReadWriteEntityCommon(cs, steamParticle);
         cs.ReadWrite(steamParticle.time_to_move);
         cs.ReadWrite(steamParticle.frame);
     }
 
-    template<> void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, MoneyEffect& moneyEffect)
+    template<>
+    void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, MoneyEffect& moneyEffect)
     {
         ReadWriteEntityCommon(cs, moneyEffect);
         cs.ReadWrite(moneyEffect.MoveDelay);
@@ -2446,25 +2456,29 @@ namespace OpenRCT2
         cs.ReadWrite(vehicleCrashParticle.acceleration_z);
     }
 
-    template<> void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, ExplosionCloud& entity)
+    template<>
+    void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, ExplosionCloud& entity)
     {
         ReadWriteEntityCommon(cs, entity);
         cs.ReadWrite(entity.frame);
     }
 
-    template<> void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, CrashSplashParticle& entity)
+    template<>
+    void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, CrashSplashParticle& entity)
     {
         ReadWriteEntityCommon(cs, entity);
         cs.ReadWrite(entity.frame);
     }
 
-    template<> void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, ExplosionFlare& entity)
+    template<>
+    void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, ExplosionFlare& entity)
     {
         ReadWriteEntityCommon(cs, entity);
         cs.ReadWrite(entity.frame);
     }
 
-    template<> void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, JumpingFountain& fountain)
+    template<>
+    void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, JumpingFountain& fountain)
     {
         ReadWriteEntityCommon(cs, fountain);
         cs.ReadWrite(fountain.NumTicksAlive);
@@ -2476,7 +2490,8 @@ namespace OpenRCT2
         cs.ReadWrite(fountain.Iteration);
     }
 
-    template<> void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, Balloon& balloon)
+    template<>
+    void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, Balloon& balloon)
     {
         ReadWriteEntityCommon(cs, balloon);
         cs.ReadWrite(balloon.popped);
@@ -2485,7 +2500,8 @@ namespace OpenRCT2
         cs.ReadWrite(balloon.colour);
     }
 
-    template<> void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, Duck& duck)
+    template<>
+    void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, Duck& duck)
     {
         ReadWriteEntityCommon(cs, duck);
         cs.ReadWrite(duck.frame);
@@ -2494,14 +2510,16 @@ namespace OpenRCT2
         cs.ReadWrite(duck.state);
     }
 
-    template<> void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, Litter& entity)
+    template<>
+    void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, Litter& entity)
     {
         ReadWriteEntityCommon(cs, entity);
         cs.ReadWrite(entity.SubType);
         cs.ReadWrite(entity.creationTick);
     }
 
-    template<typename T> void ParkFile::WriteEntitiesOfType(OrcaStream& os, OrcaStream::ChunkStream& cs)
+    template<typename T>
+    void ParkFile::WriteEntitiesOfType(OrcaStream& os, OrcaStream::ChunkStream& cs)
     {
         uint16_t count = GetEntityListCount(T::cEntityType);
         cs.Write(T::cEntityType);
@@ -2513,12 +2531,14 @@ namespace OpenRCT2
         }
     }
 
-    template<typename... T> void ParkFile::WriteEntitiesOfTypes(OrcaStream& os, OrcaStream::ChunkStream& cs)
+    template<typename... T>
+    void ParkFile::WriteEntitiesOfTypes(OrcaStream& os, OrcaStream::ChunkStream& cs)
     {
         (WriteEntitiesOfType<T>(os, cs), ...);
     }
 
-    template<typename T> void ParkFile::ReadEntitiesOfType(OrcaStream& os, OrcaStream::ChunkStream& cs)
+    template<typename T>
+    void ParkFile::ReadEntitiesOfType(OrcaStream& os, OrcaStream::ChunkStream& cs)
     {
         [[maybe_unused]] auto t = cs.Read<EntityType>();
         assert(t == T::cEntityType);
@@ -2538,7 +2558,8 @@ namespace OpenRCT2
         }
     }
 
-    template<typename... T> void ParkFile::ReadEntitiesOfTypes(OrcaStream& os, OrcaStream::ChunkStream& cs)
+    template<typename... T>
+    void ParkFile::ReadEntitiesOfTypes(OrcaStream& os, OrcaStream::ChunkStream& cs)
     {
         (ReadEntitiesOfType<T>(os, cs), ...);
     }

--- a/src/openrct2/platform/Platform.Posix.cpp
+++ b/src/openrct2/platform/Platform.Posix.cpp
@@ -170,9 +170,7 @@ namespace OpenRCT2::Platform
     uint64_t GetLastModified(std::string_view path)
     {
         uint64_t lastModified = 0;
-        struct stat statInfo
-        {
-        };
+        struct stat statInfo{};
         if (stat(std::string(path).c_str(), &statInfo) == 0)
         {
             lastModified = statInfo.st_mtime;
@@ -183,9 +181,7 @@ namespace OpenRCT2::Platform
     uint64_t GetFileSize(std::string_view path)
     {
         uint64_t size = 0;
-        struct stat statInfo
-        {
-        };
+        struct stat statInfo{};
         if (stat(std::string(path).c_str(), &statInfo) == 0)
         {
             size = statInfo.st_size;

--- a/src/openrct2/platform/Platform.Posix.cpp
+++ b/src/openrct2/platform/Platform.Posix.cpp
@@ -170,7 +170,9 @@ namespace OpenRCT2::Platform
     uint64_t GetLastModified(std::string_view path)
     {
         uint64_t lastModified = 0;
-        struct stat statInfo{};
+        struct stat statInfo
+        {
+        };
         if (stat(std::string(path).c_str(), &statInfo) == 0)
         {
             lastModified = statInfo.st_mtime;
@@ -181,7 +183,9 @@ namespace OpenRCT2::Platform
     uint64_t GetFileSize(std::string_view path)
     {
         uint64_t size = 0;
-        struct stat statInfo{};
+        struct stat statInfo
+        {
+        };
         if (stat(std::string(path).c_str(), &statInfo) == 0)
         {
             size = statInfo.st_size;

--- a/src/openrct2/platform/Platform.macOS.mm
+++ b/src/openrct2/platform/Platform.macOS.mm
@@ -101,9 +101,10 @@ namespace OpenRCT2::Platform
                 auto exeDirectory = Path::GetDirectory(exePath);
 
                 // check build and install paths
-                NSArray *dataSearchLocations = @[@"data", @"../share/openrct2"];
+                NSArray* dataSearchLocations = @[ @"data", @"../share/openrct2" ];
 
-                for (NSString *searchLocation in dataSearchLocations) {
+                for (NSString* searchLocation in dataSearchLocations)
+                {
                     path = Path::Combine(exeDirectory, [searchLocation UTF8String]);
                     NSString* nsPath = [NSString stringWithUTF8String:path.c_str()];
                     if ([[NSFileManager defaultManager] fileExistsAtPath:nsPath])
@@ -290,6 +291,6 @@ namespace OpenRCT2::Platform
     {
         return {};
     }
-}
+} // namespace OpenRCT2::Platform
 
 #endif

--- a/src/openrct2/profiling/Profiling.h
+++ b/src/openrct2/profiling/Profiling.h
@@ -137,7 +137,8 @@ namespace OpenRCT2::Profiling
             }
         };
 
-        template<typename TName> struct FunctionWrapper : FunctionInternal
+        template<typename TName>
+        struct FunctionWrapper : FunctionInternal
         {
             const char* GetName() const noexcept override
             {
@@ -149,7 +150,8 @@ namespace OpenRCT2::Profiling
         // This avoids the compiler generating thread-safe initialization
         // by making a unique type per function which hosts a global using
         // the inline keyword for the variable (C++17).
-        template<typename TName> struct Storage
+        template<typename TName>
+        struct Storage
         {
             static inline FunctionWrapper<TName> Data;
         };
@@ -159,7 +161,8 @@ namespace OpenRCT2::Profiling
 
     } // namespace Detail
 
-    template<typename T> class ScopedProfiling
+    template<typename T>
+    class ScopedProfiling
     {
         bool _enabled;
         T& _func;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1240,7 +1240,8 @@ namespace OpenRCT2::RCT1
         }
 
         void ImportEntity(const RCT12EntityBase& src);
-        template<typename T> void ImportEntity(const RCT12EntityBase& src);
+        template<typename T>
+        void ImportEntity(const RCT12EntityBase& src);
 
         void ImportEntities()
         {
@@ -2678,7 +2679,8 @@ namespace OpenRCT2::RCT1
         return output;
     }
 
-    template<> void S4Importer::ImportEntity<::Vehicle>(const RCT12EntityBase& srcBase)
+    template<>
+    void S4Importer::ImportEntity<::Vehicle>(const RCT12EntityBase& srcBase)
     {
         auto* dst = CreateEntityAt<::Vehicle>(EntityId::FromUnderlying(srcBase.EntityIndex));
         auto* src = static_cast<const RCT1::Vehicle*>(&srcBase);
@@ -2800,7 +2802,8 @@ namespace OpenRCT2::RCT1
         }
     }
 
-    template<> void S4Importer::ImportEntity<Guest>(const RCT12EntityBase& srcBase)
+    template<>
+    void S4Importer::ImportEntity<Guest>(const RCT12EntityBase& srcBase)
     {
         auto* dst = CreateEntityAt<Guest>(EntityId::FromUnderlying(srcBase.EntityIndex));
         auto* src = static_cast<const RCT1::Peep*>(&srcBase);
@@ -2891,7 +2894,8 @@ namespace OpenRCT2::RCT1
         dst->SetItemFlags(src->GetItemFlags());
     }
 
-    template<> void S4Importer::ImportEntity<Staff>(const RCT12EntityBase& srcBase)
+    template<>
+    void S4Importer::ImportEntity<Staff>(const RCT12EntityBase& srcBase)
     {
         auto* dst = CreateEntityAt<Staff>(EntityId::FromUnderlying(srcBase.EntityIndex));
         auto* src = static_cast<const RCT1::Peep*>(&srcBase);
@@ -2909,7 +2913,8 @@ namespace OpenRCT2::RCT1
         ImportStaffPatrolArea(dst, src->StaffID);
     }
 
-    template<> void S4Importer::ImportEntity<Litter>(const RCT12EntityBase& srcBase)
+    template<>
+    void S4Importer::ImportEntity<Litter>(const RCT12EntityBase& srcBase)
     {
         auto* dst = CreateEntityAt<Litter>(EntityId::FromUnderlying(srcBase.EntityIndex));
         auto* src = static_cast<const RCT12EntityLitter*>(&srcBase);
@@ -2919,7 +2924,8 @@ namespace OpenRCT2::RCT1
         dst->creationTick = src->CreationTick;
     }
 
-    template<> void S4Importer::ImportEntity<SteamParticle>(const RCT12EntityBase& srcBase)
+    template<>
+    void S4Importer::ImportEntity<SteamParticle>(const RCT12EntityBase& srcBase)
     {
         auto* dst = CreateEntityAt<SteamParticle>(EntityId::FromUnderlying(srcBase.EntityIndex));
         auto* src = static_cast<const RCT12EntitySteamParticle*>(&srcBase);
@@ -2929,7 +2935,8 @@ namespace OpenRCT2::RCT1
         dst->time_to_move = src->TimeToMove;
     }
 
-    template<> void S4Importer::ImportEntity<MoneyEffect>(const RCT12EntityBase& srcBase)
+    template<>
+    void S4Importer::ImportEntity<MoneyEffect>(const RCT12EntityBase& srcBase)
     {
         auto* dst = CreateEntityAt<MoneyEffect>(EntityId::FromUnderlying(srcBase.EntityIndex));
         auto* src = static_cast<const RCT12EntityMoneyEffect*>(&srcBase);
@@ -2943,7 +2950,8 @@ namespace OpenRCT2::RCT1
         dst->Wiggle = src->Wiggle;
     }
 
-    template<> void S4Importer::ImportEntity<VehicleCrashParticle>(const RCT12EntityBase& srcBase)
+    template<>
+    void S4Importer::ImportEntity<VehicleCrashParticle>(const RCT12EntityBase& srcBase)
     {
         auto* dst = CreateEntityAt<VehicleCrashParticle>(EntityId::FromUnderlying(srcBase.EntityIndex));
         auto* src = static_cast<const RCT12EntityCrashedVehicleParticle*>(&srcBase);
@@ -2961,7 +2969,8 @@ namespace OpenRCT2::RCT1
         dst->acceleration_z = src->AccelerationZ;
     }
 
-    template<> void S4Importer::ImportEntity<ExplosionCloud>(const RCT12EntityBase& srcBase)
+    template<>
+    void S4Importer::ImportEntity<ExplosionCloud>(const RCT12EntityBase& srcBase)
     {
         auto* dst = CreateEntityAt<ExplosionCloud>(EntityId::FromUnderlying(srcBase.EntityIndex));
         auto* src = static_cast<const RCT12EntityParticle*>(&srcBase);
@@ -2969,7 +2978,8 @@ namespace OpenRCT2::RCT1
         dst->frame = src->Frame;
     }
 
-    template<> void S4Importer::ImportEntity<ExplosionFlare>(const RCT12EntityBase& srcBase)
+    template<>
+    void S4Importer::ImportEntity<ExplosionFlare>(const RCT12EntityBase& srcBase)
     {
         auto* dst = CreateEntityAt<ExplosionFlare>(EntityId::FromUnderlying(srcBase.EntityIndex));
         auto* src = static_cast<const RCT12EntityParticle*>(&srcBase);
@@ -2977,7 +2987,8 @@ namespace OpenRCT2::RCT1
         dst->frame = src->Frame;
     }
 
-    template<> void S4Importer::ImportEntity<CrashSplashParticle>(const RCT12EntityBase& srcBase)
+    template<>
+    void S4Importer::ImportEntity<CrashSplashParticle>(const RCT12EntityBase& srcBase)
     {
         auto* dst = CreateEntityAt<CrashSplashParticle>(EntityId::FromUnderlying(srcBase.EntityIndex));
         auto* src = static_cast<const RCT12EntityParticle*>(&srcBase);
@@ -2985,7 +2996,8 @@ namespace OpenRCT2::RCT1
         dst->frame = src->Frame;
     }
 
-    template<> void S4Importer::ImportEntity<JumpingFountain>(const RCT12EntityBase& srcBase)
+    template<>
+    void S4Importer::ImportEntity<JumpingFountain>(const RCT12EntityBase& srcBase)
     {
         auto* dst = CreateEntityAt<JumpingFountain>(EntityId::FromUnderlying(srcBase.EntityIndex));
         auto* src = static_cast<const RCT12EntityJumpingFountain*>(&srcBase);
@@ -3004,7 +3016,8 @@ namespace OpenRCT2::RCT1
         dst->Iteration = src->Iteration;
     }
 
-    template<> void S4Importer::ImportEntity<Balloon>(const RCT12EntityBase& srcBase)
+    template<>
+    void S4Importer::ImportEntity<Balloon>(const RCT12EntityBase& srcBase)
     {
         auto* dst = CreateEntityAt<Balloon>(EntityId::FromUnderlying(srcBase.EntityIndex));
         auto* src = static_cast<const RCT12EntityBalloon*>(&srcBase);
@@ -3024,7 +3037,8 @@ namespace OpenRCT2::RCT1
         }
     }
 
-    template<> void S4Importer::ImportEntity<Duck>(const RCT12EntityBase& srcBase)
+    template<>
+    void S4Importer::ImportEntity<Duck>(const RCT12EntityBase& srcBase)
     {
         auto* dst = CreateEntityAt<Duck>(EntityId::FromUnderlying(srcBase.EntityIndex));
         auto* src = static_cast<const RCT12EntityDuck*>(&srcBase);

--- a/src/openrct2/rct12/CSStringConverter.cpp
+++ b/src/openrct2/rct12/CSStringConverter.cpp
@@ -217,7 +217,8 @@ static int32_t GetCodePageForRCT2Language(RCT2LanguageId languageId)
     }
 }
 
-template<typename TConvertFunc> static std::string DecodeConvertWithTable(std::string_view src, TConvertFunc func)
+template<typename TConvertFunc>
+static std::string DecodeConvertWithTable(std::string_view src, TConvertFunc func)
 {
     auto decoded = DecodeToWideChar(src);
     std::wstring u16;

--- a/src/openrct2/rct12/EntryList.h
+++ b/src/openrct2/rct12/EntryList.h
@@ -55,7 +55,8 @@ namespace OpenRCT2::RCT12
             }
         }
 
-        template<uint32_t i> void AddRange(const std::string_view (&list)[i])
+        template<uint32_t i>
+        void AddRange(const std::string_view (&list)[i])
         {
             for (auto entry : list)
             {

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -658,11 +658,13 @@ struct RCT12TileElementBase
 struct RCT12TileElement : public RCT12TileElementBase
 {
     uint8_t Pad04[4];
-    template<typename TType, RCT12TileElementType TClass> const TType* as() const
+    template<typename TType, RCT12TileElementType TClass>
+    const TType* as() const
     {
         return static_cast<RCT12TileElementType>(GetType()) == TClass ? reinterpret_cast<const TType*>(this) : nullptr;
     }
-    template<typename TType, RCT12TileElementType TClass> TType* as()
+    template<typename TType, RCT12TileElementType TClass>
+    TType* as()
     {
         return static_cast<RCT12TileElementType>(GetType()) == TClass ? reinterpret_cast<TType*>(this) : nullptr;
     }
@@ -1203,7 +1205,8 @@ static constexpr money32 RCT12_COMPANY_VALUE_ON_FAILED_OBJECTIVE = 0x80000001;
 
 money64 RCT12CompletedCompanyValueToOpenRCT2(money32 origValue);
 
-template<typename T> std::vector<uint16_t> RCT12GetRideTypesBeenOn(T* srcPeep)
+template<typename T>
+std::vector<uint16_t> RCT12GetRideTypesBeenOn(T* srcPeep)
 {
     std::vector<uint16_t> ridesTypesBeenOn;
     for (uint16_t i = 0; i < OpenRCT2::RCT12::Limits::kMaxRideObjects; i++)
@@ -1215,7 +1218,8 @@ template<typename T> std::vector<uint16_t> RCT12GetRideTypesBeenOn(T* srcPeep)
     }
     return ridesTypesBeenOn;
 }
-template<typename T> std::vector<RideId> RCT12GetRidesBeenOn(T* srcPeep)
+template<typename T>
+std::vector<RideId> RCT12GetRidesBeenOn(T* srcPeep)
 {
     std::vector<RideId> ridesBeenOn;
     for (uint16_t i = 0; i < OpenRCT2::RCT12::Limits::kMaxRidesInPark; i++)

--- a/src/openrct2/rct12/SawyerChunkReader.h
+++ b/src/openrct2/rct12/SawyerChunkReader.h
@@ -79,7 +79,8 @@ public:
      * specified type. If the chunk is smaller than the size of the type
      * then the remaining space is padded with zero.
      */
-    template<typename T> T ReadChunkAs()
+    template<typename T>
+    T ReadChunkAs()
     {
         T result;
         ReadChunk(&result, sizeof(result));

--- a/src/openrct2/rct12/SawyerChunkWriter.h
+++ b/src/openrct2/rct12/SawyerChunkWriter.h
@@ -52,7 +52,8 @@ public:
     /**
      * Writes a chunk to the stream containing the given type.
      */
-    template<typename T> void WriteChunk(const T* src, SAWYER_ENCODING encoding)
+    template<typename T>
+    void WriteChunk(const T* src, SAWYER_ENCODING encoding)
     {
         WriteChunk(src, sizeof(T), encoding);
     }

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1617,7 +1617,8 @@ namespace OpenRCT2::RCT2
             return (_s6.Header.ClassicFlag == 0xf) ? Limits::kMaxEntitiesRCTCExtended : Limits::kMaxEntities;
         }
 
-        template<typename OpenRCT2_T> void ImportEntity(const RCT12EntityBase& src);
+        template<typename OpenRCT2_T>
+        void ImportEntity(const RCT12EntityBase& src);
 
         void ImportEntityPeep(::Peep* dst, const Peep* src)
         {
@@ -1880,7 +1881,8 @@ namespace OpenRCT2::RCT2
         }
     };
 
-    template<> void S6Importer::ImportEntity<::Vehicle>(const RCT12EntityBase& baseSrc)
+    template<>
+    void S6Importer::ImportEntity<::Vehicle>(const RCT12EntityBase& baseSrc)
     {
         auto dst = CreateEntityAt<::Vehicle>(EntityId::FromUnderlying(baseSrc.EntityIndex));
         auto src = static_cast<const RCT2::Vehicle*>(&baseSrc);
@@ -2005,7 +2007,8 @@ namespace OpenRCT2::RCT2
         return s6.GameTicks1 - ticksElapsed;
     }
 
-    template<> void S6Importer::ImportEntity<::Guest>(const RCT12EntityBase& baseSrc)
+    template<>
+    void S6Importer::ImportEntity<::Guest>(const RCT12EntityBase& baseSrc)
     {
         auto dst = CreateEntityAt<::Guest>(EntityId::FromUnderlying(baseSrc.EntityIndex));
         auto src = static_cast<const Peep*>(&baseSrc);
@@ -2079,7 +2082,8 @@ namespace OpenRCT2::RCT2
         dst->FavouriteRideRating = src->FavouriteRideRating;
     }
 
-    template<> void S6Importer::ImportEntity<::Staff>(const RCT12EntityBase& baseSrc)
+    template<>
+    void S6Importer::ImportEntity<::Staff>(const RCT12EntityBase& baseSrc)
     {
         auto dst = CreateEntityAt<::Staff>(EntityId::FromUnderlying(baseSrc.EntityIndex));
         auto src = static_cast<const Peep*>(&baseSrc);
@@ -2099,7 +2103,8 @@ namespace OpenRCT2::RCT2
         ImportStaffPatrolArea(dst, src->StaffId);
     }
 
-    template<> void S6Importer::ImportEntity<::SteamParticle>(const RCT12EntityBase& baseSrc)
+    template<>
+    void S6Importer::ImportEntity<::SteamParticle>(const RCT12EntityBase& baseSrc)
     {
         auto dst = CreateEntityAt<::SteamParticle>(EntityId::FromUnderlying(baseSrc.EntityIndex));
         auto src = static_cast<const RCT12EntitySteamParticle*>(&baseSrc);
@@ -2108,7 +2113,8 @@ namespace OpenRCT2::RCT2
         dst->frame = src->Frame;
     }
 
-    template<> void S6Importer::ImportEntity<::MoneyEffect>(const RCT12EntityBase& baseSrc)
+    template<>
+    void S6Importer::ImportEntity<::MoneyEffect>(const RCT12EntityBase& baseSrc)
     {
         auto dst = CreateEntityAt<::MoneyEffect>(EntityId::FromUnderlying(baseSrc.EntityIndex));
         auto src = static_cast<const RCT12EntityMoneyEffect*>(&baseSrc);
@@ -2121,7 +2127,8 @@ namespace OpenRCT2::RCT2
         dst->Wiggle = src->Wiggle;
     }
 
-    template<> void S6Importer::ImportEntity<::VehicleCrashParticle>(const RCT12EntityBase& baseSrc)
+    template<>
+    void S6Importer::ImportEntity<::VehicleCrashParticle>(const RCT12EntityBase& baseSrc)
     {
         auto dst = CreateEntityAt<::VehicleCrashParticle>(EntityId::FromUnderlying(baseSrc.EntityIndex));
         auto src = static_cast<const RCT12EntityCrashedVehicleParticle*>(&baseSrc);
@@ -2140,7 +2147,8 @@ namespace OpenRCT2::RCT2
         dst->acceleration_z = src->AccelerationZ;
     }
 
-    template<> void S6Importer::ImportEntity<::ExplosionCloud>(const RCT12EntityBase& baseSrc)
+    template<>
+    void S6Importer::ImportEntity<::ExplosionCloud>(const RCT12EntityBase& baseSrc)
     {
         auto dst = CreateEntityAt<::ExplosionCloud>(EntityId::FromUnderlying(baseSrc.EntityIndex));
         auto src = static_cast<const RCT12EntityParticle*>(&baseSrc);
@@ -2148,7 +2156,8 @@ namespace OpenRCT2::RCT2
         dst->frame = src->Frame;
     }
 
-    template<> void S6Importer::ImportEntity<::ExplosionFlare>(const RCT12EntityBase& baseSrc)
+    template<>
+    void S6Importer::ImportEntity<::ExplosionFlare>(const RCT12EntityBase& baseSrc)
     {
         auto dst = CreateEntityAt<::ExplosionFlare>(EntityId::FromUnderlying(baseSrc.EntityIndex));
         auto src = static_cast<const RCT12EntityParticle*>(&baseSrc);
@@ -2156,7 +2165,8 @@ namespace OpenRCT2::RCT2
         dst->frame = src->Frame;
     }
 
-    template<> void S6Importer::ImportEntity<::CrashSplashParticle>(const RCT12EntityBase& baseSrc)
+    template<>
+    void S6Importer::ImportEntity<::CrashSplashParticle>(const RCT12EntityBase& baseSrc)
     {
         auto dst = CreateEntityAt<::CrashSplashParticle>(EntityId::FromUnderlying(baseSrc.EntityIndex));
         auto src = static_cast<const RCT12EntityParticle*>(&baseSrc);
@@ -2164,7 +2174,8 @@ namespace OpenRCT2::RCT2
         dst->frame = src->Frame;
     }
 
-    template<> void S6Importer::ImportEntity<::JumpingFountain>(const RCT12EntityBase& baseSrc)
+    template<>
+    void S6Importer::ImportEntity<::JumpingFountain>(const RCT12EntityBase& baseSrc)
     {
         auto dst = CreateEntityAt<::JumpingFountain>(EntityId::FromUnderlying(baseSrc.EntityIndex));
         auto src = static_cast<const RCT12EntityJumpingFountain*>(&baseSrc);
@@ -2180,7 +2191,8 @@ namespace OpenRCT2::RCT2
             : ::JumpingFountainType::Water;
     }
 
-    template<> void S6Importer::ImportEntity<::Balloon>(const RCT12EntityBase& baseSrc)
+    template<>
+    void S6Importer::ImportEntity<::Balloon>(const RCT12EntityBase& baseSrc)
     {
         auto dst = CreateEntityAt<::Balloon>(EntityId::FromUnderlying(baseSrc.EntityIndex));
         auto src = static_cast<const RCT12EntityBalloon*>(&baseSrc);
@@ -2191,7 +2203,8 @@ namespace OpenRCT2::RCT2
         dst->colour = src->Colour;
     }
 
-    template<> void S6Importer::ImportEntity<::Duck>(const RCT12EntityBase& baseSrc)
+    template<>
+    void S6Importer::ImportEntity<::Duck>(const RCT12EntityBase& baseSrc)
     {
         auto dst = CreateEntityAt<::Duck>(EntityId::FromUnderlying(baseSrc.EntityIndex));
         auto src = static_cast<const RCT12EntityDuck*>(&baseSrc);
@@ -2202,7 +2215,8 @@ namespace OpenRCT2::RCT2
         dst->state = static_cast<::Duck::DuckState>(src->State);
     }
 
-    template<> void S6Importer::ImportEntity<::Litter>(const RCT12EntityBase& baseSrc)
+    template<>
+    void S6Importer::ImportEntity<::Litter>(const RCT12EntityBase& baseSrc)
     {
         auto dst = CreateEntityAt<::Litter>(EntityId::FromUnderlying(baseSrc.EntityIndex));
         auto src = static_cast<const RCT12EntityLitter*>(&baseSrc);

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -3389,7 +3389,8 @@ namespace OpenRCT2::TrackMetaData
     };
     static_assert(std::size(TrackTypeToSpinFunction) == EnumValue(TrackElemType::Count));
 
-    template<int32_t TConstant> static int32_t EvaluatorConst(const int16_t)
+    template<int32_t TConstant>
+    static int32_t EvaluatorConst(const int16_t)
     {
         return TConstant;
     }

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -448,7 +448,8 @@ static constexpr OpenRCT2::Audio::SoundId DoorCloseSoundIds[] = {
     OpenRCT2::Audio::SoundId::Portcullis,
 };
 
-template<> bool EntityBase::Is<Vehicle>() const
+template<>
+bool EntityBase::Is<Vehicle>() const
 {
     return Type == EntityType::Vehicle;
 }
@@ -6316,7 +6317,8 @@ void Vehicle::UpdateSceneryDoor() const
     AnimateSceneryDoor<false>({ wallCoords, static_cast<Direction>(direction) }, TrackLocation, next_vehicle_on_train.IsNull());
 }
 
-template<bool isBackwards> static void AnimateLandscapeDoor(TrackElement* trackElement, bool isLastVehicle)
+template<bool isBackwards>
+static void AnimateLandscapeDoor(TrackElement* trackElement, bool isLastVehicle)
 {
     auto doorState = isBackwards ? trackElement->GetDoorAState() : trackElement->GetDoorBState();
     if (!isLastVehicle && doorState == LANDSCAPE_DOOR_CLOSED)

--- a/src/openrct2/scripting/Duktape.hpp
+++ b/src/openrct2/scripting/Duktape.hpp
@@ -24,30 +24,35 @@
 
 namespace OpenRCT2::Scripting
 {
-    template<typename T> DukValue GetObjectAsDukValue(duk_context* ctx, const std::shared_ptr<T>& value)
+    template<typename T>
+    DukValue GetObjectAsDukValue(duk_context* ctx, const std::shared_ptr<T>& value)
     {
         dukglue::types::DukType<std::shared_ptr<T>>::template push<T>(ctx, value);
         return DukValue::take_from_stack(ctx);
     }
 
-    template<typename T> T AsOrDefault(const DukValue& value, const T& defaultValue = {}) = delete;
+    template<typename T>
+    T AsOrDefault(const DukValue& value, const T& defaultValue = {}) = delete;
 
     inline std::string AsOrDefault(const DukValue& value, std::string_view defaultValue)
     {
         return value.type() == DukValue::STRING ? value.as_string() : std::string(defaultValue);
     }
 
-    template<> inline std::string AsOrDefault(const DukValue& value, const std::string& defaultValue)
+    template<>
+    inline std::string AsOrDefault(const DukValue& value, const std::string& defaultValue)
     {
         return value.type() == DukValue::STRING ? value.as_string() : defaultValue;
     }
 
-    template<> inline int32_t AsOrDefault(const DukValue& value, const int32_t& defaultValue)
+    template<>
+    inline int32_t AsOrDefault(const DukValue& value, const int32_t& defaultValue)
     {
         return value.type() == DukValue::NUMBER ? value.as_int() : defaultValue;
     }
 
-    template<> inline bool AsOrDefault(const DukValue& value, const bool& defaultValue)
+    template<>
+    inline bool AsOrDefault(const DukValue& value, const bool& defaultValue)
     {
         return value.type() == DukValue::BOOLEAN ? value.as_bool() : defaultValue;
     }
@@ -163,7 +168,8 @@ namespace OpenRCT2::Scripting
             duk_put_prop_string(_ctx, _idx, name);
         }
 
-        template<typename T> void Set(const char* name, const std::optional<T>& value)
+        template<typename T>
+        void Set(const char* name, const std::optional<T>& value)
         {
             if (value)
             {
@@ -236,7 +242,8 @@ namespace OpenRCT2::Scripting
     /**
      * Bi-directional map for converting between strings and enums / numbers.
      */
-    template<typename T> using DukEnumMap = EnumMap<T>;
+    template<typename T>
+    using DukEnumMap = EnumMap<T>;
 
     inline duk_ret_t duk_json_decode_wrapper(duk_context* ctx, void*)
     {
@@ -259,74 +266,88 @@ namespace OpenRCT2::Scripting
 
     std::string ProcessString(const DukValue& value);
 
-    template<typename T> DukValue ToDuk(duk_context* ctx, const T& value) = delete;
-    template<typename T> T FromDuk(const DukValue& s) = delete;
+    template<typename T>
+    DukValue ToDuk(duk_context* ctx, const T& value) = delete;
+    template<typename T>
+    T FromDuk(const DukValue& s) = delete;
 
-    template<> inline DukValue ToDuk(duk_context* ctx, const std::nullptr_t&)
+    template<>
+    inline DukValue ToDuk(duk_context* ctx, const std::nullptr_t&)
     {
         duk_push_null(ctx);
         return DukValue::take_from_stack(ctx);
     }
 
-    template<> inline DukValue ToDuk(duk_context* ctx, const DukUndefined&)
+    template<>
+    inline DukValue ToDuk(duk_context* ctx, const DukUndefined&)
     {
         duk_push_undefined(ctx);
         return DukValue::take_from_stack(ctx);
     }
 
-    template<> inline DukValue ToDuk(duk_context* ctx, const bool& value)
+    template<>
+    inline DukValue ToDuk(duk_context* ctx, const bool& value)
     {
         duk_push_boolean(ctx, value);
         return DukValue::take_from_stack(ctx);
     }
 
-    template<> inline DukValue ToDuk(duk_context* ctx, const uint8_t& value)
+    template<>
+    inline DukValue ToDuk(duk_context* ctx, const uint8_t& value)
     {
         duk_push_int(ctx, value);
         return DukValue::take_from_stack(ctx);
     }
 
-    template<> inline DukValue ToDuk(duk_context* ctx, const uint16_t& value)
+    template<>
+    inline DukValue ToDuk(duk_context* ctx, const uint16_t& value)
     {
         duk_push_int(ctx, value);
         return DukValue::take_from_stack(ctx);
     }
 
-    template<> inline DukValue ToDuk(duk_context* ctx, const int32_t& value)
+    template<>
+    inline DukValue ToDuk(duk_context* ctx, const int32_t& value)
     {
         duk_push_int(ctx, value);
         return DukValue::take_from_stack(ctx);
     }
 
-    template<> inline DukValue ToDuk(duk_context* ctx, const int64_t& value)
+    template<>
+    inline DukValue ToDuk(duk_context* ctx, const int64_t& value)
     {
         duk_push_number(ctx, value);
         return DukValue::take_from_stack(ctx);
     }
 
-    template<> inline DukValue ToDuk(duk_context* ctx, const std::string_view& value)
+    template<>
+    inline DukValue ToDuk(duk_context* ctx, const std::string_view& value)
     {
         duk_push_lstring(ctx, value.data(), value.size());
         return DukValue::take_from_stack(ctx);
     }
 
-    template<> inline DukValue ToDuk(duk_context* ctx, const std::string& value)
+    template<>
+    inline DukValue ToDuk(duk_context* ctx, const std::string& value)
     {
         return ToDuk(ctx, std::string_view(value));
     }
 
-    template<size_t TLen> inline DukValue ToDuk(duk_context* ctx, const char (&value)[TLen])
+    template<size_t TLen>
+    inline DukValue ToDuk(duk_context* ctx, const char (&value)[TLen])
     {
         duk_push_string(ctx, value);
         return DukValue::take_from_stack(ctx);
     }
 
-    template<typename T> inline DukValue ToDuk(duk_context* ctx, const std::optional<T>& value)
+    template<typename T>
+    inline DukValue ToDuk(duk_context* ctx, const std::optional<T>& value)
     {
         return value ? ToDuk(ctx, *value) : ToDuk(ctx, nullptr);
     }
 
-    template<> CoordsXY inline FromDuk(const DukValue& d)
+    template<>
+    CoordsXY inline FromDuk(const DukValue& d)
     {
         CoordsXY result;
         result.x = AsOrDefault(d["x"], 0);
@@ -334,7 +355,8 @@ namespace OpenRCT2::Scripting
         return result;
     }
 
-    template<> MapRange inline FromDuk(const DukValue& d)
+    template<>
+    MapRange inline FromDuk(const DukValue& d)
     {
         MapRange range;
         range.Point1 = FromDuk<CoordsXY>(d["leftTop"]);
@@ -342,7 +364,8 @@ namespace OpenRCT2::Scripting
         return range.Normalise();
     }
 
-    template<> DukValue inline ToDuk(duk_context* ctx, const CoordsXY& coords)
+    template<>
+    DukValue inline ToDuk(duk_context* ctx, const CoordsXY& coords)
     {
         DukObject dukCoords(ctx);
         dukCoords.Set("x", coords.x);
@@ -350,7 +373,8 @@ namespace OpenRCT2::Scripting
         return dukCoords.Take();
     }
 
-    template<> DukValue inline ToDuk(duk_context* ctx, const TileCoordsXY& coords)
+    template<>
+    DukValue inline ToDuk(duk_context* ctx, const TileCoordsXY& coords)
     {
         DukObject dukCoords(ctx);
         dukCoords.Set("x", coords.x);
@@ -358,7 +382,8 @@ namespace OpenRCT2::Scripting
         return dukCoords.Take();
     }
 
-    template<> DukValue inline ToDuk(duk_context* ctx, const ScreenCoordsXY& coords)
+    template<>
+    DukValue inline ToDuk(duk_context* ctx, const ScreenCoordsXY& coords)
     {
         DukObject dukCoords(ctx);
         dukCoords.Set("x", coords.x);
@@ -366,7 +391,8 @@ namespace OpenRCT2::Scripting
         return dukCoords.Take();
     }
 
-    template<> inline DukValue ToDuk(duk_context* ctx, const CoordsXYZ& value)
+    template<>
+    inline DukValue ToDuk(duk_context* ctx, const CoordsXYZ& value)
     {
         if (value.IsNull())
         {
@@ -380,7 +406,8 @@ namespace OpenRCT2::Scripting
         return dukCoords.Take();
     }
 
-    template<> inline CoordsXYZ FromDuk(const DukValue& value)
+    template<>
+    inline CoordsXYZ FromDuk(const DukValue& value)
     {
         CoordsXYZ result;
         if (value.type() == DukValue::Type::OBJECT)
@@ -396,7 +423,8 @@ namespace OpenRCT2::Scripting
         return result;
     }
 
-    template<> inline DukValue ToDuk(duk_context* ctx, const CoordsXYZD& value)
+    template<>
+    inline DukValue ToDuk(duk_context* ctx, const CoordsXYZD& value)
     {
         if (value.IsNull())
         {
@@ -411,7 +439,8 @@ namespace OpenRCT2::Scripting
         return dukCoords.Take();
     }
 
-    template<> inline DukValue ToDuk(duk_context* ctx, const GForces& value)
+    template<>
+    inline DukValue ToDuk(duk_context* ctx, const GForces& value)
     {
         DukObject dukGForces(ctx);
         dukGForces.Set("lateralG", value.LateralG);
@@ -419,7 +448,8 @@ namespace OpenRCT2::Scripting
         return dukGForces.Take();
     }
 
-    template<> inline DukValue ToDuk(duk_context* ctx, const VehicleSpriteGroup& value)
+    template<>
+    inline DukValue ToDuk(duk_context* ctx, const VehicleSpriteGroup& value)
     {
         DukObject dukSpriteGroup(ctx);
         dukSpriteGroup.Set("imageId", value.imageId);
@@ -427,7 +457,8 @@ namespace OpenRCT2::Scripting
         return dukSpriteGroup.Take();
     }
 
-    template<> inline CoordsXYZD FromDuk(const DukValue& value)
+    template<>
+    inline CoordsXYZD FromDuk(const DukValue& value)
     {
         CoordsXYZD result;
         if (value.type() == DukValue::Type::OBJECT)
@@ -444,7 +475,8 @@ namespace OpenRCT2::Scripting
         return result;
     }
 
-    template<> inline DukValue ToDuk(duk_context* ctx, const ScreenSize& value)
+    template<>
+    inline DukValue ToDuk(duk_context* ctx, const ScreenSize& value)
     {
         DukObject dukCoords(ctx);
         dukCoords.Set("width", value.width);
@@ -452,7 +484,8 @@ namespace OpenRCT2::Scripting
         return dukCoords.Take();
     }
 
-    template<> ObjectEntryIndex inline FromDuk(const DukValue& d)
+    template<>
+    ObjectEntryIndex inline FromDuk(const DukValue& d)
     {
         if (d.type() == DukValue::Type::NUMBER)
         {

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
@@ -336,13 +336,15 @@ namespace OpenRCT2::Scripting
         }
     }
 
-    template<uint32_t flag> bool ScVehicle::flag_get() const
+    template<uint32_t flag>
+    bool ScVehicle::flag_get() const
     {
         auto vehicle = GetVehicle();
         return vehicle != nullptr ? vehicle->HasFlag(flag) : false;
     }
 
-    template<uint32_t flag> void ScVehicle::flag_set(bool value)
+    template<uint32_t flag>
+    void ScVehicle::flag_set(bool value)
     {
         ThrowIfGameStateNotMutable();
         auto vehicle = GetVehicle();

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.hpp
@@ -67,8 +67,10 @@ namespace OpenRCT2::Scripting
         uint8_t bankRotation_get() const;
         void bankRotation_set(uint8_t value);
 
-        template<uint32_t flag> bool flag_get() const;
-        template<uint32_t flag> void flag_set(bool value);
+        template<uint32_t flag>
+        bool flag_get() const;
+        template<uint32_t flag>
+        void flag_set(bool value);
 
         DukValue colours_get() const;
         void colours_set(const DukValue& value);

--- a/src/openrct2/scripting/bindings/ride/ScRide.hpp
+++ b/src/openrct2/scripting/bindings/ride/ScRide.hpp
@@ -20,7 +20,8 @@
 
 namespace OpenRCT2::Scripting
 {
-    template<> inline DukValue ToDuk(duk_context* ctx, const TrackColour& value)
+    template<>
+    inline DukValue ToDuk(duk_context* ctx, const TrackColour& value)
     {
         DukObject obj(ctx);
         obj.Set("main", value.main);
@@ -29,7 +30,8 @@ namespace OpenRCT2::Scripting
         return obj.Take();
     }
 
-    template<> inline TrackColour FromDuk(const DukValue& s)
+    template<>
+    inline TrackColour FromDuk(const DukValue& s)
     {
         TrackColour result{};
         result.main = AsOrDefault(s["main"], 0);
@@ -38,7 +40,8 @@ namespace OpenRCT2::Scripting
         return result;
     }
 
-    template<> inline DukValue ToDuk(duk_context* ctx, const VehicleColour& value)
+    template<>
+    inline DukValue ToDuk(duk_context* ctx, const VehicleColour& value)
     {
         DukObject obj(ctx);
         obj.Set("body", value.Body);
@@ -48,7 +51,8 @@ namespace OpenRCT2::Scripting
         return obj.Take();
     }
 
-    template<> inline VehicleColour FromDuk(const DukValue& s)
+    template<>
+    inline VehicleColour FromDuk(const DukValue& s)
     {
         VehicleColour result{};
         result.Body = AsOrDefault(s["body"], 0);

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
@@ -262,7 +262,8 @@ int32_t ScTrackSegment::getPriceModifier() const
     return ted.priceModifier;
 }
 
-template<uint16_t flag> bool ScTrackSegment::getTrackFlag() const
+template<uint16_t flag>
+bool ScTrackSegment::getTrackFlag() const
 {
     const auto& ted = GetTrackElementDescriptor(_type);
 

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
@@ -18,7 +18,8 @@
 
 namespace OpenRCT2::Scripting
 {
-    template<> inline DukValue ToDuk(duk_context* ctx, const VehicleInfo& value)
+    template<>
+    inline DukValue ToDuk(duk_context* ctx, const VehicleInfo& value)
     {
         DukObject dukSubposition(ctx);
         dukSubposition.Set("x", value.x);
@@ -64,7 +65,8 @@ namespace OpenRCT2::Scripting
         int32_t getPriceModifier() const;
         int32_t getPreviewZOffset() const;
         int32_t getTrackGroup() const;
-        template<uint16_t flag> bool getTrackFlag() const;
+        template<uint16_t flag>
+        bool getTrackFlag() const;
         std::string getTrackCurvature() const;
         std::string getTrackPitchDirection() const;
     };

--- a/src/openrct2/scripting/bindings/world/ScParkMessage.hpp
+++ b/src/openrct2/scripting/bindings/world/ScParkMessage.hpp
@@ -48,7 +48,8 @@ namespace OpenRCT2::Scripting
         return {};
     }
 
-    template<> inline News::Item FromDuk(const DukValue& value)
+    template<>
+    inline News::Item FromDuk(const DukValue& value)
     {
         News::Item result{};
         result.Type = GetParkMessageType(value["type"].as_string());

--- a/src/openrct2/scripting/bindings/world/ScResearch.cpp
+++ b/src/openrct2/scripting/bindings/world/ScResearch.cpp
@@ -47,7 +47,8 @@ namespace OpenRCT2::Scripting
         { "scenery", Research::EntryType::Scenery },
     });
 
-    template<> inline DukValue ToDuk(duk_context* ctx, const ResearchItem& value)
+    template<>
+    inline DukValue ToDuk(duk_context* ctx, const ResearchItem& value)
     {
         DukObject obj(ctx);
         obj.Set("category", ResearchCategoryMap[value.category]);
@@ -60,7 +61,8 @@ namespace OpenRCT2::Scripting
         return obj.Take();
     }
 
-    template<> Research::EntryType inline FromDuk(const DukValue& d)
+    template<>
+    Research::EntryType inline FromDuk(const DukValue& d)
     {
         if (d.type() == DukValue::STRING)
         {
@@ -73,7 +75,8 @@ namespace OpenRCT2::Scripting
         return Research::EntryType::Scenery;
     }
 
-    template<> ResearchItem inline FromDuk(const DukValue& d)
+    template<>
+    ResearchItem inline FromDuk(const DukValue& d)
     {
         ResearchItem result;
         result.baseRideType = 0;

--- a/src/openrct2/util/Util.h
+++ b/src/openrct2/util/Util.h
@@ -90,7 +90,8 @@ bool UtilGzipCompress(FILE* source, FILE* dest);
 std::vector<uint8_t> Gzip(const void* data, const size_t dataLen);
 std::vector<uint8_t> Ungzip(const void* data, const size_t dataLen);
 
-template<typename T> constexpr T AddClamp(T value, T valueToAdd)
+template<typename T>
+constexpr T AddClamp(T value, T valueToAdd)
 {
     if (std::is_same_v<decltype(value), money64>)
     {
@@ -118,23 +119,27 @@ uint8_t SoftLight(uint8_t a, uint8_t b);
 
 size_t StrCatFTime(char* buffer, size_t bufferSize, const char* format, const struct tm* tp);
 
-template<typename T> [[nodiscard]] constexpr uint64_t EnumToFlag(T v)
+template<typename T>
+[[nodiscard]] constexpr uint64_t EnumToFlag(T v)
 {
     static_assert(std::is_enum_v<T>);
     return 1uLL << static_cast<std::underlying_type_t<T>>(v);
 }
 
-template<typename... T> [[nodiscard]] constexpr uint64_t EnumsToFlags(T... types)
+template<typename... T>
+[[nodiscard]] constexpr uint64_t EnumsToFlags(T... types)
 {
     return (EnumToFlag(types) | ...);
 }
 
-template<typename TEnum> constexpr auto EnumValue(TEnum enumerator) noexcept
+template<typename TEnum>
+constexpr auto EnumValue(TEnum enumerator) noexcept
 {
     return static_cast<std::underlying_type_t<TEnum>>(enumerator);
 }
 
-template<typename T> constexpr bool HasFlag(uint64_t holder, T v)
+template<typename T>
+constexpr bool HasFlag(uint64_t holder, T v)
 {
     static_assert(std::is_enum_v<T>);
     return (holder & EnumToFlag(v)) != 0;

--- a/src/openrct2/windows/Intent.h
+++ b/src/openrct2/windows/Intent.h
@@ -103,7 +103,8 @@ public:
     Intent* PutExtra(uint32_t key, std::string value);
     Intent* PutExtra(uint32_t key, close_callback value);
 
-    template<typename T, T TNull, typename TTag> Intent* PutExtra(uint32_t key, const TIdentifier<T, TNull, TTag>& value)
+    template<typename T, T TNull, typename TTag>
+    Intent* PutExtra(uint32_t key, const TIdentifier<T, TNull, TTag>& value)
     {
         const auto val = value.ToUnderlying();
         return PutExtra(key, static_cast<uint32_t>(val));

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -732,7 +732,8 @@ struct TileCoordsXYZD : public TileCoordsXYZ
 /**
  * Represents a range of the map using regular coordinates.
  */
-template<class T> struct CoordsRange
+template<class T>
+struct CoordsRange
 {
     T Point1{ 0, 0 };
     T Point2{ 0, 0 };
@@ -767,7 +768,8 @@ template<class T> struct CoordsRange
     }
 };
 
-template<class T> struct RectRange : public CoordsRange<T>
+template<class T>
+struct RectRange : public CoordsRange<T>
 {
     using CoordsRange<T>::CoordsRange;
 

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -181,13 +181,15 @@ int16_t TileElementWaterHeight(const CoordsXY& loc);
 void TileElementRemove(TileElement* tileElement);
 TileElement* TileElementInsert(const CoordsXYZ& loc, int32_t occupiedQuadrants, TileElementType type);
 
-template<typename T = TileElement> T* MapGetFirstTileElementWithBaseHeightBetween(const TileCoordsXYRangedZ& loc)
+template<typename T = TileElement>
+T* MapGetFirstTileElementWithBaseHeightBetween(const TileCoordsXYRangedZ& loc)
 {
     auto* element = MapGetFirstTileElementWithBaseHeightBetween(loc, T::kElementType);
     return element != nullptr ? element->template as<T>() : nullptr;
 }
 
-template<typename T> T* TileElementInsert(const CoordsXYZ& loc, int32_t occupiedQuadrants)
+template<typename T>
+T* TileElementInsert(const CoordsXYZ& loc, int32_t occupiedQuadrants)
 {
     auto* element = TileElementInsert(loc, occupiedQuadrants, T::kElementType);
     return (element != nullptr) ? element->template as<T>() : nullptr;

--- a/src/openrct2/world/MapGen.cpp
+++ b/src/openrct2/world/MapGen.cpp
@@ -336,7 +336,8 @@ static bool MapGenSurfaceTakesSnowTrees(const TerrainSurfaceObject& surface)
     return id == "rct2.terrain_surface.ice";
 }
 
-template<typename T> static bool TryFindTreeInList(std::string_view id, const T& treeList)
+template<typename T>
+static bool TryFindTreeInList(std::string_view id, const T& treeList)
 {
     for (size_t j = 0; j < std::size(treeList); j++)
     {

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -267,7 +267,8 @@ namespace OpenRCT2::Park
         return peep;
     }
 
-    template<typename T, size_t TSize> static void HistoryPushRecord(T history[TSize], T newItem)
+    template<typename T, size_t TSize>
+    static void HistoryPushRecord(T history[TSize], T newItem)
     {
         for (size_t i = TSize - 1; i > 0; i--)
         {

--- a/src/openrct2/world/TileElementsView.h
+++ b/src/openrct2/world/TileElementsView.h
@@ -18,7 +18,8 @@ namespace OpenRCT2
 {
     namespace Detail
     {
-        template<typename T, typename T2> T* NextMatchingTile(T2* element)
+        template<typename T, typename T2>
+        T* NextMatchingTile(T2* element)
         {
             if (element == nullptr)
                 return nullptr;
@@ -40,7 +41,8 @@ namespace OpenRCT2
         }
     } // namespace Detail
 
-    template<typename T = TileElement> class TileElementsView
+    template<typename T = TileElement>
+    class TileElementsView
     {
         const TileCoordsXY _loc;
 

--- a/src/openrct2/world/TilePointerIndex.hpp
+++ b/src/openrct2/world/TilePointerIndex.hpp
@@ -15,7 +15,8 @@
 #include <cstdint>
 #include <vector>
 
-template<typename T> class TilePointerIndex
+template<typename T>
+class TilePointerIndex
 {
     std::vector<T*> TilePointers;
     uint16_t MapSize{};

--- a/src/openrct2/world/tile_element/TileElementBase.h
+++ b/src/openrct2/world/tile_element/TileElementBase.h
@@ -84,7 +84,8 @@ struct TileElementBase
     uint8_t GetOwner() const;
     void SetOwner(uint8_t newOwner);
 
-    template<typename TType> const TType* as() const
+    template<typename TType>
+    const TType* as() const
     {
         if constexpr (std::is_same_v<TType, TileElement>)
             return reinterpret_cast<const TileElement*>(this);
@@ -92,7 +93,8 @@ struct TileElementBase
             return GetType() == TType::kElementType ? reinterpret_cast<const TType*>(this) : nullptr;
     }
 
-    template<typename TType> TType* as()
+    template<typename TType>
+    TType* as()
     {
         if constexpr (std::is_same_v<TType, TileElement>)
             return reinterpret_cast<TileElement*>(this);

--- a/test/tests/AssertHelpers.hpp
+++ b/test/tests/AssertHelpers.hpp
@@ -13,7 +13,8 @@
 #include <initializer_list>
 #include <vector>
 
-template<typename T, typename TExpected> static void AssertVector(const std::vector<T>& actual, TExpected expected)
+template<typename T, typename TExpected>
+static void AssertVector(const std::vector<T>& actual, TExpected expected)
 {
     ASSERT_EQ(actual.size(), expected.size()) << "Expected vector of size " << expected.size() << ", but was " << actual.size();
     size_t i = 0;
@@ -24,7 +25,8 @@ template<typename T, typename TExpected> static void AssertVector(const std::vec
     }
 }
 
-template<typename T> static void AssertVector(const std::vector<T>& actual, std::initializer_list<T> expected)
+template<typename T>
+static void AssertVector(const std::vector<T>& actual, std::initializer_list<T> expected)
 {
     AssertVector<T, std::initializer_list<T>>(actual, expected);
 }

--- a/test/tests/CryptTests.cpp
+++ b/test/tests/CryptTests.cpp
@@ -23,7 +23,8 @@ using namespace OpenRCT2;
 class CryptTests : public testing::Test
 {
 public:
-    template<typename T> void AssertHash(std::string expected, T hash)
+    template<typename T>
+    void AssertHash(std::string expected, T hash)
     {
         auto actual = String::StringFromHex(hash);
         ASSERT_EQ(expected, actual);

--- a/test/tests/EnumMapTest.cpp
+++ b/test/tests/EnumMapTest.cpp
@@ -31,7 +31,8 @@ enum class TestEnumClassNonContinuous
     G
 };
 
-template<typename TEnum> void TestEnumKeyLookup()
+template<typename TEnum>
+void TestEnumKeyLookup()
 {
     // clang-format off
     EnumMap<TEnum> enumMap = {
@@ -78,7 +79,8 @@ template<typename TEnum> void TestEnumKeyLookup()
     SUCCEED();
 }
 
-template<typename TEnum> void TestEnumValueLookup()
+template<typename TEnum>
+void TestEnumValueLookup()
 {
     // clang-format off
     EnumMap<TEnum> enumMap = {

--- a/test/tests/PlayTests.cpp
+++ b/test/tests/PlayTests.cpp
@@ -67,7 +67,8 @@ static std::unique_ptr<IContext> localStartGame(const std::string& parkPath)
     return context;
 }
 
-template<class Fn> static bool updateUntil(int maxSteps, Fn&& fn)
+template<class Fn>
+static bool updateUntil(int maxSteps, Fn&& fn)
 {
     while (maxSteps-- && !fn())
     {
@@ -76,7 +77,8 @@ template<class Fn> static bool updateUntil(int maxSteps, Fn&& fn)
     return maxSteps > 0;
 }
 
-template<class GA, class... Args> static void execute(Args&&... args)
+template<class GA, class... Args>
+static void execute(Args&&... args)
 {
     GA ga(std::forward<Args>(args)...);
     GameActions::Execute(&ga);

--- a/test/tests/ReplayTests.cpp
+++ b/test/tests/ReplayTests.cpp
@@ -104,7 +104,8 @@ static void PrintTo(const ReplayTestData& testData, std::ostream* os)
 
 struct PrintReplayParameter
 {
-    template<class ParamType> std::string operator()(const testing::TestParamInfo<ParamType>& info) const
+    template<class ParamType>
+    std::string operator()(const testing::TestParamInfo<ParamType>& info) const
     {
         auto data = static_cast<ReplayTestData>(info.param);
         return data.name;

--- a/test/tests/TileElementsView.cpp
+++ b/test/tests/TileElementsView.cpp
@@ -66,7 +66,8 @@ private:
 std::shared_ptr<IContext> TileElementsViewTests::_context;
 uint8_t TileElementsViewTests::_gScreenFlags;
 
-template<typename T> std::vector<T*> BuildListManual(const CoordsXY& pos)
+template<typename T>
+std::vector<T*> BuildListManual(const CoordsXY& pos)
 {
     std::vector<T*> res;
 
@@ -92,7 +93,8 @@ template<typename T> std::vector<T*> BuildListManual(const CoordsXY& pos)
     return res;
 }
 
-template<typename T> std::vector<T*> BuildListByView(const CoordsXY& pos)
+template<typename T>
+std::vector<T*> BuildListByView(const CoordsXY& pos)
 {
     std::vector<T*> res;
 
@@ -104,7 +106,8 @@ template<typename T> std::vector<T*> BuildListByView(const CoordsXY& pos)
     return res;
 }
 
-template<typename T> bool CompareLists(const CoordsXY& pos)
+template<typename T>
+bool CompareLists(const CoordsXY& pos)
 {
     auto listManual = BuildListManual<T>(pos);
     auto listView = BuildListByView<T>(pos);
@@ -124,7 +127,8 @@ template<typename T> bool CompareLists(const CoordsXY& pos)
     return true;
 }
 
-template<typename T> void CheckMapTiles()
+template<typename T>
+void CheckMapTiles()
 {
     for (int y = 0; y < kMaximumMapSizeTechnical; ++y)
     {


### PR DESCRIPTION
Something that's irked me for a while in this codebase, is that template declarations and function/method signatures are on the same lines. I think readability improves greatly if both are on a line of their own. With this PR, I would like to propose changing the codebase as such. Thanks to `clang-format`, the change is easy to implement and review.