### PR TITLE
Fix #23828: Vehicles passing by station entrances and exits can cause them to glitch

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -26,6 +26,7 @@
 - Fix: [#23811] Land edges glitch when vehicles go through gentle to flat tunnels.
 - Fix: [#23814] Scenarios not indexed on first start.
 - Fix: [#23818] Spinning tunnels can draw over sloped terrain in front of them.
+- Fix: [#23828] Vehicles passing by station entrances and exits can cause them to glitch (original bug).
 - Fix: [#23831] Hybrid Coaster large gentle banked right turns glitch when diagonal track is above them.
 - Fix: [#23832] Hybrid Coaster large gentle banked left turns supports glitch as train passes.
 - Fix: [#23836] Adjacent track can draw over large turns (original bug).

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -165,33 +165,30 @@ static void PaintRideEntranceExit(PaintSession& session, uint8_t direction, int3
     // Certain entrance styles have another 2 images to draw for coloured windows
 
     auto isExit = entranceEl.GetEntranceType() == ENTRANCE_TYPE_RIDE_EXIT;
-    CoordsXYZ boundBoxLength = {
-        (direction & 1) ? 2 : 28,
-        (direction & 1) ? 28 : 2,
-        isExit ? 32 : 48,
-    };
 
     // Back
     ImageIndex imageIndex = isExit ? stationObj->BaseImageId + direction + 8 : stationObj->BaseImageId + direction;
     ImageIndex glassImageIndex = isExit ? stationObj->BaseImageId + direction + 24 : stationObj->BaseImageId + direction + 16;
-    PaintAddImageAsParent(session, imageTemplate.WithIndex(imageIndex), { 0, 0, height }, { { 2, 2, height }, boundBoxLength });
+    PaintAddImageAsParentRotated(
+        session, direction, imageTemplate.WithIndex(imageIndex), { 0, 0, height }, { { 2, 2, height }, { 28, 8, 30 } });
     if (hasGlass)
     {
-        PaintAddImageAsChild(
-            session, glassImageTemplate.WithIndex(glassImageIndex), { 0, 0, height }, { { 2, 2, height }, boundBoxLength });
+        PaintAddImageAsChildRotated(
+            session, direction, glassImageTemplate.WithIndex(glassImageIndex), { 0, 0, height },
+            { { 2, 2, height }, { 28, 8, 30 } });
     }
 
     // Front
+    const auto frontBoundBoxZ = isExit ? 1 : 17;
     imageIndex += 4;
     PaintAddImageAsParent(
-        session, imageTemplate.WithIndex(imageIndex), { 0, 0, height },
-        { { (direction & 1) ? 28 : 2, (direction & 1) ? 2 : 28, height }, boundBoxLength });
+        session, imageTemplate.WithIndex(imageIndex), { 0, 0, height }, { { 2, 2, height + 30 }, { 28, 28, frontBoundBoxZ } });
     if (hasGlass)
     {
         glassImageIndex += 4;
         PaintAddImageAsChild(
             session, glassImageTemplate.WithIndex(glassImageIndex), { 0, 0, height },
-            { { (direction & 1) ? 28 : 2, (direction & 1) ? 2 : 28, height }, boundBoxLength });
+            { { 2, 2, height + 30 }, { 28, 28, frontBoundBoxZ } });
     }
 
     PaintUtilPushTunnelRotated(session, direction, height, TunnelType::SquareFlat);


### PR DESCRIPTION
This fixes #23828 Vehicles passing by station entrances and exits can cause them to glitch.

I've made a similar change as I did with the toilets to these bounding boxes. It seems that they have basically the same issue. Peeps walking through them still seems to work correctly.


https://github.com/user-attachments/assets/4b3e8bd9-42dc-4f4d-8bcc-1f4386d3ae75


https://github.com/user-attachments/assets/eeff4991-72be-4826-b72a-4669cd60253b

(Sorry this video was recorded on a build without the toilet fix)


https://github.com/user-attachments/assets/cb683006-4439-4842-9e84-6220a9613c61

