### PR TITLE
Fix #23836: Adjacent track can draw over large turns

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -25,6 +25,7 @@
 - Fix: [#23811] Land edges glitch when vehicles go through gentle to flat tunnels.
 - Fix: [#23814] Scenarios not indexed on first start.
 - Fix: [#23818] Spinning tunnels can draw over sloped terrain in front of them.
+- Fix: [#23836] Adjacent track can draw over large turns (original bug).
 - Fix: [#23858] LSM launched lift hill has a misaligned sprite.
 
 0.4.19.1 (2025-02-03)

--- a/src/openrct2/paint/track/coaster/AlpineCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/AlpineCoaster.cpp
@@ -983,7 +983,7 @@ namespace OpenRCT2::AlpineRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours.WithIndex((SPR_G2_ALPINE_TRACK_LARGE_CURVE + 26)),
-                            { 0, 0, height }, { { 4, 4, height }, { 28, 28, 3 } });
+                            { 0, 0, height }, { { 16, 16, height }, { 16, 16, 3 } });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/CompactInvertedCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/CompactInvertedCoaster.cpp
@@ -6084,7 +6084,7 @@ static void CompactInvertedRCTrackRightEighthToDiag(
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(26759), { 0, 0, height + 29 },
-                        { { 4, 4, height + 29 }, { 28, 28, 3 } });
+                        { { 16, 16, height + 29 }, { 16, 16, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/CorkscrewRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/CorkscrewRollerCoaster.cpp
@@ -5933,7 +5933,7 @@ static void CorkscrewRCTrackRightEighthToDiag(
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(16734), { 0, 0, height },
-                        { { 4, 4, height }, { 28, 28, 3 } });
+                        { { 16, 16, height }, { 16, 16, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/FlyingRollerCoasterInverted.cpp
+++ b/src/openrct2/paint/track/coaster/FlyingRollerCoasterInverted.cpp
@@ -4130,7 +4130,7 @@ static void InvertedFlyingRCTrackRightEighthToDiag(
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27501), { 0, 0, height + 24 },
-                        { { 4, 4, height + 22 }, { 28, 28, 3 } });
+                        { { 16, 16, height + 22 }, { 16, 16, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/HybridCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/HybridCoaster.cpp
@@ -1111,7 +1111,7 @@ namespace OpenRCT2::HybridRC
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 6),
-                            { 0, 0, height }, { { 0, 16, height }, { 32, 16, 3 } });
+                            { 0, 0, height }, { { 16, 16, height }, { 16, 16, 3 } });
                         WoodenASupportsPaintSetup(
                             session, supportType.wooden, WoodenSupportSubType::Corner2, height, session.SupportColours);
                         break;
@@ -1286,7 +1286,7 @@ namespace OpenRCT2::HybridRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session).WithIndex(SPR_G2_HYBRID_TRACK_LARGE_CURVE + 26),
-                            { 0, 0, height }, { { 4, 4, height }, { 28, 28, 3 } });
+                            { 0, 0, height }, { { 16, 16, height }, { 16, 16, 3 } });
                         WoodenASupportsPaintSetup(
                             session, supportType.wooden, WoodenSupportSubType::Corner2, height, session.SupportColours);
                         break;

--- a/src/openrct2/paint/track/coaster/InvertedRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/InvertedRollerCoaster.cpp
@@ -5796,7 +5796,7 @@ static void InvertedRCTrackRightEighthToDiag(
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27501), { 0, 0, height + 29 },
-                        { { 4, 4, height + 29 }, { 28, 28, 3 } });
+                        { { 16, 16, height + 29 }, { 16, 16, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/LatticeTriangleTrack.cpp
+++ b/src/openrct2/paint/track/coaster/LatticeTriangleTrack.cpp
@@ -5516,7 +5516,7 @@ static void LatticeTriangleTrackRightEighthToDiag(
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(18408), { 0, 0, height },
-                        { { 4, 4, height }, { 28, 28, 3 } });
+                        { { 16, 16, height }, { 16, 16, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/LayDownRollerCoasterInverted.cpp
+++ b/src/openrct2/paint/track/coaster/LayDownRollerCoasterInverted.cpp
@@ -3294,7 +3294,7 @@ static void LayDownRCTrackRightEighthToDiag(
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(26759), { 0, 0, height + 24 },
-                        { { 4, 4, height + 22 }, { 28, 28, 3 } });
+                        { { 16, 16, height + 22 }, { 16, 16, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/LoopingRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/LoopingRollerCoaster.cpp
@@ -5273,7 +5273,7 @@ static void LoopingRCTrackRightEighthToDiag(
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15520), { 0, 0, height },
-                        { { 4, 4, height }, { 28, 28, 3 } });
+                        { { 16, 16, height }, { 16, 16, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/MineRide.cpp
+++ b/src/openrct2/paint/track/coaster/MineRide.cpp
@@ -3379,7 +3379,7 @@ static void MineRideTrackRightEighthToDiag(
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(19558), { 0, 0, height },
-                        { { 4, 4, height }, { 28, 28, 3 } });
+                        { { 16, 16, height }, { 16, 16, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/MineTrainCoaster.cpp
@@ -4920,7 +4920,7 @@ static void MineTrainRCTrackRightEighthToDiag(
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(20446), { 0, 0, height },
-                        { { 4, 4, height }, { 28, 28, 1 } });
+                        { { 16, 16, height }, { 16, 16, 1 } });
                     WoodenASupportsPaintSetup(
                         session, supportType.wooden, WoodenSupportSubType::Corner2, height, session.SupportColours);
                     break;

--- a/src/openrct2/paint/track/coaster/MiniRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/MiniRollerCoaster.cpp
@@ -4623,7 +4623,7 @@ static void MiniRCTrackRightEighthToDiag(
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(19070), { 0, 0, height },
-                        { { 4, 4, height }, { 28, 28, 3 } });
+                        { { 16, 16, height }, { 16, 16, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/MiniSuspendedCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/MiniSuspendedCoaster.cpp
@@ -1269,7 +1269,7 @@ static void MiniSuspendedRCTrackRightEighthToDiag(
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(28469), { 0, 0, height + 24 },
-                        { { 4, 2, height + 24 }, { 28, 28, 1 } });
+                        { { 16, 16, height + 24 }, { 16, 16, 1 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/MultiDimensionRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/MultiDimensionRollerCoaster.cpp
@@ -6194,7 +6194,7 @@ static void MultiDimensionRCTrackRightEighthToDiag(
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours.WithIndex(15990), { 0, 0, height },
-                            { { 4, 4, height }, { 28, 28, 3 } });
+                            { { 16, 16, height }, { 16, 16, 3 } });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
@@ -6350,7 +6350,7 @@ static void MultiDimensionRCTrackRightEighthToDiag(
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours.WithIndex(26399), { 0, 0, height + 24 },
-                            { { 4, 4, height + 22 }, { 28, 28, 3 } });
+                            { { 16, 16, height + 22 }, { 16, 16, 3 } });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/SideFrictionRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/SideFrictionRollerCoaster.cpp
@@ -1445,7 +1445,7 @@ static void SideFrictionRCTrackLeftEighthToDiag(
                         { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21812), { 0, 0, height },
-                        { { 16, 16, height + 27 }, { 16, 16, 0 } });
+                        { { 16, 16, height + 26 }, { 18, 18, 0 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1632,10 +1632,10 @@ static void SideFrictionRCTrackRightEighthToDiag(
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21768), { 0, 0, height },
-                        { { 4, 4, height }, { 28, 28, 2 } });
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21784), { 0, 0, height },
-                        { { 4, 4, height + 27 }, { 28, 28, 0 } });
+                        { { 16, 16, height + 26 }, { 18, 18, 0 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/SingleRailRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/SingleRailRollerCoaster.cpp
@@ -1454,7 +1454,7 @@ namespace OpenRCT2::SingleRailRC
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours.WithIndex((SPR_G2_SINGLE_RAIL_TRACK_LARGE_CURVE + 26)),
-                            { 0, 0, height }, { { 4, 4, height }, { 28, 28, 3 } });
+                            { 0, 0, height }, { { 16, 16, height }, { 16, 16, 3 } });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/StandUpRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/StandUpRollerCoaster.cpp
@@ -5915,7 +5915,7 @@ static void StandUpRCTrackRightEighthToDiag(
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(25637), { 0, 0, height },
-                        { { 4, 4, height }, { 28, 28, 3 } });
+                        { { 16, 16, height }, { 16, 16, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/Steeplechase.cpp
+++ b/src/openrct2/paint/track/coaster/Steeplechase.cpp
@@ -1239,7 +1239,7 @@ static void SteeplechaseTrackRightEighthToDiag(
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(28719), { 0, 0, height },
-                        { { 4, 4, height }, { 28, 28, 3 } });
+                        { { 16, 16, height }, { 16, 16, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/SuspendedSwingingCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/SuspendedSwingingCoaster.cpp
@@ -3048,7 +3048,7 @@ static void SuspendedSwingingRCTrackRightEighthToDiag(
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(26161), { 0, 0, height + 29 },
-                        { { 4, 4, height + 29 }, { 28, 28, 3 } });
+                        { { 16, 16, height + 29 }, { 16, 16, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/TwisterRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/TwisterRollerCoaster.cpp
@@ -5368,7 +5368,7 @@ static void TwisterRCTrackRightEighthToDiag(
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(17540), { 0, 0, height },
-                        { { 4, 4, height }, { 28, 28, 3 } });
+                        { { 16, 16, height }, { 16, 16, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/WoodenRollerCoaster.cpp
@@ -7463,16 +7463,16 @@ static void WoodenRCTrackRightEighthToDiag(
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24123), { 0, 0, height },
-                        { { 4, 4, height }, { 28, 28, 2 } });
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24989), { 0, 0, height },
-                        { { 4, 4, height }, { 28, 28, 2 } });
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24135), { 0, 0, height },
-                        { { 4, 4, height + 27 }, { 28, 28, 0 } });
+                        { { 16, 16, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(25001), { 0, 0, height },
-                        { { 4, 4, height + 27 }, { 28, 28, 0 } });
+                        { { 16, 16, height + 27 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(
                         session, supportType.wooden, WoodenSupportSubType::Corner2, height, session.SupportColours);
                     break;

--- a/src/openrct2/paint/track/transport/MiniatureRailway.cpp
+++ b/src/openrct2/paint/track/transport/MiniatureRailway.cpp
@@ -318,7 +318,7 @@ static constexpr CoordsXYZ miniature_railway_track_pieces_right_eight_to_diag_bo
     {
         { 32, 32, 2 },
         { 34, 16, 2 },
-        { 28, 28, 2 },
+        { 16, 16, 2 },
         { 32, 34, 0 },
     },
     {
@@ -345,7 +345,7 @@ static constexpr CoordsXY miniature_railway_track_pieces_right_eight_to_diag_off
     {
         { 0, 0 },
         { 0, 0 },
-        { 4, 4 },
+        { 16, 16 },
         { 0, 0 },
     },
     {
@@ -507,7 +507,7 @@ static constexpr CoordsXYZ miniature_railway_track_pieces_left_eight_to_orthog_b
     {
         { 32, 32, 2 },
         { 34, 16, 2 },
-        { 28, 28, 2 },
+        { 16, 16, 2 },
         { 16, 18, 2 },
     },
     {
@@ -534,7 +534,7 @@ static constexpr CoordsXY miniature_railway_track_pieces_left_eight_to_orthog_of
     {
         { 0, 0 },
         { 0, 0 },
-        { 4, 4 },
+        { 16, 16 },
         { 0, 16 },
     },
     {
@@ -1663,7 +1663,7 @@ static constexpr CoordsXYZ kFloorPiecesRightEighthToDiagBounds[4][5] = {
     {
         { 32, 32, 2 },
         { 34, 16, 2 },
-        { 28, 28, 2 },
+        { 16, 16, 2 },
         { 16, 16, 0 },
         { 32, 34, 0 },
     },
@@ -1694,7 +1694,7 @@ static constexpr CoordsXY kFloorPiecesRightEighthToDiagOffset[4][5] = {
     {
         { 0, 0 },
         { 0, 0 },
-        { 4, 4 },
+        { 16, 16 },
         { 0, 0 },
         { 0, 0 },
     },

--- a/src/openrct2/paint/track/transport/Monorail.cpp
+++ b/src/openrct2/paint/track/transport/Monorail.cpp
@@ -294,7 +294,7 @@ static constexpr BoundBoxXY GhostTrainTrackPiecesRightEightToDiagBoxes[4][4] = {
 
         { { 0, 6 }, { 32, 20 } },
         { { 0, 0 }, { 34, 16 } },
-        { { 4, 4 }, { 28, 28 } },
+        { { 16, 16 }, { 16, 16 } },
         { { 0, 16 }, { 16, 18 } },
     },
     {

--- a/src/openrct2/paint/track/transport/SuspendedMonorail.cpp
+++ b/src/openrct2/paint/track/transport/SuspendedMonorail.cpp
@@ -1264,7 +1264,7 @@ static void SuspendedMonorailTrackRightEighthToDiag(
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(25897), { 0, 0, height + 32 },
-                        { { 4, 4, height + 32 }, { 28, 28, 3 } });
+                        { { 16, 16, height + 32 }, { 16, 16, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -1056,7 +1056,7 @@ constexpr CoordsXY defaultRightEighthToDiagBoundLengths[4][4] = {
     {
         { 32, 20 },
         { 34, 16 },
-        { 28, 28 },
+        { 16, 16 },
         { 16, 18 },
     },
     {
@@ -1083,7 +1083,7 @@ constexpr CoordsXYZ defaultRightEighthToDiagBoundOffsets[4][4] = {
     {
         { 0, 6, 0 },
         { 0, 0, 0 },
-        { 4, 4, 0 },
+        { 16, 16, 0 },
         { 0, 16, 0 },
     },
     {


### PR DESCRIPTION
This fixes #23836 adjacent track drawing over large turns.

This actually affects the large turns of every track type. One of the bounding boxes on the right turn was different compared to the left turn, so I've made them the same.


https://github.com/user-attachments/assets/3f6a0e8f-d107-4a98-b972-99072b8733b8

![largeturnboundingboxes](https://github.com/user-attachments/assets/b0cdbe00-3b1c-41cf-a804-1604d3dd9943)
