### PR TITLE
Quick patch for About screen

### DIFF
--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -233,7 +233,7 @@ namespace OpenRCT2::Ui::Windows
             textCoords += ScreenCoordsXY(
                 0, DrawTextWrapped(dpi, textCoords, textWidth, STR_ABOUT_FAIRGROUND_ORGAN, ft2, tp) + 5); // Fairground organ
             textCoords += ScreenCoordsXY(
-                0, DrawTextWrapped(dpi, textCoords, textWidth, STR_ABOUT_SPECIAL_THANKS_1, ft2, tp)); // Special Thanks
+                0, DrawTextWrapped(dpi, textCoords, textWidth, STR_ABOUT_SPECIAL_THANKS_1, ft2, tp) + 7); // Special Thanks
             textCoords += ScreenCoordsXY(
                 0, DrawTextWrapped(dpi, textCoords, textWidth, STR_ABOUT_SPECIAL_THANKS_2, ft2, tp)); // Company names
         }


### PR DESCRIPTION
It seems there's a bigger issue going on atm. This fixes the problem for now, but when we add more names we will have to extend this more. Reason being that the it centers the text in the line, rather than extending it further downwards. I personally do not know how to fix that, but this should suffice for now.

Before:
![image](https://github.com/user-attachments/assets/44208056-3528-4472-b2fa-fe7e5528aec4)

After:
![image](https://github.com/user-attachments/assets/7c0859cb-40bd-4694-b060-2714ce25fa04)
