### PR TITLE
Remove reserve call on std::string which prevents SSO

### DIFF
--- a/src/openrct2/core/OrcaStream.hpp
+++ b/src/openrct2/core/OrcaStream.hpp
@@ -604,7 +604,6 @@ namespace OpenRCT2
             std::string ReadString()
             {
                 std::string buffer;
-                buffer.reserve(64);
                 while (true)
                 {
                     char c{};
@@ -615,7 +614,6 @@ namespace OpenRCT2
                     }
                     buffer.push_back(c);
                 }
-                buffer.shrink_to_fit();
                 return buffer;
             }
 


### PR DESCRIPTION
As the title suggests, most compilers have small string optimization which means up to a certain length there will be no allocation, that varies between compilers/STL implementation, by calling reserve we take that chance away in all cases.

Edit: I realized I should clarify something, the problem is not the call to reserve but the fact that we don't know the string size beforehand.