### PR TITLE
Improve warning if language files cannot be loaded on Android

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -439,7 +439,13 @@ namespace OpenRCT2
                 {
                     LOG_FATAL("Failed to open fallback language: %s", eFallback.what());
                     auto uiContext = GetContext()->GetUiContext();
+#ifdef __ANDROID__
+                    uiContext->ShowMessageBox(
+                        "You need to copy some additional files to finish your install.\n\nSee "
+                        "https://docs.openrct2.io/en/latest/installing/installing-on-android.html for more details.");
+#else
                     uiContext->ShowMessageBox("Failed to load language file!\nYour installation may be damaged.");
+#endif
                     return false;
                 }
             }


### PR DESCRIPTION
When the language files cannot be loaded on Android, 99.9% of the time it’s because the user has not yet copied the assets. Of course, extracting the assets automatically, or reading them from the APK would be better, but they haven’t materialised by themselves in the past few years, so a better warning will have to do.