### PR TITLE
Skip setting page/widgets if we're already on the page

### DIFF
--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -199,6 +199,10 @@ namespace OpenRCT2::Ui::Windows
     private:
         void SetPage(int32_t p)
         {
+            // Skip setting page if we're already on this page, unless we're initialising the window
+            if (page == p && !widgets.empty())
+                return;
+
             page = p;
             frame_no = 0;
             pressed_widgets = 0;

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -737,6 +737,10 @@ static StringId window_cheats_page_titles[] = {
     private:
         void SetPage(int32_t p)
         {
+            // Skip setting page if we're already on this page, unless we're initialising the window
+            if (page == p && !widgets.empty())
+                return;
+
             page = p;
             frame_no = 0;
 

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1143,7 +1143,8 @@ namespace OpenRCT2::Ui::Windows
 
         void SetPage(int32_t _page)
         {
-            if (selected_tab == _page)
+            // Skip setting page if we're already on this page, unless we're initialising the window
+            if (selected_tab == _page && !widgets.empty())
                 return;
 
             selected_tab = _page;

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -303,6 +303,10 @@ namespace OpenRCT2::Ui::Windows
          */
         void SetPage(int32_t newPage)
         {
+            // Skip setting page if we're already on this page, unless we're initialising the window
+            if (page == newPage && !widgets.empty())
+                return;
+
             page = newPage;
             frame_no = 0;
             _rideableRides.clear();

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -340,6 +340,10 @@ namespace OpenRCT2::Ui::Windows
 
         void SetPage(int32_t newPage)
         {
+            // Skip setting page if we're already on this page, unless we're initialising the window
+            if (page == newPage && !widgets.empty())
+                return;
+
             page = newPage;
             frame_no = 0;
             hold_down_widgets = window_editor_scenario_options_page_hold_down_widgets[page];

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -481,6 +481,10 @@ namespace OpenRCT2::Ui::Windows
 
         void SetPage(int32_t p)
         {
+            // Skip setting page if we're already on this page, unless we're initialising the window
+            if (page == p && !widgets.empty())
+                return;
+
             page = p;
             frame_no = 0;
 

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -486,7 +486,6 @@ namespace OpenRCT2::Ui::Windows
 
         void SetPage(int32_t newPage)
         {
-            // Skip setting page if we're already on this page, unless we're initialising the window
             if (isToolActive(classification, number))
                 ToolCancel();
 
@@ -497,6 +496,7 @@ namespace OpenRCT2::Ui::Windows
                     listen = 1;
             }
 
+            // Skip setting page if we're already on this page, unless we're initialising the window
             if (page == newPage && !widgets.empty())
                 return;
 

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -486,6 +486,7 @@ namespace OpenRCT2::Ui::Windows
 
         void SetPage(int32_t newPage)
         {
+            // Skip setting page if we're already on this page, unless we're initialising the window
             if (isToolActive(classification, number))
                 ToolCancel();
 
@@ -495,6 +496,9 @@ namespace OpenRCT2::Ui::Windows
                 if (!(viewport->flags & VIEWPORT_FLAG_SOUND_ON))
                     listen = 1;
             }
+
+            if (page == newPage && !widgets.empty())
+                return;
 
             page = newPage;
             frame_no = 0;

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -274,6 +274,10 @@ namespace OpenRCT2::Ui::Windows
 
         void SetPage(int32_t newPage)
         {
+            // Skip setting page if we're already on this page, unless we're initialising the window
+            if (page == newPage && !widgets.empty())
+                return;
+
             page = newPage;
             frame_no = 0;
             RemoveViewport();

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -203,6 +203,10 @@ namespace OpenRCT2::Ui::Windows
 
     void MultiplayerWindow::SetPage(int32_t page_number)
     {
+        // Skip setting page if we're already on this page, unless we're initialising the window
+        if (page == page_number && !widgets.empty())
+            return;
+
         _windowInformationSize.reset();
 
         page = page_number;

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -539,6 +539,10 @@ namespace OpenRCT2::Ui::Windows
 
         void SetPage(NewRideTabId tab)
         {
+            // Skip setting page if we're already on this page, unless we're initialising the window
+            if (_currentTab == tab && !widgets.empty())
+                return;
+
             _currentTab = tab;
             frame_no = 0;
             _newRideVars.HighlightedRide = { kRideTypeNull, kObjectEntryIndexNull };

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -2107,6 +2107,10 @@ namespace OpenRCT2::Ui::Windows
 
         void SetPage(int32_t p)
         {
+            // Skip setting page if we're already on this page, unless we're initialising the window
+            if (page == p && !widgets.empty())
+                return;
+
             page = p;
             frame_no = 0;
             pressed_widgets = 0;

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -1183,6 +1183,10 @@ namespace OpenRCT2::Ui::Windows
             if (newPage == WINDOW_PARK_PAGE_ENTRANCE && viewport != nullptr && !(viewport->flags & VIEWPORT_FLAG_SOUND_ON))
                 listen = true;
 
+            // Skip setting page if we're already on this page, unless we're initialising the window
+            if (page == newPage && !widgets.empty())
+                return;
+
             page = newPage;
             frame_no = 0;
             _peepAnimationFrame = 0;

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -209,6 +209,10 @@ namespace OpenRCT2::Ui::Windows
     private:
         void SetPage(int32_t newPage)
         {
+            // Skip setting page if we're already on this page, unless we're initialising the window
+            if (page == newPage && !widgets.empty())
+                return;
+
             int32_t originalPage = page;
 
             page = newPage;

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -129,6 +129,9 @@ namespace OpenRCT2::Ui::Windows
 
         void SetPage(int32_t newPageIndex)
         {
+            if (page == newPageIndex && !widgets.empty())
+                return;
+
             page = newPageIndex;
             frame_no = 0;
             RemoveViewport();

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1152,6 +1152,10 @@ namespace OpenRCT2::Ui::Windows
                 && !(viewport->flags & VIEWPORT_FLAG_SOUND_ON))
                 listen = true;
 
+            // Skip setting page if we're already on this page, unless we're initialising the window
+            if (page == newPage && !widgets.empty())
+                return;
+
             page = newPage;
             frame_no = 0;
             picked_peep_frame = 0;

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1060,6 +1060,10 @@ namespace OpenRCT2::Ui::Windows
                     listen = 1;
             }
 
+            // Skip setting page if we're already on this page, unless we're initialising the window
+            if (pageNum == page && !widgets.empty())
+                return;
+
             page = pageNum;
             frame_no = 0;
             pressed_widgets = 0;

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1764,6 +1764,10 @@ static uint64_t PageDisabledWidgets[] = {
     private:
         void SetPage(const TileInspectorPage p)
         {
+            // Skip setting page if we're already on this page, unless we're initialising the window
+            if (tileInspectorPage == p && !widgets.empty())
+                return;
+
             Invalidate();
             // subtract current page height, then add new page height
             if (tileInspectorPage != TileInspectorPage::Default)


### PR DESCRIPTION
Optimisation from #23590 that should ideally be reviewed separately, hence this PR.

Only affects tabbed windows, so the test vector is limited.