### PR TITLE
Fill in the blanks in RCT1::PeepAnimationGroup enum

### DIFF
--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -523,15 +523,15 @@ namespace OpenRCT2::RCT1
         EntertainerSnowman = 9,
         EntertainerKnight = 10,
         EntertainerAstronaut = 11,
-        IceCream = 12, // Unsure
-        Chips = 13,    // Unsure
-        Burger = 14,   // Unsure
-        Drink = 15,    // Unsure
+        IceCream = 12,
+        Chips = 13,
+        Burger = 14,
+        Drink = 15,
         Balloon = 16,
         Candyfloss = 17,
         Umbrella = 18,
-        Pizza = 19,       // Unsure
-        SecurityAlt = 20, // Unknown
+        Pizza = 19,
+        SecurityAlt = 20,
         Popcorn = 21,
         ArmsCrossed = 22,
         HeadDown = 23,
@@ -539,13 +539,13 @@ namespace OpenRCT2::RCT1
         VeryNauseous = 25,
         RequireToilet = 26,
         Hat = 27,
-        HotDog = 28, // Unsure
+        HotDog = 28,
         Tentacle = 29,
         ToffeeApple = 30,
-        Doughnut = 31, // Unsure
-        Coffee = 32,   // Unsure
-        Chicken = 33,  // Unsure
-        Lemonade = 34, // Unsure
+        Doughnut = 31,
+        Coffee = 32,
+        Chicken = 33,
+        Lemonade = 34,
     };
 
     struct Peep : RCT12EntityBase

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -523,7 +523,10 @@ namespace OpenRCT2::RCT1
         EntertainerSnowman = 9,
         EntertainerKnight = 10,
         EntertainerAstronaut = 11,
-
+        IceCream = 12, // Unsure
+        Chips = 13,    // Unsure
+        Burger = 14,   // Unsure
+        Drink = 15,    // Unsure
         Balloon = 16,
         Candyfloss = 17,
         Umbrella = 18,
@@ -536,7 +539,7 @@ namespace OpenRCT2::RCT1
         VeryNauseous = 25,
         RequireToilet = 26,
         Hat = 27,
-        Burger = 28,
+        HotDog = 28, // Unsure
         Tentacle = 29,
         ToffeeApple = 30
     };

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -541,7 +541,11 @@ namespace OpenRCT2::RCT1
         Hat = 27,
         HotDog = 28, // Unsure
         Tentacle = 29,
-        ToffeeApple = 30
+        ToffeeApple = 30,
+        Doughnut = 31, // Unsure
+        Coffee = 32,   // Unsure
+        Chicken = 33,  // Unsure
+        Lemonade = 34, // Unsure
     };
 
     struct Peep : RCT12EntityBase

