### PR TITLE
Fix: Sound effects keep playing when loading another save

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#4225] Ride Construction window offers non-existent banked sloped to level curve (original bug).
 - Fix: [#10379] Banners outside the park can be renamed and modified (original bug).
+- Fix: [#23844] Sound effects keep playing when loading another save.
 - Fix: [#23897] Reverse Freefall Coaster slope up to vertical track piece does not draw a vertical tunnel.
 
 0.4.20 (2025-02-25)

--- a/src/openrct2-ui/windows/ProgressWindow.cpp
+++ b/src/openrct2-ui/windows/ProgressWindow.cpp
@@ -12,6 +12,7 @@
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/SpriteIds.h>
+#include <openrct2/audio/Audio.h>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Text.h>
 #include <openrct2/localisation/Formatting.h>
@@ -83,6 +84,7 @@ namespace OpenRCT2::Ui::Windows
     public:
         void OnOpen() override
         {
+            Audio::StopSFX();
             SetWidgets(kProgressWindowWidgets);
             WindowInitScrollWidgets(*this);
 

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -322,13 +322,18 @@ namespace OpenRCT2::Audio
         }
     }
 
-    void StopAll()
+    void StopSFX()
     {
-        StopTitleMusic();
         StopVehicleSounds();
-        RideAudio::StopAllChannels();
         PeepStopCrowdNoise();
         ClimateStopWeatherSound();
+    }
+
+    void StopAll()
+    {
+        StopSFX();
+        StopTitleMusic();
+        RideAudio::StopAllChannels();
     }
 
     int32_t GetDeviceCount()
@@ -417,11 +422,7 @@ namespace OpenRCT2::Audio
     void Pause()
     {
         gGameSoundsOff = true;
-        StopVehicleSounds();
-        RideAudio::StopAllChannels();
-        PeepStopCrowdNoise();
-        ClimateStopWeatherSound();
-        StopTitleMusic();
+        StopAll();
     }
 
     void Resume()

--- a/src/openrct2/audio/Audio.h
+++ b/src/openrct2/audio/Audio.h
@@ -170,6 +170,16 @@ namespace OpenRCT2::Audio
     const std::string& GetDeviceName(int32_t index);
 
     /**
+     * Stops all sound effects.
+     */
+    void StopSFX();
+
+    /**
+     * Stops all sound.
+     */
+    void StopAll();
+
+    /**
      * Returns the currently used device index, -1 if not available.
      */
     int32_t GetCurrentDeviceIndex();
@@ -200,7 +210,7 @@ namespace OpenRCT2::Audio
     void InitRideSounds(int32_t device);
 
     /**
-     * Temporarily stops playing sounds until audio_unpause_sounds() is called.
+     * Temporarily stops playing sounds until Resume() is called.
      * rct2: 0x006BABB4
      */
     void Pause();
@@ -217,9 +227,7 @@ namespace OpenRCT2::Audio
     /**
      * Plays the specified sound at a virtual location.
      * @param soundId The sound effect to play.
-     * @param x The x coordinate of the location.
-     * @param y The y coordinate of the location.
-     * @param z The z coordinate of the location.
+     * @param loc The coordinates of the location.
      */
     void Play3D(SoundId soundId, const CoordsXYZ& loc);
 
@@ -253,14 +261,10 @@ namespace OpenRCT2::Audio
     void ToggleAllSounds();
 
     /**
-     * Resumes playing sounds that had been paused by a call to audio_pause_sounds().
+     * Resumes playing sounds that had been paused by a call to Pause().
      * rct2: 0x006BABD8
      */
     void Resume();
-
-    void StopAll();
-
-    AudioObject* GetBaseAudioObject();
 
     std::shared_ptr<IAudioChannel> CreateAudioChannel(
         SoundId soundId, bool loop = false, int32_t volume = kMixerVolumeMax, float pan = 0.5f, double rate = 1,


### PR DESCRIPTION
This is _a_ fix for a small issue that can occur on the title screen. When the loading window pops up, the game logic stops being updated and looping sounds repeat until the the window closes, which sounds a little weird.

https://github.com/user-attachments/assets/1607a5e7-7ddc-4f0e-89e4-f18c7f902459

https://github.com/user-attachments/assets/358e6445-ddc6-4d36-99f4-42734ffb5218
