### PR TITLE
Allow scripts to specify tab image remap colours

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -4874,6 +4874,9 @@ declare global {
         frameBase: number;
         frameCount?: number;
         frameDuration?: number;
+        primaryColour?: number;
+        secondaryColour?: number;
+        tertiaryColour?: number;
         offset?: ScreenCoordsXY;
     }
 

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -218,6 +218,21 @@ namespace OpenRCT2::Ui::Windows
                 result.imageFrameCount = AsOrDefault(dukImage["frameCount"], 0);
                 result.imageFrameDuration = AsOrDefault(dukImage["frameDuration"], 0);
 
+                if (dukImage["primaryColour"].type() == DukValue::Type::NUMBER)
+                {
+                    result.imageFrameBase = result.imageFrameBase.WithPrimary(dukImage["primaryColour"].as_uint());
+
+                    if (dukImage["secondaryColour"].type() == DukValue::Type::NUMBER)
+                    {
+                        result.imageFrameBase = result.imageFrameBase.WithSecondary(dukImage["secondaryColour"].as_uint());
+
+                        if (dukImage["tertiaryColour"].type() == DukValue::Type::NUMBER)
+                        {
+                            result.imageFrameBase = result.imageFrameBase.WithTertiary(dukImage["tertiaryColour"].as_uint());
+                        }
+                    }
+                }
+
                 auto dukCoord = dukImage["offset"];
                 if (dukCoord.type() == DukValue::Type::OBJECT)
                 {


### PR DESCRIPTION
This PR allows scripts to optionally specify tab image remap colours.

<details><summary>Test script</summary>
<p>

```js
/// <reference path='../bin/openrct2.d.ts' />
// @ts-check

registerPlugin({
    name: 'Test tab widgets',
    version: '1',
    authors: ['AaronVanGeffen'],
    targetApiVersion: 104,
    type: 'local',
    licence: 'MIT',
    main()
    {
        ui.registerMenuItem('Test tab widgets', function()
        {
            var makeTab = function(frameBase, label) {
                return {
                    image: {
                        frameBase: frameBase,
                        frameCount: 1,
                        frameDuration: 1,
                        primaryColour: Math.floor(Math.random() * 32),
                        secondaryColour: Math.floor(Math.random() * 32),
                        offset: {x: 16, y: 20}
                    },
                    widgets: [
                        {
                            type: 'label',
                            x: 5,
                            y: 50,
                            width: 200,
                            height: 15,
                            text: label
                        }
                    ]
                };
            };

            var window = ui.openWindow({
                classification: 'test-tab-widgetes',
                title: 'Peep tab widgets',
                width: 210,
                height: 80,
                tabs: [
                    makeTab(6410, 'Guest'),
                    makeTab(11262, 'Handyman'),
                    makeTab(11442, 'Mechanic'),
                    makeTab(11882, 'Security'),
                    makeTab(11974, 'Entertainer')
                ]
            });
        })
    }
});
```

</p>
</details> 