### PR TITLE
Fix #23221: Track designs are saved with an incorrect ‘air’ time statistic

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Change: [#23328] All RCT2 entertainer costumes are now available in legacy parks.
 - Fix: [#1479] Incorrect values provided by the in game console “get location” command.
 - Fix: [#21794] Lay-down coaster cars reverse on first frames of downwards corkscrew.
+- Fix: [#23221] Track designs are saved with an incorrect ‘air’ time statistic. 
 - Fix: [#23368] Incorrect refund amount when deleting track pieces at or above 96m.
 - Fix: [#23508] Simultaneous virtual floors shown for ride and footpath.
 - Fix: [#23512] Holding brakes are skipped if they’re too close together.

--- a/src/openrct2/rct2/T6Exporter.cpp
+++ b/src/openrct2/rct2/T6Exporter.cpp
@@ -67,7 +67,8 @@ namespace OpenRCT2::RCT2
         tempStream.WriteValue<uint8_t>(0);
         auto entranceStyle = GetStationStyleFromIdentifier(_trackDesign.appearance.stationObjectIdentifier);
         tempStream.WriteValue<uint8_t>(entranceStyle);
-        uint16_t _totalAirTime = std::max<uint16_t>(255, (_trackDesign.statistics.totalAirTime * 123) / 1024);
+        // The 512 added is to enforce correctly rounding up, as integer division will truncate.
+        uint16_t _totalAirTime = std::min<uint16_t>(255, ((_trackDesign.statistics.totalAirTime * 123) + 512) / 1024);
         tempStream.WriteValue<uint8_t>(_totalAirTime);
         tempStream.WriteValue<uint8_t>(_trackDesign.operation.departFlags);
         tempStream.WriteValue<uint8_t>(_trackDesign.trackAndVehicle.numberOfTrains);


### PR DESCRIPTION
Thanks to @UnknownShadow200 for investigating.

Also addresses the rounding error (which was likely already present before the refactor).