### PR TITLE
Spiral slide refactor

### DIFF
--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -4741,7 +4741,7 @@ void Guest::UpdateRideApproachSpiralSlide()
         // Actually increment the real peep waypoint
         Var37++;
 
-        CoordsXY targetLoc = ride->GetStation(CurrentRideStation).Start;
+        CoordsXY targetLoc = ride->getStation(CurrentRideStation).Start;
 
         assert(rtd.specialType == RtdSpecialType::spiralSlide);
         targetLoc += kSpiralSlideWalkingPath[Var37];

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -3556,14 +3556,14 @@ static constexpr CoordsXY kMazeEntranceStart[] = {
     { 24, 8 },
 };
 
-void PeepUpdateRideLeaveEntranceMaze(Guest* peep, Ride& ride, CoordsXYZD& entrance_loc)
+void PeepUpdateRideLeaveEntranceMaze(Guest* peep, Ride& ride, CoordsXYZD& entranceLoc)
 {
-    peep->MazeLastEdge = entrance_loc.direction + 1;
+    peep->MazeLastEdge = entranceLoc.direction + 1;
 
-    entrance_loc.x += CoordsDirectionDelta[entrance_loc.direction].x;
-    entrance_loc.y += CoordsDirectionDelta[entrance_loc.direction].y;
+    entranceLoc.x += CoordsDirectionDelta[entranceLoc.direction].x;
+    entranceLoc.y += CoordsDirectionDelta[entranceLoc.direction].y;
 
-    uint8_t direction = entrance_loc.direction * 4 + 11;
+    uint8_t direction = entranceLoc.direction * 4 + 11;
     if (ScenarioRand() & 0x40)
     {
         direction += 4;
@@ -3575,29 +3575,29 @@ void PeepUpdateRideLeaveEntranceMaze(Guest* peep, Ride& ride, CoordsXYZD& entran
     peep->Var37 = direction;
     peep->MazeLastEdge &= 3;
 
-    entrance_loc.x += kMazeEntranceStart[direction / 4].x;
-    entrance_loc.y += kMazeEntranceStart[direction / 4].y;
+    entranceLoc.x += kMazeEntranceStart[direction / 4].x;
+    entranceLoc.y += kMazeEntranceStart[direction / 4].y;
 
-    peep->SetDestination(entrance_loc, 3);
+    peep->SetDestination(entranceLoc, 3);
 
     ride.curNumCustomers++;
     peep->OnEnterRide(ride);
     peep->RideSubState = PeepRideSubState::MazePathfinding;
 }
 
-void PeepUpdateRideLeaveEntranceSpiralSlide(Guest* peep, Ride& ride, CoordsXYZD& entrance_loc)
+void PeepUpdateRideLeaveEntranceSpiralSlide(Guest* peep, Ride& ride, CoordsXYZD& entranceLoc)
 {
-    entrance_loc = { ride.getStation(peep->CurrentRideStation).GetStart(), entrance_loc.direction };
+    entranceLoc = { ride.getStation(peep->CurrentRideStation).GetStart(), entranceLoc.direction };
 
-    TileElement* tile_element = RideGetStationStartTrackElement(ride, peep->CurrentRideStation);
+    TileElement* tileElement = RideGetStationStartTrackElement(ride, peep->CurrentRideStation);
 
-    uint8_t direction_track = (tile_element == nullptr ? 0 : tile_element->GetDirection());
+    uint8_t trackDirection = (tileElement == nullptr ? 0 : tileElement->GetDirection());
 
-    peep->Var37 = (entrance_loc.direction << 2) | (direction_track << 4);
+    peep->Var37 = (entranceLoc.direction << 2) | (trackDirection << 4);
 
-    entrance_loc += kSpiralSlideWalkingPath[peep->Var37];
+    entranceLoc += kSpiralSlideWalkingPath[peep->Var37];
 
-    peep->SetDestination(entrance_loc);
+    peep->SetDestination(entranceLoc);
     peep->CurrentCar = 0;
 
     ride.curNumCustomers++;
@@ -3605,7 +3605,7 @@ void PeepUpdateRideLeaveEntranceSpiralSlide(Guest* peep, Ride& ride, CoordsXYZD&
     peep->RideSubState = PeepRideSubState::ApproachSpiralSlide;
 }
 
-void PeepUpdateRideLeaveEntranceDefault(Guest* peep, Ride& ride, CoordsXYZD& entrance_loc)
+void PeepUpdateRideLeaveEntranceDefault(Guest* peep, Ride& ride, CoordsXYZD& entranceLoc)
 {
     const auto currentTicks = getGameState().currentTicks;
 
@@ -3625,7 +3625,7 @@ void PeepUpdateRideLeaveEntranceDefault(Guest* peep, Ride& ride, CoordsXYZD& ent
     }
 }
 
-uint8_t Guest::GetWaypointedSeatLocation(const Ride& ride, const CarEntry* vehicle_type, uint8_t track_direction) const
+uint8_t Guest::GetWaypointedSeatLocation(const Ride& ride, const CarEntry* vehicle_type, uint8_t trackDirection) const
 {
     // The seatlocation can be split into segments around the ride base
     // to decide the segment first split off the segmentable seat location
@@ -3635,17 +3635,17 @@ uint8_t Guest::GetWaypointedSeatLocation(const Ride& ride, const CarEntry* vehic
 
     // Enterprise has more segments (8) compared to the normal (4)
     if (ride.type != RIDE_TYPE_ENTERPRISE)
-        track_direction *= 2;
+        trackDirection *= 2;
 
     // Type 1 loading doesn't do segments and all peeps go to the same
     // location on the ride
     if (vehicle_type->peep_loading_waypoint_segments == 0)
     {
-        track_direction /= 2;
+        trackDirection /= 2;
         seatLocationSegment = 0;
         seatLocationFixed = 0;
     }
-    seatLocationSegment += track_direction;
+    seatLocationSegment += trackDirection;
     seatLocationSegment &= 0x7;
     return seatLocationSegment + seatLocationFixed;
 }
@@ -3657,11 +3657,11 @@ void Guest::UpdateRideLeaveEntranceWaypoints(const Ride& ride)
     {
         return;
     }
-    uint8_t direction_entrance = station.Entrance.direction;
+    uint8_t directionEntrance = station.Entrance.direction;
 
-    TileElement* tile_element = RideGetStationStartTrackElement(ride, CurrentRideStation);
+    TileElement* tileElement = RideGetStationStartTrackElement(ride, CurrentRideStation);
 
-    uint8_t direction_track = (tile_element == nullptr ? 0 : tile_element->GetDirection());
+    uint8_t trackDirection = (tileElement == nullptr ? 0 : tileElement->GetDirection());
 
     auto vehicle = GetEntity<Vehicle>(ride.vehicles[CurrentTrain]);
     if (vehicle == nullptr)
@@ -3672,7 +3672,7 @@ void Guest::UpdateRideLeaveEntranceWaypoints(const Ride& ride)
     const auto* rideEntry = vehicle->GetRideEntry();
     const auto* carEntry = &rideEntry->Cars[vehicle->vehicle_type];
 
-    Var37 = (direction_entrance | GetWaypointedSeatLocation(ride, carEntry, direction_track) * 4) * 4;
+    Var37 = (directionEntrance | GetWaypointedSeatLocation(ride, carEntry, trackDirection) * 4) * 4;
 
     const auto& rtd = ride.getRideTypeDescriptor();
     CoordsXY waypoint = rtd.GetGuestWaypointLocation(*vehicle, ride, CurrentRideStation);

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -4722,7 +4722,7 @@ void Guest::UpdateRideApproachSpiralSlide()
         auto exit = ride->getStation(CurrentRideStation).Exit;
         waypoint = 1;
         auto directionTemp = exit.direction;
-        if (exit.direction == INVALID_DIRECTION)
+        if (exit.direction == kInvalidDirection)
         {
             directionTemp = 0;
         }

--- a/src/openrct2/entity/Guest.h
+++ b/src/openrct2/entity/Guest.h
@@ -393,7 +393,7 @@ private:
     void UpdateRideAtEntrance();
     void UpdateRideAdvanceThroughEntrance();
     void UpdateRideLeaveEntranceWaypoints(const Ride& ride);
-    uint8_t GetWaypointedSeatLocation(const Ride& ride, const CarEntry* vehicle_type, uint8_t track_direction) const;
+    uint8_t GetWaypointedSeatLocation(const Ride& ride, const CarEntry* vehicle_type, uint8_t trackDirection) const;
     void UpdateRideFreeVehicleCheck();
     void UpdateRideFreeVehicleEnterRide(Ride& ride);
     void UpdateRideApproachVehicle();
@@ -466,9 +466,9 @@ void IncrementGuestsHeadingForPark();
 void DecrementGuestsInPark();
 void DecrementGuestsHeadingForPark();
 
-void PeepUpdateRideLeaveEntranceMaze(Guest* peep, Ride& ride, CoordsXYZD& entrance_loc);
-void PeepUpdateRideLeaveEntranceSpiralSlide(Guest* peep, Ride& ride, CoordsXYZD& entrance_loc);
-void PeepUpdateRideLeaveEntranceDefault(Guest* peep, Ride& ride, CoordsXYZD& entrance_loc);
+void PeepUpdateRideLeaveEntranceMaze(Guest* peep, Ride& ride, CoordsXYZD& entranceLoc);
+void PeepUpdateRideLeaveEntranceSpiralSlide(Guest* peep, Ride& ride, CoordsXYZD& entranceLoc);
+void PeepUpdateRideLeaveEntranceDefault(Guest* peep, Ride& ride, CoordsXYZD& entranceLoc);
 
 CoordsXY GetGuestWaypointLocationDefault(const Vehicle& vehicle, const Ride& ride, const StationIndex& CurrentRideStation);
 CoordsXY GetGuestWaypointLocationEnterprise(const Vehicle& vehicle, const Ride& ride, const StationIndex& CurrentRideStation);

--- a/src/openrct2/paint/track/gentle/MerryGoRound.cpp
+++ b/src/openrct2/paint/track/gentle/MerryGoRound.cpp
@@ -38,7 +38,7 @@ static void PaintRiders(
     if (!(ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK))
         return;
 
-    for (int32_t peep = 0; peep <= 14; peep += 2)
+    for (uint8_t peep = 0; peep <= 14; peep += 2)
     {
         if (vehicle.num_peeps <= peep)
             break;

--- a/src/openrct2/paint/track/gentle/SpiralSlide.cpp
+++ b/src/openrct2/paint/track/gentle/SpiralSlide.cpp
@@ -222,7 +222,7 @@ static void PaintSpiralSlide(
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 0, 0, height }, { 32, 32, 1 } });
     }
 
-    const uint32_t spiral_slide_fence_sprites[] = {
+    const uint32_t spiralSlideFenceSprites[] = {
         rideEntry->Cars[0].base_image_id + SpiralSlideFenceTopRight,
         rideEntry->Cars[0].base_image_id + SpiralSlideFenceBottomRight,
         rideEntry->Cars[0].base_image_id + SpiralSlideFenceBottomLeft,
@@ -230,7 +230,7 @@ static void PaintSpiralSlide(
     };
 
     TrackPaintUtilPaintFences(
-        session, edges, session.MapPosition, trackElement, ride, session.TrackColours, height, spiral_slide_fence_sprites,
+        session, edges, session.MapPosition, trackElement, ride, session.TrackColours, height, spiralSlideFenceSprites,
         session.CurrentRotation);
 
     switch (trackSequence)

--- a/src/openrct2/paint/track/gentle/SpiralSlide.cpp
+++ b/src/openrct2/paint/track/gentle/SpiralSlide.cpp
@@ -140,18 +140,18 @@ static void SpiralSlidePaintTileFront(
 
     if (session.DPI.zoom_level <= ZoomLevel{ 0 } && ride.slideInUse != 0)
     {
-        uint8_t slide_progress = ride.spiralSlideProgress;
-        if (slide_progress != 0)
+        uint8_t slideProgress = ride.spiralSlideProgress;
+        if (slideProgress != 0)
         {
-            slide_progress--;
+            slideProgress--;
         }
 
-        if (slide_progress == 46)
+        if (slideProgress == 46)
         {
-            slide_progress--;
+            slideProgress--;
         }
 
-        if (slide_progress < 46)
+        if (slideProgress < 46)
         {
             int32_t offset = rideEntry->Cars[0].base_image_id + SpiralSlidePeep + 46 * direction;
             CoordsXYZ boundingBox = { 0, 0, 108 };
@@ -186,7 +186,7 @@ static void SpiralSlidePaintTileFront(
                 boundingBox.x = 8;
             }
 
-            imageId = ImageId(offset + slide_progress, ride.slidePeepTShirtColour, COLOUR_GREY);
+            imageId = ImageId(offset + slideProgress, ride.slidePeepTShirtColour, COLOUR_GREY);
 
             PaintAddImageAsChild(session, imageId, { 16, 16, height }, { boundingBoxOffset, boundingBox });
         }

--- a/src/openrct2/paint/track/gentle/SpiralSlide.cpp
+++ b/src/openrct2/paint/track/gentle/SpiralSlide.cpp
@@ -138,7 +138,7 @@ static void SpiralSlidePaintTileFront(
         PaintAddImageAsParent(session, imageId, { 16, 16, height }, { { 8, 0, height + 3 }, { 8, 16, 108 } });
     }
 
-    if (session.DPI.zoom_level <= ZoomLevel{ 0 } && ride.slideInUse != 0)
+    if (session.DPI.zoom_level <= ZoomLevel{ 0 } && ride.slideInUse)
     {
         uint8_t slideProgress = ride.spiralSlideProgress;
         if (slideProgress != 0)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1241,13 +1241,13 @@ void updateSpiralSlide(Ride& ride)
 {
     if (getGameState().currentTicks & 3)
         return;
-    if (ride.slideInUse == 0)
+    if (!ride.slideInUse)
         return;
 
     ride.spiralSlideProgress++;
     if (ride.spiralSlideProgress >= 48)
     {
-        ride.slideInUse--;
+        ride.slideInUse = 0;
 
         auto* peep = GetEntity<Guest>(ride.slidePeep);
         if (peep != nullptr)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1205,7 +1205,7 @@ void Ride::updatePopularity(const uint8_t pop_amount)
 }
 
 /** rct2: 0x0098DDB8, 0x0098DDBA */
-static constexpr CoordsXY ride_spiral_slide_main_tile_offset[][4] = {
+static constexpr CoordsXY kRideSpiralSlideMainTileOffset[][4] = {
     {
         { 32, 32 },
         { 0, 32 },
@@ -1258,7 +1258,7 @@ void updateSpiralSlide(Ride& ride)
         }
     }
 
-    const uint8_t current_rotation = GetCurrentRotation();
+    const uint8_t currentRotation = GetCurrentRotation();
     // Invalidate something related to station start
     for (int32_t i = 0; i < OpenRCT2::Limits::kMaxStationsPerRide; i++)
     {
@@ -1272,7 +1272,7 @@ void updateSpiralSlide(Ride& ride)
             continue;
 
         int32_t rotation = tileElement->GetDirection();
-        startLoc += ride_spiral_slide_main_tile_offset[rotation][current_rotation];
+        startLoc += kRideSpiralSlideMainTileOffset[rotation][currentRotation];
 
         MapInvalidateTileZoom0({ startLoc, tileElement->GetBaseZ(), tileElement->GetClearanceZ() });
     }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1247,7 +1247,7 @@ void updateSpiralSlide(Ride& ride)
     ride.spiralSlideProgress++;
     if (ride.spiralSlideProgress >= 48)
     {
-        ride.slideInUse = 0;
+        ride.slideInUse = false;
 
         auto* peep = GetEntity<Guest>(ride.slidePeep);
         if (peep != nullptr)

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -336,7 +336,7 @@ void Ride::removePeeps()
         }
     }
     numRiders = 0;
-    slideInUse = 0;
+    slideInUse = false;
     windowInvalidateFlags |= RIDE_INVALIDATE_RIDE_MAIN;
 }
 

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -283,6 +283,11 @@ bool ClimateIsSnowingHeavily()
     return weather == WeatherType::HeavySnow || weather == WeatherType::Blizzard;
 }
 
+bool ClimateIsPrecipitating()
+{
+    return ClimateIsRaining() || ClimateIsSnowingHeavily();
+}
+
 bool WeatherIsDry(WeatherType weather)
 {
     return weather == WeatherType::Sunny || weather == WeatherType::PartiallyCloudy || weather == WeatherType::Cloudy;

--- a/src/openrct2/world/Climate.h
+++ b/src/openrct2/world/Climate.h
@@ -91,6 +91,7 @@ bool ClimateIsRaining();
 bool ClimateTransitioningToSnow();
 bool ClimateIsSnowing();
 bool ClimateIsSnowingHeavily();
+bool ClimateIsPrecipitating();
 bool WeatherIsDry(WeatherType);
 FilterPaletteID ClimateGetWeatherGloomPaletteId(const WeatherState& state);
 uint32_t ClimateGetWeatherSpriteId(const WeatherType weatherType);


### PR DESCRIPTION
This started as an attempt to fix https://github.com/OpenRCT2/OpenRCT2/issues/7984 but ended up evolving into more of a refactor of the spiral slide code which was...... Well, _really_ bad.

With this these changes are implemented:

- [x] Guest will leave immediately if the number of people on the ride is bigger than the maximum allowed (unlimited rides per admission)
- [x] Guest will leave if it's precipitating and they have already ridden once, they already refuse to go on it if it's raining (unlimited rides per admission)
- [x] Guest will leave if their GuestTimeOnRide is greater than 15, it corresponds with the threshold for when their happiness begins to decrease (unlimited rides per admission)
- [x] Guests will not slide down while the slide is broken 

I also had the intention of making it so guests will immediately head for the exit building once they finish sliding (instead of first walking to the entrance to the slide tower and _then_ going to the exit), but that behavior is so hardcoded it's best not to touch it.