### PR TITLE
Fix #23522: Steeplechase diagonal sloped support base glitched sprites

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Improved: [#23677] Building new ride track now inherits the colour scheme from the previous piece.
 - Fix: [#22617] Sloped Wooden and Side-Friction supports draw out of order when built directly above diagonal track pieces.
+- Fix: [#23522] Diagonal sloped Steeplechase supports have glitched sprites at the base.
 - Fix: [#23795] Looping Roller Coaster vertical loop supports are drawn incorrectly.
 
 0.4.19.1 (2025-02-03)

--- a/src/openrct2/paint/support/MetalSupports.cpp
+++ b/src/openrct2/paint/support/MetalSupports.cpp
@@ -199,13 +199,13 @@ static constexpr MetalSupportsImages kSupportBasesAndBeams[] = {
     { 3279, 3262, 3262 }, // MetalSupportGraphic::Fork
     { 3298, 3262, 3262 }, // MetalSupportGraphic::ForkAlt
     { 3334, 3317, 3317 }, // MetalSupportGraphic::Boxed
-    {    0, 3658, 3658 }, // MetalSupportGraphic::Stick
-    {    0, 3658, 3658 }, // MetalSupportGraphic::StickAlt
-    {    0, 3141, 3141 }, // MetalSupportGraphic::ThickCentred
-    {    0, 3158, 3158 }, // MetalSupportGraphic::Thick
-    {    0, 3175, 3175 }, // MetalSupportGraphic::ThickAlt
-    {    0, 3192, 3192 }, // MetalSupportGraphic::ThickAltCentred
-    {    0, 3124, 3124 }, // MetalSupportGraphic::Truss
+    { kImageIndexUndefined, 3658, 3658 }, // MetalSupportGraphic::Stick
+    { kImageIndexUndefined, 3658, 3658 }, // MetalSupportGraphic::StickAlt
+    { kImageIndexUndefined, 3141, 3141 }, // MetalSupportGraphic::ThickCentred
+    { kImageIndexUndefined, 3158, 3158 }, // MetalSupportGraphic::Thick
+    { kImageIndexUndefined, 3175, 3175 }, // MetalSupportGraphic::ThickAlt
+    { kImageIndexUndefined, 3192, 3192 }, // MetalSupportGraphic::ThickAltCentred
+    { kImageIndexUndefined, 3124, 3124 }, // MetalSupportGraphic::Truss
     { 3243, 3209, 3226 }, // MetalSupportGraphic::TubesInverted
     { 3334, 3353, 3353 }, // MetalSupportGraphic::BoxedCoated
 };
@@ -366,7 +366,7 @@ static bool MetalASupportsPaintSetup(
     }
     int16_t si = height;
     if (supportSegments[segment].slope & kTileSlopeAboveTrackOrScenery || height - supportSegments[segment].height < 6
-        || kSupportBasesAndBeams[supportType].base == 0)
+        || kSupportBasesAndBeams[supportType].base == kImageIndexUndefined)
     {
         height = supportSegments[segment].height;
     }
@@ -583,7 +583,7 @@ static bool MetalBSupportsPaintSetup(
     int32_t si = baseHeight;
 
     if ((supportSegments[segment].slope & kTileSlopeAboveTrackOrScenery) || (baseHeight - supportSegments[segment].height < 6)
-        || (kSupportBasesAndBeams[supportType].beamA == 0))
+        || (kSupportBasesAndBeams[supportType].base == kImageIndexUndefined))
     {
         baseHeight = supportSegments[segment].height;
     }


### PR DESCRIPTION
This fixes the glitched sprites under the steeplechase diagonal sloped track. The issue here is that the B type supports were checking if the wrong image index was invalid when drawing footers. I've swapped the 0s out to kImageIndexUndefined, and fixed the check.