### PR TITLE
Make MaskScalar more amenable to autovectorization

### DIFF
--- a/src/openrct2/drawing/AVX2Drawing.cpp
+++ b/src/openrct2/drawing/AVX2Drawing.cpp
@@ -15,16 +15,16 @@
     #include <immintrin.h>
 
 void MaskAvx2(
-    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
-    int32_t maskWrap, int32_t colourWrap, int32_t dstWrap)
+    uint32_t width, uint32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
+    uint32_t maskWrap, uint32_t colourWrap, uint32_t dstWrap)
 {
     if (width == 32)
     {
-        const int32_t maskWrapSIMD = maskWrap + 32;
-        const int32_t colourWrapSIMD = colourWrap + 32;
-        const int32_t dstWrapSIMD = dstWrap + 32;
+        const uint32_t maskWrapSIMD = maskWrap + 32;
+        const uint32_t colourWrapSIMD = colourWrap + 32;
+        const uint32_t dstWrapSIMD = dstWrap + 32;
         const __m256i zero = {};
-        for (int32_t yy = 0; yy < height; yy++)
+        for (uint32_t yy = 0; yy < height; yy++)
         {
             const __m256i colour = _mm256_lddqu_si256(reinterpret_cast<const __m256i*>(colourSrc + yy * colourWrapSIMD));
             const __m256i mask = _mm256_lddqu_si256(reinterpret_cast<const __m256i*>(maskSrc + yy * maskWrapSIMD));
@@ -48,8 +48,8 @@ void MaskAvx2(
     #endif
 
 void MaskAvx2(
-    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
-    int32_t maskWrap, int32_t colourWrap, int32_t dstWrap)
+    uint32_t width, uint32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
+    uint32_t maskWrap, uint32_t colourWrap, uint32_t dstWrap)
 {
     OpenRCT2::Guard::Fail("AVX2 function called on a CPU that doesn't support AVX2");
 }

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -387,7 +387,7 @@ static void ReadAndConvertGxDat(IStream* stream, size_t count, bool is_rctc, G1E
     }
 }
 
-void MaskScalar(
+static void MaskScalarImpl(
     uint32_t width, uint32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
     uint32_t maskWrap, uint32_t colourWrap, uint32_t dstWrap)
 {
@@ -406,6 +406,20 @@ void MaskScalar(
         maskSrc += maskWrap;
         colourSrc += colourWrap;
         dst += dstWrap;
+    }
+}
+
+void MaskScalar(
+    uint32_t width, uint32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
+    uint32_t maskWrap, uint32_t colourWrap, uint32_t dstWrap)
+{
+    if (width == 32) [[likely]]
+    {
+        MaskScalarImpl(32, height, maskSrc, colourSrc, dst, maskWrap, colourWrap, dstWrap);
+    }
+    else
+    {
+        MaskScalarImpl(width, height, maskSrc, colourSrc, dst, maskWrap, colourWrap, dstWrap);
     }
 }
 

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -396,10 +396,8 @@ void MaskScalar(
         for (int32_t xx = 0; xx < width; xx++)
         {
             uint8_t colour = (*colourSrc) & (*maskSrc);
-            if (colour != 0)
-            {
-                *dst = colour;
-            }
+            uint8_t currentDst = *dst;
+            *dst = colour != 0 ? colour : currentDst;
 
             maskSrc++;
             colourSrc++;

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -388,12 +388,12 @@ static void ReadAndConvertGxDat(IStream* stream, size_t count, bool is_rctc, G1E
 }
 
 void MaskScalar(
-    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
-    int32_t maskWrap, int32_t colourWrap, int32_t dstWrap)
+    uint32_t width, uint32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
+    uint32_t maskWrap, uint32_t colourWrap, uint32_t dstWrap)
 {
-    for (int32_t yy = 0; yy < height; yy++)
+    for (uint32_t yy = 0; yy < height; yy++)
     {
-        for (int32_t xx = 0; xx < width; xx++)
+        for (uint32_t xx = 0; xx < width; xx++)
         {
             uint8_t colour = (*colourSrc) & (*maskSrc);
             uint8_t currentDst = *dst;

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -693,8 +693,8 @@ static auto GetMaskFunction()
 static const auto MaskFunc = GetMaskFunction();
 
 void MaskFn(
-    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
-    int32_t maskWrap, int32_t colourWrap, int32_t dstWrap)
+    uint32_t width, uint32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
+    uint32_t maskWrap, uint32_t colourWrap, uint32_t dstWrap)
 {
     MaskFunc(width, height, maskSrc, colourSrc, dst, maskWrap, colourWrap, dstWrap);
 }

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -627,18 +627,18 @@ ImageId ScrollingTextSetup(
 size_t G1CalculateDataSize(const G1Element* g1);
 
 void MaskScalar(
-    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
-    int32_t maskWrap, int32_t colourWrap, int32_t dstWrap);
+    uint32_t width, uint32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
+    uint32_t maskWrap, uint32_t colourWrap, uint32_t dstWrap);
 void MaskSse4_1(
-    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
-    int32_t maskWrap, int32_t colourWrap, int32_t dstWrap);
+    uint32_t width, uint32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
+    uint32_t maskWrap, uint32_t colourWrap, uint32_t dstWrap);
 void MaskAvx2(
-    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
-    int32_t maskWrap, int32_t colourWrap, int32_t dstWrap);
+    uint32_t width, uint32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
+    uint32_t maskWrap, uint32_t colourWrap, uint32_t dstWrap);
 
 void MaskFn(
-    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
-    int32_t maskWrap, int32_t colourWrap, int32_t dstWrap);
+    uint32_t width, uint32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
+    uint32_t maskWrap, uint32_t colourWrap, uint32_t dstWrap);
 
 std::optional<uint32_t> GetPaletteG1Index(colour_t paletteId);
 std::optional<PaletteMap> GetPaletteMapForColour(colour_t paletteId);

--- a/src/openrct2/drawing/SSE41Drawing.cpp
+++ b/src/openrct2/drawing/SSE41Drawing.cpp
@@ -15,17 +15,17 @@
     #include <immintrin.h>
 
 void MaskSse4_1(
-    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
-    int32_t maskWrap, int32_t colourWrap, int32_t dstWrap)
+    uint32_t width, uint32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
+    uint32_t maskWrap, uint32_t colourWrap, uint32_t dstWrap)
 {
     if (width == 32)
     {
         const __m128i zero128 = {};
-        for (int32_t yy = 0; yy < height; yy++)
+        for (uint32_t yy = 0; yy < height; yy++)
         {
-            int32_t colourStep = yy * (colourWrap + 32);
-            int32_t maskStep = yy * (maskWrap + 32);
-            int32_t dstStep = yy * (dstWrap + 32);
+            uint32_t colourStep = yy * (colourWrap + 32);
+            uint32_t maskStep = yy * (maskWrap + 32);
+            uint32_t dstStep = yy * (dstWrap + 32);
 
             // first half
             const __m128i colour1 = _mm_lddqu_si128(reinterpret_cast<const __m128i*>(colourSrc + colourStep));
@@ -62,8 +62,8 @@ void MaskSse4_1(
     #endif
 
 void MaskSse4_1(
-    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
-    int32_t maskWrap, int32_t colourWrap, int32_t dstWrap)
+    uint32_t width, uint32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
+    uint32_t maskWrap, uint32_t colourWrap, uint32_t dstWrap)
 {
     OpenRCT2::Guard::Fail("SSE 4.1 function called on a CPU that doesn't support SSE 4.1");
 }


### PR DESCRIPTION
Inspired by the [experiences of the folks over at Rust's `png` crate](https://github.com/image-rs/image-png/pull/512), I tried to get modern compilers to autovectorize the `MaskScalar` function, by basically just copying what the current SIMD versions are doing.

This is a win for [ARM](https://gcc.godbolt.org/z/fb8GhzP45) and [older, non SSE 4.1 AMD64](https://gcc.godbolt.org/z/c8PxrW6v8), but it should also help with other architectures: V extension RISC-V vectorizes, but I can't speak to the quality of the generated code.

Compiling with `-O3` or `-ftree-vectorize` also [generates vectorized code](https://gcc.godbolt.org/z/YrW93Gfd3) for other `width`s.

I'm not sure how to benchmark this though.