### PR TITLE
Fix #23867: Crash when viewing 2 line 3D signs with 16 spaces

### DIFF
--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
@@ -262,41 +262,34 @@ static void PaintLargeScenery3DText(
                 CodepointView view(current);
                 auto lineWidth = 0;
                 auto it = view.begin();
-                while (it != view.end() && lineWidth < text->max_width)
+                size_t lastWhitespaceIndex = 0;
+                while (it != view.end())
                 {
-                    // Trim any leading spaces
-                    auto codepoint = *it;
-                    if (codepoint != ' ' || lineWidth != 0)
+                    const auto codepoint = *it;
+                    const auto glyph = text->GetGlyph(codepoint, ' ');
+                    lineWidth += glyph.width;
+
+                    if (codepoint == ' ')
                     {
-                        // Determine if this is a good place to split
-                        if (codepoint == ' ' || codepoint == '\n')
-                        {
-                            auto index = it.GetIndex();
-                            best = current.substr(0, index);
-                            next = current.substr(index + 1);
-                            if (codepoint == '\n')
-                                break;
-                        }
-
-                        auto glyph = text->GetGlyph(*it, ' ');
-                        lineWidth += glyph.width;
+                        lastWhitespaceIndex = it.GetIndex();
                     }
+
+                    if (lineWidth > text->max_width)
+                    {
+                        break;
+                    }
+
                     it++;
+
+                    const auto index = it.GetIndex();
+                    best = current.substr(0, index);
+                    next = current.substr(index);
                 }
 
-                // handle case where second line fully fits
-                if (it == view.end() && lineWidth < text->max_width)
+                if (lastWhitespaceIndex != 0 && it != view.end())
                 {
-                    best = current;
-                    next = std::string_view{};
-                }
-
-                if (best.empty())
-                {
-                    // No good split found, or reached end of string
-                    auto index = it.GetIndex();
-                    best = current.substr(0, index - 1);
-                    next = current.substr(index - 1);
+                    best = current.substr(0, lastWhitespaceIndex);
+                    next = current.substr(lastWhitespaceIndex + 1);
                 }
 
                 PaintLargeScenery3DTextLine(session, sceneryEntry, *text, best, imageTemplate, direction, offsetY);


### PR DESCRIPTION
This fixes #23867 and #23868 crash when viewing 2 line 3D signs with 16 spaces.

Some signs still displayed differently to RCT2 so in order to fix all these problems at once I've gone back to the code from before [4288589](https://github.com/OpenRCT2/OpenRCT2/commit/4288589f11538ddf6b314b5d4872a46719f5f11c) and tried to write the equivalent of how it used to work, as it had been changed around a bit. It's a bit simpler than it was and seems to show all the signs I could come up with as they were in RCT2.

@QuestionableDeer I hope it was okay that I also tried to fix this. I had started working on it before I saw your PR. I didn't mean to interfere with what you were doing.