### PR TITLE
Fix #23206: Do not rebuild the spatial index for tweening

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#23166] Add Galician translation.
 - Improved: [#23051] Add large sloped turns and new inversions to the Twister, Vertical Drop, Hyper and Flying Roller Coasters.
 - Improved: [#23123] Improve sorting of roller coasters in build new ride menu.
+- Fix: [#23206] Multiplayer desyncs when FPS is uncapped.
 
 0.4.16 (2024-11-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/entity/EntityRegistry.cpp
+++ b/src/openrct2/entity/EntityRegistry.cpp
@@ -481,6 +481,16 @@ void EntityBase::SetLocation(const CoordsXYZ& newLocation)
     SpatialIndex |= kSpatialIndexDirtyMask;
 }
 
+static void EntitySetCoordinates(const CoordsXYZ& entityPos, EntityBase* entity)
+{
+    auto screenCoords = Translate3DTo2DWithZ(GetCurrentRotation(), entityPos);
+
+    entity->SpriteData.SpriteRect = ScreenRect(
+        screenCoords - ScreenCoordsXY{ entity->SpriteData.Width, entity->SpriteData.HeightMin },
+        screenCoords + ScreenCoordsXY{ entity->SpriteData.Width, entity->SpriteData.HeightMax });
+    entity->SetLocation(entityPos);
+}
+
 void EntityBase::MoveTo(const CoordsXYZ& newLocation)
 {
     if (x != kLocationNull)
@@ -504,16 +514,6 @@ void EntityBase::MoveTo(const CoordsXYZ& newLocation)
         EntitySetCoordinates(loc, this);
         Invalidate(); // Invalidate new position.
     }
-}
-
-void EntitySetCoordinates(const CoordsXYZ& entityPos, EntityBase* entity)
-{
-    auto screenCoords = Translate3DTo2DWithZ(GetCurrentRotation(), entityPos);
-
-    entity->SpriteData.SpriteRect = ScreenRect(
-        screenCoords - ScreenCoordsXY{ entity->SpriteData.Width, entity->SpriteData.HeightMin },
-        screenCoords + ScreenCoordsXY{ entity->SpriteData.Width, entity->SpriteData.HeightMax });
-    entity->SetLocation(entityPos);
 }
 
 /**

--- a/src/openrct2/entity/EntityRegistry.h
+++ b/src/openrct2/entity/EntityRegistry.h
@@ -67,7 +67,6 @@ void ResetAllEntities();
 void ResetEntitySpatialIndices();
 void UpdateAllMiscEntities();
 void UpdateMoneyEffect();
-void EntitySetCoordinates(const CoordsXYZ& entityPos, EntityBase* entity);
 void EntityRemove(EntityBase* entity);
 uint16_t RemoveFloatingEntities();
 void UpdateEntitiesSpatialIndex();

--- a/src/openrct2/entity/EntityTweener.cpp
+++ b/src/openrct2/entity/EntityTweener.cpp
@@ -101,8 +101,6 @@ void EntityTweener::Tween(float alpha)
                       static_cast<int32_t>(std::round(posB.y * alpha + posA.y * inv)),
                       static_cast<int32_t>(std::round(posB.z * alpha + posA.z * inv)) });
     }
-
-    UpdateEntitiesSpatialIndex();
 }
 
 void EntityTweener::Restore()
@@ -113,9 +111,7 @@ void EntityTweener::Restore()
         if (ent == nullptr)
             continue;
 
-        ent->Invalidate();
-        EntitySetCoordinates(PostPos[i], ent);
-        ent->Invalidate();
+        ent->MoveTo(PostPos[i]);
     }
 }
 


### PR DESCRIPTION
Because the position is one tick behind the spatial mapping was incorrect, it's not allowed to modify that during interpolation.

Closes #23206.

Edit: Requires no network version increment, affects only clients.