### PR TITLE
Fix #23891: Inverted Hairpin Coaster track can draw over things above it

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#10582] Low clearance tunnels below water are drawn incorrectly (original bug).
 - Fix: [#23743] Parks with guest goals over 32767 do not appear in the scenario list.
 - Fix: [#23844] Sound effects keep playing when loading another save.
+- Fix: [#23891] Inverted Hairpin Coaster track can draw over things above it (original bug).
 - Fix: [#23892] Gentle banked Wooden Roller Coaster track glitches as trains pass (original bug).
 - Fix: [#23897] Reverse Freefall Coaster slope up to vertical track piece does not draw a vertical tunnel.
 - Fix: [#23939] Incorrect assertion when trying to load heightmap.

--- a/src/openrct2/paint/track/coaster/InvertedHairpinCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/InvertedHairpinCoaster.cpp
@@ -105,10 +105,10 @@ static void InvertedHairpinRCTrackStation(
         { { 0, 2, height }, { 32, 28, 1 } });
     PaintAddImageAsParentRotated(
         session, direction, session.TrackColours.WithIndex(imageIds[direction][1]), { 0, 0, height + 24 },
-        { { 0, 6, height + 24 }, { 32, 20, 3 } });
+        { { 0, 6, height + 22 }, { 32, 20, 1 } });
     PaintAddImageAsChildRotated(
         session, direction, session.SupportColours.WithIndex(imageIds[direction][2]), { 0, 6, height + 24 },
-        { { 0, 6, height + 24 }, { 32, 20, 1 } });
+        { { 0, 6, height + 22 }, { 32, 20, 1 } });
     DrawSupportsSideBySide(session, direction, height, session.SupportColours, supportType.metal);
     TrackPaintUtilDrawStationInverted(session, ride, direction, height, trackElement, STATION_VARIANT_1);
     TrackPaintUtilDrawStationTunnel(session, direction, height);
@@ -128,22 +128,22 @@ static void InvertedHairpinRCTrack25DegUp(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17070), { 0, 0, height + 24 },
-                    { { 0, 6, height + 40 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 37 }, { 32, 20, 3 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17071), { 0, 0, height + 24 },
-                    { { 0, 6, height + 40 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 37 }, { 32, 20, 3 } });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17072), { 0, 0, height + 24 },
-                    { { 0, 6, height + 40 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 37 }, { 32, 20, 3 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17073), { 0, 0, height + 24 },
-                    { { 0, 6, height + 40 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 37 }, { 32, 20, 3 } });
                 break;
         }
     }
@@ -154,22 +154,22 @@ static void InvertedHairpinRCTrack25DegUp(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17042), { 0, 0, height + 24 },
-                    { { 0, 6, height + 40 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 37 }, { 32, 20, 3 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17043), { 0, 0, height + 24 },
-                    { { 0, 6, height + 40 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 37 }, { 32, 20, 3 } });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17044), { 0, 0, height + 24 },
-                    { { 0, 6, height + 40 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 37 }, { 32, 20, 3 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17045), { 0, 0, height + 24 },
-                    { { 0, 6, height + 40 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 37 }, { 32, 20, 3 } });
                 break;
         }
     }
@@ -221,7 +221,7 @@ static void InvertedHairpinRCTrack60DegUp(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17086), { 0, 0, height + 24 },
-                    { { 0, 6, height + 88 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 85 }, { 32, 20, 3 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -236,7 +236,7 @@ static void InvertedHairpinRCTrack60DegUp(
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17089), { 0, 0, height + 24 },
-                    { { 0, 6, height + 88 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 85 }, { 32, 20, 3 } });
                 break;
         }
     }
@@ -247,7 +247,7 @@ static void InvertedHairpinRCTrack60DegUp(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17058), { 0, 0, height + 24 },
-                    { { 0, 6, height + 88 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 85 }, { 32, 20, 3 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -262,7 +262,7 @@ static void InvertedHairpinRCTrack60DegUp(
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17061), { 0, 0, height + 24 },
-                    { { 0, 6, height + 88 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 85 }, { 32, 20, 3 } });
                 break;
         }
     }
