### PR TITLE
Fix train glitching on Bobsleigh Coaster small helixes

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Fix: [#22617] Sloped Wooden and Side-Friction supports draw out of order when built directly above diagonal track pieces.
 - Fix: [#23522] Diagonal sloped Steeplechase supports have glitched sprites at the base.
 - Fix: [#23795] Looping Roller Coaster vertical loop supports are drawn incorrectly.
+- Fix: [#23809] Trains glitch on Bobsleigh Coaster small helixes.
 
 0.4.19.1 (2025-02-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/coaster/BobsleighCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/BobsleighCoaster.cpp
@@ -2314,7 +2314,7 @@ static void BobsleighRCTrackLeftHalfBankedHelixUpSmall(
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(14884), { 0, 0, height },
-                        { { 0, 6, height + 8 }, { 32, 20, 2 } });
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(14896), { 0, 0, height },
                         { { 0, 6, height + 27 }, { 32, 20, 0 } });
@@ -2551,7 +2551,7 @@ static void BobsleighRCTrackLeftHalfBankedHelixUpSmall(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(14882), { 0, 0, height },
-                        { { 0, 6, height + 8 }, { 32, 20, 2 } });
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(14894), { 0, 0, height },
                         { { 0, 6, height + 27 }, { 32, 20, 0 } });


### PR DESCRIPTION
This fixes glitching on the small helixes of the Bobsleigh Coaster. Some of the bounding boxes were raised, so I lowered them to the same height as other tracks helixes. This glitch is not in RCT1 or 2.


https://github.com/user-attachments/assets/f8840fa4-37cd-4a4a-b431-a3cb224e7812


https://github.com/user-attachments/assets/8c299609-c382-43dc-b338-624c3d5f8bdf

