### PR TITLE
Drop unused parameter from GetLegacyPeepAnimationObjects

### DIFF
--- a/src/openrct2/park/Legacy.cpp
+++ b/src/openrct2/park/Legacy.cpp
@@ -2292,7 +2292,7 @@ const std::vector<std::string_view> peepAnimObjects = {
     "rct2.peep_animations.entertainer_snowman",
 };
 
-const std::vector<std::string_view>& GetLegacyPeepAnimationObjects(const ObjectList& entryList)
+const std::vector<std::string_view>& GetLegacyPeepAnimationObjects()
 {
     return peepAnimObjects;
 }

--- a/src/openrct2/park/Legacy.h
+++ b/src/openrct2/park/Legacy.h
@@ -40,7 +40,7 @@ void UpdateFootpathsFromMapping(
     ObjectList& requiredObjects, ObjectEntryIndex& surfaceCount, ObjectEntryIndex& railingCount, ObjectEntryIndex entryIndex,
     const OpenRCT2::RCT2::FootpathMapping* footpathMapping);
 
-const std::vector<std::string_view>& GetLegacyPeepAnimationObjects(const ObjectList& entryList);
+const std::vector<std::string_view>& GetLegacyPeepAnimationObjects();
 void ConvertPeepAnimationTypeToObjects(OpenRCT2::GameState_t& gameState);
 
 /**

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -385,7 +385,7 @@ namespace OpenRCT2
 
                 if (version < kPeepAnimationObjectsVersion)
                 {
-                    auto animObjects = GetLegacyPeepAnimationObjects(requiredObjects);
+                    auto animObjects = GetLegacyPeepAnimationObjects();
                     AppendRequiredObjects(requiredObjects, ObjectType::peepAnimations, animObjects);
                 }
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1559,7 +1559,7 @@ namespace OpenRCT2::RCT1
                 AppendRequiredObjects(result, ObjectType::scenarioText, std::vector<std::string_view>({ desc.textObjectId }));
 
             // Add all legacy peep animation objects
-            auto animObjects = GetLegacyPeepAnimationObjects(result);
+            auto animObjects = GetLegacyPeepAnimationObjects();
             AppendRequiredObjects(result, ObjectType::peepAnimations, animObjects);
 
             return result;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1904,7 +1904,7 @@ namespace OpenRCT2::RCT2
                 AppendRequiredObjects(
                     objectList, ObjectType::scenarioText, std::vector<std::string_view>({ desc.textObjectId }));
 
-            auto animObjects = GetLegacyPeepAnimationObjects(objectList);
+            auto animObjects = GetLegacyPeepAnimationObjects();
             AppendRequiredObjects(objectList, ObjectType::peepAnimations, animObjects);
 
             return objectList;


### PR DESCRIPTION
This commit has been sitting in my tree for a while, apparently not finding a PR to adopt it in. Well, here it is.