### PR TITLE
Fix corner path fences drawing over adjacent sloped land

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Fix: [#23939] Incorrect assertion when trying to load heightmap.
 - Fix: [#23941] Underflow in “Repay loan and achieve a certain park value” objective when using Japanese.
 - Fix: [#23949] Walls draw over sloped rear water edges and those edge sprites are misaligned (original bug).
+- Fix: [#23960] Corner path fences can draw over adjacent sloped land (original bug).
 
 0.4.20 (2025-02-25)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -254,8 +254,7 @@ static void PathPaintFencesAndQueueBannersQueue(
                 PaintAddImageAsParent(
                     session, imageId.WithIndexOffset(17), { 0, 4, height }, { { 0, 4, height + 2 }, { 28, 1, 7 } });
                 PaintAddImageAsParent(
-                    session, imageId.WithIndexOffset(18), { 28, 0, height },
-                    { { 28, 4, height + 2 }, { 1, 28, 7 } }); // bound_box_offset_y seems to be a bug
+                    session, imageId.WithIndexOffset(18), { 28, 0, height }, { { 28, 0, height + 2 }, { 1, 28, 7 } });
                 PaintAddImageAsParent(
                     session, imageId.WithIndexOffset(25), { 0, 0, height }, { { 0, 28, height + 2 }, { 4, 4, 7 } });
                 break;
@@ -325,8 +324,7 @@ static void PathPaintFencesAndQueueBannersQueue(
                 PaintAddImageAsParent(
                     session, imageId.WithIndexOffset(16), { 4, 0, height }, { { 4, 0, height + 2 }, { 1, 28, 7 } });
                 PaintAddImageAsParent(
-                    session, imageId.WithIndexOffset(19), { 0, 28, height },
-                    { { 4, 28, height + 2 }, { 28, 1, 7 } }); // bound_box_offset_x seems to be a bug
+                    session, imageId.WithIndexOffset(19), { 0, 28, height }, { { 0, 28, height + 2 }, { 28, 1, 7 } });
                 PaintAddImageAsParent(
                     session, imageId.WithIndexOffset(27), { 0, 0, height }, { { 28, 0, height + 2 }, { 4, 4, 7 } });
                 break;
@@ -445,8 +443,7 @@ static void PathPaintFencesAndQueueBannersNonQueue(
                 PaintAddImageAsParent(
                     session, imageId.WithIndexOffset(3), { 0, 4, height }, { { 0, 4, height + 2 }, { 28, 1, 7 } });
                 PaintAddImageAsParent(
-                    session, imageId.WithIndexOffset(4), { 28, 0, height },
-                    { { 28, 4, height + 2 }, { 1, 28, 7 } }); // bound_box_offset_y seems to be a bug
+                    session, imageId.WithIndexOffset(4), { 28, 0, height }, { { 28, 0, height + 2 }, { 1, 28, 7 } });
                 if (!(drawnCorners & FOOTPATH_CORNER_0))
                 {
                     PaintAddImageAsParent(
@@ -479,8 +476,7 @@ static void PathPaintFencesAndQueueBannersNonQueue(
                 PaintAddImageAsParent(
                     session, imageId.WithIndexOffset(2), { 4, 0, height }, { { 4, 0, height + 2 }, { 1, 28, 7 } });
                 PaintAddImageAsParent(
-                    session, imageId.WithIndexOffset(5), { 0, 28, height },
-                    { { 4, 28, height + 2 }, { 28, 1, 7 } }); // bound_box_offset_x seems to be a bug
+                    session, imageId.WithIndexOffset(5), { 0, 28, height }, { { 0, 28, height + 2 }, { 28, 1, 7 } });
                 if (!(drawnCorners & FOOTPATH_CORNER_2))
                 {
                     PaintAddImageAsParent(


### PR DESCRIPTION
This fixes corner path fences drawing over adjacent sloped land.

![pathcornerturnfenceslopedlandglitch](https://github.com/user-attachments/assets/12a2d391-e067-448f-8bf9-95a26cd4a869) ![pathcornerturnfenceslopedlandfix](https://github.com/user-attachments/assets/f6946169-4d7f-456e-9419-289000cb97f1)

Just a slight bounding box adjustment. There are comments here asking if these values were bugs. I think that they were actually correctly offset, it's just that this unfortunately causes this sloped land bug. I wish I knew why bounding boxes like this are sorted in this order. Right now the only solution I have is to just change the bounding boxes to avoid it.