### PR TITLE
Fix #21794: Lay-down coaster cars reverse on first frames of downwards corkscrew

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.19 (in development)
 ------------------------------------------------------------------------
 - Improved: [#23540] The file browser now optionally shows a file size column.
+- Fix: [#21794] Lay-down coaster cars reverse on first frames of downwards corkscrew.
 
 0.4.18 (2025-01-08)
 ------------------------------------------------------------------------


### PR DESCRIPTION
As explained [here](https://github.com/OpenRCT2/OpenRCT2/issues/21794#issuecomment-2571440131), the painting code gets confused by the `CarIsInverted` flag still being set when the corkscrew is entered.

This PR changes the data for the first few frames of the FlyerCorkscrewDown in `VehicleSubposition.cpp` (which is used to select the correct sprite to draw) to match that from standard flat pieces (when in inverted mode). This results in the correct sprites being selected.

Closes #21794 