### PR TITLE
Fix #23910: Heartline Twister Coaster track draws over things above it

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Fix: [#23891] Inverted Hairpin Coaster track can draw over things above it (original bug).
 - Fix: [#23892] Gentle banked Wooden Roller Coaster track glitches as trains pass (original bug).
 - Fix: [#23897] Reverse Freefall Coaster slope up to vertical track piece does not draw a vertical tunnel.
+- Fix: [#23910] Heartline Twister Coaster track can draw over things above it (original bug).
 - Fix: [#23939] Incorrect assertion when trying to load heightmap.
 - Fix: [#23941] Underflow in “Repay loan and achieve a certain park value” objective when using Japanese.
 - Fix: [#23949] Walls draw over sloped rear water edges and those edge sprites are misaligned (original bug).

--- a/src/openrct2/paint/track/coaster/HeartlineTwisterCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/HeartlineTwisterCoaster.cpp
@@ -42,7 +42,7 @@ static void HeartlineTwisterRCTrackFlat(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21356), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 26 } });
+                    { { 0, 27, height }, { 32, 1, 24 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -50,7 +50,7 @@ static void HeartlineTwisterRCTrackFlat(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21357), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 26 } });
+                    { { 0, 27, height }, { 32, 1, 24 } });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -58,7 +58,7 @@ static void HeartlineTwisterRCTrackFlat(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21360), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 26 } });
+                    { { 0, 27, height }, { 32, 1, 24 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -66,7 +66,7 @@ static void HeartlineTwisterRCTrackFlat(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21361), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 26 } });
+                    { { 0, 27, height }, { 32, 1, 24 } });
                 break;
         }
     }
@@ -81,7 +81,7 @@ static void HeartlineTwisterRCTrackFlat(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21296), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 26 } });
+                    { { 0, 27, height }, { 32, 1, 24 } });
                 break;
             case 1:
             case 3:
@@ -90,7 +90,7 @@ static void HeartlineTwisterRCTrackFlat(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21297), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 26 } });
+                    { { 0, 27, height }, { 32, 1, 24 } });
                 break;
         }
     }
@@ -142,7 +142,7 @@ static void HeartlineTwisterRCTrack25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21382), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 50 } });
+                    { { 0, 27, height }, { 32, 1, 40 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -150,7 +150,7 @@ static void HeartlineTwisterRCTrack25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21383), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 50 } });
+                    { { 0, 27, height }, { 32, 1, 40 } });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -158,7 +158,7 @@ static void HeartlineTwisterRCTrack25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21384), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 50 } });
+                    { { 0, 27, height }, { 32, 1, 40 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -166,7 +166,7 @@ static void HeartlineTwisterRCTrack25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21385), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 50 } });
+                    { { 0, 27, height }, { 32, 1, 40 } });
                 break;
         }
     }
@@ -180,7 +180,7 @@ static void HeartlineTwisterRCTrack25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21326), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 50 } });
+                    { { 0, 27, height }, { 32, 1, 40 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -188,7 +188,7 @@ static void HeartlineTwisterRCTrack25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21327), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 50 } });
+                    { { 0, 27, height }, { 32, 1, 40 } });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -196,7 +196,7 @@ static void HeartlineTwisterRCTrack25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21328), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 50 } });
+                    { { 0, 27, height }, { 32, 1, 40 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -204,7 +204,7 @@ static void HeartlineTwisterRCTrack25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21329), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 50 } });
+                    { { 0, 27, height }, { 32, 1, 40 } });
                 break;
         }
     }
@@ -239,7 +239,7 @@ static void HeartlineTwisterRCTrack60DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21406), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 98 } });
+                    { { 0, 27, height }, { 32, 1, 88 } });
                 break;
             case 1:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -247,7 +247,7 @@ static void HeartlineTwisterRCTrack60DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21407), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 98 } });
+                    { { 0, 27, height }, { 32, 1, 88 } });
                 break;
             case 2:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -255,7 +255,7 @@ static void HeartlineTwisterRCTrack60DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21408), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 98 } });
+                    { { 0, 27, height }, { 32, 1, 88 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -263,7 +263,7 @@ static void HeartlineTwisterRCTrack60DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21409), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 98 } });
+                    { { 0, 27, height }, { 32, 1, 88 } });
                 break;
         }
     }
