### PR TITLE
Fix #18389: Gentle sloped track is not visible in fallback tunnels

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Fix: [#16357] Chairlift station covers draw incorrectly.
 - Fix: [#16657] Mine Ride right S-bend uses Mini Roller Coaster sprite (original bug).
 - Fix: [#18376] Ghost train gentle to flat track is not visible in tunnels.
+- Fix: [#18389] Gentle sloped track pieces are not visible in low clearance height tunnels (original bug).
 - Fix: [#18423] Underground Mini Golf holes can draw over land edges (original bug).
 - Fix: [#18436] Scenery on the same tile as steep to vertical track can draw over the track (original bug).
 - Fix: [#18711] Park entrances with their sides underground can cause glitching.

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -171,7 +171,7 @@ static constexpr TunnelDescriptor kTunnels[] = {
     { 3, 5, -32,  4, TunnelType::StandardFlat,        44 },  // TunnelType::StandardSlopeEnd
     { 3, 3, 0,   15, TunnelType::InvertedFlat,        48 },  // TunnelType::InvertedFlat
     { 4, 4, 0,   15, TunnelType::InvertedFlat,        52 },  // TunnelType::InvertedSlopeStart
-    { 4, 6, -48,  4, TunnelType::InvertedFlat,        56 },  // TunnelType::InvertedSlopeEnd
+    { 4, 7, -48,  4, TunnelType::InvertedFlat,        56 },  // TunnelType::InvertedSlopeEnd
     { 2, 2, 0,   15, TunnelType::SquareFlat,          60 },  // TunnelType::SquareFlat
     { 3, 3, 0,   15, TunnelType::SquareFlat,          64 },  // TunnelType::SquareSlopeStart
     { 3, 5, -32,  4, TunnelType::SquareFlat,          68 },  // TunnelType::SquareSlopeEnd
@@ -658,7 +658,8 @@ static void ViewportSurfaceDrawTileSideBottom(
 
         // Tunnels
         auto tunnelType = tunnelArray[tunnelIndex].type;
-        auto td = kTunnels[EnumValue(tunnelType)];
+        const auto tdOriginal = kTunnels[EnumValue(tunnelType)];
+        auto td = tdOriginal;
         uint8_t tunnelHeight = td.height;
         int16_t zOffset = curHeight;
 
@@ -671,8 +672,10 @@ static void ViewportSurfaceDrawTileSideBottom(
 
         zOffset *= 16;
 
-        int16_t boundBoxOffsetZ = zOffset + td.boundBoxZOffset;
-        int8_t boundBoxLength = td.boundBoxLength * 16;
+        const int8_t boundBoxLengthBase = (tdOriginal.boundBoxLength + (td.height - tdOriginal.height)) * 16;
+
+        int16_t boundBoxOffsetZ = zOffset + tdOriginal.boundBoxZOffset;
+        int8_t boundBoxLength = boundBoxLengthBase;
         if (boundBoxOffsetZ < 16)
         {
             boundBoxOffsetZ += 16;
@@ -684,8 +687,8 @@ static void ViewportSurfaceDrawTileSideBottom(
             session, imageId, { offset, zOffset }, { { 0, 0, boundBoxOffsetZ }, { tunnelBounds, boundBoxLength - 1 } });
 
         boundBoxOffsetZ = curHeight * kCoordsZPerTinyZ;
-        boundBoxLength = td.boundBoxLength * 16;
-        boundBoxOffsetZ += td.boundBoxZOffset;
+        boundBoxLength = boundBoxLengthBase;
+        boundBoxOffsetZ += tdOriginal.boundBoxZOffset;
         if (boundBoxOffsetZ == 0)
         {
             boundBoxOffsetZ += 16;


### PR DESCRIPTION
This fixes #18389 and #18796 gentle slopes not being visible in low clearance height fallback tunnels. It does this by using the bounding box values of the non fallback tunnel. I changed the length of the InvertedSlopeEnd as it seems to be too low and it was affecting the look of the fallback tunnel with this calculation.

![gentleslopetunnelglitch](https://github.com/user-attachments/assets/0e024608-451b-4894-bd23-cb9204909afc)


https://github.com/user-attachments/assets/1635121d-4e3a-468f-b451-a23b9ae8ee69


https://github.com/user-attachments/assets/70920198-1ac5-4288-987d-830470362a03

