### PR TITLE
Fix #2153: River Rapid boats draw out of order in corners and slopes

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#23876] New park save files now contain a preview image, shown in the load/save window.
 - Change: [#23932] The land rights window now checks 'Land Owned' by default.
+- Fix: [#2153] River Rapid boats can draw out of order in corners and on slopes (original bug).
 - Fix: [#4225] Ride Construction window offers non-existent banked sloped to level curve (original bug).
 - Fix: [#10379] Banners outside the park can be renamed and modified (original bug).
 - Fix: [#10582] Low clearance tunnels below water are drawn incorrectly (original bug).

--- a/src/openrct2/paint/vehicle/Vehicle.RiverRapids.cpp
+++ b/src/openrct2/paint/vehicle/Vehicle.RiverRapids.cpp
@@ -17,12 +17,85 @@
 
 namespace OpenRCT2
 {
-    // 0x0099279E:
-    static constexpr VehicleBoundBox _riverRapidsBoundbox[] = {
-        { -13, -13, 1, 26, 26, 13 }, { -13, -13, 1, 26, 26, 13 }, { -13, -13, 1, 26, 26, 13 },
-        { -13, -13, 1, 26, 26, 13 }, { -13, -13, 1, 26, 26, 13 }, { -13, -13, 1, 26, 26, 13 },
-        { -13, -13, 1, 26, 26, 13 }, { -13, -13, 1, 26, 26, 13 }, { -13, -13, 1, 26, 26, 13 },
-    };
+    constexpr BoundBoxXYZ kRiverRapidsBoundBoxStraight = { { -13, -13, 1 }, { 26, 26, 13 } };
+    constexpr BoundBoxXYZ kRiverRapidsBoundBoxCorners = { { -8, -8, 1 }, { 20, 20, 13 } };
+    constexpr BoundBoxXYZ kRiverRapidsBoundBoxPitch1 = kRiverRapidsBoundBoxCorners;
+    constexpr BoundBoxXYZ kRiverRapidsBoundBoxPitch2 = { { -8, -8, 1 }, { 16, 16, 13 } };
+
+    static constexpr std::array<std::array<BoundBoxXYZ, 16>, kNumOrthogonalDirections> kRiverRapidsBoundBoxesFlat = { {
+        { {
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+        } },
+        { {
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+        } },
+        { {
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+        } },
+        { {
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxStraight,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+            kRiverRapidsBoundBoxCorners,
+        } },
+    } };
 
     /**
      *
@@ -38,51 +111,52 @@ namespace OpenRCT2
         int32_t baseImage_id = imageDirection;
         uint32_t rotation = session.CurrentRotation;
         int32_t ecx = ((vehicle->spin_sprite / 8) + (rotation * 8)) & 31;
-        int32_t j = 0;
+        BoundBoxXYZ boundBox;
         if (vehicle->Pitch == 0)
         {
             baseImage_id = ecx & 7;
+            boundBox = kRiverRapidsBoundBoxesFlat[(vehicle->GetTrackDirection() + session.CurrentRotation) & 3]
+                                                 [imageDirection >> 1];
         }
         else
         {
             if (vehicle->Pitch == 1 || vehicle->Pitch == 5)
             {
+                boundBox = kRiverRapidsBoundBoxPitch1;
                 if (vehicle->Pitch == 5)
                 {
                     baseImage_id = imageDirection ^ 16;
                 }
                 baseImage_id &= 24;
-                j = (baseImage_id / 8) + 1;
                 baseImage_id += (ecx & 7);
                 baseImage_id += 8;
             }
             else if (vehicle->Pitch == 2 || vehicle->Pitch == 6)
             {
+                boundBox = kRiverRapidsBoundBoxPitch2;
                 if (vehicle->Pitch == 6)
                 {
                     baseImage_id = imageDirection ^ 16;
                 }
                 baseImage_id &= 24;
-                j = (baseImage_id / 8) + 5;
                 baseImage_id += (ecx & 7);
                 baseImage_id += 40;
             }
             else
             {
+                boundBox = kRiverRapidsBoundBoxStraight;
                 baseImage_id = ecx & 7;
             }
         }
         baseImage_id += carEntry->base_image_id;
 
-        const auto& riverRapidsBb = _riverRapidsBoundbox[j];
-        auto bb = BoundBoxXYZ{ { riverRapidsBb.offset_x, riverRapidsBb.offset_y, riverRapidsBb.offset_z + z },
-                               { riverRapidsBb.length_x, riverRapidsBb.length_y, riverRapidsBb.length_z } };
+        boundBox.offset.z += z;
         image_id = ImageId(baseImage_id, vehicle->colours.Body, vehicle->colours.Trim);
         if (vehicle->IsGhost())
         {
             image_id = ConstructionMarker.WithIndex(image_id.GetIndex());
         }
-        PaintAddImageAsParent(session, image_id, { 0, 0, z }, bb);
+        PaintAddImageAsParent(session, image_id, { 0, 0, z }, boundBox);
 
         if (session.DPI.zoom_level < ZoomLevel{ 2 } && vehicle->num_peeps > 0 && !vehicle->IsGhost())
         {
@@ -91,27 +165,27 @@ namespace OpenRCT2
             int32_t peeps = ((ecx / 8) + 0) & 3;
             image_id = ImageId(
                 baseImage_id + ((peeps + 1) * 72), vehicle->peep_tshirt_colours[0], vehicle->peep_tshirt_colours[1]);
-            PaintAddImageAsChild(session, image_id, { 0, 0, z }, bb);
+            PaintAddImageAsChild(session, image_id, { 0, 0, z }, boundBox);
             if (vehicle->num_peeps > 2)
             {
                 peeps = ((ecx / 8) + 2) & 3;
                 image_id = ImageId(
                     baseImage_id + ((peeps + 1) * 72), vehicle->peep_tshirt_colours[2], vehicle->peep_tshirt_colours[3]);
-                PaintAddImageAsChild(session, image_id, { 0, 0, z }, bb);
+                PaintAddImageAsChild(session, image_id, { 0, 0, z }, boundBox);
             }
             if (vehicle->num_peeps > 4)
             {
                 peeps = ((ecx / 8) + 1) & 3;
                 image_id = ImageId(
                     baseImage_id + ((peeps + 1) * 72), vehicle->peep_tshirt_colours[4], vehicle->peep_tshirt_colours[5]);
-                PaintAddImageAsChild(session, image_id, { 0, 0, z }, bb);
+                PaintAddImageAsChild(session, image_id, { 0, 0, z }, boundBox);
             }
             if (vehicle->num_peeps > 6)
             {
                 peeps = ((ecx / 8) + 3) & 3;
                 image_id = ImageId(
                     baseImage_id + ((peeps + 1) * 72), vehicle->peep_tshirt_colours[6], vehicle->peep_tshirt_colours[7]);
-                PaintAddImageAsChild(session, image_id, { 0, 0, z }, bb);
+                PaintAddImageAsChild(session, image_id, { 0, 0, z }, boundBox);
             }
         }
 


### PR DESCRIPTION
Fix #2153: River Rapid boats draw out of order in corners and slopes

This changes the river rapid boat bounding boxes when they are in a corner or on a slope to avoid glitching. I've tried to make sure that the boats still draw over the track correctly, including the rapids section which uses one of the sloped bounding boxes. For a certain angle of turns it was necessary to keep using the straight bounding box. This doesn't solve every problem with the river rapids, but it should be better than it was. Some of the problems are caused by the boats getting too close to eachother, and that can't really be fixed when drawing them.

https://github.com/user-attachments/assets/e630d301-dab8-4893-a1a4-bf8580af0a43

https://github.com/user-attachments/assets/ee30ae95-54d5-4d73-ad38-4edd8f332308

![riverrapidsslopeotherangle](https://github.com/user-attachments/assets/1b0ad7fb-b1d2-44fe-98d8-84ac230ba015)

This doesn't fix this glitch. I think that the boat behind is higher than the one in front so it gets sorted in front of it. I'm not sure how to fix this one.
![riverrapidsslopeglitch](https://github.com/user-attachments/assets/27347358-1734-4227-b6ed-90240b8b5411)
