### PR TITLE
Refactor console commands and fix #23348: signal completion of async commands

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -246,6 +246,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Mike Harvey (harvito)
 * Robert Yan (lewyche)
 * Tom Matalenas (tmatale)
+* Brendan Heinonen (staticinvocation)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Improved: [#23260] Add diagonal (block) brakes to LSM Launched Roller Coaster.
 - Fix: [#23286] Currency formatted incorrectly in the in game console.
+- Fix: [#23348] Console set commands don't print output properly.
 
 0.4.17 (2024-12-08)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -54,6 +54,12 @@ void InGameConsole::WritePrompt()
 
 void InGameConsole::Input(ConsoleInput input)
 {
+    if (_isCommandAwaitingCompletion)
+    {
+        // Do not process input while a command is running
+        return;
+    }
+
     switch (input)
     {
         case ConsoleInput::LineClear:
@@ -69,7 +75,14 @@ void InGameConsole::Input(ConsoleInput input)
                 _consoleLines.back().append(_consoleCurrentLine);
 
                 Execute(_consoleCurrentLine);
-                WritePrompt();
+                if (IsExecuting())
+                {
+                    _isCommandAwaitingCompletion = true;
+                }
+                else
+                {
+                    WritePrompt();
+                }
                 ClearInput();
                 RefreshCaret();
             }
@@ -269,6 +282,12 @@ void InGameConsole::Update()
                 }
             }
         }
+    }
+
+    if (_isCommandAwaitingCompletion && !IsExecuting())
+    {
+        WritePrompt();
+        _isCommandAwaitingCompletion = false;
     }
 
     // Flash the caret

--- a/src/openrct2-ui/interface/InGameConsole.h
+++ b/src/openrct2-ui/interface/InGameConsole.h
@@ -30,6 +30,7 @@ namespace OpenRCT2::Ui
 
         bool _isInitialised = false;
         bool _isOpen = false;
+        bool _isCommandAwaitingCompletion = false;
         ScreenCoordsXY _consoleTopLeft;
         ScreenCoordsXY _consoleBottomRight;
         ScreenCoordsXY _lastMainViewport;

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -20,6 +20,7 @@
 #include "../Version.h"
 #include "../actions/CheatSetAction.h"
 #include "../actions/ClimateSetAction.h"
+#include "../actions/GameSetSpeedAction.h"
 #include "../actions/ParkSetDateAction.h"
 #include "../actions/ParkSetParameterAction.h"
 #include "../actions/RideFreezeRatingAction.h"
@@ -93,9 +94,9 @@ static int32_t ConsoleParseInt(const std::string& src, bool* valid);
 static double ConsoleParseDouble(const std::string& src, bool* valid);
 
 static void ConsoleWriteAllCommands(InteractiveConsole& console);
-static int32_t ConsoleCommandVariables(InteractiveConsole& console, const arguments_t& argv);
-static int32_t ConsoleCommandWindows(InteractiveConsole& console, const arguments_t& argv);
-static int32_t ConsoleCommandHelp(InteractiveConsole& console, const arguments_t& argv);
+static void ConsoleCommandVariables(InteractiveConsole& console, const arguments_t& argv);
+static void ConsoleCommandWindows(InteractiveConsole& console, const arguments_t& argv);
+static void ConsoleCommandHelp(InteractiveConsole& console, const arguments_t& argv);
 
 static bool InvalidArguments(bool* invalid, bool arguments);
 
@@ -125,32 +126,28 @@ static double ConsoleParseDouble(const std::string& src, bool* valid)
     return value;
 }
 
