### PR TITLE
Remove screaming snake case constant TRACK_BLOCK_2

### DIFF
--- a/src/openrct2-ui/ride/Construction.h
+++ b/src/openrct2-ui/ride/Construction.h
@@ -150,11 +150,6 @@ namespace OpenRCT2
     // Update the magic number with the current number of track elements to silence
     static_assert(EnumValue(TrackElemType::Count) == 349, "Reminder to add new track element to special dropdown list");
 
-    constexpr bool TrackPieceDirectionIsDiagonal(const uint8_t direction)
-    {
-        return direction >= kNumOrthogonalDirections;
-    }
-
     struct SpecialElement
     {
         OpenRCT2::TrackElemType TrackType;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -504,7 +504,7 @@ bool TrackBlockGetNextFromZero(
 {
     auto trackPos = startPos;
 
-    if (!(direction_start & TRACK_BLOCK_2))
+    if (!TrackPieceDirectionIsDiagonal(direction_start))
     {
         trackPos += CoordsDirectionDelta[direction_start];
     }
@@ -538,7 +538,7 @@ bool TrackBlockGetNextFromZero(
 
         const auto& nextTrackCoordinate = ted.coordinates;
         uint8_t nextRotation = tileElement->GetDirectionWithOffset(nextTrackCoordinate.rotationBegin)
-            | (nextTrackCoordinate.rotationBegin & TRACK_BLOCK_2);
+            | (nextTrackCoordinate.rotationBegin & kNumOrthogonalDirections);
 
         if (nextRotation != direction_start)
             continue;
@@ -605,7 +605,7 @@ bool TrackBlockGetNext(CoordsXYE* input, CoordsXYE* output, int32_t* z, int32_t*
     OriginZ += trackCoordinate.zEnd;
 
     uint8_t directionStart = ((trackCoordinate.rotationEnd + rotation) & kTileElementDirectionMask)
-        | (trackCoordinate.rotationEnd & TRACK_BLOCK_2);
+        | (trackCoordinate.rotationEnd & kNumOrthogonalDirections);
 
     return TrackBlockGetNextFromZero({ coords, OriginZ }, *ride, directionStart, output, z, direction, false);
 }
@@ -625,7 +625,7 @@ bool TrackBlockGetPreviousFromZero(
     direction = DirectionReverse(direction);
     auto trackPos = startPos;
 
-    if (!(direction & TRACK_BLOCK_2))
+    if (!TrackPieceDirectionIsDiagonal(direction))
     {
         trackPos += CoordsDirectionDelta[direction];
     }
@@ -661,7 +661,7 @@ bool TrackBlockGetPreviousFromZero(
 
         const auto& nextTrackCoordinate = ted.coordinates;
         uint8_t nextRotation = tileElement->GetDirectionWithOffset(nextTrackCoordinate.rotationEnd)
-            | (nextTrackCoordinate.rotationEnd & TRACK_BLOCK_2);
+            | (nextTrackCoordinate.rotationEnd & kNumOrthogonalDirections);
 
         if (nextRotation != directionStart)
             continue;
@@ -671,7 +671,7 @@ bool TrackBlockGetPreviousFromZero(
             continue;
 
         nextRotation = tileElement->GetDirectionWithOffset(nextTrackCoordinate.rotationBegin)
-            | (nextTrackCoordinate.rotationBegin & TRACK_BLOCK_2);
+            | (nextTrackCoordinate.rotationBegin & kNumOrthogonalDirections);
         outTrackBeginEnd->begin_element = tileElement;
         outTrackBeginEnd->begin_x = trackPos.x;
         outTrackBeginEnd->begin_y = trackPos.y;
@@ -743,7 +743,7 @@ bool TrackBlockGetPrevious(const CoordsXYE& trackPos, TrackBeginEnd* outTrackBeg
     z += trackCoordinate.zBegin;
 
     rotation = ((trackCoordinate.rotationBegin + rotation) & kTileElementDirectionMask)
-        | (trackCoordinate.rotationBegin & TRACK_BLOCK_2);
+        | (trackCoordinate.rotationBegin & kNumOrthogonalDirections);
 
     return TrackBlockGetPreviousFromZero({ coords, z }, *ride, rotation, outTrackBeginEnd);
 }

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -874,11 +874,6 @@ enum
 
 enum
 {
-    TRACK_BLOCK_2 = (1 << 2)
-};
-
-enum
-{
     TRACK_ELEMENT_SET_HIGHLIGHT_FALSE = (1 << 0),
     TRACK_ELEMENT_SET_HIGHLIGHT_TRUE = (1 << 1),
     TRACK_ELEMENT_SET_COLOUR_SCHEME = (1 << 2),

--- a/src/openrct2/ride/Track.h
+++ b/src/openrct2/ride/Track.h
@@ -738,3 +738,8 @@ ResultWithMessage TrackRemoveStationElement(const CoordsXYZD& loc, RideId rideIn
 bool TrackTypeHasSpeedSetting(OpenRCT2::TrackElemType trackType);
 bool TrackTypeIsHelix(OpenRCT2::TrackElemType trackType);
 std::optional<CoordsXYZD> GetTrackSegmentOrigin(const CoordsXYE& posEl);
+
+constexpr bool TrackPieceDirectionIsDiagonal(const uint8_t direction)
+{
+    return direction >= kNumOrthogonalDirections;
+}


### PR DESCRIPTION
I wasn't sure whether I should have added a new constant i.e. `kDiagonalMask` but since `TrackPieceDirectionIsDiagonal` uses `kNumOrthogonalDirections` I used that instead.