### PR TITLE
Infer peep animation sprite bounds at runtime

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -57,6 +57,7 @@
 #include "object/ObjectRepository.h"
 #include "paint/Painter.h"
 #include "park/ParkFile.h"
+#include "peep/PeepAnimationData.h"
 #include "platform/Crash.h"
 #include "platform/Platform.h"
 #include "profiling/Profiling.h"
@@ -1006,6 +1007,7 @@ namespace OpenRCT2
             return result;
         }
 
+        // TODO: move function elsewhere?
         bool LoadBaseGraphics()
         {
             if (!GfxLoadG1(*_env))
@@ -1015,6 +1017,7 @@ namespace OpenRCT2
             GfxLoadG2();
             GfxLoadCsg();
             FontSpriteInitialiseCharacters();
+            inferMaxPeepSpriteDimensions();
             return true;
         }
 

--- a/src/openrct2/peep/PeepAnimationData.h
+++ b/src/openrct2/peep/PeepAnimationData.h
@@ -17,8 +17,16 @@ namespace OpenRCT2
     struct PeepAnimation
     {
         uint32_t base_image;
-        SpriteBounds bounds;
         std::span<const uint8_t> frame_offsets;
+        SpriteBounds bounds{};
+
+        constexpr PeepAnimation() = default;
+
+        PeepAnimation(uint32_t baseImage, std::span<const uint8_t> frameOffsets)
+            : base_image(baseImage)
+            , frame_offsets(frameOffsets)
+        {
+        }
     };
 
     struct PeepAnimations
@@ -41,4 +49,6 @@ namespace OpenRCT2
         PeepAnimationGroup spriteType, PeepAnimationType actionAnimationGroup = PeepAnimationType::None);
     const SpriteBounds& GetSpriteBounds(
         PeepAnimationGroup spriteType, PeepAnimationType actionAnimationGroup = PeepAnimationType::None);
+
+    void inferMaxPeepSpriteDimensions();
 } // namespace OpenRCT2


### PR DESCRIPTION
Following up on #21711, this PR reworks the peep animation such that animation sprite bounds are now calculated on after loading G1 instead of hardcoded, analogous to how vehicle sprites are handled. This is another step towards extracting these data into object files.

The changes from this PR necessitate the animation sets to no longer be constexpr. While that might seem like a regression, that would also no longer be the case with the introduction of objects.

Seems fine on my end, but a bit of testing wouldn't hurt.

Minor todos:
- [x] Declare calc function static (see CI)
- [x] Make inference canvas smaller. 32x32 is probably large enough; 200x200 is overkill -> reverted, caused bug