### PR TITLE
Use WindowSetResize to set min/max dimensions in most places

### DIFF
--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -1002,16 +1002,18 @@ namespace OpenRCT2::Ui::Windows
         });
     }
 
-    void WindowSetResize(WindowBase& w, int16_t minWidth, int16_t minHeight, int16_t maxWidth, int16_t maxHeight)
+    void WindowSetResize(WindowBase& w, const ScreenSize minSize, const ScreenSize maxSize)
     {
-        w.min_width = minWidth;
-        w.min_height = minHeight;
-        w.max_width = maxWidth;
-        w.max_height = maxHeight;
+        w.min_width = minSize.width;
+        w.min_height = minSize.height;
+        w.max_width = maxSize.width;
+        w.max_height = maxSize.height;
 
         // Clamp width and height to minimum and maximum
-        int16_t width = std::clamp<int16_t>(w.width, std::min(minWidth, maxWidth), std::max(minWidth, maxWidth));
-        int16_t height = std::clamp<int16_t>(w.height, std::min(minHeight, maxHeight), std::max(minHeight, maxHeight));
+        int16_t width = std::clamp<int16_t>(
+            w.width, std::min(minSize.width, maxSize.width), std::max(minSize.width, maxSize.width));
+        int16_t height = std::clamp<int16_t>(
+            w.height, std::min(minSize.height, maxSize.height), std::max(minSize.height, maxSize.height));
 
         // Resize window if size has changed
         if (w.width != width || w.height != height)

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -1002,7 +1002,7 @@ namespace OpenRCT2::Ui::Windows
         });
     }
 
-    void WindowSetResize(WindowBase& w, const ScreenSize minSize, const ScreenSize maxSize)
+    bool WindowSetResize(WindowBase& w, const ScreenSize minSize, const ScreenSize maxSize)
     {
         w.min_width = minSize.width;
         w.min_height = minSize.height;
@@ -1022,7 +1022,10 @@ namespace OpenRCT2::Ui::Windows
             w.width = width;
             w.height = height;
             w.Invalidate();
+            return true;
         }
+
+        return false;
     }
 
     bool WindowCanResize(const WindowBase& w)

--- a/src/openrct2-ui/interface/Window.h
+++ b/src/openrct2-ui/interface/Window.h
@@ -80,7 +80,7 @@ namespace OpenRCT2::Ui::Windows
     void WindowMoveAndSnap(WindowBase& w, ScreenCoordsXY newWindowCoords, int32_t snapProximity);
     void WindowRelocateWindows(int32_t width, int32_t height);
 
-    void WindowSetResize(WindowBase& w, int16_t minWidth, int16_t minHeight, int16_t maxWidth, int16_t maxHeight);
+    void WindowSetResize(WindowBase& w, const ScreenSize minSize, const ScreenSize maxSize);
     bool WindowCanResize(const WindowBase& w);
 
     void InvalidateAllWindowsAfterInput();

--- a/src/openrct2-ui/interface/Window.h
+++ b/src/openrct2-ui/interface/Window.h
@@ -80,7 +80,7 @@ namespace OpenRCT2::Ui::Windows
     void WindowMoveAndSnap(WindowBase& w, ScreenCoordsXY newWindowCoords, int32_t snapProximity);
     void WindowRelocateWindows(int32_t width, int32_t height);
 
-    void WindowSetResize(WindowBase& w, const ScreenSize minSize, const ScreenSize maxSize);
+    bool WindowSetResize(WindowBase& w, const ScreenSize minSize, const ScreenSize maxSize);
     bool WindowCanResize(const WindowBase& w);
 
     void InvalidateAllWindowsAfterInput();

--- a/src/openrct2-ui/scripting/ScWindow.hpp
+++ b/src/openrct2-ui/scripting/ScWindow.hpp
@@ -103,7 +103,7 @@ namespace OpenRCT2::Scripting
                 }
                 else
                 {
-                    WindowSetResize(*w, value, w->min_height, value, w->max_height);
+                    WindowSetResize(*w, { value, w->min_height }, { value, w->max_height });
                 }
             }
         }
@@ -127,7 +127,7 @@ namespace OpenRCT2::Scripting
                 }
                 else
                 {
-                    WindowSetResize(*w, w->min_width, value, w->max_width, value);
+                    WindowSetResize(*w, { w->min_width, value }, { w->max_width, value });
                 }
             }
         }
@@ -145,7 +145,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                WindowSetResize(*w, value, w->min_height, w->max_width, w->max_height);
+                WindowSetResize(*w, { value, w->min_height }, { w->max_width, w->max_height });
             }
         }
         int32_t maxWidth_get() const
@@ -162,7 +162,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                WindowSetResize(*w, w->min_width, w->min_height, value, w->max_height);
+                WindowSetResize(*w, { w->min_width, w->min_height }, { value, w->max_height });
             }
         }
         int32_t minHeight_get() const
@@ -179,7 +179,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                WindowSetResize(*w, w->min_width, value, w->max_width, w->max_height);
+                WindowSetResize(*w, { w->min_width, value }, { w->max_width, w->max_height });
             }
         }
         int32_t maxHeight_get() const
@@ -196,7 +196,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                WindowSetResize(*w, w->min_width, w->min_height, w->max_width, value);
+                WindowSetResize(*w, { w->min_width, w->min_height }, { w->max_width, value });
             }
         }
         bool isSticky_get() const

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -203,7 +203,7 @@ namespace OpenRCT2::Ui::Windows
             frame_no = 0;
             pressed_widgets = 0;
             SetWidgets(_windowAboutPageWidgets[p]);
