### PR TITLE
Reset all peep sprite bounds at save file import time

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Improved: [#23404] Folders are now paired with an icon in the load/save window.
 - Fix: [#23286] Currency formatted incorrectly in the in game console.
 - Fix: [#23348] Console set commands don't print output properly.
+- Fix: [#23376] Peeps with balloons, hats and umbrellas may leave artifacts on screen.
 
 0.4.17 (2024-12-08)
 ------------------------------------------------------------------------

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -337,6 +337,9 @@ void GameFixSaveVars()
     UpdateConsolidatedPatrolAreas();
 
     MapCountRemainingLandRights();
+
+    // Update sprite bounds, rather than relying on stored data
+    PeepUpdateAllBoundingBoxes();
 }
 
 void GameLoadInit()

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -353,19 +353,17 @@ void Peep::UpdateCurrentAnimationType()
 
     AnimationType = newAnimationType;
 
+    Invalidate();
     UpdateSpriteBoundingBox();
+    Invalidate();
 }
 
 void Peep::UpdateSpriteBoundingBox()
 {
-    Invalidate();
-
-    const SpriteBounds* spriteBounds = &GetSpriteBounds(AnimationGroup, AnimationType);
-    SpriteData.Width = spriteBounds->sprite_width;
-    SpriteData.HeightMin = spriteBounds->sprite_height_negative;
-    SpriteData.HeightMax = spriteBounds->sprite_height_positive;
-
-    Invalidate();
+    const& auto spriteBounds = GetSpriteBounds(AnimationGroup, AnimationType);
+    SpriteData.Width = spriteBounds.sprite_width;
+    SpriteData.HeightMin = spriteBounds.sprite_height_negative;
+    SpriteData.HeightMax = spriteBounds.sprite_height_positive;
 }
 
 /* rct2: 0x00693BE5 */

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -244,6 +244,19 @@ void PeepUpdateAll()
     }
 }
 
+void PeepUpdateAllBoundingBoxes()
+{
+    for (auto* peep : EntityList<Guest>())
+    {
+        peep->UpdateSpriteBoundingBox();
+    }
+
+    for (auto* peep : EntityList<Staff>())
+    {
+        peep->UpdateSpriteBoundingBox();
+    }
+}
+
 /*
  * rct2: 0x68F3AE
  * Set peep state to falling if path below has gone missing, return true if current path is valid, false if peep starts falling.
@@ -360,7 +373,7 @@ void Peep::UpdateCurrentAnimationType()
 
 void Peep::UpdateSpriteBoundingBox()
 {
-    const& auto spriteBounds = GetSpriteBounds(AnimationGroup, AnimationType);
+    const auto& spriteBounds = GetSpriteBounds(AnimationGroup, AnimationType);
     SpriteData.Width = spriteBounds.sprite_width;
     SpriteData.HeightMin = spriteBounds.sprite_height_negative;
     SpriteData.HeightMax = spriteBounds.sprite_height_positive;

--- a/src/openrct2/entity/Peep.h
+++ b/src/openrct2/entity/Peep.h
@@ -436,6 +436,7 @@ extern const bool gAnimationGroupToSlowWalkMap[48];
 
 int32_t PeepGetStaffCount();
 void PeepUpdateAll();
+void PeepUpdateAllBoundingBoxes();
 void PeepProblemWarningsUpdate();
 void PeepStopCrowdNoise();
 void PeepUpdateCrowdNoise();

--- a/src/openrct2/peep/PeepAnimationData.cpp
+++ b/src/openrct2/peep/PeepAnimationData.cpp
@@ -999,6 +999,15 @@ namespace OpenRCT2
                     continue;
 
                 anim.bounds = inferMaxAnimationDimensions(anim);
+
+                // Balloons, hats and umbrellas are painted separately, so the inference
+                // algorithm doesn't account for those. We manually compensate for these here.
+                // Between 8-12 pixels are needed, depending on rotation, so we're generalising.
+                auto pag = PeepAnimationGroup(groupKey);
+                if (pag == PeepAnimationGroup::Balloon || pag == PeepAnimationGroup::Hat || pag == PeepAnimationGroup::Umbrella)
+                {
+                    anim.bounds.sprite_height_negative += 12;
+                }
             }
         }
     }

--- a/src/openrct2/scripting/bindings/entity/ScGuest.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.cpp
@@ -923,7 +923,9 @@ namespace OpenRCT2::Scripting
 
         const auto& animationGroup = GetPeepAnimation(peep->AnimationGroup, peep->AnimationType);
         peep->AnimationImageIdOffset = animationGroup.frame_offsets[offset];
+        peep->Invalidate();
         peep->UpdateSpriteBoundingBox();
+        peep->Invalidate();
     }
 
     uint8_t ScGuest::animationOffset_get() const

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -354,7 +354,9 @@ namespace OpenRCT2::Scripting
 
         auto& animationGroup = GetPeepAnimation(peep->AnimationGroup, peep->AnimationType);
         peep->AnimationImageIdOffset = animationGroup.frame_offsets[offset];
+        peep->Invalidate();
         peep->UpdateSpriteBoundingBox();
+        peep->Invalidate();
     }
 
     uint8_t ScStaff::animationOffset_get() const
@@ -387,7 +389,9 @@ namespace OpenRCT2::Scripting
             peep->AnimationFrameNum = offset;
 
         peep->AnimationImageIdOffset = animationGroup.frame_offsets[offset];
+        peep->Invalidate();
         peep->UpdateSpriteBoundingBox();
+        peep->Invalidate();
     }
 
     uint8_t ScStaff::animationLength_get() const


### PR DESCRIPTION
This changes the S4/S6/park import logic to reset all peep sprite bounds at save file import time, rather than relying on bounds saved in the save file. Graphics aren't available when running the game headlessly, as is the case with most multiplayer servers, making the sprite bounds saved unreliable. I've opted not to change the entity serialising logic at this time; we're now just ignoring them for peeps as well.

In addition, we now compensate inferred sprite bounds for balloon/hat/umbrella sprites. As these items are painted in a second pass, they were previously not accounted for. This led to issues such as #23376. NB: this is not the case with other food items, which _are_ part of the peep sprites.

Fixes #23376