### PR TITLE
Benchgfx 202412

### DIFF
--- a/src/openrct2/command_line/BenchGfxCommmands.cpp
+++ b/src/openrct2/command_line/BenchGfxCommmands.cpp
@@ -1,0 +1,30 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2023 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "../interface/Screenshot.h"
+#include "CommandLine.hpp"
+
+static exitcode_t HandleBenchGfx(CommandLineArgEnumerator* argEnumerator);
+
+const CommandLineCommand CommandLine::BenchGfxCommands[]{
+    // Main commands
+    DefineCommand("", "<file> [iterations count]", nullptr, HandleBenchGfx), CommandTableEnd
+};
+
+static exitcode_t HandleBenchGfx(CommandLineArgEnumerator* argEnumerator)
+{
+    const char** argv = const_cast<const char**>(argEnumerator->GetArguments()) + argEnumerator->GetIndex();
+    int32_t argc = argEnumerator->GetCount() - argEnumerator->GetIndex();
+    int32_t result = CommandLineForGfxbench(argv, argc);
+    if (result < 0)
+    {
+        return EXITCODE_FAIL;
+    }
+    return EXITCODE_OK;
+}

--- a/src/openrct2/command_line/BenchGfxCommmands.cpp
+++ b/src/openrct2/command_line/BenchGfxCommmands.cpp
@@ -10,11 +10,13 @@
 #include "../interface/Screenshot.h"
 #include "CommandLine.hpp"
 
+using namespace OpenRCT2;
+
 static exitcode_t HandleBenchGfx(CommandLineArgEnumerator* argEnumerator);
 
 const CommandLineCommand CommandLine::BenchGfxCommands[]{
     // Main commands
-    DefineCommand("", "<file> [iterations count]", nullptr, HandleBenchGfx), CommandTableEnd
+    DefineCommand("", "<file> [iterations count]", nullptr, HandleBenchGfx), kCommandTableEnd
 };
 
 static exitcode_t HandleBenchGfx(CommandLineArgEnumerator* argEnumerator)

--- a/src/openrct2/command_line/CommandLine.hpp
+++ b/src/openrct2/command_line/CommandLine.hpp
@@ -110,6 +110,7 @@ namespace OpenRCT2::CommandLine
     extern const CommandLineCommand RootCommands[];
     extern const CommandLineCommand ScreenshotCommands[];
     extern const CommandLineCommand SpriteCommands[];
+    extern const CommandLineCommand BenchGfxCommands[];
     extern const CommandLineCommand SimulateCommands[];
     extern const CommandLineCommand ParkInfoCommands[];
 

--- a/src/openrct2/command_line/RootCommands.cpp
+++ b/src/openrct2/command_line/RootCommands.cpp
@@ -144,6 +144,7 @@ const CommandLineCommand CommandLine::RootCommands[]
     // Sub-commands
     DefineSubCommand("screenshot",      CommandLine::ScreenshotCommands       ),
     DefineSubCommand("sprite",          CommandLine::SpriteCommands           ),
+    DefineSubCommand("benchgfx",        CommandLine::BenchGfxCommands         ),
     DefineSubCommand("simulate",        CommandLine::SimulateCommands         ),
     DefineSubCommand("parkinfo",        CommandLine::ParkInfoCommands         ),
     kCommandTableEnd

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -387,7 +387,6 @@ static void BenchgfxRenderScreenshots(const char* inputPath, std::unique_ptr<ICo
         return;
     }
 
-    gIntroState = IntroState::None;
     gScreenFlags = SCREEN_FLAGS_PLAYING;
 
     // Create Viewport and DPI for every rotation and zoom.
@@ -441,9 +440,6 @@ static void BenchgfxRenderScreenshots(const char* inputPath, std::unique_ptr<ICo
         }
 
         const double average = totalTime / static_cast<double>(totalRenderCount);
-        const auto engineStringId = DrawingEngineStringIds[EnumValue(DrawingEngine::Software)];
-        const auto engineName = FormatStringID(engineStringId, nullptr);
-        std::printf("Engine: %s\n", engineName.c_str());
         std::printf("Render Count: %u\n", totalRenderCount);
         for (ZoomLevel zoom{ 0 }; zoom < ZoomLevel::max(); zoom++)
         {

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -371,6 +371,129 @@ void ScreenshotGiant()
     ReleaseDPI(dpi);
 }
 
