### PR TITLE
[Plugin] Expose RideTypeDescriptor to plugin API 

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -123,6 +123,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * John Dolph (johnwdolph) - Ride music UI, misc.
 * Harry Hopkinson (Harry-Hopkinson) - Added Cheat for guests ignoring price of rides and stalls.
 * Kendall Frey (kendfrey) - Add plugin API for spawning guests
+* (luttje) - Added plugin API for getting ride type descriptor, ride ratings descriptor and ratings modifier.
 
 ## Bug fixes & Refactors
 * Claudio Tiecher (janclod)

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -2008,6 +2008,37 @@ declare global {
     }
 
     /**
+     * Represents a ratings modifier for a ride, like a rating bonus
+     * or ride requirement penalty.
+     */
+    interface RatingsModifier {
+        /**
+         * The type of the modifier.
+         */
+        readonly type: RatingsModifierType;
+
+        /**
+         * The threshold value for the modifier.
+         */
+        readonly threshold: number;
+
+        /**
+         * The excitement rating modifier.
+         */
+        readonly excitement: number;
+
+        /**
+         * The intensity rating modifier.
+         */
+        readonly intensity: number;
+
+        /**
+         * The nausea rating modifier.
+         */
+        readonly nausea: number;
+    }
+
+    /**
      * Represents a ride or stall within the park.
      */
     interface Ride {
@@ -2236,6 +2267,87 @@ declare global {
          * Highest drop height in height units. Use `context.formatString()` to convert into metres/feet. Ex: `formatString('{HEIGHT}', ride.highestDropHeight)`.
          */
         readonly highestDropHeight: number;
+
+        /**
+         * The type descriptor for the ride with information about the ride type.
+         */
+        readonly rideTypeDescriptor: RideTypeDescriptor;
+    }
+
+    /**
+     * Represents a descriptor for ride ratings.
+     */
+    interface RideRatingsDescriptor {
+        /**
+         * The calculation type of the ratings descriptor.
+         */
+        readonly type: RatingsCalculationType;
+
+        /**
+         * The unreliability value for the ride.
+         */
+        readonly unreliability: number;
+
+        /**
+         * The ride shelter value, used for rides with a set sheltered
+         * 8ths value (-1 = normal calculation)
+         */
+        readonly rideShelter: number;
+
+        /**
+         * Whether the requirements are relaxed if the ride has inversions.
+         */
+        readonly relaxRequirementsIfInversions: boolean;
+
+        /**
+         * The list of rating modifiers associated with the ride.
+         */
+        readonly modifiers: RatingsModifier[];
+    }
+
+    /**
+     * Represents a descriptor for a ride type.
+     */
+    interface RideTypeDescriptor {
+        /**
+         * The category of the ride type.
+         */
+        readonly category: number;
+
+        /**
+         * The starting track piece for the ride type.
+         */
+        readonly startTrackPiece: number;
+
+        /**
+         * The default ride mode.
+         */
+        readonly defaultMode: RideMode;
+
+        /**
+         * The available breakdowns for the ride type.
+         */
+        readonly availableBreakdowns: number;
+
+        /**
+         * The maximum mass allowed for the ride type.
+         */
+        readonly maxMass: number;
+
+        /**
+         * The bonus value for the ride type.
+         */
+        readonly bonusValue: number;
+
+        /**
+         * The name of the ride type.
+         */
+        readonly name: string;
+
+        /**
+         * The ride ratings descriptor associated with this ride type.
+         */
+        readonly ratingsData: RideRatingsDescriptor;
     }
 
     type RideClassification = "ride" | "stall" | "facility";
@@ -2456,6 +2568,95 @@ declare global {
         Left = 2,
         Right = 4,
         UpsideDown = 15
+    }
+
+    enum RatingsModifierType {
+        NoModifier = 0,
+        BonusLength = 1,
+        BonusSynchronisation = 2,
+        BonusTrainLength = 3,
+        BonusMaxSpeed = 4,
+        BonusAverageSpeed = 5,
+        BonusDuration = 6,
+        BonusGForces = 7,
+        BonusTurns = 8,
+        BonusDrops = 9,
+        BonusSheltered = 10,
+        BonusProximity = 11,
+        BonusScenery = 12,
+        BonusRotations = 13,
+        BonusOperationOption = 14,
+        BonusReversedTrains = 15,
+        BonusGoKartRace = 16,
+        BonusTowerRide = 17,
+        BonusRotoDrop = 18,
+        BonusMazeSize = 19,
+        BonusBoatHireNoCircuit = 20,
+        BonusSlideUnlimitedRides = 21,
+        BonusMotionSimulatorMode = 22,
+        Bonus3DCinemaMode = 23,
+        BonusTopSpinMode = 24,
+        BonusReversals = 25,
+        BonusHoles = 26,
+        BonusNumTrains = 27,
+        BonusDownwardLaunch = 28,
+        BonusLaunchedFreefallSpecial = 29,
+        RequirementLength = 30,
+        RequirementMaxSpeed = 31,
+        RequirementLateralGs = 32,
+        RequirementInversions = 33,
+        RequirementUnsheltered = 34,
+        RequirementReversals = 35,
+        RequirementHoles = 36,
+        RequirementStations = 37,
+        RequirementSplashdown = 38,
+        PenaltyLateralGs = 39
+    }
+
+    enum RatingsCalculationType {
+        Normal = 0,
+        FlatRide = 1,
+        Stall = 2
+    }
+
+    enum RideMode {
+        Normal = 0,
+        ContinuousCircuit = 1,
+        ReverseInclineLaunchedShuttle = 2,
+        PoweredLaunchPasstrough = 3,
+        Shuttle = 4,
+        BoatHire = 5,
+        UpwardLaunch = 6,
+        RotatingLift = 7,
+        StationToStation = 8,
+        SingleRidePerAdmission = 9,
+        UnlimitedRidesPerAdmission = 10,
+        Maze = 11,
+        Race = 12,
+        Dodgems = 13,
+        Swing = 14,
+        ShopStall = 15,
+        Rotation = 16,
+        ForwardRotation = 17,
+        BackwardRotation = 18,
+        FilmAvengingAviators = 19,
+        MouseTails3DFilm = 20,
+        SpaceRings = 21,
+        Beginners = 22,
+        LimPoweredLaunch = 23,
+        FilmThrillRiders = 24,
+        StormChasers3DFilm = 25,
+        SpaceRaiders3DFilm = 26,
+        Intense = 27,
+        Berserk = 28,
+        HauntedHouse = 29,
+        Circus = 30,
+        DownwardLaunch = 31,
+        CrookedHouse = 32,
+        FreefallDrop = 33,
+        ContinuousCircuitBlockSectioned = 34,
+        PoweredLaunch = 35,
+        PoweredLaunchBlockSectioned = 36
     }
 
     type TrackCurveType = "straight" | "left" | "right";

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -566,7 +566,10 @@
     <ClInclude Include="scripting\bindings\network\ScPlayerGroup.hpp" />
     <ClInclude Include="scripting\bindings\object\ScInstalledObject.hpp" />
     <ClInclude Include="scripting\bindings\object\ScObjectManager.h" />
+    <ClInclude Include="scripting\bindings\ride\ScRatingsModifier.hpp" />
+    <ClInclude Include="scripting\bindings\ride\ScRideRatingsDescriptor.hpp" />
     <ClInclude Include="scripting\bindings\ride\ScRideStation.hpp" />
+    <ClInclude Include="scripting\bindings\ride\ScRideTypeDescriptor.hpp" />
     <ClInclude Include="scripting\bindings\ride\ScTrackIterator.h" />
     <ClInclude Include="scripting\bindings\ride\ScTrackSegment.h" />
     <ClInclude Include="scripting\bindings\world\ScParkMessage.hpp" />
@@ -1081,8 +1084,11 @@
     <ClCompile Include="scripting\bindings\network\ScPlayer.cpp" />
     <ClCompile Include="scripting\bindings\network\ScPlayerGroup.cpp" />
     <ClCompile Include="scripting\bindings\object\ScObjectManager.cpp" />
+    <ClCompile Include="scripting\bindings\ride\ScRatingsModifier.cpp" />
     <ClCompile Include="scripting\bindings\ride\ScRide.cpp" />
+    <ClCompile Include="scripting\bindings\ride\ScRideRatingsDescriptor.cpp" />
     <ClCompile Include="scripting\bindings\ride\ScRideStation.cpp" />
+    <ClCompile Include="scripting\bindings\ride\ScRideTypeDescriptor.cpp" />
     <ClCompile Include="scripting\bindings\ride\ScTrackIterator.cpp" />
     <ClCompile Include="scripting\bindings\ride\ScTrackSegment.cpp" />
     <ClCompile Include="scripting\bindings\world\ScMap.cpp" />

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -47,8 +47,11 @@
     #include "bindings/object/ScInstalledObject.hpp"
     #include "bindings/object/ScObject.hpp"
     #include "bindings/object/ScObjectManager.h"
+    #include "bindings/ride/ScRatingsModifier.hpp"
     #include "bindings/ride/ScRide.hpp"
+    #include "bindings/ride/ScRideRatingsDescriptor.hpp"
     #include "bindings/ride/ScRideStation.hpp"
+    #include "bindings/ride/ScRideTypeDescriptor.hpp"
     #include "bindings/world/ScClimate.hpp"
     #include "bindings/world/ScDate.hpp"
     #include "bindings/world/ScMap.hpp"
@@ -428,8 +431,11 @@ void ScriptEngine::Initialise()
     ScPlayerGroup::Register(ctx);
     ScProfiler::Register(ctx);
     ScResearch::Register(ctx);
+    ScRatingsModifier::Register(ctx);
     ScRide::Register(ctx);
+    ScRideRatingsDescriptor::Register(ctx);
     ScRideStation::Register(ctx);
+    ScRideTypeDescriptor::Register(ctx);
     ScRideObject::Register(ctx);
     ScRideObjectVehicle::Register(ctx);
     ScTile::Register(ctx);
@@ -543,6 +549,92 @@ void ScriptEngine::RegisterConstants()
         .Constant("BankLeft", EnumValue(TrackRoll::Left))
         .Constant("BankRight", EnumValue(TrackRoll::Right))
         .Constant("UpsideDown", EnumValue(TrackRoll::UpsideDown));
+    builder.Namespace("RatingsModifierType")
+        .Constant("NoModifier", EnumValue(RatingsModifierType::NoModifier))
+        .Constant("BonusLength", EnumValue(RatingsModifierType::BonusLength))
+        .Constant("BonusSynchronisation", EnumValue(RatingsModifierType::BonusSynchronisation))
+        .Constant("BonusTrainLength", EnumValue(RatingsModifierType::BonusTrainLength))
+        .Constant("BonusMaxSpeed", EnumValue(RatingsModifierType::BonusMaxSpeed))
+        .Constant("BonusAverageSpeed", EnumValue(RatingsModifierType::BonusAverageSpeed))
+        .Constant("BonusDuration", EnumValue(RatingsModifierType::BonusDuration))
+        .Constant("BonusGForces", EnumValue(RatingsModifierType::BonusGForces))
+        .Constant("BonusTurns", EnumValue(RatingsModifierType::BonusTurns))
+        .Constant("BonusDrops", EnumValue(RatingsModifierType::BonusDrops))
+        .Constant("BonusSheltered", EnumValue(RatingsModifierType::BonusSheltered))
+        .Constant("BonusProximity", EnumValue(RatingsModifierType::BonusProximity))
+        .Constant("BonusScenery", EnumValue(RatingsModifierType::BonusScenery))
+        .Constant("BonusRotations", EnumValue(RatingsModifierType::BonusRotations))
+        .Constant("BonusOperationOption", EnumValue(RatingsModifierType::BonusOperationOption))
+        .Constant("BonusReversedTrains", EnumValue(RatingsModifierType::BonusReversedTrains))
+        .Constant("BonusGoKartRace", EnumValue(RatingsModifierType::BonusGoKartRace))
+        .Constant("BonusTowerRide", EnumValue(RatingsModifierType::BonusTowerRide))
+        .Constant("BonusRotoDrop", EnumValue(RatingsModifierType::BonusRotoDrop))
+        .Constant("BonusMazeSize", EnumValue(RatingsModifierType::BonusMazeSize))
+        .Constant("BonusBoatHireNoCircuit", EnumValue(RatingsModifierType::BonusBoatHireNoCircuit))
+        .Constant("BonusSlideUnlimitedRides", EnumValue(RatingsModifierType::BonusSlideUnlimitedRides))
+        .Constant("BonusMotionSimulatorMode", EnumValue(RatingsModifierType::BonusMotionSimulatorMode))
+        .Constant("Bonus3DCinemaMode", EnumValue(RatingsModifierType::Bonus3DCinemaMode))
+        .Constant("BonusTopSpinMode", EnumValue(RatingsModifierType::BonusTopSpinMode))
+        .Constant("BonusReversals", EnumValue(RatingsModifierType::BonusReversals))
+        .Constant("BonusHoles", EnumValue(RatingsModifierType::BonusHoles))
+        .Constant("BonusNumTrains", EnumValue(RatingsModifierType::BonusNumTrains))
+        .Constant("BonusDownwardLaunch", EnumValue(RatingsModifierType::BonusDownwardLaunch))
+        .Constant("BonusLaunchedFreefallSpecial", EnumValue(RatingsModifierType::BonusLaunchedFreefallSpecial))
+        .Constant("RequirementLength", EnumValue(RatingsModifierType::RequirementLength))
+        .Constant("RequirementDropHeight", EnumValue(RatingsModifierType::RequirementDropHeight))
+        .Constant("RequirementNumDrops", EnumValue(RatingsModifierType::RequirementNumDrops))
+        .Constant("RequirementMaxSpeed", EnumValue(RatingsModifierType::RequirementMaxSpeed))
+        .Constant("RequirementNegativeGs", EnumValue(RatingsModifierType::RequirementNegativeGs))
+        .Constant("RequirementLateralGs", EnumValue(RatingsModifierType::RequirementLateralGs))
+        .Constant("RequirementInversions", EnumValue(RatingsModifierType::RequirementInversions))
+        .Constant("RequirementUnsheltered", EnumValue(RatingsModifierType::RequirementUnsheltered))
+        .Constant("RequirementReversals", EnumValue(RatingsModifierType::RequirementReversals))
+        .Constant("RequirementHoles", EnumValue(RatingsModifierType::RequirementHoles))
+        .Constant("RequirementStations", EnumValue(RatingsModifierType::RequirementStations))
+        .Constant("RequirementSplashdown", EnumValue(RatingsModifierType::RequirementSplashdown))
+        .Constant("PenaltyLateralGs", EnumValue(RatingsModifierType::PenaltyLateralGs));
+    builder.Namespace("RatingsCalculationType")
+        .Constant("Normal", EnumValue(RatingsCalculationType::Normal))
+        .Constant("FlatRide", EnumValue(RatingsCalculationType::FlatRide))
+        .Constant("Stall", EnumValue(RatingsCalculationType::Stall));
+    builder.Namespace("RideMode")
+        .Constant("Normal", EnumValue(RideMode::Normal))
+        .Constant("ContinuousCircuit", EnumValue(RideMode::ContinuousCircuit))
+        .Constant("ReverseInclineLaunchedShuttle", EnumValue(RideMode::ReverseInclineLaunchedShuttle))
+        .Constant("PoweredLaunchPasstrough", EnumValue(RideMode::PoweredLaunchPasstrough))
+        .Constant("Shuttle", EnumValue(RideMode::Shuttle))
+        .Constant("BoatHire", EnumValue(RideMode::BoatHire))
+        .Constant("UpwardLaunch", EnumValue(RideMode::UpwardLaunch))
+        .Constant("RotatingLift", EnumValue(RideMode::RotatingLift))
+        .Constant("StationToStation", EnumValue(RideMode::StationToStation))
+        .Constant("SingleRidePerAdmission", EnumValue(RideMode::SingleRidePerAdmission))
+        .Constant("UnlimitedRidesPerAdmission", EnumValue(RideMode::UnlimitedRidesPerAdmission))
+        .Constant("Maze", EnumValue(RideMode::Maze))
+        .Constant("Race", EnumValue(RideMode::Race))
+        .Constant("Dodgems", EnumValue(RideMode::Dodgems))
+        .Constant("Swing", EnumValue(RideMode::Swing))
+        .Constant("ShopStall", EnumValue(RideMode::ShopStall))
+        .Constant("Rotation", EnumValue(RideMode::Rotation))
+        .Constant("ForwardRotation", EnumValue(RideMode::ForwardRotation))
+        .Constant("BackwardRotation", EnumValue(RideMode::BackwardRotation))
+        .Constant("FilmAvengingAviators", EnumValue(RideMode::FilmAvengingAviators))
+        .Constant("MouseTails3DFilm", EnumValue(RideMode::MouseTails3DFilm))
+        .Constant("SpaceRings", EnumValue(RideMode::SpaceRings))
+        .Constant("Beginners", EnumValue(RideMode::Beginners))
+        .Constant("LimPoweredLaunch", EnumValue(RideMode::LimPoweredLaunch))
+        .Constant("FilmThrillRiders", EnumValue(RideMode::FilmThrillRiders))
+        .Constant("StormChasers3DFilm", EnumValue(RideMode::StormChasers3DFilm))
+        .Constant("SpaceRaiders3DFilm", EnumValue(RideMode::SpaceRaiders3DFilm))
+        .Constant("Intense", EnumValue(RideMode::Intense))
+        .Constant("Berserk", EnumValue(RideMode::Berserk))
+        .Constant("HauntedHouse", EnumValue(RideMode::HauntedHouse))
+        .Constant("Circus", EnumValue(RideMode::Circus))
+        .Constant("DownwardLaunch", EnumValue(RideMode::DownwardLaunch))
+        .Constant("CrookedHouse", EnumValue(RideMode::CrookedHouse))
+        .Constant("FreefallDrop", EnumValue(RideMode::FreefallDrop))
+        .Constant("ContinuousCircuitBlockSectioned", EnumValue(RideMode::ContinuousCircuitBlockSectioned))
+        .Constant("PoweredLaunch", EnumValue(RideMode::PoweredLaunch))
+        .Constant("PoweredLaunchBlockSectioned", EnumValue(RideMode::PoweredLaunchBlockSectioned));
 }
 
 void ScriptEngine::RefreshPlugins()

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -46,7 +46,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 103;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 104;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;

