### PR TITLE
Fix #20848: Junior Coaster booster track draws incorrectly in tunnels

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Fix: [#18376] Ghost train gentle to flat track is not visible in tunnels.
 - Fix: [#18436] Scenery on the same tile as steep to vertical track can draw over the track (original bug).
 - Fix: [#18711] Park entrances with their sides underground can cause glitching.
+- Fix: [#20848] Junior Roller Coaster booster track does not draw correctly in tunnels.
 - Fix: [#21768] Dirty blocks debug overlay is rendered incorrectly on high DPI screens.
 - Fix: [#22229] Opening a park save file from a newer version of OpenRCT2 yields an unhelpful error message.
 - Fix: [#22617] Sloped Wooden and Side-Friction supports draw out of order when built directly above diagonal track pieces (original bug).

--- a/resources/g2/sprites.json
+++ b/resources/g2/sprites.json
@@ -2665,8 +2665,8 @@
     },
     {
         "path": "track/junior/booster_1.png",
-        "x": -21,
-        "y": 0
+        "x": -22,
+        "y": 1
     },
     {
         "path": "track/junior/booster_2.png",

--- a/src/openrct2/paint/track/coaster/JuniorRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/JuniorRollerCoaster.cpp
@@ -5759,14 +5759,16 @@ static void JuniorRCBoosterPaintSetup(
     if (direction & 1)
     {
         PaintAddImageAsParent(
-            session, session.TrackColours.WithIndex(SPR_JUNIOR_RC_BOOSTER_NE_SW), { 0, 0, height }, { 20, 32, 1 });
+            session, session.TrackColours.WithIndex(SPR_JUNIOR_RC_BOOSTER_NE_SW), { 0, 0, height },
+            { { 6, 0, height }, { 20, 32, 1 } });
 
         PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::Flat);
     }
     else
     {
         PaintAddImageAsParent(
-            session, session.TrackColours.WithIndex(SPR_JUNIOR_RC_BOOSTER_NW_SE), { 0, 0, height }, { 32, 20, 1 });
+            session, session.TrackColours.WithIndex(SPR_JUNIOR_RC_BOOSTER_NW_SE), { 0, 0, height },
+            { { 0, 6, height }, { 32, 20, 1 } });
 
         PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::Flat);
     }


### PR DESCRIPTION
This fixes #20848 junior roller coaster booster track not drawing correctly in tunnels. The bounding boxes for these pieces were slightly different to normal flat track, so i've just given them the flat track bounding boxes. One of the sprites was also very slightly misaligned so i've fixed that too.

![juniorcoasterboosterpiecefix](https://github.com/user-attachments/assets/a520f09c-afec-42cf-914b-591e99476232)