@@ -277,7 +277,7 @@ static void HeartlineTwisterRCTrack60DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21350), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 98 } });
+                    { { 0, 27, height }, { 32, 1, 88 } });
                 break;
             case 1:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -285,7 +285,7 @@ static void HeartlineTwisterRCTrack60DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21351), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 98 } });
+                    { { 0, 27, height }, { 32, 1, 88 } });
                 break;
             case 2:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -293,7 +293,7 @@ static void HeartlineTwisterRCTrack60DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21352), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 98 } });
+                    { { 0, 27, height }, { 32, 1, 88 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -301,7 +301,7 @@ static void HeartlineTwisterRCTrack60DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21353), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 98 } });
+                    { { 0, 27, height }, { 32, 1, 88 } });
                 break;
         }
     }
@@ -336,7 +336,7 @@ static void HeartlineTwisterRCTrackFlatTo25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21366), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 42 } });
+                    { { 0, 27, height }, { 32, 1, 32 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -344,7 +344,7 @@ static void HeartlineTwisterRCTrackFlatTo25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21367), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 42 } });
+                    { { 0, 27, height }, { 32, 1, 32 } });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -352,7 +352,7 @@ static void HeartlineTwisterRCTrackFlatTo25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21368), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 42 } });
+                    { { 0, 27, height }, { 32, 1, 32 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -360,7 +360,7 @@ static void HeartlineTwisterRCTrackFlatTo25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21369), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 42 } });
+                    { { 0, 27, height }, { 32, 1, 32 } });
                 break;
         }
     }
@@ -374,7 +374,7 @@ static void HeartlineTwisterRCTrackFlatTo25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21310), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 42 } });
+                    { { 0, 27, height }, { 32, 1, 32 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -382,7 +382,7 @@ static void HeartlineTwisterRCTrackFlatTo25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21311), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 42 } });
+                    { { 0, 27, height }, { 32, 1, 32 } });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -390,7 +390,7 @@ static void HeartlineTwisterRCTrackFlatTo25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21312), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 42 } });
+                    { { 0, 27, height }, { 32, 1, 32 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -398,7 +398,7 @@ static void HeartlineTwisterRCTrackFlatTo25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21313), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 42 } });
+                    { { 0, 27, height }, { 32, 1, 32 } });
                 break;
         }
     }
@@ -433,7 +433,7 @@ static void HeartlineTwisterRCTrack25DegUpTo60DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21390), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 66 } });
+                    { { 0, 27, height }, { 32, 1, 56 } });
                 break;
             case 1:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -441,7 +441,7 @@ static void HeartlineTwisterRCTrack25DegUpTo60DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21391), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 66 } });
+                    { { 0, 27, height }, { 32, 1, 56 } });
                 break;
             case 2:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -449,7 +449,7 @@ static void HeartlineTwisterRCTrack25DegUpTo60DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21392), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 66 } });
+                    { { 0, 27, height }, { 32, 1, 56 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -457,7 +457,7 @@ static void HeartlineTwisterRCTrack25DegUpTo60DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21393), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 66 } });
+                    { { 0, 27, height }, { 32, 1, 56 } });
                 break;
         }
     }
@@ -471,7 +471,7 @@ static void HeartlineTwisterRCTrack25DegUpTo60DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21334), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 66 } });
+                    { { 0, 27, height }, { 32, 1, 56 } });
                 break;
             case 1:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -479,7 +479,7 @@ static void HeartlineTwisterRCTrack25DegUpTo60DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21335), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 66 } });
+                    { { 0, 27, height }, { 32, 1, 56 } });
                 break;
             case 2:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -487,7 +487,7 @@ static void HeartlineTwisterRCTrack25DegUpTo60DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21336), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 66 } });
+                    { { 0, 27, height }, { 32, 1, 56 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -495,7 +495,7 @@ static void HeartlineTwisterRCTrack25DegUpTo60DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21337), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 66 } });
+                    { { 0, 27, height }, { 32, 1, 56 } });
                 break;
         }
     }
@@ -530,7 +530,7 @@ static void HeartlineTwisterRCTrack60DegUpTo25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21398), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 66 } });
+                    { { 0, 27, height }, { 32, 1, 56 } });
                 break;
             case 1:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -538,7 +538,7 @@ static void HeartlineTwisterRCTrack60DegUpTo25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21399), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 66 } });
