### PR TITLE
Clean up the Climate file 

### DIFF
--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -43,18 +43,18 @@ enum class ThunderStatus
 
 struct WeatherPattern
 {
-    int8_t BaseTemperature;
-    int8_t RandomBias;
-    WeatherType Distribution[24];
+    int8_t baseTemperature;
+    int8_t randomBias;
+    WeatherType distribution[24];
 };
 
 struct WeatherTrait
 {
-    int8_t TemperatureDelta;
-    WeatherEffectType EffectLevel;
-    int8_t GloomLevel;
-    WeatherLevel Level;
-    uint32_t SpriteId;
+    int8_t temperatureDelta;
+    WeatherEffectType effectLevel;
+    int8_t gloomLevel;
+    WeatherLevel level;
+    uint32_t spriteId;
 };
 
 // TODO: no need for these to be declared extern, just move the definitions up
@@ -106,10 +106,10 @@ void ClimateReset(ClimateType climate)
     auto& gameState = GetGameState();
     gameState.Climate = climate;
     gameState.ClimateCurrent.Weather = weather;
-    gameState.ClimateCurrent.Temperature = pattern.BaseTemperature + trait.TemperatureDelta;
-    gameState.ClimateCurrent.WeatherEffect = trait.EffectLevel;
-    gameState.ClimateCurrent.WeatherGloom = trait.GloomLevel;
-    gameState.ClimateCurrent.Level = trait.Level;
+    gameState.ClimateCurrent.Temperature = pattern.baseTemperature + trait.temperatureDelta;
+    gameState.ClimateCurrent.WeatherEffect = trait.effectLevel;
+    gameState.ClimateCurrent.WeatherGloom = trait.gloomLevel;
+    gameState.ClimateCurrent.Level = trait.level;
 
     _lightningTimer = 0;
     _thunderTimer = 0;
@@ -217,10 +217,10 @@ void ClimateForceWeather(WeatherType weather)
     const auto& trait = kClimateWeatherTraits[EnumValue(weather)];
 
     gameState.ClimateCurrent.Weather = weather;
-    gameState.ClimateCurrent.WeatherGloom = trait.GloomLevel;
-    gameState.ClimateCurrent.Level = trait.Level;
-    gameState.ClimateCurrent.WeatherEffect = trait.EffectLevel;
-    gameState.ClimateCurrent.Temperature = pattern.BaseTemperature + trait.TemperatureDelta;
+    gameState.ClimateCurrent.WeatherGloom = trait.gloomLevel;
+    gameState.ClimateCurrent.Level = trait.level;
+    gameState.ClimateCurrent.WeatherEffect = trait.effectLevel;
+    gameState.ClimateCurrent.Temperature = pattern.baseTemperature + trait.temperatureDelta;
     gameState.ClimateUpdateTimer = 1920;
 
     ClimateUpdate();
@@ -282,7 +282,7 @@ uint32_t ClimateGetWeatherSpriteId(const ClimateState& state)
     uint32_t spriteId = SPR_WEATHER_SUN;
     if (EnumValue(state.Weather) < std::size(kClimateWeatherTraits))
     {
-        spriteId = kClimateWeatherTraits[EnumValue(state.Weather)].SpriteId;
+        spriteId = kClimateWeatherTraits[EnumValue(state.Weather)].spriteId;
     }
     return spriteId;
 }
@@ -308,18 +308,18 @@ static void ClimateDetermineFutureWeather(int32_t randomValue)
     int32_t month = GetDate().GetMonth();
     auto& gameState = GetGameState();
 
-    // Generate a random index with values 0 up to RandomBias-1
+    // Generate a random index with values 0 up to randomBias-1
     // and choose weather from the distribution table accordingly
     const auto& pattern = kClimatePatterns[EnumValue(gameState.Climate)][month];
-    auto randomIndex = ((randomValue % 256) * pattern.RandomBias) / 256;
-    auto nextWeather = pattern.Distribution[randomIndex];
+    auto randomIndex = ((randomValue % 256) * pattern.randomBias) / 256;
+    auto nextWeather = pattern.distribution[randomIndex];
     gameState.ClimateNext.Weather = nextWeather;
 
     const auto& nextWeatherTrait = kClimateWeatherTraits[EnumValue(nextWeather)];
