### PR TITLE
Allow editing of rides forbidden to be modified or destroyed with the All destructible cheat

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Feature: [#23759] Add see-through option to the “Cut-away View“.
 - Improved: [#23677] Building new ride track now inherits the colour scheme from the previous piece.
 - Improved: [#23720] Text fields now allow cutting to clipboard (Ctrl+X) in addition to copy and paste.
+- Improved: [#23875] Rides forbidden to be modified or destroyed can now be edited with the All destructible cheat.
 - Fix: [#1972, #11679] Vehicles passing by toilets can cause them to glitch (original bug).
 - Fix: [#9999, #10000, #10001, #10002, #10003] Truncated scenario strings when using Catalan, Czech, Japanese, Polish or Russian.
 - Fix: [#14486] Guests will fall through upwards sloped paths when making their way through a park entrance or ride exit (original bug).

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -49,7 +49,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kNetworkStreamVersion = 2;
+constexpr uint8_t kNetworkStreamVersion = 3;
 
 const std::string kNetworkStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kNetworkStreamVersion);
 

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -966,7 +966,7 @@ bool RideModify(const CoordsXYE& input)
     if (rideEntry == nullptr || !ride_check_if_construction_allowed(*ride))
         return false;
 
-    if (ride->lifecycle_flags & RIDE_LIFECYCLE_INDESTRUCTIBLE)
+    if (ride->lifecycle_flags & RIDE_LIFECYCLE_INDESTRUCTIBLE && !GetGameState().Cheats.makeAllDestructible)
     {
         Formatter ft;
         ride->FormatNameTo(ft);


### PR DESCRIPTION
This allows rides forbidden to be modified to be edited rather than just destroyed if the All destructible cheat is on. For example, Woodpecker in Haunted Harbour could be demolished with the cheat on, but couldn't be edited.

I've bumped the network version too, i'm not sure if that was necessary.