### PR TITLE
Move monochrome logo to G2 end

### DIFF
--- a/resources/g2/sprites.json
+++ b/resources/g2/sprites.json
@@ -12,9 +12,6 @@
         "path": "logo_text.png"
     },
     {
-        "path": "logo_mono_dithered.png"
-    },
-    {
         "path": "icons/fast_forward.png"
     },
     {
@@ -365,6 +362,9 @@
     {
         "path": "icons/weather_blizzard.png",
         "x": 1
+    },
+    {
+        "path": "logo_mono_dithered.png"
     },
     {
         "path": "loader/loader_hybrid_supports.png",

--- a/src/openrct2/SpriteIds.h
+++ b/src/openrct2/SpriteIds.h
@@ -884,7 +884,6 @@ enum : ImageIndex
 
     SPR_G2_LOGO,
     SPR_G2_TITLE,
-    SPR_G2_LOGO_MONO_DITHERED,
     SPR_G2_FASTFORWARD,
     SPR_G2_SPEED_ARROW,
     SPR_G2_HYPER_ARROW,
@@ -984,6 +983,7 @@ enum : ImageIndex
     SPR_G2_WEATHER_SNOW,
     SPR_G2_WEATHER_HEAVY_SNOW,
     SPR_G2_WEATHER_BLIZZARD,
+    SPR_G2_LOGO_MONO_DITHERED,
 
     // G2 Loading progress
 


### PR DESCRIPTION
This moves the recently introduced monochrome/dithered logo (#23876) more to the end of the G2 sprites, such that plugins that use hardcoded G2 offsets are no longer broken.

(Yes, plugins shouldn't be hardcoding these offsets. There is an API for getting the offsets by string identifier. However, unbreaking them is trivial _now_, so let's.)