### PR TITLE
Fix in game console incorrectly handling formatting tokens.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Improved: [#23350] Increased the maximum width of the ride graph window.
 - Improved: [#23404] Folders are now paired with an icon in the load/save window.
 - Change: [#23413] The max number of park entrance objects has been raised to 255.
+- Fix: [#22742, #22793] In game console does not handle format tokens properly.
 - Fix: [#23286] Currency formatted incorrectly in the in game console.
 - Fix: [#23348] Console set commands don't print output properly.
 - Fix: [#23376] Peeps with balloons, hats and umbrellas may leave artifacts on screen.

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -72,7 +72,7 @@ void InGameConsole::Input(ConsoleInput input)
                 HistoryAdd(_consoleCurrentLine);
 
                 // Append text we are executing to prompt line
-                _consoleLines.back().append(_consoleCurrentLine);
+                _consoleLines.back().first.append(_consoleCurrentLine);
 
                 Execute(_consoleCurrentLine);
                 if (IsExecuting())
@@ -231,12 +231,6 @@ void InGameConsole::Toggle()
 
 void InGameConsole::WriteLine(const std::string& input, FormatToken colourFormat)
 {
-    // Include text colour format only for special cases
-    // The draw function handles the default text colour differently
-    std::string colourCodepoint = "";
-    if (colourFormat != FormatToken::ColourWindow2)
-        colourCodepoint = FormatTokenToStringWithBraces(colourFormat);
-
     std::string line;
     std::size_t splitPos = 0;
     std::size_t stringOffset = 0;
@@ -244,7 +238,7 @@ void InGameConsole::WriteLine(const std::string& input, FormatToken colourFormat
     {
         splitPos = input.find('\n', stringOffset);
         line = input.substr(stringOffset, splitPos - stringOffset);
-        _consoleLines.emplace_back(colourCodepoint + line);
+        _consoleLines.emplace_back(line, colourFormat);
         stringOffset = splitPos + 1;
     }
 
@@ -301,17 +295,9 @@ void InGameConsole::Draw(DrawPixelInfo& dpi) const
 
     // Set font
     ColourWithFlags textColour = { ThemeGetColour(WindowClass::Console, 1).colour, 0 };
+    const FontStyle style = InGameConsoleGetFontStyle();
     const int32_t lineHeight = InGameConsoleGetLineHeight();
     const int32_t maxLines = GetNumVisibleLines();
-
-    // This is something of a hack to ensure the text is actually black
-    // as opposed to a desaturated grey
-    thread_local std::string _colourFormatStr;
-    _colourFormatStr.clear();
-    if (textColour.colour == COLOUR_BLACK)
-    {
-        _colourFormatStr = "{BLACK}";
-    }
 
     // TTF looks far better without the outlines
     if (!LocalisationService_UseTrueTypeFont())
@@ -343,16 +329,42 @@ void InGameConsole::Draw(DrawPixelInfo& dpi) const
     for (std::size_t i = 0; i < _consoleLines.size() && i < static_cast<size_t>(maxLines); i++)
     {
         const size_t index = i + _consoleScrollPos;
-        lineBuffer = _colourFormatStr + _consoleLines[index];
-        DrawText(dpi, screenCoords, { textColour, InGameConsoleGetFontStyle() }, lineBuffer.c_str());
+        if (_consoleLines[index].second == FormatToken::ColourWindow2)
+        {
+            // This is something of a hack to ensure the text is actually black
+            // as opposed to a desaturated grey
+            if (textColour.colour == COLOUR_BLACK)
+            {
+                DrawText(dpi, screenCoords, { textColour, style }, "{BLACK}");
+                DrawText(dpi, screenCoords, { kTextColour255, style }, _consoleLines[index].first.c_str(), true);
+            }
+            else
+            {
+                DrawText(dpi, screenCoords, { textColour, style }, _consoleLines[index].first.c_str(), true);
+            }
+        }
+        else
+        {
+            std::string lineColour = FormatTokenToStringWithBraces(_consoleLines[index].second);
+            DrawText(dpi, screenCoords, { textColour, style }, lineColour.c_str());
+            DrawText(dpi, screenCoords, { kTextColour255, style }, _consoleLines[index].first.c_str(), true);
+        }
+
         screenCoords.y += lineHeight;
     }
 
     screenCoords.y = _consoleBottomRight.y - lineHeight - CONSOLE_EDGE_PADDING - 1;
 
     // Draw current line
-    lineBuffer = _colourFormatStr + _consoleCurrentLine;
-    DrawText(dpi, screenCoords, { kTextColour255, InGameConsoleGetFontStyle() }, lineBuffer.c_str(), true);
+    if (textColour.colour == COLOUR_BLACK)
+    {
+        DrawText(dpi, screenCoords, { textColour, style }, "{BLACK}");
+        DrawText(dpi, screenCoords, { kTextColour255, style }, _consoleCurrentLine.c_str(), true);
+    }
+    else
+    {
+        DrawText(dpi, screenCoords, { textColour, style }, _consoleCurrentLine.c_str(), true);
+    }
 
     // Draw caret
     if (_consoleCaretTicks < CONSOLE_CARET_FLASH_THRESHOLD)

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -233,9 +233,9 @@ void InGameConsole::WriteLine(const std::string& input, FormatToken colourFormat
 {
     // Include text colour format only for special cases
     // The draw function handles the default text colour differently
-    auto colourCodepoint = "";
+    std::string colourCodepoint = "";
     if (colourFormat != FormatToken::ColourWindow2)
-        colourCodepoint = "{WINDOW_COLOUR_2}";
+        colourCodepoint = FormatTokenToStringWithBraces(colourFormat);
 
     std::string line;
     std::size_t splitPos = 0;

--- a/src/openrct2-ui/interface/InGameConsole.h
+++ b/src/openrct2-ui/interface/InGameConsole.h
@@ -35,7 +35,7 @@ namespace OpenRCT2::Ui
         ScreenCoordsXY _consoleBottomRight;
         ScreenCoordsXY _lastMainViewport;
 
-        std::vector<std::string> _consoleLines;
+        std::vector<std::pair<std::string, FormatToken>> _consoleLines;
         u8string _consoleCurrentLine;
 
         int32_t _consoleCaretTicks;


### PR DESCRIPTION
Fixes #22793 and #22742.

Fixes the issue of fomatting tokens being injected into text in the in game console.
Now we run `DrawText` once with a formatting token to set colours as necessary, and then we run it again with formatting turned off to print the actual text.
