### PR TITLE
Fix missing vertical tunnel on Reverse Freefall Coaster Slope up to vertical track piece

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.21 (in development)
 ------------------------------------------------------------------------
 - Fix: [#4225] Ride Construction window offers non-existent banked sloped to level curve (original bug).
+- Fix: [#23897] Reverse Freefall Coaster slope up to vertical track piece does not draw a vertical tunnel.
 
 0.4.20 (2025-02-25)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/coaster/ReverseFreefallCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/ReverseFreefallCoaster.cpp
@@ -361,6 +361,7 @@ static void PaintReverseFreefallRCSlope(
                 session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
             PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + supportHeights[trackSequence]);
+            PaintUtilSetVerticalTunnel(session, height + 240);
             break;
     }
 }


### PR DESCRIPTION
This fixes the missing vertical tunnel on the Reverse Freefall Coaster Slope up to vertical track piece.

Shown here pre fix in comparison to the Air Powered Coaster.
![missingtunnel](https://github.com/user-attachments/assets/7774c355-9a50-48e5-94ca-2aeec1dbe49c)
