### PR TITLE
Add boosters to classic wooden coaster (cheats only)

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#23166] Add Galician translation.
 - Improved: [#23051] Add large sloped turns and new inversions to the Twister, Vertical Drop, Hyper and Flying Roller Coasters.
 - Improved: [#23123] Improve sorting of roller coasters in build new ride menu.
+- Improved: [#23211] Add boosters to classic wooden roller coaster (cheats only).
 
 0.4.16 (2024-11-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/ride/rtd/coaster/ClassicWoodenRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/ClassicWoodenRollerCoaster.h
@@ -23,7 +23,7 @@ constexpr RideTypeDescriptor ClassicWoodenRollerCoasterRTD =
        .Drawer = GetTrackPaintFunctionClassicWoodenRC,
        .supportType = WoodenSupportType::Truss,
        .enabledTrackGroups = {TrackGroup::flat, TrackGroup::straight, TrackGroup::stationEnd, TrackGroup::liftHill, TrackGroup::flatRollBanking, TrackGroup::verticalLoop, TrackGroup::slope, TrackGroup::slopeSteepUp, TrackGroup::slopeSteepDown, TrackGroup::slopeCurve, TrackGroup::sBend, TrackGroup::curveSmall, TrackGroup::curve, TrackGroup::curveLarge, TrackGroup::brakes, TrackGroup::onridePhoto, TrackGroup::waterSplash, TrackGroup::blockBrakes, TrackGroup::diagBrakes, TrackGroup::diagBlockBrakes, TrackGroup::slopeSteepLong, TrackGroup::halfLoopMedium, TrackGroup::halfLoopLarge},
-       .extraTrackGroups = {},
+       .extraTrackGroups = {TrackGroup::booster},
    }),
    .InvertedTrackPaintFunctions = {},
    .Flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |


### PR DESCRIPTION
The classic wooden roller coaster can draw boosters from the RCT2 wooden coaster and it also has booster settings set, so the pieces are fully functional and they can be built with ride type changing. This just simply adds them to the extra track pieces so you can use them without ride type switching.

Fixes #23210

![Screenshot at 2024-11-16 05-02-18](https://github.com/user-attachments/assets/1de6e544-f810-4801-b60d-38ca792a152d)
