### PR TITLE
Prevent closing object selection window when selection is invalid

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Fix: [#23286] Currency formatted incorrectly in the in game console.
 - Fix: [#23348] Console set commands don't print output properly.
 - Fix: [#23376] Peeps with balloons, hats and umbrellas may leave artifacts on screen.
+- Fix: [#23486] Object selection minimum requirements can be bypassed with close window hotkey.
 
 0.4.17 (2024-12-08)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -300,6 +300,12 @@ namespace OpenRCT2::Ui::Windows
             VisibleListRefresh();
         }
 
+        bool CanClose() override
+        {
+            // Prevent window closure when selection is invalid
+            return EditorObjectSelectionWindowCheck();
+        }
+
         /**
          *
          * rct2: 0x006AB199

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -752,7 +752,7 @@ namespace OpenRCT2::Ui::Windows
             rideId = ride.id;
         }
 
-        virtual void OnOpen() override
+        void OnOpen() override
         {
             widgets = PageWidgets[WINDOW_RIDE_PAGE_MAIN];
             hold_down_widgets = PageHoldDownWidgets[WINDOW_RIDE_PAGE_MAIN];
@@ -778,7 +778,7 @@ namespace OpenRCT2::Ui::Windows
             PopulateVehicleTypeDropdown(*ride, true);
         }
 
-        virtual void OnClose() override
+        void OnClose() override
         {
             switch (page)
             {
@@ -790,7 +790,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
             }
         }
-        virtual void OnResize() override
+        void OnResize() override
         {
             switch (page)
             {
@@ -826,7 +826,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
             }
         }
-        virtual void OnUpdate() override
+        void OnUpdate() override
         {
             switch (page)
             {
@@ -863,7 +863,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        virtual void OnPrepareDraw() override
+        void OnPrepareDraw() override
         {
             switch (page)
             {
@@ -899,7 +899,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
             }
         }
-        virtual void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(DrawPixelInfo& dpi) override
         {
             switch (page)
             {
@@ -936,7 +936,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        virtual OpenRCT2String OnTooltip(WidgetIndex widgetIndex, StringId fallback) override
+        OpenRCT2String OnTooltip(WidgetIndex widgetIndex, StringId fallback) override
         {
             switch (page)
             {
@@ -947,7 +947,7 @@ namespace OpenRCT2::Ui::Windows
             }
             return { fallback, {} };
         }
-        virtual void OnMouseDown(WidgetIndex widgetIndex) override
+        void OnMouseDown(WidgetIndex widgetIndex) override
         {
             switch (page)
             {
@@ -980,7 +980,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
             }
         }
-        virtual void OnMouseUp(WidgetIndex widgetIndex) override
+        void OnMouseUp(WidgetIndex widgetIndex) override
         {
             switch (page)
             {
@@ -1016,7 +1016,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
             }
         }
-        virtual void OnDropdown(WidgetIndex widgetIndex, int32_t selectedIndex) override
+        void OnDropdown(WidgetIndex widgetIndex, int32_t selectedIndex) override
         {
             switch (page)
             {
@@ -1043,7 +1043,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
             }
         }
-        virtual void OnTextInput(WidgetIndex widgetIndex, std::string_view text) override
+        void OnTextInput(WidgetIndex widgetIndex, std::string_view text) override
         {
             switch (page)
             {
@@ -1058,7 +1058,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
             }
         }
-        virtual ScreenSize OnScrollGetSize(int32_t scrollIndex) override
+        ScreenSize OnScrollGetSize(int32_t scrollIndex) override
         {
             switch (page)
             {
@@ -1069,7 +1069,7 @@ namespace OpenRCT2::Ui::Windows
             }
             return {};
         }
-        virtual void OnScrollSelect(int32_t scrollIndex, int32_t scrollAreaType) override
+        void OnScrollSelect(int32_t scrollIndex, int32_t scrollAreaType) override
         {
             switch (page)
             {
@@ -1078,7 +1078,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
             }
         }
-        virtual void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
         {
             switch (page)
             {
@@ -1096,7 +1096,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
             }
         }
-        virtual void OnToolDown(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords) override
+        void OnToolDown(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords) override
         {
             switch (page)
             {
@@ -1108,7 +1108,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
             }
         }
-        virtual void OnToolDrag(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords) override
+        void OnToolDrag(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords) override
         {
             switch (page)
             {
@@ -1120,7 +1120,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
             }
         }
-        virtual void OnToolAbort(WidgetIndex widgetIndex) override
+        void OnToolAbort(WidgetIndex widgetIndex) override
         {
             switch (page)
             {
@@ -1129,7 +1129,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
             }
         }
-        virtual void OnViewportRotate() override
+        void OnViewportRotate() override
         {
             switch (page)
             {

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -227,6 +227,12 @@ void WindowSetWindowLimit(int32_t value)
  */
 void WindowClose(WindowBase& w)
 {
+    if (!w.CanClose())
+    {
+        // Something's preventing this window from closing -- bail out early
+        return;
+    }
+
     w.OnClose();
 
     // Remove viewport

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -85,6 +85,10 @@ struct WindowBase
     virtual void OnOpen()
     {
     }
+    virtual bool CanClose()
+    {
+        return true;
+    }
     virtual void OnClose()
     {
     }


### PR DESCRIPTION
This PR allows internal windows to prevent their own closure. This is achieved by changing the global signature for the window `OnClose` event from `void` to `bool`. Currently, all windows simply return `true` to allow their closure at all times. The one exception is the object selection window, which can now return `false` if the current selection is invalid.

Fixes #23486.