### PR TITLE
Fix spinning tunnels drawing over sloped terrain in front of them

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Fix: [#23522] Diagonal sloped Steeplechase supports have glitched sprites at the base.
 - Fix: [#23795] Looping Roller Coaster vertical loop supports are drawn incorrectly.
 - Fix: [#23809] Trains glitch on Bobsleigh Coaster small helixes.
+- Fix: [#23818] Spinning tunnels can draw over sloped terrain in front of them.
 
 0.4.19.1 (2025-02-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -1749,11 +1749,11 @@ void TrackPaintUtilSpinningTunnelPaint(PaintSession& session, int8_t thickness, 
     imageId = colourFlags.WithIndex(trackSpritesGhostTrainSpinningTunnel[direction & 1][1][frame]);
     if (direction == 0 || direction == 2)
     {
-        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 4, 28, height }, { 26, 1, 23 } });
+        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 2, 28, height }, { 28, 1, 23 } });
     }
     else
     {
-        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 28, 4, height }, { 1, 26, 23 } });
+        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 28, 2, height }, { 1, 28, 23 } });
     }
 }
 


### PR DESCRIPTION
This fixes spinning tunnels drawing over some sloped terrain that is in front of them. It does this by slightly widening the bounding boxes of the foreground tunnel sprites.

Here's how it looks in RCT1:
![spinningtunnelrct1](https://github.com/user-attachments/assets/3ae4218b-7753-483b-8be2-8d1aa0c61f96)

And here's how it currently looks in ORCT2:
![spinningtunnelglitch](https://github.com/user-attachments/assets/912f36d3-4c81-44b8-a455-40ab2292456a)