-            WindowSetResize(*this, WW, WH, WW, WH);
+            WindowSetResize(*this, { WW, WH }, { WW, WH });
 
             switch (p)
             {

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -127,10 +127,7 @@ namespace OpenRCT2::Ui::Windows
             SetWidgets(_windowChangelogWidgets);
 
             WindowInitScrollWidgets(*this);
-            min_width = MIN_WW;
-            min_height = MIN_WH;
-            max_width = MIN_WW;
-            max_height = MIN_WH;
+            WindowSetResize(*this, { MIN_WW, MIN_WH }, { MIN_WW, MIN_WH });
         }
 
         void OnResize() override
@@ -138,26 +135,11 @@ namespace OpenRCT2::Ui::Windows
             int32_t screenWidth = ContextGetWidth();
             int32_t screenHeight = ContextGetHeight();
 
-            max_width = (screenWidth * 4) / 5;
-            max_height = (screenHeight * 4) / 5;
-
-            min_width = MIN_WW;
-            min_height = MIN_WH;
+            WindowSetResize(*this, { MIN_WW, MIN_WH }, { (screenWidth * 4) / 5, (screenHeight * 4) / 5 });
 
             auto download_button_width = widgets[WIDX_OPEN_URL].width();
             widgets[WIDX_OPEN_URL].left = (width - download_button_width) / 2;
             widgets[WIDX_OPEN_URL].right = widgets[WIDX_OPEN_URL].left + download_button_width;
