### PR TITLE
Fix #23707: Crash when plugins use a custom tool

### DIFF
--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -1252,7 +1252,10 @@ public:
             return;
         }
 
-        assert(widgetIndex < w.widgets.size());
+        if (static_cast<size_t>(widgetIndex) >= w.widgets.size())
+        {
+            return;
+        }
 
         const auto& widget = w.widgets[widgetIndex];
         if (widget.left == -2)


### PR DESCRIPTION
All the hidden bugs start spilling now. This crash is because there is this silly part:
https://github.com/OpenRCT2/OpenRCT2/blob/fa0e7342ecb670e6ed84ae63e730926ce7ab0654/src/openrct2-ui/scripting/CustomMenu.cpp#L275-L282

Quite unfortunate and I think scripting might be able to pass something invalid here too, so lets just generally protect that, not a fan but its pretty difficult to find all the ones who could potentially pass something bad in here.

Close #23707