-    gameState.ClimateNext.Temperature = pattern.BaseTemperature + nextWeatherTrait.TemperatureDelta;
-    gameState.ClimateNext.WeatherEffect = nextWeatherTrait.EffectLevel;
-    gameState.ClimateNext.WeatherGloom = nextWeatherTrait.GloomLevel;
-    gameState.ClimateNext.Level = nextWeatherTrait.Level;
+    gameState.ClimateNext.Temperature = pattern.baseTemperature + nextWeatherTrait.temperatureDelta;
+    gameState.ClimateNext.WeatherEffect = nextWeatherTrait.effectLevel;
+    gameState.ClimateNext.WeatherGloom = nextWeatherTrait.gloomLevel;
+    gameState.ClimateNext.Level = nextWeatherTrait.level;
 
     gameState.ClimateUpdateTimer = 1920;
 }

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -33,12 +33,12 @@
 using namespace OpenRCT2;
 using namespace OpenRCT2::Audio;
 
-constexpr int32_t MAX_THUNDER_INSTANCES = 2;
+constexpr int32_t kMaxThunderInstances = 2;
 
-enum class THUNDER_STATUS
+enum class ThunderStatus
 {
-    NONE,
-    PLAYING,
+    None,
+    Playing,
 };
 
 struct WeatherPattern
@@ -69,10 +69,10 @@ uint16_t gClimateLightningFlash;
 static int32_t _weatherVolume = 1;
 static uint32_t _lightningTimer;
 static uint32_t _thunderTimer;
-static std::shared_ptr<IAudioChannel> _thunderSoundChannels[MAX_THUNDER_INSTANCES];
-static THUNDER_STATUS _thunderStatus[MAX_THUNDER_INSTANCES] = {
-    THUNDER_STATUS::NONE,
-    THUNDER_STATUS::NONE,
+static std::shared_ptr<IAudioChannel> _thunderSoundChannels[kMaxThunderInstances];
+static ThunderStatus _thunderStatus[kMaxThunderInstances] = {
+    ThunderStatus::None,
+    ThunderStatus::None,
 };
 static OpenRCT2::Audio::SoundId _thunderSoundId;
 static int32_t _thunderVolume;
@@ -386,15 +386,15 @@ static void ClimateUpdateThunderSound()
     }
 
     // Stop thunder sounds if they have finished
-    for (int32_t i = 0; i < MAX_THUNDER_INSTANCES; i++)
+    for (int32_t i = 0; i < kMaxThunderInstances; i++)
     {
-        if (_thunderStatus[i] != THUNDER_STATUS::NONE)
+        if (_thunderStatus[i] != ThunderStatus::None)
         {
             auto& channel = _thunderSoundChannels[i];
             if (!channel->IsPlaying())
             {
                 channel->Stop();
-                _thunderStatus[i] = THUNDER_STATUS::NONE;
+                _thunderStatus[i] = ThunderStatus::None;
             }
         }
     }