--- a/src/openrct2/scripting/bindings/ride/ScRatingsModifier.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScRatingsModifier.cpp
@@ -1,0 +1,62 @@
+/*****************************************************************************
+ * Copyright (c) 2020 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#ifdef ENABLE_SCRIPTING
+
+    #include "ScRatingsModifier.hpp"
+
+    #include "../../../Context.h"
+    #include "../../../ride/RideData.h"
+    #include "../../Duktape.hpp"
+    #include "../../ScriptEngine.h"
+    #include "../object/ScObject.hpp"
+
+namespace OpenRCT2::Scripting
+{
+    ScRatingsModifier::ScRatingsModifier(RatingsModifier ratingsModifier)
+        : _ratingsModifier(ratingsModifier)
+    {
+    }
+
+    uint8_t ScRatingsModifier::type_get() const
+    {
+        return EnumValue(_ratingsModifier.type);
+    }
+
+    int32_t ScRatingsModifier::threshold_get() const
+    {
+        return _ratingsModifier.threshold;
+    }
+
+    int32_t ScRatingsModifier::excitement_get() const
+    {
+        return _ratingsModifier.excitement;
+    }
+
+    int32_t ScRatingsModifier::intensity_get() const
+    {
+        return _ratingsModifier.intensity;
+    }
+
+    int32_t ScRatingsModifier::nausea_get() const
+    {
+        return _ratingsModifier.nausea;
+    }
+
+    void ScRatingsModifier::Register(duk_context* ctx)
+    {
+        dukglue_register_property(ctx, &ScRatingsModifier::type_get, nullptr, "type");
+        dukglue_register_property(ctx, &ScRatingsModifier::threshold_get, nullptr, "threshold");
+        dukglue_register_property(ctx, &ScRatingsModifier::excitement_get, nullptr, "excitement");
+        dukglue_register_property(ctx, &ScRatingsModifier::intensity_get, nullptr, "intensity");
+        dukglue_register_property(ctx, &ScRatingsModifier::nausea_get, nullptr, "nausea");
+    }
+} // namespace OpenRCT2::Scripting
+
+#endif // ENABLE_SCRIPTING

--- a/src/openrct2/scripting/bindings/ride/ScRatingsModifier.hpp
+++ b/src/openrct2/scripting/bindings/ride/ScRatingsModifier.hpp
@@ -1,0 +1,43 @@
+/*****************************************************************************
+ * Copyright (c) 2020 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#ifdef ENABLE_SCRIPTING
+
+    #include "../../../Context.h"
+    #include "../../../ride/RideData.h"
+    #include "../../Duktape.hpp"
+    #include "../../ScriptEngine.h"
+    #include "../object/ScObject.hpp"
+
+namespace OpenRCT2::Scripting
+{
+    class ScRatingsModifier
+    {
+    private:
+        RatingsModifier _ratingsModifier;
+
+    public:
+        ScRatingsModifier(RatingsModifier ratingsModifier);
+
+    private:
+        uint8_t type_get() const;
+        int32_t threshold_get() const;
+        int32_t excitement_get() const;
+        int32_t intensity_get() const;
+        int32_t nausea_get() const;
+
+    public:
+        static void Register(duk_context* ctx);
+    };
+
+} // namespace OpenRCT2::Scripting
+
+#endif // ENABLE_SCRIPTING

--- a/src/openrct2/scripting/bindings/ride/ScRide.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScRide.cpp
@@ -596,6 +596,12 @@ namespace OpenRCT2::Scripting
         return ride != nullptr ? ride->highest_drop_height : 0;
     }
 
+    std::shared_ptr<ScRideTypeDescriptor> ScRide::rideTypeDescriptor_get()
+    {
+        auto ride = GetRide();
+        return ride != nullptr ? std::make_shared<ScRideTypeDescriptor>(ride->GetRideTypeDescriptor()) : nullptr;
+    }
+
     void ScRide::Register(duk_context* ctx)
     {
         dukglue_register_property(ctx, &ScRide::id_get, nullptr, "id");
@@ -642,6 +648,7 @@ namespace OpenRCT2::Scripting
         dukglue_register_property(ctx, &ScRide::numDrops_get, nullptr, "numDrops");
         dukglue_register_property(ctx, &ScRide::numLiftHills_get, nullptr, "numLiftHills");
         dukglue_register_property(ctx, &ScRide::highestDropHeight_get, nullptr, "highestDropHeight");
+        dukglue_register_property(ctx, &ScRide::rideTypeDescriptor_get, nullptr, "rideTypeDescriptor");
     }
 
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/ride/ScRide.hpp
+++ b/src/openrct2/scripting/bindings/ride/ScRide.hpp
@@ -17,6 +17,7 @@
     #include "../../ScriptEngine.h"
     #include "../object/ScObject.hpp"
     #include "ScRideStation.hpp"
+    #include "ScRideTypeDescriptor.hpp"
 
 namespace OpenRCT2::Scripting
 {
@@ -189,6 +190,8 @@ namespace OpenRCT2::Scripting
         uint8_t numLiftHills_get() const;
 
         double highestDropHeight_get() const;
+
+        std::shared_ptr<ScRideTypeDescriptor> rideTypeDescriptor_get();
 
         Ride* GetRide() const;
 

--- a/src/openrct2/scripting/bindings/ride/ScRideRatingsDescriptor.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScRideRatingsDescriptor.cpp
@@ -1,0 +1,72 @@
+/*****************************************************************************
+ * Copyright (c) 2020 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#ifdef ENABLE_SCRIPTING
+
+    #include "ScRideRatingsDescriptor.hpp"
+
+    #include "../../../Context.h"
+    #include "../../Duktape.hpp"
+    #include "../../ScriptEngine.h"
+    #include "../object/ScObject.hpp"
+
+namespace OpenRCT2::Scripting
+{
+    ScRideRatingsDescriptor::ScRideRatingsDescriptor(RideRatingsDescriptor rideRatingsDescriptor)
+        : _rideRatingsDescriptor(rideRatingsDescriptor)
+    {
+    }
+
+    uint8_t ScRideRatingsDescriptor::type_get() const
+    {
+        return EnumValue(_rideRatingsDescriptor.Type);
+    }
+
+    uint8_t ScRideRatingsDescriptor::unreliability_get() const
+    {
+        return _rideRatingsDescriptor.Unreliability;
+    }
+
+    int8_t ScRideRatingsDescriptor::rideShelter_get() const
+    {
+        return _rideRatingsDescriptor.RideShelter;
+    }
+
+    bool ScRideRatingsDescriptor::relaxRequirementsIfInversions_get() const
+    {
+        return _rideRatingsDescriptor.RelaxRequirementsIfInversions;
+    }
+
+    std::vector<std::shared_ptr<ScRatingsModifier>> ScRideRatingsDescriptor::modifiers_get() const
+    {
+        std::vector<std::shared_ptr<ScRatingsModifier>> modifiers;
+        for (const auto& modifier : _rideRatingsDescriptor.Modifiers)
+        {
+            if (modifier.type == RatingsModifierType::NoModifier)
+            {
+                break;
+            }
+
+            modifiers.push_back(std::make_shared<ScRatingsModifier>(modifier));
+        }
+        return modifiers;
+    }
+
+    void ScRideRatingsDescriptor::Register(duk_context* ctx)
+    {
+        dukglue_register_property(ctx, &ScRideRatingsDescriptor::type_get, nullptr, "type");
+        dukglue_register_property(ctx, &ScRideRatingsDescriptor::unreliability_get, nullptr, "unreliability");
+        dukglue_register_property(ctx, &ScRideRatingsDescriptor::rideShelter_get, nullptr, "rideShelter");
+        dukglue_register_property(
+            ctx, &ScRideRatingsDescriptor::relaxRequirementsIfInversions_get, nullptr, "relaxRequirementsIfInversions");
+        dukglue_register_property(ctx, &ScRideRatingsDescriptor::modifiers_get, nullptr, "modifiers");
+    }
+} // namespace OpenRCT2::Scripting
+
+#endif // ENABLE_SCRIPTING

--- a/src/openrct2/scripting/bindings/ride/ScRideRatingsDescriptor.hpp
+++ b/src/openrct2/scripting/bindings/ride/ScRideRatingsDescriptor.hpp
@@ -1,0 +1,44 @@
+/*****************************************************************************
+ * Copyright (c) 2020 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#ifdef ENABLE_SCRIPTING
+
+    #include "../../../Context.h"
+    #include "../../../ride/RideData.h"
+    #include "../../Duktape.hpp"
+    #include "../../ScriptEngine.h"
+    #include "../object/ScObject.hpp"
+    #include "ScRatingsModifier.hpp"
+
+namespace OpenRCT2::Scripting
+{
+    class ScRideRatingsDescriptor
+    {
+    private:
+        RideRatingsDescriptor _rideRatingsDescriptor;
+
+    public:
+        ScRideRatingsDescriptor(RideRatingsDescriptor rideRatingsDescriptor);
+
+    private:
+        uint8_t type_get() const;
+        uint8_t unreliability_get() const;
+        int8_t rideShelter_get() const;
+        bool relaxRequirementsIfInversions_get() const;
+        std::vector<std::shared_ptr<ScRatingsModifier>> modifiers_get() const;
+
+    public:
+        static void Register(duk_context* ctx);
+    };
+
+} // namespace OpenRCT2::Scripting
+
+#endif // ENABLE_SCRIPTING

--- a/src/openrct2/scripting/bindings/ride/ScRideTypeDescriptor.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScRideTypeDescriptor.cpp
@@ -1,0 +1,80 @@
+/*****************************************************************************
+ * Copyright (c) 2020 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#ifdef ENABLE_SCRIPTING
+
+    #include "ScRideTypeDescriptor.hpp"
+
+    #include "../../../Context.h"
+    #include "../../../ride/RideData.h"
+    #include "../../Duktape.hpp"
+    #include "../../ScriptEngine.h"
+    #include "../object/ScObject.hpp"
+
+namespace OpenRCT2::Scripting
+{
+    ScRideTypeDescriptor::ScRideTypeDescriptor(RideTypeDescriptor rideTypeDescriptor)
+        : _rideTypeDescriptor(rideTypeDescriptor)
+    {
+    }
+
+    uint8_t ScRideTypeDescriptor::category_get() const
+    {
+        return _rideTypeDescriptor.Category;
+    }
+
+    uint16_t ScRideTypeDescriptor::startTrackPiece_get() const
+    {
+        return EnumValue(_rideTypeDescriptor.StartTrackPiece);
+    }
+
+    uint8_t ScRideTypeDescriptor::defaultMode_get() const
+    {
+        return EnumValue(_rideTypeDescriptor.DefaultMode);
+    }
+
+    uint8_t ScRideTypeDescriptor::availableBreakdowns_get() const
+    {
+        return _rideTypeDescriptor.AvailableBreakdowns;
+    }
+
+    uint8_t ScRideTypeDescriptor::maxMass_get() const
+    {
+        return _rideTypeDescriptor.MaxMass;
+    }
+
+    uint8_t ScRideTypeDescriptor::bonusValue_get() const
+    {
+        return _rideTypeDescriptor.BonusValue;
+    }
+
+    std::string ScRideTypeDescriptor::name_get() const
+    {
+        return std::string(_rideTypeDescriptor.Name);
+    }
+
+    std::shared_ptr<ScRideRatingsDescriptor> ScRideTypeDescriptor::ratingsData_get()
+    {
+        return std::make_shared<ScRideRatingsDescriptor>(_rideTypeDescriptor.RatingsData);
+    }
+
+    void ScRideTypeDescriptor::Register(duk_context* ctx)
+    {
+        dukglue_register_property(ctx, &ScRideTypeDescriptor::category_get, nullptr, "category");
+        dukglue_register_property(ctx, &ScRideTypeDescriptor::startTrackPiece_get, nullptr, "startTrackPiece");
+        dukglue_register_property(ctx, &ScRideTypeDescriptor::defaultMode_get, nullptr, "defaultMode");
+        dukglue_register_property(ctx, &ScRideTypeDescriptor::availableBreakdowns_get, nullptr, "availableBreakdowns");
+        dukglue_register_property(ctx, &ScRideTypeDescriptor::maxMass_get, nullptr, "maxMass");
+        dukglue_register_property(ctx, &ScRideTypeDescriptor::bonusValue_get, nullptr, "bonusValue");
+        dukglue_register_property(ctx, &ScRideTypeDescriptor::name_get, nullptr, "name");
+        dukglue_register_property(ctx, &ScRideTypeDescriptor::ratingsData_get, nullptr, "ratingsData");
+    }
+} // namespace OpenRCT2::Scripting
+
+#endif // ENABLE_SCRIPTING

--- a/src/openrct2/scripting/bindings/ride/ScRideTypeDescriptor.hpp
+++ b/src/openrct2/scripting/bindings/ride/ScRideTypeDescriptor.hpp
@@ -1,0 +1,48 @@
+/*****************************************************************************
+ * Copyright (c) 2020 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#ifdef ENABLE_SCRIPTING
+
+    #include "../../../Context.h"
+    #include "../../../ride/RideData.h"
+    #include "../../Duktape.hpp"
+    #include "../../ScriptEngine.h"
+    #include "../object/ScObject.hpp"
+    #include "ScRideRatingsDescriptor.hpp"
+
+namespace OpenRCT2::Scripting
+{
+    class ScRideTypeDescriptor
+    {
+    private:
+        RideTypeDescriptor _rideTypeDescriptor;
+
+    public:
+        ScRideTypeDescriptor(RideTypeDescriptor rideTypeDescriptor);
+
+    private:
+        uint8_t category_get() const;
+        uint16_t startTrackPiece_get() const;
+        uint8_t defaultMode_get() const;
+        uint8_t availableBreakdowns_get() const;
+        uint8_t maxMass_get() const;
+        uint8_t bonusValue_get() const;
+        std::string name_get() const;
+
+        std::shared_ptr<ScRideRatingsDescriptor> ratingsData_get();
+
+    public:
+        static void Register(duk_context* ctx);
+    };
+
+} // namespace OpenRCT2::Scripting
+
+#endif // ENABLE_SCRIPTING


### PR DESCRIPTION
Hi there!

First of all: thanks for taking the time to review this change.

## This adds

These changes expose some (not all) parts of the `RideTypeDescriptor` to the API. This means that plugins can get information related to the type of a ride. For example the category it is in, the default ride mode, and the RatingsModifiers it has. The latter was the primary reason I made this. I'm hoping that by exposing it, plugin developers can make nifty tools to show what stat requirements are needed for a ride.

[An example plugin](https://github.com/luttje/openrct2-ride-requirements/blob/8a24f133bc6d395c435bdab7184b7079088b8b81/src/ui/ride-requirements-viewmodel.ts#L40-L55) using this:
![Screenshot showing the Ride Bonus and Requirement Viewer](https://github.com/user-attachments/assets/5957f652-9542-4c67-b012-9feb3d2bd917)

## Work needed

Now I haven't exposed all available properties, since my primary goal was exposing the RatingsData property of a RideTypeDescriptor. The other properties are just along for the ride, since their primitive types made them easy to expose as well.

Currently all I've exposed is purposefully readonly, because I don't yet understand the implications of having plugins change any of this at runtime.

This is my first contribution to this project, so please do let me know if I have to clean-up or otherwise change this PR.

Thanks again!