### PR TITLE
Add null check to fix 23223

### DIFF
--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5946,6 +5946,10 @@ ResultWithMessage Ride::ChangeStatusCheckTrackValidity(const CoordsXYE& trackEle
     if (subtype != OBJECT_ENTRY_INDEX_NULL && !GetGameState().Cheats.enableAllDrawableTrackPieces)
     {
         const auto* rideEntry = GetRideEntryByIndex(subtype);
+        if (rideEntry == nullptr)
+        {
+            return { false, STR_UNKNOWN_RIDE };
+        }
         if (rideEntry->flags & RIDE_ENTRY_FLAG_NO_INVERSIONS)
         {
             if (RideCheckTrackContainsInversions(trackElement, &problematicTrackElement))


### PR DESCRIPTION
Fixes #23223

The error message is "Unknown Ride" which I think is appropriate enough for a missing object index.