### PR TITLE
Fix #18436: Scenery on same tile draws over steep to vertical track

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Improved: [#23677] Building new ride track now inherits the colour scheme from the previous piece.
 - Fix: [#9999, #10000, #10001, #10002, #10003] Truncated scenario strings when using Catalan, Czech, Japanese, Polish or Russian.
+- Fix: [#18436] Scenery on the same tile as steep to vertical track can draw over the track.
 - Fix: [#21768] Dirty blocks debug overlay is rendered incorrectly on high DPI screens.
 - Fix: [#22617] Sloped Wooden and Side-Friction supports draw out of order when built directly above diagonal track pieces.
 - Fix: [#23522] Diagonal sloped Steeplechase supports have glitched sprites at the base.

--- a/src/openrct2/paint/track/coaster/CorkscrewRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/CorkscrewRollerCoaster.cpp
@@ -11550,22 +11550,22 @@ static void CorkscrewRCTrack90DegUp(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(26607), { 0, 0, height + 8 },
-                        { { 4, 6, height }, { 2, 20, 31 } });
+                        { { 4, 6, height + 8 }, { 2, 20, 31 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(26608), { 0, 0, height + 8 },
-                        { { 24, 6, height }, { 2, 20, 31 } });
+                        { { 24, 6, height + 8 }, { 2, 20, 31 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(26605), { 0, 0, height + 8 },
-                        { { 24, 6, height }, { 2, 20, 31 } });
+                        { { 24, 6, height + 8 }, { 2, 20, 31 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(26606), { 0, 0, height + 8 },
-                        { { 4, 6, height }, { 2, 20, 31 } });
+                        { { 4, 6, height + 8 }, { 2, 20, 31 } });
                     break;
             }
             PaintUtilSetVerticalTunnel(session, height + 32);
@@ -11597,7 +11597,7 @@ static void CorkscrewRCTrack60DegUpTo90DegUp(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(SPR_G2_CORKSCREW_TRACK_VERTICAL + 0),
-                        { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
+                        { 0, 0, height }, { { 4, 6, height + 8 }, { 13, 20, 55 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -11612,7 +11612,7 @@ static void CorkscrewRCTrack60DegUpTo90DegUp(
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(SPR_G2_CORKSCREW_TRACK_VERTICAL + 3),
-                        { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
+                        { 0, 0, height }, { { 4, 6, height + 8 }, { 13, 20, 55 } });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -11645,7 +11645,7 @@ static void CorkscrewRCTrack90DegUpTo60DegUp(
         case 0:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours.WithIndex(SPR_G2_CORKSCREW_TRACK_VERTICAL + 4), { 0, 0, height },
-                { { 0, 6, height + 2 }, { 6, 20, 3 } });
+                { { 4, 6, height + 8 }, { 2, 20, 48 } });
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -11660,7 +11660,7 @@ static void CorkscrewRCTrack90DegUpTo60DegUp(
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours.WithIndex(SPR_G2_CORKSCREW_TRACK_VERTICAL + 7), { 0, 0, height },
-                { { 0, 6, height + 2 }, { 6, 20, 3 } });
+                { { 4, 6, height + 8 }, { 2, 20, 48 } });
             break;
     }
     switch (direction)

--- a/src/openrct2/paint/track/coaster/HybridCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/HybridCoaster.cpp
@@ -499,16 +499,16 @@ namespace OpenRCT2::HybridRC
         const TrackElement& trackElement, SupportType supportType)
     {
         const CoordsXYZ boundBoxOffsets[4] = {
-            { 0, 6, height },
+            { 4, 6, height + 8 },
             { 24, 6, height },
             { 24, 6, height },
-            { 0, 6, height },
+            { 4, 6, height + 8 },
         };
         static constexpr CoordsXYZ boundBoxLengths[4] = {
-            { 32, 20, 3 },
+            { 13, 20, 55 },
             { 2, 20, 55 },
             { 2, 20, 55 },
-            { 32, 20, 3 },
+            { 13, 20, 55 },
         };
         static constexpr uint32_t imageIds[4] = {
             SPR_G2_HYBRID_TRACK_VERTICAL + 0,
@@ -551,16 +551,16 @@ namespace OpenRCT2::HybridRC
         const TrackElement& trackElement, SupportType supportType)
     {
         const CoordsXYZ boundBoxOffsets[4] = {
-            { 0, 6, height + 8 },
+            { 4, 6, height + 8 },
             { 24, 6, height + 8 },
             { 24, 6, height + 8 },
-            { 0, 6, height + 8 },
+            { 4, 6, height + 8 },
         };
         static constexpr CoordsXYZ boundBoxLengths[4] = {
-            { 32, 20, 3 },
+            { 2, 20, 48 },
             { 2, 20, 31 },
             { 2, 20, 31 },
-            { 32, 20, 3 },
+            { 2, 20, 48 },
         };
         static constexpr uint32_t imageIds[4] = {
             SPR_G2_HYBRID_TRACK_VERTICAL + 4,

--- a/src/openrct2/paint/track/coaster/LatticeTriangleTrack.cpp
+++ b/src/openrct2/paint/track/coaster/LatticeTriangleTrack.cpp
@@ -10419,7 +10419,7 @@ static void LatticeTriangleTrack60DegUpTo90DegUp(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex((SPR_G2_LATTICE_TRIANGLE_TRACK_VERTICAL + 0)),
-                        { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
+                        { 0, 0, height }, { { 4, 6, height + 8 }, { 13, 20, 55 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -10434,7 +10434,7 @@ static void LatticeTriangleTrack60DegUpTo90DegUp(
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex((SPR_G2_LATTICE_TRIANGLE_TRACK_VERTICAL + 3)),
-                        { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
+                        { 0, 0, height }, { { 4, 6, height + 8 }, { 13, 20, 55 } });
                     break;
             }
             if (TrackPaintUtilShouldPaintSupports(session.MapPosition))
@@ -10472,7 +10472,7 @@ static void LatticeTriangleTrack90DegUpTo60DegUp(
         case 0:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours.WithIndex((SPR_G2_LATTICE_TRIANGLE_TRACK_VERTICAL + 4)),
-                { 0, 0, height }, { { 0, 6, height + 8 }, { 32, 20, 3 } });
+                { 0, 0, height }, { { 4, 6, height + 8 }, { 2, 20, 48 } });
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -10487,7 +10487,7 @@ static void LatticeTriangleTrack90DegUpTo60DegUp(
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours.WithIndex((SPR_G2_LATTICE_TRIANGLE_TRACK_VERTICAL + 7)),
-                { 0, 0, height }, { { 0, 6, height + 8 }, { 32, 20, 3 } });
+                { 0, 0, height }, { { 4, 6, height + 8 }, { 2, 20, 48 } });
             break;
     }
     switch (direction)

--- a/src/openrct2/paint/track/coaster/LimLaunchedRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/LimLaunchedRollerCoaster.cpp
@@ -1579,7 +1579,7 @@ static void LimLaunchedRCTrack60DegUpTo90DegUp(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15694), { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 3 } });
+                        { { 4, 6, height + 8 }, { 2, 20, 55 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1594,7 +1594,7 @@ static void LimLaunchedRCTrack60DegUpTo90DegUp(
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15697), { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 3 } });
+                        { { 4, 6, height + 8 }, { 2, 20, 55 } });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -1629,7 +1629,7 @@ static void LimLaunchedRCTrack90DegUpTo60DegUp(
         case 0:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours.WithIndex(15698), { 0, 0, height },
-                { { 0, 6, height + 2 }, { 6, 20, 3 } });
+                { { 4, 6, height + 8 }, { 2, 20, 48 } });
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -1644,7 +1644,7 @@ static void LimLaunchedRCTrack90DegUpTo60DegUp(
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours.WithIndex(15701), { 0, 0, height },
-                { { 0, 6, height + 2 }, { 6, 20, 3 } });
+                { { 4, 6, height + 8 }, { 2, 20, 48 } });
             break;
     }
     switch (direction)

--- a/src/openrct2/paint/track/coaster/MultiDimensionRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/MultiDimensionRollerCoaster.cpp
@@ -5526,7 +5526,7 @@ static void MultiDimensionRCTrack60DegUpTo90DegUp(
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours.WithIndex(16122), { 0, 0, height },
-                            { { 0, 6, height }, { 32, 20, 3 } });
+                            { { 4, 6, height + 8 }, { 13, 20, 55 } });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -5541,7 +5541,7 @@ static void MultiDimensionRCTrack60DegUpTo90DegUp(
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours.WithIndex(16125), { 0, 0, height },
-                            { { 0, 6, height }, { 32, 20, 3 } });
+                            { { 4, 6, height + 8 }, { 13, 20, 55 } });
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -5621,7 +5621,7 @@ static void MultiDimensionRCTrack90DegUpTo60DegUp(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(16126), { 0, 0, height },
-                    { { 0, 6, height + 2 }, { 6, 20, 3 } });
+                    { { 4, 6, height + 8 }, { 2, 20, 48 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -5636,7 +5636,7 @@ static void MultiDimensionRCTrack90DegUpTo60DegUp(
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(16129), { 0, 0, height },
-                    { { 0, 6, height + 2 }, { 6, 20, 3 } });
+                    { { 4, 6, height + 8 }, { 2, 20, 48 } });
                 break;
         }
         switch (direction)

--- a/src/openrct2/paint/track/coaster/SingleRailRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/SingleRailRollerCoaster.cpp
@@ -723,7 +723,7 @@ namespace OpenRCT2::SingleRailRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours.WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 0)),
-                            { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
+                            { 0, 0, height }, { { 4, 6, height + 8 }, { 13, 20, 55 } });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -738,7 +738,7 @@ namespace OpenRCT2::SingleRailRC
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours.WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 3)),
-                            { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
+                            { 0, 0, height }, { { 4, 6, height + 8 }, { 13, 20, 55 } });
                         break;
                 }
                 if (TrackPaintUtilShouldPaintSupports(session.MapPosition))
