### PR TITLE
Fix #15826, #23835: Wooden Roller Coaster steep turn supports glitch

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Improved: [#23677] Building new ride track now inherits the colour scheme from the previous piece.
 - Fix: [#1972, #11679] Vehicles passing by toilets can cause them to glitch.
 - Fix: [#9999, #10000, #10001, #10002, #10003] Truncated scenario strings when using Catalan, Czech, Japanese, Polish or Russian.
+- Fix: [#15826, #23835] Wooden Roller Coaster steep turn supports glitch when train goes over them (original bug).
 - Fix: [#16357] Chairlift station covers draw incorrectly.
 - Fix: [#18436] Scenery on the same tile as steep to vertical track can draw over the track.
 - Fix: [#21768] Dirty blocks debug overlay is rendered incorrectly on high DPI screens.

--- a/src/openrct2/paint/track/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/WoodenRollerCoaster.cpp
@@ -2492,7 +2492,7 @@ static void WoodenRCTrack60DegUpTo25DegUp(
         {
             session.WoodenSupportsPrependTo = WoodenRCTrackPaint<isClassic>(
                 session, direction, imageIdsChained[direction][0], imageIdsChained[direction][1], { 0, 0, height },
-                { { 4, 28, height - 16 }, { 24, 1, 61 } });
+                { { 28, 4, height + 2 }, { 2, 24, 43 } });
             WoodenRCTrackPaint<isClassic>(
                 session, direction, imageIdsChained[direction][2], imageIdsChained[direction][3], { 0, 0, height },
                 { { 0, 4, height }, { 32, 2, 43 } });
@@ -2510,7 +2510,7 @@ static void WoodenRCTrack60DegUpTo25DegUp(
         {
             session.WoodenSupportsPrependTo = WoodenRCTrackPaint<isClassic>(
                 session, direction, imageIds[direction][0], imageIds[direction][1], { 0, 0, height },
-                { { 4, 28, height - 16 }, { 24, 1, 61 } });
+                { { 28, 4, height + 2 }, { 2, 24, 43 } });
             WoodenRCTrackPaint<isClassic>(
                 session, direction, imageIds[direction][2], imageIds[direction][3], { 0, 0, height },
                 { { 0, 4, height }, { 32, 2, 43 } });
@@ -5617,10 +5617,10 @@ static void WoodenRCTrackLeftQuarterTurn160DegUp(
                 { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24217), { 0, 0, height },
-                { { 2, 2, height + 99 }, { 28, 28, 1 } });
+                { { 2, 2, height + 86 }, { 28, 28, 1 } });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRCGetRailsColour(session).WithIndex(25083), { 0, 0, height },
-                { { 2, 2, height + 99 }, { 28, 28, 1 } });
+                { { 2, 2, height + 86 }, { 28, 28, 1 } });
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -5631,10 +5631,10 @@ static void WoodenRCTrackLeftQuarterTurn160DegUp(
                 { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24218), { 0, 0, height },
-                { { 2, 2, height + 99 }, { 28, 28, 1 } });
+                { { 26, 26, height }, { 2, 2, 87 } });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRCGetRailsColour(session).WithIndex(25084), { 0, 0, height },
-                { { 2, 2, height + 99 }, { 28, 28, 1 } });
+                { { 26, 26, height }, { 2, 2, 87 } });
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -5645,10 +5645,10 @@ static void WoodenRCTrackLeftQuarterTurn160DegUp(
                 { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24219), { 0, 0, height },
-                { { 2, 2, height + 99 }, { 28, 28, 1 } });
+                { { 26, 28, height }, { 2, 2, 87 } });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRCGetRailsColour(session).WithIndex(25085), { 0, 0, height },
-                { { 2, 2, height + 99 }, { 28, 28, 1 } });
+                { { 26, 28, height }, { 2, 2, 87 } });
             break;
         case 3:
             PaintAddImageAsParentRotated(
@@ -5659,10 +5659,10 @@ static void WoodenRCTrackLeftQuarterTurn160DegUp(
                 { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24220), { 0, 0, height },
-                { { 2, 2, height + 99 }, { 28, 28, 1 } });
+                { { 28, 28, height }, { 2, 2, 87 } });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRCGetRailsColour(session).WithIndex(25086), { 0, 0, height },
-                { { 2, 2, height + 99 }, { 28, 28, 1 } });
+                { { 28, 28, height }, { 2, 2, 87 } });
             break;
     }
     TrackPaintUtilLeftQuarterTurn1TileTunnel(
@@ -5688,10 +5688,10 @@ static void WoodenRCTrackRightQuarterTurn160DegUp(
                 { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24221), { 0, 0, height },
-                { { 2, 2, height + 99 }, { 28, 28, 1 } });
+                { { 28, 28, height }, { 2, 2, 87 } });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRCGetRailsColour(session).WithIndex(25087), { 0, 0, height },
-                { { 2, 2, height + 99 }, { 28, 28, 1 } });
+                { { 28, 28, height }, { 2, 2, 87 } });
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -5702,10 +5702,10 @@ static void WoodenRCTrackRightQuarterTurn160DegUp(
                 { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24222), { 0, 0, height },
-                { { 2, 2, height + 99 }, { 28, 28, 1 } });
+                { { 26, 28, height }, { 2, 2, 87 } });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRCGetRailsColour(session).WithIndex(25088), { 0, 0, height },
-                { { 2, 2, height + 99 }, { 28, 28, 1 } });
+                { { 26, 28, height }, { 2, 2, 87 } });
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -5716,10 +5716,10 @@ static void WoodenRCTrackRightQuarterTurn160DegUp(
                 { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24223), { 0, 0, height },
-                { { 2, 2, height + 99 }, { 28, 28, 1 } });
+                { { 26, 26, height }, { 2, 2, 87 } });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRCGetRailsColour(session).WithIndex(25089), { 0, 0, height },
-                { { 2, 2, height + 99 }, { 28, 28, 1 } });
+                { { 26, 26, height }, { 2, 2, 87 } });
             break;
         case 3:
             PaintAddImageAsParentRotated(
@@ -5730,10 +5730,10 @@ static void WoodenRCTrackRightQuarterTurn160DegUp(
                 { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24224), { 0, 0, height },
-                { { 2, 2, height + 99 }, { 28, 28, 1 } });
+                { { 2, 2, height + 86 }, { 28, 28, 1 } });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRCGetRailsColour(session).WithIndex(25090), { 0, 0, height },
-                { { 2, 2, height + 99 }, { 28, 28, 1 } });
+                { { 2, 2, height + 86 }, { 28, 28, 1 } });
             break;
     }
     TrackPaintUtilRightQuarterTurn1TileTunnel(


### PR DESCRIPTION
This fixes #15826 and #23835 Wooden Roller Coaster steep turn supports glitching when trains go over them.

I've changed the bounding boxes so that the supports don't glitch any more. Unfortunately there is still a little bit of clipping and some minor glitching with the track, but it is the wooden roller coasters sole desire in life to glitch as much as possible. I wasn't able to do better than this without causing extra issues with scenery and land. It's still better than it was. Another angle of the turn has also been improved. I've also fixed a small glitch with the flat to gentle down track, visible in the 2nd video.


https://github.com/user-attachments/assets/8df2802a-b1e6-4b8f-a499-876039f121d1


https://github.com/user-attachments/assets/76ff15d2-3c5b-474d-9b9d-80ab8d750f53


https://github.com/user-attachments/assets/d16a8a28-7078-4f58-a7b4-76bbaac98696

