### PR TITLE
Prevent closing object selection window when selection is invalid

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Fix: [#4225] Ride Construction window offers non-existent banked sloped to level curve (original bug).
 - Fix: [#10379] Banners outside the park can be renamed and modified (original bug).
 - Fix: [#10582] Low clearance tunnels below water are drawn incorrectly (original bug).
+- Fix: [#23486] Object selection minimum requirements can be bypassed with close window hotkey.
 - Fix: [#23743] Parks with guest goals over 32767 do not appear in the scenario list.
 - Fix: [#23844] Sound effects keep playing when loading another save.
 - Fix: [#23897] Reverse Freefall Coaster slope up to vertical track piece does not draw a vertical tunnel.

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -931,6 +931,12 @@ public:
      */
     void Close(WindowBase& w) override
     {
+        if (!w.CanClose())
+        {
+            // Something's preventing this window from closing -- bail out early
+            return;
+        }
+
         w.OnClose();
 
         // Remove viewport

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -199,6 +199,9 @@ namespace OpenRCT2::Ui::Windows
             if (!EditorObjectSelectionWindowCheck())
                 return;
 
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->CloseByClass(WindowClass::EditorObjectSelection);
+
             FinishObjectSelection();
             if (gLegacyScene == LegacyScene::trackDesigner)
             {

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -364,8 +364,12 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_CLOSE:
-                    if (!(gLegacyScene == LegacyScene::trackDesignsManager) && !EditorObjectSelectionWindowCheck())
+                {
+                    if (gLegacyScene != LegacyScene::trackDesignsManager && !EditorObjectSelectionWindowCheck())
                         return;
+
+                    auto* windowMgr = Ui::GetWindowManager();
+                    windowMgr->CloseByClass(WindowClass::EditorObjectSelection);
 
                     if (isInEditorMode())
                     {
@@ -380,6 +384,7 @@ namespace OpenRCT2::Ui::Windows
                         context->SetActiveScene(context->GetTitleScene());
                     }
                     break;
+                }
 
                 case WIDX_SUB_TAB_0:
                 case WIDX_SUB_TAB_1:
@@ -1702,17 +1707,15 @@ namespace OpenRCT2::Ui::Windows
 
     bool EditorObjectSelectionWindowCheck()
     {
-        auto* windowMgr = Ui::GetWindowManager();
-
         auto [missingObjectType, errorString] = Editor::CheckObjectSelection();
         if (missingObjectType == ObjectType::none)
         {
-            windowMgr->CloseByClass(WindowClass::EditorObjectSelection);
             return true;
         }
 
         ContextShowError(STR_INVALID_SELECTION_OF_OBJECTS, errorString, {});
 
+        auto* windowMgr = Ui::GetWindowManager();
         WindowBase* w = windowMgr->FindByClass(WindowClass::EditorObjectSelection);
         if (w != nullptr)
         {


### PR DESCRIPTION
Take two for this issue. This time around, I've spotted the recursion issue that made things go sour the first time around (#23487).

To fix the recursion problem, I've changed the `EditorObjectSelectionWindowCheck` function to no longer close the object selection window. It just returns a boolean now. Actually closing the window is moved out to caller side. (This is just two places, not counting `CanClose`.)

Fixes #23486.