-static int32_t ConsoleCommandClear(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
+static void ConsoleCommandClear(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     console.Clear();
-    return 0;
 }
 
-static int32_t ConsoleCommandClose(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
+static void ConsoleCommandClose(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     console.Close();
-    return 0;
 }
 
-static int32_t ConsoleCommandHide(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
+static void ConsoleCommandHide(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     console.Hide();
-    return 0;
 }
 
-static int32_t ConsoleCommandEcho(InteractiveConsole& console, const arguments_t& argv)
+static void ConsoleCommandEcho(InteractiveConsole& console, const arguments_t& argv)
 {
     if (!argv.empty())
         console.WriteLine(argv[0]);
-    return 0;
 }
 
-static int32_t ConsoleCommandRides(InteractiveConsole& console, const arguments_t& argv)
+static void ConsoleCommandRides(InteractiveConsole& console, const arguments_t& argv)
 {
     if (!argv.empty())
     {
@@ -189,7 +186,7 @@ static int32_t ConsoleCommandRides(InteractiveConsole& console, const arguments_
                     console.WriteFormatLine("rides set nausea <ride id> <nausea value>");
                     console.WriteFormatLine("rides set price <ride id / all [type]> <price>");
                 }
-                return 0;
+                return;
             }
             if (argv[1] == "type")
             {
@@ -455,10 +452,9 @@ static int32_t ConsoleCommandRides(InteractiveConsole& console, const arguments_
     {
         console.WriteFormatLine("subcommands: list, set");
     }
-    return 0;
 }
 
-static int32_t ConsoleCommandStaff(InteractiveConsole& console, const arguments_t& argv)
+static void ConsoleCommandStaff(InteractiveConsole& console, const arguments_t& argv)
 {
     if (!argv.empty())
     {
@@ -487,7 +483,7 @@ static int32_t ConsoleCommandStaff(InteractiveConsole& console, const arguments_
                     // that don't work well with the console, so manually skip past them.
                     console.WriteFormatLine("        costume %i: %s", i, costume_name + 7);
                 }
-                return 0;
+                return;
             }
             if (argv[1] == "energy")
             {
@@ -515,23 +511,23 @@ static int32_t ConsoleCommandStaff(InteractiveConsole& console, const arguments_
                 if (!int_valid[0])
                 {
                     console.WriteLineError("Invalid staff ID");
-                    return 1;
+                    return;
                 }
                 auto staff = GetEntity<Staff>(EntityId::FromUnderlying(int_val[0]));
                 if (staff == nullptr)
                 {
                     console.WriteLineError("Invalid staff ID");
-                    return 1;
+                    return;
                 }
                 if (staff->AssignedStaffType != StaffType::Entertainer)
                 {
                     console.WriteLineError("Specified staff is not entertainer");
-                    return 1;
+                    return;
                 }
                 if (!int_valid[1] || int_val[1] < 0 || int_val[1] >= static_cast<uint8_t>(EntertainerCostume::Count))
                 {
                     console.WriteLineError("Invalid costume ID");
-                    return 1;
+                    return;
                 }
 
                 EntertainerCostume costume = static_cast<EntertainerCostume>(int_val[1]);
@@ -544,10 +540,9 @@ static int32_t ConsoleCommandStaff(InteractiveConsole& console, const arguments_
     {
         console.WriteFormatLine("subcommands: list, set");
     }
-    return 0;
 }
 
-static int32_t ConsoleCommandGet(InteractiveConsole& console, const arguments_t& argv)
+static void ConsoleCommandGet(InteractiveConsole& console, const arguments_t& argv)
 {
     auto& gameState = GetGameState();
 
@@ -744,9 +739,24 @@ static int32_t ConsoleCommandGet(InteractiveConsole& console, const arguments_t&
             console.WriteLineWarning("Invalid variable.");
         }
     }
-    return 0;
 }
-static int32_t ConsoleCommandSet(InteractiveConsole& console, const arguments_t& argv)
+
+template<typename TAction, typename... TArgs>
+static void ConsoleSetVariableAction(InteractiveConsole& console, std::string var, TArgs&&... args)
+{
+    auto action = TAction(std::forward<TArgs>(args)...);
+    action.SetCallback([&console, var](const GameAction*, const GameActions::Result* res) {
+        if (res->Error != GameActions::Status::Ok)
+            console.WriteLineError(String::stdFormat("set %s command failed, likely due to permissions.", var.c_str()));
+        else
+            console.Execute(String::stdFormat("get %s", var.c_str()));
+        console.EndAsyncExecution();
+    });
+    console.BeginAsyncExecution();
+    GameActions::Execute(&action);
+}
+
+static void ConsoleCommandSet(InteractiveConsole& console, const arguments_t& argv)
 {
     if (argv.size() > 1)
     {
@@ -772,255 +782,130 @@ static int32_t ConsoleCommandSet(InteractiveConsole& console, const arguments_t&
             }
         }
 
+        std::string varName = argv[0];
+
         auto& gameState = GetGameState();
-        if (argv[0] == "money" && InvalidArguments(&invalidArgs, double_valid[0]))
+        if (varName == "money" && InvalidArguments(&invalidArgs, double_valid[0]))
         {
             money64 money = ToMoney64FromGBP(double_val[0]);
             if (gameState.Cash != money)
             {
-                auto cheatSetAction = CheatSetAction(CheatType::SetMoney, money);
-                cheatSetAction.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                    if (res->Error != GameActions::Status::Ok)
-                        console.WriteLineError("set money command failed, likely due to permissions.");
-                    else
-                        console.Execute("get money");
-                });
-                GameActions::Execute(&cheatSetAction);
+                ConsoleSetVariableAction<CheatSetAction>(console, varName, CheatType::SetMoney, money);
             }
             else
             {
                 console.Execute("get money");
             }
         }
-        else if (argv[0] == "scenario_initial_cash" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "scenario_initial_cash" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
-            auto scenarioSetSetting = ScenarioSetSettingAction(
-                ScenarioSetSetting::InitialCash, std::clamp(ToMoney64FromGBP(int_val[0]), 0.00_GBP, 1000000.00_GBP));
-            scenarioSetSetting.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                if (res->Error != GameActions::Status::Ok)
-                    console.WriteLineError("set scenario_initial_cash command failed, likely due to permissions.");
-                else
-                    console.Execute("get scenario_initial_cash");
-            });
-            GameActions::Execute(&scenarioSetSetting);
+            ConsoleSetVariableAction<ScenarioSetSettingAction>(
+                console, varName, ScenarioSetSetting::InitialCash,
+                std::clamp(ToMoney64FromGBP(int_val[0]), 0.00_GBP, 1000000.00_GBP));
         }
-        else if (argv[0] == "current_loan" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "current_loan" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
             auto amount = std::clamp(
                 ToMoney64FromGBP(int_val[0]) - ToMoney64FromGBP(int_val[0] % 1000), 0.00_GBP, gameState.MaxBankLoan);
-            auto scenarioSetSetting = ScenarioSetSettingAction(ScenarioSetSetting::InitialLoan, amount);
-            scenarioSetSetting.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                if (res->Error != GameActions::Status::Ok)
-                    console.WriteLineError("set current_loan command failed, likely due to permissions.");
-                else
-                    console.Execute("get current_loan");
-            });
-            GameActions::Execute(&scenarioSetSetting);
+            ConsoleSetVariableAction<ScenarioSetSettingAction>(console, varName, ScenarioSetSetting::InitialLoan, amount);
         }
-        else if (argv[0] == "max_loan" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "max_loan" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
             auto amount = std::clamp(
                 ToMoney64FromGBP(int_val[0]) - ToMoney64FromGBP(int_val[0] % 1000), 0.00_GBP, 5000000.00_GBP);
-            auto scenarioSetSetting = ScenarioSetSettingAction(ScenarioSetSetting::MaximumLoanSize, amount);
-            scenarioSetSetting.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                if (res->Error != GameActions::Status::Ok)
-                    console.WriteLineError("set max_loan command failed, likely due to permissions.");
-                else
-                    console.Execute("get max_loan");
-            });
-            GameActions::Execute(&scenarioSetSetting);
+            ConsoleSetVariableAction<ScenarioSetSettingAction>(console, varName, ScenarioSetSetting::MaximumLoanSize, amount);
         }
-        else if (argv[0] == "guest_initial_cash" && InvalidArguments(&invalidArgs, double_valid[0]))
+        else if (varName == "guest_initial_cash" && InvalidArguments(&invalidArgs, double_valid[0]))
         {
-            auto scenarioSetSetting = ScenarioSetSettingAction(
-                ScenarioSetSetting::AverageCashPerGuest, std::clamp(ToMoney64FromGBP(double_val[0]), 0.00_GBP, 1000.00_GBP));
-            scenarioSetSetting.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                if (res->Error != GameActions::Status::Ok)
-                    console.WriteLineError("set guest_initial_cash command failed, likely due to permissions.");
-                else
-                    console.Execute("get guest_initial_cash");
-            });
-            GameActions::Execute(&scenarioSetSetting);
+            ConsoleSetVariableAction<ScenarioSetSettingAction>(
+                console, varName, ScenarioSetSetting::AverageCashPerGuest,
+                std::clamp(ToMoney64FromGBP(double_val[0]), 0.00_GBP, 1000.00_GBP));
         }
