### PR TITLE
Fix #23781: Changing weather does not update state for next weather

### DIFF
--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -49,7 +49,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kNetworkStreamVersion = 0;
+constexpr uint8_t kNetworkStreamVersion = 1;
 
 const std::string kNetworkStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kNetworkStreamVersion);
 

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -223,7 +223,7 @@ void ClimateForceWeather(WeatherType weather)
     gameState.ClimateCurrent.Temperature = pattern.baseTemperature + trait.temperatureDelta;
     gameState.ClimateUpdateTimer = 1920;
 
-    ClimateUpdate();
+    ClimateDetermineFutureWeather(ScenarioRand());
 
     // In case of change in gloom level force a complete redraw
     GfxInvalidateScreen();
@@ -311,8 +311,8 @@ static void ClimateDetermineFutureWeather(uint32_t randomValue)
     // Generate a random index with values 0 up to randomBias-1
     // and choose weather from the distribution table accordingly
     const auto& pattern = kClimatePatterns[EnumValue(gameState.Climate)][month];
-    size_t randomIndex = ((randomValue % 256) * pattern.randomBias) / 256;
-    auto nextWeather = pattern.distribution[randomIndex];
+    const auto randomIndex = ((randomValue % 256) * pattern.randomBias) / 256;
+    const auto nextWeather = pattern.distribution[randomIndex];
     gameState.ClimateNext.Weather = nextWeather;
 
     const auto& nextWeatherTrait = kClimateWeatherTraits[EnumValue(nextWeather)];


### PR DESCRIPTION
The actual issue that the weather never changes is that the variable level contains garbage so its never able to reach the condition for the next weather to activate. 

It seems that the cheat also had the issue that it would not update the next weather state which is decided on the current one so that was sort of buggy, now the cheat properly selects the next weather when its forced.

Close #23781