### PR TITLE
Split FileBrowser and OverwritePrompt from LoadSave unit

### DIFF
--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -9,6 +9,7 @@
 
 #include "WindowManager.h"
 
+#include "interface/FileBrowser.h"
 #include "interface/Theme.h"
 #include "interface/Window.h"
 #include "ride/VehicleSounds.h"
@@ -257,12 +258,12 @@ public:
             case WindowClass::Loadsave:
             {
                 uint32_t type = intent->GetUIntExtra(INTENT_EXTRA_LOADSAVE_TYPE);
-                std::string defaultName = intent->GetStringExtra(INTENT_EXTRA_PATH);
+                std::string defaultPath = intent->GetStringExtra(INTENT_EXTRA_PATH);
                 LoadSaveCallback callback = reinterpret_cast<LoadSaveCallback>(
                     intent->GetCloseCallbackExtra(INTENT_EXTRA_CALLBACK));
                 TrackDesign* trackDesign = static_cast<TrackDesign*>(intent->GetPointerExtra(INTENT_EXTRA_TRACK_DESIGN));
-                auto* w = LoadsaveOpen(
-                    type, defaultName,
+                auto* w = FileBrowser::OpenPreferred(
+                    type, defaultPath,
                     [callback](int32_t result, std::string_view path) {
                         if (callback != nullptr)
                         {

--- a/src/openrct2-ui/interface/FileBrowser.cpp
+++ b/src/openrct2-ui/interface/FileBrowser.cpp
@@ -467,11 +467,11 @@ namespace OpenRCT2::Ui::FileBrowser
         StringId title = GetTitleStringId(type, isSave);
 
         Ui::FileDialogDesc desc = {
-            .InitialDirectory = defaultDirectory,
             .Type = isSave ? FileDialogType::Save : FileDialogType::Open,
+            .Title = LanguageGetString(title),
+            .InitialDirectory = defaultDirectory,
             .DefaultFilename = isSave ? path : u8string(),
             .Filters = { GetFilterForType(type, isSave), { LanguageGetString(STR_ALL_FILES), "*" } },
-            .Title = LanguageGetString(title),
         };
 
         return ContextOpenCommonFileDialog(desc);

--- a/src/openrct2-ui/interface/FileBrowser.cpp
+++ b/src/openrct2-ui/interface/FileBrowser.cpp
@@ -70,9 +70,9 @@ namespace OpenRCT2::Ui::FileBrowser
             case FileBrowserSort::NameDescending:
                 return -String::logicalCmp(a.name.c_str(), b.name.c_str()) < 0;
             case FileBrowserSort::DateDescending:
-                return -difftime(a.date_modified, b.date_modified) < 0;
+                return -difftime(a.dateModified, b.dateModified) < 0;
             case FileBrowserSort::DateAscending:
-                return difftime(a.date_modified, b.date_modified) < 0;
+                return difftime(a.dateModified, b.dateModified) < 0;
             case FileBrowserSort::SizeDescending:
                 return a.fileSizeBytes - b.fileSizeBytes;
             case FileBrowserSort::SizeAscending:

--- a/src/openrct2-ui/interface/FileBrowser.cpp
+++ b/src/openrct2-ui/interface/FileBrowser.cpp
@@ -1,0 +1,420 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2025 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "FileBrowser.h"
+
+#include <cstdint>
+#include <functional>
+#include <openrct2-ui/UiStringIds.h>
+#include <openrct2-ui/windows/Windows.h>
+#include <openrct2/Game.h>
+#include <openrct2/GameState.h>
+#include <openrct2/PlatformEnvironment.h>
+#include <openrct2/config/Config.h>
+#include <openrct2/core/Path.hpp>
+#include <openrct2/core/String.hpp>
+#include <openrct2/interface/Window.h>
+#include <openrct2/localisation/StringIds.h>
+#include <openrct2/platform/Platform.h>
+#include <openrct2/rct2/T6Exporter.h>
+#include <openrct2/ride/TrackDesign.h>
+#include <openrct2/scenario/Scenario.h>
+#include <openrct2/ui/UiContext.h>
+#include <openrct2/ui/WindowManager.h>
+#include <openrct2/windows/Intent.h>
+
+namespace OpenRCT2::Ui::FileBrowser
+{
+    static std::function<void(int32_t result, std::string_view)> _loadSaveCallback;
+
+    bool ListItemSort(LoadSaveListItem& a, LoadSaveListItem& b)
+    {
+        if (a.type != b.type)
+            return EnumValue(a.type) - EnumValue(b.type) < 0;
+
+        switch (Config::Get().general.LoadSaveSort)
+        {
+            case FileBrowserSort::NameAscending:
+                return String::logicalCmp(a.name.c_str(), b.name.c_str()) < 0;
+            case FileBrowserSort::NameDescending:
+                return -String::logicalCmp(a.name.c_str(), b.name.c_str()) < 0;
+            case FileBrowserSort::DateDescending:
+                return -difftime(a.date_modified, b.date_modified) < 0;
+            case FileBrowserSort::DateAscending:
+                return difftime(a.date_modified, b.date_modified) < 0;
+            case FileBrowserSort::SizeDescending:
+                return a.fileSizeBytes - b.fileSizeBytes;
+            case FileBrowserSort::SizeAscending:
+                return b.fileSizeBytes - a.fileSizeBytes;
+        }
+        return String::logicalCmp(a.name.c_str(), b.name.c_str()) < 0;
+    }
+
+    void SetAndSaveConfigPath(u8string& config_str, u8string_view path)
+    {
+        config_str = Path::GetDirectory(path);
+        Config::Save();
+    }
+
+    bool IsValidPath(const char* path)
+    {
+        // HACK This is needed because tracks get passed through with td?
+        //      I am sure this will change eventually to use the new FileScanner
+        //      which handles multiple patterns
+        auto filename = Path::GetFileNameWithoutExtension(path);
+
+        return Platform::IsFilenameValid(filename);
+    }
+
+    u8string GetLastDirectoryByType(int32_t type)
+    {
+        switch (type & 0x0E)
+        {
+            case LOADSAVETYPE_GAME:
+                return Config::Get().general.LastSaveGameDirectory;
+
+            case LOADSAVETYPE_LANDSCAPE:
+                return Config::Get().general.LastSaveLandscapeDirectory;
+
+            case LOADSAVETYPE_SCENARIO:
+                return Config::Get().general.LastSaveScenarioDirectory;
+
+            case LOADSAVETYPE_TRACK:
+                return Config::Get().general.LastSaveTrackDirectory;
+
+            default:
+                return u8string();
+        }
+    }
+
+    u8string GetInitialDirectoryByType(const int32_t type)
+    {
+        std::optional<DIRID> subdir = std::nullopt;
+        switch (type & 0x0E)
+        {
+            case LOADSAVETYPE_GAME:
+                subdir = DIRID::SAVE;
+                break;
+
+            case LOADSAVETYPE_LANDSCAPE:
+                subdir = DIRID::LANDSCAPE;
+                break;
+
+            case LOADSAVETYPE_SCENARIO:
+                subdir = DIRID::SCENARIO;
+                break;
+
+            case LOADSAVETYPE_TRACK:
+                subdir = DIRID::TRACK;
+                break;
+
+            case LOADSAVETYPE_HEIGHTMAP:
+                subdir = DIRID::HEIGHTMAP;
+                break;
+        }
+
+        auto env = GetContext()->GetPlatformEnvironment();
+        if (subdir.has_value())
+            return env->GetDirectoryPath(DIRBASE::USER, subdir.value());
+        else
+            return env->GetDirectoryPath(DIRBASE::USER);
+    }
+
+    const char* GetFilterPatternByType(const int32_t type, const bool isSave)
+    {
+        switch (type & 0x0E)
+        {
+            case LOADSAVETYPE_GAME:
+                return isSave ? "*.park" : "*.park;*.sv6;*.sc6;*.sc4;*.sv4;*.sv7;*.sea";
+
+            case LOADSAVETYPE_LANDSCAPE:
+                return isSave ? "*.park" : "*.park;*.sc6;*.sv6;*.sc4;*.sv4;*.sv7;*.sea";
+
+            case LOADSAVETYPE_SCENARIO:
+                return isSave ? "*.park" : "*.park;*.sc6;*.sc4";
+
+            case LOADSAVETYPE_TRACK:
+                return isSave ? "*.td6" : "*.td6;*.td4";
+
+            case LOADSAVETYPE_HEIGHTMAP:
+                return "*.bmp;*.png";
+
+            default:
+                Guard::Fail("Unsupported load/save directory type.");
+        }
+
+        return "";
+    }
+
+    u8string RemovePatternWildcard(u8string_view pattern)
+    {
+        while (pattern.length() >= 1 && pattern.front() == '*')
+        {
+            pattern.remove_prefix(1);
+        }
+        return u8string{ pattern };
+    }
+
+    u8string GetDir(const int32_t type)
+    {
+        u8string result = GetLastDirectoryByType(type);
+        if (result.empty() || !Path::DirectoryExists(result))
+        {
+            result = GetInitialDirectoryByType(type);
+        }
+        return result;
+    }
+
+    void RegisterCallback(std::function<void(int32_t result, std::string_view)> callback)
+    {
+        _loadSaveCallback = callback;
+    }
+
+    void InvokeCallback(int32_t result, const utf8* path)
+    {
+        if (_loadSaveCallback != nullptr)
+        {
+            _loadSaveCallback(result, path);
+        }
+    }
+
+    void Select(const char* path, int32_t type, TrackDesign* trackDesignPtr)
+    {
+        if (!IsValidPath(path))
+        {
+            ContextShowError(STR_ERROR_INVALID_CHARACTERS, kStringIdNone, {});
+            return;
+        }
+
+        char pathBuffer[MAX_PATH];
+        String::safeUtf8Copy(pathBuffer, path, sizeof(pathBuffer));
+
+        // Closing this will cause a Ride window to pop up, so we have to do this to ensure that
+        // no windows are open (besides the toolbars and LoadSave window).
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseByClass(WindowClass::RideConstruction);
+        windowMgr->CloseAllExceptClass(WindowClass::Loadsave);
+
+        auto& gameState = GetGameState();
+
+        switch (type & 0x0F)
+        {
+            case (LOADSAVETYPE_LOAD | LOADSAVETYPE_GAME):
+                SetAndSaveConfigPath(Config::Get().general.LastSaveGameDirectory, pathBuffer);
+                if (GetContext()->LoadParkFromFile(pathBuffer))
+                {
+                    InvokeCallback(MODAL_RESULT_OK, pathBuffer);
+                    windowMgr->CloseByClass(WindowClass::Loadsave);
+                    GfxInvalidateScreen();
+                }
+                else
+                {
+                    auto windowManager = GetWindowManager();
+                    if (!windowManager->FindByClass(WindowClass::Error))
+                    {
+                        // Not the best message...
+                        ContextShowError(STR_LOAD_GAME, STR_FAILED_TO_LOAD_FILE_CONTAINS_INVALID_DATA, {});
+                    }
+                    InvokeCallback(MODAL_RESULT_FAIL, pathBuffer);
+                }
+                break;
+
+            case (LOADSAVETYPE_SAVE | LOADSAVETYPE_GAME):
+                SetAndSaveConfigPath(Config::Get().general.LastSaveGameDirectory, pathBuffer);
+                if (ScenarioSave(gameState, pathBuffer, Config::Get().general.SavePluginData ? 1 : 0))
+                {
+                    gScenarioSavePath = pathBuffer;
+                    gCurrentLoadedPath = pathBuffer;
+                    gIsAutosaveLoaded = false;
+                    gFirstTimeSaving = false;
+
+                    windowMgr->CloseByClass(WindowClass::Loadsave);
+                    GfxInvalidateScreen();
+
+                    InvokeCallback(MODAL_RESULT_OK, pathBuffer);
+                }
+                else
+                {
+                    ContextShowError(STR_SAVE_GAME, STR_GAME_SAVE_FAILED, {});
+                    InvokeCallback(MODAL_RESULT_FAIL, pathBuffer);
+                }
+                break;
+
+            case (LOADSAVETYPE_LOAD | LOADSAVETYPE_LANDSCAPE):
+                SetAndSaveConfigPath(Config::Get().general.LastSaveLandscapeDirectory, pathBuffer);
+                if (Editor::LoadLandscape(pathBuffer))
+                {
+                    gCurrentLoadedPath = pathBuffer;
+                    GfxInvalidateScreen();
+                    InvokeCallback(MODAL_RESULT_OK, pathBuffer);
+                }
+                else
+                {
+                    // Not the best message...
+                    ContextShowError(STR_LOAD_LANDSCAPE, STR_FAILED_TO_LOAD_FILE_CONTAINS_INVALID_DATA, {});
+                    InvokeCallback(MODAL_RESULT_FAIL, pathBuffer);
+                }
+                break;
+
+            case (LOADSAVETYPE_SAVE | LOADSAVETYPE_LANDSCAPE):
+                SetAndSaveConfigPath(Config::Get().general.LastSaveLandscapeDirectory, pathBuffer);
+                gameState.ScenarioFileName = std::string(String::toStringView(pathBuffer, std::size(pathBuffer)));
+                if (ScenarioSave(gameState, pathBuffer, Config::Get().general.SavePluginData ? 3 : 2))
+                {
+                    gCurrentLoadedPath = pathBuffer;
+                    windowMgr->CloseByClass(WindowClass::Loadsave);
+                    GfxInvalidateScreen();
+                    InvokeCallback(MODAL_RESULT_OK, pathBuffer);
+                }
+                else
+                {
+                    ContextShowError(STR_SAVE_LANDSCAPE, STR_LANDSCAPE_SAVE_FAILED, {});
+                    InvokeCallback(MODAL_RESULT_FAIL, pathBuffer);
+                }
+                break;
+
+            case (LOADSAVETYPE_SAVE | LOADSAVETYPE_SCENARIO):
+            {
+                SetAndSaveConfigPath(Config::Get().general.LastSaveScenarioDirectory, pathBuffer);
+                int32_t parkFlagsBackup = gameState.Park.Flags;
+                gameState.Park.Flags &= ~PARK_FLAGS_SPRITES_INITIALISED;
+                gameState.EditorStep = EditorStep::Invalid;
+                gameState.ScenarioFileName = std::string(String::toStringView(pathBuffer, std::size(pathBuffer)));
+                int32_t success = ScenarioSave(gameState, pathBuffer, Config::Get().general.SavePluginData ? 3 : 2);
+                gameState.Park.Flags = parkFlagsBackup;
+
+                if (success)
+                {
+                    windowMgr->CloseByClass(WindowClass::Loadsave);
+                    InvokeCallback(MODAL_RESULT_OK, pathBuffer);
+
+                    auto* context = GetContext();
+                    context->SetActiveScene(context->GetTitleScene());
+                }
+                else
+                {
+                    ContextShowError(STR_FILE_DIALOG_TITLE_SAVE_SCENARIO, STR_SCENARIO_SAVE_FAILED, {});
+                    gameState.EditorStep = EditorStep::ObjectiveSelection;
+                    InvokeCallback(MODAL_RESULT_FAIL, pathBuffer);
+                }
+                break;
+            }
+
+            case (LOADSAVETYPE_LOAD | LOADSAVETYPE_TRACK):
+            {
+                SetAndSaveConfigPath(Config::Get().general.LastSaveTrackDirectory, pathBuffer);
+                auto intent = Intent(WindowClass::InstallTrack);
+                intent.PutExtra(INTENT_EXTRA_PATH, std::string{ pathBuffer });
+                ContextOpenIntent(&intent);
+                windowMgr->CloseByClass(WindowClass::Loadsave);
+                InvokeCallback(MODAL_RESULT_OK, pathBuffer);
+                break;
+            }
+
+            case (LOADSAVETYPE_SAVE | LOADSAVETYPE_TRACK):
+            {
+                SetAndSaveConfigPath(Config::Get().general.LastSaveTrackDirectory, pathBuffer);
+
+                const auto withExtension = Path::WithExtension(pathBuffer, ".td6");
+                String::set(pathBuffer, sizeof(pathBuffer), withExtension.c_str());
+
+                RCT2::T6Exporter t6Export{ *trackDesignPtr };
+
+                auto success = t6Export.SaveTrack(pathBuffer);
+
+                if (success)
+                {
+                    windowMgr->CloseByClass(WindowClass::Loadsave);
+                    Windows::WindowRideMeasurementsDesignCancel();
+                    InvokeCallback(MODAL_RESULT_OK, path);
+                }
+                else
+                {
+                    ContextShowError(STR_FILE_DIALOG_TITLE_SAVE_TRACK, STR_TRACK_SAVE_FAILED, {});
+                    InvokeCallback(MODAL_RESULT_FAIL, path);
+                }
+                break;
+            }
+
+            case (LOADSAVETYPE_LOAD | LOADSAVETYPE_HEIGHTMAP):
+                windowMgr->CloseByClass(WindowClass::Loadsave);
+                InvokeCallback(MODAL_RESULT_OK, pathBuffer);
+                break;
+        }
+    }
+
+    u8string OpenSystemFileBrowser(bool isSave, int32_t type, u8string defaultDirectory, u8string defaultPath)
+    {
+        Ui::FileDialogDesc desc = {};
+        u8string extension;
+        StringId title = kStringIdNone;
+        switch (type & 0x0E)
+        {
+            case LOADSAVETYPE_GAME:
+                extension = u8".park";
+                title = isSave ? STR_FILE_DIALOG_TITLE_SAVE_GAME : STR_FILE_DIALOG_TITLE_LOAD_GAME;
+                desc.Filters.emplace_back(LanguageGetString(STR_OPENRCT2_SAVED_GAME), GetFilterPatternByType(type, isSave));
+                break;
+
+            case LOADSAVETYPE_LANDSCAPE:
+                extension = u8".park";
+                title = isSave ? STR_FILE_DIALOG_TITLE_SAVE_LANDSCAPE : STR_FILE_DIALOG_TITLE_LOAD_LANDSCAPE;
+                desc.Filters.emplace_back(
+                    LanguageGetString(STR_OPENRCT2_LANDSCAPE_FILE), GetFilterPatternByType(type, isSave));
+                break;
+
+            case LOADSAVETYPE_SCENARIO:
+                extension = u8".park";
+                title = STR_FILE_DIALOG_TITLE_SAVE_SCENARIO;
+                desc.Filters.emplace_back(LanguageGetString(STR_OPENRCT2_SCENARIO_FILE), GetFilterPatternByType(type, isSave));
+                break;
+
+            case LOADSAVETYPE_TRACK:
+                extension = u8".td6";
+                title = isSave ? STR_FILE_DIALOG_TITLE_SAVE_TRACK : STR_FILE_DIALOG_TITLE_INSTALL_NEW_TRACK_DESIGN;
+                desc.Filters.emplace_back(
+                    LanguageGetString(STR_OPENRCT2_TRACK_DESIGN_FILE), GetFilterPatternByType(type, isSave));
+                break;
+
+            case LOADSAVETYPE_HEIGHTMAP:
+                title = STR_FILE_DIALOG_TITLE_LOAD_HEIGHTMAP;
+                desc.Filters.emplace_back(
+                    LanguageGetString(STR_OPENRCT2_HEIGHTMAP_FILE), GetFilterPatternByType(type, isSave));
+                break;
+        }
+
+        u8string path = defaultDirectory;
+        if (isSave)
+        {
+            // The file browser requires a file path instead of just a directory
+            if (!defaultPath.empty())
+            {
+                path = Path::Combine(path, defaultPath);
+            }
+            else
+            {
+                auto buffer = GetGameState().Park.Name;
+                if (buffer.empty())
+                {
+                    buffer = LanguageGetString(STR_UNNAMED_PARK);
+                }
+                path = Path::Combine(path, buffer);
+            }
+        }
+
+        desc.InitialDirectory = defaultDirectory;
+        desc.Type = isSave ? FileDialogType::Save : FileDialogType::Open;
+        desc.DefaultFilename = isSave ? path : u8string();
+
+        desc.Filters.emplace_back(LanguageGetString(STR_ALL_FILES), "*");
+
+        desc.Title = LanguageGetString(title);
+        return ContextOpenCommonFileDialog(desc);
+    }
+} // namespace OpenRCT2::Ui::FileBrowser

--- a/src/openrct2-ui/interface/FileBrowser.cpp
+++ b/src/openrct2-ui/interface/FileBrowser.cpp
@@ -372,41 +372,60 @@ namespace OpenRCT2::Ui::FileBrowser
         }
     }
 
+    StringId GetTitleStringId(int32_t type, bool isSave)
+    {
+        switch (type & 0x0E)
+        {
+            case LOADSAVETYPE_GAME:
+                return isSave ? STR_FILE_DIALOG_TITLE_SAVE_GAME : STR_FILE_DIALOG_TITLE_LOAD_GAME;
+
+            case LOADSAVETYPE_LANDSCAPE:
+                return isSave ? STR_FILE_DIALOG_TITLE_SAVE_LANDSCAPE : STR_FILE_DIALOG_TITLE_LOAD_LANDSCAPE;
+
+            case LOADSAVETYPE_SCENARIO:
+                return STR_FILE_DIALOG_TITLE_SAVE_SCENARIO;
+
+            case LOADSAVETYPE_TRACK:
+                return isSave ? STR_FILE_DIALOG_TITLE_SAVE_TRACK : STR_FILE_DIALOG_TITLE_INSTALL_NEW_TRACK_DESIGN;
+
+            case LOADSAVETYPE_HEIGHTMAP:
+                return STR_FILE_DIALOG_TITLE_LOAD_HEIGHTMAP;
+
+            default:
+                return kStringIdNone;
+        }
+    }
+
     u8string OpenSystemFileBrowser(bool isSave, int32_t type, u8string defaultDirectory, u8string defaultPath)
     {
         Ui::FileDialogDesc desc = {};
         u8string extension;
-        StringId title = kStringIdNone;
+        StringId title = GetTitleStringId(type, isSave);
         switch (type & 0x0E)
         {
             case LOADSAVETYPE_GAME:
                 extension = u8".park";
-                title = isSave ? STR_FILE_DIALOG_TITLE_SAVE_GAME : STR_FILE_DIALOG_TITLE_LOAD_GAME;
                 desc.Filters.emplace_back(LanguageGetString(STR_OPENRCT2_SAVED_GAME), GetFilterPatternByType(type, isSave));
                 break;
 
             case LOADSAVETYPE_LANDSCAPE:
                 extension = u8".park";
-                title = isSave ? STR_FILE_DIALOG_TITLE_SAVE_LANDSCAPE : STR_FILE_DIALOG_TITLE_LOAD_LANDSCAPE;
                 desc.Filters.emplace_back(
                     LanguageGetString(STR_OPENRCT2_LANDSCAPE_FILE), GetFilterPatternByType(type, isSave));
                 break;
 
             case LOADSAVETYPE_SCENARIO:
                 extension = u8".park";
-                title = STR_FILE_DIALOG_TITLE_SAVE_SCENARIO;
                 desc.Filters.emplace_back(LanguageGetString(STR_OPENRCT2_SCENARIO_FILE), GetFilterPatternByType(type, isSave));
                 break;
 
             case LOADSAVETYPE_TRACK:
                 extension = u8".td6";
-                title = isSave ? STR_FILE_DIALOG_TITLE_SAVE_TRACK : STR_FILE_DIALOG_TITLE_INSTALL_NEW_TRACK_DESIGN;
                 desc.Filters.emplace_back(
                     LanguageGetString(STR_OPENRCT2_TRACK_DESIGN_FILE), GetFilterPatternByType(type, isSave));
                 break;
 
             case LOADSAVETYPE_HEIGHTMAP:
-                title = STR_FILE_DIALOG_TITLE_LOAD_HEIGHTMAP;
                 desc.Filters.emplace_back(
                     LanguageGetString(STR_OPENRCT2_HEIGHTMAP_FILE), GetFilterPatternByType(type, isSave));
                 break;

--- a/src/openrct2-ui/interface/FileBrowser.cpp
+++ b/src/openrct2-ui/interface/FileBrowser.cpp
@@ -43,8 +43,10 @@ namespace OpenRCT2::Ui::FileBrowser
         // Open system file picker?
         if (config.UseNativeBrowseDialog && hasFilePicker)
         {
-            bool isSave = (type & 0x01) == LOADSAVETYPE_SAVE;
-            const u8string path = OpenSystemFileBrowser(isSave, type, defaultPath, defaultPath);
+            const bool isSave = (type & 0x01) == LOADSAVETYPE_SAVE;
+            const auto defaultDirectory = GetDir(type);
+
+            const u8string path = OpenSystemFileBrowser(isSave, type, defaultDirectory, defaultPath);
             if (!path.empty())
             {
                 Select(path.c_str(), type, trackDesign);

--- a/src/openrct2-ui/interface/FileBrowser.cpp
+++ b/src/openrct2-ui/interface/FileBrowser.cpp
@@ -31,7 +31,30 @@
 
 namespace OpenRCT2::Ui::FileBrowser
 {
-    static std::function<void(int32_t result, std::string_view)> _loadSaveCallback;
+    static LoadSaveCallback _loadSaveCallback;
+
+    WindowBase* OpenPreferred(int32_t type, u8string defaultPath, LoadSaveCallback callback, TrackDesign* trackDesign)
+    {
+        RegisterCallback(callback);
+
+        auto hasFilePicker = OpenRCT2::GetContext()->GetUiContext()->HasFilePicker();
+        auto& config = Config::Get().general;
+
+        // Open system file picker?
+        if (config.UseNativeBrowseDialog && hasFilePicker)
+        {
+            bool isSave = (type & 0x01) == LOADSAVETYPE_SAVE;
+            const u8string path = OpenSystemFileBrowser(isSave, type, defaultPath, defaultPath);
+            if (!path.empty())
+            {
+                Select(path.c_str(), type, trackDesign);
+            }
+            return nullptr;
+        }
+
+        // Use built-in load/save window
+        return Windows::LoadsaveOpen(type, defaultPath, callback, trackDesign);
+    }
 
     bool ListItemSort(LoadSaveListItem& a, LoadSaveListItem& b)
     {

--- a/src/openrct2-ui/interface/FileBrowser.h
+++ b/src/openrct2-ui/interface/FileBrowser.h
@@ -57,6 +57,7 @@ namespace OpenRCT2::Ui::FileBrowser
     void RegisterCallback(std::function<void(int32_t result, std::string_view)> callback);
     void InvokeCallback(int32_t result, const utf8* path);
     void Select(const char* path, int32_t type, TrackDesign* trackDesignPtr);
+    StringId GetTitleStringId(int32_t type, bool isSave);
     u8string OpenSystemFileBrowser(bool isSave, int32_t type, u8string defaultDirectory, u8string defaultPath);
     WindowBase* OpenPreferred(int32_t type, u8string defaultPath, LoadSaveCallback callback, TrackDesign* trackDesign);
 } // namespace OpenRCT2::Ui::FileBrowser

--- a/src/openrct2-ui/interface/FileBrowser.h
+++ b/src/openrct2-ui/interface/FileBrowser.h
@@ -17,6 +17,11 @@
 
 struct TrackDesign;
 
+namespace OpenRCT2
+{
+    struct WindowBase;
+}
+
 namespace OpenRCT2::Ui::FileBrowser
 {
     enum class FileType : uint8_t
@@ -39,6 +44,8 @@ namespace OpenRCT2::Ui::FileBrowser
         bool loaded{ false };
     };
 
+    using LoadSaveCallback = std::function<void(int32_t result, std::string_view)>;
+
     bool ListItemSort(LoadSaveListItem& a, LoadSaveListItem& b);
     void SetAndSaveConfigPath(u8string& config_str, u8string_view path);
     bool IsValidPath(const char* path);
@@ -51,4 +58,5 @@ namespace OpenRCT2::Ui::FileBrowser
     void InvokeCallback(int32_t result, const utf8* path);
     void Select(const char* path, int32_t type, TrackDesign* trackDesignPtr);
     u8string OpenSystemFileBrowser(bool isSave, int32_t type, u8string defaultDirectory, u8string defaultPath);
+    WindowBase* OpenPreferred(int32_t type, u8string defaultPath, LoadSaveCallback callback, TrackDesign* trackDesign);
 } // namespace OpenRCT2::Ui::FileBrowser

--- a/src/openrct2-ui/interface/FileBrowser.h
+++ b/src/openrct2-ui/interface/FileBrowser.h
@@ -1,0 +1,54 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2025 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <openrct2/core/StringTypes.h>
+#include <openrct2/localisation/StringIdType.h>
+#include <string>
+
+struct TrackDesign;
+
+namespace OpenRCT2::Ui::FileBrowser
+{
+    enum class FileType : uint8_t
+    {
+        directory,
+        file,
+    };
+
+    struct LoadSaveListItem
+    {
+        std::string name{};
+        std::string path{};
+        time_t date_modified{ 0 };
+        std::string date_formatted{};
+        std::string time_formatted{};
+        uint64_t fileSizeBytes;
+        uint64_t fileSizeFormatted;
+        StringId fileSizeUnit;
+        FileType type{};
+        bool loaded{ false };
+    };
+
+    bool ListItemSort(LoadSaveListItem& a, LoadSaveListItem& b);
+    void SetAndSaveConfigPath(u8string& config_str, u8string_view path);
+    bool IsValidPath(const char* path);
+    u8string GetLastDirectoryByType(int32_t type);
+    u8string GetInitialDirectoryByType(const int32_t type);
+    const char* GetFilterPatternByType(const int32_t type, const bool isSave);
+    u8string RemovePatternWildcard(u8string_view pattern);
+    u8string GetDir(const int32_t type);
+    void RegisterCallback(std::function<void(int32_t result, std::string_view)> callback);
+    void InvokeCallback(int32_t result, const utf8* path);
+    void Select(const char* path, int32_t type, TrackDesign* trackDesignPtr);
+    u8string OpenSystemFileBrowser(bool isSave, int32_t type, u8string defaultDirectory, u8string defaultPath);
+} // namespace OpenRCT2::Ui::FileBrowser

--- a/src/openrct2-ui/interface/FileBrowser.h
+++ b/src/openrct2-ui/interface/FileBrowser.h
@@ -34,9 +34,9 @@ namespace OpenRCT2::Ui::FileBrowser
     {
         std::string name{};
         std::string path{};
-        time_t date_modified{ 0 };
-        std::string date_formatted{};
-        std::string time_formatted{};
+        time_t dateModified{ 0 };
+        std::string dateFormatted{};
+        std::string timeFormatted{};
         uint64_t fileSizeBytes;
         uint64_t fileSizeFormatted;
         StringId fileSizeUnit;

--- a/src/openrct2-ui/libopenrct2ui.vcxproj
+++ b/src/openrct2-ui/libopenrct2ui.vcxproj
@@ -69,6 +69,7 @@
     <ClInclude Include="input\ShortcutManager.h" />
     <ClInclude Include="interface\Dropdown.h" />
     <ClInclude Include="interface\Graph.h" />
+    <ClInclude Include="interface\FileBrowser.h" />
     <ClInclude Include="interface\InGameConsole.h" />
     <ClInclude Include="interface\LandTool.h" />
     <ClInclude Include="interface\Objective.h" />
@@ -134,6 +135,7 @@
     <ClCompile Include="input\ShortcutInput.cpp" />
     <ClCompile Include="input\ShortcutManager.cpp" />
     <ClCompile Include="interface\Graph.cpp" />
+    <ClCompile Include="interface\FileBrowser.cpp" />
     <ClCompile Include="interface\InGameConsole.cpp" />
     <ClCompile Include="interface\LandTool.cpp" />
     <ClCompile Include="interface\Objective.cpp" />
@@ -198,6 +200,7 @@
     <ClCompile Include="windows\NewsOptions.cpp" />
     <ClCompile Include="windows\ObjectLoadError.cpp" />
     <ClCompile Include="windows\Options.cpp" />
+    <ClCompile Include="windows\OverwritePrompt.cpp" />
     <ClCompile Include="windows\Park.cpp" />
     <ClCompile Include="windows\PatrolArea.cpp" />
     <ClCompile Include="windows\Player.cpp" />

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -222,11 +222,11 @@ namespace OpenRCT2::Ui::Windows
                         LoadSaveListItem newListItem;
                         newListItem.path = scanner->GetPath();
                         newListItem.type = FileType::file;
-                        newListItem.date_modified = Platform::FileGetModifiedTime(newListItem.path.c_str());
+                        newListItem.dateModified = Platform::FileGetModifiedTime(newListItem.path.c_str());
 
                         // Cache a human-readable version of the modified date.
-                        newListItem.date_formatted = Platform::FormatShortDate(newListItem.date_modified);
-                        newListItem.time_formatted = Platform::FormatTime(newListItem.date_modified);
+                        newListItem.dateFormatted = Platform::FormatShortDate(newListItem.dateModified);
+                        newListItem.timeFormatted = Platform::FormatTime(newListItem.dateModified);
 
                         // File size
                         newListItem.fileSizeBytes = Platform::GetFileSize(newListItem.path.c_str());
@@ -902,13 +902,13 @@ namespace OpenRCT2::Ui::Windows
                 {
                     ft = Formatter();
                     ft.Add<StringId>(STR_STRING);
-                    ft.Add<char*>(_listItems[i].date_formatted.c_str());
+                    ft.Add<char*>(_listItems[i].dateFormatted.c_str());
                     DrawTextEllipsised(
                         dpi, { dateAnchor - kDateTimeGap, y }, maxDateWidth, stringId, ft, { TextAlignment::RIGHT });
 
                     ft = Formatter();
                     ft.Add<StringId>(STR_STRING);
-                    ft.Add<char*>(_listItems[i].time_formatted.c_str());
+                    ft.Add<char*>(_listItems[i].timeFormatted.c_str());
                     DrawTextEllipsised(dpi, { dateAnchor + kDateTimeGap, y }, maxTimeWidth, stringId, ft);
                 }
             }

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -326,7 +326,6 @@ namespace OpenRCT2::Ui::Windows
 
             // TODO: Split LOADSAVETYPE_* into two proper enum classes (one for load/save, the other for the type)
             const bool isSave = (type & 0x01) == LOADSAVETYPE_SAVE;
-            const auto path = GetDir(type);
 
             // Pause the game if not on title scene, nor in network play.
             if (!(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) && NetworkGetMode() == NETWORK_MODE_NONE)
@@ -355,6 +354,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Populate file list
             const char* pattern = GetFilterPatternByType(type, isSave);
+            const auto path = GetDir(type);
             PopulateList(isSave, path, pattern);
             no_list_items = static_cast<uint16_t>(_listItems.size());
             selected_list_item = -1;
@@ -923,10 +923,6 @@ namespace OpenRCT2::Ui::Windows
 
         RegisterCallback(callback);
 
-        bool isSave = (type & 0x01) == LOADSAVETYPE_SAVE;
-
-        const u8string path = GetDir(type);
-
         auto* windowMgr = GetWindowManager();
         auto* w = static_cast<LoadSaveWindow*>(windowMgr->BringToFrontByClass(WindowClass::Loadsave));
         if (w == nullptr)
@@ -947,6 +943,8 @@ namespace OpenRCT2::Ui::Windows
                 WindowClass::Loadsave, width, height, WF_STICK_TO_FRONT | WF_RESIZABLE | WF_AUTO_POSITION | WF_CENTRE_SCREEN,
                 type);
         }
+
+        bool isSave = (type & 0x01) == LOADSAVETYPE_SAVE;
 
         if ((type & 0x0E) == LOADSAVETYPE_HEIGHTMAP && !isSave)
         {

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -948,34 +948,15 @@ namespace OpenRCT2::Ui::Windows
                 type);
         }
 
-        switch (type & 0x0E)
+        if ((type & 0x0E) == LOADSAVETYPE_HEIGHTMAP && !isSave)
         {
-            case LOADSAVETYPE_GAME:
-                w->widgets[WIDX_TITLE].text = isSave ? STR_FILE_DIALOG_TITLE_SAVE_GAME : STR_FILE_DIALOG_TITLE_LOAD_GAME;
-                break;
+            Guard::Fail("Cannot save images through loadsave window");
+        }
 
-            case LOADSAVETYPE_LANDSCAPE:
-                w->widgets[WIDX_TITLE].text = isSave ? STR_FILE_DIALOG_TITLE_SAVE_LANDSCAPE
-                                                     : STR_FILE_DIALOG_TITLE_LOAD_LANDSCAPE;
-                break;
-
-            case LOADSAVETYPE_SCENARIO:
-                w->widgets[WIDX_TITLE].text = STR_FILE_DIALOG_TITLE_SAVE_SCENARIO;
-                break;
-
-            case LOADSAVETYPE_TRACK:
-                w->widgets[WIDX_TITLE].text = isSave ? STR_FILE_DIALOG_TITLE_SAVE_TRACK
-                                                     : STR_FILE_DIALOG_TITLE_INSTALL_NEW_TRACK_DESIGN;
-                break;
-
-            case LOADSAVETYPE_HEIGHTMAP:
-                Guard::Assert(!isSave, "Cannot save images through loadsave window");
-                w->widgets[WIDX_TITLE].text = STR_FILE_DIALOG_TITLE_LOAD_HEIGHTMAP;
-                break;
-
-            default:
-                Guard::Fail("Unsupported load/save type: %d", type & 0x0F);
-                break;
+        w->widgets[WIDX_TITLE].text = GetTitleStringId(type, isSave);
+        if (w->widgets[WIDX_TITLE].text == kStringIdNone)
+        {
+            Guard::Fail("Unsupported load/save type: %d", type & 0x0F);
         }
 
         return w;

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -916,29 +916,14 @@ namespace OpenRCT2::Ui::Windows
 #pragma endregion
     };
 
-    WindowBase* LoadsaveOpen(
-        int32_t type, std::string_view defaultPath, std::function<void(int32_t result, std::string_view)> callback,
-        TrackDesign* trackDesign)
+    WindowBase* LoadsaveOpen(int32_t type, std::string_view defaultPath, LoadSaveCallback callback, TrackDesign* trackDesign)
     {
         _trackDesign = trackDesign;
         _defaultPath = defaultPath;
 
         RegisterCallback(callback);
 
-        auto& config = Config::Get().general;
         bool isSave = (type & 0x01) == LOADSAVETYPE_SAVE;
-
-        // Bypass the lot?
-        auto hasFilePicker = OpenRCT2::GetContext()->GetUiContext()->HasFilePicker();
-        if (config.UseNativeBrowseDialog && hasFilePicker)
-        {
-            const u8string path = OpenSystemFileBrowser(isSave, type, _directory, _defaultPath);
-            if (!path.empty())
-            {
-                Select(path.c_str(), type, _trackDesign);
-            }
-            return nullptr;
-        }
 
         const u8string path = GetDir(type);
 
@@ -946,6 +931,7 @@ namespace OpenRCT2::Ui::Windows
         auto* w = static_cast<LoadSaveWindow*>(windowMgr->BringToFrontByClass(WindowClass::Loadsave));
         if (w == nullptr)
         {
+            auto& config = Config::Get().general;
             if (config.FileBrowserWidth < kWindowSizeMin.width || config.FileBrowserHeight < kWindowSizeMin.height
                 || config.FileBrowserWidth > kWindowSizeMax.width || config.FileBrowserHeight > kWindowSizeMax.height)
             {

--- a/src/openrct2-ui/windows/OverwritePrompt.cpp
+++ b/src/openrct2-ui/windows/OverwritePrompt.cpp
@@ -47,7 +47,8 @@ namespace OpenRCT2::Ui::Windows
         TrackDesign* _trackDesign;
 
     public:
-    OverwritePromptWindow(const std::string_view name, const std::string_view path, int32_t type, TrackDesign* trackDesignPtr)
+        OverwritePromptWindow(
+            const std::string_view name, const std::string_view path, int32_t type, TrackDesign* trackDesignPtr)
             : _name(name)
             , _path(path)
             , _type(type)
@@ -95,7 +96,8 @@ namespace OpenRCT2::Ui::Windows
         }
     };
 
-    WindowBase* WindowOverwritePromptOpen(const std::string_view name, const std::string_view path, int32_t type, TrackDesign* trackDesignPtr)
+    WindowBase* WindowOverwritePromptOpen(
+        const std::string_view name, const std::string_view path, int32_t type, TrackDesign* trackDesignPtr)
     {
         auto* windowMgr = Ui::GetWindowManager();
         windowMgr->CloseByClass(WindowClass::LoadsaveOverwritePrompt);

--- a/src/openrct2-ui/windows/OverwritePrompt.cpp
+++ b/src/openrct2-ui/windows/OverwritePrompt.cpp
@@ -1,0 +1,126 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2025 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include <SDL_keycode.h>
+#include <openrct2-ui/interface/FileBrowser.h>
+#include <openrct2-ui/interface/Widget.h>
+#include <openrct2-ui/windows/Windows.h>
+#include <openrct2/localisation/StringIds.h>
+#include <openrct2/ui/WindowManager.h>
+#include <string>
+
+struct TrackDesign;
+
+namespace OpenRCT2::Ui::Windows
+{
+    constexpr int32_t OVERWRITE_WW = 200;
+    constexpr int32_t OVERWRITE_WH = 100;
+
+    enum
+    {
+        WIDX_OVERWRITE_BACKGROUND,
+        WIDX_OVERWRITE_TITLE,
+        WIDX_OVERWRITE_CLOSE,
+        WIDX_OVERWRITE_OVERWRITE,
+        WIDX_OVERWRITE_CANCEL
+    };
+
+    // clang-format off
+    static constexpr Widget window_overwrite_prompt_widgets[] = {
+        WINDOW_SHIM_WHITE(STR_FILEBROWSER_OVERWRITE_TITLE, OVERWRITE_WW, OVERWRITE_WH),
+        MakeWidget({                10, OVERWRITE_WH - 20 }, { 84, 11 }, WindowWidgetType::Button, WindowColour::Primary, STR_FILEBROWSER_OVERWRITE_TITLE),
+        MakeWidget({ OVERWRITE_WW - 95, OVERWRITE_WH - 20 }, { 85, 11 }, WindowWidgetType::Button, WindowColour::Primary, STR_SAVE_PROMPT_CANCEL),
+    };
+    // clang-format on
+
+    class OverwritePromptWindow final : public Window
+    {
+        std::string _name;
+        std::string _path;
+        int32_t _type;
+        TrackDesign* _trackDesign;
+
+    public:
+    OverwritePromptWindow(const std::string_view name, const std::string_view path, int32_t type, TrackDesign* trackDesignPtr)
+            : _name(name)
+            , _path(path)
+            , _type(type)
+            , _trackDesign(trackDesignPtr)
+        {
+        }
+
+        void OnOpen() override
+        {
+            SetWidgets(window_overwrite_prompt_widgets);
+        }
+
+        void OnMouseUp(WidgetIndex widgetIndex) override
+        {
+            switch (widgetIndex)
+            {
+                case WIDX_OVERWRITE_OVERWRITE:
+                {
+                    FileBrowser::Select(_path.c_str(), _type, _trackDesign);
+
+                    // As the LoadSaveWindow::Select function can change the order of the
+                    // windows we can't use WindowClose(w).
+                    auto* windowMgr = Ui::GetWindowManager();
+                    windowMgr->CloseByClass(WindowClass::LoadsaveOverwritePrompt);
+                    break;
+                }
+
+                case WIDX_OVERWRITE_CANCEL:
+                case WIDX_OVERWRITE_CLOSE:
+                    Close();
+                    break;
+            }
+        }
+
+        void OnDraw(DrawPixelInfo& dpi) override
+        {
+            DrawWidgets(dpi);
+
+            auto ft = Formatter();
+            ft.Add<StringId>(STR_STRING);
+            ft.Add<char*>(_name.c_str());
+
+            ScreenCoordsXY stringCoords(windowPos.x + width / 2, windowPos.y + (height / 2) - 3);
+            DrawTextWrapped(dpi, stringCoords, width - 4, STR_FILEBROWSER_OVERWRITE_PROMPT, ft, { TextAlignment::CENTRE });
+        }
+    };
+
+    WindowBase* WindowOverwritePromptOpen(const std::string_view name, const std::string_view path, int32_t type, TrackDesign* trackDesignPtr)
+    {
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->CloseByClass(WindowClass::LoadsaveOverwritePrompt);
+
+        return windowMgr->Create<OverwritePromptWindow>(
+            WindowClass::LoadsaveOverwritePrompt, OVERWRITE_WW, OVERWRITE_WH,
+            WF_TRANSPARENT | WF_STICK_TO_FRONT | WF_CENTRE_SCREEN, name, path, type, trackDesignPtr);
+    }
+
+    void WindowLoadSaveOverwritePromptInputKey(WindowBase* w, uint32_t keycode)
+    {
+        if (w->classification != WindowClass::LoadsaveOverwritePrompt)
+        {
+            return;
+        }
+
+        auto promptWindow = static_cast<OverwritePromptWindow*>(w);
+
+        if (keycode == SDLK_RETURN || keycode == SDLK_KP_ENTER)
+        {
+            promptWindow->OnMouseUp(WIDX_OVERWRITE_OVERWRITE);
+        }
+        else if (keycode == SDLK_ESCAPE)
+        {
+            promptWindow->OnMouseUp(WIDX_OVERWRITE_CANCEL);
+        }
+    }
+} // namespace OpenRCT2::Ui::Windows

--- a/src/openrct2-ui/windows/Windows.h
+++ b/src/openrct2-ui/windows/Windows.h
@@ -187,7 +187,8 @@ namespace OpenRCT2::Ui::Windows
     WindowBase* OptionsOpen();
 
     // OverwritePrompt
-    WindowBase* WindowOverwritePromptOpen(const std::string_view name, const std::string_view path, int32_t type, TrackDesign* trackDesignPtr);
+    WindowBase* WindowOverwritePromptOpen(
+        const std::string_view name, const std::string_view path, int32_t type, TrackDesign* trackDesignPtr);
     void WindowLoadSaveOverwritePromptInputKey(WindowBase* w, uint32_t keycode);
 
     // Park

--- a/src/openrct2-ui/windows/Windows.h
+++ b/src/openrct2-ui/windows/Windows.h
@@ -136,7 +136,6 @@ namespace OpenRCT2::Ui::Windows
         int32_t type, std::string_view defaultPath, std::function<void(int32_t result, std::string_view)> callback,
         TrackDesign* trackDesign);
     void WindowLoadSaveInputKey(WindowBase* w, uint32_t keycode);
-    void WindowLoadSaveOverwritePromptInputKey(WindowBase* w, uint32_t keycode);
 
     // Main
     WindowBase* MainOpen();
@@ -186,6 +185,10 @@ namespace OpenRCT2::Ui::Windows
 
     // Options
     WindowBase* OptionsOpen();
+
+    // OverwritePrompt
+    WindowBase* WindowOverwritePromptOpen(const std::string_view name, const std::string_view path, int32_t type, TrackDesign* trackDesignPtr);
+    void WindowLoadSaveOverwritePromptInputKey(WindowBase* w, uint32_t keycode);
 
     // Park
     WindowBase* ParkAwardsOpen();


### PR DESCRIPTION
While working on the in-game file browser for another as-yet-undisclosed feature, I really wanted to split up the `LoadSave.cpp` unit. This PR contains the cherry-picked commits.

If the player has set the `UseNativeBrowseDialog` config to true, the file browser is no longer opened through the in-game `LoadSaveWindow`. Instead, we introduce `Ui::FileBrowser::OpenPreferred`, which calls `OpenSystemFileBrowser` if preferred. This is a better separation of concerns, imo.