### PR TITLE
Fix #23814: Scenarios not indexed on first start

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Fix: [#23795] Looping Roller Coaster vertical loop supports are drawn incorrectly.
 - Fix: [#23809] Trains glitch on Bobsleigh Coaster small helixes.
 - Fix: [#23811] Land edges glitch when vehicles go through gentle to flat tunnels.
+- Fix: [#23814] Scenarios not indexed on first start.
 - Fix: [#23818] Spinning tunnels can draw over sloped terrain in front of them.
 
 0.4.19.1 (2025-02-03)

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -174,10 +174,6 @@ namespace OpenRCT2
             , _audioContext(audioContext)
             , _uiContext(uiContext)
             , _localisationService(std::make_unique<LocalisationService>(env))
-            , _objectRepository(CreateObjectRepository(_env))
-            , _objectManager(CreateObjectManager(*_objectRepository))
-            , _trackDesignRepository(CreateTrackDesignRepository(_env))
-            , _scenarioRepository(CreateScenarioRepository(_env))
             , _replayManager(CreateReplayManager())
             , _gameStateSnapshots(CreateGameStateSnapshots())
 #ifdef ENABLE_SCRIPTING
@@ -465,6 +461,13 @@ namespace OpenRCT2
                 }
                 _env->SetBasePath(DIRBASE::RCT2, rct2InstallPath);
             }
+
+            // The repositories are all dependent on the RCT2 path being set,
+            // so they cannot be set in the constructor.
+            _objectRepository = CreateObjectRepository(_env);
+            _objectManager = CreateObjectManager(*_objectRepository);
+            _trackDesignRepository = CreateTrackDesignRepository(_env);
+            _scenarioRepository = CreateScenarioRepository(_env);
 
             if (!gOpenRCT2Headless)
             {


### PR DESCRIPTION
Regression from https://github.com/OpenRCT2/OpenRCT2/commit/ddc386b186152b83e97b70627429f82050882768