-        else if (argv[0] == "guest_initial_happiness" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "guest_initial_happiness" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
-            auto scenarioSetSetting = ScenarioSetSettingAction(
-                ScenarioSetSetting::GuestInitialHappiness,
+            ConsoleSetVariableAction<ScenarioSetSettingAction>(
+                console, varName, ScenarioSetSetting::GuestInitialHappiness,
                 Park::CalculateGuestInitialHappiness(static_cast<uint8_t>(int_val[0])));
-            scenarioSetSetting.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                if (res->Error != GameActions::Status::Ok)
-                    console.WriteLineError("set guest_initial_happiness command failed, likely due to permissions.");
-                else
-                    console.Execute("get guest_initial_happiness");
-            });
-            GameActions::Execute(&scenarioSetSetting);
         }
-        else if (argv[0] == "guest_initial_hunger" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "guest_initial_hunger" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
-            auto scenarioSetSetting = ScenarioSetSettingAction(
-                ScenarioSetSetting::GuestInitialHunger, (std::clamp(int_val[0], 1, 84) * 255 / 100 - 255) * -1);
-            scenarioSetSetting.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                if (res->Error != GameActions::Status::Ok)
-                    console.WriteLineError("set guest_initial_hunger command failed, likely due to permissions.");
-                else
-                    console.Execute("get guest_initial_happiness");
-            });
-            GameActions::Execute(&scenarioSetSetting);
+            ConsoleSetVariableAction<ScenarioSetSettingAction>(
+                console, varName, ScenarioSetSetting::GuestInitialHunger,
+                (std::clamp(int_val[0], 1, 84) * 255 / 100 - 255) * -1);
         }
-        else if (argv[0] == "guest_initial_thirst" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "guest_initial_thirst" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
-            auto scenarioSetSetting = ScenarioSetSettingAction(
-                ScenarioSetSetting::GuestInitialThirst, (std::clamp(int_val[0], 1, 84) * 255 / 100 - 255) * -1);
-            scenarioSetSetting.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                if (res->Error != GameActions::Status::Ok)
-                    console.WriteLineError("set guest_initial_thirst command failed, likely due to permissions.");
-                else
-                    console.Execute("get guest_initial_thirst");
-            });
-            GameActions::Execute(&scenarioSetSetting);
+            ConsoleSetVariableAction<ScenarioSetSettingAction>(
+                console, varName, ScenarioSetSetting::GuestInitialThirst,
+                (std::clamp(int_val[0], 1, 84) * 255 / 100 - 255) * -1);
         }
-        else if (argv[0] == "guest_prefer_less_intense_rides" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "guest_prefer_less_intense_rides" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
-            auto scenarioSetSetting = ScenarioSetSettingAction(ScenarioSetSetting::GuestsPreferLessIntenseRides, int_val[0]);
-            scenarioSetSetting.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                if (res->Error != GameActions::Status::Ok)
-                    console.WriteLineError("set guest_prefer_less_intense_rides command failed, likely due to permissions.");
-                else
-                    console.Execute("get guest_prefer_less_intense_rides");
-            });
-            GameActions::Execute(&scenarioSetSetting);
+            ConsoleSetVariableAction<ScenarioSetSettingAction>(
+                console, varName, ScenarioSetSetting::GuestsPreferLessIntenseRides, int_val[0]);
         }
-        else if (argv[0] == "guest_prefer_more_intense_rides" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "guest_prefer_more_intense_rides" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
-            auto scenarioSetSetting = ScenarioSetSettingAction(ScenarioSetSetting::GuestsPreferMoreIntenseRides, int_val[0]);
-            scenarioSetSetting.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                if (res->Error != GameActions::Status::Ok)
-                    console.WriteLineError("set guest_prefer_more_intense_rides command failed, likely due to permissions.");
-                else
-                    console.Execute("get guest_prefer_more_intense_rides");
-            });
-            GameActions::Execute(&scenarioSetSetting);
+            ConsoleSetVariableAction<ScenarioSetSettingAction>(
+                console, varName, ScenarioSetSetting::GuestsPreferMoreIntenseRides, int_val[0]);
         }
-        else if (argv[0] == "forbid_marketing_campaigns" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "forbid_marketing_campaigns" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
-            auto scenarioSetSetting = ScenarioSetSettingAction(ScenarioSetSetting::ForbidMarketingCampaigns, int_val[0]);
-            scenarioSetSetting.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                if (res->Error != GameActions::Status::Ok)
-                    console.WriteLineError("set forbid_marketing_campaigns command failed, likely due to permissions.");
-                else
-                    console.Execute("get forbid_marketing_campaigns");
-            });
-            GameActions::Execute(&scenarioSetSetting);
+            ConsoleSetVariableAction<ScenarioSetSettingAction>(
+                console, varName, ScenarioSetSetting::ForbidMarketingCampaigns, int_val[0]);
         }
-        else if (argv[0] == "forbid_landscape_changes" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "forbid_landscape_changes" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
-            auto scenarioSetSetting = ScenarioSetSettingAction(ScenarioSetSetting::ForbidLandscapeChanges, int_val[0]);
-            scenarioSetSetting.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                if (res->Error != GameActions::Status::Ok)
-                    console.WriteLineError("set forbid_landscape_changes command failed, likely due to permissions.");
-                else
-                    console.Execute("get forbid_landscape_changes");
-            });
-            GameActions::Execute(&scenarioSetSetting);
+            ConsoleSetVariableAction<ScenarioSetSettingAction>(
+                console, varName, ScenarioSetSetting::ForbidLandscapeChanges, int_val[0]);
         }
-        else if (argv[0] == "forbid_tree_removal" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "forbid_tree_removal" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
-            auto scenarioSetSetting = ScenarioSetSettingAction(ScenarioSetSetting::ForbidTreeRemoval, int_val[0]);
-            scenarioSetSetting.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                if (res->Error != GameActions::Status::Ok)
-                    console.WriteLineError("set forbid_tree_removal command failed, likely due to permissions.");
-                else
-                    console.Execute("get forbid_tree_removal");
-            });
-            GameActions::Execute(&scenarioSetSetting);
+            ConsoleSetVariableAction<ScenarioSetSettingAction>(
+                console, varName, ScenarioSetSetting::ForbidTreeRemoval, int_val[0]);
         }
-        else if (argv[0] == "forbid_high_construction" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "forbid_high_construction" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
-            auto scenarioSetSetting = ScenarioSetSettingAction(ScenarioSetSetting::ForbidHighConstruction, int_val[0]);
-            scenarioSetSetting.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                if (res->Error != GameActions::Status::Ok)
-                    console.WriteLineError("set forbid_high_construction command failed, likely due to permissions.");
-                else
-                    console.Execute("get forbid_high_construction");
-            });
-            GameActions::Execute(&scenarioSetSetting);
+            ConsoleSetVariableAction<ScenarioSetSettingAction>(
+                console, varName, ScenarioSetSetting::ForbidHighConstruction, int_val[0]);
         }
