### PR TITLE
Fix #18376: Ghost train gentle to flat track is not visible in tunnels

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Fix: [#9999, #10000, #10001, #10002, #10003] Truncated scenario strings when using Catalan, Czech, Japanese, Polish or Russian.
 - Fix: [#16357] Chairlift station covers draw incorrectly.
 - Fix: [#16657] Mine Ride right S-bend uses Mini Roller Coaster sprite (original bug).
+- Fix: [#18376] Ghost train gentle to flat track is not visible in tunnels.
 - Fix: [#18436] Scenery on the same tile as steep to vertical track can draw over the track (original bug).
 - Fix: [#18711] Park entrances with their sides underground can cause glitching.
 - Fix: [#21768] Dirty blocks debug overlay is rendered incorrectly on high DPI screens.

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -189,7 +189,15 @@ static constexpr TunnelDescriptor kTunnels[] = {
     { 2, 2, 0,   15, TunnelType::Doors4,              92 },  // TunnelType::Doors4
     { 2, 2, 0,   15, TunnelType::Doors5,              96 },  // TunnelType::Doors5
     { 2, 2, 0,   15, TunnelType::Doors6,              100 }, // TunnelType::Doors6
+    { 2, 3, -16,  4, TunnelType::Doors0,              76 },  // TunnelType::DoorsFlatTo25Deg0
+    { 2, 3, -16,  4, TunnelType::Doors1,              80 },  // TunnelType::DoorsFlatTo25Deg1
+    { 2, 3, -16,  4, TunnelType::Doors2,              84 },  // TunnelType::DoorsFlatTo25Deg2
+    { 2, 3, -16,  4, TunnelType::Doors3,              88 },  // TunnelType::DoorsFlatTo25Deg3
+    { 2, 3, -16,  4, TunnelType::Doors4,              92 },  // TunnelType::DoorsFlatTo25Deg4
+    { 2, 3, -16,  4, TunnelType::Doors5,              96 },  // TunnelType::DoorsFlatTo25Deg5
+    { 2, 3, -16,  4, TunnelType::Doors6,              100 }, // TunnelType::DoorsFlatTo25Deg6
 };
+static_assert(std::size(kTunnels) == EnumValue(TunnelType::Count));
 
 // clang-format on
 // tunnel offset

--- a/src/openrct2/paint/tile_element/Paint.Tunnel.h
+++ b/src/openrct2/paint/tile_element/Paint.Tunnel.h
@@ -45,6 +45,14 @@ enum class TunnelType : uint8_t
     Doors5 = 21,
     Doors6 = 22,
 
+    DoorsFlatTo25Deg0 = 23,
+    DoorsFlatTo25Deg1 = 24,
+    DoorsFlatTo25Deg2 = 25,
+    DoorsFlatTo25Deg3 = 26,
+    DoorsFlatTo25Deg4 = 27,
+    DoorsFlatTo25Deg5 = 28,
+    DoorsFlatTo25Deg6 = 29,
+
     Count,
 
     Null = 255,

--- a/src/openrct2/paint/track/gentle/GhostTrain.cpp
+++ b/src/openrct2/paint/track/gentle/GhostTrain.cpp
@@ -189,6 +189,26 @@ static TunnelType GetTunnelDoorsImageStraightFlat(const TrackElement& trackEleme
     return TunnelType::Doors2;
 }
 
+static constexpr TunnelType kDoorFlatTo25DegOpeningOutwardsToImage[] = {
+    TunnelType::DoorsFlatTo25Deg2, // Closed
+    TunnelType::DoorsFlatTo25Deg2, // Unused?
+    TunnelType::DoorsFlatTo25Deg3, // Half open
+    TunnelType::DoorsFlatTo25Deg4, // Fully open
+    TunnelType::DoorsFlatTo25Deg2, // Unused?
+    TunnelType::DoorsFlatTo25Deg2, // Unused?
+    TunnelType::DoorsFlatTo25Deg2, // Unused?
+};
+
+static constexpr TunnelType kDoorFlatTo25DegOpeningInwardsToImage[] = {
+    TunnelType::DoorsFlatTo25Deg2, // Closed
+    TunnelType::DoorsFlatTo25Deg2, // Unused?
+    TunnelType::DoorsFlatTo25Deg5, // Half open
+    TunnelType::DoorsFlatTo25Deg6, // Fully open
+    TunnelType::DoorsFlatTo25Deg2, // Unused?
+    TunnelType::DoorsFlatTo25Deg2, // Unused?
+    TunnelType::DoorsFlatTo25Deg2, // Unused?
+};
+
 /** rct2: 0x00770BEC */
 static void PaintGhostTrainTrackFlat(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
@@ -341,10 +361,10 @@ static void PaintGhostTrainTrack25DegUpToFlat(
             PaintUtilPushTunnelLeft(session, height - 8, kTunnelGroupIncline, TunnelSubType::Flat);
             break;
         case 1:
-            PaintUtilPushTunnelRight(session, height + 8, kDoorOpeningOutwardsToImage[trackElement.GetDoorBState()]);
+            PaintUtilPushTunnelRight(session, height + 8, kDoorFlatTo25DegOpeningOutwardsToImage[trackElement.GetDoorBState()]);
             break;
         case 2:
-            PaintUtilPushTunnelLeft(session, height + 8, kDoorOpeningOutwardsToImage[trackElement.GetDoorBState()]);
+            PaintUtilPushTunnelLeft(session, height + 8, kDoorFlatTo25DegOpeningOutwardsToImage[trackElement.GetDoorBState()]);
             break;
         case 3:
             PaintUtilPushTunnelRight(session, height - 8, kTunnelGroupIncline, TunnelSubType::Flat);
@@ -374,10 +394,10 @@ static void PaintGhostTrainTrackFlatTo25DegDown(
             PaintUtilPushTunnelLeft(session, height - 8, kTunnelGroupIncline, TunnelSubType::Flat);
             break;
         case 1:
-            PaintUtilPushTunnelRight(session, height + 8, kDoorOpeningInwardsToImage[trackElement.GetDoorAState()]);
+            PaintUtilPushTunnelRight(session, height + 8, kDoorFlatTo25DegOpeningInwardsToImage[trackElement.GetDoorAState()]);
             break;
         case 2:
-            PaintUtilPushTunnelLeft(session, height + 8, kDoorOpeningInwardsToImage[trackElement.GetDoorAState()]);
+            PaintUtilPushTunnelLeft(session, height + 8, kDoorFlatTo25DegOpeningInwardsToImage[trackElement.GetDoorAState()]);
             break;
         case 3:
             PaintUtilPushTunnelRight(session, height - 8, kTunnelGroupIncline, TunnelSubType::Flat);


### PR DESCRIPTION
This fixes #18376 Ghost train gentle to flat track not being visible in tunnels. The issue here is that it always draws a door tunnel, even when the landscape edges don't have them, which has bounding boxes meant for flat track. There may be a better way to refactor this code here but I have just added a second set of FlatTo25Deg door tunnels, which look the same but have different bounding boxes.

![ghosttraintunnelglitch](https://github.com/user-attachments/assets/3a7be0b9-f1d5-4f1b-8b4c-604039e18fa6)

This will work best with #23811, as it exposes that bug on this piece.