@@ -427,7 +427,7 @@ static void ClimateUpdateThunder()
         uint32_t randomNumber = UtilRand();
         if (randomNumber & 0x10000)
         {
-            if (_thunderStatus[0] == THUNDER_STATUS::NONE && _thunderStatus[1] == THUNDER_STATUS::NONE)
+            if (_thunderStatus[0] == ThunderStatus::None && _thunderStatus[1] == ThunderStatus::None)
             {
                 // Play thunder on left side
                 _thunderSoundId = (randomNumber & 0x20000) ? OpenRCT2::Audio::SoundId::Thunder1
@@ -441,7 +441,7 @@ static void ClimateUpdateThunder()
         }
         else
         {
-            if (_thunderStatus[0] == THUNDER_STATUS::NONE)
+            if (_thunderStatus[0] == ThunderStatus::None)
             {
                 _thunderSoundId = (randomNumber & 0x20000) ? OpenRCT2::Audio::SoundId::Thunder1
                                                            : OpenRCT2::Audio::SoundId::Thunder2;
@@ -457,7 +457,7 @@ static void ClimatePlayThunder(int32_t instanceIndex, OpenRCT2::Audio::SoundId s
     _thunderSoundChannels[instanceIndex] = CreateAudioChannel(soundId, false, DStoMixerVolume(volume), DStoMixerPan(pan));
     if (_thunderSoundChannels[instanceIndex] != nullptr)
     {
-        _thunderStatus[instanceIndex] = THUNDER_STATUS::PLAYING;
+        _thunderStatus[instanceIndex] = ThunderStatus::Playing;
     }
 }
 

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -48,9 +48,18 @@ struct WeatherPattern
     WeatherType Distribution[24];
 };
 
+struct WeatherTrait
+{
+    int8_t TemperatureDelta;
+    WeatherEffectType EffectLevel;
+    int8_t GloomLevel;
+    WeatherLevel Level;
+    uint32_t SpriteId;
+};
+
 // TODO: no need for these to be declared extern, just move the definitions up
 extern const WeatherPattern* kClimatePatterns[4];
-extern const WeatherState kClimateWeatherData[EnumValue(WeatherType::Count)];
+extern const WeatherTrait kClimateWeatherTraits[EnumValue(WeatherType::Count)];
 extern const FilterPaletteID kClimateWeatherGloomColours[4];
 
 // Climate data
@@ -92,15 +101,15 @@ void ClimateReset(ClimateType climate)
     int32_t month = GetDate().GetMonth();
 
     const WeatherPattern* transition = &kClimatePatterns[EnumValue(climate)][month];
-    const WeatherState* weatherState = &kClimateWeatherData[EnumValue(weather)];
+    const WeatherTrait* weatherTrait = &kClimateWeatherTraits[EnumValue(weather)];
 
     auto& gameState = GetGameState();
     gameState.Climate = climate;
     gameState.ClimateCurrent.Weather = weather;
-    gameState.ClimateCurrent.Temperature = transition->BaseTemperature + weatherState->TemperatureDelta;
-    gameState.ClimateCurrent.WeatherEffect = weatherState->EffectLevel;
-    gameState.ClimateCurrent.WeatherGloom = weatherState->GloomLevel;
-    gameState.ClimateCurrent.Level = weatherState->Level;
+    gameState.ClimateCurrent.Temperature = transition->BaseTemperature + weatherTrait->TemperatureDelta;
+    gameState.ClimateCurrent.WeatherEffect = weatherTrait->EffectLevel;
+    gameState.ClimateCurrent.WeatherGloom = weatherTrait->GloomLevel;
+    gameState.ClimateCurrent.Level = weatherTrait->Level;
 
     _lightningTimer = 0;
     _thunderTimer = 0;
@@ -205,13 +214,13 @@ void ClimateForceWeather(WeatherType weather)
     int32_t month = GetDate().GetMonth();
 
     const auto* transition = &kClimatePatterns[EnumValue(gameState.Climate)][month];
-    const auto weatherState = &kClimateWeatherData[EnumValue(weather)];
+    const auto weatherTrait = &kClimateWeatherTraits[EnumValue(weather)];
 
     gameState.ClimateCurrent.Weather = weather;
-    gameState.ClimateCurrent.WeatherGloom = weatherState->GloomLevel;
-    gameState.ClimateCurrent.Level = weatherState->Level;
-    gameState.ClimateCurrent.WeatherEffect = weatherState->EffectLevel;
-    gameState.ClimateCurrent.Temperature = transition->BaseTemperature + weatherState->TemperatureDelta;
+    gameState.ClimateCurrent.WeatherGloom = weatherTrait->GloomLevel;
+    gameState.ClimateCurrent.Level = weatherTrait->Level;
+    gameState.ClimateCurrent.WeatherEffect = weatherTrait->EffectLevel;
+    gameState.ClimateCurrent.Temperature = transition->BaseTemperature + weatherTrait->TemperatureDelta;
     gameState.ClimateUpdateTimer = 1920;
 
     ClimateUpdate();
@@ -271,9 +280,9 @@ FilterPaletteID ClimateGetWeatherGloomPaletteId(const ClimateState& state)
 uint32_t ClimateGetWeatherSpriteId(const ClimateState& state)
 {
     uint32_t spriteId = SPR_WEATHER_SUN;
-    if (EnumValue(state.Weather) < std::size(kClimateWeatherData))
+    if (EnumValue(state.Weather) < std::size(kClimateWeatherTraits))
     {
-        spriteId = kClimateWeatherData[EnumValue(state.Weather)].SpriteId;
+        spriteId = kClimateWeatherTraits[EnumValue(state.Weather)].SpriteId;
     }
     return spriteId;
 }
@@ -306,11 +315,11 @@ static void ClimateDetermineFutureWeather(int32_t randomValue)
     auto nextWeather = transition.Distribution[randomIndex];
     gameState.ClimateNext.Weather = nextWeather;
 
-    const auto nextWeatherState = &kClimateWeatherData[EnumValue(nextWeather)];
-    gameState.ClimateNext.Temperature = transition.BaseTemperature + nextWeatherState->TemperatureDelta;
-    gameState.ClimateNext.WeatherEffect = nextWeatherState->EffectLevel;
-    gameState.ClimateNext.WeatherGloom = nextWeatherState->GloomLevel;
-    gameState.ClimateNext.Level = nextWeatherState->Level;
+    const auto nextWeatherTrait = &kClimateWeatherTraits[EnumValue(nextWeather)];
+    gameState.ClimateNext.Temperature = transition.BaseTemperature + nextWeatherTrait->TemperatureDelta;
+    gameState.ClimateNext.WeatherEffect = nextWeatherTrait->EffectLevel;
+    gameState.ClimateNext.WeatherGloom = nextWeatherTrait->GloomLevel;
+    gameState.ClimateNext.Level = nextWeatherTrait->Level;
 
     gameState.ClimateUpdateTimer = 1920;
 }
@@ -462,7 +471,7 @@ const FilterPaletteID kClimateWeatherGloomColours[4] = {
 };
 
 // clang-format off
-const WeatherState kClimateWeatherData[EnumValue(WeatherType::Count)] = {
+const WeatherTrait kClimateWeatherTraits[EnumValue(WeatherType::Count)] = {
     {  10, WeatherEffectType::None,     0, WeatherLevel::None,  SPR_WEATHER_SUN        }, // Sunny
     {   5, WeatherEffectType::None,     0, WeatherLevel::None,  SPR_WEATHER_SUN_CLOUD  }, // Partially Cloudy
     {   0, WeatherEffectType::None,     0, WeatherLevel::None,  SPR_WEATHER_CLOUD      }, // Cloudy

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -37,8 +37,8 @@ constexpr int32_t kMaxThunderInstances = 2;
 
 enum class ThunderStatus
 {
-    None,
-    Playing,
+    none,
+    playing,
 };
 
 struct WeatherPattern
@@ -71,8 +71,8 @@ static uint32_t _lightningTimer;
 static uint32_t _thunderTimer;
 static std::shared_ptr<IAudioChannel> _thunderSoundChannels[kMaxThunderInstances];
 static ThunderStatus _thunderStatus[kMaxThunderInstances] = {
-    ThunderStatus::None,
-    ThunderStatus::None,
+    ThunderStatus::none,
+    ThunderStatus::none,
 };
 static OpenRCT2::Audio::SoundId _thunderSoundId;
 static int32_t _thunderVolume;
@@ -388,13 +388,13 @@ static void ClimateUpdateThunderSound()
     // Stop thunder sounds if they have finished
     for (int32_t i = 0; i < kMaxThunderInstances; i++)
     {
-        if (_thunderStatus[i] != ThunderStatus::None)
+        if (_thunderStatus[i] != ThunderStatus::none)
         {
             auto& channel = _thunderSoundChannels[i];
             if (!channel->IsPlaying())
             {
                 channel->Stop();
-                _thunderStatus[i] = ThunderStatus::None;
+                _thunderStatus[i] = ThunderStatus::none;
             }
         }
     }
@@ -427,7 +427,7 @@ static void ClimateUpdateThunder()
         uint32_t randomNumber = UtilRand();
         if (randomNumber & 0x10000)
         {
-            if (_thunderStatus[0] == ThunderStatus::None && _thunderStatus[1] == ThunderStatus::None)
+            if (_thunderStatus[0] == ThunderStatus::none && _thunderStatus[1] == ThunderStatus::none)
             {
                 // Play thunder on left side
                 _thunderSoundId = (randomNumber & 0x20000) ? OpenRCT2::Audio::SoundId::Thunder1
@@ -441,7 +441,7 @@ static void ClimateUpdateThunder()
         }
         else
         {
-            if (_thunderStatus[0] == ThunderStatus::None)
+            if (_thunderStatus[0] == ThunderStatus::none)
             {
                 _thunderSoundId = (randomNumber & 0x20000) ? OpenRCT2::Audio::SoundId::Thunder1
                                                            : OpenRCT2::Audio::SoundId::Thunder2;
@@ -457,7 +457,7 @@ static void ClimatePlayThunder(int32_t instanceIndex, OpenRCT2::Audio::SoundId s
     _thunderSoundChannels[instanceIndex] = CreateAudioChannel(soundId, false, DStoMixerVolume(volume), DStoMixerPan(pan));
     if (_thunderSoundChannels[instanceIndex] != nullptr)
     {
-        _thunderStatus[instanceIndex] = ThunderStatus::Playing;
+        _thunderStatus[instanceIndex] = ThunderStatus::playing;
     }
 }
 

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -41,7 +41,7 @@ enum class THUNDER_STATUS
     PLAYING,
 };
 
-struct WeatherTransition
+struct WeatherPattern
 {
     int8_t BaseTemperature;
     int8_t RandomBias;
@@ -49,7 +49,7 @@ struct WeatherTransition
 };
 
 // TODO: no need for these to be declared extern, just move the definitions up
-extern const WeatherTransition* kClimateTransitions[4];
+extern const WeatherPattern* kClimatePatterns[4];
 extern const WeatherState kClimateWeatherData[EnumValue(WeatherType::Count)];
 extern const FilterPaletteID kClimateWeatherGloomColours[4];
 
@@ -91,7 +91,7 @@ void ClimateReset(ClimateType climate)
     auto weather = WeatherType::PartiallyCloudy;
     int32_t month = GetDate().GetMonth();
 
-    const WeatherTransition* transition = &kClimateTransitions[EnumValue(climate)][month];
+    const WeatherPattern* transition = &kClimatePatterns[EnumValue(climate)][month];
     const WeatherState* weatherState = &kClimateWeatherData[EnumValue(weather)];
 
     auto& gameState = GetGameState();
@@ -204,7 +204,7 @@ void ClimateForceWeather(WeatherType weather)
     auto& gameState = GetGameState();
     int32_t month = GetDate().GetMonth();
 
-    const auto* transition = &kClimateTransitions[EnumValue(gameState.Climate)][month];
+    const auto* transition = &kClimatePatterns[EnumValue(gameState.Climate)][month];
     const auto weatherState = &kClimateWeatherData[EnumValue(weather)];
 
     gameState.ClimateCurrent.Weather = weather;
@@ -301,7 +301,7 @@ static void ClimateDetermineFutureWeather(int32_t randomValue)
 
     // Generate a random index with values 0 up to RandomBias-1
     // and choose weather from the distribution table accordingly
-    const auto& transition = kClimateTransitions[EnumValue(gameState.Climate)][month];
+    const auto& transition = kClimatePatterns[EnumValue(gameState.Climate)][month];
     auto randomIndex = ((randomValue % 256) * transition.RandomBias) / 256;
     auto nextWeather = transition.Distribution[randomIndex];
     gameState.ClimateNext.Weather = nextWeather;
@@ -461,18 +461,19 @@ const FilterPaletteID kClimateWeatherGloomColours[4] = {
     FilterPaletteID::PaletteDarken3,
 };
 
-// There is actually a sprite at 0x5A9C for snow but only these weather types seem to be fully implemented
+// clang-format off
 const WeatherState kClimateWeatherData[EnumValue(WeatherType::Count)] = {
-    { 10, WeatherEffectType::None, 0, WeatherLevel::None, SPR_WEATHER_SUN },         // Sunny
-    { 5, WeatherEffectType::None, 0, WeatherLevel::None, SPR_WEATHER_SUN_CLOUD },    // Partially Cloudy
-    { 0, WeatherEffectType::None, 0, WeatherLevel::None, SPR_WEATHER_CLOUD },        // Cloudy
-    { -2, WeatherEffectType::Rain, 1, WeatherLevel::Light, SPR_WEATHER_LIGHT_RAIN }, // Rain
-    { -4, WeatherEffectType::Rain, 2, WeatherLevel::Heavy, SPR_WEATHER_HEAVY_RAIN }, // Heavy Rain
-    { 2, WeatherEffectType::Storm, 2, WeatherLevel::Heavy, SPR_WEATHER_STORM },      // Thunderstorm
-    { -10, WeatherEffectType::Snow, 1, WeatherLevel::Light, SPR_WEATHER_SNOW },      // Snow
-    { -15, WeatherEffectType::Snow, 2, WeatherLevel::Heavy, SPR_WEATHER_SNOW },      // Heavy Snow
-    { -20, WeatherEffectType::Blizzard, 2, WeatherLevel::Heavy, SPR_WEATHER_SNOW },  // Blizzard
+    {  10, WeatherEffectType::None,     0, WeatherLevel::None,  SPR_WEATHER_SUN        }, // Sunny
+    {   5, WeatherEffectType::None,     0, WeatherLevel::None,  SPR_WEATHER_SUN_CLOUD  }, // Partially Cloudy
+    {   0, WeatherEffectType::None,     0, WeatherLevel::None,  SPR_WEATHER_CLOUD      }, // Cloudy
+    {  -2, WeatherEffectType::Rain,     1, WeatherLevel::Light, SPR_WEATHER_LIGHT_RAIN }, // Rain
+    {  -4, WeatherEffectType::Rain,     2, WeatherLevel::Heavy, SPR_WEATHER_HEAVY_RAIN }, // Heavy Rain
+    {   2, WeatherEffectType::Storm,    2, WeatherLevel::Heavy, SPR_WEATHER_STORM      }, // Thunderstorm
+    { -10, WeatherEffectType::Snow,     1, WeatherLevel::Light, SPR_WEATHER_SNOW       }, // Snow
+    { -15, WeatherEffectType::Snow,     2, WeatherLevel::Heavy, SPR_WEATHER_SNOW       }, // Heavy Snow
+    { -20, WeatherEffectType::Blizzard, 2, WeatherLevel::Heavy, SPR_WEATHER_SNOW       }, // Blizzard
 };
+// clang-format on
 
 constexpr auto S = WeatherType::Sunny;
 constexpr auto P = WeatherType::PartiallyCloudy;
@@ -481,7 +482,7 @@ constexpr auto R = WeatherType::Rain;
 constexpr auto H = WeatherType::HeavyRain;
 constexpr auto T = WeatherType::Thunder;
 
-static constexpr WeatherTransition kClimateTransitionsCoolAndWet[] = {
+static constexpr WeatherPattern kClimatePatternsCoolAndWet[] = {
     { 8, 18, { S, P, P, P, P, P, C, C, C, C, C, C, C, R, R, R, H, H, S, S, S, S, S } },
     { 10, 21, { P, P, P, P, P, C, C, C, C, C, C, C, C, C, R, R, R, H, H, H, T, S, S } },
     { 14, 17, { S, S, S, P, P, P, P, P, P, C, C, C, C, R, R, R, H, S, S, S, S, S, S } },
@@ -491,7 +492,7 @@ static constexpr WeatherTransition kClimateTransitionsCoolAndWet[] = {
     { 16, 19, { S, S, S, P, P, P, P, P, C, C, C, C, C, C, R, R, H, H, T, S, S, S, S } },
     { 13, 16, { S, S, P, P, P, P, C, C, C, C, C, C, R, R, H, T, S, S, S, S, S, S, S } },
 };
-static constexpr WeatherTransition kClimateTransitionsWarm[] = {
+static constexpr WeatherPattern kClimatePatternsWarm[] = {
     { 12, 21, { S, S, S, S, S, P, P, P, P, P, P, P, P, C, C, C, C, C, C, C, H, S, S } },
     { 13, 22, { S, S, S, S, S, P, P, P, P, P, P, C, C, C, C, C, C, C, C, C, R, T, S } },
     { 16, 17, { S, S, S, S, S, S, P, P, P, P, P, P, C, C, C, C, R, S, S, S, S, S, S } },
@@ -501,7 +502,7 @@ static constexpr WeatherTransition kClimateTransitionsWarm[] = {
     { 19, 17, { S, S, S, S, S, P, P, P, P, P, C, C, C, C, C, C, R, S, S, S, S, S, S } },
     { 16, 17, { S, S, P, P, P, P, P, C, C, C, C, C, C, C, C, C, H, S, S, S, S, S, S } },
 };
-static constexpr WeatherTransition kClimateTransitionsHotAndDry[] = {
+static constexpr WeatherPattern kClimatePatternsHotAndDry[] = {
     { 12, 15, { S, S, S, S, P, P, P, P, P, P, P, P, C, C, R, S, S, S, S, S, S, S, S } },
     { 14, 12, { S, S, S, S, S, P, P, P, P, P, C, C, S, S, S, S, S, S, S, S, S, S, S } },
     { 16, 11, { S, S, S, S, S, S, P, P, P, P, C, S, S, S, S, S, S, S, S, S, S, S, S } },
@@ -511,7 +512,7 @@ static constexpr WeatherTransition kClimateTransitionsHotAndDry[] = {
     { 21, 12, { S, S, S, S, S, S, S, P, P, P, C, T, S, S, S, S, S, S, S, S, S, S, S } },
     { 16, 13, { S, S, S, S, S, S, S, S, P, P, P, C, R, S, S, S, S, S, S, S, S, S, S } },
 };
-static constexpr WeatherTransition kClimateTransitionsCold[] = {
+static constexpr WeatherPattern kClimatePatternsCold[] = {
     { 4, 18, { S, S, S, S, P, P, P, P, P, C, C, C, C, C, C, C, R, H, S, S, S, S, S } },
     { 5, 21, { S, S, S, S, P, P, P, P, P, C, C, C, C, C, C, C, C, C, R, H, T, S, S } },
     { 7, 17, { S, S, S, S, P, P, P, P, P, P, P, C, C, C, C, R, H, S, S, S, S, S, S } },
@@ -522,11 +523,11 @@ static constexpr WeatherTransition kClimateTransitionsCold[] = {
     { 6, 16, { S, S, P, P, P, P, C, C, C, C, C, C, R, R, H, T, S, S, S, S, S, S, S } },
 };
 
-const WeatherTransition* kClimateTransitions[] = {
-    kClimateTransitionsCoolAndWet,
-    kClimateTransitionsWarm,
-    kClimateTransitionsHotAndDry,
-    kClimateTransitionsCold,
+const WeatherPattern* kClimatePatterns[] = {
+    kClimatePatternsCoolAndWet,
+    kClimatePatternsWarm,
+    kClimatePatternsHotAndDry,
+    kClimatePatternsCold,
 };
 
 #pragma endregion

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -100,16 +100,16 @@ void ClimateReset(ClimateType climate)
     auto weather = WeatherType::PartiallyCloudy;
     int32_t month = GetDate().GetMonth();
 
-    const WeatherPattern* transition = &kClimatePatterns[EnumValue(climate)][month];
-    const WeatherTrait* weatherTrait = &kClimateWeatherTraits[EnumValue(weather)];
+    const WeatherPattern& pattern = kClimatePatterns[EnumValue(climate)][month];
+    const WeatherTrait& trait = kClimateWeatherTraits[EnumValue(weather)];
 
     auto& gameState = GetGameState();
     gameState.Climate = climate;
     gameState.ClimateCurrent.Weather = weather;
-    gameState.ClimateCurrent.Temperature = transition->BaseTemperature + weatherTrait->TemperatureDelta;
-    gameState.ClimateCurrent.WeatherEffect = weatherTrait->EffectLevel;
-    gameState.ClimateCurrent.WeatherGloom = weatherTrait->GloomLevel;
-    gameState.ClimateCurrent.Level = weatherTrait->Level;
+    gameState.ClimateCurrent.Temperature = pattern.BaseTemperature + trait.TemperatureDelta;
+    gameState.ClimateCurrent.WeatherEffect = trait.EffectLevel;
+    gameState.ClimateCurrent.WeatherGloom = trait.GloomLevel;
+    gameState.ClimateCurrent.Level = trait.Level;
 
     _lightningTimer = 0;
     _thunderTimer = 0;
@@ -213,14 +213,14 @@ void ClimateForceWeather(WeatherType weather)
     auto& gameState = GetGameState();
     int32_t month = GetDate().GetMonth();
 
-    const auto* transition = &kClimatePatterns[EnumValue(gameState.Climate)][month];
-    const auto weatherTrait = &kClimateWeatherTraits[EnumValue(weather)];
+    const auto& pattern = kClimatePatterns[EnumValue(gameState.Climate)][month];
+    const auto& trait = kClimateWeatherTraits[EnumValue(weather)];
 
     gameState.ClimateCurrent.Weather = weather;
-    gameState.ClimateCurrent.WeatherGloom = weatherTrait->GloomLevel;
-    gameState.ClimateCurrent.Level = weatherTrait->Level;
-    gameState.ClimateCurrent.WeatherEffect = weatherTrait->EffectLevel;
-    gameState.ClimateCurrent.Temperature = transition->BaseTemperature + weatherTrait->TemperatureDelta;
+    gameState.ClimateCurrent.WeatherGloom = trait.GloomLevel;
+    gameState.ClimateCurrent.Level = trait.Level;
+    gameState.ClimateCurrent.WeatherEffect = trait.EffectLevel;
+    gameState.ClimateCurrent.Temperature = pattern.BaseTemperature + trait.TemperatureDelta;
     gameState.ClimateUpdateTimer = 1920;
 
     ClimateUpdate();
@@ -310,16 +310,16 @@ static void ClimateDetermineFutureWeather(int32_t randomValue)
 
     // Generate a random index with values 0 up to RandomBias-1
     // and choose weather from the distribution table accordingly
-    const auto& transition = kClimatePatterns[EnumValue(gameState.Climate)][month];
-    auto randomIndex = ((randomValue % 256) * transition.RandomBias) / 256;
-    auto nextWeather = transition.Distribution[randomIndex];
+    const auto& pattern = kClimatePatterns[EnumValue(gameState.Climate)][month];
+    auto randomIndex = ((randomValue % 256) * pattern.RandomBias) / 256;
+    auto nextWeather = pattern.Distribution[randomIndex];
     gameState.ClimateNext.Weather = nextWeather;
 
-    const auto nextWeatherTrait = &kClimateWeatherTraits[EnumValue(nextWeather)];
-    gameState.ClimateNext.Temperature = transition.BaseTemperature + nextWeatherTrait->TemperatureDelta;
-    gameState.ClimateNext.WeatherEffect = nextWeatherTrait->EffectLevel;
-    gameState.ClimateNext.WeatherGloom = nextWeatherTrait->GloomLevel;
-    gameState.ClimateNext.Level = nextWeatherTrait->Level;
+    const auto& nextWeatherTrait = kClimateWeatherTraits[EnumValue(nextWeather)];
+    gameState.ClimateNext.Temperature = pattern.BaseTemperature + nextWeatherTrait.TemperatureDelta;
+    gameState.ClimateNext.WeatherEffect = nextWeatherTrait.EffectLevel;
+    gameState.ClimateNext.WeatherGloom = nextWeatherTrait.GloomLevel;
+    gameState.ClimateNext.Level = nextWeatherTrait.Level;
 
     gameState.ClimateUpdateTimer = 1920;
 }

--- a/src/openrct2/world/Climate.h
+++ b/src/openrct2/world/Climate.h
@@ -50,15 +50,6 @@ enum class WeatherLevel
     Heavy,
 };
 
-struct WeatherState
-{
-    int8_t TemperatureDelta;
-    WeatherEffectType EffectLevel;
-    int8_t GloomLevel;
-    WeatherLevel Level;
-    uint32_t SpriteId;
-};
-
 struct ClimateState
 {
     WeatherType Weather;


### PR DESCRIPTION
Before implementing climate objects, I first wanted to first get the terminology straight. What follows is a short summary of the changes in this PR.

First, the `WeatherTransition` type is renamed to `WeatherPattern`, which more accurately reflects the data it represents. The term 'transition' implies a mapping, which this is not.

Second, the term `DistributionSize` is replaced with `RandomBias`. The weather distributions inside the (now) `WeatherPattern` struct are in fact always the same size, namely 24 units. The factor in question is, in fact, a bias used for randomly indexing into the distribution.

Continuing, the `WeatherState` type is renamed to `WeatherTrait`. The struct in question doesn't actually represent state. Instead, it is a collection of constants pertaining to a particular weather type. In other word, traits.

Finally, there are some minor changes to make the unit adhere to our current code style, mostly k-prefixes for constants.