--- a/src/openrct2/rct1/Tables.cpp
+++ b/src/openrct2/rct1/Tables.cpp
@@ -71,41 +71,41 @@ namespace OpenRCT2::RCT1
     {
         static constexpr ::PeepAnimationGroup map[] =
         {
-            ::PeepAnimationGroup::Normal,               // 0x00
-            ::PeepAnimationGroup::Handyman,             // 0x01
-            ::PeepAnimationGroup::Mechanic,             // 0x02
-            ::PeepAnimationGroup::Security,             // 0x03
-            ::PeepAnimationGroup::EntertainerPanda,     // 0x04
-            ::PeepAnimationGroup::EntertainerTiger,     // 0x05
-            ::PeepAnimationGroup::EntertainerElephant,  // 0x06
-            ::PeepAnimationGroup::EntertainerRoman,     // 0x07
-            ::PeepAnimationGroup::EntertainerGorilla,   // 0x08
-            ::PeepAnimationGroup::EntertainerSnowman,   // 0x09
-            ::PeepAnimationGroup::EntertainerKnight,    // 0x0A
+            ::PeepAnimationGroup::Normal, // 0x00
+            ::PeepAnimationGroup::Handyman, // 0x01
+            ::PeepAnimationGroup::Mechanic, // 0x02
+            ::PeepAnimationGroup::Security, // 0x03
+            ::PeepAnimationGroup::EntertainerPanda, // 0x04
+            ::PeepAnimationGroup::EntertainerTiger, // 0x05
+            ::PeepAnimationGroup::EntertainerElephant, // 0x06
+            ::PeepAnimationGroup::EntertainerRoman, // 0x07
+            ::PeepAnimationGroup::EntertainerGorilla, // 0x08
+            ::PeepAnimationGroup::EntertainerSnowman, // 0x09
+            ::PeepAnimationGroup::EntertainerKnight, // 0x0A
             ::PeepAnimationGroup::EntertainerAstronaut, // 0x0B
-            ::PeepAnimationGroup::IceCream,             // 0x0C
-            ::PeepAnimationGroup::Chips,                // 0x0D
-            ::PeepAnimationGroup::Burger,               // 0x0E
-            ::PeepAnimationGroup::Drink,                // 0x0F
-            ::PeepAnimationGroup::Balloon,              // 0x10
-            ::PeepAnimationGroup::Candyfloss,           // 0x11
-            ::PeepAnimationGroup::Umbrella,             // 0x12
-            ::PeepAnimationGroup::Pizza,                // 0x13
-            ::PeepAnimationGroup::SecurityAlt,          // 0x14
-            ::PeepAnimationGroup::Popcorn,              // 0x15
-            ::PeepAnimationGroup::ArmsCrossed,          // 0x16
-            ::PeepAnimationGroup::HeadDown,             // 0x17
-            ::PeepAnimationGroup::Nauseous,             // 0x18
-            ::PeepAnimationGroup::VeryNauseous,         // 0x19
-            ::PeepAnimationGroup::RequireToilet,        // 0x1A
-            ::PeepAnimationGroup::Hat,                  // 0x1B
-            ::PeepAnimationGroup::HotDog,               // 0x1C
-            ::PeepAnimationGroup::Tentacle,             // 0x1D
-            ::PeepAnimationGroup::ToffeeApple,          // 0x1E
-            ::PeepAnimationGroup::Doughnut,             // 0x1F
-            ::PeepAnimationGroup::Coffee,               // 0x20
-            ::PeepAnimationGroup::Chicken,              // 0x21
-            ::PeepAnimationGroup::Lemonade,             // 0x22
+            ::PeepAnimationGroup::IceCream, // 0x0C
+            ::PeepAnimationGroup::Chips, // 0x0D
+            ::PeepAnimationGroup::Burger, // 0x0E
+            ::PeepAnimationGroup::Drink, // 0x0F
+            ::PeepAnimationGroup::Balloon, // 0x10
+            ::PeepAnimationGroup::Candyfloss, // 0x11
+            ::PeepAnimationGroup::Umbrella, // 0x12
+            ::PeepAnimationGroup::Pizza, // 0x13
+            ::PeepAnimationGroup::SecurityAlt, // 0x14
+            ::PeepAnimationGroup::Popcorn, // 0x15
+            ::PeepAnimationGroup::ArmsCrossed, // 0x16
+            ::PeepAnimationGroup::HeadDown, // 0x17
+            ::PeepAnimationGroup::Nauseous, // 0x18
+            ::PeepAnimationGroup::VeryNauseous, // 0x19
+            ::PeepAnimationGroup::RequireToilet, // 0x1A
+            ::PeepAnimationGroup::Hat, // 0x1B
+            ::PeepAnimationGroup::HotDog, // 0x1C
+            ::PeepAnimationGroup::Tentacle, // 0x1D
+            ::PeepAnimationGroup::ToffeeApple, // 0x1E
+            ::PeepAnimationGroup::Doughnut, // 0x1F
+            ::PeepAnimationGroup::Coffee, // 0x20
+            ::PeepAnimationGroup::Chicken, // 0x21
+            ::PeepAnimationGroup::Lemonade, // 0x22
         };
         if (EnumValue(rct1AnimationGroup) >= std::size(map))
         {

--- a/src/openrct2/rct1/Tables.cpp
+++ b/src/openrct2/rct1/Tables.cpp
@@ -71,41 +71,41 @@ namespace OpenRCT2::RCT1
     {
         static constexpr ::PeepAnimationGroup map[] =
         {
-            ::PeepAnimationGroup::Normal, // 0x00
-            ::PeepAnimationGroup::Handyman, // 0x01
-            ::PeepAnimationGroup::Mechanic, // 0x02
-            ::PeepAnimationGroup::Security, // 0x03
-            ::PeepAnimationGroup::EntertainerPanda, // 0x04
-            ::PeepAnimationGroup::EntertainerTiger, // 0x05
-            ::PeepAnimationGroup::EntertainerElephant, // 0x06
-            ::PeepAnimationGroup::EntertainerRoman, // 0x07
-            ::PeepAnimationGroup::EntertainerGorilla, // 0x08
-            ::PeepAnimationGroup::EntertainerSnowman, // 0x09
-            ::PeepAnimationGroup::EntertainerKnight, // 0x0A
+            ::PeepAnimationGroup::Normal,               // 0x00
+            ::PeepAnimationGroup::Handyman,             // 0x01
+            ::PeepAnimationGroup::Mechanic,             // 0x02
+            ::PeepAnimationGroup::Security,             // 0x03
+            ::PeepAnimationGroup::EntertainerPanda,     // 0x04
+            ::PeepAnimationGroup::EntertainerTiger,     // 0x05
+            ::PeepAnimationGroup::EntertainerElephant,  // 0x06
+            ::PeepAnimationGroup::EntertainerRoman,     // 0x07
+            ::PeepAnimationGroup::EntertainerGorilla,   // 0x08
+            ::PeepAnimationGroup::EntertainerSnowman,   // 0x09
+            ::PeepAnimationGroup::EntertainerKnight,    // 0x0A
             ::PeepAnimationGroup::EntertainerAstronaut, // 0x0B
-            ::PeepAnimationGroup::IceCream, // 0x0C
-            ::PeepAnimationGroup::Chips, // 0x0D
-            ::PeepAnimationGroup::Burger, // 0x0E
-            ::PeepAnimationGroup::Drink, // 0x0F
-            ::PeepAnimationGroup::Balloon, // 0x10
-            ::PeepAnimationGroup::Candyfloss, // 0x11
-            ::PeepAnimationGroup::Umbrella, // 0x12
-            ::PeepAnimationGroup::Pizza, // 0x13
-            ::PeepAnimationGroup::SecurityAlt, // 0x14
-            ::PeepAnimationGroup::Popcorn, // 0x15
-            ::PeepAnimationGroup::ArmsCrossed, // 0x16
-            ::PeepAnimationGroup::HeadDown, // 0x17
-            ::PeepAnimationGroup::Nauseous, // 0x18
-            ::PeepAnimationGroup::VeryNauseous, // 0x19
-            ::PeepAnimationGroup::RequireToilet, // 0x1A
-            ::PeepAnimationGroup::Hat, // 0x1B
-            ::PeepAnimationGroup::HotDog, // 0x1C
-            ::PeepAnimationGroup::Tentacle, // 0x1D
-            ::PeepAnimationGroup::ToffeeApple, // 0x1E
-            ::PeepAnimationGroup::Doughnut, // 0x1F
-            ::PeepAnimationGroup::Coffee, // 0x20
-            ::PeepAnimationGroup::Chicken, // 0x21
-            ::PeepAnimationGroup::Lemonade, // 0x22
+            ::PeepAnimationGroup::IceCream,             // 0x0C
+            ::PeepAnimationGroup::Chips,                // 0x0D
+            ::PeepAnimationGroup::Burger,               // 0x0E
+            ::PeepAnimationGroup::Drink,                // 0x0F
+            ::PeepAnimationGroup::Balloon,              // 0x10
+            ::PeepAnimationGroup::Candyfloss,           // 0x11
+            ::PeepAnimationGroup::Umbrella,             // 0x12
+            ::PeepAnimationGroup::Pizza,                // 0x13
+            ::PeepAnimationGroup::SecurityAlt,          // 0x14
+            ::PeepAnimationGroup::Popcorn,              // 0x15
+            ::PeepAnimationGroup::ArmsCrossed,          // 0x16
+            ::PeepAnimationGroup::HeadDown,             // 0x17
+            ::PeepAnimationGroup::Nauseous,             // 0x18
+            ::PeepAnimationGroup::VeryNauseous,         // 0x19
+            ::PeepAnimationGroup::RequireToilet,        // 0x1A
+            ::PeepAnimationGroup::Hat,                  // 0x1B
+            ::PeepAnimationGroup::HotDog,               // 0x1C
+            ::PeepAnimationGroup::Tentacle,             // 0x1D
+            ::PeepAnimationGroup::ToffeeApple,          // 0x1E
+            ::PeepAnimationGroup::Doughnut,             // 0x1F
+            ::PeepAnimationGroup::Coffee,               // 0x20
+            ::PeepAnimationGroup::Chicken,              // 0x21
+            ::PeepAnimationGroup::Lemonade,             // 0x22
         };
         if (EnumValue(rct1AnimationGroup) >= std::size(map))
         {


### PR DESCRIPTION
Looking at the RCT1 peep animation group conversion, I noticed an inconsistency in the peep animation import tables. Consider these lines from rct1/RCT1.h:
```cpp
    enum class RCT1::PeepAnimationGroup : uint8_t
    {
        // ...
        Burger = 28,     // 0x1C
        Tentacle = 29,   // 0x1D
        ToffeeApple = 30 // 0xE1
    };
```
Then, in rct1/Tables.cpp:
```cpp
    ::PeepAnimationGroup GetPeepAnimationGroup(RCT1::PeepAnimationGroup rct1AnimationGroup)
    {
        static constexpr ::PeepAnimationGroup map[] =
        {
            // ...
            ::PeepAnimationGroup::HotDog,               // 0x1C
            ::PeepAnimationGroup::Tentacle,             // 0x1D
            ::PeepAnimationGroup::ToffeeApple,          // 0x1E
            // ...
        };
        // ...
        return map[EnumValue(rct1AnimationGroup)];
    }
```
Note how burger sprites appear to be assigned the hot dog sprite. Tentacles and Toffee apples seem fine. Considering burgers are part of the base game, it is likely the hot dogs are correct, meaning the enum is wrong.

Taking the conversion table as ground truth, I've added the four missing enum values in the middle and four at the end as well.