### PR TITLE
Increase the maximum width of the ride graph window

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.18 (in development)
 ------------------------------------------------------------------------
 - Improved: [#23260] Add diagonal (block) brakes to LSM Launched Roller Coaster.
+- Improved: [#23350] Increased the maximum width of the ride graph window.
 - Fix: [#23286] Currency formatted incorrectly in the in game console.
 
 0.4.17 (2024-12-08)

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -918,7 +918,7 @@ namespace OpenRCT2::Ui::Windows
         return _currentTextBox;
     }
 
-    void WindowResize(WindowBase& w, int32_t dw, int32_t dh)
+    void WindowResize(WindowBase& w, int16_t dw, int16_t dh)
     {
         if (dw == 0 && dh == 0)
             return;
@@ -927,8 +927,8 @@ namespace OpenRCT2::Ui::Windows
         w.Invalidate();
 
         // Clamp new size to minimum and maximum
-        w.width = std::clamp<int32_t>(w.width + dw, w.min_width, w.max_width);
-        w.height = std::clamp<int32_t>(w.height + dh, w.min_height, w.max_height);
+        w.width = std::clamp<int16_t>(w.width + dw, w.min_width, w.max_width);
+        w.height = std::clamp<int16_t>(w.height + dh, w.min_height, w.max_height);
 
         w.OnResize();
         w.OnPrepareDraw();
@@ -1251,7 +1251,7 @@ namespace OpenRCT2::Ui::Windows
         });
     }
 
-    void WindowSetResize(WindowBase& w, int32_t minWidth, int32_t minHeight, int32_t maxWidth, int32_t maxHeight)
+    void WindowSetResize(WindowBase& w, int16_t minWidth, int16_t minHeight, int16_t maxWidth, int16_t maxHeight)
     {
         w.min_width = minWidth;
         w.min_height = minHeight;
@@ -1259,8 +1259,8 @@ namespace OpenRCT2::Ui::Windows
         w.max_height = maxHeight;
 
         // Clamp width and height to minimum and maximum
-        int32_t width = std::clamp<int32_t>(w.width, std::min(minWidth, maxWidth), std::max(minWidth, maxWidth));
-        int32_t height = std::clamp<int32_t>(w.height, std::min(minHeight, maxHeight), std::max(minHeight, maxHeight));
+        int16_t width = std::clamp<int16_t>(w.width, std::min(minWidth, maxWidth), std::max(minWidth, maxWidth));
+        int16_t height = std::clamp<int16_t>(w.height, std::min(minHeight, maxHeight), std::max(minHeight, maxHeight));
 
         // Resize window if size has changed
         if (w.width != width || w.height != height)

--- a/src/openrct2-ui/interface/Window.h
+++ b/src/openrct2-ui/interface/Window.h
@@ -130,7 +130,7 @@ namespace OpenRCT2::Ui::Windows
     bool TextBoxCaretIsFlashed();
     const WidgetIdentifier& GetCurrentTextBox();
 
-    void WindowResize(WindowBase& w, int32_t dw, int32_t dh);
+    void WindowResize(WindowBase& w, int16_t dw, int16_t dh);
     void WindowInitScrollWidgets(WindowBase& w);
     void WindowUpdateScrollWidgets(WindowBase& w);
 
@@ -139,7 +139,7 @@ namespace OpenRCT2::Ui::Windows
     void WindowMoveAndSnap(WindowBase& w, ScreenCoordsXY newWindowCoords, int32_t snapProximity);
     void WindowRelocateWindows(int32_t width, int32_t height);
 
-    void WindowSetResize(WindowBase& w, int32_t minWidth, int32_t minHeight, int32_t maxWidth, int32_t maxHeight);
+    void WindowSetResize(WindowBase& w, int16_t minWidth, int16_t minHeight, int16_t maxWidth, int16_t maxHeight);
     bool WindowCanResize(const WindowBase& w);
 
     void InvalidateAllWindowsAfterInput();

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -412,8 +412,8 @@ namespace OpenRCT2::Ui::Windows
             {
                 min_width = _info.Desc.MinWidth.value_or(0);
                 min_height = _info.Desc.MinHeight.value_or(0);
-                max_width = _info.Desc.MaxWidth.value_or(std::numeric_limits<uint16_t>::max());
-                max_height = _info.Desc.MaxHeight.value_or(std::numeric_limits<uint16_t>::max());
+                max_width = _info.Desc.MaxWidth.value_or(std::numeric_limits<int16_t>::max());
+                max_height = _info.Desc.MaxHeight.value_or(std::numeric_limits<int16_t>::max());
             }
             RefreshWidgets();
         }

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -521,7 +521,9 @@ namespace OpenRCT2::Ui::Windows
                 || p == WINDOW_FINANCES_PAGE_FINANCIAL_GRAPH)
             {
                 flags |= WF_RESIZABLE;
-                WindowSetResize(*this, WW_OTHER_TABS, WH_OTHER_TABS, 2000, 2000);
+                WindowSetResize(
+                    *this, WW_OTHER_TABS, WH_OTHER_TABS, std::numeric_limits<uint16_t>::max(),
+                    std::numeric_limits<int16_t>::max());
             }
             else
             {

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -5946,7 +5946,7 @@ namespace OpenRCT2::Ui::Windows
 
         void GraphsResize()
         {
-            WindowSetResize(*this, 316, 182, 5000, 450);
+            WindowSetResize(*this, 316, 182, std::numeric_limits<int16_t>::max(), 450);
         }
 
         void GraphsOnMouseDown(WidgetIndex widgetIndex)

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -5946,7 +5946,7 @@ namespace OpenRCT2::Ui::Windows
 
         void GraphsResize()
         {
-            WindowSetResize(*this, 316, 182, 500, 450);
+            WindowSetResize(*this, 316, 182, 5000, 450);
         }
 
         void GraphsOnMouseDown(WidgetIndex widgetIndex)


### PR DESCRIPTION
QOL improvement. It is frustrating that you can only see a small fraction of the ride data in one window - especially when you have a big screen.

Also fixed the parameter types of the related function.

Maximum size before:

![image](https://github.com/user-attachments/assets/56a8b7a5-a0d8-4d19-864f-531dd40812c5)

Maximum size is now bigger than the width of my game window:

![image](https://github.com/user-attachments/assets/e386beb8-c2f3-4bd5-98cf-81646db9365f)

