### PR TITLE
Don't override incompatible park version errors

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Fix: [#16357] Chairlift station covers draw incorrectly.
 - Fix: [#18436] Scenery on the same tile as steep to vertical track can draw over the track.
 - Fix: [#21768] Dirty blocks debug overlay is rendered incorrectly on high DPI screens.
+- Fix: [#22229] Opening a park save file from a newer version of OpenRCT2 yields an unhelpful error message.
 - Fix: [#22617] Sloped Wooden and Side-Friction supports draw out of order when built directly above diagonal track pieces.
 - Fix: [#22620] RCT1 Mine Train Coaster trains glitch on large banked turns.
 - Fix: [#23522] Diagonal sloped Steeplechase supports have glitched sprites at the base.

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -311,8 +311,12 @@ namespace OpenRCT2::Ui::Windows
                 }
                 else
                 {
-                    // Not the best message...
-                    ContextShowError(STR_LOAD_GAME, STR_FAILED_TO_LOAD_FILE_CONTAINS_INVALID_DATA, {});
+                    auto windowManager = GetWindowManager();
+                    if (!windowManager->FindByClass(WindowClass::Error))
+                    {
+                        // Not the best message...
+                        ContextShowError(STR_LOAD_GAME, STR_FAILED_TO_LOAD_FILE_CONTAINS_INVALID_DATA, {});
+                    }
                     InvokeCallback(MODAL_RESULT_FAIL, pathBuffer);
                 }
                 break;


### PR DESCRIPTION
Before:
<img width="519" alt="Screenshot 2025-02-17 at 11 42 51" src="https://github.com/user-attachments/assets/37bd6347-5d56-4d03-9e72-d0716814a469" />

After:
<img width="531" alt="Screenshot 2025-02-17 at 11 42 29" src="https://github.com/user-attachments/assets/78b8077a-c268-4902-b111-97a2e4362680" />

Fixes #22229

cc @Basssiiie 