### PR TITLE
Fix #1972 #11679: Vehicles passing by toilets can cause them to glitch

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.20 (in development)
 ------------------------------------------------------------------------
 - Improved: [#23677] Building new ride track now inherits the colour scheme from the previous piece.
+- Fix: [#1972, #11679] Vehicles passing by toilets can cause them to glitch.
 - Fix: [#9999, #10000, #10001, #10002, #10003] Truncated scenario strings when using Catalan, Czech, Japanese, Polish or Russian.
 - Fix: [#21768] Dirty blocks debug overlay is rendered incorrectly on high DPI screens.
 - Fix: [#22617] Sloped Wooden and Side-Friction supports draw out of order when built directly above diagonal track pieces.

--- a/src/openrct2/paint/track/shops/Facility.cpp
+++ b/src/openrct2/paint/track/shops/Facility.cpp
@@ -42,11 +42,10 @@ static void PaintFacility(
     if (firstCarEntry == nullptr)
         return;
 
-    auto lengthX = (direction & 1) == 0 ? 28 : 2;
-    auto lengthY = (direction & 1) == 0 ? 2 : 28;
-    CoordsXYZ offset(0, 0, height);
-    BoundBoxXYZ bb = { { direction == 3 ? 28 : 2, direction == 0 ? 28 : 2, height },
-                       { lengthX, lengthY, trackElement.GetClearanceZ() - trackElement.GetBaseZ() - 3 } };
+    const auto lengthZ = trackElement.GetClearanceZ() - trackElement.GetBaseZ() - 3;
+    const CoordsXYZ offset(0, 0, height);
+    const BoundBoxXYZ bb = (direction == 0 || direction == 3) ? BoundBoxXYZ{ { 2, 2, height + lengthZ }, { 28, 28, 1 } }
+                                                              : BoundBoxXYZ{ { 2, 2, height }, { 28, 8, lengthZ } };
 
     auto imageTemplate = session.TrackColours;
     auto imageIndex = firstCarEntry->base_image_id + ((direction + 2) & 3);
@@ -57,21 +56,21 @@ static void PaintFacility(
         auto foundationImageIndex = (direction & 1) ? SPR_FLOOR_PLANKS_90_DEG : SPR_FLOOR_PLANKS;
         auto foundationImageId = foundationImageTemplate.WithIndex(foundationImageIndex);
         PaintAddImageAsParent(session, foundationImageId, offset, bb);
-        PaintAddImageAsChild(session, imageId, offset, bb);
+        PaintAddImageAsChildRotated(session, direction, imageId, offset, bb);
     }
     else
     {
-        PaintAddImageAsParent(session, imageId, offset, bb);
+        PaintAddImageAsParentRotated(session, direction, imageId, offset, bb);
     }
 
     // Base image if door was drawn
     if (direction == 1)
     {
-        PaintAddImageAsParent(session, imageId.WithIndexOffset(2), offset, { { 28, 2, height }, { 2, 28, 29 } });
+        PaintAddImageAsParent(session, imageId.WithIndexOffset(2), offset, { { 2, 2, height + lengthZ }, { 28, 28, 1 } });
     }
     else if (direction == 2)
     {
-        PaintAddImageAsParent(session, imageId.WithIndexOffset(4), offset, { { 2, 28, height }, { 28, 2, 29 } });
+        PaintAddImageAsParent(session, imageId.WithIndexOffset(4), offset, { { 2, 2, height + lengthZ }, { 28, 28, 1 } });
     }
 
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);


### PR DESCRIPTION
This fixes #1972 and #11679 vehicles passing by toilets causing them to glitch. I've changed the bounding boxes for the toilets quite a bit in order to get them to stop glitching and also cover peeps correctly. The main issue was that they were using zero width bounding boxes that obviously didn't interact well with other things.


https://github.com/user-attachments/assets/efb97791-fbeb-41df-824d-f411f3363974


https://github.com/user-attachments/assets/ebaaf0b1-b16e-4a65-9741-e2f4fccaba06


https://github.com/user-attachments/assets/83565ab0-6801-4c59-8d19-bd442ec5b918


https://github.com/user-attachments/assets/9dec5e2f-6b3a-4e50-9bc0-08f848fdfe9e


https://github.com/user-attachments/assets/52b34abc-9d33-44ae-9450-15df3f23abbb

