### PR TITLE
Prevent drawing peep accessories whilst drowning

### DIFF
--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -2924,6 +2924,10 @@ void Peep::Paint(PaintSession& session, int32_t imageDirection) const
     if (guest == nullptr)
         return;
 
+    // Can't display any accessories whilst drowning
+    if (Action == PeepActionType::Drowning)
+        return;
+
     // There are only 6 walking frames available for each item,
     // as well as 1 sprite for sitting and 1 for standing still.
     auto itemFrame = imageOffset % 6;


### PR DESCRIPTION
Fixes #23726. I'd assumed this wouldn't be necessary as peeps lose their balloons when moved onto water, but this clearly isn't the case for hats.