### PR TITLE
Fix #10582: Low clearance tunnels below water draw incorrectly

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Change: [#23932] The land rights window now checks 'Land Owned' by default.
 - Fix: [#4225] Ride Construction window offers non-existent banked sloped to level curve (original bug).
 - Fix: [#10379] Banners outside the park can be renamed and modified (original bug).
+- Fix: [#10582] Low clearance tunnels below water are drawn incorrectly (original bug).
 - Fix: [#23743] Parks with guest goals over 32767 do not appear in the scenario list.
 - Fix: [#23844] Sound effects keep playing when loading another save.
 - Fix: [#23897] Reverse Freefall Coaster slope up to vertical track piece does not draw a vertical tunnel.

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -573,6 +573,9 @@ static void ViewportSurfaceDrawTileSideBottom(
             return;
         }
 
+        neighbourCornerHeight1 = std::max(cornerHeight1, neighbourCornerHeight1);
+        neighbourCornerHeight2 = std::max(cornerHeight2, neighbourCornerHeight2);
+
         cornerHeight1 = height;
         cornerHeight2 = height;
     }
@@ -762,6 +765,9 @@ static void ViewportSurfaceDrawTileSideTop(
             {
                 return;
             }
+
+            neighbourCornerHeight1 = std::max(cornerHeight1, neighbourCornerHeight1);
+            neighbourCornerHeight2 = std::max(cornerHeight2, neighbourCornerHeight2);
 
             cornerHeight1 = height;
             cornerHeight2 = height;


### PR DESCRIPTION
Fixes #10582 Low clearance tunnels below water draw incorrectly.

![lowclearanceunderwatertunnelglitch](https://github.com/user-attachments/assets/ff8ac62d-a0a8-48e8-bb30-cfdf9c8ec917) ![lowclearanceunderwatertunnelfix](https://github.com/user-attachments/assets/a2e0cfa8-f983-4697-8541-3d9dd653c4be)

The issue here was that water was actually drawing edges down to the neighbouring terrain corners, covering the ones already drawn by the land underneath. When it got up to the tunnel height, it fell through a branch and drew another tunnel, except it thought that the height was above the tunnel and it did not draw the same low clearance fallback tunnel. So you could see the top of the original tunnel through the gap of the missing edge.

When it's drawing a water edge, i've taken the max of the tile corners and neighbouring tile corners to start the current height at.