### PR TITLE
Tighten the use of locks in JobPool

### DIFF
--- a/src/openrct2/core/JobPool.h
+++ b/src/openrct2/core/JobPool.h
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include <atomic>
 #include <condition_variable>
 #include <deque>
 #include <functional>
@@ -28,8 +27,8 @@ private:
         TaskData(std::function<void()> workFn, std::function<void()> completionFn);
     };
 
-    std::atomic_bool _shouldStop = { false };
-    std::atomic<size_t> _processing = { 0 };
+    bool _shouldStop = false;
+    size_t _processing = 0;
     std::vector<std::thread> _threads;
     std::deque<TaskData> _pending;
     std::deque<TaskData> _completed;
@@ -45,8 +44,7 @@ public:
 
     void AddTask(std::function<void()> workFn, std::function<void()> completionFn = nullptr);
     void Join(std::function<void()> reportFn = nullptr);
-    size_t CountPending();
-    size_t CountProcessing();
+    bool IsBusy();
 
 private:
     void ProcessQueue();

--- a/src/openrct2/scenes/preloader/PreloaderScene.cpp
+++ b/src/openrct2/scenes/preloader/PreloaderScene.cpp
@@ -54,7 +54,7 @@ void PreloaderScene::Tick()
 
     gInUpdateCode = false;
 
-    if (_jobs.CountPending() == 0 && _jobs.CountProcessing() == 0)
+    if (!_jobs.IsBusy())
     {
         // Make sure the job is fully completed.
         _jobs.Join();


### PR DESCRIPTION
This PR addresses several very minor things in JobPool:

1. `std::thread::hardware_concurrency()` **can** technically return 0 (I don't know if it ever does, though), so protect against it.
2. Functions are now moved around more and not copied.
3. Condition variables are now notified when the lock is not held. This avoids a scenario where an idle thread is notified, tries to re-acquire the lock, and immediately goes back to sleep because the notifying thread is still holding the same lock.
4. `_shouldStop ` and `_processing` are always read and written when the lock is held, so there is no point in making them atomic.

I don't know if these changes are measurable, so it might not be worth putting in the changelog.