### PR TITLE
Hotfix: Disappearing large half loops on BM track

### DIFF
--- a/src/openrct2/park/Legacy.cpp
+++ b/src/openrct2/park/Legacy.cpp
@@ -2622,10 +2622,6 @@ bool TrackTypeMustBeMadeInvisible(ride_type_t rideType, OpenRCT2::TrackElemType 
             case TrackElemType::RightMediumHalfLoopUp:
             case TrackElemType::LeftMediumHalfLoopDown:
             case TrackElemType::RightMediumHalfLoopDown:
-            case TrackElemType::LeftLargeHalfLoopUp:
-            case TrackElemType::RightLargeHalfLoopUp:
-            case TrackElemType::LeftLargeHalfLoopDown:
-            case TrackElemType::RightLargeHalfLoopDown:
             case TrackElemType::LeftZeroGRollUp:
             case TrackElemType::RightZeroGRollUp:
             case TrackElemType::LeftZeroGRollDown:


### PR DESCRIPTION
Hotfix for issue introduced in #23051 with import code turning large loops invisible.