### PR TITLE
Fix #22726: Force park rating cheat does not save

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Improved: [#23051] Add large sloped turns and new inversions to the Twister, Vertical Drop, Hyper and Flying Roller Coasters.
 - Improved: [#23123] Improve sorting of roller coasters in build new ride menu.
 - Improved: [#23211] Add boosters to classic wooden roller coaster (cheats only).
+- Fix: [#22726] ‘Force park rating’ cheat is not saved with the park.
 - Fix: [#23206] Multiplayer desyncs when FPS is uncapped.
 - Fix: [#23238] Updating a guest’s favourite ride works differently from vanilla RCT2.
 

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -27,6 +27,8 @@ using namespace OpenRCT2;
 // TODO: Refactor this. Cheat variables should contain the cheat type
 // and a serialisation method.
 
+const int kForcedParkRatingDisabled = -1;
+
 void CheatsReset()
 {
     auto& gameState = GetGameState();
@@ -57,7 +59,7 @@ void CheatsReset()
     gameState.Cheats.AllowSpecialColourSchemes = false;
     gameState.Cheats.MakeAllDestructible = false;
     gameState.Cheats.SelectedStaffSpeed = StaffSpeedCheat::None;
-    gameState.Cheats.ForcedParkRating = -1;
+    gameState.Cheats.ForcedParkRating = kForcedParkRatingDisabled;
 }
 
 void CheatsSet(CheatType cheatType, int64_t param1 /* = 0*/, int64_t param2 /* = 0*/)

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -27,7 +27,7 @@ using namespace OpenRCT2;
 // TODO: Refactor this. Cheat variables should contain the cheat type
 // and a serialisation method.
 
-const int kForcedParkRatingDisabled = -1;
+const int32_t kForcedParkRatingDisabled = -1;
 
 void CheatsReset()
 {

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -57,6 +57,7 @@ void CheatsReset()
     gameState.Cheats.AllowSpecialColourSchemes = false;
     gameState.Cheats.MakeAllDestructible = false;
     gameState.Cheats.SelectedStaffSpeed = StaffSpeedCheat::None;
+    gameState.Cheats.ForcedParkRating = -1;                                 //Reuses previously implemented logic. -1 means cheat is off, any positive value means cheat is on
 }
 
 void CheatsSet(CheatType cheatType, int64_t param1 /* = 0*/, int64_t param2 /* = 0*/)
@@ -115,6 +116,7 @@ void CheatsSerialise(DataSerialiser& ds)
         CheatEntrySerialise(ds, CheatType::MakeDestructible, gameState.Cheats.MakeAllDestructible, count);
         CheatEntrySerialise(ds, CheatType::SetStaffSpeed, gameState.Cheats.SelectedStaffSpeed, count);
         CheatEntrySerialise(ds, CheatType::IgnorePrice, gameState.Cheats.IgnorePrice, count);
+        CheatEntrySerialise(ds, CheatType::SetForcedParkRating, gameState.Cheats.ForcedParkRating, count);
 
         // Remember current position and update count.
         uint64_t endOffset = stream.GetPosition();
@@ -222,6 +224,8 @@ void CheatsSerialise(DataSerialiser& ds)
                 case CheatType::SetStaffSpeed:
                     ds << gameState.Cheats.SelectedStaffSpeed;
                     break;
+                case CheatType::SetForcedParkRating:
+                    ds << gameState.Cheats.ForcedParkRating;
                 default:
                     break;
             }

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -27,8 +27,6 @@ using namespace OpenRCT2;
 // TODO: Refactor this. Cheat variables should contain the cheat type
 // and a serialisation method.
 
-const int32_t kForcedParkRatingDisabled = -1;
-
 void CheatsReset()
 {
     auto& gameState = GetGameState();
@@ -59,7 +57,7 @@ void CheatsReset()
     gameState.Cheats.AllowSpecialColourSchemes = false;
     gameState.Cheats.MakeAllDestructible = false;
     gameState.Cheats.SelectedStaffSpeed = StaffSpeedCheat::None;
-    gameState.Cheats.ForcedParkRating = kForcedParkRatingDisabled;
+    gameState.Cheats.forcedParkRating = kForcedParkRatingDisabled;
 }
 
 void CheatsSet(CheatType cheatType, int64_t param1 /* = 0*/, int64_t param2 /* = 0*/)
@@ -118,7 +116,7 @@ void CheatsSerialise(DataSerialiser& ds)
         CheatEntrySerialise(ds, CheatType::MakeDestructible, gameState.Cheats.MakeAllDestructible, count);
         CheatEntrySerialise(ds, CheatType::SetStaffSpeed, gameState.Cheats.SelectedStaffSpeed, count);
         CheatEntrySerialise(ds, CheatType::IgnorePrice, gameState.Cheats.IgnorePrice, count);
-        CheatEntrySerialise(ds, CheatType::SetForcedParkRating, gameState.Cheats.ForcedParkRating, count);
+        CheatEntrySerialise(ds, CheatType::SetForcedParkRating, gameState.Cheats.forcedParkRating, count);
 
         // Remember current position and update count.
         uint64_t endOffset = stream.GetPosition();
@@ -227,7 +225,7 @@ void CheatsSerialise(DataSerialiser& ds)
                     ds << gameState.Cheats.SelectedStaffSpeed;
                     break;
                 case CheatType::SetForcedParkRating:
-                    ds << gameState.Cheats.ForcedParkRating;
+                    ds << gameState.Cheats.forcedParkRating;
                 default:
                     break;
             }

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -57,7 +57,7 @@ void CheatsReset()
     gameState.Cheats.AllowSpecialColourSchemes = false;
     gameState.Cheats.MakeAllDestructible = false;
     gameState.Cheats.SelectedStaffSpeed = StaffSpeedCheat::None;
-    gameState.Cheats.ForcedParkRating = -1;                                 //Reuses previously implemented logic. -1 means cheat is off, any positive value means cheat is on
+    gameState.Cheats.ForcedParkRating = -1;
 }
 
 void CheatsSet(CheatType cheatType, int64_t param1 /* = 0*/, int64_t param2 /* = 0*/)

--- a/src/openrct2/Cheats.h
+++ b/src/openrct2/Cheats.h
@@ -135,7 +135,7 @@ constexpr int kCheatsDuckIncrement = 20;
 constexpr int kCheatsStaffFastSpeed = 0xFF;
 constexpr int kCheatsStaffNormalSpeed = 0x60;
 constexpr int kCheatsStaffFreezeSpeed = 0;
-const int32_t kForcedParkRatingDisabled = -1;
+constexpr int32_t kForcedParkRatingDisabled = -1;
 
 void CheatsReset();
 const char* CheatsGetName(CheatType cheatType);

--- a/src/openrct2/Cheats.h
+++ b/src/openrct2/Cheats.h
@@ -47,7 +47,7 @@ struct CheatsState
     bool AllowSpecialColourSchemes;
     bool MakeAllDestructible;
     StaffSpeedCheat SelectedStaffSpeed;
-    int ForcedParkRating;
+    int32_t forcedParkRating;
 };
 
 enum class CheatType : int32_t

--- a/src/openrct2/Cheats.h
+++ b/src/openrct2/Cheats.h
@@ -135,6 +135,7 @@ constexpr int kCheatsDuckIncrement = 20;
 constexpr int kCheatsStaffFastSpeed = 0xFF;
 constexpr int kCheatsStaffNormalSpeed = 0x60;
 constexpr int kCheatsStaffFreezeSpeed = 0;
+const int32_t kForcedParkRatingDisabled = -1;
 
 void CheatsReset();
 const char* CheatsGetName(CheatType cheatType);

--- a/src/openrct2/Cheats.h
+++ b/src/openrct2/Cheats.h
@@ -47,6 +47,7 @@ struct CheatsState
     bool AllowSpecialColourSchemes;
     bool MakeAllDestructible;
     StaffSpeedCheat SelectedStaffSpeed;
+    int ForcedParkRating;
 };
 
 enum class CheatType : int32_t

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -49,7 +49,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kNetworkStreamVersion = 2;
+constexpr uint8_t kNetworkStreamVersion = 3;
 
 const std::string kNetworkStreamID = std::string(OPENRCT2_VERSION) + "-" + std::to_string(kNetworkStreamVersion);
 

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -394,7 +394,7 @@ namespace OpenRCT2::Park
     {
         auto& gameState = GetGameState();
 
-        if (gameState.Cheats.ForcedParkRating >= 0)
+        if (gameState.Cheats.ForcedParkRating != kForcedParkRatingDisabled)
         {
             return gameState.Cheats.ForcedParkRating;
         }

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -734,7 +734,8 @@ namespace OpenRCT2::Park
     {
         auto& gameState = GetGameState();
         gameState.Cheats.forcedParkRating = rating;
-        GetGameState().Park.Rating = CalculateParkRating();
+        gameState.Park.Rating = CalculateParkRating();
+        
         auto intent = Intent(INTENT_ACTION_UPDATE_PARK_RATING);
         ContextBroadcastIntent(&intent);
     }

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -735,7 +735,7 @@ namespace OpenRCT2::Park
         auto& gameState = GetGameState();
         gameState.Cheats.forcedParkRating = rating;
         gameState.Park.Rating = CalculateParkRating();
-        
+
         auto intent = Intent(INTENT_ACTION_UPDATE_PARK_RATING);
         ContextBroadcastIntent(&intent);
     }

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -49,9 +49,6 @@ using namespace OpenRCT2::Scripting;
 
 namespace OpenRCT2::Park
 {
-    // If this value is more than or equal to 0, the park rating is forced to this value. Used for cheat
-    static int32_t _forcedParkRating = -1;
-
     static money64 calculateRideValue(const Ride& ride);
     static money64 calculateTotalRideValueForMoney();
     static uint32_t calculateSuggestedMaxGuests();
@@ -395,12 +392,13 @@ namespace OpenRCT2::Park
 
     int32_t CalculateParkRating()
     {
-        if (_forcedParkRating >= 0)
+        auto& gameState = GetGameState();
+
+        if (gameState.Cheats.ForcedParkRating >= 0)
         {
-            return _forcedParkRating;
+            return gameState.Cheats.ForcedParkRating;
         }
 
-        auto& gameState = GetGameState();
         int32_t result = 1150;
         if (gameState.Park.Flags & PARK_FLAGS_DIFFICULT_PARK_RATING)
         {
@@ -734,7 +732,7 @@ namespace OpenRCT2::Park
 
     void SetForcedRating(int32_t rating)
     {
-        _forcedParkRating = rating;
+        GetGameState().Cheats.ForcedParkRating = rating;
         GetGameState().Park.Rating = CalculateParkRating();
         auto intent = Intent(INTENT_ACTION_UPDATE_PARK_RATING);
         ContextBroadcastIntent(&intent);
@@ -742,7 +740,7 @@ namespace OpenRCT2::Park
 
     int32_t GetForcedRating()
     {
-        return _forcedParkRating;
+        return GetGameState().Cheats.ForcedParkRating;
     }
 
     money64 GetEntranceFee()

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -732,7 +732,8 @@ namespace OpenRCT2::Park
 
     void SetForcedRating(int32_t rating)
     {
-        GetGameState().Cheats.forcedParkRating = rating;
+        auto& gameState = GetGameState();
+        gameState.Cheats.forcedParkRating = rating;
         GetGameState().Park.Rating = CalculateParkRating();
         auto intent = Intent(INTENT_ACTION_UPDATE_PARK_RATING);
         ContextBroadcastIntent(&intent);

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -394,9 +394,9 @@ namespace OpenRCT2::Park
     {
         auto& gameState = GetGameState();
 
-        if (gameState.Cheats.ForcedParkRating != kForcedParkRatingDisabled)
+        if (gameState.Cheats.forcedParkRating != kForcedParkRatingDisabled)
         {
-            return gameState.Cheats.ForcedParkRating;
+            return gameState.Cheats.forcedParkRating;
         }
 
         int32_t result = 1150;
@@ -732,7 +732,7 @@ namespace OpenRCT2::Park
 
     void SetForcedRating(int32_t rating)
     {
-        GetGameState().Cheats.ForcedParkRating = rating;
+        GetGameState().Cheats.forcedParkRating = rating;
         GetGameState().Park.Rating = CalculateParkRating();
         auto intent = Intent(INTENT_ACTION_UPDATE_PARK_RATING);
         ContextBroadcastIntent(&intent);
@@ -740,7 +740,7 @@ namespace OpenRCT2::Park
 
     int32_t GetForcedRating()
     {
-        return GetGameState().Cheats.ForcedParkRating;
+        return GetGameState().Cheats.forcedParkRating;
     }
 
     money64 GetEntranceFee()


### PR DESCRIPTION
Force park rating is stored in Park.cpp rather than Gamestate with the rest of the cheats. Added forced park rating variable to Gamestate cheats struct. Added serialization for forced park rating. Removed and refactored prior variable and logic in Park.cpp