### PR TITLE
Fix crash in map.getAllEntities("car") when car has an invalid ride (#22182)

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Change: [#24069] [Plugin] Plugins are now available in the scenario editor and track designer.
 - Change: [#24135] Compress Emscripten js/wasm files.
 - Fix: [#21919] Non-recolourable cars still show colour picker.
+- Fix: [#22182] [Plugin] Crash when using map.getAllEntities("car")
 - Fix: [#23108] Missing pieces on Hypercoaster and Hyper-Twister, even with the ‘all drawable track pieces’ cheat enabled.
 - Fix: [#24013] Failure to load a scenario preview image (minimap) could lead to an uncaught exception error message.
 - Fix: [#24142] [Plugin] Track origin is miscalculated on downward slopes.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,7 +5,7 @@
 - Change: [#24069] [Plugin] Plugins are now available in the scenario editor and track designer.
 - Change: [#24135] Compress Emscripten js/wasm files.
 - Fix: [#21919] Non-recolourable cars still show colour picker.
-- Fix: [#22182] [Plugin] Crash when using map.getAllEntities("car")
+- Fix: [#22182] [Plugin] Crash when using map.getAllEntities("car").
 - Fix: [#23108] Missing pieces on Hypercoaster and Hyper-Twister, even with the ‘all drawable track pieces’ cheat enabled.
 - Fix: [#24013] Failure to load a scenario preview image (minimap) could lead to an uncaught exception error message.
 - Fix: [#24142] [Plugin] Track origin is miscalculated on downward slopes.

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -46,7 +46,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t kPluginApiVersion = 105;
+    static constexpr int32_t kPluginApiVersion = 106;
 
     // Versions marking breaking changes.
     static constexpr int32_t kApiVersionPeepDeprecation = 33;

--- a/src/openrct2/scripting/bindings/world/ScMap.cpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.cpp
@@ -121,7 +121,7 @@ namespace OpenRCT2::Scripting
 
                     if (car == nullptr)
                     {
-                        break; // If car is invalid, exit loop safely
+                        break;
                     }
 
                     // Add the car to the result list

--- a/src/openrct2/scripting/bindings/world/ScMap.cpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.cpp
@@ -124,7 +124,6 @@ namespace OpenRCT2::Scripting
                         break;
                     }
 
-                    // Add the car to the result list
                     result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScVehicle>(carId)));
 
                     // Prevent infinite loops: Ensure next_vehicle_on_train is valid

--- a/src/openrct2/scripting/bindings/world/ScMap.cpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.cpp
@@ -131,7 +131,7 @@ namespace OpenRCT2::Scripting
                     auto nextCarId = car->next_vehicle_on_train;
                     if (nextCarId.IsNull() || nextCarId == carId)
                     {
-                        break; // Stop if next car is invalid or self-referencing
+                        break;
                     }
 
                     carId = nextCarId; // Move to the next car in the train

--- a/src/openrct2/scripting/bindings/world/ScMap.cpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.cpp
@@ -119,7 +119,6 @@ namespace OpenRCT2::Scripting
                 {
                     auto car = GetEntity<Vehicle>(carId);
 
-                    // Prevent crashes by checking if the car is valid
                     if (car == nullptr)
                     {
                         break; // If car is invalid, exit loop safely

--- a/src/openrct2/scripting/bindings/world/ScMap.cpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.cpp
@@ -126,7 +126,7 @@ namespace OpenRCT2::Scripting
 
                     result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScVehicle>(carId)));
 
-                    // Prevent infinite loops: Ensure next_vehicle_on_train is valid
+                    // Prevent infinite loops: Ensure next_vehicle_on_train is valid and not self-referencing
                     auto nextCarId = car->next_vehicle_on_train;
                     if (nextCarId.IsNull() || nextCarId == carId)
                     {

--- a/src/openrct2/scripting/bindings/world/ScMap.cpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.cpp
@@ -120,7 +120,7 @@ namespace OpenRCT2::Scripting
                     auto car = GetEntity<Vehicle>(carId);
 
                     // Prevent crashes by checking if the car is valid
-                    if (!car)
+                    if (car == nullptr)
                     {
                         break; // If car is invalid, exit loop safely
                     }

--- a/src/openrct2/scripting/bindings/world/ScMap.cpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.cpp
@@ -134,7 +134,7 @@ namespace OpenRCT2::Scripting
                         break;
                     }
 
-                    carId = nextCarId; // Move to the next car in the train
+                    carId = nextCarId;
                 }
             }
         }

--- a/src/openrct2/scripting/bindings/world/ScMap.cpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.cpp
@@ -118,8 +118,24 @@ namespace OpenRCT2::Scripting
                 for (auto carId = trainHead->Id; !carId.IsNull();)
                 {
                     auto car = GetEntity<Vehicle>(carId);
+
+                    // Prevent crashes by checking if the car is valid
+                    if (!car)
+                    {
+                        break; // If car is invalid, exit loop safely
+                    }
+
+                    // Add the car to the result list
                     result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScVehicle>(carId)));
-                    carId = car->next_vehicle_on_train;
+
+                    // Prevent infinite loops: Ensure next_vehicle_on_train is valid
+                    auto nextCarId = car->next_vehicle_on_train;
+                    if (nextCarId.IsNull() || nextCarId == carId)
+                    {
+                        break; // Stop if next car is invalid or self-referencing
+                    }
+
+                    carId = nextCarId; // Move to the next car in the train
                 }
             }
         }


### PR DESCRIPTION
This PR fixes issue #22182, where calling 'map.createEntity("car",{})' and `map.getAllEntities("car")` would crash
when a car had a ride assigned to a nonexistent ride.

- Added a check to ensure `car` is valid before accessing it.
- Prevented infinite loops by verifying `next_vehicle_on_train` is not self-referencing.
- Ensured safe exit from the loop if `car->next_vehicle_on_train` is null or invalid.

Fixes #22182