### PR TITLE
Fix #23701: Potential crash when using mouse wheel on some widgets

### DIFF
--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -163,6 +163,9 @@ namespace OpenRCT2
         if (widgets[index].type != WindowWidgetType::Spinner && widgets[index].type != WindowWidgetType::ImgBtn)
             return false;
 
+        if (static_cast<size_t>(index + 2) >= widgets.size())
+            return false;
+
         if (widgets[index + 1].type != buttonType)
             return false;
 
@@ -239,6 +242,8 @@ namespace OpenRCT2
             // Expected widget order: increase, decrease
             targetWidgetIndex += wheel < 0 ? 1 : 2;
         }
+
+        assert(targetWidgetIndex >= 0 && targetWidgetIndex < w.widgets.size());
 
         if (WidgetIsDisabled(w, targetWidgetIndex))
         {


### PR DESCRIPTION
The widget refactor reveals so many hidden bugs since the memory is now on the heap rather than the process image in where reading memory typically doesn't segfault but the contents is junk.

Close #23701