### PR TITLE
Fix empty changelog window appearing at startup

### DIFF
--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -144,9 +144,9 @@ namespace OpenRCT2::Ui::Windows
             min_width = MIN_WW;
             min_height = MIN_WH;
 
-            auto download_button_width = widgets[WIDX_OPEN_URL].width();
-            widgets[WIDX_OPEN_URL].left = (width - download_button_width) / 2;
-            widgets[WIDX_OPEN_URL].right = widgets[WIDX_OPEN_URL].left + download_button_width;
+            auto downloadButtonWidth = widgets[WIDX_OPEN_URL].width();
+            widgets[WIDX_OPEN_URL].left = (width - downloadButtonWidth) / 2;
+            widgets[WIDX_OPEN_URL].right = widgets[WIDX_OPEN_URL].left + downloadButtonWidth;
 
             if (width < min_width)
             {
@@ -235,12 +235,12 @@ namespace OpenRCT2::Ui::Windows
             _newVersionInfo = GetContext()->GetNewVersionInfo();
             if (_newVersionInfo != nullptr)
             {
-                char version_info[256];
+                char versionInfo[256];
 
-                const char* version_info_ptr = _newVersionInfo->name.c_str();
-                FormatStringLegacy(version_info, 256, STR_NEW_RELEASE_VERSION_INFO, &version_info_ptr);
+                const char* versionInfoPtr = _newVersionInfo->name.c_str();
+                FormatStringLegacy(versionInfo, 256, STR_NEW_RELEASE_VERSION_INFO, &versionInfoPtr);
 
-                _changelogLines.emplace_back(version_info);
+                _changelogLines.emplace_back(versionInfo);
                 _changelogLines.emplace_back("");
 
                 ProcessText(_newVersionInfo->changelog);

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -238,17 +238,6 @@ namespace OpenRCT2::Ui::Windows
         }
 
         /**
-         * @brief Get the absolute path for the changelog file
-         *
-         * @return std::string
-         */
-        std::string GetChangelogPath()
-        {
-            auto env = GetContext()->GetPlatformEnvironment();
-            return env->GetFilePath(PATHID::CHANGELOG);
-        }
-
-        /**
          * @brief Attempts to read the changelog file, returns true on success
          *
          */

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -211,20 +211,6 @@ namespace OpenRCT2::Ui::Windows
                 static_cast<int32_t>(_changelogLines.size()) * FontGetLineHeight(FontStyle::Medium));
         }
 
-        // TODO: This probably should be a utility function defined elsewhere for reusability
-        /**
-         * @brief Reimplementation of Window's GetCentrePositionForNewWindow for ChangelogWindow.
-         *
-         * @return ScreenCoordsXY
-         */
-        static ScreenCoordsXY GetCentrePositionForNewWindow(int32_t width, int32_t height)
-        {
-            auto uiContext = GetContext()->GetUiContext();
-            auto screenWidth = uiContext->GetWidth();
-            auto screenHeight = uiContext->GetHeight();
-            return ScreenCoordsXY{ (screenWidth - width) / 2, std::max(kTopToolbarHeight + 1, (screenHeight - height) / 2) };
-        }
-
     private:
         /**
          * @brief Converts NewVersionInfo into changelog lines
@@ -322,14 +308,10 @@ namespace OpenRCT2::Ui::Windows
         auto* window = windowMgr->BringToFrontByClass(WindowClass::Changelog);
         if (window == nullptr)
         {
-            // Create a new centred window
-            int32_t screenWidth = ContextGetWidth();
-            int32_t screenHeight = ContextGetHeight();
-            int32_t width = (screenWidth * 4) / 5;
-            int32_t height = (screenHeight * 4) / 5;
-
-            auto pos = ChangelogWindow::GetCentrePositionForNewWindow(width, height);
-            auto* newWindow = windowMgr->Create<ChangelogWindow>(WindowClass::Changelog, pos, width, height, WF_RESIZABLE);
+            int32_t width = (ContextGetWidth() * 4) / 5;
+            int32_t height = (ContextGetHeight() * 4) / 5;
+            auto* newWindow = windowMgr->Create<ChangelogWindow>(
+                WindowClass::Changelog, width, height, WF_CENTRE_SCREEN | WF_RESIZABLE);
             newWindow->SetPersonality(personality);
             return newWindow;
         }

--- a/src/openrct2/scenes/title/TitleScene.cpp
+++ b/src/openrct2/scenes/title/TitleScene.cpp
@@ -15,9 +15,11 @@
 #include "../../GameState.h"
 #include "../../Input.h"
 #include "../../OpenRCT2.h"
+#include "../../PlatformEnvironment.h"
 #include "../../audio/Audio.h"
 #include "../../config/Config.h"
 #include "../../core/Console.hpp"
+#include "../../core/File.h"
 #include "../../drawing/Text.h"
 #include "../../interface/Screenshot.h"
 #include "../../interface/Viewport.h"
@@ -127,8 +129,12 @@ void TitleScene::Load()
 
     if (gOpenRCT2ShowChangelog)
     {
-        gOpenRCT2ShowChangelog = false;
-        ContextOpenWindow(WindowClass::Changelog);
+        auto path = GetContext().GetPlatformEnvironment()->GetFilePath(PATHID::CHANGELOG);
+        if (File::Exists(path))
+        {
+            gOpenRCT2ShowChangelog = false;
+            ContextOpenWindow(WindowClass::Changelog);
+        }
     }
 
     LOG_VERBOSE("TitleScene::Load() finished");


### PR DESCRIPTION
I _think_ it might be possible to simplify obtaining the changelog's path so we don't have to include PlatformEnvironment.h in TitleScene.cpp so I'd be happy if someone could chime in.

Right now it's still possible to get an empty changelog window if you click in the OpenRCT2 logo in the title screen and click the changelog button, but I'll be fixing this next, I just wanted to get some feedback on this fix before moving on.

Fixes https://github.com/OpenRCT2/OpenRCT2/issues/21512

Note: this issue can happen in all OSes, but for some reason it's more common in Linux from what I've experienced.