-        else if (argv[0] == "pay_for_rides" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "pay_for_rides" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
             SET_FLAG(gameState.Park.Flags, PARK_FLAGS_PARK_FREE_ENTRY, int_val[0]);
             console.Execute("get pay_for_rides");
         }
-        else if (argv[0] == "no_money" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "no_money" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
-            auto cheatSetAction = CheatSetAction(CheatType::NoMoney, int_val[0] != 0);
-            cheatSetAction.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                if (res->Error != GameActions::Status::Ok)
-                    console.WriteLineError("set no_money command failed, likely due to permissions.");
-                else
-                    console.Execute("get no_money");
-            });
-            GameActions::Execute(&cheatSetAction);
+            ConsoleSetVariableAction<CheatSetAction>(console, varName, CheatType::NoMoney, int_val[0] != 0);
         }
-        else if (argv[0] == "difficult_park_rating" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "difficult_park_rating" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
-            auto scenarioSetSetting = ScenarioSetSettingAction(ScenarioSetSetting::ParkRatingHigherDifficultyLevel, int_val[0]);
-            scenarioSetSetting.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                if (res->Error != GameActions::Status::Ok)
-                    console.WriteLineError("set difficult_park_rating command failed, likely due to permissions.");
-                else
-                    console.Execute("get difficult_park_rating");
-            });
-            GameActions::Execute(&scenarioSetSetting);
+            ConsoleSetVariableAction<ScenarioSetSettingAction>(
+                console, varName, ScenarioSetSetting::ParkRatingHigherDifficultyLevel, int_val[0]);
         }
-        else if (argv[0] == "difficult_guest_generation" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "difficult_guest_generation" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
-            auto scenarioSetSetting = ScenarioSetSettingAction(
-                ScenarioSetSetting::GuestGenerationHigherDifficultyLevel, int_val[0]);
-            scenarioSetSetting.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                if (res->Error != GameActions::Status::Ok)
-                    console.WriteLineError("set difficult_guest_generation command failed, likely due to permissions.");
-                else
-                    console.Execute("get difficult_guest_generation");
-            });
-            GameActions::Execute(&scenarioSetSetting);
+            ConsoleSetVariableAction<ScenarioSetSettingAction>(
+                console, varName, ScenarioSetSetting::GuestGenerationHigherDifficultyLevel, int_val[0]);
         }
-        else if (argv[0] == "park_open" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "park_open" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
-            auto parkSetParameter = ParkSetParameterAction((int_val[0] == 1) ? ParkParameter::Open : ParkParameter::Close);
-            parkSetParameter.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                if (res->Error != GameActions::Status::Ok)
-                    console.WriteLineError("set park_open command failed, likely due to permissions.");
-                else
-                    console.Execute("get park_open");
-            });
-            GameActions::Execute(&parkSetParameter);
+            ConsoleSetVariableAction<ParkSetParameterAction>(
+                console, varName, (int_val[0] == 1) ? ParkParameter::Open : ParkParameter::Close);
         }
-        else if (argv[0] == "land_rights_cost" && InvalidArguments(&invalidArgs, double_valid[0]))
+        else if (varName == "land_rights_cost" && InvalidArguments(&invalidArgs, double_valid[0]))
         {
-            auto scenarioSetSetting = ScenarioSetSettingAction(
-                ScenarioSetSetting::CostToBuyLand, std::clamp(ToMoney64FromGBP(double_val[0]), 0.00_GBP, 200.00_GBP));
-            scenarioSetSetting.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                if (res->Error != GameActions::Status::Ok)
-                    console.WriteLineError("set land_rights_cost command failed, likely due to permissions.");
-                else
-                    console.Execute("get land_rights_cost");
-            });
-            GameActions::Execute(&scenarioSetSetting);
-        }
-        else if (argv[0] == "construction_rights_cost" && InvalidArguments(&invalidArgs, double_valid[0]))
-        {
-            auto scenarioSetSetting = ScenarioSetSettingAction(
-                ScenarioSetSetting::CostToBuyConstructionRights,
+            ConsoleSetVariableAction<ScenarioSetSettingAction>(
+                console, varName, ScenarioSetSetting::CostToBuyLand,
                 std::clamp(ToMoney64FromGBP(double_val[0]), 0.00_GBP, 200.00_GBP));
-            scenarioSetSetting.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                if (res->Error != GameActions::Status::Ok)
-                    console.WriteLineError("set construction_rights_cost command failed, likely due to permissions.");
-                else
-                    console.Execute("get construction_rights_cost");
-            });
-            GameActions::Execute(&scenarioSetSetting);
         }
-        else if (argv[0] == "climate")
+        else if (varName == "construction_rights_cost" && InvalidArguments(&invalidArgs, double_valid[0]))
+        {
+            ConsoleSetVariableAction<ScenarioSetSettingAction>(
+                console, varName, ScenarioSetSetting::CostToBuyConstructionRights,
+                std::clamp(ToMoney64FromGBP(double_val[0]), 0.00_GBP, 200.00_GBP));
+        }
+        else if (varName == "climate")
         {
             uint8_t newClimate = static_cast<uint8_t>(ClimateType::Count);
             invalidArgs = true;
@@ -1048,24 +933,20 @@ static int32_t ConsoleCommandSet(InteractiveConsole& console, const arguments_t&
             }
             else
             {
-                auto gameAction = ClimateSetAction(ClimateType{ newClimate });
-                GameActions::Execute(&gameAction);
-
-                console.Execute("get climate");
+                ConsoleSetVariableAction<ClimateSetAction>(console, varName, ClimateType{ newClimate });
             }
         }
-        else if (argv[0] == "game_speed" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "game_speed" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
-            gGameSpeed = std::clamp(int_val[0], 1, 8);
-            console.Execute("get game_speed");
+            ConsoleSetVariableAction<GameSetSpeedAction>(console, varName, std::clamp(int_val[0], 1, 8));
         }
-        else if (argv[0] == "console_small_font" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "console_small_font" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
             Config::Get().interface.ConsoleSmallFont = (int_val[0] != 0);
             Config::Save();
             console.Execute("get console_small_font");
         }
-        else if (argv[0] == "location" && InvalidArguments(&invalidArgs, int_valid[0] && int_valid[1]))
+        else if (varName == "location" && InvalidArguments(&invalidArgs, int_valid[0] && int_valid[1]))
         {
             WindowBase* w = WindowGetMain();
             if (w != nullptr)
@@ -1077,7 +958,7 @@ static int32_t ConsoleCommandSet(InteractiveConsole& console, const arguments_t&
                 console.Execute("get location");
             }
         }