+                    { { 0, 27, height }, { 32, 1, 56 } });
                 break;
             case 2:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -546,7 +546,7 @@ static void HeartlineTwisterRCTrack60DegUpTo25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21400), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 66 } });
+                    { { 0, 27, height }, { 32, 1, 56 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -554,7 +554,7 @@ static void HeartlineTwisterRCTrack60DegUpTo25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21401), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 66 } });
+                    { { 0, 27, height }, { 32, 1, 56 } });
                 break;
         }
     }
@@ -568,7 +568,7 @@ static void HeartlineTwisterRCTrack60DegUpTo25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21342), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 66 } });
+                    { { 0, 27, height }, { 32, 1, 56 } });
                 break;
             case 1:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -576,7 +576,7 @@ static void HeartlineTwisterRCTrack60DegUpTo25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21343), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 66 } });
+                    { { 0, 27, height }, { 32, 1, 56 } });
                 break;
             case 2:
                 session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -584,7 +584,7 @@ static void HeartlineTwisterRCTrack60DegUpTo25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21344), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 66 } });
+                    { { 0, 27, height }, { 32, 1, 56 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -592,7 +592,7 @@ static void HeartlineTwisterRCTrack60DegUpTo25DegUp(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21345), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 66 } });
+                    { { 0, 27, height }, { 32, 1, 56 } });
                 break;
         }
     }
@@ -627,7 +627,7 @@ static void HeartlineTwisterRCTrack25DegUpToFlat(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21374), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 34 } });
+                    { { 0, 27, height }, { 32, 1, 32 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -635,7 +635,7 @@ static void HeartlineTwisterRCTrack25DegUpToFlat(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21375), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 34 } });
+                    { { 0, 27, height }, { 32, 1, 32 } });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -643,7 +643,7 @@ static void HeartlineTwisterRCTrack25DegUpToFlat(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21376), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 34 } });
+                    { { 0, 27, height }, { 32, 1, 32 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -651,7 +651,7 @@ static void HeartlineTwisterRCTrack25DegUpToFlat(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21377), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 34 } });
+                    { { 0, 27, height }, { 32, 1, 32 } });
                 break;
         }
     }
@@ -665,7 +665,7 @@ static void HeartlineTwisterRCTrack25DegUpToFlat(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21318), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 34 } });
+                    { { 0, 27, height }, { 32, 1, 32 } });
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -673,7 +673,7 @@ static void HeartlineTwisterRCTrack25DegUpToFlat(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21319), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 34 } });
+                    { { 0, 27, height }, { 32, 1, 32 } });
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -681,7 +681,7 @@ static void HeartlineTwisterRCTrack25DegUpToFlat(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21320), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 34 } });
+                    { { 0, 27, height }, { 32, 1, 32 } });
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -689,7 +689,7 @@ static void HeartlineTwisterRCTrack25DegUpToFlat(
                     { { 0, 6, height }, { 32, 20, 2 } });
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours.WithIndex(21321), { 0, 0, height },
-                    { { 0, 27, height }, { 32, 1, 34 } });
+                    { { 0, 27, height }, { 32, 1, 32 } });
                 break;
         }
     }
@@ -893,7 +893,7 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21302), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -901,7 +901,7 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21303), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -909,7 +909,7 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21304), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -917,7 +917,7 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21305), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
             }
 
