### PR TITLE
Fix #22620: RCT1 Mine Coaster trains glitch on large banked turns

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Improved: [#23677] Building new ride track now inherits the colour scheme from the previous piece.
 - Fix: [#21768] Dirty blocks debug overlay is rendered incorrectly on high DPI screens.
 - Fix: [#22617] Sloped Wooden and Side-Friction supports draw out of order when built directly above diagonal track pieces.
+- Fix: [#22620] RCT1 Mine Train Coaster trains glitch on large banked turns.
 - Fix: [#23522] Diagonal sloped Steeplechase supports have glitched sprites at the base.
 - Fix: [#23795] Looping Roller Coaster vertical loop supports are drawn incorrectly.
 - Fix: [#23809] Trains glitch on Bobsleigh Coaster small helixes.

--- a/src/openrct2/paint/track/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/MineTrainCoaster.cpp
@@ -5024,7 +5024,7 @@ static void MineTrainRCTrackLeftEighthBankToDiag(
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(20496), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 32, 1 } });
+                        { { 0, 0, height }, { 32, 32, 1 } });
                     WoodenASupportsPaintSetup(
                         session, supportType.wooden, WoodenSupportSubType::NwSe, height, session.SupportColours);
                     break;


### PR DESCRIPTION
This fixes #22620 RCT1 Mine Coaster trains glitching on large banked turns. The bounding box for this section of track was almost completely on a different tile. I've moved it back where it should be.

![minetrainlargeturnfix](https://github.com/user-attachments/assets/295808a8-b728-4659-946e-e8f3115c5a5c)
