### PR TITLE
Fix #23655: Crash with invalid widget index

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -290,7 +290,7 @@ namespace OpenRCT2
 
         // Get window and widget under cursor position
         w = windowMgr->FindFromPoint(screenCoords);
-        widgetIndex = w == nullptr ? -1 : windowMgr->FindWidgetFromPoint(*w, screenCoords);
+        widgetIndex = w == nullptr ? kWidgetIndexNull : windowMgr->FindWidgetFromPoint(*w, screenCoords);
         widget = widgetIndex == kWidgetIndexNull ? nullptr : &w->widgets[widgetIndex];
 
         switch (_inputState)
@@ -1557,7 +1557,8 @@ namespace OpenRCT2
         {
             if (gTooltipCursor == screenCoords)
             {
-                if (gCurrentRealTimeTicks >= _tooltipNotShownTimeout && w != nullptr && WidgetIsVisible(*w, widgetIndex))
+                if (gCurrentRealTimeTicks >= _tooltipNotShownTimeout && w != nullptr && widgetIndex != kWidgetIndexNull
+                    && WidgetIsVisible(*w, widgetIndex))
                 {
                     gTooltipCloseTimeout = gCurrentRealTimeTicks + 8000;
                     WindowTooltipOpen(w, widgetIndex, screenCoords);


### PR DESCRIPTION
I'm not sure how to reproduce this issue but given the call stack and variables it seems that widget index was set to kWidgetIndexNull which is 0xFFFF so adding the offset to the field is the bad memory address. This part of the code is quite  something but this should do the trick.

This seems to be a recent regression from my widget refactor PR but it is not exactly a new bug it's just that the progress bar forces to draw the game and that can happen before the window state is fully initialized, the crash is just slightly different as the widgets member is not just a simple pointer but a vector.

Close #23655, Close #23654, Close #23664