### PR TITLE
Fix #18711: Underground park entrance sides can cause glitching

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Fix: [#16357] Chairlift station covers draw incorrectly.
 - Fix: [#16657] Mine Ride right S-bend uses Mini Roller Coaster sprite (original bug).
 - Fix: [#18436] Scenery on the same tile as steep to vertical track can draw over the track (original bug).
+- Fix: [#18711] Park entrances with their sides underground can cause glitching.
 - Fix: [#21768] Dirty blocks debug overlay is rendered incorrectly on high DPI screens.
 - Fix: [#22229] Opening a park save file from a newer version of OpenRCT2 yields an unhelpful error message.
 - Fix: [#22617] Sloped Wooden and Side-Friction supports draw out of order when built directly above diagonal track pieces (original bug).

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -323,9 +323,8 @@ static void PaintParkEntrance(PaintSession& session, uint8_t direction, int32_t 
             if (entrance != nullptr)
             {
                 auto imageIndex = entrance->GetImage(sequence, direction);
-                auto y = ((direction / 2 + sequence / 2) & 1) ? 26 : 32;
                 PaintAddImageAsParent(
-                    session, imageTemplate.WithIndex(imageIndex), { 0, 0, height }, { { 3, 3, height }, { 26, y, 79 } });
+                    session, imageTemplate.WithIndex(imageIndex), { 0, 0, height }, { { 3, 3, height }, { 26, 26, 79 } });
             }
             break;
     }


### PR DESCRIPTION
This fixes #18711 underground park entrance sides glitching. There's a weird calculation for one of the bounding box sizes that I just removed because it seems to do nothing other than cause glitching by extending the bounding box beyond the tile it's on. As far as I can tell, there is no reason to be changing it per view anyway.