### PR TITLE
Fix holding brakes being skipped if they're too close together

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Fix: [#21794] Lay-down coaster cars reverse on first frames of downwards corkscrew.
 - Fix: [#23368] Incorrect refund amount when deleting track pieces at or above 96m.
 - Fix: [#23508] Simultaneous virtual floors shown for ride and footpath.
+- Fix: [#23512] Holding brakes are skipped if they’re too close together.
 - Fix: [#23581] [Plugin] Food/drink items given to guests have no consumption duration set.
 - Fix: [#23591] “Install new track” button in Track Designs Manager is misaligned.
 - Fix: [#23618] Can no longer build diagonal brakes & block brakes on Steeplechase, Inverted Lay-down, & Inverted Multi-Dim roller coasters.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -50,7 +50,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kNetworkStreamVersion = 2;
+constexpr uint8_t kNetworkStreamVersion = 3;
 
 const std::string kNetworkStreamID = std::string(OPENRCT2_VERSION) + "-" + std::to_string(kNetworkStreamVersion);
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7056,7 +7056,7 @@ bool Vehicle::UpdateTrackMotionForwardsGetNewTrack(
     SetTrackDirection(location.direction);
     SetTrackType(trackType);
     PopulateBrakeSpeed(TrackLocation, *tileElement->AsTrack());
-    if (HasFlag(VehicleFlags::StoppedOnHoldingBrake) && vertical_drop_countdown == 0)
+    if (HasFlag(VehicleFlags::StoppedOnHoldingBrake) && vertical_drop_countdown <= 0)
     {
         ClearFlag(VehicleFlags::StoppedOnHoldingBrake);
     }
@@ -7470,7 +7470,7 @@ bool Vehicle::UpdateTrackMotionBackwardsGetNewTrack(TrackElemType trackType, con
     SetTrackType(trackType);
     SetTrackDirection(direction);
     PopulateBrakeSpeed(TrackLocation, *tileElement->AsTrack());
-    if (HasFlag(VehicleFlags::StoppedOnHoldingBrake) && vertical_drop_countdown == 0)
+    if (HasFlag(VehicleFlags::StoppedOnHoldingBrake) && vertical_drop_countdown <= 0)
     {
         ClearFlag(VehicleFlags::StoppedOnHoldingBrake);
     }

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -5566,8 +5566,6 @@ void Vehicle::UpdateVelocity()
     {
         if (vertical_drop_countdown > 0)
         {
-            ClearFlag(VehicleFlags::StoppedOnHoldingBrake);
-
             nextVelocity = 0;
             acceleration = 0;
             vertical_drop_countdown--;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -5564,15 +5564,13 @@ void Vehicle::UpdateVelocity()
     }
     if (HasFlag(VehicleFlags::StoppedOnHoldingBrake))
     {
-        vertical_drop_countdown--;
-        if (vertical_drop_countdown == -70)
+        if (vertical_drop_countdown > 0)
         {
             ClearFlag(VehicleFlags::StoppedOnHoldingBrake);
-        }
-        if (vertical_drop_countdown >= 0)
-        {
+
             nextVelocity = 0;
             acceleration = 0;
+            vertical_drop_countdown--;
         }
     }
     velocity = nextVelocity;
@@ -7060,6 +7058,7 @@ bool Vehicle::UpdateTrackMotionForwardsGetNewTrack(
     SetTrackDirection(location.direction);
     SetTrackType(trackType);
     PopulateBrakeSpeed(TrackLocation, *tileElement->AsTrack());
+    ClearFlag(VehicleFlags::StoppedOnHoldingBrake);
     if (trackType == TrackElemType::OnRidePhoto)
     {
         trigger_on_ride_photo(TrackLocation, tileElement);
@@ -7470,6 +7469,7 @@ bool Vehicle::UpdateTrackMotionBackwardsGetNewTrack(TrackElemType trackType, con
     SetTrackType(trackType);
     SetTrackDirection(direction);
     PopulateBrakeSpeed(TrackLocation, *tileElement->AsTrack());
+    ClearFlag(VehicleFlags::StoppedOnHoldingBrake);
 
     // There are two bytes before the move info list
     uint16_t trackTotalProgress = GetTrackProgress();

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7056,7 +7056,10 @@ bool Vehicle::UpdateTrackMotionForwardsGetNewTrack(
     SetTrackDirection(location.direction);
     SetTrackType(trackType);
     PopulateBrakeSpeed(TrackLocation, *tileElement->AsTrack());
-    ClearFlag(VehicleFlags::StoppedOnHoldingBrake);
+    if (HasFlag(VehicleFlags::StoppedOnHoldingBrake) && vertical_drop_countdown == 0)
+    {
+        ClearFlag(VehicleFlags::StoppedOnHoldingBrake);
+    }
     if (trackType == TrackElemType::OnRidePhoto)
     {
         trigger_on_ride_photo(TrackLocation, tileElement);
@@ -7467,8 +7470,10 @@ bool Vehicle::UpdateTrackMotionBackwardsGetNewTrack(TrackElemType trackType, con
     SetTrackType(trackType);
     SetTrackDirection(direction);
     PopulateBrakeSpeed(TrackLocation, *tileElement->AsTrack());
-    ClearFlag(VehicleFlags::StoppedOnHoldingBrake);
-
+    if (HasFlag(VehicleFlags::StoppedOnHoldingBrake) && vertical_drop_countdown == 0)
+    {
+        ClearFlag(VehicleFlags::StoppedOnHoldingBrake);
+    }
     // There are two bytes before the move info list
     uint16_t trackTotalProgress = GetTrackProgress();
     *progress = trackTotalProgress - 1;


### PR DESCRIPTION
I found a bug where the vertical drop coaster can fail to stop at a holding brake if it is too close to a previous one 

https://i.imgur.com/Eks6Ejp.gif

I appreciate it's a very minor issue but it's causing problems for a feature I'd like to add and the best situation seems to be to fix the bug at the source. Nobody answered my question about whether this would be considered acceptable, so here's a PR with my proposed change. The current behaviour is that the holding brake flag is only cleared 1.75 seconds after the timer expires; the train will not stop again until the flag is cleared.

The flag cannot be cleared as soon as the timer expires because if the flag is cleared while the vehicle is still on the holding brake it will start a new timing interval. My proposal is to instead clear the flag whenever the vehicle moves onto a new track piece (in VehicleUpdateMotionForwardsGetNewTrack). 

I don't think this can break existing saves because the state of the flag and the timer countdown have no effect on a vehicle which is not on a holding brake and this ensures that the vehicle will always have the flag and the timer reset upon entering a holding brake piece, regardless of the previous state. The fact that the timer will no longer count down below zero, and the flag may be cleared earlier or later than it previously would have, shouldn't have any effect on the game except in the event that the vehicle hits another holding brake before the timer would have expired.

Note that this change also means that vertical_drop_countdown can never be negative. I tried changing it to an unsigned value to allow a greater maximum value but this does break saves that contain a vehicle with a negative value. I can fix it with import code but that change is not needed to fix the bug, so I decided to leave it.