### PR TITLE
ImageTable: make parsing ranges more robust

### DIFF
--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -92,9 +92,12 @@ std::vector<std::unique_ptr<ImageTable::RequiredImage>> ImageTable::ParseImages(
     }
     else if (String::StartsWith(s, "$CSG"))
     {
-        auto range = ParseRange(s.substr(4));
-        if (!range.empty())
+        auto rangeStart = s.find('[');
+        auto rangeEnd = s.find(']');
+        if (rangeStart != std::string::npos && rangeEnd != std::string::npos)
         {
+            auto rangeString = s.substr(rangeStart, rangeEnd - rangeStart + 1);
+            auto range = ParseRange(rangeString);
             if (IsCsgLoaded())
             {
                 for (auto i : range)
@@ -118,9 +121,12 @@ std::vector<std::unique_ptr<ImageTable::RequiredImage>> ImageTable::ParseImages(
     }
     else if (String::StartsWith(s, "$G1"))
     {
-        auto range = ParseRange(s.substr(3));
-        if (!range.empty())
+        auto rangeStart = s.find('[');
+        auto rangeEnd = s.find(']');
+        if (rangeStart != std::string::npos && rangeEnd != std::string::npos)
         {
+            auto rangeString = s.substr(rangeStart, rangeEnd - rangeStart + 1);
+            auto range = ParseRange(rangeString);
             for (auto i : range)
             {
                 result.push_back(std::make_unique<RequiredImage>(
@@ -132,10 +138,11 @@ std::vector<std::unique_ptr<ImageTable::RequiredImage>> ImageTable::ParseImages(
     {
         auto name = s.substr(14);
         auto rangeStart = name.find('[');
-        if (rangeStart != std::string::npos)
+        auto rangeEnd = name.find(']');
+        if (rangeStart != std::string::npos && rangeEnd != std::string::npos)
         {
-            auto rangeString = name.substr(rangeStart);
-            auto range = ParseRange(name.substr(rangeStart));
+            auto rangeString = name.substr(rangeStart, rangeEnd - rangeStart + 1);
+            auto range = ParseRange(rangeString);
             name = name.substr(0, rangeStart);
             result = LoadObjectImages(context, name, range);
         }
@@ -144,10 +151,11 @@ std::vector<std::unique_ptr<ImageTable::RequiredImage>> ImageTable::ParseImages(
     {
         auto name = s.substr(5);
         auto rangeStart = name.find('[');
-        if (rangeStart != std::string::npos)
+        auto rangeEnd = name.find(']');
+        if (rangeStart != std::string::npos && rangeEnd != std::string::npos)
         {
-            auto rangeString = name.substr(rangeStart);
-            auto range = ParseRange(name.substr(rangeStart));
+            auto rangeString = name.substr(rangeStart, rangeEnd - rangeStart + 1);
+            auto range = ParseRange(rangeString);
             name = name.substr(0, rangeStart);
             result = LoadImageArchiveImages(context, name, range);
         }


### PR DESCRIPTION
This changes `ImageTable::ParseImages` such that it ensures that ranges are terminated properly before passing them into `ImageTable::ParseRange`. Moreover, only the actual ranges are now passed into the latter function. This has the added benefit of allowing 'comments' in image tables, as anything after the range will now be completely ignored. For example, this is now a valid image table:
```json
    "images": [
        "$G1[5490..5490]  // Inline sprite id",
        "$G1[6409..6432]  // Normal.walking",
        "$G1[6433..6456]  // ArmsCrossed.walking",
        "$G1[6457..6480]  // HeadDown.walking",
        "$G1[6481..6504]  // Nauseous.walking",
        "$G1[6505..6528]  // VeryNauseous.walking",
```