### PR TITLE
Perform auto saves in background

### DIFF
--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -105,7 +105,8 @@ namespace OpenRCT2::Ui::Windows
                 }
                 else if (!(gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER))
                 {
-                    if (GetNumFreeEntities() != MAX_ENTITIES || GetGameState().Park.Flags & PARK_FLAGS_SPRITES_INITIALISED)
+                    if (GetNumFreeEntities() != OpenRCT2::Limits::kMaxEntities
+                        || GetGameState().Park.Flags & PARK_FLAGS_SPRITES_INITIALISED)
                     {
                         HidePreviousStepButton();
                     }
@@ -141,7 +142,8 @@ namespace OpenRCT2::Ui::Windows
             if (widgetIndex == WIDX_PREVIOUS_STEP_BUTTON)
             {
                 if ((gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER)
-                    || (GetNumFreeEntities() == MAX_ENTITIES && !(gameState.Park.Flags & PARK_FLAGS_SPRITES_INITIALISED)))
+                    || (GetNumFreeEntities() == OpenRCT2::Limits::kMaxEntities
+                        && !(gameState.Park.Flags & PARK_FLAGS_SPRITES_INITIALISED)))
                 {
                     ((this)->*(_previousButtonMouseUp[EnumValue(gameState.EditorStep)]))();
                 }

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -950,7 +950,7 @@ namespace OpenRCT2::Ui::Windows
                 // Compare name
                 if constexpr (!TRealNames)
                 {
-                    if (peepA->Name == nullptr && peepB->Name == nullptr)
+                    if (peepA->Name.empty() && peepB->Name.empty())
                     {
                         // Simple ID comparison for when both peeps use a number or a generated name
                         return peepA->PeepId < peepB->PeepId;

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -161,6 +161,7 @@ namespace OpenRCT2
         // We keep track of this to perform certain operations differently.
         std::thread::id _mainThreadId{};
         Timer _forcedUpdateTimer;
+        JobPool _backgroundJobs{ 2 };
 
     public:
         // Singleton of Context.
@@ -225,6 +226,8 @@ namespace OpenRCT2
             GfxUnloadG2();
             GfxUnloadG1();
             Audio::Close();
+
+            _backgroundJobs.Join();
 
             Instance = nullptr;
         }
@@ -1535,6 +1538,11 @@ namespace OpenRCT2
         float GetTimeScale() const override
         {
             return _timeScale;
+        }
+
+        JobPool& GetBackgroundJobs() override
+        {
+            return _backgroundJobs;
         }
     };
 

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "core/JobPool.h"
 #include "core/StringTypes.h"
 #include "interface/WindowClasses.h"
 #include "localisation/StringIdType.h"
@@ -176,6 +177,8 @@ namespace OpenRCT2
 
         virtual void SetTimeScale(float newScale) = 0;
         virtual float GetTimeScale() const = 0;
+
+        virtual JobPool& GetBackgroundJobs() = 0;
     };
 
     [[nodiscard]] std::unique_ptr<IContext> CreateContext();

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -590,7 +590,8 @@ void GameAutosave()
     int32_t autosavesToKeep = Config::Get().general.AutosaveAmount;
     LimitAutosaveCount(autosavesToKeep - 1, (gScreenFlags & SCREEN_FLAGS_EDITOR));
 
-    auto env = GetContext()->GetPlatformEnvironment();
+    auto* ctx = GetContext();
+    auto env = ctx->GetPlatformEnvironment();
     auto autosaveDir = Path::Combine(env->GetDirectoryPath(DIRBASE::USER, subDirectory), u8"autosave");
     Path::CreateDirectory(autosaveDir);
 
@@ -603,10 +604,20 @@ void GameAutosave()
         File::Copy(path, backupPath, true);
     }
 
-    auto& gameState = GetGameState();
+    auto& backgroundJobs = ctx->GetBackgroundJobsMgr();
 
