### PR TITLE
Fix widget access

### DIFF
--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -83,7 +83,7 @@ namespace OpenRCT2::Ui::Windows
 
         void CreateViewport()
         {
-            const auto& viewportWidget = window_banner_widgets[WIDX_VIEWPORT];
+            const auto& viewportWidget = widgets[WIDX_VIEWPORT];
             ViewportCreate(
                 this, windowPos + ScreenCoordsXY{ viewportWidget.left + 1, viewportWidget.top + 1 },
                 (viewportWidget.width()) - 1, (viewportWidget.height()) - 1, Focus(_bannerViewPos));

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -760,7 +760,7 @@ namespace OpenRCT2::Ui::Windows
             // Draw campaign button text
             for (int32_t i = 0; i < ADVERTISING_CAMPAIGN_COUNT; i++)
             {
-                auto campaignButton = &_windowFinancesMarketingWidgets[WIDX_CAMPAIGN_1 + i];
+                auto campaignButton = &widgets[WIDX_CAMPAIGN_1 + i];
                 if (campaignButton->type != WindowWidgetType::Empty)
                 {
                     // Draw button text


### PR DESCRIPTION
Fixes the marketing campaign buttons not disappearing, I swear I double checked last time but still two of them slipped, this should be the last ones for good. 