### PR TITLE
Refactor Intent

### DIFF
--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -247,7 +247,7 @@ public:
                 uint32_t type = intent->GetUIntExtra(INTENT_EXTRA_LOADSAVE_TYPE);
                 std::string defaultName = intent->GetStringExtra(INTENT_EXTRA_PATH);
                 loadsave_callback callback = reinterpret_cast<loadsave_callback>(
-                    intent->GetPointerExtra(INTENT_EXTRA_CALLBACK));
+                    intent->GetCloseCallbackExtra(INTENT_EXTRA_CALLBACK));
                 TrackDesign* trackDesign = static_cast<TrackDesign*>(intent->GetPointerExtra(INTENT_EXTRA_TRACK_DESIGN));
                 auto* w = LoadsaveOpen(
                     type, defaultName,
@@ -294,7 +294,7 @@ public:
             }
             case WindowClass::ScenarioSelect:
                 return ScenarioselectOpen(
-                    reinterpret_cast<scenarioselect_callback>(intent->GetPointerExtra(INTENT_EXTRA_CALLBACK)));
+                    reinterpret_cast<scenarioselect_callback>(intent->GetCloseCallbackExtra(INTENT_EXTRA_CALLBACK)));
 
             case WindowClass::Null:
                 // Intent does not hold a window class

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -246,7 +246,7 @@ public:
             {
                 uint32_t type = intent->GetUIntExtra(INTENT_EXTRA_LOADSAVE_TYPE);
                 std::string defaultName = intent->GetStringExtra(INTENT_EXTRA_PATH);
-                loadsave_callback callback = reinterpret_cast<loadsave_callback>(
+                LoadSaveCallback callback = reinterpret_cast<LoadSaveCallback>(
                     intent->GetCloseCallbackExtra(INTENT_EXTRA_CALLBACK));
                 TrackDesign* trackDesign = static_cast<TrackDesign*>(intent->GetPointerExtra(INTENT_EXTRA_TRACK_DESIGN));
                 auto* w = LoadsaveOpen(
@@ -265,7 +265,7 @@ public:
             case WindowClass::NetworkStatus:
             {
                 std::string message = intent->GetStringExtra(INTENT_EXTRA_MESSAGE);
-                close_callback callback = intent->GetCloseCallbackExtra(INTENT_EXTRA_CALLBACK);
+                CloseCallback callback = intent->GetCloseCallbackExtra(INTENT_EXTRA_CALLBACK);
                 return NetworkStatusOpen(message, callback);
             }
             case WindowClass::ObjectLoadError:
@@ -294,7 +294,7 @@ public:
             }
             case WindowClass::ScenarioSelect:
                 return ScenarioselectOpen(
-                    reinterpret_cast<scenarioselect_callback>(intent->GetCloseCallbackExtra(INTENT_EXTRA_CALLBACK)));
+                    reinterpret_cast<ScenarioSelectCallback>(intent->GetCloseCallbackExtra(INTENT_EXTRA_CALLBACK)));
 
             case WindowClass::Null:
                 // Intent does not hold a window class
@@ -335,7 +335,7 @@ public:
             case INTENT_ACTION_PROGRESS_OPEN:
             {
                 std::string message = intent->GetStringExtra(INTENT_EXTRA_MESSAGE);
-                close_callback callback = intent->GetCloseCallbackExtra(INTENT_EXTRA_CALLBACK);
+                CloseCallback callback = intent->GetCloseCallbackExtra(INTENT_EXTRA_CALLBACK);
                 return ProgressWindowOpen(message, callback);
             }
 

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -942,7 +942,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     auto intent = Intent(WindowClass::Loadsave);
                     intent.PutExtra(INTENT_EXTRA_LOADSAVE_TYPE, LOADSAVETYPE_LOAD | LOADSAVETYPE_HEIGHTMAP);
-                    intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<close_callback>(HeightmapLoadsaveCallback));
+                    intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<CloseCallback>(HeightmapLoadsaveCallback));
                     ContextOpenIntent(&intent);
                     return;
                 }

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -942,7 +942,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     auto intent = Intent(WindowClass::Loadsave);
                     intent.PutExtra(INTENT_EXTRA_LOADSAVE_TYPE, LOADSAVETYPE_LOAD | LOADSAVETYPE_HEIGHTMAP);
