### PR TITLE
Update objects to v1.4.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,9 +69,9 @@ set(TITLE_SEQUENCE_VERSION "0.4.14")
 set(TITLE_SEQUENCE_URL  "https://github.com/OpenRCT2/title-sequences/releases/download/v${TITLE_SEQUENCE_VERSION}/title-sequences.zip")
 set(TITLE_SEQUENCE_SHA1 "6c04781b959b468e1f65ec2d2f21f5aaa5e5724d")
 
-set(OBJECTS_VERSION "1.4.11")
+set(OBJECTS_VERSION "1.4.12")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v${OBJECTS_VERSION}/objects.zip")
-set(OBJECTS_SHA1 "da04330679de2eff53a94a6505802512bfec6403")
+set(OBJECTS_SHA1 "3f841b67f6a9383626667fadce10250b36dd3b34")
 
 set(OPENSFX_VERSION "1.0.5")
 set(OPENSFX_URL  "https://github.com/OpenRCT2/OpenSoundEffects/releases/download/v${OPENSFX_VERSION}/opensound.zip")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ set(TITLE_SEQUENCE_SHA1 "6c04781b959b468e1f65ec2d2f21f5aaa5e5724d")
 
 set(OBJECTS_VERSION "1.4.12")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v${OBJECTS_VERSION}/objects.zip")
-set(OBJECTS_SHA1 "3f841b67f6a9383626667fadce10250b36dd3b34")
+set(OBJECTS_SHA1 "d9b745f3b9dacf5c204a43375e4d93dfe3548938")
 
 set(OPENSFX_VERSION "1.0.5")
 set(OPENSFX_URL  "https://github.com/OpenRCT2/OpenSoundEffects/releases/download/v${OPENSFX_VERSION}/opensound.zip")

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Improved: [#23404] Folders are now paired with an icon in the load/save window.
 - Improved: [#23405] Filenames can now be input directly into the file browser (load/save) window.
 - Improved: [#23431] Opaque water and Corkscrew Roller Coaster boosters now show up if RCT1 isn’t linked. 
+- Improved: [objects#369] Updated Russian translation.
 - Change: [#23413] The max number of park entrance objects has been raised to 255.
 - Fix: [#1122] Trains spawned on a cable lift hill will fall down and crash (original bug).
 - Fix: [#19780] Guest screams loop on long drops.
@@ -17,6 +18,10 @@
 - Fix: [#23486] Object selection minimum requirements can be bypassed with close window hotkey.
 - Fix: [#23496] Newly spawned vehicles are invisible when spawned while the game is paused.
 - Fix: [#23509] Map generator window reverts to flatland after selecting a heightmap image.
+- Fix: [objects#359] Fix water colours in Hover Cars preview image.
+- Fix: [objects#361] Fix water colours in River Styx boats preview image.
+- Fix: [objects#362] Fix water colours in Neptune Ride preview image.
+- Fix: [objects#363] Fix water colours in Harpies Trains preview image.
 
 0.4.17 (2024-12-08)
 ------------------------------------------------------------------------

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -45,8 +45,8 @@
     <LibsSha1 Condition="'$(Platform)'=='Win32'">9984c1e317dcfb3aaf8e17f1db2ebb0f771e2373</LibsSha1>
     <TitleSequencesUrl>https://github.com/OpenRCT2/title-sequences/releases/download/v0.4.14/title-sequences.zip</TitleSequencesUrl>
     <TitleSequencesSha1>6c04781b959b468e1f65ec2d2f21f5aaa5e5724d</TitleSequencesSha1>
-    <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.4.11/objects.zip</ObjectsUrl>
-    <ObjectsSha1>da04330679de2eff53a94a6505802512bfec6403</ObjectsSha1>
+    <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.4.12/objects.zip</ObjectsUrl>
+    <ObjectsSha1>3f841b67f6a9383626667fadce10250b36dd3b34</ObjectsSha1>
     <OpenSFXUrl>https://github.com/OpenRCT2/OpenSoundEffects/releases/download/v1.0.5/opensound.zip</OpenSFXUrl>
     <OpenSFXSha1>b1b1f1b241d2cbff63a1889c4dc5a09bdf769bfb</OpenSFXSha1>
     <OpenMSXUrl>https://github.com/OpenRCT2/OpenMusic/releases/download/v1.6/openmusic.zip</OpenMSXUrl>

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -46,7 +46,7 @@
     <TitleSequencesUrl>https://github.com/OpenRCT2/title-sequences/releases/download/v0.4.14/title-sequences.zip</TitleSequencesUrl>
     <TitleSequencesSha1>6c04781b959b468e1f65ec2d2f21f5aaa5e5724d</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.4.12/objects.zip</ObjectsUrl>
-    <ObjectsSha1>3f841b67f6a9383626667fadce10250b36dd3b34</ObjectsSha1>
+    <ObjectsSha1>d9b745f3b9dacf5c204a43375e4d93dfe3548938</ObjectsSha1>
     <OpenSFXUrl>https://github.com/OpenRCT2/OpenSoundEffects/releases/download/v1.0.5/opensound.zip</OpenSFXUrl>
     <OpenSFXSha1>b1b1f1b241d2cbff63a1889c4dc5a09bdf769bfb</OpenSFXSha1>
     <OpenMSXUrl>https://github.com/OpenRCT2/OpenMusic/releases/download/v1.6/openmusic.zip</OpenMSXUrl>


### PR DESCRIPTION
This updates the objects bundle to v1.4.12.

With #23328 on hold for the current release, this bundle does not yet include the peep animation objects.