### PR TITLE
Increase _support_height values on TrackRemoveAction

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Fix: [#23508] Simultaneous virtual floors shown for ride and footpath.
 - Fix: [#23581] [Plugin] Food/drink items given to guests have no consumption duration set.
 - Fix: [#23591] “Install new track” button in Track Designs Manager is misaligned.
+- Fix: [#23368] Wrong refund amount for Giga Coaster tracks at or above 96m.
 
 0.4.18 (2025-01-08)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,10 +6,10 @@
 - Change: [#23328] All RCT2 entertainer costumes are now available in legacy parks.
 - Fix: [#1479] Incorrect values provided by the in game console “get location” command.
 - Fix: [#21794] Lay-down coaster cars reverse on first frames of downwards corkscrew.
+- Fix: [#23368] Incorrect refund amount for Giga Coaster tracks at or above 96m.
 - Fix: [#23508] Simultaneous virtual floors shown for ride and footpath.
 - Fix: [#23581] [Plugin] Food/drink items given to guests have no consumption duration set.
 - Fix: [#23591] “Install new track” button in Track Designs Manager is misaligned.
-- Fix: [#23368] Wrong refund amount for Giga Coaster tracks at or above 96m.
 
 0.4.18 (2025-01-08)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,7 +6,7 @@
 - Change: [#23328] All RCT2 entertainer costumes are now available in legacy parks.
 - Fix: [#1479] Incorrect values provided by the in game console “get location” command.
 - Fix: [#21794] Lay-down coaster cars reverse on first frames of downwards corkscrew.
-- Fix: [#23368] Incorrect refund amount for Giga Coaster tracks at or above 96m.
+- Fix: [#23368] Incorrect refund amount when deleting track pieces at or above 96m.
 - Fix: [#23508] Simultaneous virtual floors shown for ride and footpath.
 - Fix: [#23581] [Plugin] Food/drink items given to guests have no consumption duration set.
 - Fix: [#23591] “Install new track” button in Track Designs Manager is misaligned.

--- a/src/openrct2/actions/TrackRemoveAction.cpp
+++ b/src/openrct2/actions/TrackRemoveAction.cpp
@@ -234,7 +234,7 @@ GameActions::Result TrackRemoveAction::Query() const
                 GameActions::Status::Unknown, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS, STR_ERR_SURFACE_ELEMENT_NOT_FOUND);
         }
 
-        int8_t _support_height = tileElement->BaseHeight - surfaceElement->BaseHeight;
+        int16_t _support_height = tileElement->BaseHeight - surfaceElement->BaseHeight;
         if (_support_height < 0)
         {
             _support_height = 10;
@@ -410,7 +410,7 @@ GameActions::Result TrackRemoveAction::Execute() const
                 GameActions::Status::Unknown, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS, STR_ERR_SURFACE_ELEMENT_NOT_FOUND);
         }
 
-        int8_t _support_height = tileElement->BaseHeight - surfaceElement->BaseHeight;
+        int16_t _support_height = tileElement->BaseHeight - surfaceElement->BaseHeight;
         if (_support_height < 0)
         {
             _support_height = 10;


### PR DESCRIPTION
Quick fix to kick off my initial contribution and 2025:
1. Updating the `_support_height` variable to a `int16_t` to absolve refund errors above 96m (320 ft) for Giga Coasters.

Closes #23368 

Before:
![BuggedGiga](https://github.com/user-attachments/assets/7e7080f4-9727-4e01-a7d8-9586ec4fc1a8)


After:
![image](https://github.com/user-attachments/assets/93ba6628-4e70-431e-bf1d-6df31bd02210)