-                    intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<void*>(HeightmapLoadsaveCallback));
+                    intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<close_callback>(HeightmapLoadsaveCallback));
                     ContextOpenIntent(&intent);
                     return;
                 }

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -110,7 +110,7 @@ namespace OpenRCT2::Ui::Windows
             DrawText(dpi, screenCoords, { COLOUR_BLACK }, _buffer.c_str());
         }
 
-        void SetCloseCallBack(close_callback onClose)
+        void SetCloseCallBack(CloseCallback onClose)
         {
             _onClose = onClose;
         }
@@ -127,12 +127,12 @@ namespace OpenRCT2::Ui::Windows
         }
 
     private:
-        close_callback _onClose = nullptr;
+        CloseCallback _onClose = nullptr;
         std::string _windowNetworkStatusText;
         std::string _password;
     };
 
-    WindowBase* NetworkStatusOpen(const std::string& text, close_callback onClose)
+    WindowBase* NetworkStatusOpen(const std::string& text, CloseCallback onClose)
     {
         ContextForceCloseWindowByClass(WindowClass::ProgressWindow);
 

--- a/src/openrct2-ui/windows/ProgressWindow.cpp
+++ b/src/openrct2-ui/windows/ProgressWindow.cpp
@@ -70,7 +70,7 @@ namespace OpenRCT2::Ui::Windows
     class ProgressWindow final : public Window
     {
     private:
-        close_callback _onClose = nullptr;
+        CloseCallback _onClose = nullptr;
 
         StringId _progressFormat;
         std::string _progressTitle;
@@ -213,7 +213,7 @@ namespace OpenRCT2::Ui::Windows
             Invalidate();
         }
 
-        void SetCloseCallback(close_callback onClose)
+        void SetCloseCallback(CloseCallback onClose)
         {
             _onClose = onClose;
         }
@@ -231,7 +231,7 @@ namespace OpenRCT2::Ui::Windows
         }
     };
 
-    WindowBase* ProgressWindowOpen(const std::string& text, close_callback onClose)
+    WindowBase* ProgressWindowOpen(const std::string& text, CloseCallback onClose)
     {
         ContextForceCloseWindowByClass(WindowClass::NetworkStatus);
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -5456,7 +5456,7 @@ namespace OpenRCT2::Ui::Windows
             intent.PutExtra(INTENT_EXTRA_LOADSAVE_TYPE, LOADSAVETYPE_SAVE | LOADSAVETYPE_TRACK);
             intent.PutExtra(INTENT_EXTRA_TRACK_DESIGN, _trackDesign.get());
             intent.PutExtra(INTENT_EXTRA_PATH, trackName);
-            intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<void*>(&TrackDesignCallback));
+            intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<close_callback>(&TrackDesignCallback));
 
             ContextOpenIntent(&intent);
         }

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -5456,7 +5456,7 @@ namespace OpenRCT2::Ui::Windows
             intent.PutExtra(INTENT_EXTRA_LOADSAVE_TYPE, LOADSAVETYPE_SAVE | LOADSAVETYPE_TRACK);
             intent.PutExtra(INTENT_EXTRA_TRACK_DESIGN, _trackDesign.get());
             intent.PutExtra(INTENT_EXTRA_PATH, trackName);
-            intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<close_callback>(&TrackDesignCallback));
+            intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<CloseCallback>(&TrackDesignCallback));
 
             ContextOpenIntent(&intent);
         }

--- a/src/openrct2-ui/windows/SavePrompt.cpp
+++ b/src/openrct2-ui/windows/SavePrompt.cpp
@@ -173,7 +173,7 @@ namespace OpenRCT2::Ui::Windows
                         intent = CreateSaveGameAsIntent();
                     }
                     Close();
-                    intent->PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<void*>(WindowSavePromptCallback));
+                    intent->PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<close_callback>(WindowSavePromptCallback));
                     ContextOpenIntent(intent.get());
                     break;
                 }