@@ -290,22 +290,22 @@ static void InvertedHairpinRCTrackFlatTo25DegUp(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17062), { 0, 0, height + 24 },
-                    { { 0, 6, height + 32 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 29 }, { 32, 20, 3 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17063), { 0, 0, height + 24 },
-                    { { 0, 6, height + 32 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 29 }, { 32, 20, 3 } });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17064), { 0, 0, height + 24 },
-                    { { 0, 6, height + 32 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 29 }, { 32, 20, 3 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17065), { 0, 0, height + 24 },
-                    { { 0, 6, height + 32 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 29 }, { 32, 20, 3 } });
                 break;
         }
     }
@@ -316,22 +316,22 @@ static void InvertedHairpinRCTrackFlatTo25DegUp(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17034), { 0, 0, height + 24 },
-                    { { 0, 6, height + 32 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 29 }, { 32, 20, 3 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17035), { 0, 0, height + 24 },
-                    { { 0, 6, height + 32 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 29 }, { 32, 20, 3 } });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17036), { 0, 0, height + 24 },
-                    { { 0, 6, height + 32 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 29 }, { 32, 20, 3 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17037), { 0, 0, height + 24 },
-                    { { 0, 6, height + 32 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 29 }, { 32, 20, 3 } });
                 break;
         }
     }
@@ -383,7 +383,7 @@ static void InvertedHairpinRCTrack25DegUpTo60DegUp(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17074), { 0, 0, height + 24 },
-                    { { 0, 6, height + 56 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 53 }, { 32, 20, 3 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -404,7 +404,7 @@ static void InvertedHairpinRCTrack25DegUpTo60DegUp(
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17077), { 0, 0, height + 24 },
-                    { { 0, 6, height + 56 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 53 }, { 32, 20, 3 } });
                 break;
         }
     }
@@ -415,7 +415,7 @@ static void InvertedHairpinRCTrack25DegUpTo60DegUp(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17046), { 0, 0, height + 24 },
-                    { { 0, 6, height + 56 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 53 }, { 32, 20, 3 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -436,7 +436,7 @@ static void InvertedHairpinRCTrack25DegUpTo60DegUp(
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17049), { 0, 0, height + 24 },
-                    { { 0, 6, height + 56 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 53 }, { 32, 20, 3 } });
                 break;
         }
     }
@@ -464,7 +464,7 @@ static void InvertedHairpinRCTrack60DegUpTo25DegUp(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17080), { 0, 0, height + 24 },
-                    { { 0, 6, height + 56 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 53 }, { 32, 20, 3 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -485,7 +485,7 @@ static void InvertedHairpinRCTrack60DegUpTo25DegUp(
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17083), { 0, 0, height + 24 },
-                    { { 0, 6, height + 56 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 53 }, { 32, 20, 3 } });
                 break;
         }
     }
@@ -496,7 +496,7 @@ static void InvertedHairpinRCTrack60DegUpTo25DegUp(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17052), { 0, 0, height + 24 },
-                    { { 0, 6, height + 56 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 53 }, { 32, 20, 3 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -517,7 +517,7 @@ static void InvertedHairpinRCTrack60DegUpTo25DegUp(
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17055), { 0, 0, height + 24 },
-                    { { 0, 6, height + 56 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 53 }, { 32, 20, 3 } });
                 break;
         }
     }
@@ -569,22 +569,22 @@ static void InvertedHairpinRCTrack25DegUpToFlat(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17066), { 0, 0, height + 24 },
-                    { { 0, 6, height + 32 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 29 }, { 32, 20, 3 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17067), { 0, 0, height + 24 },
-                    { { 0, 6, height + 32 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 29 }, { 32, 20, 3 } });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17068), { 0, 0, height + 24 },
-                    { { 0, 6, height + 32 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 29 }, { 32, 20, 3 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17069), { 0, 0, height + 24 },
-                    { { 0, 6, height + 32 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 29 }, { 32, 20, 3 } });
                 break;
         }
     }
