### PR TITLE
Correct copyright on ZoomLevel

### DIFF
--- a/src/openrct2/interface/ZoomLevel.cpp
+++ b/src/openrct2/interface/ZoomLevel.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2020 OpenRCT2 developers
+ * Copyright (c) 2014-2024 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2


### PR DESCRIPTION
change from 2020 to 2014-2024