--- a/src/openrct2-ui/windows/SavePrompt.cpp
+++ b/src/openrct2-ui/windows/SavePrompt.cpp
@@ -173,7 +173,7 @@ namespace OpenRCT2::Ui::Windows
                         intent = CreateSaveGameAsIntent();
                     }
                     Close();
-                    intent->PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<close_callback>(WindowSavePromptCallback));
+                    intent->PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<CloseCallback>(WindowSavePromptCallback));
                     ContextOpenIntent(intent.get());
                     break;
                 }

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -761,7 +761,7 @@ namespace OpenRCT2::Ui::Windows
         }
     };
 
-    WindowBase* ScenarioselectOpen(scenarioselect_callback callback)
+    WindowBase* ScenarioselectOpen(ScenarioSelectCallback callback)
     {
         return ScenarioselectOpen([callback](std::string_view scenario) { callback(std::string(scenario).c_str()); });
     }

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -139,7 +139,7 @@ namespace OpenRCT2::Ui::Windows
                     NetworkSetPassword(_password);
                     auto intent = Intent(WindowClass::Loadsave);
                     intent.PutExtra(INTENT_EXTRA_LOADSAVE_TYPE, LOADSAVETYPE_LOAD | LOADSAVETYPE_GAME);
-                    intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<close_callback>(LoadSaveCallback));
+                    intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<CloseCallback>(LoadSaveCallback));
                     ContextOpenIntent(&intent);
                     break;
             }

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -139,7 +139,7 @@ namespace OpenRCT2::Ui::Windows
                     NetworkSetPassword(_password);
                     auto intent = Intent(WindowClass::Loadsave);
                     intent.PutExtra(INTENT_EXTRA_LOADSAVE_TYPE, LOADSAVETYPE_LOAD | LOADSAVETYPE_GAME);
-                    intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<void*>(LoadSaveCallback));
+                    intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<close_callback>(LoadSaveCallback));
                     ContextOpenIntent(&intent);
                     break;
             }

--- a/src/openrct2-ui/windows/Window.h
+++ b/src/openrct2-ui/windows/Window.h
@@ -24,8 +24,8 @@ struct Vehicle;
 enum class GuestListFilterType : int32_t;
 enum class ScatterToolDensity : uint8_t;
 
-using loadsave_callback = void (*)(int32_t result, const utf8* path);
-using scenarioselect_callback = void (*)(const utf8* path);
+using LoadSaveCallback = void (*)(int32_t result, const utf8* path);
+using ScenarioSelectCallback = void (*)(const utf8* path);
 
 namespace OpenRCT2::Ui::Windows
 {
@@ -118,7 +118,7 @@ namespace OpenRCT2::Ui::Windows
     WindowBase* GuestListOpen();
     WindowBase* GuestListOpenWithFilter(GuestListFilterType type, int32_t index);
     WindowBase* StaffFirePromptOpen(Peep* peep);
-    WindowBase* ScenarioselectOpen(scenarioselect_callback callback);
+    WindowBase* ScenarioselectOpen(ScenarioSelectCallback callback);
     WindowBase* ScenarioselectOpen(std::function<void(std::string_view)> callback);
 
     WindowBase* ErrorOpen(StringId title, StringId message, const class Formatter& formatter, bool autoClose = false);
@@ -174,11 +174,11 @@ namespace OpenRCT2::Ui::Windows
     WindowBase* MazeConstructionOpen();
     void WindowMazeConstructionUpdatePressedWidgets();
 
-    WindowBase* NetworkStatusOpen(const std::string& text, close_callback onClose);
+    WindowBase* NetworkStatusOpen(const std::string& text, CloseCallback onClose);
     WindowBase* NetworkStatusOpenPassword();
     void WindowNetworkStatusClose();
 
-    WindowBase* ProgressWindowOpen(const std::string& text, close_callback onClose = nullptr);
+    WindowBase* ProgressWindowOpen(const std::string& text, CloseCallback onClose = nullptr);
     void ProgressWindowSet(uint32_t currentProgress, uint32_t totalCount, StringId format = STR_NONE);
     void ProgressWindowClose();
 

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -128,7 +128,7 @@ namespace OpenRCT2::Editor
         ToolCancel();
         auto intent = Intent(WindowClass::Loadsave);
         intent.PutExtra(INTENT_EXTRA_LOADSAVE_TYPE, LOADSAVETYPE_LOAD | LOADSAVETYPE_GAME);
-        intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<close_callback>(ConvertSaveToScenarioCallback));
+        intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<CloseCallback>(ConvertSaveToScenarioCallback));
         ContextOpenIntent(&intent);
     }
 

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -128,7 +128,7 @@ namespace OpenRCT2::Editor
         ToolCancel();
         auto intent = Intent(WindowClass::Loadsave);
         intent.PutExtra(INTENT_EXTRA_LOADSAVE_TYPE, LOADSAVETYPE_LOAD | LOADSAVETYPE_GAME);
