### PR TITLE
fix g2.dat path on win arm64 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: g2-${{ needs.build_variables.outputs.name }}.dat
-          path: bin/data/g2.dat
+          path: bin/data
       - name: Build artifacts
         run: |
           . scripts/setenv -q


### PR DESCRIPTION
The windows arm64 releases for 0.4.17 (installer, portable) have g2.dat nested one level too far: e.g. `OpenRCT2-v0.4.17-windows-portable-arm64.zip\data\g2.dat\g2.dat` which causes the game to be unable to find them on launch. This PR should fix the github actions workflow to correctly path the file.