### PR TITLE
Refactor CarEntrySetImageMaxSizes to use constants

### DIFF
--- a/src/openrct2/ride/CarEntry.cpp
+++ b/src/openrct2/ride/CarEntry.cpp
@@ -49,13 +49,13 @@ void CarEntrySetImageMaxSizes(CarEntry& carEntry, int32_t numImages)
     uint8_t bitmap[200][200] = { 0 };
 
     DrawPixelInfo dpi = {
-        /*.bits = */ reinterpret_cast<uint8_t*>(bitmap),
-        /*.x = */ -100,
-        /*.y = */ -100,
-        /*.width = */ 200,
-        /*.height = */ 200,
-        /*.pitch = */ 0,
-        /*.zoom_level = */ ZoomLevel{ 0 },
+        .bits = reinterpret_cast<uint8_t*>(bitmap),
+        .x = -100,
+        .y = -100,
+        .width = 200,
+        .height = 200,
+        .pitch = 0,
+        .zoom_level = ZoomLevel{ 0 },
     };
 
     for (int32_t i = 0; i < numImages; ++i)

--- a/src/openrct2/ride/CarEntry.cpp
+++ b/src/openrct2/ride/CarEntry.cpp
@@ -46,14 +46,19 @@ uint32_t CarEntry::SpriteOffset(SpriteGroupType spriteGroup, int32_t imageDirect
  */
 void CarEntrySetImageMaxSizes(CarEntry& carEntry, int32_t numImages)
 {
-    uint8_t bitmap[200][200] = { 0 };
+    constexpr uint8_t kWidth = 200;
+    constexpr uint8_t kHeight = 200;
+    constexpr uint8_t kCentreX = kWidth / 2;
+    constexpr uint8_t kCentreY = kHeight / 2;
+
+    uint8_t bitmap[kHeight][kWidth] = { 0 };
 
     DrawPixelInfo dpi = {
         .bits = reinterpret_cast<uint8_t*>(bitmap),
-        .x = -100,
-        .y = -100,
-        .width = 200,
-        .height = 200,
+        .x = -(kWidth / 2),
+        .y = -(kHeight / 2),
+        .width = kWidth,
+        .height = kHeight,
         .pitch = 0,
         .zoom_level = ZoomLevel{ 0 },
     };
@@ -62,12 +67,13 @@ void CarEntrySetImageMaxSizes(CarEntry& carEntry, int32_t numImages)
     {
         GfxDrawSpriteSoftware(dpi, ImageId(carEntry.base_image_id + i), { 0, 0 });
     }
+
     int32_t spriteWidth = -1;
-    for (int32_t i = 99; i != 0; --i)
+    for (int32_t i = kCentreX - 1; i != 0; --i)
     {
-        for (int32_t j = 0; j < 200; j++)
+        for (int32_t j = 0; j < kWidth; j++)
         {
-            if (bitmap[j][100 - i] != 0)
+            if (bitmap[j][kCentreX - i] != 0)
             {
                 spriteWidth = i;
                 break;
@@ -77,9 +83,9 @@ void CarEntrySetImageMaxSizes(CarEntry& carEntry, int32_t numImages)
         if (spriteWidth != -1)
             break;
 
-        for (int32_t j = 0; j < 200; j++)
+        for (int32_t j = 0; j < kWidth; j++)
         {
-            if (bitmap[j][100 + i] != 0)
+            if (bitmap[j][kCentreX + i] != 0)
             {
                 spriteWidth = i;
                 break;
@@ -89,15 +95,14 @@ void CarEntrySetImageMaxSizes(CarEntry& carEntry, int32_t numImages)
         if (spriteWidth != -1)
             break;
     }
-
     spriteWidth++;
-    int32_t spriteHeightNegative = -1;
 
-    for (int32_t i = 99; i != 0; --i)
+    int32_t spriteHeightNegative = -1;
+    for (int32_t i = kCentreY - 1; i != 0; --i)
     {
-        for (int32_t j = 0; j < 200; j++)
+        for (int32_t j = 0; j < kWidth; j++)
         {
-            if (bitmap[100 - i][j] != 0)
+            if (bitmap[kCentreY - i][j] != 0)
             {
                 spriteHeightNegative = i;
                 break;
@@ -110,12 +115,11 @@ void CarEntrySetImageMaxSizes(CarEntry& carEntry, int32_t numImages)
     spriteHeightNegative++;
 
     int32_t spriteHeightPositive = -1;
-
-    for (int32_t i = 99; i != 0; --i)
+    for (int32_t i = kCentreY - 1; i != 0; --i)
     {
-        for (int32_t j = 0; j < 200; j++)
+        for (int32_t j = 0; j < kWidth; j++)
         {
-            if (bitmap[100 + i][j] != 0)
+            if (bitmap[kCentreY + i][j] != 0)
             {
                 spriteHeightPositive = i;
                 break;


### PR DESCRIPTION
This should make this code a bit easier to read. Backported from another branch I've been working on.