-        intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<void*>(ConvertSaveToScenarioCallback));
+        intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<close_callback>(ConvertSaveToScenarioCallback));
         ContextOpenIntent(&intent);
     }
 

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -654,7 +654,7 @@ void GameLoadOrQuitNoSavePrompt()
             {
                 auto intent = Intent(WindowClass::Loadsave);
                 intent.PutExtra(INTENT_EXTRA_LOADSAVE_TYPE, LOADSAVETYPE_LOAD | LOADSAVETYPE_GAME);
-                intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<close_callback>(GameLoadOrQuitNoSavePromptCallback));
+                intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<CloseCallback>(GameLoadOrQuitNoSavePromptCallback));
                 ContextOpenIntent(&intent);
             }
             break;
@@ -683,7 +683,7 @@ void GameLoadOrQuitNoSavePrompt()
             GameActions::Execute(&loadOrQuitAction);
             ToolCancel();
             auto intent = Intent(WindowClass::ScenarioSelect);
-            intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<close_callback>(NewGameWindowCallback));
+            intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<CloseCallback>(NewGameWindowCallback));
             ContextOpenIntent(&intent);
             break;
         }

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -654,7 +654,7 @@ void GameLoadOrQuitNoSavePrompt()
             {
                 auto intent = Intent(WindowClass::Loadsave);
                 intent.PutExtra(INTENT_EXTRA_LOADSAVE_TYPE, LOADSAVETYPE_LOAD | LOADSAVETYPE_GAME);
-                intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<void*>(GameLoadOrQuitNoSavePromptCallback));
+                intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<close_callback>(GameLoadOrQuitNoSavePromptCallback));
                 ContextOpenIntent(&intent);
             }
             break;
@@ -683,7 +683,7 @@ void GameLoadOrQuitNoSavePrompt()
             GameActions::Execute(&loadOrQuitAction);
             ToolCancel();
             auto intent = Intent(WindowClass::ScenarioSelect);
-            intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<void*>(NewGameWindowCallback));
+            intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<close_callback>(NewGameWindowCallback));
             ContextOpenIntent(&intent);
             break;
         }

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -445,7 +445,7 @@ extern Tool gCurrentToolId;
 extern WidgetRef gCurrentToolWidget;
 
 using modal_callback = void (*)(int32_t result);
-using close_callback = void (*)();
+using CloseCallback = void (*)();
 
 constexpr int8_t kWindowLimitMin = 4;
 constexpr int8_t kWindowLimitMax = 64;

--- a/src/openrct2/windows/Intent.cpp
+++ b/src/openrct2/windows/Intent.cpp
@@ -82,7 +82,7 @@ Intent* Intent::PutExtra(uint32_t key, std::string value)
     return this;
 }
 
-Intent* Intent::PutExtra(uint32_t key, close_callback value)
+Intent* Intent::PutExtra(uint32_t key, CloseCallback value)
 {
     putExtraImpl(_Data, key, value);
     return this;
@@ -123,7 +123,7 @@ std::string Intent::GetStringExtra(uint32_t key) const
     return getExtraImpl<std::string>(_Data, key);
 }
 