@@ -595,22 +595,22 @@ static void InvertedHairpinRCTrack25DegUpToFlat(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17038), { 0, 0, height + 24 },
-                    { { 0, 6, height + 32 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 29 }, { 32, 20, 3 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17039), { 0, 0, height + 24 },
-                    { { 0, 6, height + 32 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 29 }, { 32, 20, 3 } });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17040), { 0, 0, height + 24 },
-                    { { 0, 6, height + 32 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 29 }, { 32, 20, 3 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17041), { 0, 0, height + 24 },
-                    { { 0, 6, height + 32 }, { 32, 20, 3 } });
+                    { { 0, 6, height + 29 }, { 32, 20, 3 } });
                 break;
         }
     }
@@ -713,22 +713,22 @@ static void InvertedHairpinRCTrackLeftQuarterTurn3(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(17123), { 0, 0, height + 24 },
-                        { { 0, 6, height + 22 }, { 32, 20, 3 } });
+                        { { 0, 6, height + 21 }, { 32, 20, 3 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(17126), { 0, 0, height + 24 },
-                        { { 0, 6, height + 22 }, { 32, 20, 3 } });
+                        { { 0, 6, height + 21 }, { 32, 20, 3 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(17129), { 0, 0, height + 24 },
-                        { { 0, 6, height + 22 }, { 32, 20, 3 } });
+                        { { 0, 6, height + 21 }, { 32, 20, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(17120), { 0, 0, height + 24 },
-                        { { 0, 6, height + 22 }, { 32, 20, 3 } });
+                        { { 0, 6, height + 21 }, { 32, 20, 3 } });
                     break;
             }
 
@@ -758,22 +758,22 @@ static void InvertedHairpinRCTrackLeftQuarterTurn3(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(17122), { 0, 0, height + 24 },
-                        { { 16, 0, height + 22 }, { 16, 16, 3 } });
+                        { { 16, 0, height + 21 }, { 16, 16, 3 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(17125), { 0, 0, height + 24 },
-                        { { 0, 0, height + 22 }, { 16, 16, 3 } });
+                        { { 0, 0, height + 21 }, { 16, 16, 3 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(17128), { 0, 0, height + 24 },
-                        { { 0, 16, height + 22 }, { 16, 16, 3 } });
+                        { { 0, 16, height + 21 }, { 16, 16, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(17119), { 0, 0, height + 24 },
-                        { { 16, 16, height + 22 }, { 16, 16, 3 } });
+                        { { 16, 16, height + 21 }, { 16, 16, 3 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -792,22 +792,22 @@ static void InvertedHairpinRCTrackLeftQuarterTurn3(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(17121), { 0, 0, height + 24 },
-                        { { 6, 0, height + 22 }, { 20, 32, 3 } });
+                        { { 6, 0, height + 21 }, { 20, 32, 3 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(17124), { 0, 0, height + 24 },
-                        { { 6, 0, height + 22 }, { 20, 32, 3 } });
+                        { { 6, 0, height + 21 }, { 20, 32, 3 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(17127), { 0, 0, height + 24 },
-                        { { 6, 0, height + 22 }, { 20, 32, 3 } });
+                        { { 6, 0, height + 21 }, { 20, 32, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(17118), { 0, 0, height + 24 },
-                        { { 6, 0, height + 22 }, { 20, 32, 3 } });
+                        { { 6, 0, height + 21 }, { 20, 32, 3 } });
                     break;
             }
 
@@ -1070,22 +1070,22 @@ static void InvertedHairpinRCTrackLeftQuarterTurn1(
         case 0:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours.WithIndex(17114), { 0, 0, height + 24 },
-                { { 6, 2, height + 24 }, { 26, 24, 3 } });
+                { { 6, 2, height + 21 }, { 26, 24, 3 } });
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours.WithIndex(17115), { 0, 0, height + 24 },
-                { { 0, 0, height + 24 }, { 26, 26, 3 } });
+                { { 0, 0, height + 21 }, { 26, 26, 3 } });
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours.WithIndex(17116), { 0, 0, height + 24 },
-                { { 2, 6, height + 24 }, { 24, 26, 3 } });
+                { { 2, 6, height + 21 }, { 24, 26, 3 } });
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours.WithIndex(17117), { 0, 0, height + 24 },
-                { { 6, 6, height + 24 }, { 24, 24, 3 } });
+                { { 6, 6, height + 21 }, { 24, 24, 3 } });
             break;
     }
 
