### PR TITLE
Make title bar bigger in Enlarged UI mode

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.22 (in development)
 ------------------------------------------------------------------------
 - Improved: [#21767] RCT Classic for macOS can now be used as the source game.
+- Improved: [#23590] Title bars are now drawn bigger when “Enlarged UI” is enabled.
 - Improved: [#23982] The scenario objective window has been merged into the scenario options window.
 - Change: [#23803] Lightning strikes and thunder happen at the same frequency independently of the game speed.
 - Change: [#23857] Replace display options tab with custom sprites.

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -840,6 +840,8 @@ public:
         std::unique_ptr<WindowBase>&& wp, WindowClass cls, ScreenCoordsXY pos, int32_t width, int32_t height,
         uint32_t flags) override
     {
+        // auto titleBarHeight = (flags & WF_NO_TITLE_BAR) ? 0 : GetTitleBarHeight();
+
         if (flags & WF_AUTO_POSITION)
         {
             if (flags & WF_CENTRE_SCREEN)

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -840,7 +840,7 @@ public:
         std::unique_ptr<WindowBase>&& wp, WindowClass cls, ScreenCoordsXY pos, int32_t width, int32_t height,
         uint32_t flags) override
     {
-        // auto titleBarHeight = (flags & WF_NO_TITLE_BAR) ? 0 : GetTitleBarHeight();
+        height += getTitleHeightDiff();
 
         if (flags & WF_AUTO_POSITION)
         {
@@ -853,6 +853,8 @@ public:
                 pos = GetAutoPositionForNewWindow(width, height);
             }
         }
+
+        height -= getTitleHeightDiff();
 
         // Check if there are any window slots left
         // include kWindowLimitReserved for items such as the main viewport and toolbars to not appear to be counted.

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -840,7 +840,7 @@ public:
         std::unique_ptr<WindowBase>&& wp, WindowClass cls, ScreenCoordsXY pos, int32_t width, int32_t height,
         uint32_t flags) override
     {
-        height += getTitleHeightDiff();
+        height += wp->getTitleBarDiffTarget();
 
         if (flags & WF_AUTO_POSITION)
         {
@@ -854,7 +854,7 @@ public:
             }
         }
 
-        height -= getTitleHeightDiff();
+        height -= wp->getTitleBarDiffTarget();
 
         // Check if there are any window slots left
         // include kWindowLimitReserved for items such as the main viewport and toolbars to not appear to be counted.

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -568,6 +568,8 @@ namespace OpenRCT2::Ui
         topLeft.x += width / 2;
         if (Config::Get().interface.WindowButtonsOnTheLeft)
             topLeft.x += kCloseButtonSize;
+        if (Config::Get().interface.EnlargedUi)
+            topLeft.y += 6;
 
         DrawTextEllipsised(
             dpi, topLeft, width, widget->text, Formatter::Common(),

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -569,7 +569,7 @@ namespace OpenRCT2::Ui
         if (Config::Get().interface.WindowButtonsOnTheLeft)
             topLeft.x += kCloseButtonSize;
         if (Config::Get().interface.EnlargedUi)
-            topLeft.y += 6;
+            topLeft.y += kTitleHeightLarge / 4;
 
         DrawTextEllipsised(
             dpi, topLeft, width, widget->text, Formatter::Common(),
@@ -601,17 +601,15 @@ namespace OpenRCT2::Ui
         // Draw the button
         GfxFillRectInset(dpi, { topLeft, bottomRight }, colour, press);
 
-        if (widget.text == kStringIdNone)
+        if (widget.string == nullptr)
             return;
 
         topLeft = w.windowPos + ScreenCoordsXY{ widget.midX() - 1, std::max<int32_t>(widget.top, widget.midY() - 5) };
 
         if (WidgetIsDisabled(w, widgetIndex))
             colour.setFlag(ColourFlag::inset, true);
-        ;
 
-        DrawTextEllipsised(
-            dpi, topLeft, widget.width() - 2, widget.text, Formatter::Common(), { colour, TextAlignment::CENTRE });
+        DrawText(dpi, topLeft, { colour, TextAlignment::CENTRE }, widget.string);
     }
 
     /**

--- a/src/openrct2-ui/interface/Widget.h
+++ b/src/openrct2-ui/interface/Widget.h
@@ -15,18 +15,25 @@
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/interface/Widget.h>
 
+// clang-format off
+#define WINDOW_SHIM_RAW(TITLE, WIDTH, HEIGHT, CLOSE_STR) \
+    { WindowWidgetType::Frame,    0,  0,  WIDTH - 1, 0, HEIGHT - 1, 0xFFFFFFFF,  kStringIdNone        }, \
+    { WindowWidgetType::Caption,  0,  1,  WIDTH - 2, 1, 14,         TITLE,       STR_WINDOW_TITLE_TIP }, \
+    { .type    = WindowWidgetType::CloseBox, \
+      .colour  = 0,                          \
+      .left    = WIDTH - 13,                 \
+      .right   = WIDTH - 3,                  \
+      .top     = 2,                          \
+      .bottom  = 13,                         \
+      .string  = CLOSE_STR,                  \
+      .tooltip = STR_CLOSE_WINDOW_TIP }
+
+#define WINDOW_SHIM(TITLE, WIDTH, HEIGHT) WINDOW_SHIM_RAW(TITLE, WIDTH, HEIGHT, kCloseBoxStringBlackNormal)
+#define WINDOW_SHIM_WHITE(TITLE, WIDTH, HEIGHT) WINDOW_SHIM_RAW(TITLE, WIDTH, HEIGHT, kCloseBoxStringWhiteNormal)
+// clang-format on
+
 namespace OpenRCT2::Ui
 {
-    // clang-format off
-#define WINDOW_SHIM_RAW(TITLE, WIDTH, HEIGHT, CLOSE_STR) \
-    { WindowWidgetType::Frame,    0,  0,          WIDTH - 1, 0, HEIGHT - 1, 0xFFFFFFFF,  kStringIdNone }, \
-    { WindowWidgetType::Caption,  0,  1,          WIDTH - 2, 1, 14,         TITLE,       STR_WINDOW_TITLE_TIP }, \
-    { WindowWidgetType::CloseBox, 0,  WIDTH - 13, WIDTH - 3, 2, 13,         CLOSE_STR,   STR_CLOSE_WINDOW_TIP }
-
-#define WINDOW_SHIM(TITLE, WIDTH, HEIGHT) WINDOW_SHIM_RAW(TITLE, WIDTH, HEIGHT, STR_CLOSE_X)
-#define WINDOW_SHIM_WHITE(TITLE, WIDTH, HEIGHT) WINDOW_SHIM_RAW(TITLE, WIDTH, HEIGHT, STR_CLOSE_X_WHITE)
-    // clang-format on
-
     ImageId GetColourButtonImage(colour_t colour);
     Widget* GetWidgetByIndex(const WindowBase& w, WidgetIndex widgetIndex);
 

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -984,8 +984,18 @@ namespace OpenRCT2::Ui::Windows
 
         if (Config::Get().interface.EnlargedUi)
         {
-            w.min_height += getTitleHeightDiff();
-            w.max_height += getTitleHeightDiff();
+            // Not sure why plugin windows have to be treated differently,
+            // but they currently show a deviation if we don't.
+            if (w.classification == WindowClass::Custom)
+            {
+                w.min_height += w.getTitleBarDiffTarget();
+                w.max_height += w.getTitleBarDiffTarget();
+            }
+            else
+            {
+                w.min_height += w.getTitleBarDiffNormal();
+                w.max_height += w.getTitleBarDiffNormal();
+            }
         }
 
         // Clamp width and height to minimum and maximum

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -470,32 +470,55 @@ namespace OpenRCT2
             this, callWidget, title, description, descriptionArgs, existingText, existingArgs, maxLength);
     }
 
-    void Window::ResizeFrame()
+    int32_t Window::ResizeFrame()
     {
         // Frame
         widgets[0].right = width - 1;
         widgets[0].bottom = height - 1;
+
         // Title
         widgets[1].right = width - 2;
+
         // Close button
+        auto closeButtonSize = Config::Get().interface.EnlargedUi ? kCloseButtonSizeTouch : kCloseButtonSize;
         if (Config::Get().interface.WindowButtonsOnTheLeft)
         {
             widgets[2].left = 2;
-            widgets[2].right = 2 + kCloseButtonSize;
+            widgets[2].right = 2 + closeButtonSize;
         }
         else
         {
-            widgets[2].left = width - 3 - kCloseButtonSize;
+            widgets[2].left = width - 3 - closeButtonSize;
             widgets[2].right = width - 3;
         }
+
+        auto defaultHeight = OpenRCT2::Ui::Windows::GetTitleBarHeight();
+        auto currentHeight = widgets[1].height();
+        auto heightDifference = defaultHeight - currentHeight;
+        if (heightDifference != 0)
+        {
+            widgets[1].bottom += heightDifference;
+            widgets[2].bottom += heightDifference;
+
+            for (size_t i = 3; i < widgets.size(); i++)
+            {
+                widgets[i].top += heightDifference;
+                widgets[i].bottom += heightDifference;
+            }
+        }
+
+        return heightDifference;
     }
 
-    void Window::ResizeFrameWithPage()
+    int32_t Window::ResizeFrameWithPage()
     {
-        ResizeFrame();
-        // Page background
-        widgets[3].right = width - 1;
-        widgets[3].bottom = height - 1;
+        auto heightDifference = ResizeFrame();
+
+        constexpr auto pageBackgroundOffset = 3;
+        widgets[pageBackgroundOffset].right = width - 1;
+        widgets[pageBackgroundOffset].bottom = height - 1;
+
+        return heightDifference;
     }
 
     void Window::ResizeSpinner(WidgetIndex widgetIndex, const ScreenCoordsXY& origin, const ScreenSize& size)
@@ -1134,6 +1157,11 @@ namespace OpenRCT2::Ui::Windows
             WindowZoomIn(*mainWindow, atCursor);
         else
             WindowZoomOut(*mainWindow, atCursor);
+    }
+
+    int16_t GetTitleBarHeight()
+    {
+        return Config::Get().interface.EnlargedUi ? 24 : 12;
     }
 
 } // namespace OpenRCT2::Ui::Windows

--- a/src/openrct2-ui/interface/Window.h
+++ b/src/openrct2-ui/interface/Window.h
@@ -40,8 +40,8 @@ namespace OpenRCT2
             WidgetIndex callWidget, StringId title, StringId description, const Formatter& descriptionArgs,
             StringId existingText, uintptr_t existingArgs, int32_t maxLength);
 
-        void ResizeFrame();
-        void ResizeFrameWithPage();
+        int32_t ResizeFrame();
+        int32_t ResizeFrameWithPage();
 
         void ResizeSpinner(WidgetIndex widgetIndex, const ScreenCoordsXY& origin, const ScreenSize& size);
         void ResizeDropdown(WidgetIndex widgetIndex, const ScreenCoordsXY& origin, const ScreenSize& size);
@@ -91,4 +91,6 @@ namespace OpenRCT2::Ui::Windows
     void WindowZoomIn(WindowBase& w, bool atCursor);
     void WindowZoomOut(WindowBase& w, bool atCursor);
     void MainWindowZoom(bool zoomIn, bool atCursor);
+
+    int16_t GetTitleBarHeight();
 } // namespace OpenRCT2::Ui::Windows

--- a/src/openrct2-ui/interface/Window.h
+++ b/src/openrct2-ui/interface/Window.h
@@ -16,6 +16,8 @@ struct TextInputSession;
 
 namespace OpenRCT2
 {
+    constexpr ScreenSize kMaxWindowSize = { 5000, 5000 };
+
     struct Window : WindowBase
     {
         void OnDraw(DrawPixelInfo& dpi) override;
@@ -39,9 +41,6 @@ namespace OpenRCT2
         void TextInputOpen(
             WidgetIndex callWidget, StringId title, StringId description, const Formatter& descriptionArgs,
             StringId existingText, uintptr_t existingArgs, int32_t maxLength);
-
-        int32_t ResizeFrame();
-        int32_t ResizeFrameWithPage();
 
         void ResizeSpinner(WidgetIndex widgetIndex, const ScreenCoordsXY& origin, const ScreenSize& size);
         void ResizeDropdown(WidgetIndex widgetIndex, const ScreenCoordsXY& origin, const ScreenSize& size);
@@ -80,7 +79,7 @@ namespace OpenRCT2::Ui::Windows
     void WindowMoveAndSnap(WindowBase& w, ScreenCoordsXY newWindowCoords, int32_t snapProximity);
     void WindowRelocateWindows(int32_t width, int32_t height);
 
-    bool WindowSetResize(WindowBase& w, const ScreenSize minSize, const ScreenSize maxSize);
+    bool WindowSetResize(WindowBase& w, ScreenSize minSize, ScreenSize maxSize);
     bool WindowCanResize(const WindowBase& w);
 
     void InvalidateAllWindowsAfterInput();
@@ -91,6 +90,4 @@ namespace OpenRCT2::Ui::Windows
     void WindowZoomIn(WindowBase& w, bool atCursor);
     void WindowZoomOut(WindowBase& w, bool atCursor);
     void MainWindowZoom(bool zoomIn, bool atCursor);
-
-    int16_t GetTitleBarHeight();
 } // namespace OpenRCT2::Ui::Windows

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -21,6 +21,7 @@
 
     #include <limits>
     #include <openrct2/SpriteIds.h>
+    #include <openrct2/config/Config.h>
     #include <openrct2/drawing/Drawing.h>
     #include <openrct2/interface/Window.h>
     #include <openrct2/localisation/Formatter.h>
@@ -475,10 +476,11 @@ namespace OpenRCT2::Ui::Windows
 
         void OnPrepareDraw() override
         {
-            // This has to be called to ensure the window frame is correctly initialised - not doing this will
-            // cause an assertion to be hit.
-            ResizeFrameWithPage();
-            widgets[WIDX_CLOSE].text = colours[0].hasFlag(ColourFlag::translucent) ? STR_CLOSE_X_WHITE : STR_CLOSE_X;
+            bool useWhite = colours[0].hasFlag(ColourFlag::translucent);
+            if (Config::Get().interface.EnlargedUi)
+                widgets[WIDX_CLOSE].string = !useWhite ? kCloseBoxStringBlackLarge : kCloseBoxStringWhiteLarge;
+            else
+                widgets[WIDX_CLOSE].string = !useWhite ? kCloseBoxStringBlackNormal : kCloseBoxStringWhiteNormal;
 
             // Having the content panel visible for transparent windows makes the borders darker than they should be
             // For now just hide it if there are no tabs and the window is not resizable

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -425,8 +425,8 @@ namespace OpenRCT2::Ui::Windows
             {
                 min_width = _info.Desc.MinWidth.value_or(0);
                 min_height = _info.Desc.MinHeight.value_or(0);
-                max_width = _info.Desc.MaxWidth.value_or(std::numeric_limits<int16_t>::max());
-                max_height = _info.Desc.MaxHeight.value_or(std::numeric_limits<int16_t>::max());
+                max_width = _info.Desc.MaxWidth.value_or(kMaxWindowSize.width);
+                max_height = _info.Desc.MaxHeight.value_or(kMaxWindowSize.height);
             }
             RefreshWidgets();
         }
@@ -438,16 +438,6 @@ namespace OpenRCT2::Ui::Windows
 
         void OnResize() override
         {
-            if (width < min_width)
-            {
-                Invalidate();
-                width = min_width;
-            }
-            if (height < min_height)
-            {
-                Invalidate();
-                height = min_height;
-            }
             UpdateViewport();
         }
 

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -439,6 +439,16 @@ namespace OpenRCT2::Ui::Windows
 
         void OnResize() override
         {
+            if (width < min_width)
+            {
+                Invalidate();
+                width = min_width;
+            }
+            if (height < min_height)
+            {
+                Invalidate();
+                height = min_height;
+            }
             UpdateViewport();
         }
 
@@ -747,6 +757,9 @@ namespace OpenRCT2::Ui::Windows
 
         void ChangeTab(size_t tabIndex)
         {
+            if (page == static_cast<int16_t>(tabIndex) && !widgets.empty())
+                return;
+
             page = static_cast<int16_t>(tabIndex);
             frame_no = 0;
             RefreshWidgets();

--- a/src/openrct2-ui/scripting/ScWidget.hpp
+++ b/src/openrct2-ui/scripting/ScWidget.hpp
@@ -167,7 +167,7 @@ namespace OpenRCT2::Scripting
             auto widget = GetWidget();
             if (widget != nullptr)
             {
-                return widget->top;
+                return widget->top - getTitleHeightDiff();
             }
             return 0;
         }
@@ -176,6 +176,7 @@ namespace OpenRCT2::Scripting
             auto widget = GetWidget();
             if (widget != nullptr)
             {
+                value += getTitleHeightDiff();
                 auto delta = value - widget->top;
 
                 Invalidate();

--- a/src/openrct2-ui/scripting/ScWidget.hpp
+++ b/src/openrct2-ui/scripting/ScWidget.hpp
@@ -167,7 +167,8 @@ namespace OpenRCT2::Scripting
             auto widget = GetWidget();
             if (widget != nullptr)
             {
-                return widget->top - getTitleHeightDiff();
+                auto w = GetWindow();
+                return widget->top - w->getTitleBarDiffNormal();
             }
             return 0;
         }
@@ -176,7 +177,8 @@ namespace OpenRCT2::Scripting
             auto widget = GetWidget();
             if (widget != nullptr)
             {
-                value += getTitleHeightDiff();
+                auto w = GetWindow();
+                value += w->getTitleBarDiffNormal();
                 auto delta = value - widget->top;
 
                 Invalidate();

--- a/src/openrct2-ui/scripting/ScWindow.hpp
+++ b/src/openrct2-ui/scripting/ScWindow.hpp
@@ -97,8 +97,14 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                w->width = value;
-                WindowSetResize(*w, { w->min_width, w->min_height }, { w->max_width, w->max_height });
+                if (WindowCanResize(*w))
+                {
+                    WindowResizeByDelta(*w, value - w->width, 0);
+                }
+                else
+                {
+                    WindowSetResize(*w, { value, w->min_height }, { value, w->max_height });
+                }
             }
         }
         int32_t height_get() const
@@ -106,7 +112,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                return w->height - getTitleHeightDiff();
+                return w->height - w->getTitleBarDiffNormal();
             }
             return 0;
         }
@@ -115,8 +121,15 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                w->height = value + getTitleHeightDiff();
-                WindowSetResize(*w, { w->min_width, w->min_height }, { w->max_width, w->max_height });
+                value += w->getTitleBarDiffNormal();
+                if (WindowCanResize(*w))
+                {
+                    WindowResizeByDelta(*w, 0, value - w->height);
+                }
+                else
+                {
+                    WindowSetResize(*w, { w->min_width, value }, { w->max_width, value });
+                }
             }
         }
         int32_t minWidth_get() const
@@ -158,7 +171,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                return w->min_height;
+                return w->min_height - w->getTitleBarDiffNormal();
             }
             return 0;
         }
@@ -167,6 +180,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
+                value += w->getTitleBarDiffNormal();
                 WindowSetResize(*w, { w->min_width, value }, { w->max_width, w->max_height });
             }
         }
@@ -175,7 +189,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                return w->max_height;
+                return w->max_height - w->getTitleBarDiffNormal();
             }
             return 0;
         }
@@ -184,6 +198,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
+                value += w->getTitleBarDiffNormal();
                 WindowSetResize(*w, { w->min_width, w->min_height }, { w->max_width, value });
             }
         }

--- a/src/openrct2-ui/scripting/ScWindow.hpp
+++ b/src/openrct2-ui/scripting/ScWindow.hpp
@@ -97,14 +97,8 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                if (WindowCanResize(*w))
-                {
-                    WindowResizeByDelta(*w, value - w->width, 0);
-                }
-                else
-                {
-                    WindowSetResize(*w, { value, w->min_height }, { value, w->max_height });
-                }
+                w->width = value;
+                WindowSetResize(*w, { w->min_width, w->min_height }, { w->max_width, w->max_height });
             }
         }
         int32_t height_get() const
@@ -112,7 +106,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                return w->height;
+                return w->height - getTitleHeightDiff();
             }
             return 0;
         }
@@ -121,14 +115,8 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                if (WindowCanResize(*w))
-                {
-                    WindowResizeByDelta(*w, 0, value - w->height);
-                }
-                else
-                {
-                    WindowSetResize(*w, { w->min_width, value }, { w->max_width, value });
-                }
+                w->height = value + getTitleHeightDiff();
+                WindowSetResize(*w, { w->min_width, w->min_height }, { w->max_width, w->max_height });
             }
         }
         int32_t minWidth_get() const

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -180,17 +180,17 @@ namespace OpenRCT2::Ui::Windows
             int32_t newHeight = 0;
             if (page == WINDOW_ABOUT_PAGE_OPENRCT2)
             {
-                newHeight = DrawOpenRCT2Info(dpi) + kPadding + 1;
+                newHeight = DrawOpenRCT2Info(dpi) + kPadding;
             }
             else if (page == WINDOW_ABOUT_PAGE_RCT2)
             {
-                newHeight = DrawRCT2Info(dpi) + kPadding + 1;
+                newHeight = DrawRCT2Info(dpi) + kPadding;
             }
 
             if (newHeight != height)
             {
                 Invalidate();
-                widgets[WIDX_PAGE_BACKGROUND].bottom = newHeight - 1;
+                widgets[WIDX_PAGE_BACKGROUND].bottom = newHeight;
                 widgets[WIDX_BACKGROUND].bottom = newHeight;
                 height = newHeight;
             }
@@ -206,8 +206,9 @@ namespace OpenRCT2::Ui::Windows
             page = p;
             frame_no = 0;
             pressed_widgets = 0;
-            SetWidgets(_windowAboutPageWidgets[p]);
+
             WindowSetResize(*this, { WW, WH }, { WW, WH });
+            SetWidgets(_windowAboutPageWidgets[p]);
 
             switch (p)
             {
@@ -218,9 +219,6 @@ namespace OpenRCT2::Ui::Windows
                     pressed_widgets |= (1uLL << WIDX_TAB_ABOUT_RCT2);
                     break;
             }
-
-            InitScrollWidgets();
-            Invalidate();
         }
 
         int32_t DrawOpenRCT2Info(DrawPixelInfo& dpi)
@@ -282,11 +280,6 @@ namespace OpenRCT2::Ui::Windows
             GfxDrawSprite(dpi, ImageId(SPR_CREDITS_CHRIS_SAWYER_SMALL), imageCoords);
 
             return textCoords.y - windowPos.y;
-        }
-
-        void OnPrepareDraw() override
-        {
-            ResizeFrameWithPage();
         }
     };
 

--- a/src/openrct2-ui/windows/AssetPacks.cpp
+++ b/src/openrct2-ui/windows/AssetPacks.cpp
@@ -151,8 +151,6 @@ namespace OpenRCT2::Ui::Windows
 
         void OnPrepareDraw() override
         {
-            ResizeFrame();
-
             auto& list = widgets[WIDX_LIST];
             list.left = 6;
             list.top = widgets[WIDX_TITLE].height() + 8 + 11 + 3;

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -280,8 +280,6 @@ namespace OpenRCT2::Ui::Windows
                 return;
             }
 
-            ResizeFrame();
-
             Widget& colourBtn = widgets[WIDX_MAIN_COLOUR];
             colourBtn.type = WindowWidgetType::Empty;
 
@@ -302,11 +300,6 @@ namespace OpenRCT2::Ui::Windows
             colourBtn.image = GetColourButtonImage(banner->colour);
             Widget& dropDownWidget = widgets[WIDX_TEXT_COLOUR_DROPDOWN];
             dropDownWidget.text = BannerColouredTextFormats[banner->text_colour];
-        }
-
-        void OnResize() override
-        {
-            ResizeFrame();
         }
     };
 

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -149,7 +149,6 @@ namespace OpenRCT2::Ui::Windows
 
         void OnPrepareDraw() override
         {
-            ResizeFrameWithPage();
             widgets[WIDX_SCROLL].right = width - 3;
             widgets[WIDX_SCROLL].bottom = height - 22;
             widgets[WIDX_OPEN_URL].bottom = height - 5;

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -763,11 +763,13 @@ static StringId window_cheats_page_titles[] = {
             }
             maxY += 6;
 
-            Invalidate();
-            WindowInitScrollWidgets(*this);
-            height = maxY;
-            ResizeFrameWithPage();
-            Invalidate();
+            if (maxY != height)
+            {
+                Invalidate();
+                height = maxY;
+                ResizeFrame();
+                Invalidate();
+            }
         }
 
         void UpdateTabPositions()
@@ -1348,11 +1350,6 @@ static StringId window_cheats_page_titles[] = {
                 }
                 break;
             }
-        }
-
-        void OnResize() override
-        {
-            ResizeFrameWithPage();
         }
     };
 

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -77,6 +77,7 @@ namespace OpenRCT2::Ui::Windows
         void OnOpen() override
         {
             SetWidgets(window_clear_scenery_widgets);
+
             hold_down_widgets = (1uLL << WIDX_INCREMENT) | (1uLL << WIDX_DECREMENT);
             WindowInitScrollWidgets(*this);
             WindowPushOthersBelow(*this);
@@ -205,11 +206,6 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords.y = widgets[WIDX_PREVIEW].bottom + windowPos.y + 5 + 27;
                 DrawTextBasic(dpi, screenCoords, STR_COST_AMOUNT, ft, { TextAlignment::CENTRE });
             }
-        }
-
-        void OnResize() override
-        {
-            ResizeFrame();
         }
 
         ClearAction GetClearAction()

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -222,11 +222,6 @@ namespace OpenRCT2::Ui::Windows
                 : STR_SUFFIX;
             DrawTextBasic(dpi, drawPos, stringId, {}, { colours[1] });
         }
-
-        void OnResize() override
-        {
-            ResizeFrame();
-        }
     };
 
     WindowBase* CustomCurrencyOpen()

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -92,11 +92,6 @@ namespace OpenRCT2::Ui::Windows
                 DrawTextWrapped(dpi, stringCoords, WW - 4, stringId, ft, { TextAlignment::CENTRE });
             }
         }
-
-        void OnResize() override
-        {
-            ResizeFrame();
-        }
     };
 
     WindowBase* RideDemolishPromptOpen(const Ride& ride)

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -450,8 +450,6 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WindowWidgetType::Empty
                                                                                    : WindowWidgetType::CloseBox;
 
-            ResizeFrameWithPage();
-
             int16_t scrollListHeight = (height - 88) / 2;
 
             widgets[WIDX_PRE_RESEARCHED_SCROLL].bottom = 60 + scrollListHeight;

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -844,7 +844,6 @@ namespace OpenRCT2::Ui::Windows
         void OnPrepareDraw() override
         {
             // Resize widgets
-            ResizeFrameWithPage();
             widgets[WIDX_LIST].right = width - 309;
             widgets[WIDX_LIST].bottom = height - 14;
             widgets[WIDX_PREVIEW].left = width - 209;

--- a/src/openrct2-ui/windows/EditorParkEntrance.cpp
+++ b/src/openrct2-ui/windows/EditorParkEntrance.cpp
@@ -284,8 +284,6 @@ namespace OpenRCT2::Ui::Windows
 
         void OnPrepareDraw() override
         {
-            ResizeFrameWithPage();
-
             widgets[WIDX_LIST].right = width - 30;
             widgets[WIDX_LIST].bottom = height - 5;
         }

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -576,11 +576,6 @@ namespace OpenRCT2::Ui::Windows
             SetWidgetPressed(WIDX_TAB_1 + page, true);
         }
 
-        void AnchorBorderWidgets()
-        {
-            ResizeFrameWithPage();
-        }
-
         void DrawTabImages(DrawPixelInfo& dpi)
         {
             Widget* widget;
@@ -1086,8 +1081,6 @@ namespace OpenRCT2::Ui::Windows
                                                                                    : WindowWidgetType::CloseBox;
 
             SetWidgetPressed(WIDX_HARD_PARK_RATING, gameState.park.Flags & PARK_FLAGS_DIFFICULT_PARK_RATING);
-
-            AnchorBorderWidgets();
         }
 
         /**
@@ -1255,7 +1248,6 @@ namespace OpenRCT2::Ui::Windows
         void ScenarioDetailsOnPrepareDraw()
         {
             SetPressedTab();
-            AnchorBorderWidgets();
         }
 
         void ScenarioDetailsOnDraw(DrawPixelInfo& dpi)
@@ -1662,8 +1654,6 @@ namespace OpenRCT2::Ui::Windows
 
             widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WindowWidgetType::Empty
                                                                                    : WindowWidgetType::CloseBox;
-
-            AnchorBorderWidgets();
         }
 
         void FinancialDraw(DrawPixelInfo& dpi)
@@ -1951,8 +1941,6 @@ namespace OpenRCT2::Ui::Windows
                                                                                    : WindowWidgetType::CloseBox;
 
             SetWidgetPressed(WIDX_HARD_GUEST_GENERATION, gameState.park.Flags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION);
-
-            AnchorBorderWidgets();
         }
 
         void GuestsDraw(DrawPixelInfo& dpi)
@@ -2152,8 +2140,6 @@ namespace OpenRCT2::Ui::Windows
 
             widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WindowWidgetType::Empty
                                                                                    : WindowWidgetType::CloseBox;
-
-            AnchorBorderWidgets();
         }
 
         void LandDraw(DrawPixelInfo& dpi)
@@ -2285,8 +2271,6 @@ namespace OpenRCT2::Ui::Windows
 
             widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WindowWidgetType::Empty
                                                                                    : WindowWidgetType::CloseBox;
-
-            AnchorBorderWidgets();
         }
 
         /**

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -327,9 +327,6 @@ namespace OpenRCT2::Ui::Windows
                 case WINDOW_FINANCES_PAGE_RESEARCH:
                     WindowResearchFundingPrepareDraw(this, WIDX_RESEARCH_FUNDING);
                     return;
-                default:
-                    return;
-
                 case WINDOW_FINANCES_PAGE_VALUE_GRAPH:
                     graphPageWidget = &widgets[WIDX_PAGE_BACKGROUND];
                     centredGraph = false;
@@ -345,6 +342,8 @@ namespace OpenRCT2::Ui::Windows
                     centredGraph = true;
                     _graphProps.series = getGameState().cashHistory;
                     break;
+                default:
+                    return;
             }
             OnPrepareDrawGraph(graphPageWidget, centredGraph);
         }
@@ -488,12 +487,7 @@ namespace OpenRCT2::Ui::Windows
             page = p;
             frame_no = 0;
 
-            hold_down_widgets = _windowFinancesPageHoldDownWidgets[p];
-            pressed_widgets = 0;
-            SetWidgets(_windowFinancesPageWidgets[p]);
-            SetDisabledTabs();
             Invalidate();
-
             if (p == WINDOW_FINANCES_PAGE_RESEARCH)
             {
                 width = WW_RESEARCH;
@@ -511,9 +505,12 @@ namespace OpenRCT2::Ui::Windows
                 || p == WINDOW_FINANCES_PAGE_FINANCIAL_GRAPH)
             {
                 flags |= WF_RESIZABLE;
-                WindowSetResize(
-                    *this, { WW_OTHER_TABS, kHeightOtherTabs },
-                    { std::numeric_limits<int16_t>::max(), std::numeric_limits<int16_t>::max() });
+
+                // We need to compensate for the enlarged title bar for windows that do not
+                // constrain the window height between tabs (e.g. chart tabs)
+                height -= getTitleHeightDiff();
+
+                WindowSetResize(*this, { WW_OTHER_TABS, kHeightOtherTabs }, kMaxWindowSize);
             }
             else
             {
@@ -521,7 +518,14 @@ namespace OpenRCT2::Ui::Windows
                 height = kHeightOtherTabs;
                 flags &= ~WF_RESIZABLE;
             }
-            OnResize();
+
+            SetWidgets(_windowFinancesPageWidgets[p]);
+            SetDisabledTabs();
+
+            hold_down_widgets = _windowFinancesPageHoldDownWidgets[p];
+            pressed_widgets = 0;
+
+            ResizeFrame();
             OnPrepareDraw();
             InitScrollWidgets();
 
@@ -874,11 +878,6 @@ namespace OpenRCT2::Ui::Windows
             DrawTabImage(dpi, WINDOW_FINANCES_PAGE_PROFIT_GRAPH, SPR_TAB_FINANCES_PROFIT_GRAPH_0);
             DrawTabImage(dpi, WINDOW_FINANCES_PAGE_MARKETING, SPR_TAB_FINANCES_MARKETING_0);
             DrawTabImage(dpi, WINDOW_FINANCES_PAGE_RESEARCH, SPR_TAB_FINANCES_RESEARCH_0);
-        }
-
-        void OnResize() override
-        {
-            ResizeFrameWithPage();
         }
     };
 

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -508,7 +508,7 @@ namespace OpenRCT2::Ui::Windows
 
                 // We need to compensate for the enlarged title bar for windows that do not
                 // constrain the window height between tabs (e.g. chart tabs)
-                height -= getTitleHeightDiff();
+                height -= getTitleBarDiffNormal();
 
                 WindowSetResize(*this, { WW_OTHER_TABS, kHeightOtherTabs }, kMaxWindowSize);
             }

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -1616,11 +1616,6 @@ namespace OpenRCT2::Ui::Windows
             OnMouseDown(WIDX_CONSTRUCT);
         }
 
-        void OnResize() override
-        {
-            ResizeFrame();
-        }
-
 #pragma endregion
     };
 

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -452,7 +452,6 @@ namespace OpenRCT2::Ui::Windows
             maxSize.width = std::max(minSize.width, maxSize.width);
 
             WindowSetResize(*this, minSize, maxSize);
-            ResizeFrameWithPage();
         }
 
         void OnPrepareDrawCommon()

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -405,7 +405,6 @@ namespace OpenRCT2::Ui::Windows
             if (_selectedTab == TabId::Individual && _selectedFilter)
                 widgets[WIDX_MAP].type = WindowWidgetType::FlatBtn;
 
-            ResizeFrameWithPage();
             widgets[WIDX_GUEST_LIST].right = width - 4;
             widgets[WIDX_GUEST_LIST].bottom = height - 15;
             widgets[WIDX_MAP].left = 273 - 350 + width;

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -354,11 +354,6 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnResize() override
-        {
-            ResizeFrame();
-        }
-
     private:
         void UpdatePreview()
         {

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -90,6 +90,7 @@ namespace OpenRCT2::Ui::Windows
         void OnOpen() override
         {
             SetWidgets(window_land_widgets);
+
             hold_down_widgets = (1uLL << WIDX_DECREMENT) | (1uLL << WIDX_INCREMENT);
             WindowInitScrollWidgets(*this);
             WindowPushOthersBelow(*this);
@@ -323,11 +324,6 @@ namespace OpenRCT2::Ui::Windows
                     DrawTextBasic(dpi, screenCoords, STR_COST_AMOUNT, ft, { TextAlignment::CENTRE });
                 }
             }
-        }
-
-        void OnResize() override
-        {
-            ResizeFrame();
         }
 
     private:

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -127,6 +127,7 @@ namespace OpenRCT2::Ui::Windows
         void OnOpen() override
         {
             SetWidgets(window_land_rights_widgets);
+
             hold_down_widgets = (1uLL << WIDX_INCREMENT) | (1uLL << WIDX_DECREMENT);
             WindowInitScrollWidgets(*this);
             WindowPushOthersBelow(*this);
@@ -386,7 +387,6 @@ namespace OpenRCT2::Ui::Windows
             if (windowPos.x + width > ContextGetWidth())
                 windowPos.x = ContextGetWidth() - width;
 
-            ResizeFrame();
             Invalidate();
         }
 

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -570,7 +570,7 @@ namespace OpenRCT2::Ui::Windows
 
             auto& config = Config::Get().general;
             config.FileBrowserWidth = width;
-            config.FileBrowserHeight = height - getTitleHeightDiff();
+            config.FileBrowserHeight = height - getTitleBarDiffNormal();
         }
 
         void OnUpdate() override

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -570,7 +570,7 @@ namespace OpenRCT2::Ui::Windows
 
             auto& config = Config::Get().general;
             config.FileBrowserWidth = width;
-            config.FileBrowserHeight = height;
+            config.FileBrowserHeight = height - getTitleHeightDiff();
         }
 
         void OnUpdate() override
@@ -584,8 +584,6 @@ namespace OpenRCT2::Ui::Windows
 
         void OnPrepareDraw() override
         {
-            ResizeFrameWithPage();
-
             auto toolbarXPos = width - 5;
             for (auto widgetIndex = 3; widgetIndex >= 0; widgetIndex--)
             {

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -619,7 +619,6 @@ namespace OpenRCT2::Ui::Windows
             SetWidgetDisabled(WIDX_MAP_SIZE_LINK, gameState.mapSize.x != gameState.mapSize.y);
 
             // Resize widgets to window size
-            ResizeFrameWithPage();
             ResizeMiniMap();
 
             widgets[WIDX_MAP_SIZE_SPINNER_Y].top = height - 15;
@@ -1205,6 +1204,8 @@ namespace OpenRCT2::Ui::Windows
             height = std::min<int16_t>(height, maxWindowHeight);
 
             _adjustedForSandboxMode = isEditorOrSandbox();
+
+            ResizeFrame();
         }
 
         void ResetMaxWindowDimensions()

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -281,8 +281,8 @@ namespace OpenRCT2::Ui::Windows
             frame_no = 0;
             RemoveViewport();
 
-            hold_down_widgets = HoldDownWidgets[newPage];
             SetWidgets(PageWidgets[newPage]);
+            hold_down_widgets = HoldDownWidgets[newPage];
             disabled_widgets = PageDisabledWidgets[newPage];
             pressed_widgets = PressedWidgets[newPage];
 
@@ -1526,7 +1526,7 @@ namespace OpenRCT2::Ui::Windows
 
         void OnResize() override
         {
-            ResizeFrameWithPage();
+            WindowSetResize(*this, kWindowSize, kWindowSize);
         }
     };
 

--- a/src/openrct2-ui/windows/MapTooltip.cpp
+++ b/src/openrct2-ui/windows/MapTooltip.cpp
@@ -128,7 +128,8 @@ namespace OpenRCT2::Ui::Windows
         else
         {
             w = windowMgr->Create<MapTooltip>(
-                WindowClass::MapTooltip, pos, width, height, WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_NO_BACKGROUND);
+                WindowClass::MapTooltip, pos, width, height,
+                WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_NO_BACKGROUND | WF_NO_TITLE_BAR);
         }
     }
 } // namespace OpenRCT2::Ui::Windows

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -166,7 +166,6 @@ namespace OpenRCT2::Ui::Windows
 
         void OnResize() override
         {
-            ResizeFrameWithPage();
             uint64_t disabledWidgets = 0;
             if (_rideConstructionState == RideConstructionState::Place)
             {

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -395,7 +395,6 @@ namespace OpenRCT2::Ui::Windows
     {
         ResetPressedWidgets();
         SetWidgetPressed(WIDX_TAB1 + page, true);
-        ResizeFrameWithPage();
         switch (page)
         {
             case WINDOW_MULTIPLAYER_PAGE_INFORMATION:

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -35,9 +35,8 @@ namespace OpenRCT2::Ui::Windows
     public:
         void OnOpen() override
         {
-            SetWidgets(window_network_status_widgets);
-            WindowInitScrollWidgets(*this);
             WindowSetResize(*this, { 320, 90 }, { 320, 90 });
+            SetWidgets(window_network_status_widgets);
 
             frame_no = 0;
             page = 0;
@@ -86,18 +85,15 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnPrepareDraw() override
-        {
-            ResizeFrame();
-        }
-
         void OnDraw(DrawPixelInfo& dpi) override
         {
             WindowDrawWidgets(*this, dpi);
             thread_local std::string _buffer;
+
             _buffer.assign("{WHITE}");
             _buffer += _windowNetworkStatusText;
             GfxClipString(_buffer.data(), widgets[WIDX_BACKGROUND].right - 50, FontStyle::Medium);
+
             ScreenCoordsXY screenCoords(windowPos.x + (width / 2), windowPos.y + (height / 2));
             screenCoords.x -= GfxGetStringWidth(_buffer, FontStyle::Medium) / 2;
             DrawText(dpi, screenCoords, { COLOUR_BLACK }, _buffer.c_str());

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -390,11 +390,6 @@ namespace OpenRCT2::Ui::Windows
             DrawTextBasic(dpi, screenCoords, STR_MARKETING_TOTAL_COST, ft);
         }
 
-        void OnResize() override
-        {
-            ResizeFrame();
-        }
-
         int16_t GetCampaignType() const
         {
             return Campaign.campaign_type;

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -862,16 +862,12 @@ namespace OpenRCT2::Ui::Windows
             // Handle new window size
             if (width != newWidth || height != newHeight)
             {
-                Invalidate();
+                ScreenSize newSize = { newWidth, newHeight };
+                WindowSetResize(*this, newSize, newSize);
+                OnResize();
 
-                // Resize widgets to new window size
-                width = newWidth;
-                height = newHeight;
-                ResizeFrameWithPage();
                 widgets[WIDX_GROUP_BY_TRACK_TYPE].left = newWidth - 8 - GroupByTrackTypeWidth;
                 widgets[WIDX_GROUP_BY_TRACK_TYPE].right = newWidth - 8;
-
-                Invalidate();
             }
 
             InitScrollWidgets();

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -315,11 +315,6 @@ namespace OpenRCT2::Ui::Windows
                 i++;
             }
         }
-
-        void OnResize() override
-        {
-            ResizeFrame();
-        }
     };
 
     WindowBase* NewsOpen()

--- a/src/openrct2-ui/windows/NewsOptions.cpp
+++ b/src/openrct2-ui/windows/NewsOptions.cpp
@@ -264,11 +264,6 @@ namespace OpenRCT2::Ui::Windows
             return configValue;
         }
 
-        void OnResize() override
-        {
-            ResizeFrameWithPage();
-        }
-
         static constexpr int32_t TabAnimationDivisor[3] = {
             1, // Park
             4, // Ride

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -556,11 +556,6 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnResize() override
-        {
-            ResizeFrame();
-        }
-
         void Initialise(utf8* path, const size_t numMissingObjects, const ObjectEntryDescriptor* missingObjects)
         {
             _invalidEntries = std::vector<ObjectEntryDescriptor>(missingObjects, missingObjects + numMissingObjects);

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -675,13 +675,15 @@ namespace OpenRCT2::Ui::Windows
                 const auto& widget = widgets[widgetIdx];
                 y = std::max<int32_t>(y, widget.bottom);
             }
-            height = y + 6;
-            ResizeFrameWithPage();
-        }
+            y += 6;
 
-        void OnResize() override
-        {
-            ResizeFrameWithPage();
+            if (height != y)
+            {
+                Invalidate();
+                height = y;
+                ResizeFrame();
+                Invalidate();
+            }
         }
 
         void CommonUpdate()
@@ -1618,6 +1620,7 @@ namespace OpenRCT2::Ui::Windows
                     Config::Save();
                     Invalidate();
                     windowMgr->InvalidateAll();
+                    WindowVisitEach([](WindowBase* w) { w->ResizeFrame(); });
                     break;
                 case WIDX_TOUCH_ENHANCEMENTS:
                     Config::Get().interface.TouchEnhancements ^= 1;
@@ -2117,8 +2120,8 @@ namespace OpenRCT2::Ui::Windows
             SetWidgets(window_options_page_widgets[page]);
 
             Invalidate();
-            OnResize();
             OnPrepareDraw();
+            OnResize();
             InitScrollWidgets();
             Invalidate();
         }

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -1197,7 +1197,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 // We need to compensate for the enlarged title bar for windows that do not
                 // constrain the window height between tabs (e.g. chart tabs)
-                height -= getTitleHeightDiff();
+                height -= getTitleBarDiffNormal();
             }
 
             OnResize();

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -514,7 +514,6 @@ namespace OpenRCT2::Ui::Windows
         void OnPrepareDrawEntrance()
         {
             const auto& gameState = getGameState();
-            SetWidgets(_pagedWidgets[page]);
             InitScrollWidgets();
 
             SetPressedTab();
@@ -548,7 +547,6 @@ namespace OpenRCT2::Ui::Windows
                 widgets[WIDX_BUY_LAND_RIGHTS].type = WindowWidgetType::FlatBtn;
 
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
-            AnchorBorderWidgets();
 
             // Anchor entrance page specific widgets
             widgets[WIDX_VIEWPORT].right = width - 26;
@@ -677,7 +675,7 @@ namespace OpenRCT2::Ui::Windows
         void OnResizeRating()
         {
             flags |= WF_RESIZABLE;
-            WindowSetResize(*this, { 268, 174 + 9 }, { 2000, 2000 });
+            WindowSetResize(*this, { 268, 174 + 9 }, kMaxWindowSize);
         }
 
         void OnUpdateRating()
@@ -696,7 +694,6 @@ namespace OpenRCT2::Ui::Windows
             PrepareWindowTitleText();
 
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
-            AnchorBorderWidgets();
 
             _ratingProps.min = 0;
             _ratingProps.max = 1000;
@@ -745,7 +742,7 @@ namespace OpenRCT2::Ui::Windows
         void OnResizeGuests()
         {
             flags |= WF_RESIZABLE;
-            WindowSetResize(*this, { 268, 174 + 9 }, { 2000, 2000 });
+            WindowSetResize(*this, { 268, 174 + 9 }, kMaxWindowSize);
         }
 
         void OnUpdateGuests()
@@ -765,7 +762,6 @@ namespace OpenRCT2::Ui::Windows
             PrepareWindowTitleText();
 
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
-            AnchorBorderWidgets();
 
             const auto& gameState = getGameState();
             _guestProps.series = gameState.guestsInParkHistory;
@@ -892,7 +888,6 @@ namespace OpenRCT2::Ui::Windows
             }
 
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
-            AnchorBorderWidgets();
         }
 
         void OnDrawPrice(DrawPixelInfo& dpi)
@@ -953,7 +948,6 @@ namespace OpenRCT2::Ui::Windows
             PrepareWindowTitleText();
 
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
-            AnchorBorderWidgets();
         }
 
         void OnDrawStats(DrawPixelInfo& dpi)
@@ -1080,7 +1074,6 @@ namespace OpenRCT2::Ui::Windows
                 widgets[WIDX_ENTER_NAME].type = WindowWidgetType::Empty;
 
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
-            AnchorBorderWidgets();
         }
 
         void OnDrawObjective(DrawPixelInfo& dpi)
@@ -1146,7 +1139,6 @@ namespace OpenRCT2::Ui::Windows
             PrepareWindowTitleText();
 
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
-            AnchorBorderWidgets();
         }
 
         void OnDrawAwards(DrawPixelInfo& dpi)
@@ -1201,16 +1193,18 @@ namespace OpenRCT2::Ui::Windows
             Invalidate();
             InitScrollWidgets();
 
+            if (page == WINDOW_PARK_PAGE_GUESTS || WINDOW_PARK_PAGE_RATING)
+            {
+                // We need to compensate for the enlarged title bar for windows that do not
+                // constrain the window height between tabs (e.g. chart tabs)
+                height -= getTitleHeightDiff();
+            }
+
             OnResize();
             OnPrepareDraw();
             OnUpdate();
             if (listen && viewport != nullptr)
                 viewport->flags |= VIEWPORT_FLAG_SOUND_ON;
-        }
-
-        void AnchorBorderWidgets()
-        {
-            ResizeFrameWithPage();
         }
 
         void SetPressedTab()

--- a/src/openrct2-ui/windows/PatrolArea.cpp
+++ b/src/openrct2-ui/windows/PatrolArea.cpp
@@ -58,6 +58,7 @@ namespace OpenRCT2::Ui::Windows
         void OnOpen() override
         {
             SetWidgets(PatrolAreaWidgets);
+
             hold_down_widgets = (1uLL << WIDX_INCREMENT) | (1uLL << WIDX_DECREMENT);
             WindowInitScrollWidgets(*this);
             WindowPushOthersBelow(*this);
@@ -284,11 +285,6 @@ namespace OpenRCT2::Ui::Windows
         {
             auto coords = FootpathGetCoordinatesFromPos(pos, nullptr, nullptr);
             return coords.IsNull() ? std::nullopt : std::make_optional(coords);
-        }
-
-        void OnResize() override
-        {
-            ResizeFrame();
         }
     };
 

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -379,7 +379,6 @@ namespace OpenRCT2::Ui::Windows
 
             UpdateTitle();
 
-            ResizeFrameWithPage();
             widgets[WIDX_LOCATE].right = width - 2;
             widgets[WIDX_LOCATE].left = width - 25;
             widgets[WIDX_KICK].right = width - 2;
@@ -591,8 +590,6 @@ namespace OpenRCT2::Ui::Windows
             pressed_widgets |= 1uLL << (page + WIDX_TAB_1);
 
             UpdateTitle();
-
-            ResizeFrameWithPage();
 
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_2);
         }

--- a/src/openrct2-ui/windows/ProgressWindow.cpp
+++ b/src/openrct2-ui/windows/ProgressWindow.cpp
@@ -83,14 +83,14 @@ namespace OpenRCT2::Ui::Windows
         void OnOpen() override
         {
             Audio::StopSFX();
+
             SetWidgets(kProgressWindowWidgets);
-            WindowInitScrollWidgets(*this);
             WindowSetResize(*this, { kWindowWidth, kWindowHeight }, { kWindowWidth, kWindowHeight });
 
             frame_no = 0;
 
             ApplyStyle();
-            OnResize();
+            ResizeFrame();
         }
 
         void OnClose() override
@@ -119,11 +119,10 @@ namespace OpenRCT2::Ui::Windows
         void OnPrepareDraw() override
         {
             if (_onClose != nullptr)
-                widgets[WIDX_CLOSE].type = WindowWidgetType::Button;
+                widgets[WIDX_CLOSE].type = WindowWidgetType::CloseBox;
             else
                 widgets[WIDX_CLOSE].type = WindowWidgetType::Empty;
 
-            ResizeFrame();
             PrepareCaption();
         }
 

--- a/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
@@ -91,16 +91,6 @@ namespace OpenRCT2::Ui::Windows
                 DrawTextWrapped(dpi, stringCoords, WW - 4, stringId, ft, { TextAlignment::CENTRE });
             }
         }
-
-        void OnPrepareDraw() override
-        {
-            ResizeFrame();
-        }
-
-        void OnResize() override
-        {
-            ResizeFrame();
-        }
     };
 
     WindowBase* RideRefurbishPromptOpen(const Ride& ride)

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -132,12 +132,6 @@ namespace OpenRCT2::Ui::Windows
 
             page = newPageIndex;
             frame_no = 0;
-            RemoveViewport();
-
-            hold_down_widgets = 0;
-            SetWidgets(window_research_page_widgets[newPageIndex]);
-            disabled_widgets = 0;
-            pressed_widgets = 0;
 
             Invalidate();
             if (newPageIndex == WINDOW_RESEARCH_PAGE_DEVELOPMENT)
@@ -150,10 +144,12 @@ namespace OpenRCT2::Ui::Windows
                 width = WW_FUNDING;
                 height = WH_FUNDING;
             }
-            OnResize();
-
-            InitScrollWidgets();
             Invalidate();
+
+            SetWidgets(window_research_page_widgets[newPageIndex]);
+            hold_down_widgets = 0;
+            disabled_widgets = 0;
+            pressed_widgets = 0;
         }
 
     private:
@@ -270,11 +266,6 @@ namespace OpenRCT2::Ui::Windows
                     break;
                 }
             }
-        }
-
-        void OnResize() override
-        {
-            ResizeFrameWithPage();
         }
 
         void DrawTabImage(DrawPixelInfo& dpi, int32_t tabPage, int32_t spriteIndex)

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -815,6 +815,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
             }
         }
+
         void OnUpdate() override
         {
             switch (page)
@@ -1471,11 +1472,6 @@ namespace OpenRCT2::Ui::Windows
             for (i = 0; i < WINDOW_RIDE_PAGE_COUNT; i++)
                 pressed_widgets &= ~(1 << (WIDX_TAB_1 + i));
             pressed_widgets |= 1LL << (WIDX_TAB_1 + page);
-        }
-
-        void AnchorBorderWidgets()
-        {
-            ResizeFrameWithPage();
         }
 
 #pragma region Main
@@ -2368,8 +2364,6 @@ namespace OpenRCT2::Ui::Windows
                 + WidgetIsPressed(*this, WIDX_OPEN_LIGHT);
             widgets[WIDX_OPEN_LIGHT].image = ImageId(openLightImage);
 
-            AnchorBorderWidgets();
-
             const int32_t offset = gameState.cheats.allowArbitraryRideTypeChanges ? 15 : 0;
             // Anchor main page specific widgets
             widgets[WIDX_VIEWPORT].right = width - 26;
@@ -2660,7 +2654,7 @@ namespace OpenRCT2::Ui::Windows
 
         void VehicleResize()
         {
-            auto bottom = widgets[WIDX_VEHICLE_TRAINS].bottom + 6;
+            auto bottom = widgets[WIDX_VEHICLE_TRAINS].bottom + 6 - getTitleBarDiffNormal();
             WindowSetResize(*this, { kMinimumWindowWidth, bottom }, { kMinimumWindowWidth, bottom });
         }
 
@@ -2858,7 +2852,6 @@ namespace OpenRCT2::Ui::Windows
 
             ride->formatNameTo(ft);
 
-            AnchorBorderWidgets();
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
 
             if (abs(ride->numCarsPerTrain - rideEntry->zero_cars) == 1)
@@ -2942,7 +2935,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 auto heightIncrease = minimumPreviewStart - widgets[WIDX_VEHICLE_TRAINS_PREVIEW].top;
                 height += heightIncrease;
-                ResizeFrameWithPage();
+                ResizeFrame();
 
                 for (auto i = EnumValue(WIDX_VEHICLE_TRAINS_PREVIEW); i <= WIDX_VEHICLE_CARS_PER_TRAIN_DECREASE; i++)
                 {
@@ -3205,7 +3198,7 @@ namespace OpenRCT2::Ui::Windows
 
         void OperatingResize()
         {
-            auto bottom = widgets[WIDX_SYNCHRONISE_WITH_ADJACENT_STATIONS_CHECKBOX].bottom + 6;
+            auto bottom = widgets[WIDX_SYNCHRONISE_WITH_ADJACENT_STATIONS_CHECKBOX].bottom + 6 - getTitleBarDiffNormal();
             WindowSetResize(*this, { kMinimumWindowWidth, bottom }, { kMinimumWindowWidth, bottom });
         }
 
@@ -3686,7 +3679,6 @@ namespace OpenRCT2::Ui::Windows
                 widgets[WIDX_MODE_TWEAK_DECREASE].type = WindowWidgetType::Empty;
             }
 
-            AnchorBorderWidgets();
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
         }
 
@@ -3776,7 +3768,7 @@ namespace OpenRCT2::Ui::Windows
 
         void MaintenanceResize()
         {
-            auto bottom = widgets[WIDX_LOCATE_MECHANIC].bottom + 6;
+            auto bottom = widgets[WIDX_LOCATE_MECHANIC].bottom + 6 - getTitleBarDiffNormal();
             WindowSetResize(*this, { kMinimumWindowWidth, bottom }, { kMinimumWindowWidth, bottom });
         }
 
@@ -4009,7 +4001,6 @@ namespace OpenRCT2::Ui::Windows
 
             widgets[WIDX_INSPECTION_INTERVAL].text = kRideInspectionIntervalNames[ride->inspectionInterval];
 
-            AnchorBorderWidgets();
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
 
             if (Config::Get().general.DebuggingTools && NetworkGetMode() == NETWORK_MODE_NONE)
@@ -4307,7 +4298,7 @@ namespace OpenRCT2::Ui::Windows
 
         void ColourResize()
         {
-            auto bottom = widgets[WIDX_VEHICLE_PREVIEW].bottom + 6;
+            auto bottom = widgets[WIDX_VEHICLE_PREVIEW].bottom + 6 - getTitleBarDiffNormal();
             WindowSetResize(*this, { kMinimumWindowWidth, bottom }, { kMinimumWindowWidth, bottom });
         }
 
@@ -4817,7 +4808,6 @@ namespace OpenRCT2::Ui::Windows
             ft.Increment(14);
             ft.Add<StringId>(ColourSchemeNames[colourScheme]);
 
-            AnchorBorderWidgets();
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
         }
 
@@ -5243,7 +5233,6 @@ namespace OpenRCT2::Ui::Windows
                 disabled_widgets |= (1uLL << WIDX_MUSIC) | (1uLL << WIDX_MUSIC_DROPDOWN) | (1uLL << WIDX_MUSIC_DATA);
             }
 
-            AnchorBorderWidgets();
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
         }
 
@@ -5616,7 +5605,6 @@ namespace OpenRCT2::Ui::Windows
                 }
             }
 
-            AnchorBorderWidgets();
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
         }
 
@@ -5910,7 +5898,7 @@ namespace OpenRCT2::Ui::Windows
 
         void GraphsResize()
         {
-            WindowSetResize(*this, { kMinimumWindowWidth, 182 }, { std::numeric_limits<int16_t>::max(), 450 });
+            WindowSetResize(*this, { kMinimumWindowWidth, 182 }, { kMaxWindowSize.width, 450 });
         }
 
         void GraphsOnMouseDown(WidgetIndex widgetIndex)
@@ -6061,7 +6049,6 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_GRAPH_VERTICAL].bottom = y;
             widgets[WIDX_GRAPH_LATERAL].bottom = y;
 
-            AnchorBorderWidgets();
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
         }
 
@@ -6623,7 +6610,6 @@ namespace OpenRCT2::Ui::Windows
                     widgets[WIDX_SECONDARY_PRICE].text = STR_FREE;
             }
 
-            AnchorBorderWidgets();
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
         }
 
@@ -6822,7 +6808,6 @@ namespace OpenRCT2::Ui::Windows
                     widgets[WIDX_SHOW_GUESTS_QUEUING].type = WindowWidgetType::FlatBtn;
                 }
 
-                AnchorBorderWidgets();
                 WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
             }
         }

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -332,7 +332,6 @@ namespace OpenRCT2::Ui::Windows
 
         void OnResize() override
         {
-            ResizeFrame();
             WindowRideConstructionUpdateEnabledTrackPieces();
 
             auto currentRide = GetRide(_currentRideIndex);

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -465,8 +465,6 @@ namespace OpenRCT2::Ui::Windows
             else
                 pressed_widgets &= ~(1uLL << WIDX_QUICK_DEMOLISH);
 
-            ResizeFrameWithPage();
-
             widgets[WIDX_LIST].right = width - 26;
             widgets[WIDX_LIST].bottom = height - 15;
             widgets[WIDX_OPEN_CLOSE_ALL].right = width - 2;

--- a/src/openrct2-ui/windows/SavePrompt.cpp
+++ b/src/openrct2-ui/windows/SavePrompt.cpp
@@ -196,11 +196,6 @@ namespace OpenRCT2::Ui::Windows
         {
             DrawWidgets(dpi);
         }
-
-        void OnResize() override
-        {
-            ResizeFrame();
-        }
     };
 
     WindowBase* SavePromptOpen()

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -359,7 +359,6 @@ namespace OpenRCT2::Ui::Windows
 
             pressed_widgets |= 1LL << (selected_tab + WIDX_TAB1);
 
-            ResizeFrameWithPage();
             const int32_t bottomMargin = Config::Get().general.DebuggingTools ? 17 : 5;
             widgets[WIDX_SCENARIOLIST].right = width - kPreviewPaneWidth;
             widgets[WIDX_SCENARIOLIST].bottom = height - bottomMargin;

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -71,8 +71,7 @@ namespace OpenRCT2::Ui::Windows
     constexpr int32_t WINDOW_SCENERY_MIN_HEIGHT = 195 - kTitleHeightNormal;
     constexpr int32_t SCENERY_BUTTON_WIDTH = 66;
     constexpr int32_t SCENERY_BUTTON_HEIGHT = 80;
-    constexpr int32_t InitTabPosX = 3;
-    constexpr int32_t InitTabPosY = 17;
+    constexpr int32_t kTabMargin = 3;
     constexpr int32_t TabWidth = 31;
     constexpr int32_t TabHeight = 28;
     constexpr int32_t ReservedTabCount = 2;
@@ -637,7 +636,7 @@ namespace OpenRCT2::Ui::Windows
 
         void OnPrepareDraw() override
         {
-            _actualMinHeight = WINDOW_SCENERY_MIN_HEIGHT + getTitleBarHeight();
+            _actualMinHeight = WINDOW_SCENERY_MIN_HEIGHT + getTitleBarTargetHeight();
 
             // Set the window title
             StringId titleStringId = STR_MISCELLANEOUS;
@@ -784,7 +783,7 @@ namespace OpenRCT2::Ui::Windows
                 const auto lastTabWidget = &widgets[WIDX_SCENERY_TAB_1 + lastTabIndex];
                 windowWidth = std::max<int32_t>(windowWidth, lastTabWidget->right + 3);
 
-                auto tabTop = widgets[WIDX_SCENERY_TITLE].bottom + 3;
+                auto tabTop = widgets[WIDX_SCENERY_TITLE].bottom + kTabMargin;
                 if (GetSceneryTabInfoForMisc() != nullptr)
                 {
                     auto miscTabWidget = &widgets[WIDX_SCENERY_TAB_1 + _tabEntries.size() - 2];
@@ -1376,7 +1375,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Add tabs
             int32_t tabsInThisRow = 0;
-            ScreenCoordsXY pos = { InitTabPosX, InitTabPosY + getTitleHeightDiff() };
+            ScreenCoordsXY pos = { kTabMargin, widgets[WIDX_SCENERY_TITLE].bottom + kTabMargin };
             for (const auto& tabInfo : _tabEntries)
             {
                 auto widget = MakeTab(pos, STR_STRING_DEFINED_TOOLTIP);
@@ -1408,7 +1407,7 @@ namespace OpenRCT2::Ui::Windows
                 tabsInThisRow++;
                 if (tabsInThisRow >= maxTabsInThisRow)
                 {
-                    pos.x = InitTabPosX;
+                    pos.x = kTabMargin;
                     pos.y += TabHeight;
                     tabsInThisRow = 0;
                     _actualMinHeight += TabHeight;

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -68,7 +68,7 @@ namespace OpenRCT2::Ui::Windows
 {
     static constexpr StringId WINDOW_TITLE = kStringIdNone;
     constexpr int32_t WINDOW_SCENERY_MIN_WIDTH = 634;
-    constexpr int32_t WINDOW_SCENERY_MIN_HEIGHT = 195;
+    constexpr int32_t WINDOW_SCENERY_MIN_HEIGHT = 195 - kTitleHeightNormal;
     constexpr int32_t SCENERY_BUTTON_WIDTH = 66;
     constexpr int32_t SCENERY_BUTTON_HEIGHT = 80;
     constexpr int32_t InitTabPosX = 3;
@@ -370,7 +370,7 @@ namespace OpenRCT2::Ui::Windows
                 ContentUpdateScroll();
             }
 
-            ResizeFrameWithPage();
+            ResizeFrame();
         }
 
         void OnMouseDown(WidgetIndex widgetIndex) override
@@ -637,6 +637,8 @@ namespace OpenRCT2::Ui::Windows
 
         void OnPrepareDraw() override
         {
+            _actualMinHeight = WINDOW_SCENERY_MIN_HEIGHT + getTitleBarHeight();
+
             // Set the window title
             StringId titleStringId = STR_MISCELLANEOUS;
             const auto tabIndex = _activeTabIndex;
@@ -802,7 +804,7 @@ namespace OpenRCT2::Ui::Windows
                 }
             }
 
-            ResizeFrameWithPage();
+            ResizeFrame();
             widgets[WIDX_SCENERY_LIST].right = windowWidth - 26;
             widgets[WIDX_SCENERY_LIST].bottom = height - 24;
 
@@ -1369,15 +1371,12 @@ namespace OpenRCT2::Ui::Windows
             // Add the base widgets
             SetWidgets(WindowSceneryBaseWidgets);
 
-            // Add tabs
-            _actualMinHeight = WINDOW_SCENERY_MIN_HEIGHT;
-            int32_t xInit = InitTabPosX;
-            int32_t tabsInThisRow = 0;
-
             auto hasMisc = GetSceneryTabInfoForMisc() != nullptr;
             auto maxTabsInThisRow = MaxTabsPerRow - 1 - (hasMisc ? 1 : 0);
 
-            ScreenCoordsXY pos = { xInit, InitTabPosY };
+            // Add tabs
+            int32_t tabsInThisRow = 0;
+            ScreenCoordsXY pos = { InitTabPosX, InitTabPosY + getTitleHeightDiff() };
             for (const auto& tabInfo : _tabEntries)
             {
                 auto widget = MakeTab(pos, STR_STRING_DEFINED_TOOLTIP);
@@ -1409,7 +1408,7 @@ namespace OpenRCT2::Ui::Windows
                 tabsInThisRow++;
                 if (tabsInThisRow >= maxTabsInThisRow)
                 {
-                    pos.x = xInit;
+                    pos.x = InitTabPosX;
                     pos.y += TabHeight;
                     tabsInThisRow = 0;
                     _actualMinHeight += TabHeight;

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -58,6 +58,7 @@ namespace OpenRCT2::Ui::Windows
         void OnOpen() override
         {
             SetWidgets(_sceneryScatterWidgets);
+
             hold_down_widgets = (1uLL << WIDX_INCREMENT) | (1uLL << WIDX_DECREMENT);
             WindowInitScrollWidgets(*this);
             WindowPushOthersBelow(*this);
@@ -192,11 +193,6 @@ namespace OpenRCT2::Ui::Windows
                 DrawTextBasic(
                     dpi, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, ft, { TextAlignment::CENTRE });
             }
-        }
-
-        void OnResize() override
-        {
-            ResizeFrame();
         }
     };
 

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -515,8 +515,6 @@ namespace OpenRCT2::Ui::Windows
 
         void OnPrepareDraw() override
         {
-            ResizeFrame();
-
             int32_t margin = 6;
             int32_t buttonHeight = 13;
             int32_t buttonTop = height - margin - buttonHeight - 13;

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -248,11 +248,6 @@ namespace OpenRCT2::Ui::Windows
                 dpi, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_MAXPLAYERS].top }, STR_MAX_PLAYERS, {}, { colours[1] });
         }
 
-        void OnResize() override
-        {
-            ResizeFrame();
-        }
-
     private:
         char _port[7];
         char _name[65];

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -189,8 +189,6 @@ namespace OpenRCT2::Ui::Windows
             InitialiseTabs();
             InitialiseWidgets();
             InitialiseList();
-
-            WindowSetResize(*this, { WW, WH }, { WW_SC_MAX, WH_SC_MAX });
         }
 
         void OnClose() override
@@ -201,7 +199,7 @@ namespace OpenRCT2::Ui::Windows
 
         void OnResize() override
         {
-            WindowSetResize(*this, { min_width, min_height }, { max_width, max_height });
+            WindowSetResize(*this, { WW, WH }, { WW_SC_MAX, WH_SC_MAX });
         }
 
         void OnUpdate() override
@@ -240,7 +238,6 @@ namespace OpenRCT2::Ui::Windows
 
         void OnPrepareDraw() override
         {
-            ResizeFrameWithPage();
             widgets[WIDX_SCROLL].right = width - 5;
             widgets[WIDX_SCROLL].bottom = height - 19;
             widgets[WIDX_RESET].top = height - 16;
@@ -458,6 +455,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             WindowInitScrollWidgets(*this);
+            ResizeFrame();
         }
 
         void SetTab(size_t index)

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -322,11 +322,6 @@ namespace OpenRCT2::Ui::Windows
                 viewport->flags = Config::Get().general.AlwaysShowGridlines ? VIEWPORT_FLAG_GRIDLINES : VIEWPORT_FLAG_NONE;
             Invalidate();
         }
-
-        void OnResize() override
-        {
-            ResizeFrame();
-        }
     };
 
     /**

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -355,8 +355,6 @@ namespace OpenRCT2::Ui::Windows
 
             auto ft = Formatter::Common();
             staff->FormatNameTo(ft);
-
-            ResizeFrameWithPage();
         }
 
         void CommonPrepareDrawAfter()

--- a/src/openrct2-ui/windows/StaffFirePrompt.cpp
+++ b/src/openrct2-ui/windows/StaffFirePrompt.cpp
@@ -89,11 +89,6 @@ namespace OpenRCT2::Ui::Windows
             ScreenCoordsXY textCoords(windowPos + ScreenCoordsXY{ WW / 2, (WH / 2) - 3 });
             DrawTextWrapped(dpi, textCoords, WW - 4, STR_FIRE_STAFF_ID, ft, { TextAlignment::CENTRE });
         }
-
-        void OnResize() override
-        {
-            ResizeFrame();
-        }
     };
 
     WindowBase* StaffFirePromptOpen(Peep* peep)

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -165,11 +165,6 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnResize() override
-        {
-            ResizeFrameWithPage();
-        }
-
         void OnUpdate() override
         {
             auto animPeepType = AnimationPeepType(static_cast<uint8_t>(_selectedTab) + 1);
@@ -263,7 +258,6 @@ namespace OpenRCT2::Ui::Windows
             }
             SetWidgetPressed(WIDX_STAFF_LIST_QUICK_FIRE, _quickFireMode);
 
-            ResizeFrameWithPage();
             widgets[WIDX_STAFF_LIST_LIST].right = width - 4;
             widgets[WIDX_STAFF_LIST_LIST].bottom = height - 15;
             widgets[WIDX_STAFF_LIST_QUICK_FIRE].left = width - 77;

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -306,12 +306,10 @@ namespace OpenRCT2::Ui::Windows
             // String length needs to add 12 either side of box +13 for cursor when max length.
             int32_t numLines{};
             GfxWrapString(text, WW - (24 + 13), FontStyle::Medium, nullptr, &numLines);
-            return numLines * 10 + WH;
-        }
 
-        void OnResize() override
-        {
-            ResizeFrame();
+            const auto textHeight = numLines * 10;
+            const auto addedTitleHeight = getTitleBarHeight() - kTitleHeightNormal;
+            return WH + textHeight + addedTitleHeight;
         }
 
     private:

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -301,15 +301,14 @@ namespace OpenRCT2::Ui::Windows
             Close();
         }
 
-        static int32_t CalculateWindowHeight(std::string_view text)
+        int32_t CalculateWindowHeight(std::string_view text)
         {
             // String length needs to add 12 either side of box +13 for cursor when max length.
             int32_t numLines{};
             GfxWrapString(text, WW - (24 + 13), FontStyle::Medium, nullptr, &numLines);
 
             const auto textHeight = numLines * 10;
-            const auto addedTitleHeight = getTitleBarHeight() - kTitleHeightNormal;
-            return WH + textHeight + addedTitleHeight;
+            return WH + textHeight + getTitleBarDiffNormal();
         }
 
     private:
@@ -371,8 +370,7 @@ namespace OpenRCT2::Ui::Windows
         auto* windowMgr = GetWindowManager();
         windowMgr->CloseByClass(WindowClass::Textinput);
 
-        auto height = TextInputWindow::CalculateWindowHeight(existing_text);
-        auto w = windowMgr->Create<TextInputWindow>(WindowClass::Textinput, WW, height, WF_CENTRE_SCREEN | WF_STICK_TO_FRONT);
+        auto w = windowMgr->Create<TextInputWindow>(WindowClass::Textinput, WW, WH + 10, WF_CENTRE_SCREEN | WF_STICK_TO_FRONT);
         if (w != nullptr)
         {
             w->SetParentWindow(call_w, call_widget);
@@ -386,8 +384,7 @@ namespace OpenRCT2::Ui::Windows
         std::function<void(std::string_view)> callback, std::function<void()> cancelCallback)
     {
         auto* windowMgr = GetWindowManager();
-        auto height = TextInputWindow::CalculateWindowHeight(initialValue);
-        auto w = windowMgr->Create<TextInputWindow>(WindowClass::Textinput, WW, height, WF_CENTRE_SCREEN | WF_STICK_TO_FRONT);
+        auto w = windowMgr->Create<TextInputWindow>(WindowClass::Textinput, WW, WH + 10, WF_CENTRE_SCREEN | WF_STICK_TO_FRONT);
         if (w != nullptr)
         {
             w->SetTitle(title, description);

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -289,8 +289,6 @@ namespace OpenRCT2::Ui::Windows
             {
                 WindowSetResize(*this, { 320, 270 }, { 320, 450 });
             }
-
-            ResizeFrameWithPage();
         }
 
         void OnUpdate() override
@@ -319,7 +317,6 @@ namespace OpenRCT2::Ui::Windows
                 _buttonIndex = -1;
             }
 
-            ResizeFrameWithPage();
             widgets[WIDX_THEMES_LIST].right = width - 4;
             widgets[WIDX_THEMES_LIST].bottom = height - 0x0F;
 

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -763,7 +763,6 @@ static uint64_t PageDisabledWidgets[] = {
                 Invalidate();
                 height = min_height;
             }
-            ResizeFrame();
         }
 
         void OnMouseDown(WidgetIndex widgetIndex) override

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -34,19 +34,17 @@ namespace OpenRCT2::Ui::Windows
     private:
         u8string _tooltipText;
         int16_t _tooltipNumLines = 1;
+        int32_t _textWidth;
+        int32_t _textHeight;
 
     public:
         TooltipWindow(const OpenRCT2String& message, ScreenCoordsXY screenCoords)
         {
-            int32_t textWidth = FormatTextForTooltip(message);
-            int32_t textHeight = ((_tooltipNumLines + 1) * FontGetLineHeight(FontStyle::Small));
+            _textWidth = FormatTextForTooltip(message);
+            _textHeight = ((_tooltipNumLines + 1) * FontGetLineHeight(FontStyle::Small));
 
-            width = textWidth + 5;
-            height = textHeight + 4;
-
-            SetWidgets(_tooltipWidgets);
-            widgets[WIDX_BACKGROUND].right = width;
-            widgets[WIDX_BACKGROUND].bottom = height;
+            width = _textWidth + 5;
+            height = _textHeight + 4;
 
             UpdatePosition(screenCoords);
         }
@@ -87,6 +85,14 @@ namespace OpenRCT2::Ui::Windows
 
         void OnOpen() override
         {
+            SetWidgets(_tooltipWidgets);
+
+            width = _textWidth + 5;
+            height = _textHeight + 4;
+
+            widgets[WIDX_BACKGROUND].right = width;
+            widgets[WIDX_BACKGROUND].bottom = height;
+
             ResetTooltipNotShown();
         }
 

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -72,11 +72,6 @@ namespace OpenRCT2::Ui::Windows
         void OnMouseUp(WidgetIndex widgetIndex) override;
         void OnTextInput(WidgetIndex widgetIndex, std::string_view text) override;
         void OnDraw(DrawPixelInfo& dpi) override;
-
-        void OnResize() override
-        {
-            ResizeFrame();
-        }
     };
 
     class TrackDeletePromptWindow final : public Window
@@ -93,11 +88,6 @@ namespace OpenRCT2::Ui::Windows
         void OnOpen() override;
         void OnMouseUp(WidgetIndex widgetIndex) override;
         void OnDraw(DrawPixelInfo& dpi) override;
-
-        void OnResize() override
-        {
-            ResizeFrame();
-        }
     };
 
     static void WindowTrackDeletePromptOpen(TrackDesignFileRef* tdFileRef);

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -363,11 +363,6 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnResize() override
-        {
-            ResizeFrame();
-        }
-
         void ClearProvisionalTemporarily()
         {
             if (_hasPlacementGhost)

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -740,11 +740,6 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnResize() override
-        {
-            ResizeFrame();
-        }
-
         void SetIsBeingUpdated(const bool beingUpdated)
         {
             _selectedItemIsBeingUpdated = beingUpdated;

--- a/src/openrct2-ui/windows/Transparency.cpp
+++ b/src/openrct2-ui/windows/Transparency.cpp
@@ -240,11 +240,6 @@ namespace OpenRCT2::Ui::Windows
             Config::Get().general.InvisibleSupports = wflags & VIEWPORT_FLAG_INVISIBLE_SUPPORTS;
             Config::Save();
         }
-
-        void OnResize() override
-        {
-            ResizeFrame();
-        }
     };
 
     WindowBase* TransparencyOpen()

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -362,6 +362,7 @@ namespace OpenRCT2::Ui::Windows
         void OnOpen() override
         {
             SetWidgets(_viewClippingWidgets);
+
             this->hold_down_widgets = (1uLL << WIDX_CLIP_HEIGHT_INCREASE) | (1uL << WIDX_CLIP_HEIGHT_DECREASE);
             WindowInitScrollWidgets(*this);
 
@@ -381,11 +382,6 @@ namespace OpenRCT2::Ui::Windows
                 mainWindow->viewport->flags |= VIEWPORT_FLAG_CLIP_VIEW;
                 mainWindow->Invalidate();
             }
-        }
-
-        void OnResize() override
-        {
-            ResizeFrame();
         }
 
     private:

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -187,7 +187,6 @@ namespace OpenRCT2::Ui::Windows
 
         void OnPrepareDraw() override
         {
-            ResizeFrameWithPage();
             widgets[WIDX_ZOOM_IN].left = width - 27;
             widgets[WIDX_ZOOM_IN].right = width - 2;
             widgets[WIDX_ZOOM_OUT].left = width - 27;

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -58,6 +58,7 @@ namespace OpenRCT2::Ui::Windows
         void OnOpen() override
         {
             SetWidgets(_waterWidgets);
+
             hold_down_widgets = (1uLL << WIDX_INCREMENT) | (1uLL << WIDX_DECREMENT);
             WindowInitScrollWidgets(*this);
             WindowPushOthersBelow(*this);
@@ -183,11 +184,6 @@ namespace OpenRCT2::Ui::Windows
                     DrawTextBasic(dpi, screenCoords, STR_LOWER_COST_AMOUNT, ft, { TextAlignment::CENTRE });
                 }
             }
-        }
-
-        void OnResize() override
-        {
-            ResizeFrame();
         }
 
         void OnToolUpdate(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords) override

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -152,6 +152,7 @@ namespace OpenRCT2
     };
 
     constexpr uint8_t kCloseButtonSize = 10;
+    constexpr uint8_t kCloseButtonSizeTouch = 20;
 
     constexpr int32_t kScrollableRowHeight = 12;
     constexpr uint8_t kListRowHeight = 12;

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -151,6 +151,9 @@ namespace OpenRCT2
         }
     };
 
+    constexpr uint8_t kTitleHeightNormal = 13;
+    constexpr uint8_t kTitleHeightLarge = 24;
+
     constexpr uint8_t kCloseButtonSize = 10;
     constexpr uint8_t kCloseButtonSizeTouch = 20;
 

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -68,6 +68,11 @@ namespace OpenRCT2
         SCROLL_BOTH = SCROLL_HORIZONTAL | SCROLL_VERTICAL
     };
 
+    constexpr const char* kCloseBoxStringBlackNormal = u8"{BLACK}❌";
+    constexpr const char* kCloseBoxStringBlackLarge = u8"{BLACK}X";
+    constexpr const char* kCloseBoxStringWhiteNormal = u8"{WHITE}❌";
+    constexpr const char* kCloseBoxStringWhiteLarge = u8"{WHITE}X";
+
     struct Widget
     {
         WindowWidgetType type{};
@@ -81,7 +86,7 @@ namespace OpenRCT2
             uint32_t content;
             ImageId image{};
             StringId text;
-            utf8* string;
+            const utf8* string;
         };
         StringId tooltip{ kStringIdNone };
 

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -975,6 +975,19 @@ static constexpr float kWindowScrollLocations[][2] = {
         return w->viewport;
     }
 
+    int16_t getTitleBarHeight()
+    {
+        return Config::Get().interface.EnlargedUi ? kTitleHeightLarge : kTitleHeightNormal;
+    }
+
+    int16_t getTitleHeightDiff()
+    {
+        if (Config::Get().interface.EnlargedUi)
+            return kTitleHeightLarge - kTitleHeightNormal;
+        else
+            return 0;
+    }
+
     // TODO: declared in WindowManager.h; move when refactors continue
     Ui::IWindowManager* Ui::GetWindowManager()
     {

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -975,19 +975,6 @@ static constexpr float kWindowScrollLocations[][2] = {
         return w->viewport;
     }
 
-    int16_t getTitleBarHeight()
-    {
-        return Config::Get().interface.EnlargedUi ? kTitleHeightLarge : kTitleHeightNormal;
-    }
-
-    int16_t getTitleHeightDiff()
-    {
-        if (Config::Get().interface.EnlargedUi)
-            return kTitleHeightLarge - kTitleHeightNormal;
-        else
-            return 0;
-    }
-
     // TODO: declared in WindowManager.h; move when refactors continue
     Ui::IWindowManager* Ui::GetWindowManager()
     {

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -348,7 +348,4 @@ namespace OpenRCT2
 
     void WindowFollowSprite(WindowBase& w, EntityId spriteIndex);
     void WindowUnfollowSprite(WindowBase& w);
-
-    int16_t getTitleBarHeight();
-    int16_t getTitleHeightDiff();
 } // namespace OpenRCT2

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -349,4 +349,6 @@ namespace OpenRCT2
     void WindowFollowSprite(WindowBase& w, EntityId spriteIndex);
     void WindowUnfollowSprite(WindowBase& w);
 
+    int16_t getTitleBarHeight();
+    int16_t getTitleHeightDiff();
 } // namespace OpenRCT2

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -89,14 +89,12 @@ namespace OpenRCT2
         WF_10 = (1 << 10),
         WF_WHITE_BORDER_ONE = (1 << 12),
         WF_WHITE_BORDER_MASK = (1 << 12) | (1 << 13),
-
+        WF_NO_TITLE_BAR = (1 << 14),
         WF_NO_SNAPPING = (1 << 15),
 
-        // Create only flags
+        // *ONLY* create only flags below
         WF_AUTO_POSITION = (1 << 16),
         WF_CENTRE_SCREEN = (1 << 17),
-
-        WF_NO_TITLE_BAR = (1 << 18),
     };
 
     enum

--- a/src/openrct2/interface/WindowBase.cpp
+++ b/src/openrct2/interface/WindowBase.cpp
@@ -99,7 +99,7 @@ namespace OpenRCT2
         }
 
         // Figure out if we need to push the other widgets down to accommodate a resized title/caption
-        auto preferredHeight = getTitleBarHeight();
+        auto preferredHeight = getTitleBarTargetHeight();
         auto currentHeight = titleWidget.height();
         auto heightDifference = preferredHeight - currentHeight;
 
@@ -132,5 +132,28 @@ namespace OpenRCT2
         // Offset viewport
         if (viewport != nullptr)
             viewport->pos.y += heightDifference;
+    }
+
+    int16_t WindowBase::getTitleBarTargetHeight() const
+    {
+        return Config::Get().interface.EnlargedUi ? kTitleHeightLarge : kTitleHeightNormal;
+    }
+
+    int16_t WindowBase::getTitleBarCurrentHeight() const
+    {
+        if (!(flags & WF_NO_TITLE_BAR) && widgets.size() > 2)
+            return widgets[1].height();
+        else
+            return 0;
+    }
+
+    int16_t WindowBase::getTitleBarDiffTarget() const
+    {
+        return getTitleBarTargetHeight() - getTitleBarCurrentHeight();
+    }
+
+    int16_t WindowBase::getTitleBarDiffNormal() const
+    {
+        return getTitleBarCurrentHeight() - kTitleHeightNormal;
     }
 } // namespace OpenRCT2

--- a/src/openrct2/interface/WindowBase.cpp
+++ b/src/openrct2/interface/WindowBase.cpp
@@ -1,5 +1,6 @@
 #include "WindowBase.h"
 
+#include "../config/Config.h"
 #include "../entity/EntityList.h"
 #include "../entity/EntityRegistry.h"
 #include "Cursors.h"
@@ -31,10 +32,98 @@ namespace OpenRCT2
     {
         widgets.clear();
         widgets.insert(widgets.end(), newWidgets.begin(), newWidgets.end());
+
+        ResizeFrame();
     }
 
     CursorID WindowBase::OnCursor(WidgetIndex, const ScreenCoordsXY&, CursorID)
     {
         return CursorID::Arrow;
+    }
+
+    static inline void repositionCloseButton(Widget& closeButton, int32_t windowWidth)
+    {
+        auto closeButtonSize = Config::Get().interface.EnlargedUi ? kCloseButtonSizeTouch : kCloseButtonSize;
+        if (Config::Get().interface.WindowButtonsOnTheLeft)
+        {
+            closeButton.left = 2;
+            closeButton.right = 2 + closeButtonSize;
+        }
+        else
+        {
+            closeButton.left = windowWidth - 3 - closeButtonSize;
+            closeButton.right = windowWidth - 3;
+        }
+    }
+
+    void WindowBase::ResizeFrame()
+    {
+        if (widgets.size() < 3)
+            return;
+
+        // Frame
+        auto& frameWidget = widgets[0];
+        if (frameWidget.type == WindowWidgetType::Frame)
+        {
+            frameWidget.right = width - 1;
+            frameWidget.bottom = height - 1;
+        }
+
+        // Title/caption
+        auto& titleWidget = widgets[1];
+        bool hasTitleWidget = titleWidget.type == WindowWidgetType::Caption;
+        if (hasTitleWidget)
+            titleWidget.right = width - 2;
+
+        // Close button
+        auto& closeButton = widgets[2];
+        if (closeButton.type == WindowWidgetType::CloseBox || closeButton.type == WindowWidgetType::Empty)
+            repositionCloseButton(closeButton, width);
+
+        // Page/resize widget
+        if (widgets.size() >= 4)
+        {
+            auto& pageWidget = widgets[3];
+            if (pageWidget.type == WindowWidgetType::Resize)
+            {
+                pageWidget.right = width - 1;
+                pageWidget.bottom = height - 1;
+            }
+        }
+
+        // Figure out if we need to push the other widgets down to accommodate a resized title/caption
+        auto preferredHeight = getTitleBarHeight();
+        auto currentHeight = titleWidget.height();
+        auto heightDifference = preferredHeight - currentHeight;
+
+        if (!hasTitleWidget || heightDifference == 0)
+            return;
+
+        Invalidate();
+
+        // Offset title and close button
+        titleWidget.bottom += heightDifference;
+        closeButton.bottom += heightDifference;
+
+        height += heightDifference;
+        min_height += heightDifference;
+        max_height += heightDifference;
+
+        Invalidate();
+
+        // Resize frame again to match new height
+        frameWidget.bottom = height - 1;
+
+        // Offset body widgets
+        // NB: we're offsetting page widget as well!
+        for (WidgetIndex i = 3; i < widgets.size(); i++)
+        {
+            widgets[i].top += heightDifference;
+            widgets[i].bottom += heightDifference;
+        }
+
+        // Offset viewport
+        if (viewport != nullptr)
+            viewport->pos.y += heightDifference;
     }
 } // namespace OpenRCT2

--- a/src/openrct2/interface/WindowBase.cpp
+++ b/src/openrct2/interface/WindowBase.cpp
@@ -54,6 +54,13 @@ namespace OpenRCT2
             closeButton.left = windowWidth - 3 - closeButtonSize;
             closeButton.right = windowWidth - 3;
         }
+
+        // Set appropriate close button
+        bool useWhite = closeButton.string == kCloseBoxStringWhiteLarge || closeButton.string == kCloseBoxStringWhiteNormal;
+        if (closeButtonSize == kCloseButtonSizeTouch)
+            closeButton.string = !useWhite ? kCloseBoxStringBlackLarge : kCloseBoxStringWhiteLarge;
+        else
+            closeButton.string = !useWhite ? kCloseBoxStringBlackNormal : kCloseBoxStringWhiteNormal;
     }
 
     void WindowBase::ResizeFrame()

--- a/src/openrct2/interface/WindowBase.h
+++ b/src/openrct2/interface/WindowBase.h
@@ -113,6 +113,7 @@ namespace OpenRCT2
         void Invalidate();
         void RemoveViewport();
         void SetWidgets(const std::span<const Widget> newWidgets);
+        void ResizeFrame();
 
         WindowBase() = default;
         WindowBase(WindowBase&) = delete;

--- a/src/openrct2/interface/WindowBase.h
+++ b/src/openrct2/interface/WindowBase.h
@@ -115,6 +115,11 @@ namespace OpenRCT2
         void SetWidgets(const std::span<const Widget> newWidgets);
         void ResizeFrame();
 
+        int16_t getTitleBarTargetHeight() const;
+        int16_t getTitleBarCurrentHeight() const;
+        int16_t getTitleBarDiffTarget() const;
+        int16_t getTitleBarDiffNormal() const;
+
         WindowBase() = default;
         WindowBase(WindowBase&) = delete;
         virtual ~WindowBase() = default;


### PR DESCRIPTION
Due to our window system being old and clunky, this required quite a lot of refactoring, mostly to replace coordinates being calculated from the topleft of the window with calculating them from the top left of the window body instead. Also splits the title bar and window body height, as windows have no good way of determining their full height in advance - and frankly, how big or small the title bars are is more of a concern to the window manager than to the window itself anyway.

![afbeelding](https://github.com/user-attachments/assets/74a9c147-00fb-496d-b794-852565e0d73b)

https://github.com/user-attachments/assets/acf323b8-8765-480f-828d-15f304698021