### PR TITLE
Add original bug to changelog for toilet, steep track scenery and wood support draw fixes

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,14 +1,14 @@
 0.4.20 (in development)
 ------------------------------------------------------------------------
 - Improved: [#23677] Building new ride track now inherits the colour scheme from the previous piece.
-- Fix: [#1972, #11679] Vehicles passing by toilets can cause them to glitch.
+- Fix: [#1972, #11679] Vehicles passing by toilets can cause them to glitch (original bug).
 - Fix: [#9999, #10000, #10001, #10002, #10003] Truncated scenario strings when using Catalan, Czech, Japanese, Polish or Russian.
 - Fix: [#16357] Chairlift station covers draw incorrectly.
-- Fix: [#18436] Scenery on the same tile as steep to vertical track can draw over the track.
+- Fix: [#18436] Scenery on the same tile as steep to vertical track can draw over the track (original bug).
 - Fix: [#21768] Dirty blocks debug overlay is rendered incorrectly on high DPI screens.
 - Fix: [#22229] Opening a park save file from a newer version of OpenRCT2 yields an unhelpful error message.
-- Fix: [#22617] Sloped Wooden and Side-Friction supports draw out of order when built directly above diagonal track pieces.
-- Fix: [#22620] RCT1 Mine Train Coaster trains glitch on large banked turns.
+- Fix: [#22617] Sloped Wooden and Side-Friction supports draw out of order when built directly above diagonal track pieces (original bug).
+- Fix: [#22620] Mine Train Coaster trains glitch on large banked turns.
 - Fix: [#23522] Diagonal sloped Steeplechase supports have glitched sprites at the base.
 - Fix: [#23795] Looping Roller Coaster vertical loop supports are drawn incorrectly.
 - Fix: [#23809] Trains glitch on Bobsleigh Coaster small helixes.


### PR DESCRIPTION
This adds (original bug) to the changelog of 3 of the recent paint fixes. I didn't realise that they were being marked like this, sorry about that. I also removed the RCT1 part of the mine train coaster fix because it's not actually just the RCT1 train that glitches.