### PR TITLE
Fix #5281: Missing supports on miniature railways built backwards

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Change: [#23932] The land rights window now checks 'Land Owned' by default.
 - Change: [#23936] The ‘guests prefer less/more intense rides’ settings have been turned into a dropdown.
 - Fix: [#4225] Ride Construction window offers non-existent banked sloped to level curve (original bug).
+- Fix: [#5281] Missing supports on miniature railways built backwards.
 - Fix: [#10379] Banners outside the park can be renamed and modified (original bug).
 - Fix: [#10582] Low clearance tunnels below water are drawn incorrectly (original bug).
 - Fix: [#23486] Object selection minimum requirements can be bypassed with close window hotkey.

--- a/src/openrct2/paint/track/transport/MiniatureRailway.cpp
+++ b/src/openrct2/paint/track/transport/MiniatureRailway.cpp
@@ -1611,7 +1611,9 @@ static void PaintMiniatureRailwayTrackLeftEighthToDiag(
     }
 
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+
+    if (trackSequence != 4 || !isRightEighthToOrthog)
+        PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
 }
 
 static constexpr uint32_t kFloorPiecesRightEighthToDiag[4][5] = {
@@ -1777,7 +1779,10 @@ static void PaintMiniatureRailwayTrackRightEighthToDiag(
     }
 
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+
+    // Fixes #5281.
+    if (trackSequence != 4 || !isLeftEighthToOrthog)
+        PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
 }
 
 /** rct2: 0x008AD1E0 */
@@ -1871,7 +1876,10 @@ static void MiniatureRailwayTrackDiagFlat(
     }
 
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+
+    // Fixes #5281.
+    if (supportSubType != WoodenSupportSubType::Null)
+        PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
 }
 
 /** rct2: 0x008AD230 */
@@ -1952,7 +1960,10 @@ static void MiniatureRailwayTrackDiag25DegUp(
     }
 
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + 56);
+
+    // Fixes #5281
+    if (supportSubType != WoodenSupportSubType::Null)
+        PaintUtilSetGeneralSupportHeight(session, height + 56);
 }
 
 /** rct2: 0x008AD210 */
@@ -2003,7 +2014,9 @@ static void MiniatureRailwayTrackDiagFlatTo25DegUp(
     }
 
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + 48);
+
+    if (supportSubType != WoodenSupportSubType::Null)
+        PaintUtilSetGeneralSupportHeight(session, height + 48);
 }
 
 /** rct2: 0x008AD220 */
@@ -2082,7 +2095,9 @@ static void MiniatureRailwayTrackDiag25DegUpToFlat(
     }
 
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + 56);
+
+    if (supportSubType != WoodenSupportSubType::Null)
+        PaintUtilSetGeneralSupportHeight(session, height + 56);
 }
 
 /** rct2: 0x008AD260 */
@@ -2160,7 +2175,10 @@ static void MiniatureRailwayTrackDiag25DegDown(
     }
 
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + 56);
+
+    // Fixes #5281
+    if (supportSubType != WoodenSupportSubType::Null)
+        PaintUtilSetGeneralSupportHeight(session, height + 56);
 }
 
 /** rct2: 0x008AD240 */
@@ -2237,7 +2255,10 @@ static void MiniatureRailwayTrackDiagFlatTo25DegDown(
     }
 
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + 56);
+
+    // Fixes #5281,
+    if (supportSubType != WoodenSupportSubType::Null)
+        PaintUtilSetGeneralSupportHeight(session, height + 56);
 }
 
 static void MiniatureRailwayTrackDiag25DegDownToFlat(
@@ -2286,7 +2307,10 @@ static void MiniatureRailwayTrackDiag25DegDownToFlat(
     }
 
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + 48);
+
+    // Fixes #5281.
+    if (supportSubType != WoodenSupportSubType::Null)
+        PaintUtilSetGeneralSupportHeight(session, height + 48);
 }
 
 /**


### PR DESCRIPTION
Seems to fix all cases of missing supports. It doesn’t yet address the weird changing heights, I can do that in another PR though.

I did notice that there a little bit of glitching here (the corner supports eating a bit into the track).
![Schermafdruk van 2025-02-20 22-53-19](https://github.com/user-attachments/assets/d7ea64ee-f107-4195-aaf4-333eb95c65a4)
This is however, a big improvement from how it currently looks on develop:
![Schermafdruk van 2025-02-20 22-52-29](https://github.com/user-attachments/assets/7b3f2b1c-c5e4-494a-a778-4ecf398393f6)

Maybe @mixiate has an idea on how to fix it.

Would appreciate a thorough test, with both backwards and forwards bits.