### PR TITLE
Offset dropdown text labels and separators

### DIFF
--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -113,9 +113,9 @@ namespace OpenRCT2::Ui::Windows
 
                 if (gDropdownItems[i].IsSeparator())
                 {
-                    const ScreenCoordsXY leftTop = screenCoords + ScreenCoordsXY{ 0, (ItemHeight / 2) };
-                    const ScreenCoordsXY rightBottom = leftTop + ScreenCoordsXY{ ItemWidth - 1, 0 };
-                    const ScreenCoordsXY shadowOffset{ 0, 1 };
+                    const auto leftTop = screenCoords + ScreenCoordsXY{ 2, (ItemHeight / 2) - 1 };
+                    const auto rightBottom = leftTop + ScreenCoordsXY{ ItemWidth - 4, 0 };
+                    const auto shadowOffset = ScreenCoordsXY{ 0, 1 };
 
                     if (colours[0].hasFlag(ColourFlag::translucent))
                     {

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -166,7 +166,8 @@ namespace OpenRCT2::Ui::Windows
                         // Draw item string
                         auto yOffset = GetAdditionalRowPadding();
                         Formatter ft(reinterpret_cast<uint8_t*>(&gDropdownItems[i].Args));
-                        DrawTextEllipsised(dpi, { screenCoords.x, screenCoords.y + yOffset }, width - 5, item, ft, { colour });
+                        DrawTextEllipsised(
+                            dpi, { screenCoords.x + 2, screenCoords.y + yOffset }, width - 7, item, ft, { colour });
                     }
                 }
             }


### PR DESCRIPTION
This PR adds a slight offset to dropdown text labels and separators. This acts as padding, and as a subtle margin for multi-column dropdowns. Backported from #23660. (See also https://github.com/OpenRCT2/OpenRCT2/pull/23660#issuecomment-2605565308.)

Before:
<img width="164" alt="Screenshot 2025-01-25 at 12 00 04" src="https://github.com/user-attachments/assets/2dfd55df-28bc-47fa-9979-e7ff440acce4" />

After:
<img width="163" alt="Screenshot 2025-01-25 at 11 59 46" src="https://github.com/user-attachments/assets/27eb614a-bc1c-496c-8207-af2a84b8c6ae" />
