### PR TITLE
Fix #23831: Hybrid Coaster large gentle banked right turns glitch when diagonal track is above them

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -25,6 +25,7 @@
 - Fix: [#23811] Land edges glitch when vehicles go through gentle to flat tunnels.
 - Fix: [#23814] Scenarios not indexed on first start.
 - Fix: [#23818] Spinning tunnels can draw over sloped terrain in front of them.
+- Fix: [#23831] Hybrid Coaster large gentle banked right turns glitch when diagonal track is above them.
 - Fix: [#23836] Adjacent track can draw over large turns (original bug).
 - Fix: [#23858] LSM launched lift hill has a misaligned sprite.
 

--- a/src/openrct2/paint/track/coaster/HybridCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/HybridCoaster.cpp
@@ -14230,7 +14230,7 @@ namespace OpenRCT2::HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction,
                             GetTrackColour(session).WithIndex((SPR_G2_HYBRID_TRACK_GENTLE_LARGE_CURVE_BANKED + 124)),
-                            { 0, 0, height }, { { 16, 0, height }, { 18, 32, 3 } });
+                            { 0, 0, height }, { { 0, 0, height }, { 34, 32, 3 } });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(


### PR DESCRIPTION
This fixes #23831 Hybrid Coaster large gentle banked right turns glitch when diagonal track is above them. As far as I can tell, this doesn't happen on the left turn, so I copied the bounding box from it to the right turn, as it was different.


https://github.com/user-attachments/assets/1bd6da44-1f81-494c-9b3f-8e12a0cfcdbf

