### PR TITLE
Fix #23508: RideConstruction and Footpath windows racing to set the VirtualFloor

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Improved: [#23540] The file browser now optionally shows a file size column.
 - Change: [#23328] All RCT2 entertainer costumes are now available in legacy parks.
 - Fix: [#21794] Lay-down coaster cars reverse on first frames of downwards corkscrew.
+- Fix: [#23508] Simultaneous virtual floors shown for ride and footpath.
 - Fix: [#23581] [Plugin] Food/drink items given to guests have no consumption duration set.
 
 0.4.18 (2025-01-08)

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -51,6 +51,7 @@
 #include <openrct2/windows/Intent.h>
 #include <openrct2/world/ConstructionClearance.h>
 #include <openrct2/world/Entrance.h>
+#include <openrct2/world/Map.h>
 #include <openrct2/world/Park.h>
 #include <openrct2/world/tile_element/EntranceElement.h>
 #include <openrct2/world/tile_element/PathElement.h>
@@ -1051,13 +1052,13 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_NEXT_SECTION:
                     VirtualFloorInvalidate();
                     RideSelectNextSection();
-                    if (!isToolActive(WindowClass::Scenery))
+                    if (!(gMapSelectFlags & MAP_SELECT_FLAG_ENABLE))
                         VirtualFloorSetHeight(_currentTrackBegin.z);
                     break;
                 case WIDX_PREVIOUS_SECTION:
                     VirtualFloorInvalidate();
                     RideSelectPreviousSection();
-                    if (!isToolActive(WindowClass::Scenery))
+                    if (!(gMapSelectFlags & MAP_SELECT_FLAG_ENABLE))
                         VirtualFloorSetHeight(_currentTrackBegin.z);
                     break;
                 case WIDX_LEFT_CURVE:
@@ -3163,7 +3164,7 @@ namespace OpenRCT2::Ui::Windows
                         // Invalidate previous track piece (we may not be changing height!)
                         VirtualFloorInvalidate();
 
-                        if (!isToolActive(WindowClass::Scenery))
+                        if (!(gMapSelectFlags & MAP_SELECT_FLAG_ENABLE))
                         {
                             // Set height to where the next track piece would begin
                             VirtualFloorSetHeight(_currentTrackBegin.z);
@@ -4766,7 +4767,7 @@ namespace OpenRCT2::Ui::Windows
         // Invalidate previous track piece (we may not be changing height!)
         VirtualFloorInvalidate();
 
-        if (!isToolActive(WindowClass::Scenery))
+        if (!(gMapSelectFlags & MAP_SELECT_FLAG_ENABLE))
         {
             // Set height to where the next track piece would begin
             VirtualFloorSetHeight(trackPos.z - zBegin + zEnd);

--- a/src/openrct2/paint/VirtualFloor.cpp
+++ b/src/openrct2/paint/VirtualFloor.cpp
@@ -31,6 +31,7 @@
 using namespace OpenRCT2;
 
 static uint16_t _virtualFloorBaseSize = 5 * 32;
+static CoordsXY _virtualFloorBaseSizeXY = { _virtualFloorBaseSize, _virtualFloorBaseSize };
 static uint16_t _virtualFloorHeight = 0;
 static CoordsXYZ _virtualFloorLastMinPos;
 static CoordsXYZ _virtualFloorLastMaxPos;
@@ -187,12 +188,12 @@ bool VirtualFloorTileIsFloor(const CoordsXY& loc)
     }
 
     // Check if map selection (usually single tiles) are enabled
-    //  and if the current tile is near or on them
-    if ((gMapSelectFlags & MAP_SELECT_FLAG_ENABLE) && loc.x >= gMapSelectPositionA.x - _virtualFloorBaseSize
-        && loc.y >= gMapSelectPositionA.y - _virtualFloorBaseSize && loc.x <= gMapSelectPositionB.x + _virtualFloorBaseSize
-        && loc.y <= gMapSelectPositionB.y + _virtualFloorBaseSize)
+    // and if the current tile is near or on them
+    // (short-circuit to false otherwise - we don't want to show a second
+    //  virtual floor from e. g. an open ride construction window)
+    if (gMapSelectFlags & MAP_SELECT_FLAG_ENABLE)
     {
-        return true;
+        return loc >= gMapSelectPositionA - _virtualFloorBaseSizeXY && loc <= gMapSelectPositionB + _virtualFloorBaseSizeXY;
     }
 
     if (gMapSelectFlags & MAP_SELECT_FLAG_ENABLE_CONSTRUCT)

--- a/src/openrct2/paint/VirtualFloor.cpp
+++ b/src/openrct2/paint/VirtualFloor.cpp
@@ -30,8 +30,8 @@
 
 using namespace OpenRCT2;
 
-static uint16_t _virtualFloorBaseSize = 5 * 32;
-static CoordsXY _virtualFloorBaseSizeXY = { _virtualFloorBaseSize, _virtualFloorBaseSize };
+static constexpr uint16_t kVirtualFloorBaseSize = 5 * kCoordsXYStep;
+static constexpr CoordsXY kVirtualFloorBaseSizeXY = { kVirtualFloorBaseSize, kVirtualFloorBaseSize };
 static uint16_t _virtualFloorHeight = 0;
 static CoordsXYZ _virtualFloorLastMinPos;
 static CoordsXYZ _virtualFloorLastMaxPos;
@@ -131,10 +131,10 @@ void VirtualFloorInvalidate()
            && max_position.y != std::numeric_limits<int32_t>::lowest());
 
     // Apply the virtual floor size to the computed invalidation area.
-    min_position.x -= _virtualFloorBaseSize + 16;
-    min_position.y -= _virtualFloorBaseSize + 16;
-    max_position.x += _virtualFloorBaseSize + 16;
-    max_position.y += _virtualFloorBaseSize + 16;
+    min_position.x -= kVirtualFloorBaseSize + 16;
+    min_position.y -= kVirtualFloorBaseSize + 16;
+    max_position.x += kVirtualFloorBaseSize + 16;
+    max_position.y += kVirtualFloorBaseSize + 16;
 
     // Invalidate previous region if appropriate.
     if (_virtualFloorLastMinPos.x != std::numeric_limits<int32_t>::max()
@@ -193,7 +193,7 @@ bool VirtualFloorTileIsFloor(const CoordsXY& loc)
     //  virtual floor from e. g. an open ride construction window)
     if (gMapSelectFlags & MAP_SELECT_FLAG_ENABLE)
     {
-        return loc >= gMapSelectPositionA - _virtualFloorBaseSizeXY && loc <= gMapSelectPositionB + _virtualFloorBaseSizeXY;
+        return loc >= gMapSelectPositionA - kVirtualFloorBaseSizeXY && loc <= gMapSelectPositionB + kVirtualFloorBaseSizeXY;
     }
 
     if (gMapSelectFlags & MAP_SELECT_FLAG_ENABLE_CONSTRUCT)
@@ -201,8 +201,8 @@ bool VirtualFloorTileIsFloor(const CoordsXY& loc)
         // Check if we are anywhere near the selection tiles (larger scenery / rides)
         for (const auto& tile : gMapSelectionTiles)
         {
-            if (loc.x >= tile.x - _virtualFloorBaseSize && loc.y >= tile.y - _virtualFloorBaseSize
-                && loc.x <= tile.x + _virtualFloorBaseSize && loc.y <= tile.y + _virtualFloorBaseSize)
+            if (loc.x >= tile.x - kVirtualFloorBaseSize && loc.y >= tile.y - kVirtualFloorBaseSize
+                && loc.x <= tile.x + kVirtualFloorBaseSize && loc.y <= tile.y + kVirtualFloorBaseSize)
             {
                 return true;
             }


### PR DESCRIPTION
This PR disables the `VirtualFloor` for the `RideConstruction` window when `MAP_SELECT_FLAG_ENABLE` is set, thus preventing double virtual floors to be shown e. g. from the ride construction and footpath windows.

Closes #23508 