### PR TITLE
Autospread spawned trains

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#23328] Introducing peep animation objects, enabling custom entertainer costumes.
 - Feature: [#23569] Add large diagonal flat to steep and dive loop track pieces.
+- Improved: [#17842] When spawning trains, they are now spread evenly across stations.
 - Improved: [#20683] Allow Giga Coaster cable lift to start after block brake section.
 - Improved: [#23328] The costume list in the staff window is now ordered alphabetically.
 - Improved: [#23540] The file browser now optionally shows a file size column.

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -312,7 +312,7 @@ public:
 private:
     void Update();
     void UpdateQueueLength(StationIndex stationIndex);
-    ResultWithMessage CreateVehicles(const CoordsXYE& element, bool isApplying);
+    ResultWithMessage CreateVehicles(bool isApplying);
     void MoveTrainsToBlockBrakes(const CoordsXYZ& firstBlockPosition, TrackElement& firstBlock);
     money64 CalculateIncomePerHour() const;
     void ChainQueues() const;


### PR DESCRIPTION
Closes #17842.

Changes the way the trains are spawned, dividing them over the stations a ride has. Should make building Möbius rides a lot easier, and will also help spreading vehicles on non-möbius multi-station rides.