### PR TITLE
Link to libatomic for arm-linux-gnueabihf library architecture

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Fix: [#23486] Object selection minimum requirements can be bypassed with close window hotkey.
 - Fix: [#23743] Parks with guest goals over 32767 do not appear in the scenario list.
 - Fix: [#23844] Sound effects keep playing when loading another save.
+- Fix: [#23881] Compiling on Raspbian/arm-linux-gnueabihf fails.
 - Fix: [#23891] Inverted Hairpin Coaster track can draw over things above it (original bug).
 - Fix: [#23892] Gentle banked Wooden Roller Coaster track glitches as trains pass (original bug).
 - Fix: [#23897] Reverse Freefall Coaster slope up to vertical track piece does not draw a vertical tunnel.

--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -288,3 +288,8 @@ endif ()
 if (UNIX)
     add_definitions(-D_FILE_OFFSET_BITS=64)
 endif ()
+
+if (CMAKE_LIBRARY_ARCHITECTURE MATCHES "arm-linux-gnueabihf")
+    message(STATUS "Linking to armhf libs; adding libatomic")
+    target_link_libraries(${PROJECT_NAME} atomic)
+endif()


### PR DESCRIPTION
Allows builds on Raspbian. Unlike #17146 this limits the build so shouldn't affect other arm64 builds. Note Raspbian is kind of strange, my processor architecture is aarch64 but the included gcc compiles under armhf libraries probably for compatibility with older hardware.

Close #23881  