### PR TITLE
Sign Windows binaries with SignPath certificate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,9 +161,31 @@ jobs:
         uses: ammaraskar/msvc-problem-matcher@master
       - name: Build OpenRCT2
         run: . scripts/setenv && build
+      - name: Upload unsigned binaries
+        id: upload-windows-binaries-unsigned
+        uses: actions/upload-artifact@v4
+        with:
+          name: OpenRCT2-${{ needs.build_variables.outputs.name }}-windows-unsigned-${{ matrix.platform }}
+          path: |
+            bin/openrct2.exe
+            bin/openrct2.com
+      - name: Sign binaries
+        id: sign-binaries
+        uses: signpath/github-action-submit-signing-request@v1
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: 645b821f-6283-45e1-8198-264997072801
+          project-slug: OpenRCT2
+          signing-policy-slug: 'test-signing'
+          artifact-configuration-slug: 'binaries'
+          github-artifact-id: ${{ steps.upload-windows-binaries-unsigned.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: files-signed
       - name: Build artifacts
         run: |
           . scripts/setenv -q
+          mv files-signed/openrct2.com bin/openrct2.com
+          mv files-signed/openrct2.exe bin/openrct2.exe
           build-portable
           build-symbols
           build-installer -i
@@ -178,11 +200,31 @@ jobs:
           name: OpenRCT2-${{ needs.build_variables.outputs.name }}-${{ runner.os }}-portable-${{ matrix.platform }}
           path: artifacts/OpenRCT2-${{ needs.build_variables.outputs.name }}-windows-portable-${{ matrix.platform }}.zip
           if-no-files-found: error
-      - name: Upload installer artifact (CI)
+      - name: Upload unsigned installer artifact (CI)
+        id: upload-windows-installer-unsigned
+        uses: actions/upload-artifact@v4
+        with:
+          name: OpenRCT2-${{ needs.build_variables.outputs.name }}-${{ runner.os }}-installer-${{ matrix.platform }}-unsigned
+          path: artifacts/OpenRCT2-${{ needs.build_variables.outputs.name }}-windows-installer-${{ matrix.platform }}.exe
+          if-no-files-found: error
+      - name: Sign installer
+        id: sign-installer
+        uses: signpath/github-action-submit-signing-request@v1
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: 645b821f-6283-45e1-8198-264997072801
+          project-slug: OpenRCT2
+          signing-policy-slug: 'test-signing'
+          artifact-configuration-slug: 'installer'
+          github-artifact-id: ${{ steps.upload-windows-installer-unsigned.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: files-signed
+      - name: Upload signed installer artifact (CI)
+        id: upload-windows-installer-signed
         uses: actions/upload-artifact@v4
         with:
           name: OpenRCT2-${{ needs.build_variables.outputs.name }}-${{ runner.os }}-installer-${{ matrix.platform }}
-          path: artifacts/OpenRCT2-${{ needs.build_variables.outputs.name }}-windows-installer-${{ matrix.platform }}.exe
+          path: files-signed/OpenRCT2-${{ needs.build_variables.outputs.name }}-windows-installer-${{ matrix.platform }}.exe
           if-no-files-found: error
       - name: Upload symbols artifact (CI)
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,8 @@ jobs:
           github-artifact-id: ${{ steps.upload-windows-binaries-unsigned.outputs.artifact-id }}
           wait-for-completion: true
           output-artifact-directory: files-signed
+          parameters: |
+            version: "${{ env.OPENRCT2_VERSION }}.${{ needs.build_variables.outputs.distance }}-${{ needs.build_variables.outputs.short-sha }}"
       - name: Use signed binaries
         if: ${{ needs.build_variables.outputs.sign == 'true' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,7 @@ jobs:
   macos-cmake:
     name: macOS (${{ matrix.arch }}) using CMake
     runs-on: macos-14
-    needs: check-code-formatting
+    needs: [check-code-formatting, build_variables]
     strategy:
       fail-fast: false
       matrix:
@@ -505,7 +505,7 @@ jobs:
           if-no-files-found: error
   linux-docker:
     name: Ubuntu Linux (Docker)
-    needs: check-code-formatting
+    needs: [check-code-formatting, build_variables]
     if: github.repository == 'OpenRCT2/OpenRCT2' && github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     steps:
@@ -531,7 +531,7 @@ jobs:
   linux-clang:
     name: Ubuntu Linux (noble, debug, [http, network, flac, vorbis OpenGL] disabled) using clang
     runs-on: ubuntu-latest
-    needs: check-code-formatting
+    needs: [check-code-formatting, build_variables]
     container: openrct2/openrct2-build:16-noble
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
   windows:
     name: Windows
     runs-on: windows-latest
-    needs: [check-code-formatting, build_variables]
+    needs: [check-code-formatting, build_variables, g2dat]
     strategy:
       fail-fast: false
       matrix:
@@ -181,6 +181,12 @@ jobs:
           github-artifact-id: ${{ steps.upload-windows-binaries-unsigned.outputs.artifact-id }}
           wait-for-completion: true
           output-artifact-directory: files-signed
+      - name: Download g2.dat on ARM64
+        if: matrix.platform == 'arm64'
+        uses: actions/download-artifact@v4
+        with:
+          name: g2-${{ needs.build_variables.outputs.name }}.dat
+          path: bin/data/g2.dat
       - name: Build artifacts
         run: |
           . scripts/setenv -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,6 +587,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           merge-multiple: true
+      # Having multiple artifacts named the same might be onfusing to the users. Drop the unsigned versions
+      - name: Remove unsigned artifacts
+        run: |
+          rm -rf *unsigned*
       - name: Concatenate sha1 files
         run: |
           ls -lR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       distance: ${{ steps.ghd.outputs.distance }}
       tag: ${{ steps.ghd.outputs.tag }}
       push: ${{ steps.setenv.outputs.push }}
+      sign: ${{ steps.sign.outputs.sign }}
     steps:
       # We need to fetch entire repo to get the tags and correctly run `describe`
       - name: Check out code
@@ -75,6 +76,11 @@ jobs:
         run: |
           echo "name=${{ steps.ghd.outputs.describe }}"
           echo "name=${{ steps.ghd.outputs.describe }}" >> $GITHUB_OUTPUT
+      - name: Sign
+        id: sign
+        run: |
+          echo "sign=${{ env.SIGNPATH_API_TOKEN != '' && (needs.build_variables.outputs.push || startsWith(github.ref, 'refs/tags/v')) }}"
+          echo "sign=${{ env.SIGNPATH_API_TOKEN != '' && (needs.build_variables.outputs.push || startsWith(github.ref, 'refs/tags/v')) }}" >> $GITHUB_OUTPUT
   lint-commit:
     name: Lint Commit Message
     if: github.event_name == 'pull_request'
@@ -169,8 +175,12 @@ jobs:
           path: |
             bin/openrct2.exe
             bin/openrct2.com
+      # Sign the binaries first, so that all other artifacts (portable, installer, symbols) use signed binaries
       - name: Sign binaries
         id: sign-binaries
+        env:
+          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+        if: ${{ needs.build_variables.outputs.sign == 'true' }}
         uses: signpath/github-action-submit-signing-request@v1
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
@@ -181,6 +191,11 @@ jobs:
           github-artifact-id: ${{ steps.upload-windows-binaries-unsigned.outputs.artifact-id }}
           wait-for-completion: true
           output-artifact-directory: files-signed
+      - name: Use signed binaries
+        if: ${{ needs.build_variables.outputs.sign == 'true' }}
+        run: |
+          mv files-signed/openrct2.com bin/openrct2.com
+          mv files-signed/openrct2.exe bin/openrct2.exe
       - name: Download g2.dat on ARM64
         if: matrix.platform == 'arm64'
         uses: actions/download-artifact@v4
@@ -190,8 +205,6 @@ jobs:
       - name: Build artifacts
         run: |
           . scripts/setenv -q
-          mv files-signed/openrct2.com bin/openrct2.com
-          mv files-signed/openrct2.exe bin/openrct2.exe
           build-portable
           build-symbols
           build-installer -i
@@ -215,6 +228,7 @@ jobs:
           if-no-files-found: error
       - name: Sign installer
         id: sign-installer
+        if: ${{ needs.build_variables.outputs.sign == 'true' }}
         uses: signpath/github-action-submit-signing-request@v1
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
@@ -227,6 +241,7 @@ jobs:
           output-artifact-directory: files-signed
       - name: Upload signed installer artifact (CI)
         id: upload-windows-installer-signed
+        if: ${{ needs.build_variables.outputs.sign == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: OpenRCT2-${{ needs.build_variables.outputs.name }}-${{ runner.os }}-installer-${{ matrix.platform }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,7 @@ jobs:
           build-portable
           build-symbols
           build-installer -i
+          echo "OPENRCT2_VERSION_EXTRA=$OPENRCT2_VERSION_EXTRA" >> "$GITHUB_ENV"
       - name: Rename artifacts
         run: |
           mv artifacts/openrct2-portable-*.zip artifacts/OpenRCT2-${{ needs.build_variables.outputs.name }}-windows-portable-$PLATFORM.zip
@@ -270,6 +271,9 @@ jobs:
           github-artifact-id: ${{ steps.upload-windows-installer-unsigned.outputs.artifact-id }}
           wait-for-completion: true
           output-artifact-directory: files-signed
+          parameters: |
+            version: "${{ env.OPENRCT2_VERSION }}${{ env.OPENRCT2_VERSION_EXTRA }}"
+            product: "OpenRCT2 ${{ matrix.platform }} Installer for Windows 7 and later"
       - name: Upload signed installer artifact (CI)
         id: upload-windows-installer-signed
         if: ${{ needs.build_variables.outputs.sign == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ on:
         description: Sign binaries
         type: choice
         options:
+          - 'no'
           - test-signing
           - release-signing
         default: test-signing
@@ -95,16 +96,18 @@ jobs:
       - name: Sign
         id: sign
         run: |
-          echo "sign=${{ env.SIGNPATH_API_TOKEN != '' && (needs.build_variables.outputs.push || startsWith(github.ref, 'refs/tags/v')) }}"
+          sign=${{ env.SIGNPATH_API_TOKEN != '' && github.event.inputs.sign != 'no' && (needs.build_variables.outputs.push || startsWith(github.ref, 'refs/tags/v')) }}
           # if using workflow_dispatch, use the provided certificate
           if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
             certificate=${{ github.event.inputs.sign }}
           else
-            # Default to test-signing
-            certificate=test-signing
+            # Default to no signing
+            certificate=no
+            sign=false
           fi
+          echo "sign=$sign"
           echo "certificate=$certificate"
-          echo "sign=${{ env.SIGNPATH_API_TOKEN != '' && (needs.build_variables.outputs.push || startsWith(github.ref, 'refs/tags/v')) }}" >> $GITHUB_OUTPUT
+          echo "sign=$sign" >> $GITHUB_OUTPUT
           echo "certificate=$certificate" >> $GITHUB_OUTPUT
   lint-commit:
     name: Lint Commit Message

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -660,7 +660,6 @@ jobs:
         with:
           draft: true
           files: |
-            OpenRCT2-${{ needs.build_variables.outputs.name }}-sha1sums.txt
             OpenRCT2-${{ needs.build_variables.outputs.name }}-*
           body_path: release_notes.txt
           tag_name: ${{ needs.build_variables.outputs.tag }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,16 @@ on:
       - '.github/workflows/localisation.yml'
       - '.gitignore'
       - '.vscode/**'
+  workflow_dispatch:
+    inputs:
+      sign:
+        description: Sign binaries
+        type: choice
+        options:
+          - test-signing
+          - release-signing
+        default: test-signing
+
 defaults:
   run:
     shell: bash
@@ -34,6 +44,11 @@ jobs:
   build_variables:
     name: Get version info
     runs-on: ubuntu-latest
+    # We want to sign tagged releases with release certificates, but it is only allowed to be ran manually.
+    # Disable automatic runs for tags and force release signing for tags.
+    if: |
+      (startsWith(github.ref, 'refs/tags/v') && github.event_name == 'workflow_dispatch' && github.event.inputs.sign == 'release-signing') ||
+      (!startsWith(github.ref, 'refs/tags/v') && github.event.inputs.sign != 'release-signing')
     outputs:
       name: ${{ steps.artifact-name.outputs.name }}
       describe: ${{ steps.ghd.outputs.describe }}
@@ -42,6 +57,7 @@ jobs:
       tag: ${{ steps.ghd.outputs.tag }}
       push: ${{ steps.setenv.outputs.push }}
       sign: ${{ steps.sign.outputs.sign }}
+      certificate: ${{ steps.sign.outputs.certificate }}
     steps:
       # We need to fetch entire repo to get the tags and correctly run `describe`
       - name: Check out code
@@ -80,7 +96,16 @@ jobs:
         id: sign
         run: |
           echo "sign=${{ env.SIGNPATH_API_TOKEN != '' && (needs.build_variables.outputs.push || startsWith(github.ref, 'refs/tags/v')) }}"
+          # if using workflow_dispatch, use the provided certificate
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            certificate=${{ github.event.inputs.sign }}
+          else
+            # Default to test-signing
+            certificate=test-signing
+          fi
+          echo "certificate=$certificate"
           echo "sign=${{ env.SIGNPATH_API_TOKEN != '' && (needs.build_variables.outputs.push || startsWith(github.ref, 'refs/tags/v')) }}" >> $GITHUB_OUTPUT
+          echo "certificate=$certificate" >> $GITHUB_OUTPUT
   lint-commit:
     name: Lint Commit Message
     if: github.event_name == 'pull_request'
@@ -186,7 +211,7 @@ jobs:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: 645b821f-6283-45e1-8198-264997072801
           project-slug: OpenRCT2
-          signing-policy-slug: 'test-signing'
+          signing-policy-slug: ${{ needs.build_variables.outputs.certificate }}
           artifact-configuration-slug: 'binaries'
           github-artifact-id: ${{ steps.upload-windows-binaries-unsigned.outputs.artifact-id }}
           wait-for-completion: true
@@ -234,7 +259,7 @@ jobs:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: 645b821f-6283-45e1-8198-264997072801
           project-slug: OpenRCT2
-          signing-policy-slug: 'test-signing'
+          signing-policy-slug: ${{ needs.build_variables.outputs.certificate }}
           artifact-configuration-slug: 'installer'
           github-artifact-id: ${{ steps.upload-windows-installer-unsigned.outputs.artifact-id }}
           wait-for-completion: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ jobs:
         platform: [win32, x64, arm64]
     env:
       PLATFORM: ${{ matrix.platform }}
+      DISTANCE_FROM_TAG: ${{ needs.build_variables.outputs.distance }}
     steps:
       - name: Setup environment
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,7 +637,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           merge-multiple: true
-      # Having multiple artifacts named the same might be onfusing to the users. Drop the unsigned versions
+      # Having multiple artifacts named the same might be confusing to the users. Drop the unsigned versions.
       - name: Remove unsigned artifacts
         run: |
           rm -rf *unsigned*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,11 +643,16 @@ jobs:
           sed -n '1,/^$/p' distribution/changelog.txt >> release_notes.txt
           echo "" >> release_notes.txt
 
+          echo "Release created in ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> release_notes.txt
+          echo "" >> release_notes.txt
+
           echo "SHA1 checksums:" >> release_notes.txt
           echo "\`\`\`" >> release_notes.txt
           cat OpenRCT2-${{ needs.build_variables.outputs.name }}-sha1sums.txt >> release_notes.txt
           echo "\`\`\`" >> release_notes.txt
           echo "" >> release_notes.txt
+
+          cat release_notes.txt
       # Only upload tagged releases, mark them as draft for manual verification
       - name: Create tagged release
         uses: softprops/action-gh-release@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,6 +436,7 @@ if (NOT MACOS_BUNDLE OR (MACOS_BUNDLE AND WITH_TESTS))
     add_definitions(-DDOCDIR="${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DOCDIR}")
     file(GLOB DOC_FILES "${ROOT_DIR}/distribution/*.txt")
     list(APPEND DOC_FILES "${ROOT_DIR}/contributors.md"
+                        "${ROOT_DIR}/PRIVACY.md"
                         "${ROOT_DIR}/licence.txt"
                         "${ROOT_DIR}/distribution/scripting.md"
                         "${ROOT_DIR}/distribution/openrct2.d.ts")

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,55 @@
+# Privacy Policy
+
+## Overview
+This document describes how this project collects, handles, and processes data.
+
+## Data Collection
+- No personal information is collected without explicit user consent
+- For multiplayer functionality, we only collect necessary data:
+  - Username
+  - Game session data
+  - Network connection details
+
+## Data Storage
+- User preferences and settings are stored locally on your device
+- No sensitive data is transmitted to external servers
+- Game saves and configurations remain on your local system
+
+## Network Communications
+- Multiplayer sessions only transmit game-relevant data
+- Server connections are used solely for gameplay functionality
+- No tracking or analytics services are implemented
+
+## Crash Reporting
+- Crash dumps may be sent to Backtrace.io for diagnostic purposes
+- Each crash report transfer requires explicit user consent
+- Crash dumps contain:
+  - System information
+  - Machine hostname
+  - System username
+  - Technical data about the crash
+  - In-game screenshot
+- This data helps improve software stability
+- Users can decline sending crash reports without limiting gameplay functionality
+- Only team members have access to crash reports
+
+## Third-Party Services
+If you use optional features:
+- Server hosting services may collect connection data
+- Plugin systems operate under their own privacy terms
+
+## User Rights
+You have the right to:
+- Access your data
+- Delete your data
+- Opt out of any data collection
+- Request information about stored data
+
+## Changes to Privacy Policy
+- Users will be notified of any privacy policy updates
+- Changes will be documented in the project's changelog
+
+## Contact
+For privacy concerns or questions, please open an issue in the project repository or contact the team via [Discord](https://discord.gg/ZXZd8D8)
+
+Last updated: 2024-11-18

--- a/distribution/readme.txt
+++ b/distribution/readme.txt
@@ -1,4 +1,4 @@
-Last updated:    2024-08-04
+Last updated:    2024-11-19
 ------------------------------------------------------------------------
 
 
@@ -13,7 +13,8 @@ Table of contents
 6.0) Translation
 7.0) Troubleshooting
 8.0) Licensing
-9.0) Credits
+9.0) Privacy policy
+10.0) Credits
 
 1.0) About
 ---- -----
@@ -156,6 +157,10 @@ Google Benchmark | Apache 2.0 licence.
 
 Licences for sub-libraries used by the above may vary. For more information, visit the libraries' respective official websites.
 
-9.0) Credits
+9.0) Privacy policy
+
+For privacy policy, see the file 'PRIVACY.md'.
+
+10.0) Credits
 ---- -------
 For the full list of contributors to OpenRCT2, see the file 'contributors.md'.

--- a/distribution/windows/install.nsi
+++ b/distribution/windows/install.nsi
@@ -170,6 +170,9 @@ Section "!OpenRCT2" Section1
     File ..\..\contributors.md
     Push "$INSTDIR\contributors.md"
     Call unix2dos
+    File ..\..\PRIVACY.md
+    Push "$INSTDIR\PRIVACY.md"
+    Call unix2dos
     File ..\scripting.md
     Push "$INSTDIR\scripting.md"
     Call unix2dos
@@ -204,6 +207,7 @@ Section "!OpenRCT2" Section1
     CreateShortCut "$SMPROGRAMS\$SHORTCUTS\Readme.lnk" "$INSTDIR\Readme.txt"
     CreateShortCut "$SMPROGRAMS\$SHORTCUTS\Changelog.lnk" "$INSTDIR\Changelog.txt"
     CreateShortCut "$SMPROGRAMS\$SHORTCUTS\Contributors.lnk" "$INSTDIR\contributors.md"
+    CreateShortCut "$SMPROGRAMS\$SHORTCUTS\PrivacyPolicy.lnk" "$INSTDIR\PRIVACY.md"
     !insertmacro MUI_STARTMENU_WRITE_END
 SectionEnd
 
@@ -240,12 +244,14 @@ Section "Uninstall"
     Delete "$SMPROGRAMS\$SHORTCUTS\Readme.lnk"
     Delete "$SMPROGRAMS\$SHORTCUTS\Changelog.lnk"
     Delete "$SMPROGRAMS\$SHORTCUTS\Contributors.lnk"
+    Delete "$SMPROGRAMS\$SHORTCUTS\PrivacyPolicy.lnk"
 
     ; Clean up OpenRCT2 dir
     Delete "$INSTDIR\changelog.txt"
     Delete "$INSTDIR\licence.txt"
     Delete "$INSTDIR\readme.txt"
     Delete "$INSTDIR\contributors.md"
+    Delete "$INSTDIR\PRIVACY.md"
     Delete "$INSTDIR\scripting.md"
     Delete "$INSTDIR\openrct2.d.ts"
     Delete "$INSTDIR\${OPENRCT2_EXE}"

--- a/distribution/windows/install.nsi
+++ b/distribution/windows/install.nsi
@@ -35,7 +35,7 @@ SetCompressor LZMA
 
 ; Version Info
 VIProductVersion "${APPVERSIONINTERNAL}"
-VIAddVersionKey "ProductName" "OpenRCT2 ${APPBITS}-bit Installer for ${SUPPORTED_OS}"
+VIAddVersionKey "ProductName" "OpenRCT2 ${PLATFORM} Installer for ${SUPPORTED_OS}"
 VIAddVersionKey "Comments" "Installs ${APPNAMEANDVERSION}"
 VIAddVersionKey "CompanyName" "OpenRCT2 Developers"
 VIAddVersionKey "FileDescription" "Installs ${APPNAMEANDVERSION}"
@@ -44,7 +44,7 @@ VIAddVersionKey "InternalName" "InstOpenRCT2-${APPARCH}"
 VIAddVersionKey "FileVersion" "${APPVERSION}-${APPARCH}"
 VIAddVersionKey "LegalCopyright" " "
 ; Main Install settings
-Name "${APPNAMEANDVERSION} ${APPBITS}-bit for ${SUPPORTED_OS}"
+Name "${APPNAMEANDVERSION} ${PLATFORM} for ${SUPPORTED_OS}"
 
 ; NOTE: Keep trailing backslash!
 InstallDirRegKey HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\OpenRCT2" "Install Folder"

--- a/distribution/windows/install.nsi
+++ b/distribution/windows/install.nsi
@@ -207,7 +207,7 @@ Section "!OpenRCT2" Section1
     CreateShortCut "$SMPROGRAMS\$SHORTCUTS\Readme.lnk" "$INSTDIR\Readme.txt"
     CreateShortCut "$SMPROGRAMS\$SHORTCUTS\Changelog.lnk" "$INSTDIR\Changelog.txt"
     CreateShortCut "$SMPROGRAMS\$SHORTCUTS\Contributors.lnk" "$INSTDIR\contributors.md"
-    CreateShortCut "$SMPROGRAMS\$SHORTCUTS\PrivacyPolicy.lnk" "$INSTDIR\PRIVACY.md"
+    CreateShortCut "$SMPROGRAMS\$SHORTCUTS\Privacy Policy.lnk" "$INSTDIR\PRIVACY.md"
     !insertmacro MUI_STARTMENU_WRITE_END
 SectionEnd
 
@@ -244,7 +244,7 @@ Section "Uninstall"
     Delete "$SMPROGRAMS\$SHORTCUTS\Readme.lnk"
     Delete "$SMPROGRAMS\$SHORTCUTS\Changelog.lnk"
     Delete "$SMPROGRAMS\$SHORTCUTS\Contributors.lnk"
-    Delete "$SMPROGRAMS\$SHORTCUTS\PrivacyPolicy.lnk"
+    Delete "$SMPROGRAMS\$SHORTCUTS\Privacy Policy.lnk"
 
     ; Clean up OpenRCT2 dir
     Delete "$INSTDIR\changelog.txt"

--- a/readme.md
+++ b/readme.md
@@ -52,9 +52,10 @@ If you want to help translate the game to your language, please stop by the Loca
   - 4.4 - [Graphics](#44-graphics)
   - 4.5 - [Audio](#45-audio)
   - 4.6 - [Scenarios](#46-scenarios)
-- 5 - [Licence](#5-licence)
-- 6 - [More information](#6-more-information)
-- 7 - [Sponsors](#7-sponsors)
+- 5 - [Code signing policy](#5-code-signing-policy)
+- 5 - [Licence](#6-licence)
+- 6 - [More information](#7-more-information)
+- 7 - [Sponsors](#8-sponsors)
 
 ---
 
@@ -246,12 +247,22 @@ We would also like to distribute additional scenarios with the game, when the ti
 
 ---
 
-# 5. Licence
+# 5. Code signing policy
+
+We sign our releases digital certificate provided by SignPath Foundation.
+
+Free code signing provided by [SignPath.io](https://about.signpath.io/), certificate by [SignPath Foundation](https://signpath.org/).
+
+Signed releases can only be done by member of the [development team](https://github.com/OpenRCT2/OpenRCT2/blob/develop/contributors.md#development-team).
+
+---
+
+# 6. Licence
 **OpenRCT2** is licensed under the GNU General Public License version 3 or (at your option) any later version. See the [`licence.txt`](licence.txt) file for more details.
 
 ---
 
-# 6. More information
+# 7. More information
 - [GitHub](https://github.com/OpenRCT2/OpenRCT2)
 - [OpenRCT2.org](https://openrct2.org)
 - [Forums](https://openrct2.org/forums/)
@@ -266,11 +277,11 @@ We would also like to distribute additional scenarios with the game, when the ti
 | [![icon_x128](https://user-images.githubusercontent.com/604665/53047651-2c533c00-3493-11e9-911a-1a3540fc1156.png)](https://github.com/OpenLoco/OpenLoco) | [![](https://github.com/OpenTTD/OpenTTD/raw/850d05d24d4768c81d97765204ef2a487dd4972c/media/openttd.128.png)](https://github.com/OpenTTD/OpenTTD) | [![](https://user-images.githubusercontent.com/550290/36507534-4693f354-175a-11e8-93a7-faa0481474fb.png)](https://github.com/SFTtech/openage) | [![](https://raw.githubusercontent.com/OpenRA/OpenRA/bleed/packaging/artwork/ra_128x128.png)](https://github.com/OpenRA/OpenRA) |
 | Chris Sawyer's Locomotion | Transport Tycoon Deluxe | Age of Empires 2 | Red Alert |
 
-# 7. Sponsors
+# 8. Sponsors
 
 Companies that kindly allow us to use their stuff:
 
-| [DigitalOcean](https://www.digitalocean.com/) | [JetBrains](https://www.jetbrains.com/) | [Backtrace](https://backtrace.io/) |
-|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| [![do_logo_vertical_blue svg](https://user-images.githubusercontent.com/550290/36508276-8b572f0e-175c-11e8-8622-9febbce756b2.png)](https://www.digitalocean.com/) | [![jetbrains](https://user-images.githubusercontent.com/550290/36413299-0e0985ea-161e-11e8-8a01-3ef523b5905b.png)](https://www.jetbrains.com/) | [![backtrace](https://user-images.githubusercontent.com/550290/47113259-d0647680-d258-11e8-97c3-1a2c6bde6d11.png)](https://backtrace.io/) |
-| Hosting of various services | CLion and other products | Minidump uploads and inspection |
+| [DigitalOcean](https://www.digitalocean.com/)                                                                                                                     | [JetBrains](https://www.jetbrains.com/)                                                                                                        | [Backtrace](https://backtrace.io/)                                                                                                        | [SignPath](https://signpath.org/)                                                                                  |
+|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| [![do_logo_vertical_blue svg](https://user-images.githubusercontent.com/550290/36508276-8b572f0e-175c-11e8-8622-9febbce756b2.png)](https://www.digitalocean.com/) | [![jetbrains](https://user-images.githubusercontent.com/550290/36413299-0e0985ea-161e-11e8-8a01-3ef523b5905b.png)](https://www.jetbrains.com/) | [![backtrace](https://user-images.githubusercontent.com/550290/47113259-d0647680-d258-11e8-97c3-1a2c6bde6d11.png)](https://backtrace.io/) | [![Image](https://github.com/user-attachments/assets/2b5679e0-76a4-4ae7-bb37-a6a507a53466)](https://signpath.org/) |
+| Hosting of various services                                                                                                                                       | CLion and other products                                                                                                                       | Minidump uploads and inspection                                                                                                           | Code signing                                                                                                       |

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,10 @@ If you want to help translate the game to your language, please stop by the Loca
   - 4.4 - [Graphics](#44-graphics)
   - 4.5 - [Audio](#45-audio)
   - 4.6 - [Scenarios](#46-scenarios)
-- 5 - [Code signing policy](#5-code-signing-policy)
+- 5 - [Policies](#5-policies)
+  - 5.1 - [Code of conduct](#51-code-of-conduct)
+  - 5.2 - [Code signing policy](#52-code-signing-policy)
+  - 5.3 - [Privacy policy](#53-privacy-policy)
 - 5 - [Licence](#6-licence)
 - 6 - [More information](#7-more-information)
 - 7 - [Sponsors](#8-sponsors)
@@ -247,13 +250,23 @@ We would also like to distribute additional scenarios with the game, when the ti
 
 ---
 
-# 5. Code signing policy
+# 5. Policies
 
-We sign our releases digital certificate provided by SignPath Foundation.
+## 5.1 Code of Conduct
+
+We have a [Code of Conduct](CODE_OF_CONDUCT.md) that applies to all OpenRCT2 projects. Please read it.
+
+## 5.2 Code signing policy
+
+We sign our releases with a digital certificate provided by SignPath Foundation.
 
 Free code signing provided by [SignPath.io](https://about.signpath.io/), certificate by [SignPath Foundation](https://signpath.org/).
 
 Signed releases can only be done by member of the [development team](https://github.com/OpenRCT2/OpenRCT2/blob/develop/contributors.md#development-team).
+
+## 5.3 Privacy policy
+
+See [PRIVACY.md](PRIVACY.md) for more information.
 
 ---
 

--- a/scripts/build
+++ b/scripts/build
@@ -12,17 +12,15 @@ cd $basedir
 
 if [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]]; then
     # Patch version.h
-    if [[ -n "$OPENRCT2_BUILD" ]]; then
-        echo -e "\033[0;36mPatching version.h...\033[0m"
-        fileversion=$OPENRCT2_VERSION.$OPENRCT2_BUILD
-        productversion="$fileversion-${OPENRCT2_SHA1_SHORT}"
-        fileversion=${fileversion//./,}
-        # FILEVERSION in the resource file can only take up to 4 digits in the version string, so we remove the surplus of version numbers
-        fileversion=$(echo $fileversion | cut -f1-4 -d",")
-        echo "#define OPENRCT2_FILE_VERSION $fileversion" > "resources/version.h"
-        echo "#define OPENRCT2_PRODUCT_VERSION \"$productversion\"" >> "resources/version.h"
-        cat "resources/version.h"
-    fi
+    echo -e "\033[0;36mPatching version.h...\033[0m"
+    fileversion=$OPENRCT2_VERSION.$OPENRCT2_BUILD
+    productversion="$fileversion-${OPENRCT2_SHA1_SHORT}"
+    fileversion=${fileversion//./,}
+    # FILEVERSION in the resource file can only take up to 4 digits in the version string, so we remove the surplus of version numbers
+    fileversion=$(echo $fileversion | cut -f1-4 -d",")
+    echo "#define OPENRCT2_FILE_VERSION $fileversion" > "resources/version.h"
+    echo "#define OPENRCT2_PRODUCT_VERSION \"$productversion\"" >> "resources/version.h"
+    cat "resources/version.h"
 
     # Build everything
     echo -e "\033[0;36mBuilding OpenRCT2 for Windows $CONFIGURATION|$PLATFORM...\033[0m"

--- a/scripts/build-portable
+++ b/scripts/build-portable
@@ -22,6 +22,7 @@ if [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]]; then
     7z a -r $destination \
         openrct2.exe openrct2.com data \
         ../contributors.md \
+        ../PRIVACY.md \
         ../licence.txt \
         ../distribution/changelog.txt \
         ../distribution/readme.txt \

--- a/scripts/setenv
+++ b/scripts/setenv
@@ -16,9 +16,7 @@ echo -e "\033[0;36mSetting up environment for OpenRCT2...\033[0m"
 # Get the build number (number of commits since last tag)
 get_build_number()
 {
-    local pattern='.+-([0-9]+)-.+'
-    [[ $OPENRCT2_DESCRIBE =~ $pattern ]]
-    echo "${BASH_REMATCH[1]}"
+    echo "${DISTANCE_FROM_TAG}"
 }
 export OPENRCT2_BUILD=$(get_build_number)
 

--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -184,6 +184,7 @@ if(MACOS_BUNDLE)
         PUBLIC ${ROOT_DIR}/distribution/readme.txt
         PUBLIC ${ROOT_DIR}/distribution/changelog.txt
         PUBLIC ${ROOT_DIR}/contributors.md
+        PUBLIC ${ROOT_DIR}/PRIVACY.md
         PUBLIC ${ROOT_DIR}/resources/mac/openrct2.icns
         )
 
@@ -192,6 +193,7 @@ if(MACOS_BUNDLE)
         ${ROOT_DIR}/distribution/readme.txt
         ${ROOT_DIR}/distribution/changelog.txt
         ${ROOT_DIR}/contributors.md
+        ${ROOT_DIR}/PRIVACY.md
         ${ROOT_DIR}/resources/mac/openrct2.icns
         )
 

--- a/src/openrct2/command_line/RootCommands.cpp
+++ b/src/openrct2/command_line/RootCommands.cpp
@@ -439,9 +439,10 @@ static void PrintAbout()
     Console::WriteLine("includes some 3rd party software under different licenses. See the file");
     Console::WriteLine("\"licence.txt\" shipped with the game for details.");
     Console::WriteLine();
-    Console::WriteLine("Website:      https://openrct2.io");
-    Console::WriteLine("GitHub:       https://github.com/OpenRCT2/OpenRCT2");
-    Console::WriteLine("Contributors: https://github.com/OpenRCT2/OpenRCT2/blob/develop/contributors.md");
+    Console::WriteLine("Website:        https://openrct2.io");
+    Console::WriteLine("GitHub:         https://github.com/OpenRCT2/OpenRCT2");
+    Console::WriteLine("Contributors:   https://github.com/OpenRCT2/OpenRCT2/blob/develop/contributors.md");
+    Console::WriteLine("Privacy Policy: https://github.com/OpenRCT2/OpenRCT2/blob/develop/PRIVACY.md");
     Console::WriteLine();
 }
 


### PR DESCRIPTION
This PR adds automated, cloud-based executable signing with SignPath Foundation's certificate.

SignPath Foundation allows open source projects to use their certificate for signing executables. I have submitted OpenRCT2 as OSS project that would like to use their infrastructure and they agreed to sponsor us, among other projects.

There are some restrictions on how we can use it, they're all explained at https://signpath.org/terms, here's a brief summary:
1. We need to have an established project ownership (i.e. who can push to repository, and the need for review; we already have that: https://github.com/OpenRCT2/OpenRCT2/blob/develop/contributors.md#development-team)
2. The developers need to be using 2FA (GitHub should already that from everyone: https://github.blog/news-insights/product-news/raising-the-bar-for-software-security-github-2fa-begins-march-13/)
3. The builds need to come from trusted CI environment (e.g. GitHub actions; we already have that)
4. The binaries need to have their product name and version attributes set (this PR fixes that)
5. We can only sign our binaries (so no signing of DLLs built as our dependencies; we already adhere)
6. We need to have a privacy policy (this PR adds one)
7. We need to have a code signing policy (this PR adds one)
8. We need to name SignPath as provider of the certificates (this PR adds one)
9. We need to have SignPath listed at https://openrct2.io/ download page **this is not done yet**
10. **We can only sign manually scheduled builds** (this PR adds support for that)

Overall this means we can do almost one-click signed releases now with a certificate that should be more trusted than my own. The last point serves partially as a quota limiter, but more importantly ensures that we are actually aware of the code in repository and are not signing any malware.

An example of fully automated, signed release I created for testing this PR: https://github.com/janisozaur/OpenRCT2/releases/tag/v0.222.4, created in https://github.com/janisozaur/OpenRCT2/actions/runs/11928597564/job/33246249750

To create such a manual run, you need to go to CI workflow (pinned): https://github.com/OpenRCT2/OpenRCT2/actions/workflows/ci.yml and when this PR is merged, there will be a button to schedule a manual run. I have implemented safeguards to drop out of the job if the certificate selected is incorrect or somehow certificate gets requested when not scheduled manually. I have already updated this repository with the necessary API token.

I'm submitting this PR as draft, since the SignPath foundation only enable test certificate initially and then when process is in place they do a review and enable release certificate.

Note: This is **not** OpenRCT2 certificate, this is SignPath certificate they allow OSS projects to use.