@@ -776,7 +776,7 @@ namespace OpenRCT2::SingleRailRC
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 4)),
-                    { 0, 0, height }, { { 0, 6, height + 8 }, { 32, 20, 3 } });
+                    { 0, 0, height }, { { 4, 6, height + 8 }, { 2, 20, 48 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -791,7 +791,7 @@ namespace OpenRCT2::SingleRailRC
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 7)),
-                    { 0, 0, height }, { { 0, 6, height + 8 }, { 32, 20, 3 } });
+                    { 0, 0, height }, { { 4, 6, height + 8 }, { 2, 20, 48 } });
                 break;
         }
         switch (direction)
@@ -825,12 +825,12 @@ namespace OpenRCT2::SingleRailRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours.WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 7)),
-                            { 0, 0, height }, { { 0, 6, height + 8 }, { 32, 20, 3 } });
+                            { 0, 0, height }, { { 4, 6, height + 8 }, { 2, 20, 48 } });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours.WithIndex((SPR_G2_SINGLE_RAIL_TRACK_VERTICAL + 4)),
-                            { 0, 0, height }, { { 0, 6, height + 8 }, { 32, 20, 3 } });
+                            { 0, 0, height }, { { 4, 6, height + 8 }, { 2, 20, 48 } });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/StandUpRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/StandUpRollerCoaster.cpp
@@ -10757,7 +10757,7 @@ static void StandUpRCTrack60DegUpTo90DegUp(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex((SPR_G2_STANDUP_TRACK_VERTICAL + 0)),
-                        { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
+                        { 0, 0, height }, { { 4, 6, height + 8 }, { 13, 20, 55 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -10772,7 +10772,7 @@ static void StandUpRCTrack60DegUpTo90DegUp(
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex((SPR_G2_STANDUP_TRACK_VERTICAL + 3)),
-                        { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
+                        { 0, 0, height }, { { 4, 6, height + 8 }, { 13, 20, 55 } });
                     break;
             }
             if (TrackPaintUtilShouldPaintSupports(session.MapPosition))
@@ -10810,7 +10810,7 @@ static void StandUpRCTrack90DegUpTo60DegUp(
         case 0:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours.WithIndex((SPR_G2_STANDUP_TRACK_VERTICAL + 4)), { 0, 0, height },
-                { { 6, 4, height + 8 }, { 20, 2, 56 } });
+                { { 4, 6, height + 8 }, { 2, 20, 48 } });
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -10825,7 +10825,7 @@ static void StandUpRCTrack90DegUpTo60DegUp(
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours.WithIndex((SPR_G2_STANDUP_TRACK_VERTICAL + 7)), { 0, 0, height },
-                { { 6, 4, height + 8 }, { 20, 2, 56 } });
+                { { 4, 6, height + 8 }, { 2, 20, 48 } });
             break;
     }
     switch (direction)

--- a/src/openrct2/paint/track/coaster/TwisterRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/TwisterRollerCoaster.cpp
@@ -4994,7 +4994,7 @@ static void TwisterRCTrack60DegUpTo90DegUp(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(17518), { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 3 } });
+                        { { 4, 6, height + 8 }, { 13, 20, 55 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -5009,7 +5009,7 @@ static void TwisterRCTrack60DegUpTo90DegUp(
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(17521), { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 3 } });
+                        { { 4, 6, height + 8 }, { 13, 20, 55 } });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -5042,7 +5042,7 @@ static void TwisterRCTrack90DegUpTo60DegUp(
         case 0:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours.WithIndex(17522), { 0, 0, height },
-                { { 0, 6, height + 8 }, { 32, 20, 3 } });
+                { { 4, 6, height + 8 }, { 2, 20, 48 } });
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -5057,7 +5057,7 @@ static void TwisterRCTrack90DegUpTo60DegUp(
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours.WithIndex(17525), { 0, 0, height },
-                { { 0, 6, height + 8 }, { 32, 20, 3 } });
+                { { 4, 6, height + 8 }, { 2, 20, 48 } });
             break;
     }
     switch (direction)


### PR DESCRIPTION
This fixes #18436 scenery on the same tile as steep to vertical track drawing over the track. I've changed the bounding boxes for the steep to vertical and vertical to steep pieces so that they no longer glitch like this. The issue here is that walls above the track have bounding boxes higher than the track, so they draw over it. The solution is to make the track bounding boxes tall enough to cover any scenery. I've copied the vertical track bounding boxes and modified them for these pieces. The steep to vertical bounding box is deeper because it has to cover the support bounding box or the support will draw on top of the track. Luckily it's still thin enough to not cause glitching with the vehicles. This also fixes a small amount of glitching with the vertical to steep track on certain tracks and trains.

![steeptoverticalglitchfix](https://github.com/user-attachments/assets/79ea7d9b-5b9f-4579-8027-b95313bb8120)

https://github.com/user-attachments/assets/f37be50b-667c-495b-9a89-e0c788a9901d

