### PR TITLE
Fix #16357: Chairlift station covers draw incorrectly

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.20 (in development)
 ------------------------------------------------------------------------
 - Improved: [#23677] Building new ride track now inherits the colour scheme from the previous piece.
+- Fix: [#16357] Chairlift station covers draw incorrectly.
 - Fix: [#21768] Dirty blocks debug overlay is rendered incorrectly on high DPI screens.
 - Fix: [#22617] Sloped Wooden and Side-Friction supports draw out of order when built directly above diagonal track pieces.
 - Fix: [#23522] Diagonal sloped Steeplechase supports have glitched sprites at the base.

--- a/src/openrct2/paint/track/transport/Chairlift.cpp
+++ b/src/openrct2/paint/track/transport/Chairlift.cpp
@@ -208,7 +208,7 @@ static void ChairliftPaintStationNeSw(
     if (!isStart && !isEnd)
     {
         imageId = session.TrackColours.WithIndex(((direction == 0) ? SPR_20502 : SPR_20504));
-        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 0, 13, height + 28 }, { 32, 6, 2 } });
+        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 0, 13, height + 22 }, { 32, 6, 1 } });
     }
 
     imageId = session.SupportColours.WithIndex(SPR_FLOOR_METAL);
@@ -232,7 +232,7 @@ static void ChairliftPaintStationNeSw(
     if (hasFence)
     {
         imageId = session.TrackColours.WithIndex(SPR_FENCE_METAL_SE);
-        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 0, 30, height + 2 }, { 32, 1, 27 } });
+        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 0, 30, height + 2 }, { 32, 1, 20 } });
     }
     TrackPaintUtilDrawStationCovers(session, EDGE_SE, hasFence, stationObj, height, stationColour);
 
@@ -301,7 +301,7 @@ static void ChairliftPaintStationSeNw(
     if (!isStart && !isEnd)
     {
         imageId = session.TrackColours.WithIndex(((direction == 1) ? SPR_20503 : SPR_20505));
-        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 13, 0, height + 28 }, { 6, 32, 2 } });
+        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 13, 0, height + 22 }, { 6, 32, 1 } });
     }
 
     imageId = session.SupportColours.WithIndex(SPR_FLOOR_METAL);
@@ -325,7 +325,7 @@ static void ChairliftPaintStationSeNw(
     if (hasFence)
     {
         imageId = session.TrackColours.WithIndex(SPR_FENCE_METAL_SW);
-        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 30, 0, height + 2 }, { 1, 32, 27 } });
+        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 30, 0, height + 2 }, { 1, 32, 20 } });
     }
     TrackPaintUtilDrawStationCovers(session, EDGE_SW, hasFence, stationObj, height, stationColour);
 

--- a/src/openrct2/paint/track/transport/Chairlift.cpp
+++ b/src/openrct2/paint/track/transport/Chairlift.cpp
@@ -244,20 +244,20 @@ static void ChairliftPaintStationNeSw(
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 30, 2, height + 4 }, { 1, 28, 27 } });
 
         imageId = session.TrackColours.WithIndex(chairlift_bullwheel_frames[ride.chairlift_bullwheel_rotation / 16384]);
-        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 14, 14, height + 4 }, { 4, 4, 26 } });
+        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 14, 14, height + 4 }, { 4, 4, 19 } });
 
         imageId = session.TrackColours.WithIndex(SPR_CHAIRLIFT_STATION_END_CAP_NE);
-        PaintAddImageAsChild(session, imageId, { 0, 0, height }, { { 14, 14, height + 4 }, { 4, 4, 26 } });
+        PaintAddImageAsChild(session, imageId, { 0, 0, height }, { { 14, 14, height + 4 }, { 4, 4, 19 } });
 
         drawFrontColumn = false;
     }
     else if ((direction == 2 && isStart) || (direction == 0 && isEnd))
     {
         imageId = session.TrackColours.WithIndex(chairlift_bullwheel_frames[ride.chairlift_bullwheel_rotation / 16384]);
-        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 14, 14, height + 4 }, { 4, 4, 26 } });
+        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 14, 14, height + 4 }, { 4, 4, 19 } });
 
         imageId = session.TrackColours.WithIndex(SPR_CHAIRLIFT_STATION_END_CAP_SW);
-        PaintAddImageAsChild(session, imageId, { 0, 0, height }, { { 14, 14, height + 4 }, { 4, 4, 26 } });
+        PaintAddImageAsChild(session, imageId, { 0, 0, height }, { { 14, 14, height + 4 }, { 4, 4, 19 } });
 
         drawBackColumn = false;
     }
@@ -334,10 +334,10 @@ static void ChairliftPaintStationSeNw(
     if ((direction == 1 && isStart) || (direction == 3 && isEnd))
     {
         imageId = session.TrackColours.WithIndex(chairlift_bullwheel_frames[ride.chairlift_bullwheel_rotation / 16384]);
-        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 14, 14, height + 4 }, { 4, 4, 26 } });
+        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 14, 14, height + 4 }, { 4, 4, 19 } });
 
         imageId = session.TrackColours.WithIndex(SPR_CHAIRLIFT_STATION_END_CAP_SE);
-        PaintAddImageAsChild(session, imageId, { 0, 0, height }, { { 14, 14, height + 4 }, { 4, 4, 26 } });
+        PaintAddImageAsChild(session, imageId, { 0, 0, height }, { { 14, 14, height + 4 }, { 4, 4, 19 } });
 
         drawLeftColumn = false;
     }
@@ -348,7 +348,7 @@ static void ChairliftPaintStationSeNw(
 
         imageId = session.TrackColours.WithIndex(chairlift_bullwheel_frames[ride.chairlift_bullwheel_rotation / 16384]);
 
-        auto bb = BoundBoxXYZ{ { 14, 14, height + 4 }, { 4, 4, 26 } };
+        auto bb = BoundBoxXYZ{ { 14, 14, height + 4 }, { 4, 4, 19 } };
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, bb);
 
         imageId = session.TrackColours.WithIndex(SPR_CHAIRLIFT_STATION_END_CAP_NW);


### PR DESCRIPTION
This fixes #16357 chairlift stations drawing incorrectly. I've lowered the bounding box heights for the fences and station tops the minimum amount necessary to fix the draw order. As far as I can tell, this still draws correctly without the station covers too.

Here's a picture from RCT2 showing the original draw order of the fences and station pieces:
![chairliftrct2](https://github.com/user-attachments/assets/6620273f-4cf9-4973-b026-3b4e49819bab)

And here's a picture from ORCT2 showing how it looked and how it looks with this fix:
![chairliftstationsfixed](https://github.com/user-attachments/assets/304b2e02-9539-442a-8740-6da5a1ff50a6)
