### PR TITLE
Force guests to leave if Spiral Slide is broken down

### DIFF
--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -4695,7 +4695,7 @@ void Guest::UpdateRideApproachSpiralSlide()
     if (waypoint == 2)
     {
         bool lastRide = false;
-        if (ride->status != RideStatus::Open)
+        if (ride->status != RideStatus::Open || ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN)
             lastRide = true;
         else if (CurrentCar++ != 0)
         {


### PR DESCRIPTION
This addresses one of the issues I brought up in https://github.com/OpenRCT2/OpenRCT2/discussions/23650. It's an original bug.