-    if (!ScenarioSave(gameState, path, saveFlags))
-        Console::Error::WriteLine("Could not autosave the scenario. Is the save folder writeable?");
+    // Pretty annoying situation, GameState_t is too big for stack and unique_ptr can not be copied,
+    // so we have to use shared_ptr here.
+    std::shared_ptr<GameState_t> gameState = std::make_unique<GameState_t>(GetGameState());
+    backgroundJobs.AddTask([gameState, path, saveFlags]() {
+        //
+        if (!ScenarioSave(*gameState, path, saveFlags))
+        {
+            Console::Error::WriteLine("Could not autosave the scenario. Is the save folder writeable?");
+        }
+        // Allow to show activity, its usually too fast.
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    });
 }
 
 static void GameLoadOrQuitNoSavePromptCallback(int32_t result, const utf8* path)

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -437,7 +437,7 @@ void GameNotifyMapChanged()
  */
 void ResetAllSpriteQuadrantPlacements()
 {
-    for (EntityId::UnderlyingType i = 0; i < MAX_ENTITIES; i++)
+    for (EntityId::UnderlyingType i = 0; i < OpenRCT2::Limits::kMaxEntities; i++)
     {
         auto* spr = GetEntity(EntityId::FromUnderlying(i));
         if (spr != nullptr && spr->Type != EntityType::Null)

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -36,6 +36,9 @@ namespace OpenRCT2
 {
     struct GameState_t
     {
+        GameState_t() = default;
+        GameState_t(const GameState_t&) = default;
+
         ::OpenRCT2::Park::ParkData Park{};
         std::string PluginStorage;
         uint32_t CurrentTicks{};

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -90,9 +90,9 @@ namespace OpenRCT2
         std::string ScenarioFileName;
 
         std::vector<Banner> Banners;
-        Entity_t Entities[MAX_ENTITIES]{};
+        std::array<Entity_t, Limits::kMaxEntities> Entities{};
         // Ride storage for all the rides in the park, rides with RideId::Null are considered free.
-        std::array<Ride, OpenRCT2::Limits::kMaxRidesInPark> Rides{};
+        std::array<Ride, Limits::kMaxRidesInPark> Rides{};
         size_t RidesEndOfUsedRange{};
         ::RideRatingUpdateStates RideRatingUpdateStates;
         std::vector<TileElement> TileElements;

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -187,7 +187,8 @@ struct GameStateSnapshots final : public IGameStateSnapshots
     virtual void Capture(GameStateSnapshot_t& snapshot) override final
     {
         snapshot.SerialiseSprites(
-            [](const EntityId index) { return reinterpret_cast<EntitySnapshot*>(GetEntity(index)); }, MAX_ENTITIES, true);
+            [](const EntityId index) { return reinterpret_cast<EntitySnapshot*>(GetEntity(index)); },
+            OpenRCT2::Limits::kMaxEntities, true);
 
         // LOG_INFO("Snapshot size: %u bytes", static_cast<uint32_t>(snapshot.storedSprites.GetLength()));
     }
@@ -213,7 +214,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
     std::vector<EntitySnapshot> BuildSpriteList(GameStateSnapshot_t& snapshot) const
     {
         std::vector<EntitySnapshot> spriteList;
-        spriteList.resize(MAX_ENTITIES);
+        spriteList.resize(OpenRCT2::Limits::kMaxEntities);
 
         for (auto& sprite : spriteList)
         {
@@ -222,7 +223,8 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         }
 
         snapshot.SerialiseSprites(
-            [&spriteList](const EntityId index) { return &spriteList[index.ToUnderlying()]; }, MAX_ENTITIES, false);
+            [&spriteList](const EntityId index) { return &spriteList[index.ToUnderlying()]; }, OpenRCT2::Limits::kMaxEntities,
+            false);
 
         return spriteList;
     }
@@ -236,7 +238,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         std::memcpy(&valB, &spriteCmp.field, sizeof(struc::field));                                                            \
         uintptr_t offset = reinterpret_cast<uintptr_t>(&spriteBase.field) - reinterpret_cast<uintptr_t>(&spriteBase);          \
         changeData.diffs.push_back(                                                                                            \
-            GameStateSpriteChange::Diff{ static_cast<size_t>(offset), sizeof(struc::field), #struc, #field, valA, valB });     \
+            GameStateSpriteChange::Diff { static_cast<size_t>(offset), sizeof(struc::field), #struc, #field, valA, valB });    \
     }
 
     void CompareSpriteDataCommon(

--- a/src/openrct2/Limits.h
+++ b/src/openrct2/Limits.h
@@ -12,6 +12,7 @@
 
 namespace OpenRCT2::Limits
 {
+    constexpr uint16_t kMaxEntities = 65535;
     constexpr uint16_t kMaxRidesInPark = 1000;
     constexpr uint16_t kMaxStationsPerRide = 255;
     constexpr uint8_t kCustomerHistorySize = RCT12::Limits::kCustomerHistorySize;

--- a/src/openrct2/actions/GuestSetNameAction.cpp
+++ b/src/openrct2/actions/GuestSetNameAction.cpp
@@ -58,7 +58,7 @@ void GuestSetNameAction::Serialise(DataSerialiser& stream)
 
 GameActions::Result GuestSetNameAction::Query() const
 {
-    if (_spriteIndex.ToUnderlying() >= MAX_ENTITIES || _spriteIndex.IsNull())
+    if (_spriteIndex.ToUnderlying() >= OpenRCT2::Limits::kMaxEntities || _spriteIndex.IsNull())
     {
         return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_NAME_GUEST, STR_ERR_VALUE_OUT_OF_RANGE);
     }

--- a/src/openrct2/actions/PeepPickupAction.cpp
+++ b/src/openrct2/actions/PeepPickupAction.cpp
@@ -47,7 +47,7 @@ void PeepPickupAction::Serialise(DataSerialiser& stream)
 
 GameActions::Result PeepPickupAction::Query() const
 {
-    if (_entityId.ToUnderlying() >= MAX_ENTITIES || _entityId.IsNull())
+    if (_entityId.ToUnderlying() >= OpenRCT2::Limits::kMaxEntities || _entityId.IsNull())
     {
         LOG_ERROR("Failed to pick up peep for sprite %d", _entityId);
         return GameActions::Result(GameActions::Status::InvalidParameters, STR_ERR_CANT_PLACE_PERSON_HERE, STR_NONE);

--- a/src/openrct2/actions/StaffFireAction.cpp
+++ b/src/openrct2/actions/StaffFireAction.cpp
@@ -39,7 +39,7 @@ void StaffFireAction::Serialise(DataSerialiser& stream)
 
 GameActions::Result StaffFireAction::Query() const
 {
-    if (_spriteId.ToUnderlying() >= MAX_ENTITIES || _spriteId.IsNull())
+    if (_spriteId.ToUnderlying() >= OpenRCT2::Limits::kMaxEntities || _spriteId.IsNull())
     {
         LOG_ERROR("Invalid spriteId %u", _spriteId);
         return GameActions::Result(

--- a/src/openrct2/actions/StaffSetCostumeAction.cpp
+++ b/src/openrct2/actions/StaffSetCostumeAction.cpp
@@ -64,7 +64,7 @@ void StaffSetCostumeAction::Serialise(DataSerialiser& stream)
 
 GameActions::Result StaffSetCostumeAction::Query() const
 {
-    if (_spriteIndex.ToUnderlying() >= MAX_ENTITIES || _spriteIndex.IsNull())
+    if (_spriteIndex.ToUnderlying() >= OpenRCT2::Limits::kMaxEntities || _spriteIndex.IsNull())
     {
         LOG_ERROR("Invalid sprite index %u", _spriteIndex);
         return GameActions::Result(

--- a/src/openrct2/actions/StaffSetNameAction.cpp
+++ b/src/openrct2/actions/StaffSetNameAction.cpp
@@ -49,7 +49,7 @@ void StaffSetNameAction::Serialise(DataSerialiser& stream)
 
 GameActions::Result StaffSetNameAction::Query() const
 {
-    if (_spriteIndex.ToUnderlying() >= MAX_ENTITIES || _spriteIndex.IsNull())
+    if (_spriteIndex.ToUnderlying() >= OpenRCT2::Limits::kMaxEntities || _spriteIndex.IsNull())
     {
         LOG_ERROR("Invalid sprite index %u", _spriteIndex);
         return GameActions::Result(

--- a/src/openrct2/actions/StaffSetOrdersAction.cpp
+++ b/src/openrct2/actions/StaffSetOrdersAction.cpp
@@ -45,7 +45,7 @@ void StaffSetOrdersAction::Serialise(DataSerialiser& stream)
 
 GameActions::Result StaffSetOrdersAction::Query() const
 {
-    if (_spriteIndex.ToUnderlying() >= MAX_ENTITIES || _spriteIndex.IsNull())
+    if (_spriteIndex.ToUnderlying() >= OpenRCT2::Limits::kMaxEntities || _spriteIndex.IsNull())
     {
         LOG_ERROR("Invalid sprite index %u", _spriteIndex);
         return GameActions::Result(

--- a/src/openrct2/core/Random.hpp
+++ b/src/openrct2/core/Random.hpp
@@ -129,14 +129,14 @@ namespace OpenRCT2::Random
             seed(seed_value);
         }
 
-        RotateEngine(RotateEngine& r)
+        RotateEngine(const RotateEngine& r)
         {
             s0 = r.s0;
             s1 = r.s1;
         }
 
         template<typename TSseq, typename = typename std::enable_if<!std::is_same<TSseq, RotateEngine>::value>::type>
-        explicit RotateEngine(TSseq& seed_seq)
+        explicit RotateEngine(const TSseq& seed_seq)
         {
             seed(seed_seq);
         }

--- a/src/openrct2/entity/EntityRegistry.cpp
+++ b/src/openrct2/entity/EntityRegistry.cpp
@@ -44,7 +44,7 @@ using namespace OpenRCT2;
 static std::array<std::list<EntityId>, EnumValue(EntityType::Count)> gEntityLists;
 static std::vector<EntityId> _freeIdList;
 
-static bool _entityFlashingList[MAX_ENTITIES];
+static bool _entityFlashingList[Limits::kMaxEntities];
 
 static constexpr const uint32_t kSpatialIndexSize = (kMaximumMapSizeTechnical * kMaximumMapSizeTechnical) + 1;
 static constexpr uint32_t kSpatialIndexNullBucket = kSpatialIndexSize - 1;
@@ -114,7 +114,7 @@ EntityBase* TryGetEntity(EntityId entityIndex)
 {
     auto& gameState = GetGameState();
     const auto idx = entityIndex.ToUnderlying();
-    return idx >= MAX_ENTITIES ? nullptr : &gameState.Entities[idx].base;
+    return idx >= OpenRCT2::Limits::kMaxEntities ? nullptr : &gameState.Entities[idx].base;
 }
 
 EntityBase* GetEntity(EntityId entityIndex)
@@ -123,7 +123,8 @@ EntityBase* GetEntity(EntityId entityIndex)
     {
         return nullptr;
     }
-    Guard::Assert(entityIndex.ToUnderlying() < MAX_ENTITIES, "Tried getting entity %u", entityIndex.ToUnderlying());
+    Guard::Assert(
+        entityIndex.ToUnderlying() < OpenRCT2::Limits::kMaxEntities, "Tried getting entity %u", entityIndex.ToUnderlying());
     return TryGetEntity(entityIndex);
 }
 
@@ -143,7 +144,7 @@ static void ResetEntityLists()
 static void ResetFreeIds()
 {
     _freeIdList.clear();
-    _freeIdList.resize(MAX_ENTITIES);
+    _freeIdList.resize(OpenRCT2::Limits::kMaxEntities);
 
     // List needs to be back to front to simplify removing
     auto nextId = 0;
@@ -165,7 +166,7 @@ const std::list<EntityId>& GetEntityList(const EntityType id)
 void ResetAllEntities()
 {
     // Free all associated Entity pointers prior to zeroing memory
-    for (int32_t i = 0; i < MAX_ENTITIES; ++i)
+    for (int32_t i = 0; i < OpenRCT2::Limits::kMaxEntities; ++i)
     {
         auto* spr = GetEntity(EntityId::FromUnderlying(i));
         if (spr == nullptr)
@@ -179,7 +180,7 @@ void ResetAllEntities()
     std::fill(std::begin(gameState.Entities), std::end(gameState.Entities), Entity_t());
     OpenRCT2::RideUse::GetHistory().Clear();
     OpenRCT2::RideUse::GetTypeHistory().Clear();
-    for (int32_t i = 0; i < MAX_ENTITIES; ++i)
+    for (int32_t i = 0; i < OpenRCT2::Limits::kMaxEntities; ++i)
     {
         auto* spr = GetEntity(EntityId::FromUnderlying(i));
         if (spr == nullptr)
@@ -210,7 +211,7 @@ void ResetEntitySpatialIndices()
     {
         vec.clear();
     }
-    for (EntityId::UnderlyingType i = 0; i < MAX_ENTITIES; i++)
+    for (EntityId::UnderlyingType i = 0; i < OpenRCT2::Limits::kMaxEntities; i++)
     {
         auto* entity = GetEntity(EntityId::FromUnderlying(i));
         if (entity != nullptr && entity->Type != EntityType::Null)
@@ -582,12 +583,12 @@ uint16_t RemoveFloatingEntities()
 
 void EntitySetFlashing(EntityBase* entity, bool flashing)
 {
-    assert(entity->Id.ToUnderlying() < MAX_ENTITIES);
+    assert(entity->Id.ToUnderlying() < kMaxEntities);
     _entityFlashingList[entity->Id.ToUnderlying()] = flashing;
 }
 
 bool EntityGetFlashing(EntityBase* entity)
 {
-    assert(entity->Id.ToUnderlying() < MAX_ENTITIES);
+    assert(entity->Id.ToUnderlying() < kMaxEntities);
     return _entityFlashingList[entity->Id.ToUnderlying()];
 }

--- a/src/openrct2/entity/EntityRegistry.h
+++ b/src/openrct2/entity/EntityRegistry.h
@@ -27,8 +27,6 @@ namespace OpenRCT2
     };
 } // namespace OpenRCT2
 
-constexpr uint16_t MAX_ENTITIES = 65535;
-
 EntityBase* GetEntity(EntityId sprite_idx);
 
 template<typename T>

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -7242,7 +7242,7 @@ Guest* Guest::Generate(const CoordsXYZ& coords)
 
     peep->GuestNumRides = 0;
     peep->PeepId = gameState.NextGuestNumber++;
-    peep->Name = nullptr;
+    peep->Name.clear();
 
     money64 cash = (static_cast<money64>(ScenarioRand() & 0x3) * 100) - 100 + gameState.GuestInitialCash;
     if (cash < 0)

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -1612,7 +1612,7 @@ static constexpr StringId _staffNames[] = {
 
 void Peep::FormatNameTo(Formatter& ft) const
 {
-    if (Name == nullptr)
+    if (Name.empty())
     {
         auto& gameState = GetGameState();
         const bool showGuestNames = gameState.Park.Flags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
@@ -1651,7 +1651,7 @@ void Peep::FormatNameTo(Formatter& ft) const
     }
     else
     {
-        ft.Add<StringId>(STR_STRING).Add<const char*>(Name);
+        ft.Add<StringId>(STR_STRING).Add<const char*>(Name.c_str());
     }
 }
 
@@ -1666,21 +1666,12 @@ bool Peep::SetName(std::string_view value)
 {
     if (value.empty())
     {
-        std::free(Name);
-        Name = nullptr;
+        Name.clear();
         return true;
     }
 
-    auto newNameMemory = static_cast<char*>(std::malloc(value.size() + 1));
-    if (newNameMemory != nullptr)
-    {
-        std::memcpy(newNameMemory, value.data(), value.size());
-        newNameMemory[value.size()] = '\0';
-        std::free(Name);
-        Name = newNameMemory;
-        return true;
-    }
-    return false;
+    Name.assign(value);
+    return true;
 }
 
 bool Peep::IsActionWalking() const
@@ -2652,7 +2643,7 @@ int32_t PeepCompare(const EntityId sprite_index_a, const EntityId sprite_index_b
         return static_cast<int32_t>(peep_a->Type) - static_cast<int32_t>(peep_b->Type);
     }
 
-    if (peep_a->Name == nullptr && peep_b->Name == nullptr)
+    if (peep_a->Name.empty() && peep_b->Name.empty())
     {
         if (GetGameState().Park.Flags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES)
         {
@@ -2806,7 +2797,7 @@ void Peep::Serialise(DataSerialiser& stream)
     EntityBase::Serialise(stream);
     if (stream.IsLoading())
     {
-        Name = nullptr;
+        Name.clear();
     }
     stream << NextLoc;
     stream << NextFlags;

--- a/src/openrct2/entity/Peep.h
+++ b/src/openrct2/entity/Peep.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../Identifiers.h"
+#include "../core/StringTypes.h"
 #include "../entity/EntityBase.h"
 #include "../localisation/StringIdType.h"
 #include "../ride/RideTypes.h"
@@ -18,8 +19,6 @@
 
 #include <array>
 #include <optional>
-#include <string>
-#include <string_view>
 
 constexpr uint8_t kPeepMinEnergy = 32;
 constexpr uint8_t kPeepMaxEnergy = 128;
@@ -302,7 +301,7 @@ struct Staff;
 
 struct Peep : EntityBase
 {
-    char* Name;
+    u8string Name;
     CoordsXYZ NextLoc;
     uint8_t NextFlags;
     PeepState State;

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1274,7 +1274,7 @@ static void ConsoleCommandShowLimits(InteractiveConsole& console, [[maybe_unused
 
     auto bannerCount = GetNumBanners();
 
-    console.WriteFormatLine("Sprites: %d/%d", spriteCount, MAX_ENTITIES);
+    console.WriteFormatLine("Sprites: %d/%d", spriteCount, OpenRCT2::Limits::kMaxEntities);
     console.WriteFormatLine("Map Elements: %zu/%d", tileElementCount, MAX_TILE_ELEMENTS);
     console.WriteFormatLine("Banners: %d/%zu", bannerCount, MAX_BANNERS);
     console.WriteFormatLine("Rides: %d/%d", rideCount, OpenRCT2::Limits::kMaxRidesInPark);

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -1434,7 +1434,7 @@ void WindowInitAll()
 
 void WindowFollowSprite(WindowBase& w, EntityId spriteIndex)
 {
-    if (spriteIndex.ToUnderlying() < MAX_ENTITIES || spriteIndex.IsNull())
+    if (spriteIndex.ToUnderlying() < OpenRCT2::Limits::kMaxEntities || spriteIndex.IsNull())
     {
         w.viewport_smart_follow_sprite = spriteIndex;
     }

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -63,18 +63,30 @@ void Painter::Paint(IDrawingEngine& de)
         de.PaintWeather();
     }
 
-    auto* replayManager = GetContext()->GetReplayManager();
-    const char* text = nullptr;
+    auto* ctx = GetContext();
 
-    if (replayManager->IsReplaying() && !gSilentReplays)
-        text = "Replaying...";
-    else if (replayManager->ShouldDisplayNotice())
-        text = "Recording...";
-    else if (replayManager->IsNormalising())
-        text = "Normalising...";
+    {
+        auto* replayManager = ctx->GetReplayManager();
+        const char* text = nullptr;
 
-    if (text != nullptr)
-        PaintReplayNotice(*dpi, text);
+        if (replayManager->IsReplaying() && !gSilentReplays)
+            text = "Replaying...";
+        else if (replayManager->ShouldDisplayNotice())
+            text = "Recording...";
+        else if (replayManager->IsNormalising())
+            text = "Normalising...";
+
+        if (text != nullptr)
+            PaintReplayNotice(*dpi, text);
+    }
+
+    {
+        auto& backgroundJobs = ctx->GetBackgroundJobsMgr();
+        if (backgroundJobs.CountPending() > 0 || backgroundJobs.CountProcessing() > 0)
+        {
+            PaintBusyStatus(*dpi);
+        }
+    }
 
     if (Config::Get().general.ShowFPS)
     {
@@ -203,4 +215,32 @@ void Painter::ReleaseSession(PaintSession* session)
 Painter::~Painter()
 {
     _paintSessionPool.clear();
+}
+
+void Painter::PaintBusyStatus(DrawPixelInfo& dpi)
+{
+    // Blink this text.
+    if (gCurrentRealTimeTicks & 0x4)
+        return;
+
+    char buffer[64]{};
+    FormatStringToBuffer(buffer, sizeof(buffer), "{OUTLINE}{WHITE}...");
+
+    const int32_t stringWidth = GfxGetStringWidth(buffer, FontStyle::Medium);
+
+    // Figure out where counter should be rendered
+    ScreenCoordsXY screenCoords(_uiContext->GetWidth() / 2, 14);
+    screenCoords.x = screenCoords.x - (stringWidth / 2);
+
+    // Move counter below toolbar if buttons are centred
+    const bool isTitle = gScreenFlags == SCREEN_FLAGS_TITLE_DEMO;
+    if (!isTitle && Config::Get().interface.ToolbarButtonsCentred)
+    {
+        screenCoords.y = kTopToolbarHeight + 16;
+    }
+
+    DrawText(dpi, screenCoords, { COLOUR_WHITE }, buffer);
+
+    // Make area dirty so the text doesn't get drawn over the last
+    GfxSetDirtyBlocks({ { screenCoords - ScreenCoordsXY{ 16, 4 } }, { dpi.lastStringPos.x + 16, screenCoords.y + 16 } });
 }

--- a/src/openrct2/paint/Painter.h
+++ b/src/openrct2/paint/Painter.h
@@ -52,6 +52,7 @@ namespace OpenRCT2
 
         private:
             void PaintReplayNotice(DrawPixelInfo& dpi, const char* text);
+            void PaintBusyStatus(DrawPixelInfo& dpi);
             void PaintFPS(DrawPixelInfo& dpi);
             void MeasureFPS();
         };

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1698,7 +1698,7 @@ namespace OpenRCT2
             }
             else
             {
-                cs.Write(static_cast<const char*>(entity.Name));
+                cs.Write(entity.Name);
             }
 
             cs.ReadWrite(entity.NextLoc);

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1463,13 +1463,13 @@ namespace OpenRCT2
                         auto hasMeasurement = cs.Read<uint8_t>();
                         if (hasMeasurement != 0)
                         {
-                            ride.measurement = std::make_unique<RideMeasurement>();
+                            ride.measurement = RideMeasurement{};
                             ReadWriteRideMeasurement(cs, *ride.measurement);
                         }
                     }
                     else
                     {
-                        if (ride.measurement == nullptr)
+                        if (!ride.measurement.has_value())
                         {
                             cs.Write<uint8_t>(0);
                         }

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1228,7 +1228,7 @@ namespace OpenRCT2::RCT1
                     auto ride = GetRide(RCT12RideIdToOpenRCT2RideId(src.RideIndex));
                     if (ride != nullptr)
                     {
-                        ride->measurement = std::make_unique<RideMeasurement>();
+                        ride->measurement = RideMeasurement{};
                         ImportRideMeasurement(*ride->measurement, src);
                     }
                 }

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1050,7 +1050,7 @@ namespace OpenRCT2::RCT2
                     auto ride = GetRide(rideId);
                     if (ride != nullptr)
                     {
-                        ride->measurement = std::make_unique<RideMeasurement>();
+                        ride->measurement = RideMeasurement{};
                         ImportRideMeasurement(*ride->measurement, src);
                     }
                 }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2069,8 +2069,9 @@ void RideMeasurementsUpdate()
     // For each ride measurement
     for (auto& ride : GetRideManager())
     {
-        auto measurement = ride.measurement.get();
-        if (measurement != nullptr && (ride.lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK) && ride.status != RideStatus::Simulating)
+        auto& measurement = ride.measurement;
+        if (measurement.has_value() && (ride.lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK)
+            && ride.status != RideStatus::Simulating)
         {
             if (measurement->flags & RIDE_MEASUREMENT_FLAG_RUNNING)
             {
@@ -2114,7 +2115,7 @@ static void RideFreeOldMeasurements()
         numRideMeasurements = 0;
         for (auto& ride : GetRideManager())
         {
-            if (ride.measurement != nullptr)
+            if (ride.measurement.has_value())
             {
                 if (lruRide == nullptr || ride.measurement->last_use_tick > lruRide->measurement->last_use_tick)
                 {
@@ -2125,7 +2126,7 @@ static void RideFreeOldMeasurements()
         }
         if (numRideMeasurements > kMaxRideMeasurements && lruRide != nullptr)
         {
-            lruRide->measurement = {};
+            lruRide->measurement.reset();
             numRideMeasurements--;
         }
     } while (numRideMeasurements > kMaxRideMeasurements);
@@ -2142,21 +2143,20 @@ std::pair<RideMeasurement*, OpenRCT2String> Ride::GetMeasurement()
     }
 
     // Check if a measurement already exists for this ride
-    if (measurement == nullptr)
+    if (!measurement.has_value())
     {
-        measurement = std::make_unique<RideMeasurement>();
+        measurement = RideMeasurement{};
         if (rtd.HasFlag(RtdFlag::hasGForces))
         {
             measurement->flags |= RIDE_MEASUREMENT_FLAG_G_FORCES;
         }
         RideFreeOldMeasurements();
-        assert(measurement != nullptr);
     }
 
     measurement->last_use_tick = GetGameState().CurrentTicks;
     if (measurement->flags & 1)
     {
-        return { measurement.get(), { STR_EMPTY, {} } };
+        return { &measurement.value(), { STR_EMPTY, {} } };
     }
 
     auto ft = Formatter();

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -306,7 +306,7 @@ public:
     uint16_t holes{};
     uint8_t sheltered_eighths{};
 
-    std::unique_ptr<RideMeasurement> measurement;
+    std::optional<RideMeasurement> measurement;
 
 private:
     void Update();

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -221,7 +221,7 @@ void Ride::RemoveVehicles()
  */
 void RideClearForConstruction(Ride& ride)
 {
-    ride.measurement = {};
+    ride.measurement.reset();
 
     ride.lifecycle_flags &= ~(RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN);
     ride.window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAIN | RIDE_INVALIDATE_RIDE_LIST;

--- a/src/openrct2/scripting/bindings/world/ScMap.cpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.cpp
@@ -55,7 +55,7 @@ namespace OpenRCT2::Scripting
 
     int32_t ScMap::numEntities_get() const
     {
-        return MAX_ENTITIES;
+        return OpenRCT2::Limits::kMaxEntities;
     }
 
     std::vector<std::shared_ptr<ScRide>> ScMap::rides_get() const
@@ -88,7 +88,7 @@ namespace OpenRCT2::Scripting
 
     DukValue ScMap::getEntity(int32_t id) const
     {
-        if (id >= 0 && id < MAX_ENTITIES)
+        if (id >= 0 && id < OpenRCT2::Limits::kMaxEntities)
         {
             auto spriteId = EntityId::FromUnderlying(id);
             auto sprite = GetEntity(spriteId);


### PR DESCRIPTION
I've refactored a bit of code to allow the game state to be copied in a safe way, I think I've got all the oddities nailed, it doesn't crash and the saved files seem to be all functional. The busy indicator is probably not the greatest thing but it does the job. Auto saves on bigger parks are quite noticeable but with this PR I would be not able to tell without the busy indicator.

This PR also has the side effect that there can be now more than 8 ride measurements, I will have to revisit that part again as this LRU code makes no sense anymore, now its possible to have for each ride the ride measurements, this adds a little of memory usage but its just a couple MB, I will try to clean this stuff up further but for this PR I just wanted to get it all working.