### PR TITLE
Reduce dependencies for Research.h

### DIFF
--- a/src/openrct2-ui/windows/EditorParkEntrance.cpp
+++ b/src/openrct2-ui/windows/EditorParkEntrance.cpp
@@ -16,6 +16,7 @@
 #include <openrct2/actions/ParkEntrancePlaceAction.h>
 #include <openrct2/audio/audio.h>
 #include <openrct2/object/EntranceObject.h>
+#include <openrct2/object/ObjectLimits.h>
 #include <openrct2/object/ObjectManager.h>
 #include <openrct2/sprites.h>
 #include <openrct2/world/tile_element/EntranceElement.h>

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -47,6 +47,7 @@
 #include <openrct2/localisation/LocalisationService.h>
 #include <openrct2/network/network.h>
 #include <openrct2/object/MusicObject.h>
+#include <openrct2/object/ObjectLimits.h>
 #include <openrct2/object/ObjectManager.h>
 #include <openrct2/object/ObjectRepository.h>
 #include <openrct2/object/StationObject.h>

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -39,6 +39,7 @@
 #include <openrct2/object/BannerSceneryEntry.h>
 #include <openrct2/object/LargeSceneryEntry.h>
 #include <openrct2/object/ObjectEntryManager.h>
+#include <openrct2/object/ObjectLimits.h>
 #include <openrct2/object/ObjectList.h>
 #include <openrct2/object/ObjectManager.h>
 #include <openrct2/object/ObjectRepository.h>

--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -18,6 +18,7 @@
 #include "../interface/Window.h"
 #include "../localisation/Localisation.Date.h"
 #include "../localisation/StringIds.h"
+#include "../object/ObjectLimits.h"
 #include "../object/ObjectManager.h"
 #include "../rct1/RCT1.h"
 #include "../ride/Ride.h"

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -24,6 +24,7 @@
 #include "../management/Finance.h"
 #include "../network/network.h"
 #include "../object/ObjectEntryManager.h"
+#include "../object/ObjectLimits.h"
 #include "../object/ObjectList.h"
 #include "../object/ObjectManager.h"
 #include "../object/PathAdditionEntry.h"

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -25,6 +25,7 @@
 #include "../localisation/Localisation.Date.h"
 #include "../localisation/StringIds.h"
 #include "../object/ObjectEntryManager.h"
+#include "../object/ObjectLimits.h"
 #include "../object/ObjectList.h"
 #include "../object/RideObject.h"
 #include "../object/SceneryGroupEntry.h"

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -10,10 +10,8 @@
 #pragma once
 
 #include "../localisation/StringIdType.h"
-#include "../object/ObjectLimits.h"
 #include "../object/ObjectTypes.h"
 #include "../ride/RideTypes.h"
-#include "../util/Util.h"
 
 #include <optional>
 

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -42,6 +42,7 @@
 #include "../management/Finance.h"
 #include "../management/NewsItem.h"
 #include "../object/Object.h"
+#include "../object/ObjectLimits.h"
 #include "../object/ObjectManager.h"
 #include "../object/ObjectRepository.h"
 #include "../peep/RideUseSystem.h"

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -45,6 +45,7 @@
 #include "../management/Marketing.h"
 #include "../management/NewsItem.h"
 #include "../object/Object.h"
+#include "../object/ObjectLimits.h"
 #include "../object/ObjectList.h"
 #include "../object/ObjectManager.h"
 #include "../object/ObjectRepository.h"

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -14,6 +14,7 @@
 #include "../management/Research.h"
 #include "../object/Object.h"
 #include "../ride/RideTypes.h"
+#include "../util/Util.h"
 #include "../world/tile_element/TileElementType.h"
 #include "Limits.h"
 

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -46,6 +46,7 @@
 #include "../object/FootpathSurfaceObject.h"
 #include "../object/LargeSceneryEntry.h"
 #include "../object/ObjectEntryManager.h"
+#include "../object/ObjectLimits.h"
 #include "../object/ObjectList.h"
 #include "../object/ObjectManager.h"
 #include "../object/ObjectRepository.h"

--- a/src/openrct2/ride/TrackDesign.h
+++ b/src/openrct2/ride/TrackDesign.h
@@ -14,6 +14,7 @@
 #include "../object/Object.h"
 #include "../ride/RideColour.h"
 #include "../ride/Track.h"
+#include "../util/Util.h"
 #include "../world/Map.h"
 #include "RideRatings.h"
 #include "VehicleColour.h"

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -39,6 +39,7 @@
 #include "../network/network.h"
 #include "../object/Object.h"
 #include "../object/ObjectEntryManager.h"
+#include "../object/ObjectLimits.h"
 #include "../object/ObjectList.h"
 #include "../object/ObjectManager.h"
 #include "../object/ScenarioTextObject.h"

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -26,6 +26,7 @@
 #include "../object/FootpathRailingsObject.h"
 #include "../object/FootpathSurfaceObject.h"
 #include "../object/ObjectEntryManager.h"
+#include "../object/ObjectLimits.h"
 #include "../object/ObjectManager.h"
 #include "../object/PathAdditionEntry.h"
 #include "../paint/VirtualFloor.h"

--- a/src/openrct2/world/Park.h
+++ b/src/openrct2/world/Park.h
@@ -12,6 +12,8 @@
 #include "../management/Finance.h"
 #include "Map.h"
 
+#include <string>
+
 constexpr auto MAX_ENTRANCE_FEE = 999.00_GBP;
 
 constexpr uint16_t kParkRatingHistoryUndefined = std::numeric_limits<uint16_t>::max();

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -25,6 +25,7 @@
 #include "../object/BannerSceneryEntry.h"
 #include "../object/LargeSceneryEntry.h"
 #include "../object/ObjectEntryManager.h"
+#include "../object/ObjectLimits.h"
 #include "../object/ObjectList.h"
 #include "../object/ObjectManager.h"
 #include "../object/PathAdditionEntry.h"


### PR DESCRIPTION
Currently, `Research.h` depends on `ObjectLimits.h` and `Util.h`, while it doesn't use them. This leads to ~300 units requiring a recompile when changing `ObjectLimits.h`, which is undesirable.

This PR moves these includes to the compilation units that actually require them.