### PR TITLE
Change widget order for land rights checkboxes

### DIFF
--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -50,11 +50,11 @@ namespace OpenRCT2::Ui::Windows
         WIDX_BUY_CONSTRUCTION_RIGHTS,
 
         // Editor/sandbox widgets
-        WIDX_UNOWNED_LAND_CHECKBOX,
-        WIDX_LAND_SALE_CHECKBOX,
         WIDX_LAND_OWNED_CHECKBOX,
-        WIDX_CONSTRUCTION_RIGHTS_SALE_CHECKBOX,
+        WIDX_LAND_SALE_CHECKBOX,
         WIDX_CONSTRUCTION_RIGHTS_OWNED_CHECKBOX,
+        WIDX_CONSTRUCTION_RIGHTS_SALE_CHECKBOX,
+        WIDX_UNOWNED_LAND_CHECKBOX,
     };
 
     // clang-format off
@@ -65,11 +65,11 @@ namespace OpenRCT2::Ui::Windows
         MakeRemapWidget({ 54, 32}, { 16, 16}, WindowWidgetType::TrnBtn, WindowColour::Primary, SPR_LAND_TOOL_INCREASE,          STR_ADJUST_LARGER_LAND_RIGHTS_TIP              ), // increment size
         MakeRemapWidget({ 22, 53}, { 24, 24}, WindowWidgetType::ImgBtn, WindowColour::Primary, SPR_BUY_LAND_RIGHTS,             STR_BUY_LAND_RIGHTS_TIP                        ), // land rights
         MakeRemapWidget({ 52, 53}, { 24, 24}, WindowWidgetType::ImgBtn, WindowColour::Primary, SPR_BUY_CONSTRUCTION_RIGHTS,     STR_BUY_CONSTRUCTION_RIGHTS_TIP                ), // construction rights
-        MakeWidget     ({100, 22}, {170, 12}, WindowWidgetType::Empty,  WindowColour::Primary, STR_LAND_NOT_OWNED,              STR_SET_LAND_TO_BE_NOT_OWNED_TIP               ),
+        MakeWidget     ({100, 22}, {170, 12}, WindowWidgetType::Empty,  WindowColour::Primary, STR_LAND_OWNED,                  STR_SET_LAND_TO_BE_OWNED_TIP                   ),
         MakeWidget     ({100, 38}, {170, 12}, WindowWidgetType::Empty,  WindowColour::Primary, STR_LAND_SALE,                   STR_SET_LAND_TO_BE_AVAILABLE_TIP               ),
-        MakeWidget     ({100, 54}, {170, 12}, WindowWidgetType::Empty,  WindowColour::Primary, STR_LAND_OWNED,                  STR_SET_LAND_TO_BE_OWNED_TIP                   ),
+        MakeWidget     ({100, 54}, {170, 12}, WindowWidgetType::Empty,  WindowColour::Primary, STR_CONSTRUCTION_RIGHTS_OWNED,   STR_SET_CONSTRUCTION_RIGHTS_TO_BE_OWNED_TIP    ),
         MakeWidget     ({100, 70}, {170, 12}, WindowWidgetType::Empty,  WindowColour::Primary, STR_CONSTRUCTION_RIGHTS_SALE,    STR_SET_CONSTRUCTION_RIGHTS_TO_BE_AVAILABLE_TIP),
-        MakeWidget     ({100, 86}, {170, 12}, WindowWidgetType::Empty,  WindowColour::Primary, STR_CONSTRUCTION_RIGHTS_OWNED,   STR_SET_CONSTRUCTION_RIGHTS_TO_BE_OWNED_TIP    ),
+        MakeWidget     ({100, 86}, {170, 12}, WindowWidgetType::Empty,  WindowColour::Primary, STR_LAND_NOT_OWNED,              STR_SET_LAND_TO_BE_NOT_OWNED_TIP               ),
     };
     // clang-format on
 
@@ -80,15 +80,15 @@ namespace OpenRCT2::Ui::Windows
         BuyConstructionRights,
 
         // Sandbox/editor mode
-        SetLandUnowned,
-        SetLandForSale,
         SetLandOwned,
-        SetConstructionRightsForSale,
+        SetLandForSale,
         SetConstructionRightsOwned,
+        SetConstructionRightsForSale,
+        SetLandUnowned,
     };
 
-    static const bool kLandRightsVisibleByMode[] = { true, false, true, true, true, false, false };
-    static const bool kConstructionRightsVisibleByMode[] = { false, true, true, false, false, true, true };
+    static const bool kLandRightsVisibleByMode[] = { true, false, true, true, false, false, true };
+    static const bool kConstructionRightsVisibleByMode[] = { false, true, false, false, true, true, true };
 
     class LandRightsWindow final : public Window
     {
@@ -143,7 +143,7 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                SwitchToMode(LandRightsMode::SetLandUnowned);
+                SwitchToMode(LandRightsMode::SetLandOwned);
             }
         }
 


### PR DESCRIPTION
This PR changes the widget order for land rights checkboxes, and sets 'owned land' as the default option in the scenario editor.

After:
<img width="360" alt="Screenshot 2025-03-04 at 23 17 12" src="https://github.com/user-attachments/assets/c8027425-8daa-4f4a-8f6d-d46154137a62" />

Before:
<img width="363" alt="Screenshot 2025-03-04 at 23 17 30" src="https://github.com/user-attachments/assets/51269d0c-f443-49e6-bbc2-2b521dce4fd2" />