-        else if (argv[0] == "window_scale" && InvalidArguments(&invalidArgs, double_valid[0]))
+        else if (varName == "window_scale" && InvalidArguments(&invalidArgs, double_valid[0]))
         {
             float newScale = static_cast<float>(0.001 * std::trunc(1000 * double_val[0]));
             Config::Get().general.WindowScale = std::clamp(newScale, 0.5f, 5.0f);
@@ -1087,78 +968,57 @@ static int32_t ConsoleCommandSet(InteractiveConsole& console, const arguments_t&
             ContextUpdateCursorScale();
             console.Execute("get window_scale");
         }
-        else if (argv[0] == "window_limit" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "window_limit" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
             WindowSetWindowLimit(int_val[0]);
             console.Execute("get window_limit");
         }
-        else if (argv[0] == "render_weather_effects" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "render_weather_effects" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
             Config::Get().general.RenderWeatherEffects = (int_val[0] != 0);
             Config::Save();
             console.Execute("get render_weather_effects");
         }
-        else if (argv[0] == "render_weather_gloom" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "render_weather_gloom" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
             Config::Get().general.RenderWeatherGloom = (int_val[0] != 0);
             Config::Save();
             console.Execute("get render_weather_gloom");
         }
-        else if (argv[0] == "cheat_sandbox_mode" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "cheat_sandbox_mode" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
             if (GetGameState().Cheats.sandboxMode != (int_val[0] != 0))
             {
-                auto cheatSetAction = CheatSetAction(CheatType::SandboxMode, int_val[0] != 0);
-                cheatSetAction.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                    if (res->Error != GameActions::Status::Ok)
-                        console.WriteLineError("Network error: Permission denied!");
-                    else
-                        console.Execute("get cheat_sandbox_mode");
-                });
-                GameActions::Execute(&cheatSetAction);
+                ConsoleSetVariableAction<CheatSetAction>(console, varName, CheatType::SandboxMode, int_val[0] != 0);
             }
             else
             {
                 console.Execute("get cheat_sandbox_mode");
             }
         }
-        else if (argv[0] == "cheat_disable_clearance_checks" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "cheat_disable_clearance_checks" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
             if (GetGameState().Cheats.disableClearanceChecks != (int_val[0] != 0))
             {
-                auto cheatSetAction = CheatSetAction(CheatType::DisableClearanceChecks, int_val[0] != 0);
-                cheatSetAction.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                    if (res->Error != GameActions::Status::Ok)
-                        console.WriteLineError("Network error: Permission denied!");
-                    else
-                        console.Execute("get cheat_disable_clearance_checks");
-                });
-                GameActions::Execute(&cheatSetAction);
+                ConsoleSetVariableAction<CheatSetAction>(console, varName, CheatType::DisableClearanceChecks, int_val[0] != 0);
             }
             else
             {
                 console.Execute("get cheat_disable_clearance_checks");
             }
         }
-        else if (argv[0] == "cheat_disable_support_limits" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "cheat_disable_support_limits" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
             if (GetGameState().Cheats.disableSupportLimits != (int_val[0] != 0))
             {
-                auto cheatSetAction = CheatSetAction(CheatType::DisableSupportLimits, int_val[0] != 0);
-                cheatSetAction.SetCallback([&console](const GameAction*, const GameActions::Result* res) {
-                    if (res->Error != GameActions::Status::Ok)
-                        console.WriteLineError("Network error: Permission denied!");
-                    else
-                        console.Execute("get cheat_disable_support_limits");
-                });
-                GameActions::Execute(&cheatSetAction);
+                ConsoleSetVariableAction<CheatSetAction>(console, varName, CheatType::DisableSupportLimits, int_val[0] != 0);
             }
             else
             {
                 console.Execute("get cheat_disable_support_limits");
             }
         }
-        else if (argv[0] == "current_rotation" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "current_rotation" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
             uint8_t currentRotation = GetCurrentRotation();
             int32_t newRotation = int_val[0];
@@ -1172,7 +1032,7 @@ static int32_t ConsoleCommandSet(InteractiveConsole& console, const arguments_t&
             }
             console.Execute("get current_rotation");
         }
