### PR TITLE
Fix #23868: Game crashes when moving to a corner of my park

### DIFF
--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
@@ -295,8 +295,9 @@ static void PaintLargeScenery3DText(
                 {
                     // No good split found, or reached end of string
                     auto index = it.GetIndex();
-                    best = current.substr(0, index - 1);
-                    next = current.substr(index - 1);
+                    index = (index > 0) ? index - 1 : index;
+                    best = current.substr(0, index);
+                    next = current.substr(index);
                 }
 
                 PaintLargeScenery3DTextLine(session, sceneryEntry, *text, best, imageTemplate, direction, offsetY);


### PR DESCRIPTION
Based on the discussion of this issue, it appears to be caused by an oversight in the 3D sign text cutoff fix (7de61c7) where in certain cases the index can wrap around and cause invalid input to substr. The documentation on what happened in this case was ambiguous, but in this case it leads to an exception. The fix is to have a check for a zero index before decrementing in the line wrapping code.

This one's one me, the documentation for `substr` indicates that when `pos + count` is greater than string length, it will simply return the remainder of the string. However if `count` itself is larger than the string's size by itself, this is an exception. I find that design confusing, but the fix is simple at least.

I've verified it works in the case of a sign with all spaces that was breaking in the discussion thread, but I do still need someone to check in the originally problematic parks, since I don't know if something else in the rendering code has been affected separately.