### PR TITLE
Ride queue safety

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,9 +81,9 @@ set(OPENMSX_VERSION "1.6")
 set(OPENMSX_URL  "https://github.com/OpenRCT2/OpenMusic/releases/download/v${OPENMSX_VERSION}/openmusic.zip")
 set(OPENMSX_SHA1 "ba170fa6d777b309c15420f4b6eb3fa25082a9d1")
 
-set(REPLAYS_VERSION "0.0.85")
+set(REPLAYS_VERSION "0.0.86")
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
-set(REPLAYS_SHA1 "2B0939953A41D2CE82809CB7C21FC3883578383F")
+set(REPLAYS_SHA1 "637E73F20C03DCD52ACA36FAEE15DADB31797FE0")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -51,8 +51,8 @@
     <OpenSFXSha1>b1b1f1b241d2cbff63a1889c4dc5a09bdf769bfb</OpenSFXSha1>
     <OpenMSXUrl>https://github.com/OpenRCT2/OpenMusic/releases/download/v1.6/openmusic.zip</OpenMSXUrl>
     <OpenMSXSha1>ba170fa6d777b309c15420f4b6eb3fa25082a9d1</OpenMSXSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.85/replays.zip</ReplaysUrl>
-    <ReplaysSha1>2B0939953A41D2CE82809CB7C21FC3883578383F</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.86/replays.zip</ReplaysUrl>
+    <ReplaysSha1>637E73F20C03DCD52ACA36FAEE15DADB31797FE0</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -150,7 +150,11 @@ GameActions::Result RideCreateAction::Execute() const
     ride->SetNameToDefault();
 
     // Default initialize all stations.
-    std::ranges::fill(ride->GetStations(), RideStation{});
+    RideStation station{};
+    station.Start.SetNull();
+    station.Entrance.SetNull();
+    station.Exit.SetNull();
+    std::ranges::fill(ride->GetStations(), station);
 
     ride->status = RideStatus::Closed;
     ride->NumTrains = 1;

--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -28,6 +28,8 @@
 #include "../scenario/Scenario.h"
 #include "../world/Park.h"
 
+#include <algorithm>
+
 using namespace OpenRCT2;
 
 RideCreateAction::RideCreateAction(
@@ -147,18 +149,8 @@ GameActions::Result RideCreateAction::Execute() const
     ride->overall_view.SetNull();
     ride->SetNameToDefault();
 
-    for (auto& station : ride->GetStations())
-    {
-        station.Start.SetNull();
-        station.Entrance.SetNull();
-        station.Exit.SetNull();
-        station.TrainAtStation = RideStation::kNoTrain;
-        station.QueueTime = 0;
-        station.SegmentLength = 0;
-        station.QueueLength = 0;
-        station.Length = 0;
-        station.Height = 0;
-    }
+    // Default initialize all stations.
+    std::ranges::fill(ride->GetStations(), RideStation{});
 
     ride->status = RideStatus::Closed;
     ride->NumTrains = 1;

--- a/src/openrct2/core/OrcaStream.hpp
+++ b/src/openrct2/core/OrcaStream.hpp
@@ -20,6 +20,7 @@
 #include <array>
 #include <cstdint>
 #include <optional>
+#include <span>
 #include <stack>
 #include <type_traits>
 #include <vector>
@@ -468,15 +469,8 @@ namespace OpenRCT2
                 }
             }
 
-            template<typename TArr, size_t TArrSize, typename TFunc>
-            void ReadWriteArray(TArr (&arr)[TArrSize], TFunc f)
-            {
-                auto& arr2 = *(reinterpret_cast<std::array<TArr, TArrSize>*>(arr));
-                ReadWriteArray(arr2, f);
-            }
-
-            template<typename TArr, size_t TArrSize, typename TFunc>
-            void ReadWriteArray(std::array<TArr, TArrSize>& arr, TFunc f)
+            template<typename TArr, typename TFunc>
+            void ReadWriteArray(std::span<TArr> arr, TFunc f)
             {
                 if (_mode == Mode::READING)
                 {
@@ -487,7 +481,7 @@ namespace OpenRCT2
                     }
                     for (size_t i = 0; i < count; i++)
                     {
-                        if (i < TArrSize)
+                        if (i < arr.size())
                         {
                             f(arr[i]);
                         }
@@ -507,6 +501,18 @@ namespace OpenRCT2
                     }
                     EndArray();
                 }
