### PR TITLE
Set consumption time when giving items to guests

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Improved: [#23540] The file browser now optionally shows a file size column.
 - Fix: [#21794] Lay-down coaster cars reverse on first frames of downwards corkscrew.
+- Fix: [#23581] [Plugin] Food/drink items given to guests have no consumption duration set.
 
 0.4.18 (2025-01-08)
 ------------------------------------------------------------------------

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -1669,9 +1669,6 @@ bool Guest::DecideAndBuyItem(Ride& ride, const ShopItem shopItem, money64 price)
     if (shopItem == ShopItem::Map)
         ResetPathfindGoal();
 
-    uint16_t consumptionTime = shopItemDescriptor.ConsumptionTime;
-    TimeToConsume = std::min((TimeToConsume + consumptionTime), 255);
-
     if (shopItem == ShopItem::Photo)
         Photo1RideRef = ride.id;
 
@@ -7552,16 +7549,22 @@ void Guest::SetItemFlags(uint64_t itemFlags)
 void Guest::RemoveAllItems()
 {
     ItemFlags = 0;
+    TimeToConsume = 0;
 }
 
 void Guest::RemoveItem(ShopItem item)
 {
     ItemFlags &= ~EnumToFlag(item);
+    TimeToConsume = 0;
 }
 
 void Guest::GiveItem(ShopItem item)
 {
     ItemFlags |= EnumToFlag(item);
+
+    const auto& shopItemDescriptor = GetShopItemDescriptor(item);
+    uint16_t consumptionTime = shopItemDescriptor.ConsumptionTime;
+    TimeToConsume = std::min((TimeToConsume + consumptionTime), 255);
 }
 
 bool Guest::HasItem(ShopItem peepItem) const


### PR DESCRIPTION
When a plugin/script gives a consumable item to guests, its consumption time was not assigned, leading the item to disappear again within a few ticks. This PR addresses this issue by moving the relevant logic to `Guest::GiveItem`. Similarly, the consumption time is now also reset when removing items.