### PR TITLE
Update docker building images to version 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
   check-code-formatting:
     name: Check code formatting
     runs-on: ubuntu-latest
-    container: openrct2/openrct2-build:17-format
+    container: openrct2/openrct2-build:18-format
     defaults:
       run:
         shell: sh
@@ -310,7 +310,7 @@ jobs:
     name: Windows (${{ matrix.platform_name }}) using mingw
     runs-on: ubuntu-latest
     needs: [check-code-formatting, build_variables]
-    container: openrct2/openrct2-build:14-mingw
+    container: openrct2/openrct2-build:18-mingw
     strategy:
       fail-fast: false
       matrix:
@@ -453,12 +453,12 @@ jobs:
           - platform: x86_64
             distro: Ubuntu
             release: noble
-            image: openrct2/openrct2-build:16-noble
+            image: openrct2/openrct2-build:18-noble
             build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz -fno-var-tracking-assignments"
           - platform: x86_64
             distro: Debian
             release: bookworm
-            image: openrct2/openrct2-build:16-bookworm
+            image: openrct2/openrct2-build:18-bookworm
             build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz -fno-var-tracking-assignments" -DWITH_TESTS=off
     steps:
       - name: Checkout
@@ -544,7 +544,7 @@ jobs:
     name: Ubuntu Linux (noble, debug, [http, network, flac, vorbis OpenGL] disabled) using clang
     runs-on: ubuntu-latest
     needs: [check-code-formatting, build_variables]
-    container: openrct2/openrct2-build:16-noble
+    container: openrct2/openrct2-build:18-noble
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -560,7 +560,7 @@ jobs:
     name: Ubuntu Linux (debug) using clang, coverage enabled
     runs-on: ubuntu-latest
     needs: [check-code-formatting, build_variables]
-    container: openrct2/openrct2-build:16-noble
+    container: openrct2/openrct2-build:18-noble
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -601,7 +601,7 @@ jobs:
     name: Android
     runs-on: ubuntu-latest
     needs: [check-code-formatting, build_variables]
-    container: openrct2/openrct2-build:14-android
+    container: openrct2/openrct2-build:18-android
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Version 18 brings Android updates, clang-format 19, libzip updates in mingw

Draft until CI is green