### PR TITLE
Explicitly use tags for describing version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Git describe
         id: ghd
         run: |
-          TAG=$(git describe --abbrev=0)
-          DESCRIBE=$(git describe)
+          TAG=$(git describe --tags --abbrev=0)
+          DESCRIBE=$(git describe --tags)
           SHORT_SHA=$(git rev-parse --short HEAD)
           DISTANCE=$(git rev-list --count $TAG..HEAD)
           echo "tag=$TAG"


### PR DESCRIPTION
While we use annotated tags for releases, apparently GitHub Actions Workers do some peculiar steps for fetching the repository, resulting in incomplete(?) tag being checked out. The lightweight version of tag is present, but annotation lives on a different git object, which is not currently checked out in the CI job. To resolve the issue where GitHub Actions would try creating a release for a previous tag instead of current, make sure lightweight tags are considered as well.

You can validate the difference between the two with following commands:
```
$ git rev-parse v0.4.16
20fff63f05dd5508c24bcd2eaf9f34845c7dd472
$ git --no-pager log -1 --oneline v0.4.16
c1082a3d6c (tag: v0.4.16, origin/master) Release v0.4.16
```