### PR TITLE
Fix #19780: Guest screams loop on long drops

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Improved: [#23431] Opaque water and Corkscrew Roller Coaster boosters now show up if RCT1 isn’t linked. 
 - Change: [#23413] The max number of park entrance objects has been raised to 255.
 - Fix: [#1122] Trains spawned on a cable lift hill will fall down and crash (original bug).
+- Fix: [#19780] Guest screams loop on long drops.
 - Fix: [#22742, #22793] In game console does not handle format tokens properly.
 - Fix: [#23135] Map generator tree placement has noticable patterns.
 - Fix: [#23286] Currency formatted incorrectly in the in game console.

--- a/src/openrct2-ui/ride/VehicleSounds.cpp
+++ b/src/openrct2-ui/ride/VehicleSounds.cpp
@@ -469,7 +469,7 @@ namespace OpenRCT2::Audio
         volume = volume / 8;
         volume = std::max(volume - 0x1FFF, -10000);
 
-        if (sound.Channel != nullptr && sound.Channel->IsDone())
+        if (sound.Channel != nullptr && sound.Channel->IsDone() && IsLoopingSound(sound.Id))
         {
             sound.Id = SoundId::Null;
             sound.Channel = nullptr;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1185,7 +1185,11 @@ struct SoundIdVolume
     uint8_t volume;
 };
 
-static SoundIdVolume Sub6D7AC0(
+/**
+ *
+ *  rct2: 0x006D7AC0
+ */
+static SoundIdVolume VehicleSoundFadeInOut(
     OpenRCT2::Audio::SoundId currentSoundId, uint8_t currentVolume, OpenRCT2::Audio::SoundId targetSoundId,
     uint8_t targetVolume)
 {
@@ -4919,12 +4923,12 @@ void Vehicle::UpdateSound()
     }
 
     // Friction sound
-    auto soundIdVolume = Sub6D7AC0(sound1_id, sound1_volume, frictionSound.id, frictionSound.volume);
+    auto soundIdVolume = VehicleSoundFadeInOut(sound1_id, sound1_volume, frictionSound.id, frictionSound.volume);
     sound1_id = soundIdVolume.id;
     sound1_volume = soundIdVolume.volume;
 
     // Scream sound
-    soundIdVolume = Sub6D7AC0(sound2_id, sound2_volume, screamSound.id, screamSound.volume);
+    soundIdVolume = VehicleSoundFadeInOut(sound2_id, sound2_volume, screamSound.id, screamSound.volume);
     sound2_id = soundIdVolume.id;
     sound2_volume = soundIdVolume.volume;
 


### PR DESCRIPTION
This PR changes the logic in `UpdateSound` in `openrct2-ui/ride/VehicleSounds.cpp` to only re-create sound channels that are done playing if the corresponding `SoundId` is marked as "looping" (as obtained via `IsLoopingSound`). (This is mostly the case for friction sounds.)

Sounds not marked as looping (mostly guest screams) will thus not be automatically replayed, unless the condition that triggered them (as defined in `UpdateScreamSound` in `openrct2/ride/Vehicle.cpp`) becomes false and then true again.

Closes #19780 