### PR TITLE
Fix hyper-twister roller coaster string

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3217,7 +3217,7 @@ STR_6102    :The value of a ride won’t decrease over time, so guests will not 
 STR_6103    :This option is disabled during network play.
 STR_6105    :Hypercoaster
 STR_6107    :Monster Trucks
-STR_6109    :Hyper-Twister
+STR_6109    :Hyper-Twister Roller Coaster
 STR_6111    :Classic Mini Roller Coaster
 STR_6113    :A tall non-inverting roller coaster with large drops, high speed, and comfortable trains with only lap bar restraints
 STR_6115    :Powered giant 4 × 4 trucks which can climb steep slopes


### PR DESCRIPTION
This seems to have been an oversight from when the hyper-twister coaster was re-split off from the twister coaster earlier in OpenRCT2's development as they were once merged to replicate RCT1 behavior. RCT2 vanilla calls it the hyper-twister roller coaster.

Vanilla:
![Screenshot at 2025-02-19 11-51-042](https://github.com/user-attachments/assets/9287584c-0883-4649-8c79-394bc59c7ade)
