### PR TITLE
Use std::chrono for easier to read durations

### DIFF
--- a/src/openrct2/Version.cpp
+++ b/src/openrct2/Version.cpp
@@ -64,7 +64,9 @@ NewVersionInfo GetLatestVersion()
 #ifndef DISABLE_HTTP
     auto now = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
     auto then = Config::Get().general.LastVersionCheckTime;
-    if (then < now - 24 * 60 * 60)
+    using namespace std::chrono_literals;
+
+    if (then < now - std::chrono::seconds(24h).count())
     {
         Http::Request request;
         request.url = "https://api.github.com/repos/OpenRCT2/OpenRCT2/releases/latest";

--- a/src/openrct2/core/FileWatcher.cpp
+++ b/src/openrct2/core/FileWatcher.cpp
@@ -17,6 +17,7 @@
 #ifdef _WIN32
     #include <windows.h>
 #elif defined(__linux__)
+    #include <chrono>
     #include <fcntl.h>
     #include <sys/inotify.h>
     #include <sys/types.h>
@@ -251,7 +252,8 @@ void FileWatcher::WatchDirectory()
         }
 
         // Sleep for 1/2 second
-        usleep(500000);
+        using namespace std::chrono_literals;
+        usleep(std::chrono::microseconds(1s).count() / 2);
     }
 #elif defined(__APPLE__)
     if (_stream)

--- a/src/openrct2/network/NetworkServerAdvertiser.cpp
+++ b/src/openrct2/network/NetworkServerAdvertiser.cpp
@@ -28,6 +28,7 @@
     #include "Socket.h"
     #include "network.h"
 
+    #include <chrono>
     #include <cstring>
     #include <iterator>
     #include <memory>
@@ -45,8 +46,9 @@ enum class MasterServerStatus
 };
 
     #ifndef DISABLE_HTTP
-constexpr int32_t kMasterServerRegisterTime = 120 * 1000; // 2 minutes
-constexpr int32_t kMasterServerHeartbeatTime = 60 * 1000; // 1 minute
+using namespace std::chrono_literals;
+constexpr int32_t kMasterServerRegisterTime = std::chrono::milliseconds(2min).count();
+constexpr int32_t kMasterServerHeartbeatTime = std::chrono::milliseconds(1min).count();
     #endif
 
 class NetworkServerAdvertiser final : public INetworkServerAdvertiser

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -64,6 +64,8 @@
 #include "ScenarioRepository.h"
 #include "ScenarioSources.h"
 
+#include <chrono>
+
 using namespace OpenRCT2;
 
 const StringId ScenarioCategoryStringIds[SCENARIO_CATEGORY_COUNT] = {
@@ -254,22 +256,24 @@ void ScenarioAutosaveCheck()
     uint32_t timeSinceSave = Platform::GetTicks() - gLastAutoSaveUpdate;
 
     bool shouldSave = false;
+    using namespace std::chrono_literals;
+
     switch (Config::Get().general.AutosaveFrequency)
     {
         case AUTOSAVE_EVERY_MINUTE:
-            shouldSave = timeSinceSave >= 1 * 60 * 1000;
+            shouldSave = timeSinceSave >= std::chrono::milliseconds(1min).count();
             break;
         case AUTOSAVE_EVERY_5MINUTES:
-            shouldSave = timeSinceSave >= 5 * 60 * 1000;
+            shouldSave = timeSinceSave >= std::chrono::milliseconds(5min).count();
             break;
         case AUTOSAVE_EVERY_15MINUTES:
-            shouldSave = timeSinceSave >= 15 * 60 * 1000;
+            shouldSave = timeSinceSave >= std::chrono::milliseconds(15min).count();
             break;
         case AUTOSAVE_EVERY_30MINUTES:
-            shouldSave = timeSinceSave >= 30 * 60 * 1000;
+            shouldSave = timeSinceSave >= std::chrono::milliseconds(30min).count();
             break;
         case AUTOSAVE_EVERY_HOUR:
-            shouldSave = timeSinceSave >= 60 * 60 * 1000;
+            shouldSave = timeSinceSave >= std::chrono::milliseconds(1h).count();
             break;
     }
 


### PR DESCRIPTION
Mostly supersedes the abandoned #23237 to use `std::chrono` instead of hardcoded magic numbers.