### PR TITLE
Move WindowClose family into WindowManager

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -308,7 +308,7 @@ namespace OpenRCT2
                         InputWidgetLeft(screenCoords, w, widgetIndex);
                         break;
                     case MouseState::RightPress:
-                        WindowCloseByClass(WindowClass::Tooltip);
+                        windowMgr->CloseByClass(WindowClass::Tooltip);
 
                         if (w != nullptr)
                         {
@@ -1044,11 +1044,11 @@ namespace OpenRCT2
             windowNumber = w->number;
         }
 
-        WindowCloseByClass(WindowClass::Error);
-        WindowCloseByClass(WindowClass::Tooltip);
+        auto* windowMgr = GetWindowManager();
+        windowMgr->CloseByClass(WindowClass::Error);
+        windowMgr->CloseByClass(WindowClass::Tooltip);
 
         // Window might have changed position in the list, therefore find it again
-        auto* windowMgr = GetWindowManager();
         w = windowMgr->FindByNumber(windowClass, windowNumber);
         if (w == nullptr)
             return;
@@ -1422,7 +1422,7 @@ namespace OpenRCT2
                             }
                         }
 
-                        WindowCloseByClass(WindowClass::Dropdown);
+                        windowMgr->CloseByClass(WindowClass::Dropdown);
 
                         if (dropdownCleanup)
                         {
@@ -1585,7 +1585,8 @@ namespace OpenRCT2
 
             if (gCurrentRealTimeTicks >= gTooltipCloseTimeout)
             {
-                WindowCloseByClass(WindowClass::Tooltip);
+                auto* windowMgr = GetWindowManager();
+                windowMgr->CloseByClass(WindowClass::Tooltip);
             }
         }
     }

--- a/src/openrct2-ui/input/ShortcutManager.cpp
+++ b/src/openrct2-ui/input/ShortcutManager.cpp
@@ -20,8 +20,8 @@
 #include <openrct2/core/FileSystem.hpp>
 #include <openrct2/core/Json.hpp>
 #include <openrct2/core/String.hpp>
-#include <openrct2/interface/Window.h>
 #include <openrct2/localisation/Language.h>
+#include <openrct2/ui/WindowManager.h>
 
 using namespace OpenRCT2::Ui;
 
@@ -174,7 +174,9 @@ void ShortcutManager::ProcessEvent(const InputEvent& e)
                 shortcut->Current.push_back(std::move(shortcutInput.value()));
             }
             _pendingShortcutChange.clear();
-            WindowCloseByClass(WindowClass::ChangeKeyboardShortcut);
+
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->CloseByClass(WindowClass::ChangeKeyboardShortcut);
             SaveUserBindings();
         }
     }

--- a/src/openrct2-ui/input/Shortcuts.cpp
+++ b/src/openrct2-ui/input/Shortcuts.cpp
@@ -16,7 +16,6 @@
 #include <openrct2-ui/interface/InGameConsole.h>
 #include <openrct2-ui/interface/Viewport.h>
 #include <openrct2-ui/interface/Widget.h>
