### PR TITLE
Fix #1122: Trains can spawn on cable lift hill

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Improved: [#23404] Folders are now paired with an icon in the load/save window.
 - Improved: [#23431] Opaque water and Corkscrew Roller Coaster boosters now show up if RCT1 isn’t linked. 
 - Change: [#23413] The max number of park entrance objects has been raised to 255.
+- Fix: [#1122] Trains spawned on a cable lift hill will fall down and crash (original bug).
 - Fix: [#22742, #22793] In game console does not handle format tokens properly.
 - Fix: [#23286] Currency formatted incorrectly in the in game console.
 - Fix: [#23348] Console set commands don't print output properly.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -50,7 +50,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kNetworkStreamVersion = 2;
+constexpr uint8_t kNetworkStreamVersion = 3;
 
 const std::string kNetworkStreamID = std::string(OPENRCT2_VERSION) + "-" + std::to_string(kNetworkStreamVersion);
 

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -523,6 +523,58 @@ void TrackGetFront(const CoordsXYE& input, CoordsXYE* output)
     *output = lastTrack;
 }
 
+TrackElement* TrackGetPreviousBlock(CoordsXYZ& location, TileElement* tileElement)
+{
+    CoordsXYZ startLocation = location;
+    TrackBeginEnd trackBeginEnd, slowTrackBeginEnd;
+    TileElement slowTileElement = *tileElement;
+    bool counter = true;
+    CoordsXY slowLocation = location;
+    do
+    {
+        if (!TrackBlockGetPrevious({ location, tileElement }, &trackBeginEnd))
+        {
+            return nullptr;
+        }
+        if (trackBeginEnd.begin_x == startLocation.x && trackBeginEnd.begin_y == startLocation.y
+            && tileElement == trackBeginEnd.begin_element)
+        {
+            return nullptr;
+        }
+
+        location.x = trackBeginEnd.end_x;
+        location.y = trackBeginEnd.end_y;
+        location.z = trackBeginEnd.begin_z;
+        tileElement = trackBeginEnd.begin_element;
+
+        // #2081: prevent infinite loop
+        counter = !counter;
+        if (counter)
+        {
+            TrackBlockGetPrevious({ slowLocation, &slowTileElement }, &slowTrackBeginEnd);
+            slowLocation.x = slowTrackBeginEnd.end_x;
+            slowLocation.y = slowTrackBeginEnd.end_y;
+            slowTileElement = *(slowTrackBeginEnd.begin_element);
+            if (slowLocation == location && slowTileElement.GetBaseZ() == tileElement->GetBaseZ()
+                && slowTileElement.GetType() == tileElement->GetType()
+                && slowTileElement.GetDirection() == tileElement->GetDirection())
+            {
+                return nullptr;
+            }
+        }
+    } while (!(trackBeginEnd.begin_element->AsTrack()->IsBlockStart()));
+
+    // Get the start of the track block instead of the end
+    location = { trackBeginEnd.begin_x, trackBeginEnd.begin_y, trackBeginEnd.begin_z };
+    auto trackOrigin = MapGetTrackElementAtOfTypeSeq(location, trackBeginEnd.begin_element->AsTrack()->GetTrackType(), 0);
+    if (trackOrigin == nullptr)
+    {
+        return nullptr;
+    }
+
+    return trackOrigin->AsTrack();
+}
+
 TrackRoll TrackGetActualBank(TileElement* tileElement, TrackRoll bank)
 {
     auto ride = GetRide(tileElement->AsTrack()->GetRideIndex());

--- a/src/openrct2/ride/Track.h
+++ b/src/openrct2/ride/Track.h
@@ -702,6 +702,8 @@ bool TrackCircuitIteratorsMatch(const TrackCircuitIterator* firstIt, const Track
 void TrackGetBack(const CoordsXYE& input, CoordsXYE* output);
 void TrackGetFront(const CoordsXYE& input, CoordsXYE* output);
 
+TrackElement* TrackGetPreviousBlock(CoordsXYZ& location, TileElement* tileElement);
+
 bool TrackElementIsCovered(OpenRCT2::TrackElemType trackElementType);
 OpenRCT2::TrackElemType UncoverTrackElement(OpenRCT2::TrackElemType trackElementType);
 bool TrackTypeIsStation(OpenRCT2::TrackElemType trackType);


### PR DESCRIPTION
Isolates just the fix for #1122 from #20683, so that it can be properly reviewed and tested.

Here is a save to easily test with. You can check if the bug is fixed by double closing the roller coaster and putting it back into test mode.

[FF-crashcablelift.park.zip](https://github.com/user-attachments/files/18222895/FF-crashcablelift.park.zip)


Do not squash merge, as it will overwrite the commit author.