### PR TITLE
Add LoongArch architecture information

### DIFF
--- a/src/openrct2/Version.h
+++ b/src/openrct2/Version.h
@@ -34,6 +34,8 @@
     #define OPENRCT2_ARCHITECTURE "mips"
 #elif defined(__riscv)
     #define OPENRCT2_ARCHITECTURE "RISC-V"
+#elif defined(__loongarch__)
+    #define OPENRCT2_ARCHITECTURE "LoongArch"
 #endif
 #ifdef __EMSCRIPTEN__
     #define OPENRCT2_ARCHITECTURE "Emscripten"


### PR DESCRIPTION
Like #7966 , this PR adds the support of LoongArch platform.

[LoongArch](https://docs.kernel.org/arch/loongarch/introduction.html) is a new RISC ISA developed by loongson. There are already a lot of [community support and testing](https://www.phoronix.com/search/LoongArch) about it.

I have tested this PR in Arch Linux's port for loong64 and build process succeeded. Here is the [log](https://github.com/user-attachments/files/18244316/build-log-all.log).