-        else if (argv[0] == "host_timescale" && InvalidArguments(&invalidArgs, double_valid[0]))
+        else if (varName == "host_timescale" && InvalidArguments(&invalidArgs, double_valid[0]))
         {
             float newScale = static_cast<float>(double_val[0]);
 
@@ -1181,7 +1041,7 @@ static int32_t ConsoleCommandSet(InteractiveConsole& console, const arguments_t&
             console.Execute("get host_timescale");
         }
 #ifndef NO_TTF
-        else if (argv[0] == "enable_hinting" && InvalidArguments(&invalidArgs, int_valid[0]))
+        else if (varName == "enable_hinting" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
             Config::Get().fonts.EnableHinting = (int_val[0] != 0);
             Config::Save();
@@ -1204,10 +1064,9 @@ static int32_t ConsoleCommandSet(InteractiveConsole& console, const arguments_t&
     {
         console.WriteLineError("Value required.");
     }
-    return 0;
 }
 
-static int32_t ConsoleCommandLoadObject(InteractiveConsole& console, const arguments_t& argv)
+static void ConsoleCommandLoadObject(InteractiveConsole& console, const arguments_t& argv)
 {
     if (!argv.empty())
     {
@@ -1223,7 +1082,7 @@ static int32_t ConsoleCommandLoadObject(InteractiveConsole& console, const argum
         if (ori == nullptr)
         {
             console.WriteLineError("Could not find the object.");
-            return 1;
+            return;
         }
 
         const RCTObjectEntry* entry = &ori->ObjectEntry;
@@ -1231,14 +1090,14 @@ static int32_t ConsoleCommandLoadObject(InteractiveConsole& console, const argum
         if (loadedObject != nullptr)
         {
             console.WriteLineError("Object is already in scenario.");
-            return 1;
+            return;
         }
 
         loadedObject = ObjectManagerLoadObject(entry);
         if (loadedObject == nullptr)
         {
             console.WriteLineError("Unable to load object.");
-            return 1;
+            return;
         }
         auto groupIndex = ObjectManagerGetLoadedObjectEntryIndex(loadedObject);
 
@@ -1281,8 +1140,6 @@ static int32_t ConsoleCommandLoadObject(InteractiveConsole& console, const argum
         GfxInvalidateScreen();
         console.WriteLine("Object file loaded.");
     }
-
-    return 0;
 }
 
 constexpr std::array _objectTypeNames = {
@@ -1308,7 +1165,7 @@ constexpr std::array _objectTypeNames = {
 };
 static_assert(_objectTypeNames.size() == EnumValue(ObjectType::Count));
 
-static int32_t ConsoleCommandCountObjects(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
+static void ConsoleCommandCountObjects(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     for (auto objectType : getAllObjectTypes())
     {
@@ -1323,11 +1180,9 @@ static int32_t ConsoleCommandCountObjects(InteractiveConsole& console, [[maybe_u
         console.WriteFormatLine(
             "%s: %d/%d", _objectTypeNames[EnumValue(objectType)], entryGroupIndex, getObjectEntryGroupCount(objectType));
     }
-
-    return 0;
 }
 
-static int32_t ConsoleCommandOpen(InteractiveConsole& console, const arguments_t& argv)
+static void ConsoleCommandOpen(InteractiveConsole& console, const arguments_t& argv)
 {
     if (!argv.empty())
     {
@@ -1389,24 +1244,21 @@ static int32_t ConsoleCommandOpen(InteractiveConsole& console, const arguments_t
             console.WriteLineError("Invalid window.");
         }
     }
-    return 0;
 }
 
-static int32_t ConsoleCommandRemoveUnusedObjects(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
+static void ConsoleCommandRemoveUnusedObjects(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     int32_t result = EditorRemoveUnusedObjects();
     console.WriteFormatLine("%d unused object entries have been removed.", result);
-    return 0;
 }
 
-static int32_t ConsoleCommandRemoveFloatingObjects(InteractiveConsole& console, const arguments_t& argv)
+static void ConsoleCommandRemoveFloatingObjects(InteractiveConsole& console, const arguments_t& argv)
 {
     uint16_t result = RemoveFloatingEntities();
     console.WriteFormatLine("Removed %d flying objects", result);
-    return 0;
 }
 
-static int32_t ConsoleCommandShowLimits(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
+static void ConsoleCommandShowLimits(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     const auto& tileElements = GetTileElements();
     const auto tileElementCount = tileElements.size();
@@ -1425,24 +1277,23 @@ static int32_t ConsoleCommandShowLimits(InteractiveConsole& console, [[maybe_unu
     console.WriteFormatLine("Banners: %d/%zu", bannerCount, MAX_BANNERS);
     console.WriteFormatLine("Rides: %d/%d", rideCount, OpenRCT2::Limits::kMaxRidesInPark);
     console.WriteFormatLine("Images: %zu/%zu", ImageListGetUsedCount(), ImageListGetMaximum());
-    return 0;
 }
 
-static int32_t ConsoleCommandForceDate([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
+static void ConsoleCommandForceDate([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     int32_t year = 0;
     int32_t month = 0;
     int32_t day = 0;
     if (argv.size() < 1 || argv.size() > 3)
     {
-        return -1;
+        return;
     }
 
     // All cases involve providing a year, so grab that first
     year = atoi(argv[0].c_str());
     if (year < 1 || year > kMaxYear)
     {
-        return -1;
+        return;
     }
 
     // YYYY (no month provided, preserve existing month)
@@ -1458,7 +1309,7 @@ static int32_t ConsoleCommandForceDate([[maybe_unused]] InteractiveConsole& cons
         month -= 2;
         if (month < 1 || month > MONTH_COUNT)
         {
-            return -1;
+            return;
         }
     }
 
@@ -1474,23 +1325,21 @@ static int32_t ConsoleCommandForceDate([[maybe_unused]] InteractiveConsole& cons
         day = atoi(argv[2].c_str());
         if (day < 1 || day > Date::GetDaysInMonth(month - 1))
         {
-            return -1;
+            return;
         }
     }
 
     auto setDateAction = ParkSetDateAction(year - 1, month - 1, day - 1);
     GameActions::Execute(&setDateAction);
     WindowInvalidateByClass(WindowClass::BottomToolbar);
-
-    return 1;
 }
 
-static int32_t ConsoleCommandLoadPark([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
+static void ConsoleCommandLoadPark([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     if (argv.size() < 1)
     {
         console.WriteLine("Parameters required <filename>");
-        return 0;
+        return;
     }
 
     u8string savePath = {};
@@ -1518,10 +1367,9 @@ static int32_t ConsoleCommandLoadPark([[maybe_unused]] InteractiveConsole& conso
     {
         console.WriteFormatLine("Loading Park %s failed", savePath.c_str());
     }
-    return 1;
 }
 
-static int32_t ConsoleCommandSavePark([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
+static void ConsoleCommandSavePark([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     if (argv.size() < 1)
     {
@@ -1531,40 +1379,38 @@ static int32_t ConsoleCommandSavePark([[maybe_unused]] InteractiveConsole& conso
     {
         SaveGameCmd(argv[0].c_str());
     }
-    return 1;
 }
 
-static int32_t ConsoleCommandSay(InteractiveConsole& console, const arguments_t& argv)
+static void ConsoleCommandSay(InteractiveConsole& console, const arguments_t& argv)
 {
     if (NetworkGetMode() == NETWORK_MODE_NONE || NetworkGetStatus() != NETWORK_STATUS_CONNECTED
         || NetworkGetAuthstatus() != NetworkAuth::Ok)
     {
         console.WriteFormatLine("This command only works in multiplayer mode.");
-        return 0;
+        return;
     }
 
     if (!argv.empty())
     {
         NetworkSendChat(argv[0].c_str());
-        return 1;
+        return;
     }
 
     console.WriteFormatLine("Input your message");
-    return 0;
 }
 
-static int32_t ConsoleCommandReplayStartRecord(InteractiveConsole& console, const arguments_t& argv)
+static void ConsoleCommandReplayStartRecord(InteractiveConsole& console, const arguments_t& argv)
 {
     if (NetworkGetMode() != NETWORK_MODE_NONE)
     {
         console.WriteFormatLine("This command is currently not supported in multiplayer mode.");
-        return 0;
+        return;
     }
 
     if (argv.size() < 1)
     {
         console.WriteFormatLine("Parameters required <replay_name> [<max_ticks = 0xFFFFFFFF>]");
-        return 0;
+        return;
     }
 
     std::string name = argv[0];
@@ -1593,26 +1439,22 @@ static int32_t ConsoleCommandReplayStartRecord(InteractiveConsole& console, cons
         const char* logFmt = "Replay recording started: (%s) %s";
         console.WriteFormatLine(logFmt, info.Name.c_str(), info.FilePath.c_str());
         Console::WriteLine(logFmt, info.Name.c_str(), info.FilePath.c_str());
-
-        return 1;
     }
-
-    return 0;
 }
 
-static int32_t ConsoleCommandReplayStopRecord(InteractiveConsole& console, const arguments_t& argv)
+static void ConsoleCommandReplayStopRecord(InteractiveConsole& console, const arguments_t& argv)
 {
     if (NetworkGetMode() != NETWORK_MODE_NONE)
     {
         console.WriteFormatLine("This command is currently not supported in multiplayer mode.");
-        return 0;
+        return;
     }
 
     auto* replayManager = OpenRCT2::GetContext()->GetReplayManager();
     if (!replayManager->IsRecording() && !replayManager->IsNormalising())
     {
         console.WriteFormatLine("Replay currently not recording");
-        return 0;
+        return;
     }
 
     OpenRCT2::ReplayRecordInfo info;
@@ -1628,25 +1470,21 @@ static int32_t ConsoleCommandReplayStopRecord(InteractiveConsole& console, const
         console.WriteFormatLine(
             logFmt, info.Name.c_str(), info.FilePath.c_str(), info.Ticks, info.NumCommands, info.NumChecksums);
         Console::WriteLine(logFmt, info.Name.c_str(), info.FilePath.c_str(), info.Ticks, info.NumCommands, info.NumChecksums);
-
-        return 1;
     }
-
-    return 0;
 }
 
-static int32_t ConsoleCommandReplayStart(InteractiveConsole& console, const arguments_t& argv)
+static void ConsoleCommandReplayStart(InteractiveConsole& console, const arguments_t& argv)
 {
     if (NetworkGetMode() != NETWORK_MODE_NONE)
     {
         console.WriteFormatLine("This command is currently not supported in multiplayer mode.");
-        return 0;
+        return;
     }
 
     if (argv.size() < 1)
     {
         console.WriteFormatLine("Parameters required <replay_name>");
-        return 0;
+        return;
     }
 
     std::string name = argv[0];
@@ -1670,43 +1508,34 @@ static int32_t ConsoleCommandReplayStart(InteractiveConsole& console, const argu
 
         console.WriteFormatLine(logFmt, info.FilePath.c_str(), recordingDate, info.Ticks, info.NumCommands, info.NumChecksums);
         Console::WriteLine(logFmt, info.FilePath.c_str(), recordingDate, info.Ticks, info.NumCommands, info.NumChecksums);
-
-        return 1;
     }
-
-    return 0;
 }
 
-static int32_t ConsoleCommandReplayStop(InteractiveConsole& console, const arguments_t& argv)
+static void ConsoleCommandReplayStop(InteractiveConsole& console, const arguments_t& argv)
 {
     if (NetworkGetMode() != NETWORK_MODE_NONE)
     {
         console.WriteFormatLine("This command is currently not supported in multiplayer mode.");
-        return 0;
+        return;
     }
 
     auto* replayManager = OpenRCT2::GetContext()->GetReplayManager();
     if (replayManager->StopPlayback())
     {
         console.WriteFormatLine("Stopped replay");
-        return 1;
     }
-
-    return 0;
 }
 
-static int32_t ConsoleCommandReplayNormalise(InteractiveConsole& console, const arguments_t& argv)
+static void ConsoleCommandReplayNormalise(InteractiveConsole& console, const arguments_t& argv)
 {
     if (NetworkGetMode() != NETWORK_MODE_NONE)
     {
         console.WriteFormatLine("This command is currently not supported in multiplayer mode.");
-        return 0;
     }
 
     if (argv.size() < 2)
     {
         console.WriteFormatLine("Parameters required <replay_input> <replay_output>");
-        return 0;
     }
 
     std::string inputFile = argv[0];
@@ -1724,13 +1553,10 @@ static int32_t ConsoleCommandReplayNormalise(InteractiveConsole& console, const 
     if (replayManager->NormaliseReplay(inputFile, outputFile))
     {
         console.WriteFormatLine("Stopped replay");
-        return 1;
     }
-
-    return 0;
 }
 
-static int32_t ConsoleCommandMpDesync(InteractiveConsole& console, const arguments_t& argv)
+static void ConsoleCommandMpDesync(InteractiveConsole& console, const arguments_t& argv)
 {
     int32_t desyncType = 0;
     if (argv.size() >= 1)
@@ -1779,45 +1605,40 @@ static int32_t ConsoleCommandMpDesync(InteractiveConsole& console, const argumen
             break;
         }
     }
-    return 0;
 }
 
 #pragma warning(push)
 #pragma warning(disable : 4702) // unreachable code
-static int32_t ConsoleCommandAbort([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
+static void ConsoleCommandAbort([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     std::abort();
-    return 0;
 }
 
-static int32_t ConsoleCommandDereference([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
+static void ConsoleCommandDereference([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnull-dereference"
     // Dereference a nullptr to induce a crash to be caught by crash handler, on supported platforms
     uint8_t* myptr = nullptr;
     *myptr = 42;
-    return 0;
 #pragma GCC diagnostic pop
 }
 
-static int32_t ConsoleCommandTerminate([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
+static void ConsoleCommandTerminate([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     std::terminate();
-    return 0;
 }
 #pragma warning(pop)
 
-static int32_t ConsoleCommandAssert([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
+static void ConsoleCommandAssert([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     if (!argv.empty())
         Guard::Assert(false, "%s", argv[0].c_str());
     else
         Guard::Assert(false);
-    return 0;
 }
 
-static int32_t ConsoleCommandAddNewsItem([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
+static void ConsoleCommandAddNewsItem([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     if (argv.size() < 2)
     {
@@ -1839,7 +1660,7 @@ static int32_t ConsoleCommandAddNewsItem([[maybe_unused]] InteractiveConsole& co
         console.WriteLine("message is the message to display, wrapped in quotes for multiple words");
         console.WriteLine("assoc is the associated id of ride/peep/tile/etc. If the selected ItemType doesn't need an assoc "
                           "(Null, Money, Award, Graph), you can leave this field blank");
-        return 1;
+        return;
     }
 
     auto type = atoi(argv[0].c_str());
@@ -1857,52 +1678,43 @@ static int32_t ConsoleCommandAddNewsItem([[maybe_unused]] InteractiveConsole& co
         if (News::CheckIfItemRequiresAssoc(itemType))
         {
             console.WriteLine("Selected ItemType requires an assoc");
-            return 0;
+            return;
         }
     }
 
     News::AddItemToQueue(itemType, msg, assoc);
     console.WriteLine("Successfully added News Item");
-    return 0;
 }
 
-static int32_t ConsoleCommandProfilerReset(
-    [[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
+static void ConsoleCommandProfilerReset([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     OpenRCT2::Profiling::ResetData();
-    return 0;
 }
-static int32_t ConsoleCommandProfilerStart(
-    [[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
+static void ConsoleCommandProfilerStart([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     if (!OpenRCT2::Profiling::IsEnabled())
         console.WriteLine("Started profiler");
     OpenRCT2::Profiling::Enable();
-    return 0;
 }
 
-static int32_t ConsoleCommandProfilerExportCSV(
+static void ConsoleCommandProfilerExportCSV(
     [[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     if (argv.size() < 1)
     {
         console.WriteLineError("Missing argument: <file path>");
-        return 1;
     }
 
     const auto& csvFilePath = argv[0];
     if (!OpenRCT2::Profiling::ExportCSV(csvFilePath))
     {
         console.WriteFormatLine("Unable to export CSV file to %s", csvFilePath.c_str());
-        return 1;
     }
 
     console.WriteFormatLine("Wrote file CSV file: \"%s\"", csvFilePath.c_str());
-    return 0;
 }
 
-static int32_t ConsoleCommandProfilerStop(
-    [[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
+static void ConsoleCommandProfilerStop([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     if (OpenRCT2::Profiling::IsEnabled())
         console.WriteLine("Stopped profiler");
@@ -1913,16 +1725,14 @@ static int32_t ConsoleCommandProfilerStop(
     {
         return ConsoleCommandProfilerExportCSV(console, argv);
     }
-
-    return 0;
 }
 
-static int32_t ConsoleSpawnBalloon(InteractiveConsole& console, const arguments_t& argv)
+static void ConsoleSpawnBalloon(InteractiveConsole& console, const arguments_t& argv)
 {
     if (argv.size() < 3)
     {
         console.WriteLineError("Need arguments: <x> <y> <z> <colour>");
-        return 1;
+        return;
     }
     int32_t x = kCoordsXYStep * atof(argv[0].c_str());
     int32_t y = kCoordsXYStep * atof(argv[1].c_str());
@@ -1931,10 +1741,9 @@ static int32_t ConsoleSpawnBalloon(InteractiveConsole& console, const arguments_
     if (argv.size() > 3)
         col = atoi(argv[3].c_str());
     Balloon::Create({ x, y, z }, col, false);
-    return 0;
 }
 
-using console_command_func = int32_t (*)(InteractiveConsole& console, const arguments_t& argv);
+using console_command_func = void (*)(InteractiveConsole& console, const arguments_t& argv);
 struct ConsoleCommand
 {
     const utf8* command;
@@ -2047,25 +1856,23 @@ static constexpr ConsoleCommand console_command_table[] = {
       "profiler_exportcsv <output file>" },
 };
 
-static int32_t ConsoleCommandWindows(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
+static void ConsoleCommandWindows(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     for (auto s : console_window_table)
     {
         console.WriteLine(s);
     }
-    return 0;
 }
 
-static int32_t ConsoleCommandVariables(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
+static void ConsoleCommandVariables(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     for (auto s : console_variable_table)
     {
         console.WriteLine(s);
     }
-    return 0;
 }
 
-static int32_t ConsoleCommandHelp(InteractiveConsole& console, const arguments_t& argv)
+static void ConsoleCommandHelp(InteractiveConsole& console, const arguments_t& argv)
 {
     if (!argv.empty())
     {
@@ -2082,7 +1889,6 @@ static int32_t ConsoleCommandHelp(InteractiveConsole& console, const arguments_t
     {
         ConsoleWriteAllCommands(console);
     }
-    return 0;
 }
 
 static void ConsoleWriteAllCommands(InteractiveConsole& console)
@@ -2149,7 +1955,6 @@ void InteractiveConsole::Execute(const std::string& s)
         return;
 
     bool validCommand = false;
-
     for (const auto& c : console_command_table)
     {
         if (argv[0] == c.command)
@@ -2189,4 +1994,19 @@ void InteractiveConsole::WriteFormatLine(const char* format, ...)
     auto buffer = String::Format_VA(format, list);
     va_end(list);
     WriteLine(buffer);
+}
+
+void InteractiveConsole::BeginAsyncExecution()
+{
+    OpenRCT2::Guard::Assert(!_commandExecuting.test_and_set(), "Command already executing asynchronously");
+}
+
+void InteractiveConsole::EndAsyncExecution()
+{
+    _commandExecuting.clear();
+}
+
+bool InteractiveConsole::IsExecuting()
+{
+    return _commandExecuting.test();
 }

--- a/src/openrct2/interface/InteractiveConsole.h
+++ b/src/openrct2/interface/InteractiveConsole.h
@@ -11,6 +11,7 @@
 
 #include "../localisation/FormatCodes.h"
 
+#include <atomic>
 #include <cstdint>
 #include <string>
 
@@ -30,6 +31,9 @@ enum class ConsoleInput : uint8_t
 
 class InteractiveConsole
 {
+private:
+    std::atomic_flag _commandExecuting;
+
 public:
     virtual ~InteractiveConsole()
     {
@@ -40,6 +44,11 @@ public:
     void WriteLineError(const std::string& s);
     void WriteLineWarning(const std::string& s);
     void WriteFormatLine(const char* format, ...);
+
+    void BeginAsyncExecution();
+    void EndAsyncExecution();
+
+    bool IsExecuting();
 
     virtual void Clear() = 0;
     virtual void Close() = 0;


### PR DESCRIPTION
This patch is split into three commits.

The first commit reduces code reuse in `InteractiveConsole.cpp` by simplifying the "set" command implementation. This command typically uses `GameAction`s to set the specified variable, and originally this implementation used the same block of code repeated many times for each individual game action. This patch introduces the templated function `ConsoleSetVariableAction` that sets a variable via game action to eliminate this code reuse within the function, for better maintainability.

The second commit removes unused return codes from console commands. Console command functions originally returned an `int32_t`. This value was never used, and is in fact poor error handling since the command handlers typically print their own user-friendly error message anyway. This commit removes all return values from console commands.

The last commit fixes #23348 by introducing a new way for commands that run asynchronously (on another thread) to signal their completion. The purpose of this change is to fix the graphical bug as reported, but also the original design seemed a little dubious in terms of thread safety. The `InteractiveConsole` class was given three new functions, `BeginAsyncExecution()` to signal a command handler will run asynchronously, `EndAsyncExecution()` to signal that execution is complete, and `IsExecuting()` that returns if an asynchronous command is currently running. 

After spending a lot of time trying to figure out the correct synchronization primitive for this, I've settled on a design centered around `std::atomic_flag`. The actual concrete implementation of `InteractiveConsole` is responsible for checking this value through `IsExecuting()`. A basic state machine is used in the `InGameConsole`. I admit this feels a little hacky, but I do not think any other concurrency primitive in the standard library is really suitable for this. I tried to use `std::future` which I think would be the most clean solution, but it cannot be used with callbacks in `GameAction` because futures are not copyable.