### PR TITLE
Prefer tiled windows over cornered windows

### DIFF
--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -741,10 +741,7 @@ public:
 
         // Place window in an empty corner of the screen
         const ScreenCoordsXY cornerPositions[] = {
-            { 0, 30 },                                           // topLeft
-            { screenWidth - width, 30 },                         // topRight
-            { 0, screenHeight - 34 - height },                   // bottomLeft
-            { screenWidth - width, screenHeight - 34 - height }, // bottomRight
+            { 0, 30 }, // topLeft
         };
 
         for (const auto& cornerPos : cornerPositions)


### PR DESCRIPTION
This PR is a proof of concept, showing we can make windows tile with a minimal patch. Of the previous corner positions, this patch only retains the top-left one.

The code can be cleaned up a bit more if we decide to indeed forego the other corner positions -- we can unroll the loop, basically.

For now, I'm presenting this PR as-is to collect feedback. Do people this new window arrangement?

<img width="1512" alt="Screenshot 2025-01-30 at 15 42 16" src="https://github.com/user-attachments/assets/d55cbe9b-1d5f-43ff-8d52-f2d0f004fa46" />