-
-            if (width < min_width)
-            {
-                Invalidate();
-                width = min_width;
-            }
-            if (height < min_height)
-            {
-                Invalidate();
-                height = min_height;
-            }
         }
 
         void OnPrepareDraw() override

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -122,20 +122,25 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnOpen() override
-        {
-            SetWidgets(_windowChangelogWidgets);
-
-            WindowInitScrollWidgets(*this);
-            WindowSetResize(*this, { MIN_WW, MIN_WH }, { MIN_WW, MIN_WH });
-        }
-
-        void OnResize() override
+        void SetResizeDimensions()
         {
             int32_t screenWidth = ContextGetWidth();
             int32_t screenHeight = ContextGetHeight();
 
             WindowSetResize(*this, { MIN_WW, MIN_WH }, { (screenWidth * 4) / 5, (screenHeight * 4) / 5 });
+        }
+
+        void OnOpen() override
+        {
+            SetWidgets(_windowChangelogWidgets);
+
+            WindowInitScrollWidgets(*this);
+            SetResizeDimensions();
+        }
+
+        void OnResize() override
+        {
+            SetResizeDimensions();
 
             auto download_button_width = widgets[WIDX_OPEN_URL].width();
             widgets[WIDX_OPEN_URL].left = (width - download_button_width) / 2;

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -155,10 +155,7 @@ namespace OpenRCT2::Ui::Windows
             selected_tab = 0;
             _selectedResearchItem = nullptr;
 
-            min_width = WW;
-            min_height = WH;
-            max_width = WW * 2;
-            max_height = WH * 2;
+            WindowSetResize(*this, { WW, WH }, { WW * 2, WH * 2 });
         }
 
         void OnClose() override

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -481,7 +481,7 @@ namespace OpenRCT2::Ui::Windows
 
         void OnResize() override
         {
-            WindowSetResize(*this, WW, WH, 1200, 1000);
+            WindowSetResize(*this, { WW, WH }, { 1200, 1000 });
         }
 
         static constexpr StringId kSourceStringIds[] = {

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -279,10 +279,8 @@ namespace OpenRCT2::Ui::Windows
 
             selected_tab = 0;
             selected_list_item = -1;
-            min_width = WW;
-            min_height = WH;
-            max_width = 1200;
-            max_height = 1000;
+
+            WindowSetResize(*this, { WW, WH }, { 1200, 1000 });
 
             _listSortType = RIDE_SORT_TYPE;
             _listSortDescending = false;

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -676,7 +676,7 @@ namespace OpenRCT2::Ui::Windows
          */
         void OnResizeMain()
         {
-            WindowSetResize(*this, 450, 229, 450, 229);
+            WindowSetResize(*this, { 450, 229 }, { 450, 229 });
         }
 
         /**
@@ -1005,7 +1005,7 @@ namespace OpenRCT2::Ui::Windows
          */
         void OnResizeRides()
         {
-            WindowSetResize(*this, 380, 224, 380, 224);
+            WindowSetResize(*this, { 380, 224 }, { 380, 224 });
         }
 
         /**

--- a/src/openrct2-ui/windows/EditorParkEntrance.cpp
+++ b/src/openrct2-ui/windows/EditorParkEntrance.cpp
@@ -35,7 +35,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t kScrollWidth = (kImageSize * kNumColumns) + kScrollBarWidth + 4;
     static constexpr int32_t kScrollHeight = (kImageSize * kNumRows);
     static constexpr int32_t kWindowWidth = kScrollWidth + 28;
-    static constexpr int32_t kWindowHeight = kScrollHeight + 50;
+    static constexpr int32_t kWindowHeight = kScrollHeight + 51;
 
     struct EntranceSelection
     {
@@ -247,8 +247,8 @@ namespace OpenRCT2::Ui::Windows
 
             list_information_type = 0;
 
-            WindowSetResize(
-                *this, { kWindowWidth, kWindowHeight }, { kWindowWidth, static_cast<int16_t>(43 + kImageSize * GetNumRows()) });
+            int16_t maxHeight = kWindowHeight + kImageSize * (GetNumRows() - 1);
+            WindowSetResize(*this, { kWindowWidth, kWindowHeight }, { kWindowWidth, maxHeight });
 
             pressed_widgets |= 1LL << WIDX_TAB;
 

--- a/src/openrct2-ui/windows/EditorParkEntrance.cpp
+++ b/src/openrct2-ui/windows/EditorParkEntrance.cpp
@@ -247,7 +247,7 @@ namespace OpenRCT2::Ui::Windows
 
             list_information_type = 0;
 
-            int16_t maxHeight = kWindowHeight + kImageSize * (GetNumRows() - 1);
+            auto maxHeight = static_cast<int16_t>(kWindowHeight + kImageSize * (GetNumRows() - 1));
             WindowSetResize(*this, { kWindowWidth, kWindowHeight }, { kWindowWidth, maxHeight });
 
             pressed_widgets |= 1LL << WIDX_TAB;

--- a/src/openrct2-ui/windows/EditorParkEntrance.cpp
+++ b/src/openrct2-ui/windows/EditorParkEntrance.cpp
@@ -246,10 +246,9 @@ namespace OpenRCT2::Ui::Windows
             InitParkEntranceItems();
 
             list_information_type = 0;
-            min_width = kWindowWidth;
-            min_height = kWindowHeight;
-            max_width = kWindowWidth;
-            max_height = static_cast<int16_t>(43 + kImageSize * GetNumRows());
+
+            WindowSetResize(
+                *this, { kWindowWidth, kWindowHeight }, { kWindowWidth, static_cast<int16_t>(43 + kImageSize * GetNumRows()) });
 
             pressed_widgets |= 1LL << WIDX_TAB;
 

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -404,7 +404,7 @@ namespace OpenRCT2::Ui::Windows
 
         void FinancialResize()
         {
-            WindowSetResize(*this, 280, 149, 280, 149);
+            WindowSetResize(*this, { 280, 149 }, { 280, 149 });
         }
 
         void ShowClimateDropdown()
@@ -700,7 +700,7 @@ namespace OpenRCT2::Ui::Windows
 
         void GuestsResize()
         {
-            WindowSetResize(*this, 380, 149, 380, 149);
+            WindowSetResize(*this, { 380, 149 }, { 380, 149 });
         }
 
         void GuestsMouseDown(WidgetIndex widgetIndex)
@@ -972,7 +972,7 @@ namespace OpenRCT2::Ui::Windows
 
         void ParkResize()
         {
-            WindowSetResize(*this, 400, 200, 400, 200);
+            WindowSetResize(*this, { 400, 200 }, { 400, 200 });
         }
 
         void ParkMouseDown(WidgetIndex widgetIndex)

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -508,8 +508,8 @@ namespace OpenRCT2::Ui::Windows
             {
                 flags |= WF_RESIZABLE;
                 WindowSetResize(
-                    *this, WW_OTHER_TABS, kHeightOtherTabs, std::numeric_limits<int16_t>::max(),
-                    std::numeric_limits<int16_t>::max());
+                    *this, { WW_OTHER_TABS, kHeightOtherTabs },
+                    { std::numeric_limits<int16_t>::max(), std::numeric_limits<int16_t>::max() });
             }
             else
             {

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -434,7 +434,7 @@ namespace OpenRCT2::Ui::Windows
             }
             maxWidth = std::max(minWidth, maxWidth);
 
-            WindowSetResize(*this, minWidth, minHeight, maxWidth, maxHeight);
+            WindowSetResize(*this, { minWidth, minHeight }, { maxWidth, maxHeight });
         }
 
         void OnPrepareDrawCommon()

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -195,10 +195,9 @@ namespace OpenRCT2::Ui::Windows
             frame_no = 0;
             _marqueePosition = 0;
             picked_peep_frame = 0;
-            min_width = width;
-            min_height = 157;
-            max_width = 500;
-            max_height = 450;
+
+            WindowSetResize(*this, { WW, WH }, { 500, 450 });
+
             selected_list_item = -1;
         }
 

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -169,10 +169,9 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_FILTER_BY_NAME].type = WindowWidgetType::FlatBtn;
             widgets[WIDX_PAGE_DROPDOWN].type = WindowWidgetType::Empty;
             widgets[WIDX_PAGE_DROPDOWN_BUTTON].type = WindowWidgetType::Empty;
-            min_width = 350;
-            min_height = 330;
-            max_width = 500;
-            max_height = 450;
+
+            WindowSetResize(*this, { 350, 330 }, { 500, 450 });
+
             RefreshList();
         }
 
@@ -246,22 +245,6 @@ namespace OpenRCT2::Ui::Windows
             }
 
             RefreshList();
-        }
-
-        void OnResize() override
-        {
-            min_width = 350;
-            min_height = 330;
-            if (width < min_width)
-            {
-                Invalidate();
-                width = min_width;
-            }
-            if (height < min_height)
-            {
-                Invalidate();
-                height = min_height;
-            }
         }
 
         void OnUpdate() override

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -354,11 +354,7 @@ namespace OpenRCT2::Ui::Windows
             // Reset window dimensions
             InitScrollWidgets();
             ComputeMaxDateWidth();
-
-            min_width = kWindowSizeMin.width;
-            min_height = kWindowSizeMin.height;
-            max_width = kWindowSizeMax.width;
-            max_height = kWindowSizeMax.height;
+            WindowSetResize(*this, kWindowSizeMin, kWindowSizeMax);
         }
 
         void OnClose() override

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -376,8 +376,7 @@ namespace OpenRCT2::Ui::Windows
 
         void OnResize() override
         {
-            WindowSetResize(
-                *this, { kWindowSizeMin.width, kWindowSizeMin.height }, { kWindowSizeMax.width, kWindowSizeMax.height });
+            WindowSetResize(*this, kWindowSizeMin, kWindowSizeMax);
 
             auto& config = Config::Get().general;
             config.FileBrowserWidth = width;

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -380,7 +380,8 @@ namespace OpenRCT2::Ui::Windows
 
         void OnResize() override
         {
-            WindowSetResize(*this, kWindowSizeMin.width, kWindowSizeMin.height, kWindowSizeMax.width, kWindowSizeMax.height);
+            WindowSetResize(
+                *this, { kWindowSizeMin.width, kWindowSizeMin.height }, { kWindowSizeMax.width, kWindowSizeMax.height });
 
             auto& config = Config::Get().general;
             config.FileBrowserWidth = width;

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -239,9 +239,8 @@ namespace OpenRCT2::Ui::Windows
                 | (1uLL << WIDX_MAP_SIZE_SPINNER_X_UP) | (1uLL << WIDX_MAP_SIZE_SPINNER_X_DOWN);
 
             flags |= WF_RESIZABLE;
-            min_width = WW;
-            min_height = WH;
 
+            WindowSetResize(*this, { WW, WH }, { WW, WH });
             SetInitialWindowDimensions();
             ResetMaxWindowDimensions();
             ResizeMiniMap();

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -342,12 +342,12 @@ namespace OpenRCT2::Ui::Windows
             case WINDOW_MULTIPLAYER_PAGE_INFORMATION:
             {
                 auto size = _windowInformationSize ? _windowInformationSize.value() : InformationGetSize();
-                WindowSetResize(*this, size.x, size.y, size.x, size.y);
+                WindowSetResize(*this, { size.x, size.y }, { size.x, size.y });
                 break;
             }
             case WINDOW_MULTIPLAYER_PAGE_PLAYERS:
             {
-                WindowSetResize(*this, 420, 124, 500, 450);
+                WindowSetResize(*this, { 420, 124 }, { 500, 450 });
 
                 no_list_items = (IsServerPlayerInvisible() ? NetworkGetNumVisiblePlayers() : NetworkGetNumPlayers());
 
@@ -359,7 +359,7 @@ namespace OpenRCT2::Ui::Windows
             }
             case WINDOW_MULTIPLAYER_PAGE_GROUPS:
             {
-                WindowSetResize(*this, 320, 200, 320, 500);
+                WindowSetResize(*this, { 320, 200 }, { 320, 500 });
 
                 no_list_items = NetworkGetNumActions();
 
@@ -369,7 +369,7 @@ namespace OpenRCT2::Ui::Windows
             }
             case WINDOW_MULTIPLAYER_PAGE_OPTIONS:
             {
-                WindowSetResize(*this, 300, 100, 300, 100);
+                WindowSetResize(*this, { 300, 100 }, { 300, 100 });
                 break;
             }
         }

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -142,7 +142,7 @@ namespace OpenRCT2::Ui::Windows
     class MultiplayerWindow final : public Window
     {
     private:
-        std::optional<ScreenCoordsXY> _windowInformationSize;
+        std::optional<ScreenSize> _windowInformationSize;
         uint8_t _selectedGroup{ 0 };
 
     private:
@@ -159,7 +159,7 @@ namespace OpenRCT2::Ui::Windows
         void GroupsScrollPaint(int32_t scrollIndex, DrawPixelInfo& dpi) const;
 
         void ShowGroupDropdown(WidgetIndex widgetIndex);
-        ScreenCoordsXY InformationGetSize();
+        ScreenSize InformationGetSize();
 
     public:
         void OnOpen() override;
@@ -289,7 +289,7 @@ namespace OpenRCT2::Ui::Windows
         }
     }
 
-    ScreenCoordsXY MultiplayerWindow::InformationGetSize()
+    ScreenSize MultiplayerWindow::InformationGetSize()
     {
         assert(!_windowInformationSize.has_value());
 
@@ -342,7 +342,7 @@ namespace OpenRCT2::Ui::Windows
             case WINDOW_MULTIPLAYER_PAGE_INFORMATION:
             {
                 auto size = _windowInformationSize ? _windowInformationSize.value() : InformationGetSize();
-                WindowSetResize(*this, { size.x, size.y }, { size.x, size.y });
+                WindowSetResize(*this, size, size);
                 break;
             }
             case WINDOW_MULTIPLAYER_PAGE_PLAYERS:

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -39,13 +39,9 @@ namespace OpenRCT2::Ui::Windows
         {
             SetWidgets(window_network_status_widgets);
             WindowInitScrollWidgets(*this);
+            WindowSetResize(*this, { 320, 90 }, { 320, 90 });
 
             frame_no = 0;
-            min_width = 320;
-            min_height = 90;
-            max_width = min_width;
-            max_height = min_height;
-
             page = 0;
             list_information_type = 0;
         }

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -449,7 +449,7 @@ namespace OpenRCT2::Ui::Windows
         void OnResizeEntrance()
         {
             flags |= WF_RESIZABLE;
-            WindowSetResize(*this, 230, 174 + 9, 230 * 3, (274 + 9) * 3);
+            WindowSetResize(*this, { 230, 174 + 9 }, { 230 * 3, (274 + 9) * 3 });
             InitViewport();
         }
 
@@ -677,7 +677,7 @@ namespace OpenRCT2::Ui::Windows
         void OnResizeRating()
         {
             flags |= WF_RESIZABLE;
-            WindowSetResize(*this, 268, 174 + 9, 2000, 2000);
+            WindowSetResize(*this, { 268, 174 + 9 }, { 2000, 2000 });
         }
 
         void OnUpdateRating()
@@ -745,7 +745,7 @@ namespace OpenRCT2::Ui::Windows
         void OnResizeGuests()
         {
             flags |= WF_RESIZABLE;
-            WindowSetResize(*this, 268, 174 + 9, 2000, 2000);
+            WindowSetResize(*this, { 268, 174 + 9 }, { 2000, 2000 });
         }
 
         void OnUpdateGuests()
@@ -824,7 +824,7 @@ namespace OpenRCT2::Ui::Windows
 #pragma region Price page
         void OnResizePrice()
         {
-            WindowSetResize(*this, 230, 124, 230, 124);
+            WindowSetResize(*this, { 230, 124 }, { 230, 124 });
         }
 
         void OnMouseDownPrice(WidgetIndex widgetIndex)
@@ -922,7 +922,7 @@ namespace OpenRCT2::Ui::Windows
 #pragma region Stats page
         void OnResizeStats()
         {
-            WindowSetResize(*this, 230, 119, 230, 119);
+            WindowSetResize(*this, { 230, 119 }, { 230, 119 });
         }
 
         void OnUpdateStats()
@@ -1025,10 +1025,10 @@ namespace OpenRCT2::Ui::Windows
         {
 #ifndef NO_TTF
             if (gCurrentTTFFontSet != nullptr)
-                WindowSetResize(*this, 230, 270, 230, 270);
+                WindowSetResize(*this, { 230, 270 }, { 230, 270 });
             else
 #endif
-                WindowSetResize(*this, 230, 226, 230, 226);
+                WindowSetResize(*this, { 230, 226 }, { 230, 226 });
         }
 
         void OnUpdateObjective()
@@ -1131,7 +1131,7 @@ namespace OpenRCT2::Ui::Windows
 #pragma region Awards page
         void OnResizeAwards()
         {
-            WindowSetResize(*this, 230, 182, 230, 182);
+            WindowSetResize(*this, { 230, 182 }, { 230, 182 });
         }
 
         void OnUpdateAwards()

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -338,7 +338,7 @@ namespace OpenRCT2::Ui::Windows
 
         void OnResizeOverview()
         {
-            WindowSetResize(*this, 240, 170, 500, 300);
+            WindowSetResize(*this, { 240, 170 }, { 500, 300 });
         }
 
         void OnUpdateOverview()
@@ -569,7 +569,7 @@ namespace OpenRCT2::Ui::Windows
 
         void OnResizeStatistics()
         {
-            WindowSetResize(*this, 210, 80, 210, 80);
+            WindowSetResize(*this, { 210, 80 }, { 210, 80 });
         }
 
         void OnUpdateStatistics()

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -99,10 +99,9 @@ namespace OpenRCT2::Ui::Windows
             page = 0;
             frame_no = 0;
             list_information_type = 0;
-            min_width = 210;
-            min_height = 134;
-            max_width = 500;
-            max_height = 450;
+
+            WindowSetResize(*this, { 210, 134 }, { 500, 450 });
+
             hold_down_widgets = 0;
             pressed_widgets = 0;
             SetPage(WINDOW_PLAYER_PAGE_OVERVIEW);

--- a/src/openrct2-ui/windows/ProgressWindow.cpp
+++ b/src/openrct2-ui/windows/ProgressWindow.cpp
@@ -87,12 +87,9 @@ namespace OpenRCT2::Ui::Windows
             Audio::StopSFX();
             SetWidgets(kProgressWindowWidgets);
             WindowInitScrollWidgets(*this);
+            WindowSetResize(*this, { kWindowWidth, kWindowHeight }, { kWindowWidth, kWindowHeight });
 
             frame_no = 0;
-            min_width = kWindowWidth;
-            min_height = kWindowHeight;
-            max_width = min_width;
-            max_height = min_height;
 
             ApplyStyle();
         }

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1710,7 +1710,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             flags |= WF_RESIZABLE;
-            WindowSetResize(*this, kMinimumWindowWidth, minHeight, 500, 450);
+            WindowSetResize(*this, { kMinimumWindowWidth, minHeight }, { 500, 450 });
             // Unlike with other windows, the focus needs to be recentred so it’s best to just reset it.
             focus = std::nullopt;
             InitViewport();
@@ -2658,7 +2658,7 @@ namespace OpenRCT2::Ui::Windows
         void VehicleResize()
         {
             auto bottom = widgets[WIDX_VEHICLE_TRAINS].bottom + 6;
-            WindowSetResize(*this, kMinimumWindowWidth, bottom, kMinimumWindowWidth, bottom);
+            WindowSetResize(*this, { kMinimumWindowWidth, bottom }, { kMinimumWindowWidth, bottom });
         }
 
         void VehicleOnMouseDown(WidgetIndex widgetIndex)
@@ -3203,7 +3203,7 @@ namespace OpenRCT2::Ui::Windows
         void OperatingResize()
         {
             auto bottom = widgets[WIDX_SYNCHRONISE_WITH_ADJACENT_STATIONS_CHECKBOX].bottom + 6;
-            WindowSetResize(*this, kMinimumWindowWidth, bottom, kMinimumWindowWidth, bottom);
+            WindowSetResize(*this, { kMinimumWindowWidth, bottom }, { kMinimumWindowWidth, bottom });
         }
 
         void OperatingOnMouseDown(WidgetIndex widgetIndex)
@@ -3774,7 +3774,7 @@ namespace OpenRCT2::Ui::Windows
         void MaintenanceResize()
         {
             auto bottom = widgets[WIDX_LOCATE_MECHANIC].bottom + 6;
-            WindowSetResize(*this, kMinimumWindowWidth, bottom, kMinimumWindowWidth, bottom);
+            WindowSetResize(*this, { kMinimumWindowWidth, bottom }, { kMinimumWindowWidth, bottom });
         }
 
         void MaintenanceOnMouseDown(WidgetIndex widgetIndex)
@@ -4299,7 +4299,7 @@ namespace OpenRCT2::Ui::Windows
         void ColourResize()
         {
             auto bottom = widgets[WIDX_VEHICLE_PREVIEW].bottom + 6;
-            WindowSetResize(*this, kMinimumWindowWidth, bottom, kMinimumWindowWidth, bottom);
+            WindowSetResize(*this, { kMinimumWindowWidth, bottom }, { kMinimumWindowWidth, bottom });
         }
 
         void ColourOnMouseDown(WidgetIndex widgetIndex)
@@ -5022,7 +5022,7 @@ namespace OpenRCT2::Ui::Windows
             auto standardHeight = widgets[WIDX_MUSIC_DROPDOWN].bottom + 6;
             auto minHeight = isMusicActivated ? standardHeight + 133 : standardHeight;
             auto maxHeight = isMusicActivated ? standardHeight + 369 : standardHeight;
-            WindowSetResize(*this, kMinimumWindowWidth, minHeight, 500, maxHeight);
+            WindowSetResize(*this, { kMinimumWindowWidth, minHeight }, { 500, maxHeight });
         }
 
         static std::string GetMusicString(ObjectEntryIndex musicObjectIndex)
@@ -5463,7 +5463,7 @@ namespace OpenRCT2::Ui::Windows
 
         void MeasurementsResize()
         {
-            WindowSetResize(*this, kMinimumWindowWidth, 234, kMinimumWindowWidth, 234);
+            WindowSetResize(*this, { kMinimumWindowWidth, 234 }, { kMinimumWindowWidth, 234 });
         }
 
         void MeasurementsOnMouseDown(WidgetIndex widgetIndex)
@@ -5899,7 +5899,7 @@ namespace OpenRCT2::Ui::Windows
 
         void GraphsResize()
         {
-            WindowSetResize(*this, kMinimumWindowWidth, 182, std::numeric_limits<int16_t>::max(), 450);
+            WindowSetResize(*this, { kMinimumWindowWidth, 182 }, { std::numeric_limits<int16_t>::max(), 450 });
         }
 
         void GraphsOnMouseDown(WidgetIndex widgetIndex)
@@ -6452,7 +6452,7 @@ namespace OpenRCT2::Ui::Windows
         void IncomeResize()
         {
             auto newHeight = 194;
-            WindowSetResize(*this, kMinimumWindowWidth, newHeight, kMinimumWindowWidth, newHeight);
+            WindowSetResize(*this, { kMinimumWindowWidth, newHeight }, { kMinimumWindowWidth, newHeight });
         }
 
         void IncomeOnMouseDown(WidgetIndex widgetIndex)
@@ -6768,7 +6768,7 @@ namespace OpenRCT2::Ui::Windows
         void CustomerResize()
         {
             flags |= WF_RESIZABLE;
-            WindowSetResize(*this, kMinimumWindowWidth, 163, kMinimumWindowWidth, 163);
+            WindowSetResize(*this, { kMinimumWindowWidth, 163 }, { kMinimumWindowWidth, 163 });
         }
 
         void CustomerUpdate()

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -754,10 +754,8 @@ namespace OpenRCT2::Ui::Windows
             list_information_type = 0;
             picked_peep_frame = 0;
             DisableTabs();
-            min_width = kMinimumWindowWidth;
-            min_height = 180;
-            max_width = 500;
-            max_height = 450;
+
+            WindowSetResize(*this, { kMinimumWindowWidth, 180 }, { 500, 450 });
 
             auto ride = GetRide(rideId);
             if (ride == nullptr)

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -176,13 +176,12 @@ namespace OpenRCT2::Ui::Windows
         {
             SetWidgets(_rideListWidgets);
             WindowInitScrollWidgets(*this);
+            WindowSetResize(*this, { 340, 240 }, { 400, 700 });
+
             page = PAGE_RIDES;
             selected_list_item = -1;
             frame_no = 0;
-            min_width = 340;
-            min_height = 240;
-            max_width = 400;
-            max_height = 700;
+
             RefreshList();
 
             list_information_type = 0;

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -109,7 +109,7 @@ namespace OpenRCT2::Ui::Windows
             page = 0;
             list_information_type = 0;
 
-            WindowSetResize(*this, kWindowWidthMin, kWindowHeightMin, kWindowWidthMax, kWindowHeightMax);
+            WindowSetResize(*this, { kWindowWidthMin, kWindowHeightMin }, { kWindowWidthMax, kWindowHeightMax });
 
             no_list_items = static_cast<uint16_t>(_serverList.GetCount());
 
@@ -166,7 +166,7 @@ namespace OpenRCT2::Ui::Windows
 
         void OnResize() override
         {
-            WindowSetResize(*this, kWindowWidthMin, kWindowHeightMin, kWindowWidthMax, kWindowHeightMax);
+            WindowSetResize(*this, { kWindowWidthMin, kWindowHeightMin }, { kWindowWidthMax, kWindowHeightMax });
         }
 
         void OnDropdown(WidgetIndex widgetIndex, int32_t selectedIndex) override

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -98,14 +98,11 @@ namespace OpenRCT2::Ui::Windows
             SetWidgets(_serverListWidgets);
             widgets[WIDX_PLAYER_NAME_INPUT].string = const_cast<utf8*>(_playerName.c_str());
             InitScrollWidgets();
+            WindowSetResize(*this, { 320, 90 }, { 320, 90 });
+
             no_list_items = 0;
             selected_list_item = -1;
             frame_no = 0;
-            min_width = 320;
-            min_height = 90;
-            max_width = min_width;
-            max_height = min_height;
-
             page = 0;
             list_information_type = 0;
 

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -73,13 +73,11 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_DESCRIPTION_INPUT].string = _description;
             widgets[WIDX_GREETING_INPUT].string = _greeting;
             widgets[WIDX_PASSWORD_INPUT].string = _password;
-            InitScrollWidgets();
-            frame_no = 0;
-            min_width = width;
-            min_height = height;
-            max_width = min_width;
-            max_height = min_height;
 
+            InitScrollWidgets();
+            WindowSetResize(*this, { width, height }, { width, height });
+
+            frame_no = 0;
             page = 0;
             list_information_type = 0;
 

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -204,7 +204,7 @@ namespace OpenRCT2::Ui::Windows
 
         void OnResize() override
         {
-            WindowSetResize(*this, min_width, min_height, max_width, max_height);
+            WindowSetResize(*this, { min_width, min_height }, { max_width, max_height });
         }
 
         void OnUpdate() override

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -190,10 +190,7 @@ namespace OpenRCT2::Ui::Windows
             InitialiseWidgets();
             InitialiseList();
 
-            min_width = WW;
-            min_height = WH;
-            max_width = WW_SC_MAX;
-            max_height = WH_SC_MAX;
+            WindowSetResize(*this, { WW, WH }, { WW_SC_MAX, WH_SC_MAX });
         }
 
         void OnClose() override

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -605,31 +605,7 @@ namespace OpenRCT2::Ui::Windows
 
         void OverviewResize()
         {
-            min_width = WW;
-            max_width = 500;
-            min_height = WH;
-            max_height = 450;
-
-            if (width < min_width)
-            {
-                width = min_width;
-                Invalidate();
-            }
-            if (width > max_width)
-            {
-                Invalidate();
-                width = max_width;
-            }
-            if (height < min_height)
-            {
-                height = min_height;
-                Invalidate();
-            }
-            if (height > max_height)
-            {
-                Invalidate();
-                height = max_height;
-            }
+            WindowSetResize(*this, { WW, WH }, { 500, 450 });
 
             if (viewport != nullptr)
             {
@@ -934,31 +910,7 @@ namespace OpenRCT2::Ui::Windows
 
         void OptionsResize()
         {
-            min_width = 190;
-            max_width = 190;
-            min_height = 126;
-            max_height = 126;
-
-            if (width < min_width)
-            {
-                width = min_width;
-                Invalidate();
-            }
-            if (width > max_width)
-            {
-                Invalidate();
-                width = max_width;
-            }
-            if (height < min_height)
-            {
-                height = min_height;
-                Invalidate();
-            }
-            if (height > max_height)
-            {
-                Invalidate();
-                height = max_height;
-            }
+            WindowSetResize(*this, { 190, 126 }, { 190, 126 });
         }
 
         void OptionsUpdate()
@@ -1037,31 +989,7 @@ namespace OpenRCT2::Ui::Windows
 
         void StatsResize()
         {
-            min_width = 190;
-            max_width = 190;
-            min_height = 126;
-            max_height = 126;
-
-            if (width < min_width)
-            {
-                width = min_width;
-                Invalidate();
-            }
-            if (width > max_width)
-            {
-                Invalidate();
-                width = max_width;
-            }
-            if (height < min_height)
-            {
-                height = min_height;
-                Invalidate();
-            }
-            if (height > max_height)
-            {
-                Invalidate();
-                height = max_height;
-            }
+            WindowSetResize(*this, { 190, 126 }, { 190, 126 });
         }
 
         void StatsUpdate()

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -122,12 +122,9 @@ namespace OpenRCT2::Ui::Windows
         {
             SetWidgets(_staffListWidgets);
             WindowInitScrollWidgets(*this);
+            WindowSetResize(*this, { WW, WH }, { MAX_WW, MAX_WH });
 
             widgets[WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER].type = WindowWidgetType::Empty;
-            min_width = WW;
-            min_height = WH;
-            max_width = MAX_WW;
-            max_height = MAX_WH;
 
             RefreshList();
         }
@@ -170,18 +167,6 @@ namespace OpenRCT2::Ui::Windows
 
         void OnResize() override
         {
-            min_width = WW;
-            min_height = WH;
-            if (width < min_width)
-            {
-                width = min_width;
-                Invalidate();
-            }
-            if (height < min_height)
-            {
-                height = min_height;
-                Invalidate();
-            }
             ResizeFrameWithPage();
         }
 

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -172,7 +172,7 @@ namespace OpenRCT2::Ui::Windows
             int32_t newHeight = CalculateWindowHeight(_buffer.data());
             if (newHeight != height)
             {
-                WindowSetResize(*this, WW, newHeight, WW, newHeight);
+                WindowSetResize(*this, { WW, newHeight }, { WW, newHeight });
             }
 
             widgets[WIDX_OKAY].top = newHeight - 22;

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -266,102 +266,29 @@ namespace OpenRCT2::Ui::Windows
             SetWidgets(_themesWidgets);
 
             WindowThemesInitVars();
-
             WindowInitScrollWidgets(*this);
+            WindowSetResize(*this, { 320, 107 }, { 320, 107 });
+
             list_information_type = 0;
             _classIndex = -1;
             _buttonIndex = -1;
-            min_width = 320;
-            min_height = 107;
-            max_width = 320;
-            max_height = 107;
         }
 
         void OnResize() override
         {
             if (_selected_tab == WINDOW_THEMES_TAB_SETTINGS)
             {
-                min_width = 320;
-                min_height = 107;
-                max_width = 320;
-                max_height = 107;
-
-                if (width < min_width)
-                {
-                    width = min_width;
+                if (WindowSetResize(*this, { 320, 107 }, { 320, 107 }))
                     GfxInvalidateScreen();
-                }
-                if (height < min_height)
-                {
-                    height = min_height;
-                    GfxInvalidateScreen();
-                }
-                if (width > max_width)
-                {
-                    width = max_width;
-                    GfxInvalidateScreen();
-                }
-                if (height > max_height)
-                {
-                    height = max_height;
-                    GfxInvalidateScreen();
-                }
             }
             else if (_selected_tab == WINDOW_THEMES_TAB_FEATURES)
             {
-                min_width = 320;
-                min_height = 122;
-                max_width = 320;
-                max_height = 122;
-
-                if (width < min_width)
-                {
-                    width = min_width;
+                if (WindowSetResize(*this, { 320, 122 }, { 320, 122 }))
                     GfxInvalidateScreen();
-                }
-                if (height < min_height)
-                {
-                    height = min_height;
-                    GfxInvalidateScreen();
-                }
-                if (width > max_width)
-                {
-                    width = max_width;
-                    GfxInvalidateScreen();
-                }
-                if (height > max_height)
-                {
-                    height = max_height;
-                    GfxInvalidateScreen();
-                }
             }
             else
             {
-                min_width = 320;
-                min_height = 270;
-                max_width = 320;
-                max_height = 450;
-
-                if (width < min_width)
-                {
-                    width = min_width;
-                    Invalidate();
-                }
-                if (height < min_height)
-                {
-                    height = min_height;
-                    Invalidate();
-                }
-                if (width > max_width)
-                {
-                    width = max_width;
-                    Invalidate();
-                }
-                if (height > max_height)
-                {
-                    height = max_height;
-                    Invalidate();
-                }
+                WindowSetResize(*this, { 320, 270 }, { 320, 450 });
             }
 
             ResizeFrameWithPage();

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -513,10 +513,7 @@ static uint64_t PageDisabledWidgets[] = {
     public:
         void OnOpen() override
         {
-            min_width = MIN_WW;
-            min_height = MIN_WH;
-            max_width = MAX_WW;
-            max_height = MAX_WH;
+            WindowSetResize(*this, { MIN_WW, MIN_WH }, { MAX_WW, MAX_WH });
 
             windowTileInspectorSelectedIndex = -1;
             SetPage(TileInspectorPage::Default);

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -185,7 +185,7 @@ namespace OpenRCT2::Ui::Windows
             min_width = WW;
             min_height = WH;
 
-            WindowSetResize(*this, min_width, min_height, max_width, max_height);
+            WindowSetResize(*this, { min_width, min_height }, { max_width, max_height });
         }
 
         void OnPrepareDraw() override

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -98,10 +98,7 @@ namespace OpenRCT2::Ui::Windows
 
             viewport->flags |= VIEWPORT_FLAG_SOUND_ON | VIEWPORT_FLAG_INDEPEDENT_ROTATION;
 
-            min_width = WW;
-            min_height = WH;
-            max_width = WW;
-            max_height = WH;
+            WindowSetResize(*this, { WW, WH }, { WW, WH });
         }
 
         void OnUpdate() override


### PR DESCRIPTION
This PR leverages the `WindowSetResize` function in more windows, instead of letting windows sort their own dimensions in their respective `OnResize` events.

Split off from #23590.

The following windows were modified and therefore warrant attention during testing. I've denoted a few as 'trivial', by which I mean the only changes were due the new `WindowSetResize` signature changing.

- About (trivial)
- Changelog
- EditorInventionsList
- EditorObjectSelection
- EditorObjectiveOptions (trivial)
- EditorParkEntrance
- EditorScenarioOptions (trivial)
- Finances
- Guest
- GuestList
- LoadSave
- Map
- Multiplayer (trivial)
- NetworkStatus
- Park (trivial)
- Player
- ProgressWindow
- Ride
- RideList
- ServerList
- ServerStart
- ShortcutKeys
- Staff
- StaffList
- TextInput (trivial)
- Themes
- TileInspector
- Viewport