-close_callback Intent::GetCloseCallbackExtra(uint32_t key) const
+CloseCallback Intent::GetCloseCallbackExtra(uint32_t key) const
 {
-    return getExtraImpl<close_callback>(_Data, key);
+    return getExtraImpl<CloseCallback>(_Data, key);
 }

--- a/src/openrct2/windows/Intent.cpp
+++ b/src/openrct2/windows/Intent.cpp
@@ -33,9 +33,7 @@ static auto getExtraImpl(const IntentDataStorage& storage, uint32_t key)
     auto it = std::ranges::lower_bound(storage, key, {}, &IntentDataEntry::first);
     if (it == storage.end() || it->first != key)
     {
-        // If key does not exist then the usage of Intent is incorrect.
-        assert(false);
-
+        // TODO: The code currently assumes that some things are optional, we need to handle this better.
         return T{};
     }
 

--- a/src/openrct2/windows/Intent.cpp
+++ b/src/openrct2/windows/Intent.cpp
@@ -32,55 +32,35 @@ Intent::Intent(IntentAction intentAction)
 
 Intent* Intent::PutExtra(uint32_t key, uint32_t value)
 {
-    IntentData data = {};
-    data.intVal.unsignedInt = value;
-    data.type = IntentData::DataType::Int;
-
-    _Data.insert(std::make_pair(key, data));
+    _Data.emplace(key, static_cast<int64_t>(value));
 
     return this;
 }
 
 Intent* Intent::PutExtra(uint32_t key, void* value)
 {
-    IntentData data = {};
-    data.pointerVal = value;
-    data.type = IntentData::DataType::Pointer;
-
-    _Data.insert(std::make_pair(key, data));
+    _Data.emplace(key, value);
 
     return this;
 }
 
 Intent* Intent::PutExtra(uint32_t key, int32_t value)
 {
-    IntentData data = {};
-    data.intVal.signedInt = value;
-    data.type = IntentData::DataType::Int;
-
-    _Data.insert(std::make_pair(key, data));
+    _Data.emplace(key, static_cast<int64_t>(value));
 
     return this;
 }
 
 Intent* Intent::PutExtra(uint32_t key, std::string value)
 {
-    IntentData data = {};
-    data.stringVal = std::move(value);
-    data.type = IntentData::DataType::String;
-
-    _Data.insert(std::make_pair(key, data));
+    _Data.emplace(key, value);
 
     return this;
 }
 
 Intent* Intent::PutExtra(uint32_t key, close_callback value)
 {
-    IntentData data = {};
-    data.closeCallbackVal = value;
-    data.type = IntentData::DataType::CloseCallback;
-
-    _Data.insert(std::make_pair(key, data));
+    _Data.emplace(key, value);
 
     return this;
 }
@@ -108,8 +88,9 @@ void* Intent::GetPointerExtra(uint32_t key) const
     }
 
     auto data = _Data.at(key);
-    Guard::Assert(data.type == IntentData::DataType::Pointer, "Actual type doesn't match requested type");
-    return static_cast<void*>(data.pointerVal);
+
+    assert(std::holds_alternative<void*>(data));
+    return std::get<void*>(data);
 }
 
 uint32_t Intent::GetUIntExtra(uint32_t key) const
@@ -120,8 +101,9 @@ uint32_t Intent::GetUIntExtra(uint32_t key) const
     }
 
     auto data = _Data.at(key);
-    Guard::Assert(data.type == IntentData::DataType::Int, "Actual type doesn't match requested type");
-    return data.intVal.unsignedInt;
+
+    assert(std::holds_alternative<int64_t>(data));
+    return static_cast<uint32_t>(std::get<int64_t>(data));
 }
 
 int32_t Intent::GetSIntExtra(uint32_t key) const
@@ -132,8 +114,9 @@ int32_t Intent::GetSIntExtra(uint32_t key) const
     }
 
     auto data = _Data.at(key);
-    Guard::Assert(data.type == IntentData::DataType::Int, "Actual type doesn't match requested type");
-    return data.intVal.signedInt;
+
+    assert(std::holds_alternative<int64_t>(data));
+    return static_cast<int32_t>(std::get<int64_t>(data));
 }
 
 std::string Intent::GetStringExtra(uint32_t key) const
