### PR TITLE
Remove dead lines in Cmake Config

### DIFF
--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -9,10 +9,6 @@ endif ()
 file(GLOB_RECURSE OPENRCT2_CORE_SOURCES "${CMAKE_CURRENT_LIST_DIR}/*.cpp")
 file(GLOB_RECURSE OPENRCT2_CORE_HEADERS "${CMAKE_CURRENT_LIST_DIR}/*.h"
                                         "${CMAKE_CURRENT_LIST_DIR}/*.hpp")
-list(REMOVE_ITEM OPENRCT2_CORE_HEADERS
-    "${CMAKE_CURRENT_LIST_DIR}/thirdparty/filesystem.hpp"
-    "${CMAKE_CURRENT_LIST_DIR}/thirdparty/linenoise.hpp"
-)
 
 if (APPLE)
     file(GLOB_RECURSE OPENRCT2_CORE_MM_SOURCES "${CMAKE_CURRENT_LIST_DIR}/*.mm")


### PR DESCRIPTION
These files are in a parent directory and so are never picked up by the GLOB anyway. Appears to be old code that was never updated.