### PR TITLE
Fix clearance error for medium half-loops in track placement (#23120)

### DIFF
--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -10145,12 +10145,12 @@ namespace OpenRCT2::TrackMetaData
     };
 
     static constexpr SequenceDescriptor kLeftMediumHalfLoopDownSeq3 = {
-        .clearance = { 0, -32, -200, 48, { 0b1111, 0 }, 0 },
+        .clearance = { 0, -32, -200, 48, { 0b1111, 0b1100 }, 0 },
         .allowedWallEdges = 0b1000,
     };
 
     static constexpr SequenceDescriptor kLeftMediumHalfLoopDownSeq4 = {
-        .clearance = { 32, -32, -216, 24, { 0b1111, 0 }, 0 },
+        .clearance = { 32, -32, -216, 24, { 0b1111, 0b1100 }, 0 },
         .allowedWallEdges = 0b1010,
     };
 
@@ -10170,12 +10170,12 @@ namespace OpenRCT2::TrackMetaData
     };
 
     static constexpr SequenceDescriptor kRightMediumHalfLoopDownSeq3 = {
-        .clearance = { 0, 32, -200, 48, { 0b1111, 0 }, 0 },
+        .clearance = { 0, 32, -200, 48, { 0b1111, 0b1100 }, 0 },
         .allowedWallEdges = 0b0010,
     };
 
     static constexpr SequenceDescriptor kRightMediumHalfLoopDownSeq4 = {
-        .clearance = { 32, 32, -216, 24, { 0b1111, 0 }, 0 },
+        .clearance = { 32, 32, -216, 24, { 0b1111, 0b1100 }, 0 },
         .allowedWallEdges = 0b1010,
     };
 

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -10080,12 +10080,12 @@ namespace OpenRCT2::TrackMetaData
     };
 
     static constexpr SequenceDescriptor kLeftMediumHalfLoopUpSeq0 = {
-        .clearance = { 0, 0, 0, 24, { 0b1111, 0 }, 0 },
+        .clearance = { 0, 0, 0, 24, { 0b1111, 0b1100 }, 0 },
         .allowedWallEdges = 0b1010,
     };
 
     static constexpr SequenceDescriptor kLeftMediumHalfLoopUpSeq1 = {
-        .clearance = { -32, 0, 16, 48, { 0b1111, 0 }, 0 },
+        .clearance = { -32, 0, 16, 48, { 0b1111, 0b1100 }, 0 },
         .allowedWallEdges = 0b0010,
     };
 
@@ -10105,12 +10105,12 @@ namespace OpenRCT2::TrackMetaData
     };
 
     static constexpr SequenceDescriptor kRightMediumHalfLoopUpSeq0 = {
-        .clearance = { 0, 0, 0, 24, { 0b1111, 0 }, 0 },
+        .clearance = { 0, 0, 0, 24, { 0b1111, 0b1100 }, 0 },
         .allowedWallEdges = 0b1010,
     };
 
     static constexpr SequenceDescriptor kRightMediumHalfLoopUpSeq1 = {
-        .clearance = { -32, 0, 16, 48, { 0b1111, 0 }, 0 },
+        .clearance = { -32, 0, 16, 48, { 0b1111, 0b1100 }, 0 },
         .allowedWallEdges = 0b1000,
     };
 


### PR DESCRIPTION
Fixes #23120, which addresses a bug where medium half-loops were incorrectly flagged as having insufficient clearance for placement. This issue stemmed from an incorrect configuration of the 'zQuarterOccupied' value in the 'SequenceDescriptor' for medium half-loops. The clearance bitmask has been updated to align with the intended behavior, following the same logic applied to small and large half-loops.


Specifically, the 'zQuarterOccupied' value was changed to 0b1100 for the first two upward sequences and the last two downward sequences of the medium half-loops. This adjustment ensures consistency with the small half-loop and large half-loop logic. Below is the corresponding code for the small half-loop, where the 'zQuarterOccupied' value is correctly set to '0b1100'. This now serves as the basis for the updated medium half-loop configuration.
 

    static constexpr SequenceDescriptor kHalfLoopUpSeq0 = {
        .clearance = { 0, 0, 0, 16, { 0b1111, 0b1100 }, 0 },
        .allowedWallEdges = 0b1010,
        .metalSupports = { MetalSupportPlace::Centre },
    };

    static constexpr SequenceDescriptor kHalfLoopUpSeq1 = {
        .clearance = { -32, 0, 16, 16, { 0b1111, 0b1100 }, 0 },
        .allowedWallEdges = 0b1010,
        .metalSupports = { MetalSupportPlace::Centre },
    };

    static constexpr SequenceDescriptor kHalfLoopUpSeq2 = {
        .clearance = { -64, 0, 32, 96, { 0b0011, 0 }, 0 },
        .allowedWallEdges = 0b1011,
    };

    static constexpr SequenceDescriptor kHalfLoopUpSeq3 = {
        .clearance = { -32, 0, 120, 16, { 0b1111, 0 }, 0 },
    };

    static constexpr SequenceDescriptor kHalfLoopDownSeq0 = {
        .clearance = { 0, 0, -32, 16, { 0b1111, 0 }, 0 },
    };

    static constexpr SequenceDescriptor kHalfLoopDownSeq1 = {
        .clearance = { -32, 0, -120, 96, { 0b0011, 0 }, 0 },
        .allowedWallEdges = 0b1011,
    };

    static constexpr SequenceDescriptor kHalfLoopDownSeq2 = {
        .clearance = { 0, 0, -136, 16, { 0b1111, 0b1100 }, 0 },
        .allowedWallEdges = 0b1010,
        .metalSupports = { MetalSupportPlace::Centre },
    };

    static constexpr SequenceDescriptor kHalfLoopDownSeq3 = {
        .clearance = { 32, 0, -152, 16, { 0b1111, 0b1100 }, 0 },
        .allowedWallEdges = 0b1010,
        .metalSupports = { MetalSupportPlace::Centre },
    };`


Below is a screenshot illustrating the bug where medium half-loops were incorrectly flagged as having insufficient clearance for placement. Following the fix, the second screenshot demonstrates the correct behavior, where the medium half-loops can now be placed successfully without triggering a clearance error.

![382586255-e2423188-2a7b-4961-aad6-3e4da2756c1b](https://github.com/user-attachments/assets/033966af-4d9d-4f08-846b-dce9c0627852)


<img width="662" alt="Screenshot 2024-12-06 044356" src="https://github.com/user-attachments/assets/4da4721d-a242-4590-ac37-057af86f619e">
