### PR TITLE
Use std::clamp in AddClamp

### DIFF
--- a/src/openrct2/util/Util.h
+++ b/src/openrct2/util/Util.h
@@ -11,6 +11,7 @@
 
 #include "../core/Money.hpp"
 
+#include <algorithm>
 #include <limits>
 #include <type_traits>
 
@@ -24,20 +25,9 @@ constexpr T AddClamp(T value, T valueToAdd)
     {
         static_assert(sizeof(money64) == sizeof(int64_t));
     }
-    auto maxCap = std::numeric_limits<T>::max();
     auto minCap = std::numeric_limits<T>::lowest();
-    if ((valueToAdd > 0) && (value > (maxCap - (valueToAdd))))
-    {
-        return maxCap;
-    }
-    else if ((valueToAdd < 0) && (value < (minCap - (valueToAdd))))
-    {
-        return minCap;
-    }
-    else
-    {
-        return value + valueToAdd;
-    }
+    auto maxCap = std::numeric_limits<T>::max();
+    return std::clamp(value + valueToAdd, minCap, maxCap);
 }
 
 uint8_t Lerp(uint8_t a, uint8_t b, float t);


### PR DESCRIPTION
Simplifies AddClamp by using `std::clamp`. I did some preliminary testing but I'd really appreciate if someone could help test this more extensively.

I didn't explicitly add the template argument `<T>` in the call to clamp but I believe that shouldn't be an issue because the AddClamp already has a return type of `T`. I can change this if necessary.