### PR TITLE
Make ride preview window larger

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -280,9 +280,9 @@ namespace OpenRCT2::Ui::Windows
         MakeWidget        ({  7,  50}, {302, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                    ),
         MakeWidget        ({297,  51}, { 11, 10}, WindowWidgetType::Button,   WindowColour::Secondary, STR_DROPDOWN_GLYPH                                ),
         MakeWidget        ({  7, 137}, {302, 12}, WindowWidgetType::Checkbox, WindowColour::Secondary, STR_OPTION_REVERSE_TRAINS, STR_OPTION_REVERSE_TRAINS_TIP  ),
-        MakeWidget        ({  7, 154}, {302, 43}, WindowWidgetType::Scroll,   WindowColour::Secondary, STR_EMPTY                                         ),
-        MakeSpinnerWidgets({  7, 203}, {145, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_RIDE_VEHICLE_COUNT, STR_MAX_VEHICLES_TIP      ),
-        MakeSpinnerWidgets({164, 203}, {145, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_1_CAR_PER_TRAIN,    STR_MAX_CARS_PER_TRAIN_TIP),
+        MakeWidget        ({  7, 162}, {302, 178}, WindowWidgetType::Scroll,   WindowColour::Secondary, STR_EMPTY                                         ),
+        MakeSpinnerWidgets({  7, 344}, {145, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_RIDE_VEHICLE_COUNT, STR_MAX_VEHICLES_TIP      ),
+        MakeSpinnerWidgets({164, 344}, {145, 12}, WindowWidgetType::Spinner,  WindowColour::Secondary, STR_1_CAR_PER_TRAIN,    STR_MAX_CARS_PER_TRAIN_TIP),
         kWidgetsEnd,
     };
 


### PR DESCRIPTION
does not make it scrollable. may or may not fix https://github.com/OpenRCT2/OpenRCT2/issues/21416 because the rides are still cut off
before:
![305561661-e20883e2-670a-4dca-9857-25b4b18ffd41](https://github.com/user-attachments/assets/f743250f-c9f6-4445-b703-e22b02c185ec)

after:
![e](https://github.com/user-attachments/assets/e672131b-8dbf-4d1a-bb08-661215908208)

I marked it as draft because I would like the sprites to be centered and not cut off on the bottom
several rides are still cut off:
![qt](https://github.com/user-attachments/assets/a04ad4c7-8570-4634-82d2-3ebd42a9194f)