@@ -144,8 +127,9 @@ std::string Intent::GetStringExtra(uint32_t key) const
     }
 
     auto data = _Data.at(key);
-    Guard::Assert(data.type == IntentData::DataType::String, "Actual type doesn't match requested type");
-    return data.stringVal;
+
+    assert(std::holds_alternative<std::string>(data));
+    return std::get<std::string>(data);
 }
 
 close_callback Intent::GetCloseCallbackExtra(uint32_t key) const
@@ -156,6 +140,7 @@ close_callback Intent::GetCloseCallbackExtra(uint32_t key) const
     }
 
     auto data = _Data.at(key);
-    Guard::Assert(data.type == IntentData::DataType::CloseCallback, "Actual type doesn't match requested type");
-    return data.closeCallbackVal;
+
+    assert(std::holds_alternative<close_callback>(data));
+    return std::get<close_callback>(data);
 }

--- a/src/openrct2/windows/Intent.cpp
+++ b/src/openrct2/windows/Intent.cpp
@@ -11,6 +11,7 @@
 
 #include "../core/Guard.hpp"
 
+#include <ranges>
 #include <utility>
 
 using namespace OpenRCT2;
@@ -32,35 +33,50 @@ Intent::Intent(IntentAction intentAction)
 
 Intent* Intent::PutExtra(uint32_t key, uint32_t value)
 {
-    _Data.emplace(key, static_cast<int64_t>(value));
+    auto it = std::ranges::lower_bound(_Data, key, {}, &DataEntry::first);
+    assert(it == _Data.end() || it->first != key);
+
+    _Data.emplace(it, key, static_cast<int64_t>(value));
 
     return this;
 }
 
 Intent* Intent::PutExtra(uint32_t key, void* value)
 {
-    _Data.emplace(key, value);
+    auto it = std::ranges::lower_bound(_Data, key, {}, &DataEntry::first);
+    assert(it == _Data.end() || it->first != key);
+
+    _Data.emplace(it, key, value);
 
     return this;
 }
 
 Intent* Intent::PutExtra(uint32_t key, int32_t value)
 {
-    _Data.emplace(key, static_cast<int64_t>(value));
+    auto it = std::ranges::lower_bound(_Data, key, {}, &DataEntry::first);
+    assert(it == _Data.end() || it->first != key);
+
+    _Data.emplace(it, key, static_cast<int64_t>(value));
 
     return this;
 }
 
 Intent* Intent::PutExtra(uint32_t key, std::string value)
 {
-    _Data.emplace(key, value);
+    auto it = std::ranges::lower_bound(_Data, key, {}, &DataEntry::first);
+    assert(it == _Data.end() || it->first != key);
+
+    _Data.emplace(it, key, std::move(value));
 
     return this;
 }
 
 Intent* Intent::PutExtra(uint32_t key, close_callback value)
 {
-    _Data.emplace(key, value);
+    auto it = std::ranges::lower_bound(_Data, key, {}, &DataEntry::first);
+    assert(it == _Data.end() || it->first != key);
+
+    _Data.emplace(it, key, value);
 
     return this;
 }
