### PR TITLE
Fix #14486: Guests falling if path after park entrance is an upward slope

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Improved: [#23677] Building new ride track now inherits the colour scheme from the previous piece.
 - Fix: [#1972, #11679] Vehicles passing by toilets can cause them to glitch (original bug).
 - Fix: [#9999, #10000, #10001, #10002, #10003] Truncated scenario strings when using Catalan, Czech, Japanese, Polish or Russian.
+- Fix: [#14486] Guests will fall through upwards sloped paths when making their way through a park entrance or ride exit (original bug).
 - Fix: [#15826, #23835] Wooden Roller Coaster steep turn supports glitch when train goes over them (original bug).
 - Fix: [#16357] Chairlift station covers draw incorrectly.
 - Fix: [#16657] Mine Ride right S-bend uses Mini Roller Coaster sprite (original bug).

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -808,7 +808,7 @@ void Peep::UpdateFalling()
                                      { x, y }, tile_element->AsPath()->GetSlopeDirection(), tile_element->AsPath()->IsSloped())
                     + tile_element->GetBaseZ();
 
-                if (height < z - 1 || height > z + 4)
+                if (height < z - 1 || height > z + 8)
                     continue;
 
                 saved_height = height;


### PR DESCRIPTION
The problem was that some energetic guests would charge through the entrance, after which the game detected them as being under the path.

This raises the safety margin from 4 to 8, which in my tests appears to solve the problem. More testing is appreciated, though.

I think this might also fix the same issue with ride exits, but again, would appreciate some tests.