### PR TITLE
TTF Support on Android

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#5281] Missing supports on miniature railways built backwards.
 - Fix: [#10379] Banners outside the park can be renamed and modified (original bug).
 - Fix: [#10582] Low clearance tunnels below water are drawn incorrectly (original bug).
+- Fix: [#18169] CJK, Arabic and Vietnamese display all text as ‘???’ on Android.
 - Fix: [#18309] Flying and Multi Dimension trains glitch when changing between inverted and uninverted track when uncap fps is on.
 - Fix: [#23486] Object selection minimum requirements can be bypassed with close window hotkey.
 - Fix: [#23743] Parks with guest goals over 32767 do not appear in the scenario list.

--- a/src/openrct2-android/app/src/main/CMakeLists.txt
+++ b/src/openrct2-android/app/src/main/CMakeLists.txt
@@ -194,7 +194,6 @@ include_directories(SYSTEM "${CMAKE_BINARY_DIR}/libs/include/freetype")
 include_directories(SYSTEM "${CMAKE_BINARY_DIR}/libs/include/SDL2")
 
 # now build app's shared lib
-#add_definitions(-DDISABLE_DISCORD_RPC -DDISABLE_OPENGL -DGL_GLEXT_PROTOTYPES -D__STDC_LIMIT_MACROS -DNO_TTF -DSDL_MAIN_HANDLED)
 add_definitions(-DDISABLE_DISCORD_RPC -DDISABLE_OPENGL -DGL_GLEXT_PROTOTYPES -D__STDC_LIMIT_MACROS -DSDL_MAIN_HANDLED)
 
 # Enable scripting

--- a/src/openrct2-android/app/src/main/CMakeLists.txt
+++ b/src/openrct2-android/app/src/main/CMakeLists.txt
@@ -190,11 +190,12 @@ add_dependencies(bz2 libs)
 
 
 include_directories(SYSTEM "${CMAKE_BINARY_DIR}/libs/include")
-include_directories(SYSTEM "${CMAKE_BINARY_DIR}/libs/include/freetype2")
+include_directories(SYSTEM "${CMAKE_BINARY_DIR}/libs/include/freetype")
 include_directories(SYSTEM "${CMAKE_BINARY_DIR}/libs/include/SDL2")
 
 # now build app's shared lib
-add_definitions(-DDISABLE_DISCORD_RPC -DDISABLE_OPENGL -DGL_GLEXT_PROTOTYPES -D__STDC_LIMIT_MACROS -DNO_TTF -DSDL_MAIN_HANDLED)
+#add_definitions(-DDISABLE_DISCORD_RPC -DDISABLE_OPENGL -DGL_GLEXT_PROTOTYPES -D__STDC_LIMIT_MACROS -DNO_TTF -DSDL_MAIN_HANDLED)
+add_definitions(-DDISABLE_DISCORD_RPC -DDISABLE_OPENGL -DGL_GLEXT_PROTOTYPES -D__STDC_LIMIT_MACROS -DSDL_MAIN_HANDLED)
 
 # Enable scripting
 add_definitions(-DENABLE_SCRIPTING)
@@ -250,7 +251,7 @@ file(GLOB_RECURSE OPENRCT2_CLI_SOURCES
     "${ORCT2_ROOT}/src/openrct2-cli/*.hpp")
 
 add_library(openrct2 SHARED ${LIBOPENRCT2_SOURCES})
-target_link_libraries(openrct2 android stdc++ log dl SDL2 png z icu icuuc icudata crypto ssl)
+target_link_libraries(openrct2 android stdc++ log dl SDL2 png z icu icuuc icudata crypto ssl freetype)
 
 add_library(openrct2-ui SHARED ${OPENRCT2_GUI_SOURCES})
 target_link_libraries(openrct2-ui openrct2 android stdc++ GLESv1_CM GLESv2 SDL2main speexdsp brotlicommon brotlidec bz2 freetype ogg vorbis vorbisfile FLAC)

--- a/src/openrct2/interface/FontFamilies.cpp
+++ b/src/openrct2/interface/FontFamilies.cpp
@@ -17,29 +17,34 @@ TTFontFamily const TTFFamilyChineseSimplified = {
     &TTFFontSimSun,
     &TTFFontHeiti,
     &TTFFontMicroHei,
+    &TTFFontNotoSansCJK,
 };
 
 TTFontFamily const TTFFamilyChineseTraditional = {
     &TTFFontMingLiu,
     &TTFFontLiHeiPro,
     &TTFFontMicroHei,
+    &TTFFontNotoSansCJK,
 };
 
 TTFontFamily const TTFFamilyJapanese = {
     &TTFFontHiragano,
     &TTFFontNotoSansMono,
     &TTFFontMSGothic,
+    &TTFFontNotoSansCJK,
 };
 
 TTFontFamily const TTFFamilyKorean = {
     &TTFFontGulim,
     &TTFFontNanum,
     &TTFFontMalgun,
+    &TTFFontNotoSansCJK,
 };
 
 TTFontFamily const TTFFamilySansSerif = {
     &TTFFontArialUnicode,
     &TTFFontArial,
+    &TTFFontNotoSansCJK,
 };
 
 #endif // NO_TTF

--- a/src/openrct2/interface/FontFamilies.cpp
+++ b/src/openrct2/interface/FontFamilies.cpp
@@ -41,10 +41,16 @@ TTFontFamily const TTFFamilyKorean = {
     &TTFFontNotoSansCJK,
 };
 
+TTFontFamily const TTFFamilyArabic = {
+    &TTFFontArialUnicode,
+    &TTFFontArial,
+    &TTFFontNotoNaskhArabic,
+};
+
 TTFontFamily const TTFFamilySansSerif = {
     &TTFFontArialUnicode,
     &TTFFontArial,
-    &TTFFontNotoSansCJK,
+    &TTFFontRoboto,
 };
 
 #endif // NO_TTF

--- a/src/openrct2/interface/FontFamilies.h
+++ b/src/openrct2/interface/FontFamilies.h
@@ -25,6 +25,7 @@ extern TTFontFamily const TTFFamilyChineseSimplified;
 extern TTFontFamily const TTFFamilyChineseTraditional;
 extern TTFontFamily const TTFFamilyJapanese;
 extern TTFontFamily const TTFFamilyKorean;
+extern TTFontFamily const TTFFamilyArabic;
 extern TTFontFamily const TTFFamilySansSerif;
 
     #define FAMILY(x) x

--- a/src/openrct2/interface/Fonts.cpp
+++ b/src/openrct2/interface/Fonts.cpp
@@ -104,6 +104,12 @@ TTFFontSetDescriptor TTFFontMicroHei = { {
     { "wqy-microhei.ttc", "WenQuanYi Micro Hei", 11,  1, -2, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
     { "wqy-microhei.ttc", "WenQuanYi Micro Hei", 10, -1, -1,  10, HINTING_THRESHOLD_MEDIUM, nullptr },
 } };
+
+TTFFontSetDescriptor TTFFontNotoSansCJK = { {
+     { "NotoSansCJK-Regular.ttc", "Noto Sans CJK", 12, 1, -3, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
+     { "NotoSansCJK-Regular.ttc", "Noto Sans CJK", 12, 1, -3, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
+     { "NotoSansCJK-Regular.ttc", "Noto Sans CJK",  9, 1, -2,  9, HINTING_THRESHOLD_MEDIUM, nullptr },
+} };
 // clang-format on
 #endif // NO_TTF
 

--- a/src/openrct2/interface/Fonts.cpp
+++ b/src/openrct2/interface/Fonts.cpp
@@ -105,10 +105,22 @@ TTFFontSetDescriptor TTFFontMicroHei = { {
     { "wqy-microhei.ttc", "WenQuanYi Micro Hei", 10, -1, -1,  10, HINTING_THRESHOLD_MEDIUM, nullptr },
 } };
 
+TTFFontSetDescriptor TTFFontRoboto = { {
+    { "Roboto-Regular.ttf", "Roboto", 12, 0, -1, 12, HINTING_THRESHOLD_LOW, nullptr },
+    { "Roboto-Regular.ttf", "Roboto", 12, 0, -1, 12, HINTING_THRESHOLD_LOW, nullptr },
+    { "Roboto-Regular.ttf", "Roboto", 10, 0, -1,  9, HINTING_THRESHOLD_LOW, nullptr },
+} };
+
 TTFFontSetDescriptor TTFFontNotoSansCJK = { {
-     { "NotoSansCJK-Regular.ttc", "Noto Sans CJK", 12, 1, -3, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
-     { "NotoSansCJK-Regular.ttc", "Noto Sans CJK", 12, 1, -3, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
-     { "NotoSansCJK-Regular.ttc", "Noto Sans CJK",  9, 1, -2,  9, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { "NotoSansCJK-Regular.ttc", "Noto Sans CJK", 12, 1, -3, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { "NotoSansCJK-Regular.ttc", "Noto Sans CJK", 12, 1, -3, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { "NotoSansCJK-Regular.ttc", "Noto Sans CJK",  9, 1, -2,  9, HINTING_THRESHOLD_MEDIUM, nullptr },
+} };
+
+TTFFontSetDescriptor TTFFontNotoNaskhArabic = { {
+    { "NotoNaskhArabic-Regular.ttf", "Noto Naskh Arabic", 12, 1, -3, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { "NotoNaskhArabic-Regular.ttf", "Noto Naskh Arabic", 12, 1, -3, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { "NotoNaskhArabic-Regular.ttf", "Noto Naskh Arabic",  9, 1, -2,  9, HINTING_THRESHOLD_MEDIUM, nullptr },
 } };
 // clang-format on
 #endif // NO_TTF

--- a/src/openrct2/interface/Fonts.h
+++ b/src/openrct2/interface/Fonts.h
@@ -30,6 +30,7 @@ extern TTFFontSetDescriptor TTFFontNanum;
 extern TTFFontSetDescriptor TTFFontArial;
 extern TTFFontSetDescriptor TTFFontArialUnicode;
 extern TTFFontSetDescriptor TTFFontMicroHei;
+extern TTFFontSetDescriptor TTFFontNotoSansCJK;
 #endif // NO_TTF
 
 void TryLoadFonts(OpenRCT2::Localisation::LocalisationService& localisationService);

--- a/src/openrct2/interface/Fonts.h
+++ b/src/openrct2/interface/Fonts.h
@@ -30,7 +30,9 @@ extern TTFFontSetDescriptor TTFFontNanum;
 extern TTFFontSetDescriptor TTFFontArial;
 extern TTFFontSetDescriptor TTFFontArialUnicode;
 extern TTFFontSetDescriptor TTFFontMicroHei;
+extern TTFFontSetDescriptor TTFFontRoboto;
 extern TTFFontSetDescriptor TTFFontNotoSansCJK;
+extern TTFFontSetDescriptor TTFFontNotoNaskhArabic;
 #endif // NO_TTF
 
 void TryLoadFonts(OpenRCT2::Localisation::LocalisationService& localisationService);

--- a/src/openrct2/localisation/Language.cpp
+++ b/src/openrct2/localisation/Language.cpp
@@ -20,7 +20,7 @@ using namespace OpenRCT2;
 const LanguageDescriptor LanguagesDescriptors[LANGUAGE_COUNT] =
 {
     { "",       "",                     "",                      LANGUAGE_UNDEFINED, kFamilyOpenRCT2Sprite,                false }, // LANGUAGE_UNDEFINED
-    { "ar-EG", "Arabic (experimental)", "Arabic (experimental)", LANGUAGE_UNDEFINED, FAMILY(&TTFFamilySansSerif),          true  }, // LANGUAGE_ARABIC
+    { "ar-EG", "Arabic (experimental)", "Arabic (experimental)", LANGUAGE_UNDEFINED, FAMILY(&TTFFamilyArabic),             true  }, // LANGUAGE_ARABIC
     { "ca-ES", "Catalan",               u8"Català",              LANGUAGE_UNDEFINED, kFamilyOpenRCT2Sprite,                false }, // LANGUAGE_CATALAN
     { "zh-CN", "Chinese (Simplified)",  "Chinese (Simplified)",  LANGUAGE_UNDEFINED, FAMILY(&TTFFamilyChineseSimplified),  false }, // LANGUAGE_CHINESE_SIMPLIFIED
     { "zh-TW", "Chinese (Traditional)", "Chinese (Traditional)", LANGUAGE_UNDEFINED, FAMILY(&TTFFamilyChineseTraditional), false }, // LANGUAGE_CHINESE_TRADITIONAL

--- a/src/openrct2/platform/Platform.Android.cpp
+++ b/src/openrct2/platform/Platform.Android.cpp
@@ -165,8 +165,7 @@ namespace OpenRCT2::Platform
     #ifndef NO_TTF
     std::string GetFontPath(const TTFFontDescriptor& font)
     {
-        STUB();
-        return {};
+        return "/sdcard/openrct2/rct2.ttf";
     }
     #endif
 

--- a/src/openrct2/platform/Platform.Android.cpp
+++ b/src/openrct2/platform/Platform.Android.cpp
@@ -12,6 +12,7 @@
     #include "Platform.h"
 
     #include "../Diagnostic.h"
+    #include "../core/File.h"
     #include "../core/Guard.hpp"
     #include "../localisation/Language.h"
 
@@ -165,7 +166,13 @@ namespace OpenRCT2::Platform
     #ifndef NO_TTF
     std::string GetFontPath(const TTFFontDescriptor& font)
     {
-        return "/sdcard/openrct2/rct2.ttf";
+        auto expectedPath = std::string("/system/fonts/") + std::string(font.filename);
+        if (File::Exists(expectedPath))
+        {
+            return expectedPath;
+        }
+
+        return "";
     }
     #endif
 


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/ab6a43ae-d6cf-4a68-a768-dc3d1e5dcbb2)


This patch is available using TTF for CJK language.
I build success and Tested on my Poco X5.


1. copy TTF file on Android device in 
"/sdcard/openrct2/rct2.ttf" (alike "Noto Sans CJK" or "NanumGothic")
filename is "rct2.ttf"

2. Edit config.ini character size and offset.
3. Play by CJK language!