### PR TITLE
Change StaffHireArgs params to reflect internal visitor

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1206,7 +1206,7 @@ declare global {
     interface StaffHireArgs extends GameActionArgs {
         autoPosition: boolean;
         staffType: number; // 0: handyman, 1: mechanic, 2: security, 3: entertainer
-        entertainerType: number; // see EntertainerCostume in openrct2/entity/Staff.h
+        costumeIndex: number; // peep animation object id to use as costume
         staffOrders: number; // bit mask. See STAFF_ORDERS in openrct2/entity/Staff.h
     }
 


### PR DESCRIPTION
The old `entertainerType` parameter was changed to `costumeIndex` when peep animation objects were introduced in #23328. The `StaffHireArgs` in `openrct2.d.ts` hadn't been changed to reflect this.

First step towards addressing #23790.