+            }
+
+            template<typename TArr, size_t TArrSize, typename TFunc>
+            void ReadWriteArray(TArr (&arr)[TArrSize], TFunc f)
+            {
+                ReadWriteArray(std::span<TArr>{ arr, TArrSize }, f);
+            }
+
+            template<typename TArr, size_t TArrSize, typename TFunc>
+            void ReadWriteArray(std::array<TArr, TArrSize>& arr, TFunc f)
+            {
+                ReadWriteArray(std::span<TArr>{ arr.begin(), arr.end() }, f);
             }
 
             template<typename T>

--- a/src/openrct2/entity/EntityRegistry.cpp
+++ b/src/openrct2/entity/EntityRegistry.cpp
@@ -531,6 +531,8 @@ static void FreeEntity(EntityBase& entity)
     else if (guest != nullptr)
     {
         guest->SetName({});
+        guest->GuestNextInQueue = EntityId::GetNull();
+
         OpenRCT2::RideUse::GetHistory().RemoveHandle(guest->Id);
         OpenRCT2::RideUse::GetTypeHistory().RemoveHandle(guest->Id);
     }

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -7280,6 +7280,7 @@ Guest* Guest::Generate(const CoordsXYZ& coords)
     peep->ResetPathfindGoal();
     peep->RemoveAllItems();
     peep->GuestHeadingToRideId = RideId::GetNull();
+    peep->GuestNextInQueue = EntityId::GetNull();
     peep->LitterCount = 0;
     peep->DisgustingCount = 0;
     peep->VandalismSeen = 0;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1046,12 +1046,12 @@ const RideStation& Ride::GetStation(StationIndex stationIndex) const
     return stations[stationIndex.ToUnderlying()];
 }
 
-std::array<RideStation, OpenRCT2::Limits::kMaxStationsPerRide>& Ride::GetStations()
+std::span<RideStation> Ride::GetStations()
 {
     return stations;
 }
 
-const std::array<RideStation, OpenRCT2::Limits::kMaxStationsPerRide>& Ride::GetStations() const
+std::span<const RideStation> Ride::GetStations() const
 {
     return stations;
 }

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -28,6 +28,7 @@
 #include <array>
 #include <limits>
 #include <memory>
+#include <span>
 #include <string_view>
 
 struct IObjectManager;
@@ -293,8 +294,8 @@ private:
 public:
     RideStation& GetStation(StationIndex stationIndex = StationIndex::FromUnderlying(0));
     const RideStation& GetStation(StationIndex stationIndex = StationIndex::FromUnderlying(0)) const;
-    std::array<RideStation, OpenRCT2::Limits::kMaxStationsPerRide>& GetStations();
-    const std::array<RideStation, OpenRCT2::Limits::kMaxStationsPerRide>& GetStations() const;
+    std::span<RideStation> GetStations();
+    std::span<const RideStation> GetStations() const;
     StationIndex GetStationIndex(const RideStation* station) const;
 
     // Returns the logical station number from the given station. Index 0 = station 1, index 1 = station 2. It accounts for gaps

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -2308,7 +2308,7 @@ static void test_finish(Ride& ride)
     ride.lifecycle_flags &= ~RIDE_LIFECYCLE_TEST_IN_PROGRESS;
     ride.lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
 
-    auto& rideStations = ride.GetStations();
+    auto rideStations = ride.GetStations();
     for (int32_t i = ride.num_stations - 1; i >= 1; i--)
     {
         if (rideStations[i - 1].SegmentTime != 0)

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2352,7 +2352,7 @@ void ShiftMap(const TileCoordsXY& amount)
     // Rides
     for (auto& ride : GetRideManager())
     {
-        auto& stations = ride.GetStations();
+        auto stations = ride.GetStations();
         for (auto& station : stations)
         {
             shiftIfNotNull(station.Start, amountToMove);


### PR DESCRIPTION
Makes sure that some fields relevant to the queues are not uninitialized, sprinkled in some std::span usage.