### PR TITLE
Add missing headers, latest MSVC has build errors

### DIFF
--- a/src/openrct2/entity/Peep.h
+++ b/src/openrct2/entity/Peep.h
@@ -18,6 +18,7 @@
 
 #include <array>
 #include <optional>
+#include <string>
 #include <string_view>
 
 constexpr uint8_t kPeepMinEnergy = 32;

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -18,6 +18,7 @@
 #include "../world/tile_element/TileElementType.h"
 #include "Limits.h"
 
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <vector>


### PR DESCRIPTION
I don't think the CI currently has the latest MSVC version, on my end it didn't build as those headers were missing, looks like Microsoft did some house cleaning.