### PR TITLE
Extend ObjectList::Find to match DAT names as well

### DIFF
--- a/src/openrct2/object/ObjectList.cpp
+++ b/src/openrct2/object/ObjectList.cpp
@@ -176,8 +176,8 @@ ObjectEntryIndex ObjectList::Find(ObjectType type, std::string_view identifier) 
     for (size_t i = 0; i < subList.size(); i++)
     {
         auto& entry = subList[i];
-        if ((entry.Generation == ObjectGeneration::JSON && entry.Identifier == identifier) ||
-            (entry.Generation == ObjectGeneration::DAT && entry.Entry.GetName() == identifier))
+        if ((entry.Generation == ObjectGeneration::JSON && entry.Identifier == identifier)
+            || (entry.Generation == ObjectGeneration::DAT && entry.Entry.GetName() == identifier))
         {
             return static_cast<ObjectEntryIndex>(i);
         }

--- a/src/openrct2/object/ObjectList.cpp
+++ b/src/openrct2/object/ObjectList.cpp
@@ -183,6 +183,7 @@ ObjectEntryIndex ObjectList::Find(ObjectType type, std::string_view identifier) 
     return OBJECT_ENTRY_INDEX_NULL;
 }
 
+// Intended to be used to find non-custom legacy objects. For internal use only.
 ObjectEntryIndex ObjectList::FindLegacy(ObjectType type, std::string_view identifier) const
 {
     auto& subList = GetList(type);

--- a/src/openrct2/object/ObjectList.cpp
+++ b/src/openrct2/object/ObjectList.cpp
@@ -175,7 +175,9 @@ ObjectEntryIndex ObjectList::Find(ObjectType type, std::string_view identifier) 
     auto& subList = GetList(type);
     for (size_t i = 0; i < subList.size(); i++)
     {
-        if (subList[i].Identifier == identifier)
+        auto& entry = subList[i];
+        if ((entry.Generation == ObjectGeneration::JSON && entry.Identifier == identifier) ||
+            (entry.Generation == ObjectGeneration::DAT && entry.Entry.GetName() == identifier))
         {
             return static_cast<ObjectEntryIndex>(i);
         }

--- a/src/openrct2/object/ObjectList.cpp
+++ b/src/openrct2/object/ObjectList.cpp
@@ -175,9 +175,21 @@ ObjectEntryIndex ObjectList::Find(ObjectType type, std::string_view identifier) 
     auto& subList = GetList(type);
     for (size_t i = 0; i < subList.size(); i++)
     {
-        auto& entry = subList[i];
-        if ((entry.Generation == ObjectGeneration::JSON && entry.Identifier == identifier)
-            || (entry.Generation == ObjectGeneration::DAT && entry.Entry.GetName() == identifier))
+        if (subList[i].Generation == ObjectGeneration::JSON && subList[i].Identifier == identifier)
+        {
+            return static_cast<ObjectEntryIndex>(i);
+        }
+    }
+    return OBJECT_ENTRY_INDEX_NULL;
+}
+
+ObjectEntryIndex ObjectList::FindLegacy(ObjectType type, std::string_view identifier) const
+{
+    auto& subList = GetList(type);
+    for (size_t i = 0; i < subList.size(); i++)
+    {
+        if (subList[i].Generation == ObjectGeneration::DAT && subList[i].Entry.GetName() == identifier
+            && subList[i].Entry.GetSourceGame() != ObjectSourceGame::Custom)
         {
             return static_cast<ObjectEntryIndex>(i);
         }

--- a/src/openrct2/object/ObjectList.cpp
+++ b/src/openrct2/object/ObjectList.cpp
@@ -170,7 +170,7 @@ void ObjectList::SetObject(ObjectType type, ObjectEntryIndex index, std::string_
     SetObject(index, entry);
 }
 
-ObjectEntryIndex ObjectList::Find(ObjectType type, std::string_view identifier)
+ObjectEntryIndex ObjectList::Find(ObjectType type, std::string_view identifier) const
 {
     auto& subList = GetList(type);
     for (size_t i = 0; i < subList.size(); i++)

--- a/src/openrct2/object/ObjectList.h
+++ b/src/openrct2/object/ObjectList.h
@@ -26,6 +26,7 @@ public:
     void SetObject(ObjectEntryIndex index, const ObjectEntryDescriptor& entry);
     void SetObject(ObjectType type, ObjectEntryIndex index, std::string_view identifier);
     ObjectEntryIndex Find(ObjectType type, std::string_view identifier) const;
+    ObjectEntryIndex FindLegacy(ObjectType type, std::string_view identifier) const;
 
     struct const_iterator
     {

--- a/src/openrct2/object/ObjectList.h
+++ b/src/openrct2/object/ObjectList.h
@@ -25,7 +25,7 @@ public:
     const ObjectEntryDescriptor& GetObject(ObjectType type, ObjectEntryIndex index) const;
     void SetObject(ObjectEntryIndex index, const ObjectEntryDescriptor& entry);
     void SetObject(ObjectType type, ObjectEntryIndex index, std::string_view identifier);
-    ObjectEntryIndex Find(ObjectType type, std::string_view identifier);
+    ObjectEntryIndex Find(ObjectType type, std::string_view identifier) const;
 
     struct const_iterator
     {


### PR DESCRIPTION
Working on my peep animation object branch, I needed to match the object list against both JSON identifiers and DAT identifiers/names. There was no option for the latter, though.

This PR introduces a `ObjectList::FindLegacy` function to handle DAT cases. Additionally, the existing `ObjectList::Find` function now explicitly checks against JSON cases, and is marked `const` to allow for additional optimisations.