+// TODO: Move this at some point into a more appropriate place.
+template<typename FN> static inline double MeasureFunctionTime(const FN& fn)
+{
+    const auto startTime = std::chrono::high_resolution_clock::now();
+    fn();
+    const auto endTime = std::chrono::high_resolution_clock::now();
+    return std::chrono::duration<double>(endTime - startTime).count();
+}
+
+static void BenchgfxRenderScreenshots(const char* inputPath, std::unique_ptr<IContext>& context, uint32_t iterationCount)
+{
+    if (!context->LoadParkFromFile(inputPath))
+    {
+        return;
+    }
+
+    gIntroState = IntroState::None;
+    gScreenFlags = SCREEN_FLAGS_PLAYING;
+
+    // Create Viewport and DPI for every rotation and zoom.
+    // We iterate from the default zoom level to the max zoomed out zoom level, then run GetGiantViewport once for each
+    // rotation.
+    constexpr int32_t NUM_ROTATIONS = 4;
+    constexpr auto NUM_ZOOM_LEVELS = static_cast<int8_t>(ZoomLevel::max());
+    std::array<DrawPixelInfo, NUM_ROTATIONS * NUM_ZOOM_LEVELS> dpis;
+    std::array<Viewport, NUM_ROTATIONS * NUM_ZOOM_LEVELS> viewports;
+
+    for (ZoomLevel zoom{ 0 }; zoom < ZoomLevel::max(); zoom++)
+    {
+        int32_t zoomIndex{ static_cast<int8_t>(zoom) };
+        for (int32_t rotation = 0; rotation < NUM_ROTATIONS; rotation++)
+        {
+            auto& viewport = viewports[zoomIndex * NUM_ZOOM_LEVELS + rotation];
+            auto& dpi = dpis[zoomIndex * NUM_ZOOM_LEVELS + rotation];
+            viewport = GetGiantViewport(rotation, zoom);
+            dpi = CreateDPI(viewport);
+        }
+    }
+
+    const uint32_t totalRenderCount = iterationCount * NUM_ROTATIONS * NUM_ZOOM_LEVELS;
+
+    try
+    {
+        double totalTime = 0.0;
+
+        std::array<double, NUM_ZOOM_LEVELS> zoomAverages;
+
+        // Render at every zoom.
+        for (int32_t zoom = 0; zoom < NUM_ZOOM_LEVELS; zoom++)
+        {
+            double zoomLevelTime = 0.0;
+
+            // Render at every rotation.
+            for (int32_t rotation = 0; rotation < NUM_ROTATIONS; rotation++)
+            {
+                // N iterations.
+                for (uint32_t i = 0; i < iterationCount; i++)
+                {
+                    auto& dpi = dpis[zoom * NUM_ZOOM_LEVELS + rotation];
+                    auto& viewport = viewports[zoom * NUM_ZOOM_LEVELS + rotation];
+                    double elapsed = MeasureFunctionTime([&viewport, &dpi]() { RenderViewport(nullptr, viewport, dpi); });
+                    totalTime += elapsed;
+                    zoomLevelTime += elapsed;
+                }
+            }
+
+            zoomAverages[zoom] = zoomLevelTime / static_cast<double>(NUM_ROTATIONS * iterationCount);
+        }
+
+        const double average = totalTime / static_cast<double>(totalRenderCount);
+        const auto engineStringId = DrawingEngineStringIds[EnumValue(DrawingEngine::Software)];
+        const auto engineName = FormatStringID(engineStringId, nullptr);
+        std::printf("Engine: %s\n", engineName.c_str());
+        std::printf("Render Count: %u\n", totalRenderCount);
+        for (ZoomLevel zoom{ 0 }; zoom < ZoomLevel::max(); zoom++)
+        {
+            int32_t zoomIndex{ static_cast<int8_t>(zoom) };
+            const auto zoomAverage = zoomAverages[zoomIndex];
+            std::printf("Zoom[%d] average: %.06fs, %.f FPS\n", zoomIndex, zoomAverage, 1.0 / zoomAverage);
+        }
+        std::printf("Total average: %.06fs, %.f FPS\n", average, 1.0 / average);
+        std::printf("Time: %.05fs\n", totalTime);
+    }
+    catch (const std::exception& e)
+    {
+        Console::Error::WriteLine("%s", e.what());
+    }
+
+    for (auto& dpi : dpis)
+        ReleaseDPI(dpi);
+}
+
+int32_t CommandLineForGfxbench(const char** argv, int32_t argc)
+{
+    if (argc != 1 && argc != 2)
+    {
+        printf("Usage: openrct2 benchgfx <file> [<iteration_count>]\n");
+        return -1;
+    }
+
+    int32_t iterationCount = 5;
+    if (argc == 2)
+    {
+        iterationCount = atoi(argv[1]);
+    }
+
+    const char* inputPath = argv[0];
+
+    gOpenRCT2Headless = true;
+
+    std::unique_ptr<IContext> context(CreateContext());
+    if (context->Initialise())
+    {
+        DrawingEngineInit();
+
+        BenchgfxRenderScreenshots(inputPath, context, iterationCount);
+
+        DrawingEngineDispose();
+    }
+
+    return 1;
+}
+
 static void ApplyOptions(const ScreenshotOptions* options, Viewport& viewport)
 {
     if (options->weather != WeatherType::Sunny && options->weather != WeatherType::Count)

--- a/src/openrct2/interface/Screenshot.h
+++ b/src/openrct2/interface/Screenshot.h
@@ -57,5 +57,6 @@ std::string ScreenshotDumpPNG(DrawPixelInfo& dpi);
 
 void ScreenshotGiant();
 int32_t CommandLineForScreenshot(const char** argv, int32_t argc, ScreenshotOptions* options);
+int32_t CommandLineForGfxbench(const char** argv, int32_t argc);
 
 void CaptureImage(const CaptureOptions& options);

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -736,6 +736,7 @@
     <ClCompile Include="audio\DummyAudioContext.cpp" />
     <ClCompile Include="Cheats.cpp" />
     <ClCompile Include="CommandLineSprite.cpp" />
+    <ClCompile Include="command_line\BenchGfxCommmands.cpp" />
     <ClCompile Include="command_line\CommandLine.cpp" />
     <ClCompile Include="command_line\ConvertCommand.cpp" />
     <ClCompile Include="command_line\ParkInfoCommands.cpp" />


### PR DESCRIPTION
This restores compilation of benchgfx for 0.4.17. Brought back for some testing of possible improvements to rendering code.