### PR TITLE
Fix #23871: Trains draw over rear facing steep Wooden RollerCoaster track if there is terrain directly below

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -34,6 +34,7 @@
 - Fix: [#23832] Hybrid Coaster large gentle banked left turns supports glitch as train passes.
 - Fix: [#23836] Adjacent track can draw over large turns (original bug).
 - Fix: [#23858] LSM launched lift hill has a misaligned sprite.
+- Fix: [#23871] Trains draw over rear facing steep Wooden RollerCoaster track if there is terrain directly below (original bug).
 
 0.4.19.1 (2025-02-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/WoodenRollerCoaster.cpp
@@ -2183,7 +2183,7 @@ static void WoodenRCTrack60DegUp(
         {
             session.WoodenSupportsPrependTo = WoodenRCTrackPaint<isClassic>(
                 session, direction, imageIdsChained[direction][0], imageIdsChained[direction][1], { 0, 0, height },
-                { { 28, 4, height - 16 }, { 2, 24, 93 } });
+                { { 28, 4, height }, { 2, 24, 88 } });
         }
     }
     else
@@ -2198,7 +2198,7 @@ static void WoodenRCTrack60DegUp(
         {
             session.WoodenSupportsPrependTo = WoodenRCTrackPaint<isClassic>(
                 session, direction, imageIds[direction][0], imageIds[direction][1], { 0, 0, height },
-                { { 28, 4, height - 16 }, { 2, 24, 93 } });
+                { { 28, 4, height }, { 2, 24, 88 } });
         }
     }
 


### PR DESCRIPTION
This fixes #23871 trains drawing over rear facing steep Wooden RollerCoaster track if there is terrain directly below.

The problem here was that the bounding boxes were offset down and in to any terrain that was below. I've raised them up and they're now within the track clearances.

This is a bit of a stop gap solution as the train still clips in to the track quite a bit. It already did, it's just that in RCT1 this doesn't happen. I've already tried to fix this in the past, but it's the whole steep prepended wooden supports issue, and I just can't find any real solution to it yet. I don't know what RCT1 does differently to stop this. This is still an improvement to how it was however. This particular bug is actually in RCT2. It does seem like something changed with the wooden rollercoaster between 1 and 2.

https://github.com/user-attachments/assets/ff0a8e32-9373-44a9-abaf-8b39996fcca0

