### PR TITLE
map frame click now goes exactly to where player clicked

### DIFF
--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1134,7 +1134,7 @@ namespace OpenRCT2::Ui::Windows
 
         CoordsXY ScreenToMap(ScreenCoordsXY screenCoords)
         {
-            screenCoords.x = ((screenCoords.x + 8) - getPracticalMapSize()) / 2;
+            screenCoords.x = (screenCoords.x - getPracticalMapSize()) / 2;
             screenCoords.y = ((screenCoords.y + 8)) / 2;
             auto location = TileCoordsXY(screenCoords.y - screenCoords.x, screenCoords.x + screenCoords.y).ToCoordsXY();
 

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1050,7 +1050,7 @@ namespace OpenRCT2::Ui::Windows
             mapOffset.y *= getPracticalMapSize();
 
             auto leftTop = widgetOffset + mapOffset
-                + ScreenCoordsXY{ (mainViewport->viewPos.x / kCoordsXYStep), (mainViewport->viewPos.y / kCoordsXYHalfTile) };
+                + ScreenCoordsXY{ (mainViewport->viewPos.x / kCoordsXYStep), (mainViewport->viewPos.y / kCoordsXYHalfTile + 8) };
             auto rightBottom = leftTop
                 + ScreenCoordsXY{ mainViewport->ViewWidth() / kCoordsXYStep, mainViewport->ViewHeight() / kCoordsXYHalfTile };
             auto rightTop = ScreenCoordsXY{ rightBottom.x, leftTop.y };
@@ -1134,8 +1134,8 @@ namespace OpenRCT2::Ui::Windows
 
         CoordsXY ScreenToMap(ScreenCoordsXY screenCoords)
         {
-            screenCoords.x = (screenCoords.x - getPracticalMapSize()) / 2;
-            screenCoords.y = ((screenCoords.y + 8)) / 2;
+            screenCoords.x = ((screenCoords.x) - getPracticalMapSize()) / 2;
+            screenCoords.y = (screenCoords.y) / 2;
             auto location = TileCoordsXY(screenCoords.y - screenCoords.x, screenCoords.x + screenCoords.y).ToCoordsXY();
 
             switch (GetCurrentRotation())

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1050,7 +1050,8 @@ namespace OpenRCT2::Ui::Windows
             mapOffset.y *= getPracticalMapSize();
 
             auto leftTop = widgetOffset + mapOffset
-                + ScreenCoordsXY{ (mainViewport->viewPos.x / kCoordsXYStep), (mainViewport->viewPos.y / kCoordsXYHalfTile + 8) };
+                + ScreenCoordsXY{ (mainViewport->viewPos.x / kCoordsXYStep),
+                                  (mainViewport->viewPos.y / kCoordsXYHalfTile + 8) };
             auto rightBottom = leftTop
                 + ScreenCoordsXY{ mainViewport->ViewWidth() / kCoordsXYStep, mainViewport->ViewHeight() / kCoordsXYHalfTile };
             auto rightTop = ScreenCoordsXY{ rightBottom.x, leftTop.y };


### PR DESCRIPTION
This PR is a fix to the following bug: https://github.com/OpenRCT2/OpenRCT2/issues/22792

I tested with various zoom levels and the view is properly centered when clicking the map