### PR TITLE
Fix #23832: Hybrid large gentle banked left turns supports glitch

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -26,6 +26,7 @@
 - Fix: [#23814] Scenarios not indexed on first start.
 - Fix: [#23818] Spinning tunnels can draw over sloped terrain in front of them.
 - Fix: [#23831] Hybrid Coaster large gentle banked right turns glitch when diagonal track is above them.
+- Fix: [#23832] Hybrid Coaster large gentle banked left turns supports glitch as train passes.
 - Fix: [#23836] Adjacent track can draw over large turns (original bug).
 - Fix: [#23858] LSM launched lift hill has a misaligned sprite.
 

--- a/src/openrct2/paint/track/coaster/HybridCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/HybridCoaster.cpp
@@ -14086,7 +14086,7 @@ namespace OpenRCT2::HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction,
                             GetTrackColour(session).WithIndex((SPR_G2_HYBRID_TRACK_GENTLE_LARGE_CURVE_BANKED + 120)),
-                            { 0, 0, height }, { { 0, 0, height }, { 34, 34, 16 } });
+                            { 0, 0, height }, { { 0, 16, height }, { 34, 18, 3 } });
                         break;
                 }
                 WoodenASupportsPaintSetupRotated(
@@ -14123,7 +14123,7 @@ namespace OpenRCT2::HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction,
                             GetTrackColour(session).WithIndex((SPR_G2_HYBRID_TRACK_GENTLE_LARGE_CURVE_BANKED + 121)),
-                            { 0, 0, height }, { { 0, 0, height }, { 32, 1, 32 } });
+                            { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
                         break;
                 }
                 WoodenASupportsPaintSetupRotated(


### PR DESCRIPTION
This fixes #23832 hybrid coaster large gentle banked left turns supports glitching as the train passes them. Two of the bounding boxes on this piece were different than the right turn, so i've copied them over to the left side.


https://github.com/user-attachments/assets/a3e68615-81c1-4438-8ac9-275552bb0ff1

![hybridlargebankedgentleturnfix](https://github.com/user-attachments/assets/603f28a4-5199-45ed-9480-98f8b5024806)