@@ -1136,7 +1136,7 @@ static void InvertedHairpinRCTrackFlatTo60DegUp(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17102), { 0, 0, height + 24 },
-                    { { 0, 6, height + 56 }, { 30, 20, 3 } });
+                    { { 0, 6, height + 45 }, { 30, 20, 3 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -1157,7 +1157,7 @@ static void InvertedHairpinRCTrackFlatTo60DegUp(
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17105), { 0, 0, height + 24 },
-                    { { 0, 6, height + 56 }, { 30, 20, 3 } });
+                    { { 0, 6, height + 45 }, { 30, 20, 3 } });
                 break;
         }
     }
@@ -1168,7 +1168,7 @@ static void InvertedHairpinRCTrackFlatTo60DegUp(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17090), { 0, 0, height + 24 },
-                    { { 0, 6, height + 56 }, { 30, 20, 3 } });
+                    { { 0, 6, height + 45 }, { 30, 20, 3 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -1189,7 +1189,7 @@ static void InvertedHairpinRCTrackFlatTo60DegUp(
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17093), { 0, 0, height + 24 },
-                    { { 0, 6, height + 56 }, { 30, 20, 3 } });
+                    { { 0, 6, height + 45 }, { 30, 20, 3 } });
                 break;
         }
     }
@@ -1217,7 +1217,7 @@ static void InvertedHairpinRCTrack60DegUpToFlat(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17108), { 0, 0, height + 24 },
-                    { { 0, 6, height + 48 }, { 30, 20, 3 } });
+                    { { 0, 6, height + 45 }, { 30, 20, 3 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -1238,7 +1238,7 @@ static void InvertedHairpinRCTrack60DegUpToFlat(
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17111), { 0, 0, height + 24 },
-                    { { 0, 6, height + 48 }, { 30, 20, 3 } });
+                    { { 0, 6, height + 45 }, { 30, 20, 3 } });
                 break;
         }
     }
@@ -1249,7 +1249,7 @@ static void InvertedHairpinRCTrack60DegUpToFlat(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17096), { 0, 0, height + 24 },
-                    { { 0, 6, height + 48 }, { 30, 20, 3 } });
+                    { { 0, 6, height + 45 }, { 30, 20, 3 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -1270,7 +1270,7 @@ static void InvertedHairpinRCTrack60DegUpToFlat(
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(17099), { 0, 0, height + 24 },
-                    { { 0, 6, height + 48 }, { 30, 20, 3 } });
+                    { { 0, 6, height + 45 }, { 30, 20, 3 } });
                 break;
         }
     }


### PR DESCRIPTION
This fixes #23891 Inverted Hairpin Coaster track drawing over things above it.

This is another case of track pieces with bounding boxes taller than their clearance, and can cause the track to draw over anything that is directly above it. As this coaster only has a few pieces, I thought i'd just do it now. The vehicle bounding box hangs low enough below the track that there doesn't seem to be an issue lowering the bounding boxes the few units they need to stop glitching. As you can see the top of the support still draws over the scenery above, but i'm not sure yet how to deal with that. This change still needs to be done, and hopefully a solution for that can come later.

![invertedhairpincoasterpathfix](https://github.com/user-attachments/assets/55d4641b-5395-4491-bef9-9b64dbc83ce9)

![invertedhairpincoasterglitch](https://github.com/user-attachments/assets/153bf99c-9217-4a7b-bdf4-b6e473246692)

![invertedhairpincoasterfix](https://github.com/user-attachments/assets/9392ae81-dec7-41e9-8846-40918d8894a1)
