### PR TITLE
Fix #23496: missing spatial index update when paused

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,6 +13,7 @@
 - Fix: [#23348] Console set commands don't print output properly.
 - Fix: [#23376] Peeps with balloons, hats and umbrellas may leave artifacts on screen.
 - Fix: [#23486] Object selection minimum requirements can be bypassed with close window hotkey.
+- Fix: [#23496] Newly spawned vehicles are invisible when spawned while the game is paused.
 
 0.4.17 (2024-12-08)
 ------------------------------------------------------------------------

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -177,6 +177,7 @@ namespace OpenRCT2
 
                 // Post-tick game actions.
                 GameActions::ProcessQueue();
+                UpdateEntitiesSpatialIndex();
             }
         }
 


### PR DESCRIPTION
Hey,

This adds a missing spatial index update when the game is in pause mode, as discussed in #development on Discord. Thanks to @ZehMatt for pointing out what needed to be changed.

Fixes #23496 and similar issues in #23359. 

Thank you for your time! 🙂

CC: @guysv 