### PR TITLE
Remove outdated note

### DIFF
--- a/distribution/windows/readme.md
+++ b/distribution/windows/readme.md
@@ -1,6 +1,4 @@
 # Windows Installer
 This directory contains the script and resources for the Windows installer. The installer is created using [Nullsoft Scriptable Install System (NSIS)](http://nsis.sourceforge.net) version v3.0a0+.
 
-As there is currently only a 32 bit version of OpenRCT2 available, the architecture and windows version checks have been disabled. These will be re-enabled once OpenRCT2 is a stand alone executable.
-
 Code based on [OpenTTD](http://openttd.org) installer.


### PR DESCRIPTION
Removed entirely, may need to be altered to mention that OpenRCT2 requires original game files