@@ -82,12 +98,13 @@ IntentAction Intent::GetAction() const
 
 void* Intent::GetPointerExtra(uint32_t key) const
 {
-    if (_Data.count(key) == 0)
+    auto it = std::ranges::lower_bound(_Data, key, {}, &DataEntry::first);
+    if (it == _Data.end() || it->first != key)
     {
         return nullptr;
     }
 
-    auto data = _Data.at(key);
+    const auto& [_, data] = *it;
 
     assert(std::holds_alternative<void*>(data));
     return std::get<void*>(data);
@@ -95,12 +112,13 @@ void* Intent::GetPointerExtra(uint32_t key) const
 
 uint32_t Intent::GetUIntExtra(uint32_t key) const
 {
-    if (_Data.count(key) == 0)
+    auto it = std::ranges::lower_bound(_Data, key, {}, &DataEntry::first);
+    if (it == _Data.end() || it->first != key)
     {
         return 0;
     }
 
-    auto data = _Data.at(key);
+    const auto& [_, data] = *it;
 
     assert(std::holds_alternative<int64_t>(data));
     return static_cast<uint32_t>(std::get<int64_t>(data));
@@ -108,12 +126,13 @@ uint32_t Intent::GetUIntExtra(uint32_t key) const
 
 int32_t Intent::GetSIntExtra(uint32_t key) const
 {
-    if (_Data.count(key) == 0)
+    auto it = std::ranges::lower_bound(_Data, key, {}, &DataEntry::first);
+    if (it == _Data.end() || it->first != key)
     {
         return 0;
     }
 
-    auto data = _Data.at(key);
+    const auto& [_, data] = *it;
 
     assert(std::holds_alternative<int64_t>(data));
     return static_cast<int32_t>(std::get<int64_t>(data));
@@ -121,12 +140,13 @@ int32_t Intent::GetSIntExtra(uint32_t key) const
 
 std::string Intent::GetStringExtra(uint32_t key) const
 {
-    if (_Data.count(key) == 0)
+    auto it = std::ranges::lower_bound(_Data, key, {}, &DataEntry::first);
+    if (it == _Data.end() || it->first != key)
     {
         return std::string{};
     }
 
-    auto data = _Data.at(key);
+    const auto& [_, data] = *it;
 
     assert(std::holds_alternative<std::string>(data));
     return std::get<std::string>(data);
@@ -134,12 +154,13 @@ std::string Intent::GetStringExtra(uint32_t key) const
 
 close_callback Intent::GetCloseCallbackExtra(uint32_t key) const
 {
-    if (_Data.count(key) == 0)
+    auto it = std::ranges::lower_bound(_Data, key, {}, &DataEntry::first);
+    if (it == _Data.end() || it->first != key)
     {
         return nullptr;
     }
 
-    auto data = _Data.at(key);
+    const auto& [_, data] = *it;
 
     assert(std::holds_alternative<close_callback>(data));
     return std::get<close_callback>(data);

--- a/src/openrct2/windows/Intent.h
+++ b/src/openrct2/windows/Intent.h
@@ -62,7 +62,7 @@ enum IntentAction
 // The maximum amount of data the Intent can hold, 8 should be sufficient, raise this if needed.
 static constexpr size_t kIntentMaxDataSlots = 8;
 
-using IntentData = std::variant<int64_t, std::string, close_callback, void*>;
+using IntentData = std::variant<int64_t, std::string, CloseCallback, void*>;
 using IntentDataEntry = std::pair<uint32_t, IntentData>;
 using IntentDataStorage = sfl::static_vector<IntentDataEntry, kIntentMaxDataSlots>;
 
@@ -86,13 +86,13 @@ public:
     std::string GetStringExtra(uint32_t key) const;
     uint32_t GetUIntExtra(uint32_t key) const;
     int32_t GetSIntExtra(uint32_t key) const;
-    close_callback GetCloseCallbackExtra(uint32_t key) const;
+    CloseCallback GetCloseCallbackExtra(uint32_t key) const;
 
     Intent* PutExtra(uint32_t key, uint32_t value);
     Intent* PutExtra(uint32_t key, void* value);
     Intent* PutExtra(uint32_t key, int32_t value);
     Intent* PutExtra(uint32_t key, std::string value);
-    Intent* PutExtra(uint32_t key, close_callback value);
+    Intent* PutExtra(uint32_t key, CloseCallback value);
 
     template<typename T, T TNull, typename TTag>
     Intent* PutExtra(uint32_t key, const TIdentifier<T, TNull, TTag>& value)

--- a/src/openrct2/windows/Intent.h
+++ b/src/openrct2/windows/Intent.h
@@ -13,6 +13,7 @@
 #include "../interface/Window.h"
 
 #include <map>
+#include <sfl/static_vector.hpp>
 #include <string>
 #include <variant>
 
@@ -60,12 +61,17 @@ enum IntentAction
 
 class Intent
 {
+    // The maximum amount of data the Intent can hold, 8 should be sufficient, raise this if needed.
+    static constexpr size_t kMaxDataSlots = 8;
+
     using IntentData = std::variant<int64_t, std::string, close_callback, void*>;
 
     WindowClass _Class{ WindowClass::Null };
     WindowDetail _WindowDetail{ WD_NULL };
     IntentAction _Action{ INTENT_ACTION_NULL };
-    std::map<uint32_t, IntentData> _Data;
+
+    using DataEntry = std::pair<uint32_t, IntentData>;
+    sfl::static_vector<DataEntry, kMaxDataSlots> _Data;
 
 public:
     explicit Intent(WindowClass windowClass);

--- a/src/openrct2/windows/Intent.h
+++ b/src/openrct2/windows/Intent.h
@@ -14,6 +14,7 @@
 
 #include <map>
 #include <string>
+#include <variant>
 
 enum IntentAction
 {
@@ -57,29 +58,10 @@ enum IntentAction
     INTENT_ACTION_NULL = 255,
 };
 
-struct IntentData
-{
-    enum class DataType
-    {
-        Int,
-        String,
-        Pointer,
-        CloseCallback
-    } type;
-
-    union
-    {
-        uint32_t unsignedInt;
-        int32_t signedInt;
-    } intVal;
-    std::string stringVal;
-    close_callback closeCallbackVal;
-    void* pointerVal;
-};
-
 class Intent
 {
-private:
+    using IntentData = std::variant<int64_t, std::string, close_callback, void*>;
+
     WindowClass _Class{ WindowClass::Null };
     WindowDetail _WindowDetail{ WD_NULL };
     IntentAction _Action{ INTENT_ACTION_NULL };

--- a/src/openrct2/windows/Intent.h
+++ b/src/openrct2/windows/Intent.h
@@ -59,32 +59,35 @@ enum IntentAction
     INTENT_ACTION_NULL = 255,
 };
 
+// The maximum amount of data the Intent can hold, 8 should be sufficient, raise this if needed.
+static constexpr size_t kIntentMaxDataSlots = 8;
+
+using IntentData = std::variant<int64_t, std::string, close_callback, void*>;
+using IntentDataEntry = std::pair<uint32_t, IntentData>;
+using IntentDataStorage = sfl::static_vector<IntentDataEntry, kIntentMaxDataSlots>;
+
 class Intent
 {
-    // The maximum amount of data the Intent can hold, 8 should be sufficient, raise this if needed.
-    static constexpr size_t kMaxDataSlots = 8;
-
-    using IntentData = std::variant<int64_t, std::string, close_callback, void*>;
-
     WindowClass _Class{ WindowClass::Null };
     WindowDetail _WindowDetail{ WD_NULL };
     IntentAction _Action{ INTENT_ACTION_NULL };
-
-    using DataEntry = std::pair<uint32_t, IntentData>;
-    sfl::static_vector<DataEntry, kMaxDataSlots> _Data;
+    IntentDataStorage _Data;
 
 public:
     explicit Intent(WindowClass windowClass);
     explicit Intent(WindowDetail windowDetail);
     explicit Intent(IntentAction windowclass);
+
     WindowClass GetWindowClass() const;
     WindowDetail GetWindowDetail() const;
     IntentAction GetAction() const;
+
     void* GetPointerExtra(uint32_t key) const;
     std::string GetStringExtra(uint32_t key) const;
     uint32_t GetUIntExtra(uint32_t key) const;
     int32_t GetSIntExtra(uint32_t key) const;
     close_callback GetCloseCallbackExtra(uint32_t key) const;
+
     Intent* PutExtra(uint32_t key, uint32_t value);
     Intent* PutExtra(uint32_t key, void* value);
     Intent* PutExtra(uint32_t key, int32_t value);


### PR DESCRIPTION
I was looking at what allocates memory and my simple breakpoint on malloc revealed that Intent does allocate almost every time it is used, this is obviously not ideal. This PR refactors the code to use std::variant and fixed size storage with sfl::static_vector as no one will ever have the need to put hundreds of things into it, now its entirely free of allocations (for as long it doesn't store std::string).

The class is still not perfect, we shouldn't need all those special functions but I wanted to avoid having a huge PR to just achieve my initial goal of allocation reduction.