### PR TITLE
Fix misaligned LSM launched lift hill sprite

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -22,6 +22,7 @@
 - Fix: [#23809] Trains glitch on Bobsleigh Coaster small helixes.
 - Fix: [#23811] Land edges glitch when vehicles go through gentle to flat tunnels.
 - Fix: [#23818] Spinning tunnels can draw over sloped terrain in front of them.
+- Fix: [#23858] LSM launched lift hill has a misaligned sprite.
 
 0.4.19.1 (2025-02-03)
 ------------------------------------------------------------------------

--- a/resources/g2/sprites.json
+++ b/resources/g2/sprites.json
@@ -3018,7 +3018,7 @@
     {
         "path": "track/lattice_triangle/liftbooster_alt_2.png",
         "x": -21,
-        "y": -4,
+        "y": -5,
         "palette": "keep"
     },
     {


### PR DESCRIPTION
This fixes a misaligned sprite for the LSM launched lift hill.

![LSMlaunchedlifthillfix](https://github.com/user-attachments/assets/5bd64c73-08f7-41d0-a776-90976bd48ea6)