-#include <openrct2-ui/interface/Window.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/Editor.h>
@@ -158,11 +157,11 @@ static void ShortcutRemoveTopBottomToolbarToggle()
     {
         if (windowMgr->FindByClass(WindowClass::TitleLogo) != nullptr)
         {
-            WindowCloseByClass(WindowClass::TitleLogo);
-            WindowCloseByClass(WindowClass::TitleOptions);
-            WindowCloseByClass(WindowClass::TitleMenu);
-            WindowCloseByClass(WindowClass::TitleExit);
-            WindowCloseByClass(WindowClass::TitleVersion);
+            windowMgr->CloseByClass(WindowClass::TitleLogo);
+            windowMgr->CloseByClass(WindowClass::TitleOptions);
+            windowMgr->CloseByClass(WindowClass::TitleMenu);
+            windowMgr->CloseByClass(WindowClass::TitleExit);
+            windowMgr->CloseByClass(WindowClass::TitleVersion);
         }
         else
         {
@@ -173,9 +172,9 @@ static void ShortcutRemoveTopBottomToolbarToggle()
     {
         if (windowMgr->FindByClass(WindowClass::TopToolbar) != nullptr)
         {
-            WindowCloseByClass(WindowClass::Dropdown);
-            WindowCloseByClass(WindowClass::TopToolbar);
-            WindowCloseByClass(WindowClass::BottomToolbar);
+            windowMgr->CloseByClass(WindowClass::Dropdown);
+            windowMgr->CloseByClass(WindowClass::TopToolbar);
+            windowMgr->CloseByClass(WindowClass::BottomToolbar);
         }
         else
         {
@@ -376,7 +375,7 @@ static void ShortcutOpenCheatWindow()
     WindowBase* window = windowMgr->FindByClass(WindowClass::Cheats);
     if (window != nullptr)
     {
-        WindowClose(*window);
+        windowMgr->Close(*window);
         return;
     }
     ContextOpenWindow(WindowClass::Cheats);
@@ -748,15 +747,19 @@ void ShortcutManager::RegisterDefaultShortcuts()
 {
     // clang-format off
     // Interface
-    RegisterShortcut(ShortcutId::kInterfaceCloseTop, STR_SHORTCUT_CLOSE_TOP_MOST_WINDOW, "BACKSPACE", WindowCloseTop);
+    RegisterShortcut(ShortcutId::kInterfaceCloseTop, STR_SHORTCUT_CLOSE_TOP_MOST_WINDOW, "BACKSPACE", []() {
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseTop();
+    });
     RegisterShortcut(ShortcutId::kInterfaceCloseAll, STR_SHORTCUT_CLOSE_ALL_FLOATING_WINDOWS, "SHIFT+BACKSPACE", []() {
+        auto* windowMgr = GetWindowManager();
         if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR))
         {
-            WindowCloseAll();
+            windowMgr->CloseAll();
         }
         else if (GetGameState().EditorStep == EditorStep::LandscapeEditor)
         {
-            WindowCloseTop();
+            windowMgr->CloseTop();
         }
     });
     RegisterShortcut(ShortcutId::kInterfaceRotateConstruction, STR_SHORTCUT_ROTATE_CONSTRUCTION_OBJECT, "Z", ShortcutRotateConstructionObject);
@@ -767,7 +770,7 @@ void ShortcutManager::RegisterDefaultShortcuts()
             auto window = windowMgr->FindByClass(WindowClass::Error);
             if (window != nullptr)
             {
-                WindowClose(*window);
+                windowMgr->Close(*window);
             }
             else if (InputTestFlag(INPUT_FLAG_TOOL_ACTIVE))
             {
@@ -904,7 +907,7 @@ void ShortcutManager::RegisterDefaultShortcuts()
             auto window = windowMgr->FindByClass(WindowClass::DebugPaint);
             if (window != nullptr)
             {
-                WindowClose(*window);
+                windowMgr->Close(*window);
             }
             else
             {

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -423,18 +423,21 @@ namespace OpenRCT2
         }
         else
         {
-            WindowClose(*this);
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->Close(*this);
         }
     }
 
     void Window::CloseOthers()
     {
-        WindowCloseAllExceptNumberAndClass(number, classification);
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseAllExceptNumberAndClass(number, classification);
     }
 
     void Window::CloseOthersOfThisClass()
     {
-        WindowCloseByClass(classification);
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseByClass(classification);
     }
 
     CloseWindowModifier Window::GetCloseModifier()
@@ -597,7 +600,8 @@ namespace OpenRCT2::Ui::Windows
         _currentTextBox.widget_index = callWidget;
         _textBoxFrameNo = 0;
 
-        WindowCloseByClass(WindowClass::Textinput);
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseByClass(WindowClass::Textinput);
 
         _textBoxInput = existingText;
 

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -580,8 +580,11 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_CLOSE:
-                    WindowClose(*this);
+                {
+                    auto* windowMgr = Ui::GetWindowManager();
+                    windowMgr->Close(*this);
                     break;
+                }
                 default:
                 {
                     if (widgetIndex >= WIDX_TAB_0
@@ -1485,7 +1488,8 @@ namespace OpenRCT2::Ui::Windows
 
         for (auto& window : customWindows)
         {
-            WindowClose(*window.get());
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->Close(*window.get());
         }
     }
 

--- a/src/openrct2-ui/scripting/ScUi.hpp
+++ b/src/openrct2-ui/scripting/ScUi.hpp
@@ -183,23 +183,25 @@ namespace OpenRCT2::Scripting
 
         void closeWindows(std::string classification, DukValue id)
         {
+            auto* windowMgr = Ui::GetWindowManager();
             auto cls = GetClassification(classification);
             if (cls != WindowClass::Null)
             {
                 if (id.type() == DukValue::Type::NUMBER)
                 {
-                    WindowCloseByNumber(cls, id.as_uint());
+                    windowMgr->CloseByNumber(cls, id.as_uint());
                 }
                 else
                 {
-                    WindowCloseByClass(cls);
+                    windowMgr->CloseByClass(cls);
                 }
             }
         }
 
         void closeAllWindows()
         {
-            WindowCloseAll();
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->CloseAll();
         }
 
         std::shared_ptr<ScWindow> getWindow(DukValue a) const

--- a/src/openrct2-ui/scripting/ScWindow.hpp
+++ b/src/openrct2-ui/scripting/ScWindow.hpp
@@ -305,7 +305,8 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                WindowClose(*w);
+                auto* windowMgr = Ui::GetWindowManager();
+                windowMgr->Close(*w);
             }
         }
 

--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -406,26 +406,27 @@ namespace OpenRCT2::Title
 
         void CloseParkSpecificWindows()
         {
-            WindowCloseByClass(WindowClass::ConstructRide);
-            WindowCloseByClass(WindowClass::DemolishRidePrompt);
-            WindowCloseByClass(WindowClass::EditorInventionListDrag);
-            WindowCloseByClass(WindowClass::EditorInventionList);
-            WindowCloseByClass(WindowClass::EditorObjectSelection);
-            WindowCloseByClass(WindowClass::EditorObjectiveOptions);
-            WindowCloseByClass(WindowClass::EditorScenarioOptions);
-            WindowCloseByClass(WindowClass::Finances);
-            WindowCloseByClass(WindowClass::FirePrompt);
-            WindowCloseByClass(WindowClass::GuestList);
-            WindowCloseByClass(WindowClass::InstallTrack);
-            WindowCloseByClass(WindowClass::Peep);
-            WindowCloseByClass(WindowClass::Ride);
-            WindowCloseByClass(WindowClass::RideConstruction);
-            WindowCloseByClass(WindowClass::RideList);
-            WindowCloseByClass(WindowClass::Scenery);
-            WindowCloseByClass(WindowClass::Staff);
-            WindowCloseByClass(WindowClass::TrackDeletePrompt);
-            WindowCloseByClass(WindowClass::TrackDesignList);
-            WindowCloseByClass(WindowClass::TrackDesignPlace);
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->CloseByClass(WindowClass::ConstructRide);
+            windowMgr->CloseByClass(WindowClass::DemolishRidePrompt);
+            windowMgr->CloseByClass(WindowClass::EditorInventionListDrag);
+            windowMgr->CloseByClass(WindowClass::EditorInventionList);
+            windowMgr->CloseByClass(WindowClass::EditorObjectSelection);
+            windowMgr->CloseByClass(WindowClass::EditorObjectiveOptions);
+            windowMgr->CloseByClass(WindowClass::EditorScenarioOptions);
+            windowMgr->CloseByClass(WindowClass::Finances);
+            windowMgr->CloseByClass(WindowClass::FirePrompt);
+            windowMgr->CloseByClass(WindowClass::GuestList);
+            windowMgr->CloseByClass(WindowClass::InstallTrack);
+            windowMgr->CloseByClass(WindowClass::Peep);
+            windowMgr->CloseByClass(WindowClass::Ride);
+            windowMgr->CloseByClass(WindowClass::RideConstruction);
+            windowMgr->CloseByClass(WindowClass::RideList);
+            windowMgr->CloseByClass(WindowClass::Scenery);
+            windowMgr->CloseByClass(WindowClass::Staff);
+            windowMgr->CloseByClass(WindowClass::TrackDeletePrompt);
+            windowMgr->CloseByClass(WindowClass::TrackDesignList);
+            windowMgr->CloseByClass(WindowClass::TrackDesignPlace);
         }
 
         void PrepareParkForPlayback()

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -108,7 +108,8 @@ namespace OpenRCT2::Ui::Windows
         if (w != nullptr)
         {
             auto windowPos = w->windowPos;
-            WindowClose(*w);
+            windowMgr->Close(*w);
+
             newWindow = windowMgr->Create<DemolishRidePromptWindow>(
                 WindowClass::DemolishRidePrompt, windowPos, WW, WH, WF_TRANSPARENT);
         }

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -402,7 +402,8 @@ namespace OpenRCT2::Ui::Windows
 
     void WindowDropdownClose()
     {
-        WindowCloseByClass(WindowClass::Dropdown);
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseByClass(WindowClass::Dropdown);
     }
 
     /**

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -155,14 +155,18 @@ namespace OpenRCT2::Ui::Windows
     private:
         void JumpBackToObjectSelection() const
         {
-            WindowCloseAll();
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->CloseAll();
+
             GetGameState().EditorStep = EditorStep::ObjectSelection;
             GfxInvalidateScreen();
         }
 
         void JumpBackToLandscapeEditor() const
         {
-            WindowCloseAll();
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->CloseAll();
+
             SetAllSceneryItemsInvented();
             WindowScenerySetDefaultPlacementConfiguration();
             GetGameState().EditorStep = EditorStep::LandscapeEditor;
@@ -172,7 +176,9 @@ namespace OpenRCT2::Ui::Windows
 
         void JumpBackToInventionListSetUp() const
         {
-            WindowCloseAll();
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->CloseAll();
+
             ContextOpenWindow(WindowClass::EditorInventionList);
             GetGameState().EditorStep = EditorStep::InventionsListSetUp;
             GfxInvalidateScreen();
@@ -180,7 +186,9 @@ namespace OpenRCT2::Ui::Windows
 
         void JumpBackToOptionsSelection() const
         {
-            WindowCloseAll();
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->CloseAll();
+
             ContextOpenWindow(WindowClass::EditorScenarioOptions);
             GetGameState().EditorStep = EditorStep::OptionsSelection;
             GfxInvalidateScreen();
@@ -208,7 +216,8 @@ namespace OpenRCT2::Ui::Windows
             auto [checksPassed, errorString] = Editor::CheckPark();
             if (checksPassed)
             {
-                WindowCloseAll();
+                auto* windowMgr = Ui::GetWindowManager();
+                windowMgr->CloseAll();
                 ContextOpenWindow(WindowClass::EditorInventionList);
                 GetGameState().EditorStep = EditorStep::InventionsListSetUp;
             }
@@ -222,7 +231,9 @@ namespace OpenRCT2::Ui::Windows
 
         void JumpForwardToOptionsSelection() const
         {
-            WindowCloseAll();
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->CloseAll();
+
             ContextOpenWindow(WindowClass::EditorScenarioOptions);
             GetGameState().EditorStep = EditorStep::OptionsSelection;
             GfxInvalidateScreen();
@@ -230,7 +241,9 @@ namespace OpenRCT2::Ui::Windows
 
         void JumpForwardToObjectiveSelection() const
         {
-            WindowCloseAll();
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->CloseAll();
+
             ContextOpenWindow(WindowClass::EditorObjectiveOptions);
             GetGameState().EditorStep = EditorStep::ObjectiveSelection;
             GfxInvalidateScreen();
@@ -247,7 +260,8 @@ namespace OpenRCT2::Ui::Windows
                 return;
             }
 
-            WindowCloseAll();
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->CloseAll();
             auto intent = Intent(WindowClass::Loadsave);
             intent.PutExtra(INTENT_EXTRA_LOADSAVE_TYPE, LOADSAVETYPE_SAVE | LOADSAVETYPE_SCENARIO);
             intent.PutExtra(INTENT_EXTRA_PATH, gameState.ScenarioName);

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -691,7 +691,7 @@ namespace OpenRCT2::Ui::Windows
         ResearchItem* researchItem, const ScreenCoordsXY& editorPos, int objectSelectionScrollWidth)
     {
         auto* windowMgr = Ui::GetWindowManager();
-        WindowCloseByClass(WindowClass::EditorInventionListDrag);
+        windowMgr->CloseByClass(WindowClass::EditorInventionListDrag);
         auto* wnd = windowMgr->Create<InventionDragWindow>(
             WindowClass::EditorInventionListDrag, 10, 14, WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_NO_SNAPPING);
         if (wnd != nullptr)

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -602,7 +602,8 @@ namespace OpenRCT2::Ui::Windows
         {
             // Used for in-game object selection cheat to prevent crashing the game
             // when windows attempt to draw objects that don't exist any more
-            WindowCloseAllExceptClass(WindowClass::EditorObjectSelection);
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->CloseAllExceptClass(WindowClass::EditorObjectSelection);
 
             int32_t selected_object = GetObjectFromObjectSelection(GetSelectedObjectType(), screenCoords.y);
             if (selected_object == -1)
@@ -1737,16 +1738,17 @@ namespace OpenRCT2::Ui::Windows
 
     bool EditorObjectSelectionWindowCheck()
     {
+        auto* windowMgr = Ui::GetWindowManager();
+
         auto [missingObjectType, errorString] = Editor::CheckObjectSelection();
         if (missingObjectType == ObjectType::None)
         {
-            WindowCloseByClass(WindowClass::EditorObjectSelection);
+            windowMgr->CloseByClass(WindowClass::EditorObjectSelection);
             return true;
         }
 
         ContextShowError(STR_INVALID_SELECTION_OF_OBJECTS, errorString, {});
 
-        auto* windowMgr = GetWindowManager();
         WindowBase* w = windowMgr->FindByClass(WindowClass::EditorObjectSelection);
         if (w != nullptr)
         {

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -368,7 +368,7 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_CLOSE:
-                    WindowClose(*this);
+                    Close();
                     break;
                 case WIDX_TAB_1:
                 case WIDX_TAB_2:
@@ -670,7 +670,7 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_CLOSE:
-                    WindowClose(*this);
+                    Close();
                     break;
                 case WIDX_TAB_1:
                 case WIDX_TAB_2:
@@ -916,7 +916,7 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_CLOSE:
-                    WindowClose(*this);
+                    Close();
                     break;
                 case WIDX_TAB_1:
                 case WIDX_TAB_2:

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -121,7 +121,8 @@ namespace OpenRCT2::Ui::Windows
         }
 
         // Close any existing error windows if they exist.
-        WindowCloseByClass(WindowClass::Error);
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseByClass(WindowClass::Error);
 
         // How wide is the error string?
         int32_t width = GfxGetStringWidthNewLined(buffer.data(), FontStyle::Medium);
@@ -140,7 +141,6 @@ namespace OpenRCT2::Ui::Windows
 
         auto errorWindow = std::make_unique<ErrorWindow>(std::move(buffer), numLines, autoClose);
 
-        auto* windowMgr = GetWindowManager();
         return windowMgr->Create(
             std::move(errorWindow), WindowClass::Error, windowPosition, width, height, WF_STICK_TO_FRONT | WF_TRANSPARENT);
     }

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -1733,7 +1733,7 @@ namespace OpenRCT2::Ui::Windows
         else
         {
             ToolCancel();
-            WindowCloseByClass(WindowClass::Footpath);
+            windowMgr->CloseByClass(WindowClass::Footpath);
         }
     }
 

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -421,8 +421,9 @@ namespace OpenRCT2::Ui::Windows
             return nullptr;
         }
 
-        WindowCloseByClass(WindowClass::EditorObjectSelection);
-        WindowCloseConstructionWindows();
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseByClass(WindowClass::EditorObjectSelection);
+        windowMgr->CloseConstructionWindows();
 
         gTrackDesignSceneryToggle = false;
         _currentTrackPieceDirection = 2;
@@ -431,7 +432,6 @@ namespace OpenRCT2::Ui::Windows
         int32_t screenHeight = ContextGetHeight();
         auto screenPos = ScreenCoordsXY{ screenWidth / 2 - 201, std::max(kTopToolbarHeight + 1, screenHeight / 2 - 200) };
 
-        auto* windowMgr = GetWindowManager();
         auto* window = windowMgr->FocusOrCreate<InstallTrackWindow>(WindowClass::InstallTrack, screenPos, WW, WH, 0);
         window->SetupTrack(path, std::move(trackDesign));
 

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -293,8 +293,9 @@ namespace OpenRCT2::Ui::Windows
 
         // Closing this will cause a Ride window to pop up, so we have to do this to ensure that
         // no windows are open (besides the toolbars and LoadSave window).
-        WindowCloseByClass(WindowClass::RideConstruction);
-        WindowCloseAllExceptClass(WindowClass::Loadsave);
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseByClass(WindowClass::RideConstruction);
+        windowMgr->CloseAllExceptClass(WindowClass::Loadsave);
 
         auto& gameState = GetGameState();
 
@@ -305,7 +306,7 @@ namespace OpenRCT2::Ui::Windows
                 if (OpenRCT2::GetContext()->LoadParkFromFile(pathBuffer))
                 {
                     InvokeCallback(MODAL_RESULT_OK, pathBuffer);
-                    WindowCloseByClass(WindowClass::Loadsave);
+                    windowMgr->CloseByClass(WindowClass::Loadsave);
                     GfxInvalidateScreen();
                 }
                 else
@@ -325,7 +326,7 @@ namespace OpenRCT2::Ui::Windows
                     gIsAutosaveLoaded = false;
                     gFirstTimeSaving = false;
 
-                    WindowCloseByClass(WindowClass::Loadsave);
+                    windowMgr->CloseByClass(WindowClass::Loadsave);
                     GfxInvalidateScreen();
 
                     InvokeCallback(MODAL_RESULT_OK, pathBuffer);
@@ -359,7 +360,7 @@ namespace OpenRCT2::Ui::Windows
                 if (ScenarioSave(gameState, pathBuffer, Config::Get().general.SavePluginData ? 3 : 2))
                 {
                     gCurrentLoadedPath = pathBuffer;
-                    WindowCloseByClass(WindowClass::Loadsave);
+                    windowMgr->CloseByClass(WindowClass::Loadsave);
                     GfxInvalidateScreen();
                     InvokeCallback(MODAL_RESULT_OK, pathBuffer);
                 }
@@ -382,7 +383,7 @@ namespace OpenRCT2::Ui::Windows
 
                 if (success)
                 {
-                    WindowCloseByClass(WindowClass::Loadsave);
+                    windowMgr->CloseByClass(WindowClass::Loadsave);
                     InvokeCallback(MODAL_RESULT_OK, pathBuffer);
 
                     auto* context = OpenRCT2::GetContext();
@@ -403,7 +404,7 @@ namespace OpenRCT2::Ui::Windows
                 auto intent = Intent(WindowClass::InstallTrack);
                 intent.PutExtra(INTENT_EXTRA_PATH, std::string{ pathBuffer });
                 ContextOpenIntent(&intent);
-                WindowCloseByClass(WindowClass::Loadsave);
+                windowMgr->CloseByClass(WindowClass::Loadsave);
                 InvokeCallback(MODAL_RESULT_OK, pathBuffer);
                 break;
             }
@@ -421,7 +422,7 @@ namespace OpenRCT2::Ui::Windows
 
                 if (success)
                 {
-                    WindowCloseByClass(WindowClass::Loadsave);
+                    windowMgr->CloseByClass(WindowClass::Loadsave);
                     WindowRideMeasurementsDesignCancel();
                     InvokeCallback(MODAL_RESULT_OK, path);
                 }
@@ -434,7 +435,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             case (LOADSAVETYPE_LOAD | LOADSAVETYPE_HEIGHTMAP):
-                WindowCloseByClass(WindowClass::Loadsave);
+                windowMgr->CloseByClass(WindowClass::Loadsave);
                 InvokeCallback(MODAL_RESULT_OK, pathBuffer);
                 break;
         }
@@ -769,7 +770,10 @@ namespace OpenRCT2::Ui::Windows
         void OnClose() override
         {
             _listItems.clear();
-            WindowCloseByClass(WindowClass::LoadsaveOverwritePrompt);
+
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->CloseByClass(WindowClass::LoadsaveOverwritePrompt);
+
             Config::Save();
 
             // Unpause the game if not on title scene, nor in network play.
@@ -1457,7 +1461,8 @@ namespace OpenRCT2::Ui::Windows
 
                     // As the LoadSaveWindow::Select function can change the order of the
                     // windows we can't use WindowClose(w).
-                    WindowCloseByClass(WindowClass::LoadsaveOverwritePrompt);
+                    auto* windowMgr = Ui::GetWindowManager();
+                    windowMgr->CloseByClass(WindowClass::LoadsaveOverwritePrompt);
                     break;
                 }
 
@@ -1483,9 +1488,9 @@ namespace OpenRCT2::Ui::Windows
 
     static WindowBase* WindowOverwritePromptOpen(const std::string_view name, const std::string_view path)
     {
-        WindowCloseByClass(WindowClass::LoadsaveOverwritePrompt);
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseByClass(WindowClass::LoadsaveOverwritePrompt);
 
-        auto* windowMgr = GetWindowManager();
         return windowMgr->Create<OverwritePromptWindow>(
             WindowClass::LoadsaveOverwritePrompt, OVERWRITE_WW, OVERWRITE_WH,
             WF_TRANSPARENT | WF_STICK_TO_FRONT | WF_CENTRE_SCREEN, name, path);

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -286,7 +286,7 @@ namespace OpenRCT2::Ui::Windows
                     if (!windowMgr->FindByClass(WindowClass::LandRights))
                         ContextOpenWindow(WindowClass::LandRights);
                     else
-                        WindowCloseByClass(WindowClass::LandRights);
+                        windowMgr->CloseByClass(WindowClass::LandRights);
                     break;
                 }
                 case WIDX_BUILD_PARK_ENTRANCE:
@@ -294,7 +294,7 @@ namespace OpenRCT2::Ui::Windows
                     if (!windowMgr->FindByClass(WindowClass::EditorParkEntrance))
                         ContextOpenWindow(WindowClass::EditorParkEntrance);
                     else
-                        WindowCloseByClass(WindowClass::EditorParkEntrance);
+                        windowMgr->CloseByClass(WindowClass::EditorParkEntrance);
                     break;
                 }
                 case WIDX_PEOPLE_STARTING_POSITION:

--- a/src/openrct2-ui/windows/MapTooltip.cpp
+++ b/src/openrct2-ui/windows/MapTooltip.cpp
@@ -100,7 +100,8 @@ namespace OpenRCT2::Ui::Windows
         if (_cursorHoldDuration < 25 || stringId == kStringIdNone || im.IsModifierKeyPressed(ModifierKey::ctrl)
             || im.IsModifierKeyPressed(ModifierKey::shift) || wm->FindByClass(WindowClass::Error) != nullptr)
         {
-            WindowCloseByClass(WindowClass::MapTooltip);
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->CloseByClass(WindowClass::MapTooltip);
         }
         else
         {

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -370,7 +370,10 @@ namespace OpenRCT2::Ui::Windows
                 {
                     ToolCancel();
                     if (!currentRide->GetRideTypeDescriptor().HasFlag(RtdFlag::hasTrack))
-                        WindowCloseByClass(WindowClass::RideConstruction);
+                    {
+                        auto* windowMgr = Ui::GetWindowManager();
+                        windowMgr->CloseByClass(WindowClass::RideConstruction);
+                    }
                 }
                 else
                 {

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -279,7 +279,8 @@ namespace OpenRCT2::Ui::Windows
                     gameAction.SetCallback([](const GameAction* ga, const GameActions::Result* result) {
                         if (result->Error == GameActions::Status::Ok)
                         {
-                            WindowCloseByClass(WindowClass::NewCampaign);
+                            auto* windowMgr = Ui::GetWindowManager();
+                            windowMgr->CloseByClass(WindowClass::NewCampaign);
                         }
                     });
                     GameActions::Execute(&gameAction);

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -409,7 +409,7 @@ namespace OpenRCT2::Ui::Windows
             if (w->GetCampaignType() == campaignType)
                 return w;
 
-            WindowClose(*w);
+            w->Close();
         }
 
         w = windowMgr->Create<NewCampaignWindow>(WindowClass::NewCampaign, WW, WH, 0);

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -562,7 +562,9 @@ namespace OpenRCT2::Ui::Windows
             }
 
             Close();
-            WindowCloseConstructionWindows();
+
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->CloseConstructionWindows();
 
             auto count = GetNumTrackDesigns(item);
             if (count > 0)
@@ -1077,8 +1079,8 @@ namespace OpenRCT2::Ui::Windows
             return window;
         }
 
-        WindowCloseByClass(WindowClass::TrackDesignList);
-        WindowCloseByClass(WindowClass::TrackDesignPlace);
+        windowMgr->CloseByClass(WindowClass::TrackDesignList);
+        windowMgr->CloseByClass(WindowClass::TrackDesignPlace);
 
         window = windowMgr->Create<NewRideWindow>(
             WindowClass::ConstructRide, WindowWidth, WindowHeight, WF_10 | WF_AUTO_POSITION);

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -415,7 +415,7 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_CLOSE:
-                    WindowClose(*this);
+                    Close();
                     return;
                 case WIDX_COPY_CURRENT:
                     if (selected_list_item > -1 && selected_list_item < no_list_items)

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -620,7 +620,7 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_CLOSE:
-                    WindowClose(*this);
+                    Close();
                     break;
                 case WIDX_TAB_DISPLAY:
                 case WIDX_TAB_RENDERING:

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1698,10 +1698,13 @@ namespace OpenRCT2::Ui::Windows
                     Invalidate();
                     break;
                 case WIDX_SCENARIO_UNLOCKING:
+                {
                     Config::Get().general.ScenarioUnlockingEnabled ^= 1;
                     Config::Save();
-                    WindowCloseByClass(WindowClass::ScenarioSelect);
+                    auto* windowMgr = Ui::GetWindowManager();
+                    windowMgr->CloseByClass(WindowClass::ScenarioSelect);
                     break;
+                }
                 case WIDX_AUTO_OPEN_SHOPS:
                     Config::Get().general.AutoOpenShops = !Config::Get().general.AutoOpenShops;
                     Config::Save();
@@ -1820,7 +1823,8 @@ namespace OpenRCT2::Ui::Windows
                         Config::Get().interface.ScenarioselectLastTab = 0;
                         Config::Save();
                         Invalidate();
-                        WindowCloseByClass(WindowClass::ScenarioSelect);
+                        auto* windowMgr = Ui::GetWindowManager();
+                        windowMgr->CloseByClass(WindowClass::ScenarioSelect);
                     }
                     break;
             }

--- a/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
@@ -107,7 +107,8 @@ namespace OpenRCT2::Ui::Windows
         if (w != nullptr)
         {
             auto windowPos = w->windowPos;
-            WindowClose(*w);
+            windowMgr->Close(*w);
+
             newWindow = windowMgr->Create<RefurbishRidePromptWindow>(
                 WindowClass::DemolishRidePrompt, windowPos, WW, WH, WF_TRANSPARENT);
         }

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1140,7 +1140,7 @@ namespace OpenRCT2::Ui::Windows
                 auto constructionWindow = windowMgr->FindByClass(WindowClass::RideConstruction);
                 if (constructionWindow != nullptr && constructionWindow->number == number)
                 {
-                    WindowCloseByClass(WindowClass::RideConstruction);
+                    windowMgr->CloseByClass(WindowClass::RideConstruction);
                     // Closing the construction window sets the tab to the first page, which we don't want here,
                     // as user just clicked the Vehicle page
                     SetPage(WINDOW_RIDE_PAGE_VEHICLE);

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -214,7 +214,7 @@ namespace OpenRCT2::Ui::Windows
         auto* windowMgr = GetWindowManager();
         WindowBase* w = windowMgr->FindByNumber(WindowClass::Ride, rideId.ToUnderlying());
         if (w != nullptr && w->page == 1)
-            WindowClose(*w);
+            windowMgr->Close(*w);
     }
 
     static void RideConstructPlacedForwardGameActionCallback(const GameAction* ga, const GameActions::Result* result);
@@ -2595,7 +2595,8 @@ namespace OpenRCT2::Ui::Windows
                     ToolCancel();
                     if (!currentRide->GetRideTypeDescriptor().HasFlag(RtdFlag::hasTrack))
                     {
-                        WindowCloseByClass(WindowClass::RideConstruction);
+                        auto* windowMgr = Ui::GetWindowManager();
+                        windowMgr->CloseByClass(WindowClass::RideConstruction);
                     }
                 }
                 else
@@ -2827,7 +2828,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 if (RideAreAllPossibleEntrancesAndExitsBuilt(ride).Successful)
                 {
-                    WindowClose(*w);
+                    windowMgr->Close(*w);
                 }
                 else
                 {
@@ -2900,7 +2901,8 @@ namespace OpenRCT2::Ui::Windows
             WindowRideConstructionUpdateActiveElements();
         }
 
-        WindowCloseByClass(WindowClass::Error);
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseByClass(WindowClass::Error);
         if (ride != nullptr)
             CloseConstructWindowOnCompletion(*ride);
     }
@@ -2944,7 +2946,8 @@ namespace OpenRCT2::Ui::Windows
             WindowRideConstructionUpdateActiveElements();
         }
 
-        WindowCloseByClass(WindowClass::Error);
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseByClass(WindowClass::Error);
         if (ride != nullptr)
             CloseConstructWindowOnCompletion(*ride);
     }
@@ -3661,7 +3664,7 @@ namespace OpenRCT2::Ui::Windows
                 }
                 else
                 {
-                    WindowCloseByClass(WindowClass::Error);
+                    windowMgr->CloseByClass(WindowClass::Error);
                     OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::PlaceItem, _currentTrackBegin);
                     break;
                 }

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -231,7 +231,7 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_CLOSE:
-                    WindowClose(*this);
+                    Close();
                     break;
                 case WIDX_SORT:
                     list_information_type = _windowRideListInformationType;

--- a/src/openrct2-ui/windows/SavePrompt.cpp
+++ b/src/openrct2-ui/windows/SavePrompt.cpp
@@ -236,7 +236,7 @@ namespace OpenRCT2::Ui::Windows
         auto* window = windowMgr->BringToFrontByClass(WindowClass::SavePrompt);
         if (window != nullptr)
         {
-            WindowClose(*window);
+            windowMgr->Close(*window);
         }
 
         if (EnumValue(prompt_mode) >= std::size(window_save_prompt_labels))

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -253,7 +253,10 @@ namespace OpenRCT2::Ui::Windows
             ViewportSetVisibility(ViewportVisibility::Default);
 
             if (gWindowSceneryScatterEnabled)
-                WindowCloseByClass(WindowClass::SceneryScatter);
+            {
+                auto* windowMgr = Ui::GetWindowManager();
+                windowMgr->CloseByClass(WindowClass::SceneryScatter);
+            }
 
             if (isToolActive(WindowClass::Scenery))
                 ToolCancel();
@@ -261,6 +264,8 @@ namespace OpenRCT2::Ui::Windows
 
         void OnMouseUp(WidgetIndex widgetIndex) override
         {
+            auto* windowMgr = Ui::GetWindowManager();
+
             switch (widgetIndex)
             {
                 case WIDX_SCENERY_CLOSE:
@@ -276,14 +281,14 @@ namespace OpenRCT2::Ui::Windows
                     _sceneryPaintEnabled ^= true;
                     gWindowSceneryEyedropperEnabled = false;
                     if (gWindowSceneryScatterEnabled)
-                        WindowCloseByClass(WindowClass::SceneryScatter);
+                        windowMgr->CloseByClass(WindowClass::SceneryScatter);
                     Invalidate();
                     break;
                 case WIDX_SCENERY_EYEDROPPER_BUTTON:
                     _sceneryPaintEnabled = false;
                     gWindowSceneryEyedropperEnabled = !gWindowSceneryEyedropperEnabled;
                     if (gWindowSceneryScatterEnabled)
-                        WindowCloseByClass(WindowClass::SceneryScatter);
+                        windowMgr->CloseByClass(WindowClass::SceneryScatter);
                     SceneryRemoveGhostToolPlacement();
                     Invalidate();
                     break;
@@ -291,7 +296,7 @@ namespace OpenRCT2::Ui::Windows
                     _sceneryPaintEnabled = false;
                     gWindowSceneryEyedropperEnabled = false;
                     if (gWindowSceneryScatterEnabled)
-                        WindowCloseByClass(WindowClass::SceneryScatter);
+                        windowMgr->CloseByClass(WindowClass::SceneryScatter);
                     else if (
                         NetworkGetMode() != NETWORK_MODE_CLIENT
                         || NetworkCanPerformCommand(NetworkGetCurrentPlayerGroupIndex(), -2))

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -96,7 +96,7 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_CLOSE:
-                    WindowClose(*this);
+                    Close();
                     break;
 
                 case WIDX_PREVIEW:

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -81,7 +81,7 @@ namespace OpenRCT2::Ui::Windows
             if (registeredShortcut != nullptr)
             {
                 auto* windowMgr = GetWindowManager();
-                WindowCloseByClass(WindowClass::ChangeKeyboardShortcut);
+                windowMgr->CloseByClass(WindowClass::ChangeKeyboardShortcut);
                 auto* w = windowMgr->Create<ChangeShortcutWindow>(
                     WindowClass::ChangeKeyboardShortcut, CHANGE_WW, CHANGE_WH, WF_CENTRE_SCREEN);
                 if (w != nullptr)
@@ -198,7 +198,8 @@ namespace OpenRCT2::Ui::Windows
 
         void OnClose() override
         {
-            WindowCloseByClass(WindowClass::ResetShortcutKeysPrompt);
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->CloseByClass(WindowClass::ResetShortcutKeysPrompt);
         }
 
         void OnResize() override

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -470,7 +470,8 @@ namespace OpenRCT2::Ui::Windows
                             return;
                         }
 
-                        WindowCloseByClass(WindowClass::PatrolArea);
+                        auto* windowMgr = Ui::GetWindowManager();
+                        windowMgr->CloseByClass(WindowClass::PatrolArea);
 
                         auto staffSetPatrolAreaAction = StaffSetPatrolAreaAction(
                             staff->Id, {}, StaffSetPatrolAreaMode::ClearAll);
@@ -481,7 +482,8 @@ namespace OpenRCT2::Ui::Windows
                         auto staffId = EntityId::FromUnderlying(number);
                         if (WindowPatrolAreaGetCurrentStaffId() == staffId)
                         {
-                            WindowCloseByClass(WindowClass::PatrolArea);
+                            auto* windowMgr = Ui::GetWindowManager();
+                            windowMgr->CloseByClass(WindowClass::PatrolArea);
                         }
                         else
                         {

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -374,7 +374,7 @@ namespace OpenRCT2::Ui::Windows
         const_utf8string existing_text, int32_t maxLength)
     {
         auto* windowMgr = GetWindowManager();
-        WindowCloseByClass(WindowClass::Textinput);
+        windowMgr->CloseByClass(WindowClass::Textinput);
 
         auto height = TextInputWindow::CalculateWindowHeight(existing_text);
         auto w = windowMgr->Create<TextInputWindow>(WindowClass::Textinput, WW, height, WF_CENTRE_SCREEN | WF_STICK_TO_FRONT);

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -136,7 +136,7 @@ namespace OpenRCT2::Ui::Windows
                 auto parentWindow = GetParentWindow();
                 if (parentWindow == nullptr)
                 {
-                    WindowClose(*this);
+                    Close();
                     return;
                 }
             }
@@ -157,12 +157,12 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_CLOSE:
                     ContextStopTextInput();
                     ExecuteCallback(false);
-                    WindowClose(*this);
+                    Close();
                     break;
                 case WIDX_OKAY:
                     ContextStopTextInput();
                     ExecuteCallback(true);
-                    WindowClose(*this);
+                    Close();
             }
         }
 
@@ -301,7 +301,7 @@ namespace OpenRCT2::Ui::Windows
         {
             ContextStopTextInput();
             ExecuteCallback(true);
-            WindowClose(*this);
+            Close();
         }
 
         static int32_t CalculateWindowHeight(std::string_view text)

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -132,8 +132,8 @@ namespace OpenRCT2::Ui::Windows
                     }
                     else
                     {
-                        WindowCloseByClass(WindowClass::Loadsave);
-                        WindowCloseByClass(WindowClass::ServerList);
+                        windowMgr->CloseByClass(WindowClass::Loadsave);
+                        windowMgr->CloseByClass(WindowClass::ServerList);
                         ScenarioselectOpen(WindowTitleMenuScenarioselectCallback);
                     }
                     break;
@@ -145,8 +145,8 @@ namespace OpenRCT2::Ui::Windows
                     }
                     else
                     {
-                        WindowCloseByClass(WindowClass::ScenarioSelect);
-                        WindowCloseByClass(WindowClass::ServerList);
+                        windowMgr->CloseByClass(WindowClass::ScenarioSelect);
+                        windowMgr->CloseByClass(WindowClass::ServerList);
                         auto loadOrQuitAction = LoadOrQuitAction(LoadOrQuitModes::OpenSavePrompt);
                         GameActions::Execute(&loadOrQuitAction);
                     }
@@ -159,8 +159,8 @@ namespace OpenRCT2::Ui::Windows
                     }
                     else
                     {
-                        WindowCloseByClass(WindowClass::ScenarioSelect);
-                        WindowCloseByClass(WindowClass::Loadsave);
+                        windowMgr->CloseByClass(WindowClass::ScenarioSelect);
+                        windowMgr->CloseByClass(WindowClass::Loadsave);
                         ContextOpenWindow(WindowClass::ServerList);
                     }
                     break;

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -204,7 +204,9 @@ namespace OpenRCT2::Ui::Windows
 
     void WindowTooltipClose()
     {
-        WindowCloseByClass(WindowClass::Tooltip);
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseByClass(WindowClass::Tooltip);
+
         gTooltipCloseTimeout = 0;
         gTooltipWidget.window_classification = WindowClass::Null;
     }

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -500,8 +500,9 @@ namespace OpenRCT2::Ui::Windows
                             break;
                         case DDIDX_QUIT_TO_MENU:
                         {
-                            WindowCloseByClass(WindowClass::ManageTrackDesign);
-                            WindowCloseByClass(WindowClass::TrackDeletePrompt);
+                            auto* windowMgr = Ui::GetWindowManager();
+                            windowMgr->CloseByClass(WindowClass::ManageTrackDesign);
+                            windowMgr->CloseByClass(WindowClass::TrackDeletePrompt);
                             auto loadOrQuitAction = LoadOrQuitAction(
                                 LoadOrQuitModes::OpenSavePrompt, PromptMode::SaveBeforeQuit);
                             GameActions::Execute(&loadOrQuitAction);
@@ -1474,9 +1475,12 @@ namespace OpenRCT2::Ui::Windows
                 ContextOpenWindow(WindowClass::TileInspector);
                 break;
             case DDIDX_OBJECT_SELECTION:
-                WindowCloseAll();
+            {
+                auto* windowMgr = Ui::GetWindowManager();
+                windowMgr->CloseAll();
                 ContextOpenWindow(WindowClass::EditorObjectSelection);
                 break;
+            }
             case DDIDX_INVENTIONS_LIST:
                 ContextOpenWindow(WindowClass::EditorInventionList);
                 break;
@@ -1535,7 +1539,7 @@ namespace OpenRCT2::Ui::Windows
                     }
                     else
                     {
-                        WindowCloseByClass(WindowClass::DebugPaint);
+                        windowMgr->CloseByClass(WindowClass::DebugPaint);
                     }
                     break;
                 }

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -108,10 +108,10 @@ namespace OpenRCT2::Ui::Windows
      */
     WindowBase* TrackManageOpen(TrackDesignFileRef* tdFileRef)
     {
-        WindowCloseByClass(WindowClass::ManageTrackDesign);
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseByClass(WindowClass::ManageTrackDesign);
         auto trackDesignManageWindow = std::make_unique<TrackDesignManageWindow>(tdFileRef);
 
-        auto* windowMgr = GetWindowManager();
         auto* window = windowMgr->Create(
             std::move(trackDesignManageWindow), WindowClass::ManageTrackDesign, {}, WW, WH,
             WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_CENTRE_SCREEN | WF_AUTO_POSITION);
@@ -137,9 +137,12 @@ namespace OpenRCT2::Ui::Windows
         switch (widgetIndex)
         {
             case WIDX_CLOSE:
-                WindowCloseByClass(WindowClass::TrackDeletePrompt);
+            {
+                auto* windowMgr = Ui::GetWindowManager();
+                windowMgr->CloseByClass(WindowClass::TrackDeletePrompt);
                 Close();
                 break;
+            }
             case WIDX_RENAME:
                 WindowTextInputRawOpen(
                     this, widgetIndex, STR_TRACK_DESIGN_RENAME_TITLE, STR_TRACK_DESIGN_RENAME_DESC, {},
@@ -170,7 +173,8 @@ namespace OpenRCT2::Ui::Windows
 
         if (TrackRepositoryRename(_trackDesignFileReference->path, std::string(text)))
         {
-            WindowCloseByClass(WindowClass::TrackDeletePrompt);
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->CloseByClass(WindowClass::TrackDeletePrompt);
             Close();
             WindowTrackDesignListReloadTracks();
         }
@@ -192,13 +196,13 @@ namespace OpenRCT2::Ui::Windows
      */
     static void WindowTrackDeletePromptOpen(TrackDesignFileRef* tdFileRef)
     {
-        WindowCloseByClass(WindowClass::TrackDeletePrompt);
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseByClass(WindowClass::TrackDeletePrompt);
 
         int32_t screenWidth = ContextGetWidth();
         int32_t screenHeight = ContextGetHeight();
         auto trackDeletePromptWindow = std::make_unique<TrackDeletePromptWindow>(tdFileRef);
 
-        auto* windowMgr = GetWindowManager();
         windowMgr->Create(
             std::move(trackDeletePromptWindow), WindowClass::TrackDeletePrompt,
             ScreenCoordsXY(
@@ -226,7 +230,8 @@ namespace OpenRCT2::Ui::Windows
                 Close();
                 if (TrackRepositoryDelete(tdPath))
                 {
-                    WindowCloseByClass(WindowClass::ManageTrackDesign);
+                    auto* windowMgr = Ui::GetWindowManager();
+                    windowMgr->CloseByClass(WindowClass::ManageTrackDesign);
                     WindowTrackDesignListReloadTracks();
                 }
                 else

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -295,19 +295,19 @@ namespace OpenRCT2::Ui::Windows
                 auto getRide = GetRide(rideId);
                 if (getRide != nullptr)
                 {
-                    WindowCloseByClass(WindowClass::Error);
-                    Audio::Play3D(Audio::SoundId::PlaceItem, trackLoc);
+                    auto* windowMgr = Ui::GetWindowManager();
+                    windowMgr->CloseByClass(WindowClass::Error);
 
+                    Audio::Play3D(Audio::SoundId::PlaceItem, trackLoc);
                     _currentRideIndex = rideId;
 
-                    auto* windowMgr = GetWindowManager();
                     if (TrackDesignAreEntranceAndExitPlaced())
                     {
                         auto intent = Intent(WindowClass::Ride);
                         intent.PutExtra(INTENT_EXTRA_RIDE_ID, rideId.ToUnderlying());
                         ContextOpenIntent(&intent);
                         auto* wnd = windowMgr->FindByClass(WindowClass::TrackDesignPlace);
-                        WindowClose(*wnd);
+                        windowMgr->Close(*wnd);
                     }
                     else
                     {
@@ -734,9 +734,9 @@ namespace OpenRCT2::Ui::Windows
             return nullptr;
         }
 
-        WindowCloseConstructionWindows();
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseConstructionWindows();
 
-        auto* windowMgr = GetWindowManager();
         auto* window = windowMgr->FocusOrCreate<TrackDesignPlaceWindow>(WindowClass::TrackDesignPlace, WW, WH, 0);
         if (window != nullptr)
         {

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -265,8 +265,9 @@ namespace OpenRCT2::Ui::Windows
             // try to load the track manager again, and an infinite loop will result.
             if ((gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER) && gScreenAge != 0)
             {
-                WindowCloseByNumber(WindowClass::ManageTrackDesign, number);
-                WindowCloseByNumber(WindowClass::TrackDeletePrompt, number);
+                auto* windowMgr = Ui::GetWindowManager();
+                windowMgr->CloseByNumber(WindowClass::ManageTrackDesign, number);
+                windowMgr->CloseByNumber(WindowClass::TrackDeletePrompt, number);
                 Editor::LoadTrackManager();
             }
         }
@@ -757,7 +758,9 @@ namespace OpenRCT2::Ui::Windows
 
     WindowBase* TrackListOpen(const RideSelection item)
     {
-        WindowCloseConstructionWindows();
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseConstructionWindows();
+
         ScreenCoordsXY screenPos{};
         if (gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)
         {
@@ -769,7 +772,7 @@ namespace OpenRCT2::Ui::Windows
         {
             screenPos = { 0, kTopToolbarHeight + 2 };
         }
-        auto* windowMgr = GetWindowManager();
+
         return windowMgr->Create<TrackListWindow>(WindowClass::TrackDesignList, WW, WH, 0, item);
     }
 

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -88,7 +88,7 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_CLOSE:
-                    WindowClose(*this);
+                    Close();
                     break;
                 case WIDX_CLIP_CHECKBOX_ENABLE:
                 {

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -209,7 +209,9 @@ namespace OpenRCT2
 #ifndef DISABLE_NETWORK
             _network.Close();
 #endif
-            WindowCloseAll();
+
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->CloseAll();
 
             // Unload objects after closing all windows, this is to overcome windows like
             // the object selection window which loads objects when closed.

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -245,7 +245,8 @@ namespace OpenRCT2::Editor
     {
         // #4996: Make sure the object selection window closes here to prevent unload objects
         //        after we have loaded a new park.
-        WindowCloseAll();
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseAll();
 
         if (!GetContext()->LoadParkFromFile(path))
             return false;

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -615,7 +615,10 @@ static void GameLoadOrQuitNoSavePromptCallback(int32_t result, const utf8* path)
     {
         GameNotifyMapChange();
         GameUnloadScripts();
-        WindowCloseByClass(WindowClass::EditorObjectSelection);
+
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseByClass(WindowClass::EditorObjectSelection);
+
         GameLoadScripts();
         GameNotifyMapChanged();
         gIsAutosaveLoaded = gIsAutosave;
@@ -627,8 +630,9 @@ static void NewGameWindowCallback(const utf8* path)
 {
     // Closing this will cause a Ride window to pop up, so we have to do this to ensure that
     // no windows are open (besides the toolbars and LoadSave window).
-    WindowCloseByClass(WindowClass::RideConstruction);
-    WindowCloseAllExceptClass(WindowClass::Loadsave);
+    auto* windowMgr = Ui::GetWindowManager();
+    windowMgr->CloseByClass(WindowClass::RideConstruction);
+    windowMgr->CloseAllExceptClass(WindowClass::Loadsave);
 
     GameNotifyMapChange();
     GetContext()->LoadParkFromFile(path, false, true);

--- a/src/openrct2/actions/LoadOrQuitAction.cpp
+++ b/src/openrct2/actions/LoadOrQuitAction.cpp
@@ -11,6 +11,7 @@
 
 #include "../Context.h"
 #include "../OpenRCT2.h"
+#include "../ui/WindowManager.h"
 
 using namespace OpenRCT2;
 
@@ -53,8 +54,11 @@ GameActions::Result LoadOrQuitAction::Execute() const
             ContextOpenWindow(WindowClass::SavePrompt);
             break;
         case LoadOrQuitModes::CloseSavePrompt:
-            WindowCloseByClass(WindowClass::SavePrompt);
+        {
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->CloseByClass(WindowClass::SavePrompt);
             break;
+        }
         default:
             GameLoadOrQuitNoSavePrompt();
             break;

--- a/src/openrct2/actions/RideDemolishAction.cpp
+++ b/src/openrct2/actions/RideDemolishAction.cpp
@@ -160,10 +160,11 @@ GameActions::Result RideDemolishAction::DemolishRide(Ride& ride) const
     GetGameState().Park.Value = Park::CalculateParkValue();
 
     // Close windows related to the demolished ride
-    WindowCloseByNumber(WindowClass::RideConstruction, rideId.ToUnderlying());
-    WindowCloseByNumber(WindowClass::Ride, rideId.ToUnderlying());
-    WindowCloseByNumber(WindowClass::DemolishRidePrompt, rideId.ToUnderlying());
-    WindowCloseByClass(WindowClass::NewCampaign);
+    auto* windowMgr = Ui::GetWindowManager();
+    windowMgr->CloseByNumber(WindowClass::RideConstruction, rideId.ToUnderlying());
+    windowMgr->CloseByNumber(WindowClass::Ride, rideId.ToUnderlying());
+    windowMgr->CloseByNumber(WindowClass::DemolishRidePrompt, rideId.ToUnderlying());
+    windowMgr->CloseByClass(WindowClass::NewCampaign);
 
     // Refresh windows that display the ride name
     auto windowManager = OpenRCT2::Ui::GetWindowManager();
@@ -288,7 +289,8 @@ GameActions::Result RideDemolishAction::RefurbishRide(Ride& ride) const
         res.Position = { location, TileElementHeight(location) };
     }
 
-    WindowCloseByNumber(WindowClass::DemolishRidePrompt, _rideIndex.ToUnderlying());
+    auto* windowMgr = Ui::GetWindowManager();
+    windowMgr->CloseByNumber(WindowClass::DemolishRidePrompt, _rideIndex.ToUnderlying());
 
     return res;
 }

--- a/src/openrct2/actions/RideSetStatusAction.cpp
+++ b/src/openrct2/actions/RideSetStatusAction.cpp
@@ -206,7 +206,7 @@ GameActions::Result RideSetStatusAction::Execute() const
             WindowBase* constructionWindow = windowMgr->FindByNumber(WindowClass::RideConstruction, _rideIndex.ToUnderlying());
             if (constructionWindow != nullptr)
             {
-                WindowClose(*constructionWindow);
+                windowMgr->Close(*constructionWindow);
             }
 
             if (_status == RideStatus::Testing)

--- a/src/openrct2/actions/StaffFireAction.cpp
+++ b/src/openrct2/actions/StaffFireAction.cpp
@@ -13,6 +13,7 @@
 #include "../entity/EntityRegistry.h"
 #include "../entity/Staff.h"
 #include "../interface/Window.h"
+#include "../ui/WindowManager.h"
 
 using namespace OpenRCT2;
 
@@ -73,9 +74,13 @@ GameActions::Result StaffFireAction::Execute() const
         LOG_ERROR("Staff entity not found for spriteId %u", _spriteId);
         return GameActions::Result(GameActions::Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_STAFF_NOT_FOUND);
     }
-    WindowCloseByClass(WindowClass::FirePrompt);
+
+    auto* windowMgr = Ui::GetWindowManager();
+    windowMgr->CloseByClass(WindowClass::FirePrompt);
+
     PeepEntityRemove(staff);
     // Due to patrol areas best to invalidate the whole screen on removal of staff
     GfxInvalidateScreen();
+
     return GameActions::Result();
 }

--- a/src/openrct2/command_line/ConvertCommand.cpp
+++ b/src/openrct2/command_line/ConvertCommand.cpp
@@ -18,6 +18,7 @@
 #include "../object/ObjectManager.h"
 #include "../park/ParkFile.h"
 #include "../scenario/Scenario.h"
+#include "../ui/WindowManager.h"
 #include "CommandLine.hpp"
 
 #include <cassert>
@@ -123,7 +124,8 @@ exitcode_t CommandLine::HandleCommandConvert(CommandLineArgEnumerator* enumerato
 
         // HACK remove the main window so it saves the park with the
         //      correct initial view
-        WindowCloseByClass(WindowClass::MainWindow);
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseByClass(WindowClass::MainWindow);
 
         exporter->Export(gameState, destinationPath);
     }

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -720,9 +720,9 @@ void PeepEntityRemove(Peep* peep)
     }
     peep->Invalidate();
 
-    WindowCloseByNumber(WindowClass::Peep, peep->Id);
-
-    WindowCloseByNumber(WindowClass::FirePrompt, EnumValue(peep->Type));
+    auto* windowMgr = Ui::GetWindowManager();
+    windowMgr->CloseByNumber(WindowClass::Peep, peep->Id);
+    windowMgr->CloseByNumber(WindowClass::FirePrompt, EnumValue(peep->Type));
 
     auto* staff = peep->As<Staff>();
     // Needed for invalidations after sprite removal

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -61,6 +61,7 @@
 #include "../ride/RideData.h"
 #include "../ride/RideManager.hpp"
 #include "../ride/Vehicle.h"
+#include "../ui/WindowManager.h"
 #include "../util/Util.h"
 #include "../windows/Intent.h"
 #include "../world/Climate.h"
@@ -1207,7 +1208,8 @@ static void ConsoleCommandOpen(InteractiveConsole& console, const arguments_t& a
             else
             {
                 // Only this window should be open for safety reasons
-                WindowCloseAll();
+                auto* windowMgr = Ui::GetWindowManager();
+                windowMgr->CloseAll();
                 ContextOpenWindow(WindowClass::EditorObjectSelection);
             }
         }

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -380,15 +380,6 @@ namespace OpenRCT2
 
     void WindowSetWindowLimit(int32_t value);
 
-    void WindowClose(WindowBase& window);
-    void WindowCloseByClass(WindowClass cls);
-    void WindowCloseByNumber(WindowClass cls, rct_windownumber number);
-    void WindowCloseByNumber(WindowClass cls, EntityId number);
-    void WindowCloseTop();
-    void WindowCloseAll();
-    void WindowCloseAllExceptClass(WindowClass cls);
-    void WindowCloseAllExceptFlags(uint16_t flags);
-    void WindowCloseAllExceptNumberAndClass(rct_windownumber number, WindowClass cls);
     void WindowInvalidateByClass(WindowClass cls);
     void WindowInvalidateByNumber(WindowClass cls, rct_windownumber number);
     void WindowInvalidateByNumber(WindowClass cls, EntityId id);
@@ -421,8 +412,6 @@ namespace OpenRCT2
     bool isToolActive(const WindowBase& w, WidgetIndex widgetIndex);
     bool ToolSet(const WindowBase& w, WidgetIndex widgetIndex, Tool tool);
     void ToolCancel();
-
-    void WindowCloseConstructionWindows();
 
     void WindowUpdateViewportRideMusic();
 

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -649,7 +649,9 @@ void NetworkBase::UpdateClient()
                     intent.PutExtra(INTENT_EXTRA_MESSAGE, std::string{ str_disconnected });
                     ContextOpenIntent(&intent);
                 }
-                WindowCloseByClass(WindowClass::Multiplayer);
+
+                auto* windowMgr = Ui::GetWindowManager();
+                windowMgr->CloseByClass(WindowClass::Multiplayer);
                 Close();
             }
             else

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -503,11 +503,6 @@ private:
                 sgObject->UpdateEntryIndexes();
             }
         }
-
-        // HACK Scenery window will lose its tabs after changing the scenery group indexing
-        //      for now just close it, but it will be better to later tell it to invalidate the tabs
-        auto* windowMgr = Ui::GetWindowManager();
-        windowMgr->CloseByClass(WindowClass::Scenery);
     }
 
     ObjectEntryIndex GetPrimarySceneryGroupEntryIndex(Object* loadedObject)

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -17,10 +17,10 @@
 #include "../core/EnumUtils.hpp"
 #include "../core/JobPool.h"
 #include "../core/Memory.hpp"
-#include "../interface/Window.h"
 #include "../localisation/StringIds.h"
 #include "../ride/Ride.h"
 #include "../ride/RideAudio.h"
+#include "../ui/WindowManager.h"
 #include "BannerSceneryEntry.h"
 #include "LargeSceneryObject.h"
 #include "Object.h"
@@ -506,7 +506,8 @@ private:
 
         // HACK Scenery window will lose its tabs after changing the scenery group indexing
         //      for now just close it, but it will be better to later tell it to invalidate the tabs
-        WindowCloseByClass(WindowClass::Scenery);
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseByClass(WindowClass::Scenery);
     }
 
     ObjectEntryIndex GetPrimarySceneryGroupEntryIndex(Object* loadedObject)

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -52,7 +52,7 @@
 #include "../scenario/Scenario.h"
 #include "../scenario/ScenarioRepository.h"
 #include "../scripting/ScriptEngine.h"
-#include "../ui/UiContext.h"
+#include "../ui/WindowManager.h"
 #include "../world/Climate.h"
 #include "../world/Entrance.h"
 #include "../world/Map.h"
@@ -2643,7 +2643,8 @@ int32_t ScenarioSave(GameState_t& gameState, u8string_view path, int32_t flags)
     gIsAutosave = flags & S6_SAVE_FLAG_AUTOMATIC;
     if (!gIsAutosave)
     {
-        WindowCloseConstructionWindows();
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseConstructionWindows();
     }
 
     PrepareMapForSave();

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4030,7 +4030,8 @@ ResultWithMessage Ride::Test(bool isApplying)
         return { false };
     }
 
-    WindowCloseByNumber(WindowClass::RideConstruction, id.ToUnderlying());
+    auto* windowMgr = Ui::GetWindowManager();
+    windowMgr->CloseByNumber(WindowClass::RideConstruction, id.ToUnderlying());
 
     StationIndex stationIndex = {};
     auto message = ChangeStatusDoStationChecks(stationIndex);
@@ -4117,7 +4118,8 @@ ResultWithMessage Ride::Open(bool isApplying)
     // with auto open on.
     if (isToolActive(WindowClass::RideConstruction, static_cast<rct_windownumber>(id.ToUnderlying())))
     {
-        WindowCloseByNumber(WindowClass::RideConstruction, id.ToUnderlying());
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseByNumber(WindowClass::RideConstruction, id.ToUnderlying());
     }
 
     StationIndex stationIndex = {};

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -52,6 +52,7 @@
 #include "../ride/Ride.h"
 #include "../ride/RideManager.hpp"
 #include "../ride/Track.h"
+#include "../ui/WindowManager.h"
 #include "../util/Util.h"
 #include "../windows/Intent.h"
 #include "../world/Climate.h"
@@ -173,8 +174,11 @@ void ScenarioReset(GameState_t& gameState)
 static void ScenarioEnd()
 {
     GameResetSpeed();
-    WindowCloseByClass(WindowClass::Dropdown);
-    WindowCloseAllExceptFlags(WF_STICK_TO_BACK | WF_STICK_TO_FRONT);
+
+    auto* windowMgr = Ui::GetWindowManager();
+    windowMgr->CloseByClass(WindowClass::Dropdown);
+    windowMgr->CloseAllExceptFlags(WF_STICK_TO_BACK | WF_STICK_TO_FRONT);
+
     ContextOpenWindowView(WV_PARK_OBJECTIVE);
 }
 

--- a/src/openrct2/ui/DummyWindowManager.cpp
+++ b/src/openrct2/ui/DummyWindowManager.cpp
@@ -77,6 +77,18 @@ namespace OpenRCT2::Ui
             return nullptr;
         }
 
+        void Close(WindowBase& window) override {};
+        void CloseSurplus(int32_t cap, WindowClass avoid_classification) override {};
+        void CloseByClass(WindowClass cls) override {};
+        void CloseByNumber(WindowClass cls, rct_windownumber number) override {};
+        void CloseByNumber(WindowClass cls, EntityId number) override {};
+        void CloseTop() override {};
+        void CloseAll() override {};
+        void CloseAllExceptClass(WindowClass cls) override {};
+        void CloseAllExceptFlags(uint16_t flags) override {};
+        void CloseAllExceptNumberAndClass(rct_windownumber number, WindowClass cls) override {};
+        void CloseConstructionWindows() override {};
+
         WindowBase* FindByClass(WindowClass cls) override
         {
             return nullptr;

--- a/src/openrct2/ui/WindowManager.h
+++ b/src/openrct2/ui/WindowManager.h
@@ -84,6 +84,18 @@ namespace OpenRCT2::Ui
             return static_cast<T*>(w);
         }
 
+        virtual void Close(WindowBase& window) = 0;
+        virtual void CloseSurplus(int32_t cap, WindowClass avoid_classification) = 0;
+        virtual void CloseByClass(WindowClass cls) = 0;
+        virtual void CloseByNumber(WindowClass cls, rct_windownumber number) = 0;
+        virtual void CloseByNumber(WindowClass cls, EntityId number) = 0;
+        virtual void CloseTop() = 0;
+        virtual void CloseAll() = 0;
+        virtual void CloseAllExceptClass(WindowClass cls) = 0;
+        virtual void CloseAllExceptFlags(uint16_t flags) = 0;
+        virtual void CloseAllExceptNumberAndClass(rct_windownumber number, WindowClass cls) = 0;
+        virtual void CloseConstructionWindows() = 0;
+
         virtual WindowBase* FindByClass(WindowClass cls) = 0;
         virtual WindowBase* FindByNumber(WindowClass cls, rct_windownumber number) = 0;
         virtual WindowBase* FindByNumber(WindowClass cls, EntityId id) = 0;

--- a/src/openrct2/world/tile_element/TileElement.cpp
+++ b/src/openrct2/world/tile_element/TileElement.cpp
@@ -11,8 +11,8 @@
 
 #include "../../Diagnostic.h"
 #include "../../core/Guard.hpp"
-#include "../../interface/Window.h"
 #include "../../interface/WindowClasses.h"
+#include "../../ui/WindowManager.h"
 #include "../Map.h"
 #include "BannerElement.h"
 #include "EntranceElement.h"
@@ -75,7 +75,8 @@ void TileElement::RemoveBannerEntry()
     auto banner = GetBanner(bannerIndex);
     if (banner != nullptr)
     {
-        WindowCloseByNumber(WindowClass::Banner, bannerIndex.ToUnderlying());
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseByNumber(WindowClass::Banner, bannerIndex.ToUnderlying());
         DeleteBanner(banner->id);
     }
 }


### PR DESCRIPTION
Continuing from #23643, this moves the WindowClose family into the window manager.

I've removed a hack from the UpdateSceneryGroupIndexes function, as it led to the game crashing trying to access the window manager during initialisation. Please see the line note below.