### PR TITLE
require the correct minimum version of nlohmann json

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Section: misc
 Priority: optional
 Standards-Version: 3.9.2
 Multi-Arch: same
-Build-Depends: debhelper (>= 9), cmake (>= 3.8), libsdl2-dev, g++ (>= 4:10), pkg-config, nlohmann-json3-dev (>= 3.6.0), libspeex-dev, libspeexdsp-dev, libcurl4-openssl-dev, libcrypto++-dev, libfontconfig1-dev, libfreetype6-dev, libpng-dev, libssl-dev, libzip-dev (>= 1.0.0), libicu-dev (>= 59.0), libflac-dev, libvorbis-dev
+Build-Depends: debhelper (>= 9), cmake (>= 3.8), libsdl2-dev, g++ (>= 4:10), pkg-config, nlohmann-json3-dev (>= 3.9.0), libspeex-dev, libspeexdsp-dev, libcurl4-openssl-dev, libcrypto++-dev, libfontconfig1-dev, libfreetype6-dev, libpng-dev, libssl-dev, libzip-dev (>= 1.0.0), libicu-dev (>= 59.0), libflac-dev, libvorbis-dev
 
 Package: openrct2
 Architecture: any

--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,7 @@ OpenRCT2 requires original files of RollerCoaster Tycoon 2 to play. It can be bo
   - libpng (>= 1.2)
   - speexdsp (only for UI client)
   - curl (only if building with http support)
-  - nlohmann-json (>= 3.6.0)
+  - nlohmann-json (>= 3.9.0)
   - openssl (>= 1.0; only if building with multiplayer support)
   - icu (>= 59.0)
   - zlib

--- a/src/openrct2/core/Json.hpp
+++ b/src/openrct2/core/Json.hpp
@@ -15,9 +15,9 @@
 #include <string>
 #include <string_view>
 
-#if NLOHMANN_JSON_VERSION_MAJOR < 3 || (NLOHMANN_JSON_VERSION_MAJOR == 3 && NLOHMANN_JSON_VERSION_MINOR < 6)
-#    error "Unsupported version of nlohmann json library, must be >= 3.6"
-#endif // NLOHMANN_JSON_VERSION_MAJOR < 3 || (NLOHMANN_JSON_VERSION_MAJOR == 3 && NLOHMANN_JSON_VERSION_MINOR < 6)
+#if NLOHMANN_JSON_VERSION_MAJOR < 3 || (NLOHMANN_JSON_VERSION_MAJOR == 3 && NLOHMANN_JSON_VERSION_MINOR < 9)
+#    error "Unsupported version of nlohmann json library, must be >= 3.9"
+#endif // NLOHMANN_JSON_VERSION_MAJOR < 3 || (NLOHMANN_JSON_VERSION_MAJOR == 3 && NLOHMANN_JSON_VERSION_MINOR < 9)
 
 using json_t = nlohmann::json;
 


### PR DESCRIPTION
I was having a weird issue when trying to build v0.4.16, and after some digging I found it was due to d6ce62e74f34171097ccc9f827141e3cf3a024d0 back in the v0.4.12 release making use of functionality in nlohmann-json added in v3.9.0. All the documentation mentions that >=v3.6.0 is needed, and my system repos only had up to version v3.7.3 (hence why I noticed it).

I'm not entirely sure if I did this right, and I apologise if I have done it wrong. I was initially just going to update the build page on the wiki until I noticed the macro in json.hpp. Building the library myself allows me to build the game fine.

Relevant nlohmann-json [release](https://github.com/nlohmann/json/releases/tag/v3.9.0) & [PR](https://github.com/nlohmann/json/pull/2212).