@@ -936,7 +936,7 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                         { { 0, 6, height - 7 }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21320), { 0, 0, height - 8 },
-                        { { 0, 27, height - 8 }, { 32, 1, 34 } });
+                        { { 0, 27, height - 8 }, { 32, 1, 32 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -944,7 +944,7 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                         { { 0, 6, height - 7 }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21321), { 0, 0, height - 8 },
-                        { { 0, 27, height - 8 }, { 32, 1, 34 } });
+                        { { 0, 27, height - 8 }, { 32, 1, 32 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -952,7 +952,7 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                         { { 0, 6, height - 7 }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21318), { 0, 0, height - 8 },
-                        { { 0, 27, height - 8 }, { 32, 1, 34 } });
+                        { { 0, 27, height - 8 }, { 32, 1, 32 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -960,7 +960,7 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                         { { 0, 6, height - 7 }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21319), { 0, 0, height - 8 },
-                        { { 0, 27, height - 8 }, { 32, 1, 34 } });
+                        { { 0, 27, height - 8 }, { 32, 1, 32 } });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -993,7 +993,7 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                         { { 0, 6, height - 7 }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21320), { 0, 0, height - 8 },
-                        { { 0, 27, height - 8 }, { 32, 1, 34 } });
+                        { { 0, 27, height - 8 }, { 32, 1, 32 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1001,7 +1001,7 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                         { { 0, 6, height - 7 }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21321), { 0, 0, height - 8 },
-                        { { 0, 27, height - 8 }, { 32, 1, 34 } });
+                        { { 0, 27, height - 8 }, { 32, 1, 32 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1009,7 +1009,7 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                         { { 0, 6, height - 7 }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21318), { 0, 0, height - 8 },
-                        { { 0, 27, height - 8 }, { 32, 1, 34 } });
+                        { { 0, 27, height - 8 }, { 32, 1, 32 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1017,7 +1017,7 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                         { { 0, 6, height - 7 }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21319), { 0, 0, height - 8 },
-                        { { 0, 27, height - 8 }, { 32, 1, 34 } });
+                        { { 0, 27, height - 8 }, { 32, 1, 32 } });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -1107,7 +1107,7 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21302), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1115,7 +1115,7 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21303), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1123,7 +1123,7 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21304), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1131,7 +1131,7 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21305), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
             }
 
@@ -1211,7 +1211,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21422), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1219,7 +1219,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21425), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1227,7 +1227,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21428), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1235,7 +1235,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21431), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
             }
             break;
@@ -1248,7 +1248,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21423), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1256,7 +1256,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21426), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1264,7 +1264,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21429), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1272,7 +1272,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21432), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
             }
             break;
@@ -1285,7 +1285,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21424), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1293,7 +1293,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21427), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1301,7 +1301,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21430), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1309,7 +1309,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21433), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
             }
             break;
@@ -1322,7 +1322,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21430), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1330,7 +1330,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21433), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1338,7 +1338,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21424), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1346,7 +1346,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21427), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
             }
             break;
@@ -1359,7 +1359,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21429), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1367,7 +1367,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21432), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1375,7 +1375,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21423), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1383,7 +1383,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21426), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
             }
             break;
@@ -1396,7 +1396,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21428), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1404,7 +1404,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21431), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1412,7 +1412,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21422), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1420,7 +1420,7 @@ static void HeartlineTwisterRCTrackLeftHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21425), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
             }
             break;
@@ -1450,7 +1450,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21446), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1458,7 +1458,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21449), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1466,7 +1466,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21452), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1474,7 +1474,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21455), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
             }
             break;
@@ -1487,7 +1487,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21447), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1495,7 +1495,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21450), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1503,7 +1503,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21453), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1511,7 +1511,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21456), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
             }
             break;
@@ -1524,7 +1524,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21448), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1532,7 +1532,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21451), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1540,7 +1540,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21454), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1548,7 +1548,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21457), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
             }
             break;
@@ -1561,7 +1561,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21454), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1569,7 +1569,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21457), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1577,7 +1577,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21448), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1585,7 +1585,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21451), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
             }
             break;
@@ -1598,7 +1598,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21453), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1606,7 +1606,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21456), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1614,7 +1614,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21447), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1622,7 +1622,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21450), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
             }
             break;
@@ -1635,7 +1635,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21452), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1643,7 +1643,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21455), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1651,7 +1651,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21446), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1659,7 +1659,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(21449), { 0, 0, height },
-                        { { 0, 27, height }, { 32, 1, 26 } });
+                        { { 0, 27, height }, { 32, 1, 24 } });
                     break;
             }
             break;


### PR DESCRIPTION
Fixes #23910 Heartline Twister Coaster track drawing over things directly above it.

Another case of bounding boxes being too high for the track clearance. They've been lowered to their maximum height, and they all still seem to be high enough for the track to look correct and cover the vehicles.

![heartlinetwisterglitch](https://github.com/user-attachments/assets/a437506e-9517-48e6-9fd7-52f461036ebd)
![heartlinetwisterfix](https://github.com/user-attachments/assets/64d0562f-a061-4456-94e2-ac5a8a3e27e3)
