### PR TITLE
Fix walls drawing over sloped rear water edges and misaligned sprite

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Fix: [#23897] Reverse Freefall Coaster slope up to vertical track piece does not draw a vertical tunnel.
 - Fix: [#23939] Incorrect assertion when trying to load heightmap.
 - Fix: [#23941] Underflow in “Repay loan and achieve a certain park value” objective when using Japanese.
+- Fix: [#23949] Walls draw over sloped rear water edges and those edge sprites are misaligned (original bug).
 
 0.4.20 (2025-02-25)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -788,6 +788,9 @@ static void ViewportSurfaceDrawTileSideTop(
             baseImageId = GetEdgeImage(edgeObject, 1); // var_04
         }
         baseImageId = baseImageId.WithIndexOffset(edge == EDGE_TOPLEFT ? 5 : 0);
+
+        offset.x = 0;
+        offset.y = 0;
     }
     else
     {
@@ -822,12 +825,6 @@ static void ViewportSurfaceDrawTileSideTop(
     }
 
     neighbourCornerHeight1 = cornerHeight2;
-
-    if (isWater)
-    {
-        offset.x = 0;
-        offset.y = 0;
-    }
 
     while (cur_height < cornerHeight1 && cur_height < neighbourCornerHeight1)
     {


### PR DESCRIPTION
This fixes walls drawing over sloped rear water edges, and also fixes the alignment of those edge sprites.

![rearwaterwallglitch](https://github.com/user-attachments/assets/004e3145-d558-4c4c-8900-93198d9123aa)
![rearwaterwallglitchfix](https://github.com/user-attachments/assets/ec64fe51-0f64-408d-ae5e-ddf1a3c82eeb)

Other rear water edges were drawn with different offsets, but they were set after these types of sloped edges were drawn. That meant that the sprite was misaligned and the bounding box was outside of the tile.

The change I just made to water edges to fix the tunnels below water also exposed this bug on water at the edges of the map:
![misalignedsprite](https://github.com/user-attachments/assets/238cce4c-3de8-45d1-82f3-badbac82c2bf)
![misalignedspritefix](https://github.com/user-attachments/assets/f8fa8be5-7ae8-4eb1-82f2-73628fe7645c)
I'm sorry I didn't catch this before.