### PR TITLE
Refactor Editor::CheckObjectSelection

### DIFF
--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1404,7 +1404,7 @@ namespace OpenRCT2::Ui::Windows
 
         bool FilterCompatibilityObject(const ObjectRepositoryItem& item, uint8_t objectFlag)
         {
-            // Only show compat objects if they are not selected already.
+            // Only show compat objects if they are selected already.
             return !(item.Flags & ObjectItemFlags::IsCompatibilityObject) || (objectFlag & ObjectSelectionFlags::Selected);
         }
 

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -414,7 +414,7 @@ namespace OpenRCT2::Editor
             }
         }
 
-        // Beyond this point, all checks don't apply to the track designer/manager.
+        // No checks beyond this point apply to the track designer or track designs manager.
         const bool isTrackDesignerManager = gScreenFlags & (SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER);
         if (isTrackDesignerManager)
         {

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -399,57 +399,49 @@ namespace OpenRCT2::Editor
      */
     std::pair<ObjectType, StringId> CheckObjectSelection()
     {
-        bool isTrackDesignerManager = gScreenFlags & (SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER);
+        constexpr std::pair<ObjectType, StringId> kBasicCheckPairs[] = {
+            { ObjectType::Ride, STR_AT_LEAST_ONE_RIDE_OBJECT_MUST_BE_SELECTED },
+            { ObjectType::Station, STR_AT_LEAST_ONE_STATION_OBJECT_MUST_BE_SELECTED },
+            { ObjectType::TerrainSurface, STR_AT_LEAST_ONE_TERRAIN_SURFACE_OBJECT_MUST_BE_SELECTED },
+            { ObjectType::TerrainEdge, STR_AT_LEAST_ONE_TERRAIN_EDGE_OBJECT_MUST_BE_SELECTED },
+        };
 
-        if (!isTrackDesignerManager)
+        for (auto& pair : kBasicCheckPairs)
         {
-            if (!EditorCheckObjectGroupAtLeastOneSurfaceSelected(false))
+            if (!EditorCheckObjectGroupAtLeastOneSelected(pair.first))
             {
-                return { ObjectType::FootpathSurface, STR_AT_LEAST_ONE_FOOTPATH_NON_QUEUE_SURFACE_OBJECT_MUST_BE_SELECTED };
-            }
-            if (!EditorCheckObjectGroupAtLeastOneSurfaceSelected(true))
-            {
-                return { ObjectType::FootpathSurface, STR_AT_LEAST_ONE_FOOTPATH_QUEUE_SURFACE_OBJECT_MUST_BE_SELECTED };
-            }
-            if (!EditorCheckObjectGroupAtLeastOneSelected(ObjectType::FootpathRailings))
-            {
-                return { ObjectType::FootpathRailings, STR_AT_LEAST_ONE_FOOTPATH_RAILING_OBJECT_MUST_BE_SELECTED };
+                return { pair.first, pair.second };
             }
         }
 
-        if (!EditorCheckObjectGroupAtLeastOneSelected(ObjectType::Ride))
+        // Beyond this point, all checks don't apply to the track designer/manager.
+        const bool isTrackDesignerManager = gScreenFlags & (SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER);
+        if (isTrackDesignerManager)
         {
-            return { ObjectType::Ride, STR_AT_LEAST_ONE_RIDE_OBJECT_MUST_BE_SELECTED };
-        }
-        if (!EditorCheckObjectGroupAtLeastOneSelected(ObjectType::Station))
-        {
-            return { ObjectType::Station, STR_AT_LEAST_ONE_STATION_OBJECT_MUST_BE_SELECTED };
+            return { ObjectType::None, STR_NONE };
         }
 
-        if (!EditorCheckObjectGroupAtLeastOneSelected(ObjectType::TerrainSurface))
+        if (!EditorCheckObjectGroupAtLeastOneSurfaceSelected(false))
         {
-            return { ObjectType::TerrainSurface, STR_AT_LEAST_ONE_TERRAIN_SURFACE_OBJECT_MUST_BE_SELECTED };
+            return { ObjectType::FootpathSurface, STR_AT_LEAST_ONE_FOOTPATH_NON_QUEUE_SURFACE_OBJECT_MUST_BE_SELECTED };
         }
-        if (!EditorCheckObjectGroupAtLeastOneSelected(ObjectType::TerrainEdge))
+        if (!EditorCheckObjectGroupAtLeastOneSurfaceSelected(true))
         {
-            return { ObjectType::TerrainEdge, STR_AT_LEAST_ONE_TERRAIN_EDGE_OBJECT_MUST_BE_SELECTED };
+            return { ObjectType::FootpathSurface, STR_AT_LEAST_ONE_FOOTPATH_QUEUE_SURFACE_OBJECT_MUST_BE_SELECTED };
         }
 
-        if (!isTrackDesignerManager)
+        constexpr std::pair<ObjectType, StringId> kParkCheckPairs[] = {
+            { ObjectType::FootpathRailings, STR_AT_LEAST_ONE_FOOTPATH_RAILING_OBJECT_MUST_BE_SELECTED },
+            { ObjectType::ParkEntrance, STR_PARK_ENTRANCE_TYPE_MUST_BE_SELECTED },
+            { ObjectType::Water, STR_WATER_TYPE_MUST_BE_SELECTED },
+            { ObjectType::PeepNames, STR_AT_LEAST_ONE_PEEP_NAMES_OBJECT_MUST_BE_SELECTED },
+        };
+
+        for (auto& pair : kParkCheckPairs)
         {
-            if (!EditorCheckObjectGroupAtLeastOneSelected(ObjectType::ParkEntrance))
+            if (!EditorCheckObjectGroupAtLeastOneSelected(pair.first))
             {
-                return { ObjectType::ParkEntrance, STR_PARK_ENTRANCE_TYPE_MUST_BE_SELECTED };
-            }
-
-            if (!EditorCheckObjectGroupAtLeastOneSelected(ObjectType::Water))
-            {
-                return { ObjectType::Water, STR_WATER_TYPE_MUST_BE_SELECTED };
-            }
-
-            if (!EditorCheckObjectGroupAtLeastOneSelected(ObjectType::PeepNames))
-            {
-                return { ObjectType::PeepNames, STR_AT_LEAST_ONE_PEEP_NAMES_OBJECT_MUST_BE_SELECTED };
+                return { pair.first, pair.second };
             }
         }
 


### PR DESCRIPTION
There is a lot of repetitive code in the part of Editor.cpp that checks whether required object types have been selected. This PR refactors this code, such that the checks are specified in a constexpr array, instead of repeating the checking code.

Reason for doing this refactor now is that #23328 adds five more checks, immediately benefiting from this refactor.