### PR TITLE
Fix #22617: Sloped wooden supports glitch above diagonal track

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.20 (in development)
 ------------------------------------------------------------------------
 - Improved: [#23677] Building new ride track now inherits the colour scheme from the previous piece.
+- Fix: [#22617] Sloped Wooden and Side-Friction supports draw out of order when built directly above diagonal track pieces.
 
 0.4.19.1 (2025-02-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/coaster/SideFrictionRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/SideFrictionRollerCoaster.cpp
@@ -1742,7 +1742,7 @@ static void SideFrictionRCTrackDiagFlat(
             {
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(additionalImages[trackElement.HasChain()][direction]),
-                    { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
+                    { -16, -16, height }, { { -16, -16, height + 24 }, { 32, 32, 0 } });
             }
             break;
         case 2:
@@ -1750,7 +1750,7 @@ static void SideFrictionRCTrackDiagFlat(
             {
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(additionalImages[trackElement.HasChain()][direction]),
-                    { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
+                    { -16, -16, height }, { { -16, -16, height + 24 }, { 32, 32, 0 } });
             }
             break;
     }
@@ -2302,7 +2302,7 @@ static void SideFrictionRCTrackDiagFlatTo25DegDown(
                             { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours.WithIndex(21863), { -16, -16, height },
-                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
+                            { { -16, -16, height + 32 }, { 32, 32, 0 } });
                         break;
                 }
             }
@@ -2316,7 +2316,7 @@ static void SideFrictionRCTrackDiagFlatTo25DegDown(
                             { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours.WithIndex(21839), { -16, -16, height },
-                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
+                            { { -16, -16, height + 32 }, { 32, 32, 0 } });
                         break;
                 }
             }
@@ -2332,7 +2332,7 @@ static void SideFrictionRCTrackDiagFlatTo25DegDown(
                             { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours.WithIndex(21862), { -16, -16, height },
-                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
+                            { { -16, -16, height + 32 }, { 32, 32, 0 } });
                         break;
                 }
             }
@@ -2346,7 +2346,7 @@ static void SideFrictionRCTrackDiagFlatTo25DegDown(
                             { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours.WithIndex(21838), { -16, -16, height },
-                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
+                            { { -16, -16, height + 32 }, { 32, 32, 0 } });
                         break;
                 }
             }

--- a/src/openrct2/paint/track/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/WoodenRollerCoaster.cpp
@@ -8077,10 +8077,10 @@ static void WoodenRCTrackDiagFlat(
                             { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24051),
-                            { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
+                            { -16, -16, height }, { { -16, -16, height + 24 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24917), { -16, -16, height },
-                            { { -16, -16, height + 27 }, { 32, 32, 0 } });
+                            { { -16, -16, height + 24 }, { 32, 32, 0 } });
                         break;
                 }
             }
@@ -8097,10 +8097,10 @@ static void WoodenRCTrackDiagFlat(
                             { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24009),
-                            { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
+                            { -16, -16, height }, { { -16, -16, height + 24 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24875), { -16, -16, height },
-                            { { -16, -16, height + 27 }, { 32, 32, 0 } });
+                            { { -16, -16, height + 24 }, { 32, 32, 0 } });
                         break;
                 }
             }
@@ -8123,10 +8123,10 @@ static void WoodenRCTrackDiagFlat(
                             { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24052),
-                            { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
+                            { -16, -16, height }, { { -16, -16, height + 24 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24918), { -16, -16, height },
-                            { { -16, -16, height + 27 }, { 32, 32, 0 } });
+                            { { -16, -16, height + 24 }, { 32, 32, 0 } });
                         break;
                 }
             }
@@ -8143,10 +8143,10 @@ static void WoodenRCTrackDiagFlat(
                             { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24010),
-                            { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
+                            { -16, -16, height }, { { -16, -16, height + 24 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24876), { -16, -16, height },
-                            { { -16, -16, height + 27 }, { 32, 32, 0 } });
+                            { { -16, -16, height + 24 }, { 32, 32, 0 } });
                         break;
                 }
             }
@@ -9328,10 +9328,10 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                             { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24064),
-                            { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
+                            { -16, -16, height }, { { -16, -16, height + 32 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24930), { -16, -16, height },
-                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
+                            { { -16, -16, height + 32 }, { 32, 32, 0 } });
                         break;
                 }
                 WoodenBSupportsPaintSetupRotated(
@@ -9350,10 +9350,10 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                             { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24022),
-                            { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
+                            { -16, -16, height }, { { -16, -16, height + 32 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24888), { -16, -16, height },
-                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
+                            { { -16, -16, height + 32 }, { 32, 32, 0 } });
                         break;
                 }
                 WoodenBSupportsPaintSetupRotated(
@@ -9374,10 +9374,10 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                             { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24063),
-                            { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
+                            { -16, -16, height }, { { -16, -16, height + 32 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24929), { -16, -16, height },
-                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
+                            { { -16, -16, height + 32 }, { 32, 32, 0 } });
                         break;
                 }
             }
@@ -9394,10 +9394,10 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                             { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24021),
-                            { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
+                            { -16, -16, height }, { { -16, -16, height + 32 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24887), { -16, -16, height },
-                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
+                            { { -16, -16, height + 32 }, { 32, 32, 0 } });
                         break;
                 }
             }


### PR DESCRIPTION
This fixes #22617. The issue here is that the bounding boxes of the foreground sprites of these split tracks were higher than the clearances of the track pieces. This lowers them by just a little so that they are the same height as the clearance. The foreground sprites still work, and the supports no longer glitch.

https://github.com/user-attachments/assets/9b91b38d-951e-4b32-a908-8b062b2f387e

I used the multi dim train to show the wooden coaster because the wooden trains aren't actually wide enough to test the foreground sprites.