### PR TITLE
Rename 'Climate' properties to Weather

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -4250,7 +4250,7 @@ declare global {
         "heavySnow" |
         "blizzard";
 
-    interface ClimateState {
+    interface WeatherState {
         readonly weather: WeatherType;
         readonly temperature: number;
     }
@@ -4264,12 +4264,12 @@ declare global {
         /**
          * The current weather in the park.
          */
-        readonly current: ClimateState;
+        readonly current: WeatherState;
 
         /**
          * The next weather the park will experience.
          */
-        readonly future: ClimateState;
+        readonly future: WeatherState;
     }
 
     interface Cheats {

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -578,7 +578,7 @@ static StringId window_cheats_page_titles[] = {
             // Current weather
             if (page == WINDOW_CHEATS_PAGE_WEATHER)
             {
-                widgets[WIDX_WEATHER].text = WeatherTypes[EnumValue(gameState.WeatherCurrent.Weather)];
+                widgets[WIDX_WEATHER].text = WeatherTypes[EnumValue(gameState.WeatherCurrent.weatherType)];
             }
 
             // Staff speed
@@ -1023,7 +1023,7 @@ static StringId window_cheats_page_titles[] = {
                         { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
                         colours[1], 0, Dropdown::Flag::StayOpen, std::size(WeatherTypes), dropdownWidget->width() - 3);
 
-                    auto currentWeather = gameState.WeatherCurrent.Weather;
+                    auto currentWeather = gameState.WeatherCurrent.weatherType;
                     Dropdown::SetChecked(EnumValue(currentWeather), true);
 
                     break;

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -578,7 +578,7 @@ static StringId window_cheats_page_titles[] = {
             // Current weather
             if (page == WINDOW_CHEATS_PAGE_WEATHER)
             {
-                widgets[WIDX_WEATHER].text = WeatherTypes[EnumValue(gameState.ClimateCurrent.Weather)];
+                widgets[WIDX_WEATHER].text = WeatherTypes[EnumValue(gameState.WeatherCurrent.Weather)];
             }
 
             // Staff speed
@@ -1023,7 +1023,7 @@ static StringId window_cheats_page_titles[] = {
                         { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
                         colours[1], 0, Dropdown::Flag::StayOpen, std::size(WeatherTypes), dropdownWidget->width() - 3);
 
-                    auto currentWeather = gameState.ClimateCurrent.Weather;
+                    auto currentWeather = gameState.WeatherCurrent.Weather;
                     Dropdown::SetChecked(EnumValue(currentWeather), true);
 
                     break;

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -199,7 +199,7 @@ namespace OpenRCT2::Ui::Windows
             // Temperature
             screenCoords = { windowPos.x + rightPanelWidget.left + 15, static_cast<int32_t>(screenCoords.y + line_height + 1) };
 
-            int32_t temperature = GetGameState().WeatherCurrent.Temperature;
+            int32_t temperature = GetGameState().WeatherCurrent.temperature;
             StringId format = STR_CELSIUS_VALUE;
             if (Config::Get().general.TemperatureFormat == TemperatureUnit::Fahrenheit)
             {

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -219,7 +219,7 @@ namespace OpenRCT2::Ui::Windows
             auto nextWeatherSpriteId = ClimateGetWeatherSpriteId(GetGameState().WeatherNext);
             if (currentWeatherSpriteId != nextWeatherSpriteId)
             {
-                if (GetGameState().ClimateUpdateTimer < 960)
+                if (GetGameState().WeatherUpdateTimer < 960)
                 {
                     GfxDrawSprite(dpi, ImageId(SPR_NEXT_WEATHER), screenCoords + ScreenCoordsXY{ 27, 5 });
                     GfxDrawSprite(dpi, ImageId(nextWeatherSpriteId), screenCoords + ScreenCoordsXY{ 40, 0 });

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -216,7 +216,7 @@ namespace OpenRCT2::Ui::Windows
             GfxDrawSprite(dpi, ImageId(currentWeatherSpriteId), screenCoords);
 
             // Next weather
-            auto nextWeatherSpriteId = ClimateGetWeatherSpriteId(GetGameState().ClimateNext);
+            auto nextWeatherSpriteId = ClimateGetWeatherSpriteId(GetGameState().WeatherNext);
             if (currentWeatherSpriteId != nextWeatherSpriteId)
             {
                 if (GetGameState().ClimateUpdateTimer < 960)

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -199,7 +199,7 @@ namespace OpenRCT2::Ui::Windows
             // Temperature
             screenCoords = { windowPos.x + rightPanelWidget.left + 15, static_cast<int32_t>(screenCoords.y + line_height + 1) };
 
-            int32_t temperature = GetGameState().ClimateCurrent.Temperature;
+            int32_t temperature = GetGameState().WeatherCurrent.Temperature;
             StringId format = STR_CELSIUS_VALUE;
             if (Config::Get().general.TemperatureFormat == TemperatureUnit::Fahrenheit)
             {
@@ -212,7 +212,7 @@ namespace OpenRCT2::Ui::Windows
             screenCoords.x += 30;
 
             // Current weather
-            auto currentWeatherSpriteId = ClimateGetWeatherSpriteId(GetGameState().ClimateCurrent);
+            auto currentWeatherSpriteId = ClimateGetWeatherSpriteId(GetGameState().WeatherCurrent);
             GfxDrawSprite(dpi, ImageId(currentWeatherSpriteId), screenCoords);
 
             // Next weather

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -50,7 +50,7 @@ namespace OpenRCT2
         ClimateType Climate;
         WeatherState WeatherCurrent;
         WeatherState WeatherNext;
-        uint16_t ClimateUpdateTimer;
+        uint16_t WeatherUpdateTimer;
         money64 Cash;
         money64 CashHistory[kFinanceHistorySize];
         money64 InitialCash;

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -48,8 +48,8 @@ namespace OpenRCT2
         money64 CurrentProfit;
         uint32_t GuestsInParkHistory[kGuestsInParkHistorySize];
         ClimateType Climate;
-        ClimateState ClimateCurrent;
-        ClimateState ClimateNext;
+        WeatherState ClimateCurrent;
+        WeatherState ClimateNext;
         uint16_t ClimateUpdateTimer;
         money64 Cash;
         money64 CashHistory[kFinanceHistorySize];

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -48,7 +48,7 @@ namespace OpenRCT2
         money64 CurrentProfit;
         uint32_t GuestsInParkHistory[kGuestsInParkHistorySize];
         ClimateType Climate;
-        WeatherState ClimateCurrent;
+        WeatherState WeatherCurrent;
         WeatherState ClimateNext;
         uint16_t ClimateUpdateTimer;
         money64 Cash;

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -49,7 +49,7 @@ namespace OpenRCT2
         uint32_t GuestsInParkHistory[kGuestsInParkHistorySize];
         ClimateType Climate;
         WeatherState WeatherCurrent;
-        WeatherState ClimateNext;
+        WeatherState WeatherNext;
         uint16_t ClimateUpdateTimer;
         money64 Cash;
         money64 CashHistory[kFinanceHistorySize];

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -1011,7 +1011,7 @@ void UpdatePaletteEffects()
         uint32_t shade = 0;
         if (Config::Get().general.RenderWeatherGloom)
         {
-            auto paletteId = ClimateGetWeatherGloomPaletteId(GetGameState().ClimateCurrent);
+            auto paletteId = ClimateGetWeatherGloomPaletteId(GetGameState().WeatherCurrent);
             if (paletteId != FilterPaletteID::PaletteNull)
             {
                 shade = 1;

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -866,9 +866,9 @@ namespace OpenRCT2::Drawing::LightFx
 
         //  overExpose += ((lightMax - lightAvg) / lightMax) * 0.01f;
 
-        if (gameState.ClimateCurrent.Temperature > 20)
+        if (gameState.WeatherCurrent.Temperature > 20)
         {
-            float offset = (static_cast<float>(gameState.ClimateCurrent.Temperature - 20)) * 0.04f;
+            float offset = (static_cast<float>(gameState.WeatherCurrent.Temperature - 20)) * 0.04f;
             offset *= 1.0f - night;
             lightAvg /= 1.0f + offset;
             //      overExpose += offset * 0.1f;
@@ -890,12 +890,12 @@ namespace OpenRCT2::Drawing::LightFx
         natLightB *= 1.0f + overExpose;
         overExpose *= 255.0f;
 
-        float targetFogginess = static_cast<float>(gameState.ClimateCurrent.Level) / 8.0f;
+        float targetFogginess = static_cast<float>(gameState.WeatherCurrent.Level) / 8.0f;
         targetFogginess += (night * night) * 0.15f;
 
-        if (gameState.ClimateCurrent.Temperature < 10)
+        if (gameState.WeatherCurrent.Temperature < 10)
         {
-            targetFogginess += (static_cast<float>(10 - gameState.ClimateCurrent.Temperature)) * 0.01f;
+            targetFogginess += (static_cast<float>(10 - gameState.WeatherCurrent.Temperature)) * 0.01f;
         }
 
         fogginess -= (fogginess - targetFogginess) * 0.00001f;
@@ -933,7 +933,7 @@ namespace OpenRCT2::Drawing::LightFx
         natLightG /= 1.0f + lightPolution;
         natLightB /= 1.0f + lightPolution;
 
-        reduceColourLit += static_cast<float>(gameState.ClimateCurrent.Level) / 2.0f;
+        reduceColourLit += static_cast<float>(gameState.WeatherCurrent.Level) / 2.0f;
 
         reduceColourNat /= 1.0f + fogginess;
         reduceColourLit /= 1.0f + fogginess;

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -866,9 +866,9 @@ namespace OpenRCT2::Drawing::LightFx
 
         //  overExpose += ((lightMax - lightAvg) / lightMax) * 0.01f;
 
-        if (gameState.WeatherCurrent.Temperature > 20)
+        if (gameState.WeatherCurrent.temperature > 20)
         {
-            float offset = (static_cast<float>(gameState.WeatherCurrent.Temperature - 20)) * 0.04f;
+            float offset = (static_cast<float>(gameState.WeatherCurrent.temperature - 20)) * 0.04f;
             offset *= 1.0f - night;
             lightAvg /= 1.0f + offset;
             //      overExpose += offset * 0.1f;
@@ -890,12 +890,12 @@ namespace OpenRCT2::Drawing::LightFx
         natLightB *= 1.0f + overExpose;
         overExpose *= 255.0f;
 
-        float targetFogginess = static_cast<float>(gameState.WeatherCurrent.Level) / 8.0f;
+        float targetFogginess = static_cast<float>(gameState.WeatherCurrent.level) / 8.0f;
         targetFogginess += (night * night) * 0.15f;
 
-        if (gameState.WeatherCurrent.Temperature < 10)
+        if (gameState.WeatherCurrent.temperature < 10)
         {
-            targetFogginess += (static_cast<float>(10 - gameState.WeatherCurrent.Temperature)) * 0.01f;
+            targetFogginess += (static_cast<float>(10 - gameState.WeatherCurrent.temperature)) * 0.01f;
         }
 
         fogginess -= (fogginess - targetFogginess) * 0.00001f;
@@ -933,7 +933,7 @@ namespace OpenRCT2::Drawing::LightFx
         natLightG /= 1.0f + lightPolution;
         natLightB /= 1.0f + lightPolution;
 
-        reduceColourLit += static_cast<float>(gameState.WeatherCurrent.Level) / 2.0f;
+        reduceColourLit += static_cast<float>(gameState.WeatherCurrent.level) / 2.0f;
 
         reduceColourNat /= 1.0f + fogginess;
         reduceColourLit /= 1.0f + fogginess;

--- a/src/openrct2/drawing/Weather.cpp
+++ b/src/openrct2/drawing/Weather.cpp
@@ -63,7 +63,7 @@ void DrawWeather(DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer)
             viewFlags = viewport->flags;
 
         // Get weather draw function and draw weather
-        auto weatherLevel = GetGameState().WeatherCurrent.Level;
+        auto weatherLevel = GetGameState().WeatherCurrent.level;
         if (weatherLevel != WeatherLevel::None && !gTrackDesignSaveMode && !(viewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES))
         {
             auto drawFunc = DrawRainFunctions[EnumValue(weatherLevel)];

--- a/src/openrct2/drawing/Weather.cpp
+++ b/src/openrct2/drawing/Weather.cpp
@@ -63,7 +63,7 @@ void DrawWeather(DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer)
             viewFlags = viewport->flags;
 
         // Get weather draw function and draw weather
-        auto weatherLevel = GetGameState().ClimateCurrent.Level;
+        auto weatherLevel = GetGameState().WeatherCurrent.Level;
         if (weatherLevel != WeatherLevel::None && !gTrackDesignSaveMode && !(viewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES))
         {
             auto drawFunc = DrawRainFunctions[EnumValue(weatherLevel)];

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -1542,7 +1542,7 @@ bool Guest::DecideAndBuyItem(Ride& ride, const ShopItem shopItem, money64 price)
     }
 
     auto& gameState = GetGameState();
-    if ((shopItem == ShopItem::Sunglasses || shopItem == ShopItem::IceCream) && gameState.WeatherCurrent.Temperature < 12)
+    if ((shopItem == ShopItem::Sunglasses || shopItem == ShopItem::IceCream) && gameState.WeatherCurrent.temperature < 12)
     {
         return false;
     }
@@ -1581,9 +1581,9 @@ bool Guest::DecideAndBuyItem(Ride& ride, const ShopItem shopItem, money64 price)
             }
         }
 
-        if (gameState.WeatherCurrent.Temperature >= 21)
+        if (gameState.WeatherCurrent.temperature >= 21)
             itemValue = shopItemDescriptor.HotValue;
-        else if (gameState.WeatherCurrent.Temperature <= 11)
+        else if (gameState.WeatherCurrent.temperature <= 11)
             itemValue = shopItemDescriptor.ColdValue;
         else
             itemValue = shopItemDescriptor.BaseValue;
@@ -1629,9 +1629,9 @@ bool Guest::DecideAndBuyItem(Ride& ride, const ShopItem shopItem, money64 price)
         }
 
         // reset itemValue for satisfaction calculation
-        if (gameState.WeatherCurrent.Temperature >= 21)
+        if (gameState.WeatherCurrent.temperature >= 21)
             itemValue = shopItemDescriptor.HotValue;
-        else if (gameState.WeatherCurrent.Temperature <= 11)
+        else if (gameState.WeatherCurrent.temperature <= 11)
             itemValue = shopItemDescriptor.ColdValue;
         else
             itemValue = shopItemDescriptor.BaseValue;
@@ -3082,7 +3082,7 @@ static void PeepDecideWhetherToLeavePark(Guest* peep)
         peep->EnergyTarget -= 2;
     }
 
-    if (GetGameState().WeatherCurrent.Temperature >= 21 && peep->Thirst >= 5)
+    if (GetGameState().WeatherCurrent.temperature >= 21 && peep->Thirst >= 5)
     {
         peep->Thirst--;
     }

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -1542,7 +1542,7 @@ bool Guest::DecideAndBuyItem(Ride& ride, const ShopItem shopItem, money64 price)
     }
 
     auto& gameState = GetGameState();
-    if ((shopItem == ShopItem::Sunglasses || shopItem == ShopItem::IceCream) && gameState.ClimateCurrent.Temperature < 12)
+    if ((shopItem == ShopItem::Sunglasses || shopItem == ShopItem::IceCream) && gameState.WeatherCurrent.Temperature < 12)
     {
         return false;
     }
@@ -1581,9 +1581,9 @@ bool Guest::DecideAndBuyItem(Ride& ride, const ShopItem shopItem, money64 price)
             }
         }
 
-        if (gameState.ClimateCurrent.Temperature >= 21)
+        if (gameState.WeatherCurrent.Temperature >= 21)
             itemValue = shopItemDescriptor.HotValue;
-        else if (gameState.ClimateCurrent.Temperature <= 11)
+        else if (gameState.WeatherCurrent.Temperature <= 11)
             itemValue = shopItemDescriptor.ColdValue;
         else
             itemValue = shopItemDescriptor.BaseValue;
@@ -1629,9 +1629,9 @@ bool Guest::DecideAndBuyItem(Ride& ride, const ShopItem shopItem, money64 price)
         }
 
         // reset itemValue for satisfaction calculation
-        if (gameState.ClimateCurrent.Temperature >= 21)
+        if (gameState.WeatherCurrent.Temperature >= 21)
             itemValue = shopItemDescriptor.HotValue;
-        else if (gameState.ClimateCurrent.Temperature <= 11)
+        else if (gameState.WeatherCurrent.Temperature <= 11)
             itemValue = shopItemDescriptor.ColdValue;
         else
             itemValue = shopItemDescriptor.BaseValue;
@@ -3082,7 +3082,7 @@ static void PeepDecideWhetherToLeavePark(Guest* peep)
         peep->EnergyTarget -= 2;
     }
 
-    if (GetGameState().ClimateCurrent.Temperature >= 21 && peep->Thirst >= 5)
+    if (GetGameState().WeatherCurrent.Temperature >= 21 && peep->Thirst >= 5)
     {
         peep->Thirst--;
     }

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1084,7 +1084,7 @@ namespace OpenRCT2
 
     static void ViewportPaintWeatherGloom(DrawPixelInfo& dpi)
     {
-        auto paletteId = ClimateGetWeatherGloomPaletteId(GetGameState().ClimateCurrent);
+        auto paletteId = ClimateGetWeatherGloomPaletteId(GetGameState().WeatherCurrent);
         if (paletteId != FilterPaletteID::PaletteNull)
         {
             auto x = dpi.x;

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -795,7 +795,7 @@ namespace OpenRCT2
                 cs.ReadWrite(gameState.Climate);
                 cs.ReadWrite(gameState.ClimateUpdateTimer);
 
-                for (auto* cl : { &gameState.ClimateCurrent, &gameState.ClimateNext })
+                for (auto* cl : { &gameState.WeatherCurrent, &gameState.ClimateNext })
                 {
                     cs.ReadWrite(cl->Weather);
                     cs.ReadWrite(cl->Temperature);

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -795,7 +795,7 @@ namespace OpenRCT2
                 cs.ReadWrite(gameState.Climate);
                 cs.ReadWrite(gameState.ClimateUpdateTimer);
 
-                for (auto* cl : { &gameState.WeatherCurrent, &gameState.ClimateNext })
+                for (auto* cl : { &gameState.WeatherCurrent, &gameState.WeatherNext })
                 {
                     cs.ReadWrite(cl->Weather);
                     cs.ReadWrite(cl->Temperature);

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -793,7 +793,7 @@ namespace OpenRCT2
         {
             os.ReadWriteChunk(ParkFileChunkType::CLIMATE, [&gameState](OrcaStream::ChunkStream& cs) {
                 cs.ReadWrite(gameState.Climate);
-                cs.ReadWrite(gameState.ClimateUpdateTimer);
+                cs.ReadWrite(gameState.WeatherUpdateTimer);
 
                 for (auto* cl : { &gameState.WeatherCurrent, &gameState.WeatherNext })
                 {

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -797,11 +797,11 @@ namespace OpenRCT2
 
                 for (auto* cl : { &gameState.WeatherCurrent, &gameState.WeatherNext })
                 {
-                    cs.ReadWrite(cl->Weather);
-                    cs.ReadWrite(cl->Temperature);
-                    cs.ReadWrite(cl->WeatherEffect);
-                    cs.ReadWrite(cl->WeatherGloom);
-                    cs.ReadWrite(cl->Level);
+                    cs.ReadWrite(cl->weatherType);
+                    cs.ReadWrite(cl->temperature);
+                    cs.ReadWrite(cl->weatherEffect);
+                    cs.ReadWrite(cl->weatherGloom);
+                    cs.ReadWrite(cl->level);
                 }
             });
         }

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -878,7 +878,7 @@ namespace OpenRCT2::RCT1
         uint8_t Unk1F4322[8];
         uint8_t Climate;
         uint8_t Unk1F432B;
-        uint16_t ClimateTimer;
+        uint16_t WeatherUpdateTimer;
         uint8_t Weather;
         uint8_t TargetWeather;
         uint8_t Temperature;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2352,7 +2352,7 @@ namespace OpenRCT2::RCT1
         void ImportClimate(GameState_t& gameState)
         {
             gameState.Climate = ClimateType{ _s4.Climate };
-            gameState.ClimateUpdateTimer = _s4.ClimateTimer;
+            gameState.WeatherUpdateTimer = _s4.ClimateTimer;
             gameState.WeatherCurrent.Temperature = _s4.Temperature;
             gameState.WeatherCurrent.Weather = WeatherType{ _s4.Weather };
             gameState.WeatherCurrent.WeatherEffect = WeatherEffectType::None;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2354,18 +2354,18 @@ namespace OpenRCT2::RCT1
             gameState.Climate = ClimateType{ _s4.Climate };
             gameState.WeatherUpdateTimer = _s4.WeatherUpdateTimer;
             gameState.WeatherCurrent = {
-                .Weather = WeatherType{ _s4.Weather },
-                .Temperature = static_cast<int8_t>(_s4.Temperature),
-                .WeatherEffect = WeatherEffectType::None,
-                .WeatherGloom = _s4.WeatherGloom,
-                .Level = static_cast<WeatherLevel>(_s4.Rain),
+                .weatherType = WeatherType{ _s4.Weather },
+                .temperature = static_cast<int8_t>(_s4.Temperature),
+                .weatherEffect = WeatherEffectType::None,
+                .weatherGloom = _s4.WeatherGloom,
+                .level = static_cast<WeatherLevel>(_s4.Rain),
             };
             gameState.WeatherNext = {
-                .Weather = WeatherType{ _s4.TargetWeather },
-                .Temperature = static_cast<int8_t>(_s4.TargetTemperature),
-                .WeatherEffect = WeatherEffectType::None,
-                .WeatherGloom = _s4.TargetWeatherGloom,
-                .Level = static_cast<WeatherLevel>(_s4.TargetRain),
+                .weatherType = WeatherType{ _s4.TargetWeather },
+                .temperature = static_cast<int8_t>(_s4.TargetTemperature),
+                .weatherEffect = WeatherEffectType::None,
+                .weatherGloom = _s4.TargetWeatherGloom,
+                .level = static_cast<WeatherLevel>(_s4.TargetRain),
             };
         }
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2358,11 +2358,11 @@ namespace OpenRCT2::RCT1
             gameState.WeatherCurrent.WeatherEffect = WeatherEffectType::None;
             gameState.WeatherCurrent.WeatherGloom = _s4.WeatherGloom;
             gameState.WeatherCurrent.Level = static_cast<WeatherLevel>(_s4.Rain);
-            gameState.ClimateNext.Temperature = _s4.TargetTemperature;
-            gameState.ClimateNext.Weather = WeatherType{ _s4.TargetWeather };
-            gameState.ClimateNext.WeatherEffect = WeatherEffectType::None;
-            gameState.ClimateNext.WeatherGloom = _s4.TargetWeatherGloom;
-            gameState.ClimateNext.Level = static_cast<WeatherLevel>(_s4.TargetRain);
+            gameState.WeatherNext.Temperature = _s4.TargetTemperature;
+            gameState.WeatherNext.Weather = WeatherType{ _s4.TargetWeather };
+            gameState.WeatherNext.WeatherEffect = WeatherEffectType::None;
+            gameState.WeatherNext.WeatherGloom = _s4.TargetWeatherGloom;
+            gameState.WeatherNext.Level = static_cast<WeatherLevel>(_s4.TargetRain);
         }
 
         void ImportScenarioNameDetails(GameState_t& gameState)

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2352,7 +2352,7 @@ namespace OpenRCT2::RCT1
         void ImportClimate(GameState_t& gameState)
         {
             gameState.Climate = ClimateType{ _s4.Climate };
-            gameState.WeatherUpdateTimer = _s4.ClimateTimer;
+            gameState.WeatherUpdateTimer = _s4.WeatherUpdateTimer;
             gameState.WeatherCurrent = {
                 .Weather = WeatherType{ _s4.Weather },
                 .Temperature = static_cast<int8_t>(_s4.Temperature),

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2353,16 +2353,20 @@ namespace OpenRCT2::RCT1
         {
             gameState.Climate = ClimateType{ _s4.Climate };
             gameState.WeatherUpdateTimer = _s4.ClimateTimer;
-            gameState.WeatherCurrent.Temperature = _s4.Temperature;
-            gameState.WeatherCurrent.Weather = WeatherType{ _s4.Weather };
-            gameState.WeatherCurrent.WeatherEffect = WeatherEffectType::None;
-            gameState.WeatherCurrent.WeatherGloom = _s4.WeatherGloom;
-            gameState.WeatherCurrent.Level = static_cast<WeatherLevel>(_s4.Rain);
-            gameState.WeatherNext.Temperature = _s4.TargetTemperature;
-            gameState.WeatherNext.Weather = WeatherType{ _s4.TargetWeather };
-            gameState.WeatherNext.WeatherEffect = WeatherEffectType::None;
-            gameState.WeatherNext.WeatherGloom = _s4.TargetWeatherGloom;
-            gameState.WeatherNext.Level = static_cast<WeatherLevel>(_s4.TargetRain);
+            gameState.WeatherCurrent = {
+                .Weather = WeatherType{ _s4.Weather },
+                .Temperature = static_cast<int8_t>(_s4.Temperature),
+                .WeatherEffect = WeatherEffectType::None,
+                .WeatherGloom = _s4.WeatherGloom,
+                .Level = static_cast<WeatherLevel>(_s4.Rain),
+            };
+            gameState.WeatherNext = {
+                .Weather = WeatherType{ _s4.TargetWeather },
+                .Temperature = static_cast<int8_t>(_s4.TargetTemperature),
+                .WeatherEffect = WeatherEffectType::None,
+                .WeatherGloom = _s4.TargetWeatherGloom,
+                .Level = static_cast<WeatherLevel>(_s4.TargetRain),
+            };
         }
 
         void ImportScenarioNameDetails(GameState_t& gameState)

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2353,11 +2353,11 @@ namespace OpenRCT2::RCT1
         {
             gameState.Climate = ClimateType{ _s4.Climate };
             gameState.ClimateUpdateTimer = _s4.ClimateTimer;
-            gameState.ClimateCurrent.Temperature = _s4.Temperature;
-            gameState.ClimateCurrent.Weather = WeatherType{ _s4.Weather };
-            gameState.ClimateCurrent.WeatherEffect = WeatherEffectType::None;
-            gameState.ClimateCurrent.WeatherGloom = _s4.WeatherGloom;
-            gameState.ClimateCurrent.Level = static_cast<WeatherLevel>(_s4.Rain);
+            gameState.WeatherCurrent.Temperature = _s4.Temperature;
+            gameState.WeatherCurrent.Weather = WeatherType{ _s4.Weather };
+            gameState.WeatherCurrent.WeatherEffect = WeatherEffectType::None;
+            gameState.WeatherCurrent.WeatherGloom = _s4.WeatherGloom;
+            gameState.WeatherCurrent.Level = static_cast<WeatherLevel>(_s4.Rain);
             gameState.ClimateNext.Temperature = _s4.TargetTemperature;
             gameState.ClimateNext.Weather = WeatherType{ _s4.TargetWeather };
             gameState.ClimateNext.WeatherEffect = WeatherEffectType::None;

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -979,7 +979,7 @@ namespace OpenRCT2::RCT2
         uint8_t Byte13CA742[4]; // unused
         uint8_t Climate;
         uint8_t Pad013CA747;
-        uint16_t ClimateUpdateTimer;
+        uint16_t WeatherUpdateTimer;
         uint8_t CurrentWeather;
         uint8_t NextWeather;
         uint8_t Temperature;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -558,15 +558,15 @@ namespace OpenRCT2::RCT2
             // Pad013CA747
             gameState.ClimateUpdateTimer = _s6.ClimateUpdateTimer;
             gameState.WeatherCurrent.Weather = WeatherType{ _s6.CurrentWeather };
-            gameState.ClimateNext.Weather = WeatherType{ _s6.NextWeather };
+            gameState.WeatherNext.Weather = WeatherType{ _s6.NextWeather };
             gameState.WeatherCurrent.Temperature = _s6.Temperature;
-            gameState.ClimateNext.Temperature = _s6.NextTemperature;
+            gameState.WeatherNext.Temperature = _s6.NextTemperature;
             gameState.WeatherCurrent.WeatherEffect = WeatherEffectType{ _s6.CurrentWeatherEffect };
-            gameState.ClimateNext.WeatherEffect = WeatherEffectType{ _s6.NextWeatherEffect };
+            gameState.WeatherNext.WeatherEffect = WeatherEffectType{ _s6.NextWeatherEffect };
             gameState.WeatherCurrent.WeatherGloom = _s6.CurrentWeatherGloom;
-            gameState.ClimateNext.WeatherGloom = _s6.NextWeatherGloom;
+            gameState.WeatherNext.WeatherGloom = _s6.NextWeatherGloom;
             gameState.WeatherCurrent.Level = static_cast<WeatherLevel>(_s6.CurrentWeatherLevel);
-            gameState.ClimateNext.Level = static_cast<WeatherLevel>(_s6.NextWeatherLevel);
+            gameState.WeatherNext.Level = static_cast<WeatherLevel>(_s6.NextWeatherLevel);
 
             // News items
             News::InitQueue();

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -557,15 +557,15 @@ namespace OpenRCT2::RCT2
             // Byte13CA742
             // Pad013CA747
             gameState.ClimateUpdateTimer = _s6.ClimateUpdateTimer;
-            gameState.ClimateCurrent.Weather = WeatherType{ _s6.CurrentWeather };
+            gameState.WeatherCurrent.Weather = WeatherType{ _s6.CurrentWeather };
             gameState.ClimateNext.Weather = WeatherType{ _s6.NextWeather };
-            gameState.ClimateCurrent.Temperature = _s6.Temperature;
+            gameState.WeatherCurrent.Temperature = _s6.Temperature;
             gameState.ClimateNext.Temperature = _s6.NextTemperature;
-            gameState.ClimateCurrent.WeatherEffect = WeatherEffectType{ _s6.CurrentWeatherEffect };
+            gameState.WeatherCurrent.WeatherEffect = WeatherEffectType{ _s6.CurrentWeatherEffect };
             gameState.ClimateNext.WeatherEffect = WeatherEffectType{ _s6.NextWeatherEffect };
-            gameState.ClimateCurrent.WeatherGloom = _s6.CurrentWeatherGloom;
+            gameState.WeatherCurrent.WeatherGloom = _s6.CurrentWeatherGloom;
             gameState.ClimateNext.WeatherGloom = _s6.NextWeatherGloom;
-            gameState.ClimateCurrent.Level = static_cast<WeatherLevel>(_s6.CurrentWeatherLevel);
+            gameState.WeatherCurrent.Level = static_cast<WeatherLevel>(_s6.CurrentWeatherLevel);
             gameState.ClimateNext.Level = static_cast<WeatherLevel>(_s6.NextWeatherLevel);
 
             // News items

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -556,7 +556,7 @@ namespace OpenRCT2::RCT2
             // Pad13CA741;
             // Byte13CA742
             // Pad013CA747
-            gameState.ClimateUpdateTimer = _s6.ClimateUpdateTimer;
+            gameState.WeatherUpdateTimer = _s6.WeatherUpdateTimer;
             gameState.WeatherCurrent.Weather = WeatherType{ _s6.CurrentWeather };
             gameState.WeatherNext.Weather = WeatherType{ _s6.NextWeather };
             gameState.WeatherCurrent.Temperature = _s6.Temperature;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -557,16 +557,20 @@ namespace OpenRCT2::RCT2
             // Byte13CA742
             // Pad013CA747
             gameState.WeatherUpdateTimer = _s6.WeatherUpdateTimer;
-            gameState.WeatherCurrent.Weather = WeatherType{ _s6.CurrentWeather };
-            gameState.WeatherNext.Weather = WeatherType{ _s6.NextWeather };
-            gameState.WeatherCurrent.Temperature = _s6.Temperature;
-            gameState.WeatherNext.Temperature = _s6.NextTemperature;
-            gameState.WeatherCurrent.WeatherEffect = WeatherEffectType{ _s6.CurrentWeatherEffect };
-            gameState.WeatherNext.WeatherEffect = WeatherEffectType{ _s6.NextWeatherEffect };
-            gameState.WeatherCurrent.WeatherGloom = _s6.CurrentWeatherGloom;
-            gameState.WeatherNext.WeatherGloom = _s6.NextWeatherGloom;
-            gameState.WeatherCurrent.Level = static_cast<WeatherLevel>(_s6.CurrentWeatherLevel);
-            gameState.WeatherNext.Level = static_cast<WeatherLevel>(_s6.NextWeatherLevel);
+            gameState.WeatherCurrent = {
+                .Weather = WeatherType{ _s6.CurrentWeather },
+                .Temperature = static_cast<int8_t>(_s6.Temperature),
+                .WeatherEffect = WeatherEffectType{ _s6.CurrentWeatherEffect },
+                .WeatherGloom = _s6.CurrentWeatherGloom,
+                .Level = static_cast<WeatherLevel>(_s6.CurrentWeatherLevel),
+            };
+            gameState.WeatherNext = {
+                .Weather = WeatherType{ _s6.NextWeather },
+                .Temperature = static_cast<int8_t>(_s6.NextTemperature),
+                .WeatherEffect = WeatherEffectType{ _s6.NextWeatherEffect },
+                .WeatherGloom = _s6.NextWeatherGloom,
+                .Level = static_cast<WeatherLevel>(_s6.NextWeatherLevel),
+            };
 
             // News items
             News::InitQueue();

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -558,18 +558,18 @@ namespace OpenRCT2::RCT2
             // Pad013CA747
             gameState.WeatherUpdateTimer = _s6.WeatherUpdateTimer;
             gameState.WeatherCurrent = {
-                .Weather = WeatherType{ _s6.CurrentWeather },
-                .Temperature = static_cast<int8_t>(_s6.Temperature),
-                .WeatherEffect = WeatherEffectType{ _s6.CurrentWeatherEffect },
-                .WeatherGloom = _s6.CurrentWeatherGloom,
-                .Level = static_cast<WeatherLevel>(_s6.CurrentWeatherLevel),
+                .weatherType = WeatherType{ _s6.CurrentWeather },
+                .temperature = static_cast<int8_t>(_s6.Temperature),
+                .weatherEffect = WeatherEffectType{ _s6.CurrentWeatherEffect },
+                .weatherGloom = _s6.CurrentWeatherGloom,
+                .level = static_cast<WeatherLevel>(_s6.CurrentWeatherLevel),
             };
             gameState.WeatherNext = {
-                .Weather = WeatherType{ _s6.NextWeather },
-                .Temperature = static_cast<int8_t>(_s6.NextTemperature),
-                .WeatherEffect = WeatherEffectType{ _s6.NextWeatherEffect },
-                .WeatherGloom = _s6.NextWeatherGloom,
-                .Level = static_cast<WeatherLevel>(_s6.NextWeatherLevel),
+                .weatherType = WeatherType{ _s6.NextWeather },
+                .temperature = static_cast<int8_t>(_s6.NextTemperature),
+                .weatherEffect = WeatherEffectType{ _s6.NextWeatherEffect },
+                .weatherGloom = _s6.NextWeatherGloom,
+                .level = static_cast<WeatherLevel>(_s6.NextWeatherLevel),
             };
 
             // News items

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -403,7 +403,7 @@ void ScriptEngine::Initialise()
     auto ctx = static_cast<duk_context*>(_context);
     ScCheats::Register(ctx);
     ScClimate::Register(ctx);
-    ScClimateState::Register(ctx);
+    ScWeatherState::Register(ctx);
     ScConfiguration::Register(ctx);
     ScConsole::Register(ctx);
     ScContext::Register(ctx);

--- a/src/openrct2/scripting/bindings/world/ScClimate.hpp
+++ b/src/openrct2/scripting/bindings/world/ScClimate.hpp
@@ -108,15 +108,15 @@ namespace OpenRCT2::Scripting
         std::shared_ptr<ScWeatherState> current_get() const
         {
             auto& gameState = GetGameState();
-            std::string weatherType = WeatherTypeToString(gameState.WeatherCurrent.Weather);
-            return std::make_shared<ScWeatherState>(weatherType, gameState.WeatherCurrent.Temperature);
+            std::string weatherType = WeatherTypeToString(gameState.WeatherCurrent.weatherType);
+            return std::make_shared<ScWeatherState>(weatherType, gameState.WeatherCurrent.temperature);
         }
 
         std::shared_ptr<ScWeatherState> future_get() const
         {
             auto& gameState = GetGameState();
-            std::string weatherType = WeatherTypeToString(gameState.WeatherNext.Weather);
-            return std::make_shared<ScWeatherState>(weatherType, gameState.WeatherNext.Temperature);
+            std::string weatherType = WeatherTypeToString(gameState.WeatherNext.weatherType);
+            return std::make_shared<ScWeatherState>(weatherType, gameState.WeatherNext.temperature);
         }
 
         static void Register(duk_context* ctx)

--- a/src/openrct2/scripting/bindings/world/ScClimate.hpp
+++ b/src/openrct2/scripting/bindings/world/ScClimate.hpp
@@ -108,8 +108,8 @@ namespace OpenRCT2::Scripting
         std::shared_ptr<ScWeatherState> current_get() const
         {
             auto& gameState = GetGameState();
-            std::string weatherType = WeatherTypeToString(gameState.ClimateCurrent.Weather);
-            return std::make_shared<ScWeatherState>(weatherType, gameState.ClimateCurrent.Temperature);
+            std::string weatherType = WeatherTypeToString(gameState.WeatherCurrent.Weather);
+            return std::make_shared<ScWeatherState>(weatherType, gameState.WeatherCurrent.Temperature);
         }
 
         std::shared_ptr<ScWeatherState> future_get() const

--- a/src/openrct2/scripting/bindings/world/ScClimate.hpp
+++ b/src/openrct2/scripting/bindings/world/ScClimate.hpp
@@ -20,14 +20,14 @@
 
 namespace OpenRCT2::Scripting
 {
-    class ScClimateState
+    class ScWeatherState
     {
     private:
         std::string _weather;
         int8_t _temperature;
 
     public:
-        ScClimateState(std::string weather, int8_t temperature)
+        ScWeatherState(std::string weather, int8_t temperature)
             : _weather(weather)
             , _temperature(temperature)
         {
@@ -45,8 +45,8 @@ namespace OpenRCT2::Scripting
 
         static void Register(duk_context* ctx)
         {
-            dukglue_register_property(ctx, &ScClimateState::weather_get, nullptr, "weather");
-            dukglue_register_property(ctx, &ScClimateState::temperature_get, nullptr, "temperature");
+            dukglue_register_property(ctx, &ScWeatherState::weather_get, nullptr, "weather");
+            dukglue_register_property(ctx, &ScWeatherState::temperature_get, nullptr, "temperature");
         }
     };
 
@@ -105,18 +105,18 @@ namespace OpenRCT2::Scripting
             return ClimateTypeToString(gameState.Climate);
         }
 
-        std::shared_ptr<ScClimateState> current_get() const
+        std::shared_ptr<ScWeatherState> current_get() const
         {
             auto& gameState = GetGameState();
             std::string weatherType = WeatherTypeToString(gameState.ClimateCurrent.Weather);
-            return std::make_shared<ScClimateState>(weatherType, gameState.ClimateCurrent.Temperature);
+            return std::make_shared<ScWeatherState>(weatherType, gameState.ClimateCurrent.Temperature);
         }
 
-        std::shared_ptr<ScClimateState> future_get() const
+        std::shared_ptr<ScWeatherState> future_get() const
         {
             auto& gameState = GetGameState();
             std::string weatherType = WeatherTypeToString(gameState.ClimateNext.Weather);
-            return std::make_shared<ScClimateState>(weatherType, gameState.ClimateNext.Temperature);
+            return std::make_shared<ScWeatherState>(weatherType, gameState.ClimateNext.Temperature);
         }
 
         static void Register(duk_context* ctx)

--- a/src/openrct2/scripting/bindings/world/ScClimate.hpp
+++ b/src/openrct2/scripting/bindings/world/ScClimate.hpp
@@ -115,8 +115,8 @@ namespace OpenRCT2::Scripting
         std::shared_ptr<ScWeatherState> future_get() const
         {
             auto& gameState = GetGameState();
-            std::string weatherType = WeatherTypeToString(gameState.ClimateNext.Weather);
-            return std::make_shared<ScWeatherState>(weatherType, gameState.ClimateNext.Temperature);
+            std::string weatherType = WeatherTypeToString(gameState.WeatherNext.Weather);
+            return std::make_shared<ScWeatherState>(weatherType, gameState.WeatherNext.Temperature);
         }
 
         static void Register(duk_context* ctx)

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -138,14 +138,14 @@ void ClimateUpdate()
 
     if (!GetGameState().Cheats.freezeWeather)
     {
-        if (gameState.ClimateUpdateTimer)
+        if (gameState.WeatherUpdateTimer)
         {
-            if (gameState.ClimateUpdateTimer == 960)
+            if (gameState.WeatherUpdateTimer == 960)
             {
                 auto intent = Intent(INTENT_ACTION_UPDATE_CLIMATE);
                 ContextBroadcastIntent(&intent);
             }
-            gameState.ClimateUpdateTimer--;
+            gameState.WeatherUpdateTimer--;
         }
         else if (!(gameState.CurrentTicks & 0x7F))
         {
@@ -221,7 +221,7 @@ void ClimateForceWeather(WeatherType weather)
     gameState.WeatherCurrent.Level = trait.level;
     gameState.WeatherCurrent.WeatherEffect = trait.effectLevel;
     gameState.WeatherCurrent.Temperature = pattern.baseTemperature + trait.temperatureDelta;
-    gameState.ClimateUpdateTimer = 1920;
+    gameState.WeatherUpdateTimer = 1920;
 
     ClimateDetermineFutureWeather(ScenarioRand());
 
@@ -321,7 +321,7 @@ static void ClimateDetermineFutureWeather(uint32_t randomValue)
     gameState.WeatherNext.WeatherGloom = nextWeatherTrait.gloomLevel;
     gameState.WeatherNext.Level = nextWeatherTrait.level;
 
-    gameState.ClimateUpdateTimer = 1920;
+    gameState.WeatherUpdateTimer = 1920;
 }
 
 static void ClimateUpdateWeatherSound()

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -105,11 +105,11 @@ void ClimateReset(ClimateType climate)
 
     auto& gameState = GetGameState();
     gameState.Climate = climate;
-    gameState.ClimateCurrent.Weather = weather;
-    gameState.ClimateCurrent.Temperature = pattern.baseTemperature + trait.temperatureDelta;
-    gameState.ClimateCurrent.WeatherEffect = trait.effectLevel;
-    gameState.ClimateCurrent.WeatherGloom = trait.gloomLevel;
-    gameState.ClimateCurrent.Level = trait.level;
+    gameState.WeatherCurrent.Weather = weather;
+    gameState.WeatherCurrent.Temperature = pattern.baseTemperature + trait.temperatureDelta;
+    gameState.WeatherCurrent.WeatherEffect = trait.effectLevel;
+    gameState.WeatherCurrent.WeatherGloom = trait.gloomLevel;
+    gameState.WeatherCurrent.Level = trait.level;
 
     _lightningTimer = 0;
     _thunderTimer = 0;
@@ -149,39 +149,39 @@ void ClimateUpdate()
         }
         else if (!(gameState.CurrentTicks & 0x7F))
         {
-            if (gameState.ClimateCurrent.Temperature == gameState.ClimateNext.Temperature)
+            if (gameState.WeatherCurrent.Temperature == gameState.ClimateNext.Temperature)
             {
-                if (gameState.ClimateCurrent.WeatherGloom == gameState.ClimateNext.WeatherGloom)
+                if (gameState.WeatherCurrent.WeatherGloom == gameState.ClimateNext.WeatherGloom)
                 {
-                    gameState.ClimateCurrent.WeatherEffect = gameState.ClimateNext.WeatherEffect;
+                    gameState.WeatherCurrent.WeatherEffect = gameState.ClimateNext.WeatherEffect;
                     _thunderTimer = 0;
                     _lightningTimer = 0;
 
-                    if (gameState.ClimateCurrent.Level == gameState.ClimateNext.Level)
+                    if (gameState.WeatherCurrent.Level == gameState.ClimateNext.Level)
                     {
-                        gameState.ClimateCurrent.Weather = gameState.ClimateNext.Weather;
+                        gameState.WeatherCurrent.Weather = gameState.ClimateNext.Weather;
                         ClimateDetermineFutureWeather(ScenarioRand());
                         auto intent = Intent(INTENT_ACTION_UPDATE_CLIMATE);
                         ContextBroadcastIntent(&intent);
                     }
                     else if (gameState.ClimateNext.Level <= WeatherLevel::Heavy)
                     {
-                        gameState.ClimateCurrent.Level = static_cast<WeatherLevel>(ClimateStepWeatherLevel(
-                            static_cast<int8_t>(gameState.ClimateCurrent.Level),
+                        gameState.WeatherCurrent.Level = static_cast<WeatherLevel>(ClimateStepWeatherLevel(
+                            static_cast<int8_t>(gameState.WeatherCurrent.Level),
                             static_cast<int8_t>(gameState.ClimateNext.Level)));
                     }
                 }
                 else
                 {
-                    gameState.ClimateCurrent.WeatherGloom = ClimateStepWeatherLevel(
-                        gameState.ClimateCurrent.WeatherGloom, gameState.ClimateNext.WeatherGloom);
+                    gameState.WeatherCurrent.WeatherGloom = ClimateStepWeatherLevel(
+                        gameState.WeatherCurrent.WeatherGloom, gameState.ClimateNext.WeatherGloom);
                     GfxInvalidateScreen();
                 }
             }
             else
             {
-                gameState.ClimateCurrent.Temperature = ClimateStepWeatherLevel(
-                    gameState.ClimateCurrent.Temperature, gameState.ClimateNext.Temperature);
+                gameState.WeatherCurrent.Temperature = ClimateStepWeatherLevel(
+                    gameState.WeatherCurrent.Temperature, gameState.ClimateNext.Temperature);
                 auto intent = Intent(INTENT_ACTION_UPDATE_CLIMATE);
                 ContextBroadcastIntent(&intent);
             }
@@ -194,8 +194,8 @@ void ClimateUpdate()
         ClimateUpdateThunder();
     }
     else if (
-        gameState.ClimateCurrent.WeatherEffect == WeatherEffectType::Storm
-        || gameState.ClimateCurrent.WeatherEffect == WeatherEffectType::Blizzard)
+        gameState.WeatherCurrent.WeatherEffect == WeatherEffectType::Storm
+        || gameState.WeatherCurrent.WeatherEffect == WeatherEffectType::Blizzard)
     {
         // Create new thunder and lightning
         uint32_t randomNumber = UtilRand();
@@ -216,11 +216,11 @@ void ClimateForceWeather(WeatherType weather)
     const auto& pattern = kClimatePatterns[EnumValue(gameState.Climate)][month];
     const auto& trait = kClimateWeatherTraits[EnumValue(weather)];
 
-    gameState.ClimateCurrent.Weather = weather;
-    gameState.ClimateCurrent.WeatherGloom = trait.gloomLevel;
-    gameState.ClimateCurrent.Level = trait.level;
-    gameState.ClimateCurrent.WeatherEffect = trait.effectLevel;
-    gameState.ClimateCurrent.Temperature = pattern.baseTemperature + trait.temperatureDelta;
+    gameState.WeatherCurrent.Weather = weather;
+    gameState.WeatherCurrent.WeatherGloom = trait.gloomLevel;
+    gameState.WeatherCurrent.Level = trait.level;
+    gameState.WeatherCurrent.WeatherEffect = trait.effectLevel;
+    gameState.WeatherCurrent.Temperature = pattern.baseTemperature + trait.temperatureDelta;
     gameState.ClimateUpdateTimer = 1920;
 
     ClimateDetermineFutureWeather(ScenarioRand());
@@ -245,19 +245,19 @@ void ClimateUpdateSound()
 
 bool ClimateIsRaining()
 {
-    auto& weather = GetGameState().ClimateCurrent.Weather;
+    auto& weather = GetGameState().WeatherCurrent.Weather;
     return weather == WeatherType::Rain || weather == WeatherType::HeavyRain || weather == WeatherType::Thunder;
 }
 
 bool ClimateIsSnowing()
 {
-    auto& weather = GetGameState().ClimateCurrent.Weather;
+    auto& weather = GetGameState().WeatherCurrent.Weather;
     return weather == WeatherType::Snow || weather == WeatherType::HeavySnow || weather == WeatherType::Blizzard;
 }
 
 bool ClimateIsSnowingHeavily()
 {
-    auto& weather = GetGameState().ClimateCurrent.Weather;
+    auto& weather = GetGameState().WeatherCurrent.Weather;
     return weather == WeatherType::HeavySnow || weather == WeatherType::Blizzard;
 }
 
@@ -326,8 +326,8 @@ static void ClimateDetermineFutureWeather(uint32_t randomValue)
 
 static void ClimateUpdateWeatherSound()
 {
-    if (GetGameState().ClimateCurrent.WeatherEffect == WeatherEffectType::Rain
-        || GetGameState().ClimateCurrent.WeatherEffect == WeatherEffectType::Storm)
+    if (GetGameState().WeatherCurrent.WeatherEffect == WeatherEffectType::Rain
+        || GetGameState().WeatherCurrent.WeatherEffect == WeatherEffectType::Storm)
     {
         // Start playing the weather sound
         if (_weatherSoundChannel == nullptr || _weatherSoundChannel->IsDone())

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -105,11 +105,11 @@ void ClimateReset(ClimateType climate)
 
     auto& gameState = GetGameState();
     gameState.Climate = climate;
-    gameState.WeatherCurrent.Weather = weather;
-    gameState.WeatherCurrent.Temperature = pattern.baseTemperature + trait.temperatureDelta;
-    gameState.WeatherCurrent.WeatherEffect = trait.effectLevel;
-    gameState.WeatherCurrent.WeatherGloom = trait.gloomLevel;
-    gameState.WeatherCurrent.Level = trait.level;
+    gameState.WeatherCurrent.weatherType = weather;
+    gameState.WeatherCurrent.temperature = pattern.baseTemperature + trait.temperatureDelta;
+    gameState.WeatherCurrent.weatherEffect = trait.effectLevel;
+    gameState.WeatherCurrent.weatherGloom = trait.gloomLevel;
+    gameState.WeatherCurrent.level = trait.level;
 
     _lightningTimer = 0;
     _thunderTimer = 0;
@@ -149,39 +149,39 @@ void ClimateUpdate()
         }
         else if (!(gameState.CurrentTicks & 0x7F))
         {
-            if (gameState.WeatherCurrent.Temperature == gameState.WeatherNext.Temperature)
+            if (gameState.WeatherCurrent.temperature == gameState.WeatherNext.temperature)
             {
-                if (gameState.WeatherCurrent.WeatherGloom == gameState.WeatherNext.WeatherGloom)
+                if (gameState.WeatherCurrent.weatherGloom == gameState.WeatherNext.weatherGloom)
                 {
-                    gameState.WeatherCurrent.WeatherEffect = gameState.WeatherNext.WeatherEffect;
+                    gameState.WeatherCurrent.weatherEffect = gameState.WeatherNext.weatherEffect;
                     _thunderTimer = 0;
                     _lightningTimer = 0;
 
-                    if (gameState.WeatherCurrent.Level == gameState.WeatherNext.Level)
+                    if (gameState.WeatherCurrent.level == gameState.WeatherNext.level)
                     {
-                        gameState.WeatherCurrent.Weather = gameState.WeatherNext.Weather;
+                        gameState.WeatherCurrent.weatherType = gameState.WeatherNext.weatherType;
                         ClimateDetermineFutureWeather(ScenarioRand());
                         auto intent = Intent(INTENT_ACTION_UPDATE_CLIMATE);
                         ContextBroadcastIntent(&intent);
                     }
-                    else if (gameState.WeatherNext.Level <= WeatherLevel::Heavy)
+                    else if (gameState.WeatherNext.level <= WeatherLevel::Heavy)
                     {
-                        gameState.WeatherCurrent.Level = static_cast<WeatherLevel>(ClimateStepWeatherLevel(
-                            static_cast<int8_t>(gameState.WeatherCurrent.Level),
-                            static_cast<int8_t>(gameState.WeatherNext.Level)));
+                        gameState.WeatherCurrent.level = static_cast<WeatherLevel>(ClimateStepWeatherLevel(
+                            static_cast<int8_t>(gameState.WeatherCurrent.level),
+                            static_cast<int8_t>(gameState.WeatherNext.level)));
                     }
                 }
                 else
                 {
-                    gameState.WeatherCurrent.WeatherGloom = ClimateStepWeatherLevel(
-                        gameState.WeatherCurrent.WeatherGloom, gameState.WeatherNext.WeatherGloom);
+                    gameState.WeatherCurrent.weatherGloom = ClimateStepWeatherLevel(
+                        gameState.WeatherCurrent.weatherGloom, gameState.WeatherNext.weatherGloom);
                     GfxInvalidateScreen();
                 }
             }
             else
             {
-                gameState.WeatherCurrent.Temperature = ClimateStepWeatherLevel(
-                    gameState.WeatherCurrent.Temperature, gameState.WeatherNext.Temperature);
+                gameState.WeatherCurrent.temperature = ClimateStepWeatherLevel(
+                    gameState.WeatherCurrent.temperature, gameState.WeatherNext.temperature);
                 auto intent = Intent(INTENT_ACTION_UPDATE_CLIMATE);
                 ContextBroadcastIntent(&intent);
             }
@@ -194,8 +194,8 @@ void ClimateUpdate()
         ClimateUpdateThunder();
     }
     else if (
-        gameState.WeatherCurrent.WeatherEffect == WeatherEffectType::Storm
-        || gameState.WeatherCurrent.WeatherEffect == WeatherEffectType::Blizzard)
+        gameState.WeatherCurrent.weatherEffect == WeatherEffectType::Storm
+        || gameState.WeatherCurrent.weatherEffect == WeatherEffectType::Blizzard)
     {
         // Create new thunder and lightning
         uint32_t randomNumber = UtilRand();
@@ -216,11 +216,11 @@ void ClimateForceWeather(WeatherType weather)
     const auto& pattern = kClimatePatterns[EnumValue(gameState.Climate)][month];
     const auto& trait = kClimateWeatherTraits[EnumValue(weather)];
 
-    gameState.WeatherCurrent.Weather = weather;
-    gameState.WeatherCurrent.WeatherGloom = trait.gloomLevel;
-    gameState.WeatherCurrent.Level = trait.level;
-    gameState.WeatherCurrent.WeatherEffect = trait.effectLevel;
-    gameState.WeatherCurrent.Temperature = pattern.baseTemperature + trait.temperatureDelta;
+    gameState.WeatherCurrent.weatherType = weather;
+    gameState.WeatherCurrent.weatherGloom = trait.gloomLevel;
+    gameState.WeatherCurrent.level = trait.level;
+    gameState.WeatherCurrent.weatherEffect = trait.effectLevel;
+    gameState.WeatherCurrent.temperature = pattern.baseTemperature + trait.temperatureDelta;
     gameState.WeatherUpdateTimer = 1920;
 
     ClimateDetermineFutureWeather(ScenarioRand());
@@ -245,19 +245,19 @@ void ClimateUpdateSound()
 
 bool ClimateIsRaining()
 {
-    auto& weather = GetGameState().WeatherCurrent.Weather;
+    auto& weather = GetGameState().WeatherCurrent.weatherType;
     return weather == WeatherType::Rain || weather == WeatherType::HeavyRain || weather == WeatherType::Thunder;
 }
 
 bool ClimateIsSnowing()
 {
-    auto& weather = GetGameState().WeatherCurrent.Weather;
+    auto& weather = GetGameState().WeatherCurrent.weatherType;
     return weather == WeatherType::Snow || weather == WeatherType::HeavySnow || weather == WeatherType::Blizzard;
 }
 
 bool ClimateIsSnowingHeavily()
 {
-    auto& weather = GetGameState().WeatherCurrent.Weather;
+    auto& weather = GetGameState().WeatherCurrent.weatherType;
     return weather == WeatherType::HeavySnow || weather == WeatherType::Blizzard;
 }
 
@@ -269,7 +269,7 @@ bool WeatherIsDry(WeatherType weather)
 FilterPaletteID ClimateGetWeatherGloomPaletteId(const WeatherState& state)
 {
     auto paletteId = FilterPaletteID::PaletteNull;
-    auto gloom = state.WeatherGloom;
+    auto gloom = state.weatherGloom;
     if (gloom < std::size(kClimateWeatherGloomColours))
     {
         paletteId = kClimateWeatherGloomColours[gloom];
@@ -280,9 +280,9 @@ FilterPaletteID ClimateGetWeatherGloomPaletteId(const WeatherState& state)
 uint32_t ClimateGetWeatherSpriteId(const WeatherState& state)
 {
     uint32_t spriteId = SPR_WEATHER_SUN;
-    if (EnumValue(state.Weather) < std::size(kClimateWeatherTraits))
+    if (EnumValue(state.weatherType) < std::size(kClimateWeatherTraits))
     {
-        spriteId = kClimateWeatherTraits[EnumValue(state.Weather)].spriteId;
+        spriteId = kClimateWeatherTraits[EnumValue(state.weatherType)].spriteId;
     }
     return spriteId;
 }
@@ -313,21 +313,21 @@ static void ClimateDetermineFutureWeather(uint32_t randomValue)
     const auto& pattern = kClimatePatterns[EnumValue(gameState.Climate)][month];
     const auto randomIndex = ((randomValue % 256) * pattern.randomBias) / 256;
     const auto nextWeather = pattern.distribution[randomIndex];
-    gameState.WeatherNext.Weather = nextWeather;
+    gameState.WeatherNext.weatherType = nextWeather;
 
     const auto& nextWeatherTrait = kClimateWeatherTraits[EnumValue(nextWeather)];
-    gameState.WeatherNext.Temperature = pattern.baseTemperature + nextWeatherTrait.temperatureDelta;
-    gameState.WeatherNext.WeatherEffect = nextWeatherTrait.effectLevel;
-    gameState.WeatherNext.WeatherGloom = nextWeatherTrait.gloomLevel;
-    gameState.WeatherNext.Level = nextWeatherTrait.level;
+    gameState.WeatherNext.temperature = pattern.baseTemperature + nextWeatherTrait.temperatureDelta;
+    gameState.WeatherNext.weatherEffect = nextWeatherTrait.effectLevel;
+    gameState.WeatherNext.weatherGloom = nextWeatherTrait.gloomLevel;
+    gameState.WeatherNext.level = nextWeatherTrait.level;
 
     gameState.WeatherUpdateTimer = 1920;
 }
 
 static void ClimateUpdateWeatherSound()
 {
-    if (GetGameState().WeatherCurrent.WeatherEffect == WeatherEffectType::Rain
-        || GetGameState().WeatherCurrent.WeatherEffect == WeatherEffectType::Storm)
+    if (GetGameState().WeatherCurrent.weatherEffect == WeatherEffectType::Rain
+        || GetGameState().WeatherCurrent.weatherEffect == WeatherEffectType::Storm)
     {
         // Start playing the weather sound
         if (_weatherSoundChannel == nullptr || _weatherSoundChannel->IsDone())

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -266,7 +266,7 @@ bool WeatherIsDry(WeatherType weather)
     return weather == WeatherType::Sunny || weather == WeatherType::PartiallyCloudy || weather == WeatherType::Cloudy;
 }
 
-FilterPaletteID ClimateGetWeatherGloomPaletteId(const ClimateState& state)
+FilterPaletteID ClimateGetWeatherGloomPaletteId(const WeatherState& state)
 {
     auto paletteId = FilterPaletteID::PaletteNull;
     auto gloom = state.WeatherGloom;
@@ -277,7 +277,7 @@ FilterPaletteID ClimateGetWeatherGloomPaletteId(const ClimateState& state)
     return paletteId;
 }
 
-uint32_t ClimateGetWeatherSpriteId(const ClimateState& state)
+uint32_t ClimateGetWeatherSpriteId(const WeatherState& state)
 {
     uint32_t spriteId = SPR_WEATHER_SUN;
     if (EnumValue(state.Weather) < std::size(kClimateWeatherTraits))

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -149,39 +149,39 @@ void ClimateUpdate()
         }
         else if (!(gameState.CurrentTicks & 0x7F))
         {
-            if (gameState.WeatherCurrent.Temperature == gameState.ClimateNext.Temperature)
+            if (gameState.WeatherCurrent.Temperature == gameState.WeatherNext.Temperature)
             {
-                if (gameState.WeatherCurrent.WeatherGloom == gameState.ClimateNext.WeatherGloom)
+                if (gameState.WeatherCurrent.WeatherGloom == gameState.WeatherNext.WeatherGloom)
                 {
-                    gameState.WeatherCurrent.WeatherEffect = gameState.ClimateNext.WeatherEffect;
+                    gameState.WeatherCurrent.WeatherEffect = gameState.WeatherNext.WeatherEffect;
                     _thunderTimer = 0;
                     _lightningTimer = 0;
 
-                    if (gameState.WeatherCurrent.Level == gameState.ClimateNext.Level)
+                    if (gameState.WeatherCurrent.Level == gameState.WeatherNext.Level)
                     {
-                        gameState.WeatherCurrent.Weather = gameState.ClimateNext.Weather;
+                        gameState.WeatherCurrent.Weather = gameState.WeatherNext.Weather;
                         ClimateDetermineFutureWeather(ScenarioRand());
                         auto intent = Intent(INTENT_ACTION_UPDATE_CLIMATE);
                         ContextBroadcastIntent(&intent);
                     }
-                    else if (gameState.ClimateNext.Level <= WeatherLevel::Heavy)
+                    else if (gameState.WeatherNext.Level <= WeatherLevel::Heavy)
                     {
                         gameState.WeatherCurrent.Level = static_cast<WeatherLevel>(ClimateStepWeatherLevel(
                             static_cast<int8_t>(gameState.WeatherCurrent.Level),
-                            static_cast<int8_t>(gameState.ClimateNext.Level)));
+                            static_cast<int8_t>(gameState.WeatherNext.Level)));
                     }
                 }
                 else
                 {
                     gameState.WeatherCurrent.WeatherGloom = ClimateStepWeatherLevel(
-                        gameState.WeatherCurrent.WeatherGloom, gameState.ClimateNext.WeatherGloom);
+                        gameState.WeatherCurrent.WeatherGloom, gameState.WeatherNext.WeatherGloom);
                     GfxInvalidateScreen();
                 }
             }
             else
             {
                 gameState.WeatherCurrent.Temperature = ClimateStepWeatherLevel(
-                    gameState.WeatherCurrent.Temperature, gameState.ClimateNext.Temperature);
+                    gameState.WeatherCurrent.Temperature, gameState.WeatherNext.Temperature);
                 auto intent = Intent(INTENT_ACTION_UPDATE_CLIMATE);
                 ContextBroadcastIntent(&intent);
             }
@@ -313,13 +313,13 @@ static void ClimateDetermineFutureWeather(uint32_t randomValue)
     const auto& pattern = kClimatePatterns[EnumValue(gameState.Climate)][month];
     const auto randomIndex = ((randomValue % 256) * pattern.randomBias) / 256;
     const auto nextWeather = pattern.distribution[randomIndex];
-    gameState.ClimateNext.Weather = nextWeather;
+    gameState.WeatherNext.Weather = nextWeather;
 
     const auto& nextWeatherTrait = kClimateWeatherTraits[EnumValue(nextWeather)];
-    gameState.ClimateNext.Temperature = pattern.baseTemperature + nextWeatherTrait.temperatureDelta;
-    gameState.ClimateNext.WeatherEffect = nextWeatherTrait.effectLevel;
-    gameState.ClimateNext.WeatherGloom = nextWeatherTrait.gloomLevel;
-    gameState.ClimateNext.Level = nextWeatherTrait.level;
+    gameState.WeatherNext.Temperature = pattern.baseTemperature + nextWeatherTrait.temperatureDelta;
+    gameState.WeatherNext.WeatherEffect = nextWeatherTrait.effectLevel;
+    gameState.WeatherNext.WeatherGloom = nextWeatherTrait.gloomLevel;
+    gameState.WeatherNext.Level = nextWeatherTrait.level;
 
     gameState.ClimateUpdateTimer = 1920;
 }

--- a/src/openrct2/world/Climate.h
+++ b/src/openrct2/world/Climate.h
@@ -50,7 +50,7 @@ enum class WeatherLevel
     Heavy,
 };
 
-struct ClimateState
+struct WeatherState
 {
     WeatherType Weather;
     int8_t Temperature;
@@ -74,5 +74,5 @@ bool ClimateIsRaining();
 bool ClimateIsSnowing();
 bool ClimateIsSnowingHeavily();
 bool WeatherIsDry(WeatherType);
-FilterPaletteID ClimateGetWeatherGloomPaletteId(const ClimateState& state);
-uint32_t ClimateGetWeatherSpriteId(const ClimateState& state);
+FilterPaletteID ClimateGetWeatherGloomPaletteId(const WeatherState& state);
+uint32_t ClimateGetWeatherSpriteId(const WeatherState& state);

--- a/src/openrct2/world/Climate.h
+++ b/src/openrct2/world/Climate.h
@@ -52,11 +52,11 @@ enum class WeatherLevel
 
 struct WeatherState
 {
-    WeatherType Weather;
-    int8_t Temperature;
-    WeatherEffectType WeatherEffect;
-    uint8_t WeatherGloom;
-    WeatherLevel Level;
+    WeatherType weatherType;
+    int8_t temperature;
+    WeatherEffectType weatherEffect;
+    uint8_t weatherGloom;
+    WeatherLevel level;
 };
 
 extern uint16_t gClimateLightningFlash;

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -184,7 +184,7 @@ void SmallSceneryElement::UpdateAge(const CoordsXY& sceneryPos)
         return;
     }
 
-    if (!sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_CAN_BE_WATERED) || WeatherIsDry(gameState.WeatherCurrent.Weather)
+    if (!sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_CAN_BE_WATERED) || WeatherIsDry(gameState.WeatherCurrent.weatherType)
         || GetAge() < 5)
     {
         IncreaseAge(sceneryPos);

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -184,7 +184,7 @@ void SmallSceneryElement::UpdateAge(const CoordsXY& sceneryPos)
         return;
     }
 
-    if (!sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_CAN_BE_WATERED) || WeatherIsDry(gameState.ClimateCurrent.Weather)
+    if (!sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_CAN_BE_WATERED) || WeatherIsDry(gameState.WeatherCurrent.Weather)
         || GetAge() < 5)
     {
         IncreaseAge(sceneryPos);


### PR DESCRIPTION
Following up on #23755, this PR renames several more 'Climate' properties to read 'Weather' instead. This is more appropriate, as the climate is constant in the game, while the weather changes constantly.

I also wonder if we should rename the `Climate.cpp` unit to `Weather.cpp` as well, updating the functions as well. However, I think this would best be done after the climate data has been extracted to objects. It can then be done in tandem with putting the file in a namespace.

NB: This PR is intended to isolate the property and type name changes from #23774. It can be rebased easily after.