### PR TITLE
Update field names on RCT1/RCT2 Ride struct

### DIFF
--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -240,153 +240,153 @@ namespace OpenRCT2::RCT1
      */
     struct Ride
     {
-        RideType Type;                               // 0x000
-        RCT1::VehicleType VehicleType;               // 0x001
-        uint16_t LifecycleFlags;                     // 0x002
-        uint8_t OperatingMode;                       // 0x004
+        RideType type;                               // 0x000
+        RCT1::VehicleType vehicleType;               // 0x001
+        uint16_t lifecycleFlags;                     // 0x002
+        uint8_t operatingMode;                       // 0x004
         VehicleColourSettings vehicleColourSettings; // 0x005
         struct
         {
-            colour_t Body;
-            colour_t Trim;
-        } VehicleColours[Limits::kMaxTrainsPerRide];           // 0x006
-        colour_t TrackPrimaryColour;                           // 0x01E
-        colour_t TrackSecondaryColour;                         // 0x01F
-        colour_t TrackSupportColour;                           // 0x020
-        uint8_t Status;                                        // 0x021
-        uint16_t Name;                                         // 0x022
-        uint16_t NameArgumentRide;                             // 0x024
-        uint16_t NameArgumentNumber;                           // 0x026
-        RCT12xy8 OverallView;                                  // 0x028
-        RCT12xy8 StationStarts[Limits::kMaxStationsPerRide];   // 0x02A
-        uint8_t StationHeights[Limits::kMaxStationsPerRide];   // 0x032
-        uint8_t StationLengths[Limits::kMaxStationsPerRide];   // 0x036
-        uint8_t StationLights[Limits::kMaxStationsPerRide];    // 0x03A
-        uint8_t StationDeparts[Limits::kMaxStationsPerRide];   // 0x03E
-        RCT12xy8 Entrances[Limits::kMaxStationsPerRide];       // 0x042
-        RCT12xy8 Exits[Limits::kMaxStationsPerRide];           // 0x04A
-        uint16_t LastPeepInQueue[Limits::kMaxStationsPerRide]; // 0x052
-        uint8_t NumPeepsInQueue[Limits::kMaxStationsPerRide];  // 0x05A
-        uint16_t Vehicles[Limits::kMaxTrainsPerRide];          // 0x05E
-        uint8_t DepartFlags;                                   // 0x076
-        uint8_t NumStations;                                   // 0x077
-        uint8_t NumTrains;                                     // 0x078
-        uint8_t NumCarsPerTrain;                               // 0x079
-        uint8_t ProposedNumTrains;                             // 0x07A
-        uint8_t ProposedNumCarsPerTrain;                       // 0x07B
-        uint8_t MaxTrains;                                     // 0x07C
-        uint8_t MinMaxCarsPerTrain;                            // 0x07D
-        uint8_t MinWaitingTime;                                // 0x07E
-        uint8_t MaxWaitingTime;                                // 0x07F
-        uint8_t OperationOption;                               // 0x080
-        uint8_t BoatHireReturnDirection;                       // 0x081
-        RCT12xy8 BoatHireReturnPosition;                       // 0x082
-        uint8_t DataLoggingIndex;                              // 0x084
-        uint8_t SpecialTrackElements;                          // 0x085
-        uint16_t Unk6;                                         // 0x086
-        int32_t MaxSpeed;                                      // 0x088
-        int32_t AverageSpeed;                                  // 0x08C
-        uint8_t CurrentTestSegment;                            // 0x090
-        uint8_t AverageSpeedTestTimeout;                       // 0x091
-        uint8_t Pad0E2[0x2];                                   // 0x092
-        int32_t Length[Limits::kMaxStationsPerRide];           // 0x094
-        uint16_t Time[Limits::kMaxStationsPerRide];            // 0x0A4
-        fixed16_2dp MaxPositiveVerticalG;                      // 0x0AC
-        fixed16_2dp MaxNegativeVerticalG;                      // 0x0AE
-        fixed16_2dp MaxLateralG;                               // 0x0B0
-        fixed16_2dp PreviousVerticalG;                         // 0x0B2
-        fixed16_2dp PreviousLateralG;                          // 0x0B4
-        uint8_t PadB6[0x2];                                    // 0x0B6
-        uint32_t TestingFlags;                                 // 0x0B8
+            colour_t body;
+            colour_t trim;
+        } vehicleColours[Limits::kMaxTrainsPerRide];           // 0x006
+        colour_t trackPrimaryColour;                           // 0x01E
+        colour_t trackSecondaryColour;                         // 0x01F
+        colour_t trackSupportColour;                           // 0x020
+        uint8_t status;                                        // 0x021
+        uint16_t name;                                         // 0x022
+        uint16_t nameArgumentRide;                             // 0x024
+        uint16_t nameArgumentNumber;                           // 0x026
+        RCT12xy8 overallView;                                  // 0x028
+        RCT12xy8 stationStarts[Limits::kMaxStationsPerRide];   // 0x02A
+        uint8_t stationHeights[Limits::kMaxStationsPerRide];   // 0x032
+        uint8_t stationLengths[Limits::kMaxStationsPerRide];   // 0x036
+        uint8_t stationLights[Limits::kMaxStationsPerRide];    // 0x03A
+        uint8_t stationDeparts[Limits::kMaxStationsPerRide];   // 0x03E
+        RCT12xy8 entrances[Limits::kMaxStationsPerRide];       // 0x042
+        RCT12xy8 exits[Limits::kMaxStationsPerRide];           // 0x04A
+        uint16_t lastPeepInQueue[Limits::kMaxStationsPerRide]; // 0x052
+        uint8_t numPeepsInQueue[Limits::kMaxStationsPerRide];  // 0x05A
+        uint16_t vehicles[Limits::kMaxTrainsPerRide];          // 0x05E
+        uint8_t departFlags;                                   // 0x076
+        uint8_t numStations;                                   // 0x077
+        uint8_t numTrains;                                     // 0x078
+        uint8_t numCarsPerTrain;                               // 0x079
+        uint8_t proposedNumTrains;                             // 0x07A
+        uint8_t proposedNumCarsPerTrain;                       // 0x07B
+        uint8_t maxTrains;                                     // 0x07C
+        uint8_t minMaxCarsPerTrain;                            // 0x07D
+        uint8_t minWaitingTime;                                // 0x07E
+        uint8_t maxWaitingTime;                                // 0x07F
+        uint8_t operationOption;                               // 0x080
+        uint8_t boatHireReturnDirection;                       // 0x081
+        RCT12xy8 boatHireReturnPosition;                       // 0x082
+        uint8_t dataLoggingIndex;                              // 0x084
+        uint8_t specialTrackElements;                          // 0x085
+        uint16_t unk6;                                         // 0x086
+        int32_t maxSpeed;                                      // 0x088
+        int32_t averageSpeed;                                  // 0x08C
+        uint8_t currentTestSegment;                            // 0x090
+        uint8_t averageSpeedTestTimeout;                       // 0x091
+        uint8_t pad0E2[0x2];                                   // 0x092
+        int32_t length[Limits::kMaxStationsPerRide];           // 0x094
+        uint16_t time[Limits::kMaxStationsPerRide];            // 0x0A4
+        fixed16_2dp maxPositiveVerticalG;                      // 0x0AC
+        fixed16_2dp maxNegativeVerticalG;                      // 0x0AE
+        fixed16_2dp maxLateralG;                               // 0x0B0
+        fixed16_2dp previousVerticalG;                         // 0x0B2
+        fixed16_2dp previousLateralG;                          // 0x0B4
+        uint8_t padB6[0x2];                                    // 0x0B6
+        uint32_t testingFlags;                                 // 0x0B8
         // x y map location of the current track piece during a test
         // this is to prevent counting special tracks multiple times
-        RCT12xy8 CurTestTrackLocation; // 0x0BC
+        RCT12xy8 curTestTrackLocation; // 0x0BC
         // Next 3 variables are related (XXXX XYYY ZZZa aaaa)
-        uint16_t TurnCountDefault; // 0x0BE X = current turn count
-        uint16_t TurnCountBanked;  // 0x0C0
-        uint16_t TurnCountSloped;  // 0x0C2 X = number turns > 3 elements
+        uint16_t turnCountDefault; // 0x0BE X = current turn count
+        uint16_t turnCountBanked;  // 0x0C0
+        uint16_t turnCountSloped;  // 0x0C2 X = number turns > 3 elements
         union
         {
-            uint8_t NumInversions; // 0x0C4
-            uint8_t NumHoles;
+            uint8_t numInversions; // 0x0C4
+            uint8_t numHoles;
         };
-        uint8_t NumDrops;             // 0x0C5
-        uint8_t StartDropHeight;      // 0x0C6
-        uint8_t HighestDropHeight;    // 0x0C7
-        int32_t ShelteredLength;      // 0x0C8
-        uint8_t UnkCC[2];             // 0x0CC
-        uint8_t NumShelteredSections; // 0x0CE
+        uint8_t numDrops;             // 0x0C5
+        uint8_t startDropHeight;      // 0x0C6
+        uint8_t highestDropHeight;    // 0x0C7
+        int32_t shelteredLength;      // 0x0C8
+        uint8_t unkCC[2];             // 0x0CC
+        uint8_t numShelteredSections; // 0x0CE
         // see CurTestTrackLocation
-        uint8_t CurTestTrackZ; // 0x0CF
-        int16_t UnkD0;         // 0x0D0
-        int16_t UnkD2;         // 0x0D2
+        uint8_t curTestTrackZ; // 0x0CF
+        int16_t unkD0;         // 0x0D0
+        int16_t unkD2;         // 0x0D2
         // Customer count in the last 10 * 960 game ticks (sliding window)
-        uint16_t NumCustomers[Limits::kCustomerHistorySize]; // 0xD4
-        money16 Price;                                       // 0x0E8
-        RCT12xy8 ChairliftBullwheelLocation[2];              // 0x0EA
-        uint8_t ChairliftBullwheelZ[2];                      // 0x0EE
+        uint16_t numCustomers[Limits::kCustomerHistorySize]; // 0xD4
+        money16 price;                                       // 0x0E8
+        RCT12xy8 chairliftBullwheelLocation[2];              // 0x0EA
+        uint8_t chairliftBullwheelZ[2];                      // 0x0EE
         RatingTuple ratings;                                 // 0x0F0
-        money16 Value;                                       // 0x0F6
-        uint16_t ChairliftBullwheelRotation;                 // 0x0F8
-        uint8_t Satisfaction;                                // 0x0FA
-        uint8_t SatisfactionTimeOut;                         // 0x0FB
-        uint8_t SatisfactionNext;                            // 0x0FC
-        uint8_t WindowInvalidateFlags;                       // 0x0FD
-        uint8_t UnkFE[2];                                    // 0x0FE
-        uint32_t TotalCustomers;                             // 0x100
-        money32 TotalProfit;                                 // 0x104
-        uint8_t Popularity;                                  // 0x108
-        uint8_t PopularityTimeOut;                           // 0x109
-        uint8_t PopularityNext;                              // 0x10A
-        uint8_t NumRiders;                                   // 0x10B
-        uint8_t MusicTuneID;                                 // 0x10C
-        uint8_t SlideInUse;                                  // 0x10D
+        money16 value;                                       // 0x0F6
+        uint16_t chairliftBullwheelRotation;                 // 0x0F8
+        uint8_t satisfaction;                                // 0x0FA
+        uint8_t satisfactionTimeOut;                         // 0x0FB
+        uint8_t satisfactionNext;                            // 0x0FC
+        uint8_t windowInvalidateFlags;                       // 0x0FD
+        uint8_t unkFE[2];                                    // 0x0FE
+        uint32_t totalCustomers;                             // 0x100
+        money32 totalProfit;                                 // 0x104
+        uint8_t popularity;                                  // 0x108
+        uint8_t popularityTimeOut;                           // 0x109
+        uint8_t popularityNext;                              // 0x10A
+        uint8_t numRiders;                                   // 0x10B
+        uint8_t musicTuneID;                                 // 0x10C
+        uint8_t slideInUse;                                  // 0x10D
         union
         {
-            uint16_t SlidePeep; // 0x10E
-            uint16_t MazeTiles; // 0x10E
+            uint16_t slidePeep; // 0x10E
+            uint16_t mazeTiles; // 0x10E
         };
-        uint8_t Pad110[0xE];            // 0x110
-        uint8_t SlidePeepTshirtColour;  // 0x11E
-        uint8_t Pad11F[0x7];            // 0x11F
-        uint8_t SpiralSlideProgress;    // 0x126
-        uint8_t Pad127[0x9];            // 0x127
-        int16_t BuildDate;              // 0x130
-        money16 UpkeepCost;             // 0x131
-        uint16_t RaceWinner;            // 0x132
-        uint8_t Unk134[2];              // 0x134
-        uint32_t MusicPosition;         // 0x138
-        uint8_t BreakdownReasonPending; // 0x13C
-        uint8_t MechanicStatus;         // 0x13D
-        uint16_t Mechanic;              // 0x13E
-        uint8_t InspectionStation;      // 0x140
-        uint8_t BrokenVehicle;          // 0x141
-        uint8_t BrokenCar;              // 0x142
-        uint8_t BreakdownReason;        // 0x143
-        money16 PriceSecondary;         // 0x144
+        uint8_t pad110[0xE];            // 0x110
+        uint8_t slidePeepTshirtColour;  // 0x11E
+        uint8_t pad11F[0x7];            // 0x11F
+        uint8_t spiralSlideProgress;    // 0x126
+        uint8_t pad127[0x9];            // 0x127
+        int16_t buildDate;              // 0x130
+        money16 upkeepCost;             // 0x131
+        uint16_t raceWinner;            // 0x132
+        uint8_t unk134[2];              // 0x134
+        uint32_t musicPosition;         // 0x138
+        uint8_t breakdownReasonPending; // 0x13C
+        uint8_t mechanicStatus;         // 0x13D
+        uint16_t mechanic;              // 0x13E
+        uint8_t inspectionStation;      // 0x140
+        uint8_t brokenTrain;            // 0x141
+        uint8_t brokenCar;              // 0x142
+        uint8_t breakdownReason;        // 0x143
+        money16 priceSecondary;         // 0x144
         union
         {
             struct
             {
-                uint8_t ReliabilitySubvalue;   // 0x146, 0 - 255, acts like the decimals for ReliabilityPercentage
-                uint8_t ReliabilityPercentage; // 0x147, Starts at 100 and decreases from there.
+                uint8_t reliabilitySubvalue;   // 0x146, 0 - 255, acts like the decimals for ReliabilityPercentage
+                uint8_t reliabilityPercentage; // 0x147, Starts at 100 and decreases from there.
             };
-            uint16_t Reliability; // 0x146
+            uint16_t reliability; // 0x146
         };
-        uint8_t UnreliabilityFactor;                    // 0x148
-        uint8_t Downtime;                               // 0x149
-        uint8_t InspectionInterval;                     // 0x14A
-        uint8_t LastInspection;                         // 0x14B
-        uint8_t Unk14C[20];                             // 0x14C
-        money32 IncomePerHour;                          // 0x160
-        money32 Profit;                                 // 0x164
-        uint8_t QueueTime[Limits::kMaxStationsPerRide]; // 0x168
-        colour_t TrackColourMain[4];                    // 0x16C
-        colour_t TrackColourAdditional[4];              // 0x170
-        colour_t TrackColourSupports[4];                // 0x174
-        uint8_t Music;                                  // 0x178
-        uint8_t EntranceStyle;                          // 0x179
-        uint8_t Unk17A[230];                            // 0x17A
+        uint8_t unreliabilityFactor;                    // 0x148
+        uint8_t downtime;                               // 0x149
+        uint8_t inspectionInterval;                     // 0x14A
+        uint8_t lastInspection;                         // 0x14B
+        uint8_t unk14C[20];                             // 0x14C
+        money32 incomePerHour;                          // 0x160
+        money32 profit;                                 // 0x164
+        uint8_t queueTime[Limits::kMaxStationsPerRide]; // 0x168
+        colour_t trackColourMain[4];                    // 0x16C
+        colour_t trackColourAdditional[4];              // 0x170
+        colour_t trackColourSupports[4];                // 0x174
+        uint8_t music;                                  // 0x178
+        uint8_t entranceStyle;                          // 0x179
+        uint8_t unk17A[230];                            // 0x17A
     };
     static_assert(sizeof(Ride) == 0x260);
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -564,12 +564,12 @@ namespace OpenRCT2::RCT1
             for (size_t i = 0; i < std::size(_s4.Rides); i++)
             {
                 auto ride = &_s4.Rides[i];
-                if (ride->Type != RideType::Null)
+                if (ride->type != RideType::Null)
                 {
-                    if (RCT1::RideTypeUsesVehicles(ride->Type))
-                        AddEntryForVehicleType(ride->Type, ride->VehicleType);
+                    if (RCT1::RideTypeUsesVehicles(ride->type))
+                        AddEntryForVehicleType(ride->type, ride->vehicleType);
                     else
-                        AddEntryForRideType(ride->Type);
+                        AddEntryForRideType(ride->type);
                 }
             }
         }
@@ -832,7 +832,7 @@ namespace OpenRCT2::RCT1
         {
             for (int32_t i = 0; i < Limits::kMaxRidesInPark; i++)
             {
-                if (_s4.Rides[i].Type != RideType::Null)
+                if (_s4.Rides[i].type != RideType::Null)
                 {
                     const auto rideId = RideId::FromUnderlying(i);
                     ImportRide(RideAllocateAtIndex(rideId), &_s4.Rides[i], rideId);
@@ -846,22 +846,22 @@ namespace OpenRCT2::RCT1
             dst->id = rideIndex;
 
             // This is a peculiarity of this exact version number, which only Heide-Park seems to use.
-            if (_s4.GameVersion == 110018 && src->Type == RideType::InvertedRollerCoaster)
+            if (_s4.GameVersion == 110018 && src->type == RideType::InvertedRollerCoaster)
             {
                 dst->type = RIDE_TYPE_COMPACT_INVERTED_COASTER;
             }
             else
             {
-                dst->type = RCT1::GetRideType(src->Type, src->VehicleType);
+                dst->type = RCT1::GetRideType(src->type, src->vehicleType);
             }
 
-            if (RCT1::RideTypeUsesVehicles(src->Type))
+            if (RCT1::RideTypeUsesVehicles(src->type))
             {
-                dst->subtype = _vehicleTypeToRideEntryMap[EnumValue(src->VehicleType)];
+                dst->subtype = _vehicleTypeToRideEntryMap[EnumValue(src->vehicleType)];
             }
             else
             {
-                dst->subtype = _rideTypeToRideEntryMap[EnumValue(src->Type)];
+                dst->subtype = _rideTypeToRideEntryMap[EnumValue(src->type)];
             }
 
             const auto* rideEntry = GetRideEntryByIndex(dst->subtype);
@@ -874,15 +874,15 @@ namespace OpenRCT2::RCT1
             }
 
             // Ride name
-            if (IsUserStringID(src->Name))
+            if (IsUserStringID(src->name))
             {
-                dst->customName = GetUserString(src->Name);
+                dst->customName = GetUserString(src->name);
             }
 
-            dst->status = static_cast<RideStatus>(src->Status);
+            dst->status = static_cast<RideStatus>(src->status);
 
             // Flags
-            dst->lifecycleFlags = src->LifecycleFlags;
+            dst->lifecycleFlags = src->lifecycleFlags;
             // These flags were not in the base game
             if (_gameVersion == FILE_VERSION_RCT1)
             {
@@ -890,56 +890,56 @@ namespace OpenRCT2::RCT1
                 dst->lifecycleFlags &= ~RIDE_LIFECYCLE_INDESTRUCTIBLE;
                 dst->lifecycleFlags &= ~RIDE_LIFECYCLE_INDESTRUCTIBLE_TRACK;
             }
-            if (VehicleTypeIsReversed(src->VehicleType))
+            if (VehicleTypeIsReversed(src->vehicleType))
             {
                 dst->lifecycleFlags |= RIDE_LIFECYCLE_REVERSED_TRAINS;
             }
 
             // Station
-            if (src->OverallView.IsNull())
+            if (src->overallView.IsNull())
             {
                 dst->overallView.SetNull();
             }
             else
             {
-                dst->overallView = TileCoordsXY{ src->OverallView.x, src->OverallView.y }.ToCoordsXY();
+                dst->overallView = TileCoordsXY{ src->overallView.x, src->overallView.y }.ToCoordsXY();
             }
 
             for (StationIndex::UnderlyingType i = 0; i < Limits::kMaxStationsPerRide; i++)
             {
                 auto& dstStation = dst->getStation(StationIndex::FromUnderlying(i));
-                if (src->StationStarts[i].IsNull())
+                if (src->stationStarts[i].IsNull())
                 {
                     dstStation.Start.SetNull();
                 }
                 else
                 {
-                    auto tileStartLoc = TileCoordsXY{ src->StationStarts[i].x, src->StationStarts[i].y };
+                    auto tileStartLoc = TileCoordsXY{ src->stationStarts[i].x, src->stationStarts[i].y };
                     dstStation.Start = tileStartLoc.ToCoordsXY();
                 }
-                dstStation.SetBaseZ(src->StationHeights[i] * Limits::kCoordsZStep);
-                dstStation.Length = src->StationLengths[i];
-                dstStation.Depart = src->StationLights[i];
+                dstStation.SetBaseZ(src->stationHeights[i] * Limits::kCoordsZStep);
+                dstStation.Length = src->stationLengths[i];
+                dstStation.Depart = src->stationLights[i];
 
-                dstStation.TrainAtStation = src->StationDeparts[i];
+                dstStation.TrainAtStation = src->stationDeparts[i];
 
                 // Direction is fixed later.
-                if (src->Entrances[i].IsNull())
+                if (src->entrances[i].IsNull())
                     dstStation.Entrance.SetNull();
                 else
-                    dstStation.Entrance = { src->Entrances[i].x, src->Entrances[i].y, src->StationHeights[i] / 2, 0 };
+                    dstStation.Entrance = { src->entrances[i].x, src->entrances[i].y, src->stationHeights[i] / 2, 0 };
 
-                if (src->Exits[i].IsNull())
+                if (src->exits[i].IsNull())
                     dstStation.Exit.SetNull();
                 else
-                    dstStation.Exit = { src->Exits[i].x, src->Exits[i].y, src->StationHeights[i] / 2, 0 };
+                    dstStation.Exit = { src->exits[i].x, src->exits[i].y, src->stationHeights[i] / 2, 0 };
 
-                dstStation.QueueTime = src->QueueTime[i];
-                dstStation.LastPeepInQueue = EntityId::FromUnderlying(src->LastPeepInQueue[i]);
-                dstStation.QueueLength = src->NumPeepsInQueue[i];
+                dstStation.QueueTime = src->queueTime[i];
+                dstStation.LastPeepInQueue = EntityId::FromUnderlying(src->lastPeepInQueue[i]);
+                dstStation.QueueLength = src->numPeepsInQueue[i];
 
-                dstStation.SegmentTime = src->Time[i];
-                dstStation.SegmentLength = src->Length[i];
+                dstStation.SegmentTime = src->time[i];
+                dstStation.SegmentLength = src->length[i];
             }
             // All other values take 0 as their default. Since they're already memset to that, no need to do it again.
             for (int32_t i = Limits::kMaxStationsPerRide; i < OpenRCT2::Limits::kMaxStationsPerRide; i++)
@@ -952,32 +952,32 @@ namespace OpenRCT2::RCT1
                 dstStation.LastPeepInQueue = EntityId::GetNull();
             }
 
-            dst->numStations = src->NumStations;
+            dst->numStations = src->numStations;
 
             // Vehicle links (indexes converted later)
             for (int32_t i = 0; i < Limits::kMaxTrainsPerRide; i++)
             {
-                dst->vehicles[i] = EntityId::FromUnderlying(src->Vehicles[i]);
+                dst->vehicles[i] = EntityId::FromUnderlying(src->vehicles[i]);
             }
             for (int32_t i = Limits::kMaxTrainsPerRide; i <= OpenRCT2::Limits::kMaxTrainsPerRide; i++)
             {
                 dst->vehicles[i] = EntityId::GetNull();
             }
 
-            dst->numTrains = src->NumTrains;
-            dst->numCarsPerTrain = src->NumCarsPerTrain + rideEntry->zero_cars;
-            dst->proposedNumTrains = src->NumTrains;
-            dst->maxTrains = src->MaxTrains;
-            dst->proposedNumCarsPerTrain = src->NumCarsPerTrain + rideEntry->zero_cars;
-            dst->specialTrackElements = src->SpecialTrackElements;
-            dst->numShelteredSections = src->NumShelteredSections;
-            dst->shelteredLength = src->ShelteredLength;
+            dst->numTrains = src->numTrains;
+            dst->numCarsPerTrain = src->numCarsPerTrain + rideEntry->zero_cars;
+            dst->proposedNumTrains = src->numTrains;
+            dst->maxTrains = src->maxTrains;
+            dst->proposedNumCarsPerTrain = src->numCarsPerTrain + rideEntry->zero_cars;
+            dst->specialTrackElements = src->specialTrackElements;
+            dst->numShelteredSections = src->numShelteredSections;
+            dst->shelteredLength = src->shelteredLength;
 
             // Operation
-            dst->departFlags = src->DepartFlags;
-            dst->minWaitingTime = src->MinWaitingTime;
-            dst->maxWaitingTime = src->MaxWaitingTime;
-            dst->operationOption = src->OperationOption;
+            dst->departFlags = src->departFlags;
+            dst->minWaitingTime = src->minWaitingTime;
+            dst->maxWaitingTime = src->maxWaitingTime;
+            dst->operationOption = src->operationOption;
             dst->numCircuits = 1;
             dst->minCarsPerTrain = rideEntry->min_cars_in_train;
             dst->maxCarsPerTrain = rideEntry->max_cars_in_train;
@@ -999,9 +999,9 @@ namespace OpenRCT2::RCT1
 
                     // Only merry-go-round and dodgems had music and used
                     // the same flag as synchronise stations for the option to enable it
-                    if (src->Type == RideType::MerryGoRound || src->Type == RideType::Dodgems)
+                    if (src->type == RideType::MerryGoRound || src->type == RideType::Dodgems)
                     {
-                        if (src->DepartFlags & RCT1_RIDE_DEPART_PLAY_MUSIC)
+                        if (src->departFlags & RCT1_RIDE_DEPART_PLAY_MUSIC)
                         {
                             dst->departFlags &= ~RCT1_RIDE_DEPART_PLAY_MUSIC;
                             dst->lifecycleFlags |= RIDE_LIFECYCLE_MUSIC;
@@ -1010,109 +1010,109 @@ namespace OpenRCT2::RCT1
                 }
                 else
                 {
-                    dst->music = src->Music;
+                    dst->music = src->music;
                 }
             }
 
-            if (src->OperatingMode == RCT1_RIDE_MODE_POWERED_LAUNCH)
+            if (src->operatingMode == RCT1_RIDE_MODE_POWERED_LAUNCH)
             {
                 // Launched rides never passed through the station in RCT1.
                 dst->mode = RideMode::poweredLaunch;
             }
             else
             {
-                dst->mode = static_cast<RideMode>(src->OperatingMode);
+                dst->mode = static_cast<RideMode>(src->operatingMode);
             }
 
             SetRideColourScheme(dst, src);
 
             // Maintenance
-            dst->buildDate = static_cast<int32_t>(src->BuildDate);
-            dst->inspectionInterval = src->InspectionInterval;
-            dst->lastInspection = src->LastInspection;
-            dst->reliability = src->Reliability;
-            dst->unreliabilityFactor = src->UnreliabilityFactor;
-            dst->downtime = src->Downtime;
-            dst->breakdownReason = src->BreakdownReason;
-            dst->mechanicStatus = src->MechanicStatus;
-            dst->mechanic = EntityId::FromUnderlying(src->Mechanic);
-            dst->breakdownReasonPending = src->BreakdownReasonPending;
-            dst->inspectionStation = StationIndex::FromUnderlying(src->InspectionStation);
-            dst->brokenCar = src->BrokenCar;
-            dst->brokenTrain = src->BrokenVehicle;
+            dst->buildDate = static_cast<int32_t>(src->buildDate);
+            dst->inspectionInterval = src->inspectionInterval;
+            dst->lastInspection = src->lastInspection;
+            dst->reliability = src->reliability;
+            dst->unreliabilityFactor = src->unreliabilityFactor;
+            dst->downtime = src->downtime;
+            dst->breakdownReason = src->breakdownReason;
+            dst->mechanicStatus = src->mechanicStatus;
+            dst->mechanic = EntityId::FromUnderlying(src->mechanic);
+            dst->breakdownReasonPending = src->breakdownReasonPending;
+            dst->inspectionStation = StationIndex::FromUnderlying(src->inspectionStation);
+            dst->brokenCar = src->brokenCar;
+            dst->brokenTrain = src->brokenTrain;
 
             // Measurement data
             dst->ratings = src->ratings;
 
-            dst->maxSpeed = src->MaxSpeed;
-            dst->averageSpeed = src->AverageSpeed;
+            dst->maxSpeed = src->maxSpeed;
+            dst->averageSpeed = src->averageSpeed;
 
-            dst->maxPositiveVerticalG = src->MaxPositiveVerticalG;
-            dst->maxNegativeVerticalG = src->MaxNegativeVerticalG;
-            dst->maxLateralG = src->MaxLateralG;
-            dst->previousLateralG = src->PreviousLateralG;
-            dst->previousVerticalG = src->PreviousVerticalG;
-            dst->turnCountBanked = src->TurnCountBanked;
-            dst->turnCountDefault = src->TurnCountDefault;
-            dst->turnCountSloped = src->TurnCountSloped;
-            dst->dropsPoweredLifts = src->NumDrops;
-            dst->startDropHeight = src->StartDropHeight / 2;
-            dst->highestDropHeight = src->HighestDropHeight / 2;
-            if (src->Type == RideType::MiniatureGolf)
-                dst->holes = src->NumInversions & kRCT12InversionAndHoleMask;
+            dst->maxPositiveVerticalG = src->maxPositiveVerticalG;
+            dst->maxNegativeVerticalG = src->maxNegativeVerticalG;
+            dst->maxLateralG = src->maxLateralG;
+            dst->previousLateralG = src->previousLateralG;
+            dst->previousVerticalG = src->previousVerticalG;
+            dst->turnCountBanked = src->turnCountBanked;
+            dst->turnCountDefault = src->turnCountDefault;
+            dst->turnCountSloped = src->turnCountSloped;
+            dst->dropsPoweredLifts = src->numDrops;
+            dst->startDropHeight = src->startDropHeight / 2;
+            dst->highestDropHeight = src->highestDropHeight / 2;
+            if (src->type == RideType::MiniatureGolf)
+                dst->holes = src->numInversions & kRCT12InversionAndHoleMask;
             else
-                dst->inversions = src->NumInversions & kRCT12InversionAndHoleMask;
-            dst->shelteredEighths = src->NumInversions >> 5;
-            dst->boatHireReturnDirection = src->BoatHireReturnDirection;
-            dst->boatHireReturnPosition = { src->BoatHireReturnPosition.x, src->BoatHireReturnPosition.y };
-            dst->chairliftBullwheelRotation = src->ChairliftBullwheelRotation;
+                dst->inversions = src->numInversions & kRCT12InversionAndHoleMask;
+            dst->shelteredEighths = src->numInversions >> 5;
+            dst->boatHireReturnDirection = src->boatHireReturnDirection;
+            dst->boatHireReturnPosition = { src->boatHireReturnPosition.x, src->boatHireReturnPosition.y };
+            dst->chairliftBullwheelRotation = src->chairliftBullwheelRotation;
             for (int i = 0; i < 2; i++)
             {
-                dst->chairliftBullwheelLocation[i] = { src->ChairliftBullwheelLocation[i].x,
-                                                       src->ChairliftBullwheelLocation[i].y, src->ChairliftBullwheelZ[i] / 2 };
+                dst->chairliftBullwheelLocation[i] = { src->chairliftBullwheelLocation[i].x,
+                                                       src->chairliftBullwheelLocation[i].y, src->chairliftBullwheelZ[i] / 2 };
             }
 
-            if (src->CurTestTrackLocation.IsNull())
+            if (src->curTestTrackLocation.IsNull())
             {
                 dst->curTestTrackLocation.SetNull();
             }
             else
             {
-                dst->curTestTrackLocation = { src->CurTestTrackLocation.x, src->CurTestTrackLocation.y,
-                                              src->CurTestTrackZ / 2 };
+                dst->curTestTrackLocation = { src->curTestTrackLocation.x, src->curTestTrackLocation.y,
+                                              src->curTestTrackZ / 2 };
             }
-            dst->testingFlags = src->TestingFlags;
-            dst->currentTestSegment = src->CurrentTestSegment;
+            dst->testingFlags = src->testingFlags;
+            dst->currentTestSegment = src->currentTestSegment;
             dst->currentTestStation = StationIndex::GetNull();
-            dst->averageSpeedTestTimeout = src->AverageSpeedTestTimeout;
-            dst->slideInUse = src->SlideInUse;
-            dst->slidePeepTShirtColour = RCT1::GetColour(src->SlidePeepTshirtColour);
-            dst->spiralSlideProgress = src->SpiralSlideProgress;
+            dst->averageSpeedTestTimeout = src->averageSpeedTestTimeout;
+            dst->slideInUse = src->slideInUse;
+            dst->slidePeepTShirtColour = RCT1::GetColour(src->slidePeepTshirtColour);
+            dst->spiralSlideProgress = src->spiralSlideProgress;
             // Doubles as slidePeep
-            dst->mazeTiles = src->MazeTiles;
+            dst->mazeTiles = src->mazeTiles;
 
             // Finance / customers
-            dst->upkeepCost = ToMoney64(src->UpkeepCost);
-            dst->price[0] = src->Price;
-            dst->price[1] = src->PriceSecondary;
-            dst->incomePerHour = ToMoney64(src->IncomePerHour);
-            dst->totalCustomers = src->TotalCustomers;
-            dst->profit = ToMoney64(src->Profit);
-            dst->totalProfit = ToMoney64(src->TotalProfit);
-            dst->value = ToMoney64(src->Value);
-            for (size_t i = 0; i < std::size(src->NumCustomers); i++)
+            dst->upkeepCost = ToMoney64(src->upkeepCost);
+            dst->price[0] = src->price;
+            dst->price[1] = src->priceSecondary;
+            dst->incomePerHour = ToMoney64(src->incomePerHour);
+            dst->totalCustomers = src->totalCustomers;
+            dst->profit = ToMoney64(src->profit);
+            dst->totalProfit = ToMoney64(src->totalProfit);
+            dst->value = ToMoney64(src->value);
+            for (size_t i = 0; i < std::size(src->numCustomers); i++)
             {
-                dst->numCustomers[i] = src->NumCustomers[i];
+                dst->numCustomers[i] = src->numCustomers[i];
             }
 
-            dst->satisfaction = src->Satisfaction;
-            dst->satisfactionTimeout = src->SatisfactionTimeOut;
-            dst->satisfactionNext = src->SatisfactionNext;
-            dst->popularity = src->Popularity;
-            dst->popularityNext = src->PopularityNext;
-            dst->popularityTimeout = src->PopularityTimeOut;
+            dst->satisfaction = src->satisfaction;
+            dst->satisfactionTimeout = src->satisfactionTimeOut;
+            dst->satisfactionNext = src->satisfactionNext;
+            dst->popularity = src->popularity;
+            dst->popularityNext = src->popularityNext;
+            dst->popularityTimeout = src->popularityTimeOut;
 
-            dst->numRiders = src->NumRiders;
+            dst->numRiders = src->numRiders;
 
             dst->musicTuneId = kTuneIDNull;
         }
@@ -1123,16 +1123,16 @@ namespace OpenRCT2::RCT1
             dst->vehicleColourSettings = src->vehicleColourSettings;
             if (_gameVersion == FILE_VERSION_RCT1)
             {
-                dst->trackColours[0].main = RCT1::GetColour(src->TrackPrimaryColour);
-                dst->trackColours[0].additional = RCT1::GetColour(src->TrackSecondaryColour);
-                dst->trackColours[0].supports = RCT1::GetColour(src->TrackSupportColour);
+                dst->trackColours[0].main = RCT1::GetColour(src->trackPrimaryColour);
+                dst->trackColours[0].additional = RCT1::GetColour(src->trackSecondaryColour);
+                dst->trackColours[0].supports = RCT1::GetColour(src->trackSupportColour);
 
                 // Balloons were always blue in the original RCT.
-                if (src->Type == RideType::BalloonStall)
+                if (src->type == RideType::BalloonStall)
                 {
                     dst->trackColours[0].main = COLOUR_LIGHT_BLUE;
                 }
-                else if (src->Type == RideType::RiverRapids)
+                else if (src->type == RideType::RiverRapids)
                 {
                     dst->trackColours[0].main = COLOUR_WHITE;
                 }
@@ -1141,9 +1141,9 @@ namespace OpenRCT2::RCT1
             {
                 for (int i = 0; i < Limits::kNumColourSchemes; i++)
                 {
-                    dst->trackColours[i].main = RCT1::GetColour(src->TrackColourMain[i]);
-                    dst->trackColours[i].additional = RCT1::GetColour(src->TrackColourAdditional[i]);
-                    dst->trackColours[i].supports = RCT1::GetColour(src->TrackColourSupports[i]);
+                    dst->trackColours[i].main = RCT1::GetColour(src->trackColourMain[i]);
+                    dst->trackColours[i].additional = RCT1::GetColour(src->trackColourAdditional[i]);
+                    dst->trackColours[i].supports = RCT1::GetColour(src->trackColourSupports[i]);
                 }
             }
 
@@ -1157,11 +1157,11 @@ namespace OpenRCT2::RCT1
                 }
                 else
                 {
-                    dst->entranceStyle = src->EntranceStyle;
+                    dst->entranceStyle = src->entranceStyle;
                 }
             }
 
-            if (_gameVersion < FILE_VERSION_RCT1_LL && src->Type == RideType::MerryGoRound)
+            if (_gameVersion < FILE_VERSION_RCT1_LL && src->type == RideType::MerryGoRound)
             {
                 // The merry-go-round in pre-LL versions was always yellow with red
                 dst->vehicleColours[0].Body = COLOUR_YELLOW;
@@ -1172,14 +1172,14 @@ namespace OpenRCT2::RCT1
                 for (int i = 0; i < Limits::kMaxTrainsPerRide; i++)
                 {
                     // RCT1 had no third colour
-                    const auto colourSchemeCopyDescriptor = GetColourSchemeCopyDescriptor(src->VehicleType);
+                    const auto colourSchemeCopyDescriptor = GetColourSchemeCopyDescriptor(src->vehicleType);
                     if (colourSchemeCopyDescriptor.colour1 == COPY_COLOUR_1)
                     {
-                        dst->vehicleColours[i].Body = RCT1::GetColour(src->VehicleColours[i].Body);
+                        dst->vehicleColours[i].Body = RCT1::GetColour(src->vehicleColours[i].body);
                     }
                     else if (colourSchemeCopyDescriptor.colour1 == COPY_COLOUR_2)
                     {
-                        dst->vehicleColours[i].Body = RCT1::GetColour(src->VehicleColours[i].Trim);
+                        dst->vehicleColours[i].Body = RCT1::GetColour(src->vehicleColours[i].trim);
                     }
                     else
                     {
@@ -1188,11 +1188,11 @@ namespace OpenRCT2::RCT1
 
                     if (colourSchemeCopyDescriptor.colour2 == COPY_COLOUR_1)
                     {
-                        dst->vehicleColours[i].Trim = RCT1::GetColour(src->VehicleColours[i].Body);
+                        dst->vehicleColours[i].Trim = RCT1::GetColour(src->vehicleColours[i].body);
                     }
                     else if (colourSchemeCopyDescriptor.colour2 == COPY_COLOUR_2)
                     {
-                        dst->vehicleColours[i].Trim = RCT1::GetColour(src->VehicleColours[i].Trim);
+                        dst->vehicleColours[i].Trim = RCT1::GetColour(src->vehicleColours[i].trim);
                     }
                     else
                     {
@@ -1201,11 +1201,11 @@ namespace OpenRCT2::RCT1
 
                     if (colourSchemeCopyDescriptor.colour3 == COPY_COLOUR_1)
                     {
-                        dst->vehicleColours[i].Tertiary = RCT1::GetColour(src->VehicleColours[i].Body);
+                        dst->vehicleColours[i].Tertiary = RCT1::GetColour(src->vehicleColours[i].body);
                     }
                     else if (colourSchemeCopyDescriptor.colour3 == COPY_COLOUR_2)
                     {
-                        dst->vehicleColours[i].Tertiary = RCT1::GetColour(src->VehicleColours[i].Trim);
+                        dst->vehicleColours[i].Tertiary = RCT1::GetColour(src->vehicleColours[i].trim);
                     }
                     else
                     {
@@ -1216,12 +1216,12 @@ namespace OpenRCT2::RCT1
 
             // In RCT1 and AA, the maze was always hedges.
             // LL has 4 types, like RCT2. For LL, only guard against invalid values.
-            if (src->Type == RideType::HedgeMaze)
+            if (src->type == RideType::HedgeMaze)
             {
-                if (_gameVersion < FILE_VERSION_RCT1_LL || src->TrackColourSupports[0] > 3)
+                if (_gameVersion < FILE_VERSION_RCT1_LL || src->trackColourSupports[0] > 3)
                     dst->trackColours[0].supports = MAZE_WALL_TYPE_HEDGE;
                 else
-                    dst->trackColours[0].supports = src->TrackColourSupports[0];
+                    dst->trackColours[0].supports = src->trackColourSupports[0];
             }
         }
 
@@ -1298,7 +1298,7 @@ namespace OpenRCT2::RCT1
         {
             const auto& srcRide = _s4.Rides[src->Ride];
             RCT1::VehicleColourSchemeCopyDescriptor colourSchemeCopyDescriptor = RCT1::GetColourSchemeCopyDescriptor(
-                srcRide.VehicleType);
+                srcRide.vehicleType);
 
             // RCT1 had no third colour
             if (colourSchemeCopyDescriptor.colour1 == COPY_COLOUR_1)
@@ -1723,7 +1723,7 @@ namespace OpenRCT2::RCT1
                     auto src2 = src->AsTrack();
                     const auto* ride = GetRide(RCT12RideIdToOpenRCT2RideId(src2->GetRideIndex()));
                     auto rideType = (ride != nullptr) ? ride->type : kRideTypeNull;
-                    auto rct1RideType = _s4.Rides[src2->GetRideIndex()].Type;
+                    auto rct1RideType = _s4.Rides[src2->GetRideIndex()].type;
 
                     dst2->SetTrackType(RCT1TrackTypeToOpenRCT2(src2->GetTrackType(), rideType));
                     dst2->SetRideType(rideType);
@@ -2751,7 +2751,7 @@ namespace OpenRCT2::RCT1
             return;
 
         const auto& rct1Ride = _s4.Rides[src->Ride];
-        uint8_t vehicleEntryIndex = RCT1::GetVehicleSubEntryIndex(rct1Ride.VehicleType, src->CarType);
+        uint8_t vehicleEntryIndex = RCT1::GetVehicleSubEntryIndex(rct1Ride.vehicleType, src->CarType);
 
         dst->ride = RideId::FromUnderlying(src->Ride);
         dst->ride_subtype = RCTEntryIndexToOpenRCT2EntryIndex(ride->subtype);
@@ -2858,7 +2858,7 @@ namespace OpenRCT2::RCT1
         }
         dst->BlockBrakeSpeed = kRCT2DefaultBlockBrakeSpeed;
 
-        if (VehicleTypeIsReversed(rct1Ride.VehicleType))
+        if (VehicleTypeIsReversed(rct1Ride.vehicleType))
         {
             dst->SetFlag(VehicleFlags::CarIsReversed);
         }

--- a/src/openrct2/rct2/RCT2.cpp
+++ b/src/openrct2/rct2/RCT2.cpp
@@ -87,14 +87,14 @@ namespace OpenRCT2::RCT2
         }
     }
 
-    uint8_t Ride::GetMinCarsPerTrain() const
+    uint8_t Ride::getMinCarsPerTrain() const
     {
-        return MinMaxCarsPerTrain >> 4;
+        return minMaxCarsPerTrain >> 4;
     }
 
-    uint8_t Ride::GetMaxCarsPerTrain() const
+    uint8_t Ride::getMaxCarsPerTrain() const
     {
-        return MinMaxCarsPerTrain & 0xF;
+        return minMaxCarsPerTrain & 0xF;
     }
 
     OpenRCT2::TrackElemType RCT2TrackTypeToOpenRCT2(

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -71,213 +71,213 @@ namespace OpenRCT2::RCT2
      */
     struct Ride
     {
-        uint8_t Type; // 0x000
+        uint8_t type; // 0x000
         // pointer to static info. for example, wild mouse type is 0x36, subtype is
         // 0x4c.
-        RCT12ObjectEntryIndex Subtype;                                 // 0x001
-        uint16_t Pad002;                                               // 0x002
-        uint8_t Mode;                                                  // 0x004
+        RCT12ObjectEntryIndex subtype;                                 // 0x001
+        uint16_t pad002;                                               // 0x002
+        uint8_t mode;                                                  // 0x004
         VehicleColourSettings vehicleColourSettings;                   // 0x005
-        RCT12VehicleColour VehicleColours[Limits::kMaxVehicleColours]; // 0x006
-        uint8_t Pad046[0x03]; // 0x046, Used to be track colours in RCT1 without expansions
+        RCT12VehicleColour vehicleColours[Limits::kMaxVehicleColours]; // 0x006
+        uint8_t pad046[0x03]; // 0x046, Used to be track colours in RCT1 without expansions
         // 0 = closed, 1 = open, 2 = test
-        uint8_t Status; // 0x049
-        StringId Name;  // 0x04A
+        uint8_t status; // 0x049
+        StringId name;  // 0x04A
         union
         {
-            uint32_t NameArguments; // 0x04C
+            uint32_t nameArguments; // 0x04C
             struct
             {
-                StringId NameArgumentsTypeName; // 0x04C
-                uint16_t NameArgumentsNumber;   // 0x04E
+                StringId nameArgumentsTypeName; // 0x04C
+                uint16_t nameArgumentsNumber;   // 0x04E
             };
         };
-        RCT12xy8 OverallView;                                // 0x050
-        RCT12xy8 StationStarts[Limits::kMaxStationsPerRide]; // 0x052
-        uint8_t StationHeights[Limits::kMaxStationsPerRide]; // 0x05A
-        uint8_t StationLength[Limits::kMaxStationsPerRide];  // 0x05E
-        uint8_t StationDepart[Limits::kMaxStationsPerRide];  // 0x062
+        RCT12xy8 overallView;                                // 0x050
+        RCT12xy8 stationStarts[Limits::kMaxStationsPerRide]; // 0x052
+        uint8_t stationHeights[Limits::kMaxStationsPerRide]; // 0x05A
+        uint8_t stationLength[Limits::kMaxStationsPerRide];  // 0x05E
+        uint8_t stationDepart[Limits::kMaxStationsPerRide];  // 0x062
         // ride->vehicle index for current train waiting for passengers
         // at station
-        uint8_t TrainAtStation[Limits::kMaxStationsPerRide];   // 0x066
-        RCT12xy8 Entrances[Limits::kMaxStationsPerRide];       // 0x06A
-        RCT12xy8 Exits[Limits::kMaxStationsPerRide];           // 0x072
-        uint16_t LastPeepInQueue[Limits::kMaxStationsPerRide]; // 0x07A
-        uint8_t Pad082[Limits::kMaxStationsPerRide];           // 0x082, Used to be number of peeps in queue in RCT1, but this
+        uint8_t trainAtStation[Limits::kMaxStationsPerRide];   // 0x066
+        RCT12xy8 entrances[Limits::kMaxStationsPerRide];       // 0x06A
+        RCT12xy8 exits[Limits::kMaxStationsPerRide];           // 0x072
+        uint16_t lastPeepInQueue[Limits::kMaxStationsPerRide]; // 0x07A
+        uint8_t pad082[Limits::kMaxStationsPerRide];           // 0x082, Used to be number of peeps in queue in RCT1, but this
                                                                // has moved.
-        uint16_t Vehicles[Limits::kMaxTrainsPerRide];          // 0x086, Points to the first car in the train
-        uint8_t DepartFlags;                                   // 0x0C6
+        uint16_t vehicles[Limits::kMaxTrainsPerRide];          // 0x086, Points to the first car in the train
+        uint8_t departFlags;                                   // 0x0C6
 
         // Not sure if these should be uint or sint.
-        uint8_t NumStations;             // 0x0C7
-        uint8_t NumTrains;               // 0x0C8
-        uint8_t NumCarsPerTrain;         // 0x0C9
-        uint8_t ProposedNumTrains;       // 0x0CA
-        uint8_t ProposedNumCarsPerTrain; // 0x0CB
-        uint8_t MaxTrains;               // 0x0CC
-        uint8_t MinMaxCarsPerTrain;      // 0x0CD
-        uint8_t MinWaitingTime;          // 0x0CE
-        uint8_t MaxWaitingTime;          // 0x0CF
+        uint8_t numStations;             // 0x0C7
+        uint8_t numTrains;               // 0x0C8
+        uint8_t numCarsPerTrain;         // 0x0C9
+        uint8_t proposedNumTrains;       // 0x0CA
+        uint8_t proposedNumCarsPerTrain; // 0x0CB
+        uint8_t maxTrains;               // 0x0CC
+        uint8_t minMaxCarsPerTrain;      // 0x0CD
+        uint8_t minWaitingTime;          // 0x0CE
+        uint8_t maxWaitingTime;          // 0x0CF
         union
         {
-            uint8_t OperationOption; // 0x0D0
-            uint8_t TimeLimit;       // 0x0D0
-            uint8_t NumLaps;         // 0x0D0
-            uint8_t LaunchSpeed;     // 0x0D0
-            uint8_t Speed;           // 0x0D0
-            uint8_t Rotations;       // 0x0D0
+            uint8_t operationOption; // 0x0D0
+            uint8_t timeLimit;       // 0x0D0
+            uint8_t numLaps;         // 0x0D0
+            uint8_t launchSpeed;     // 0x0D0
+            uint8_t speed;           // 0x0D0
+            uint8_t rotations;       // 0x0D0
         };
 
-        uint8_t BoatHireReturnDirection; // 0x0D1
-        RCT12xy8 BoatHireReturnPosition; // 0x0D2
-        uint8_t MeasurementIndex;        // 0x0D4
+        uint8_t boatHireReturnDirection; // 0x0D1
+        RCT12xy8 boatHireReturnPosition; // 0x0D2
+        uint8_t measurementIndex;        // 0x0D4
         // bits 0 through 4 are the number of helix sections
         // bit 5: spinning tunnel, water splash, or rapids
         // bit 6: log reverser, waterfall
         // bit 7: whirlpool
-        uint8_t SpecialTrackElements; // 0x0D5
-        uint8_t Pad0D6[2];            // 0x0D6
+        uint8_t specialTrackElements; // 0x0D5
+        uint8_t pad0D6[2];            // 0x0D6
         // Use ToHumanReadableSpeed if converting to display
-        int32_t MaxSpeed;                            // 0x0D8
-        int32_t AverageSpeed;                        // 0x0DC
-        uint8_t CurrentTestSegment;                  // 0x0E0
-        uint8_t AverageSpeedTestTimeout;             // 0x0E1
-        uint8_t Pad0E2[0x2];                         // 0x0E2
-        int32_t Length[Limits::kMaxStationsPerRide]; // 0x0E4
-        uint16_t Time[Limits::kMaxStationsPerRide];  // 0x0F4
-        fixed16_2dp MaxPositiveVerticalG;            // 0x0FC
-        fixed16_2dp MaxNegativeVerticalG;            // 0x0FE
-        fixed16_2dp MaxLateralG;                     // 0x100
-        fixed16_2dp PreviousVerticalG;               // 0x102
-        fixed16_2dp PreviousLateralG;                // 0x104
-        uint8_t Pad106[0x2];                         // 0x106
-        uint32_t TestingFlags;                       // 0x108
+        int32_t maxSpeed;                            // 0x0D8
+        int32_t averageSpeed;                        // 0x0DC
+        uint8_t currentTestSegment;                  // 0x0E0
+        uint8_t averageSpeedTestTimeout;             // 0x0E1
+        uint8_t pad0E2[0x2];                         // 0x0E2
+        int32_t length[Limits::kMaxStationsPerRide]; // 0x0E4
+        uint16_t time[Limits::kMaxStationsPerRide];  // 0x0F4
+        fixed16_2dp maxPositiveVerticalG;            // 0x0FC
+        fixed16_2dp maxNegativeVerticalG;            // 0x0FE
+        fixed16_2dp maxLateralG;                     // 0x100
+        fixed16_2dp previousVerticalG;               // 0x102
+        fixed16_2dp previousLateralG;                // 0x104
+        uint8_t pad106[0x2];                         // 0x106
+        uint32_t testingFlags;                       // 0x108
         // x y map location of the current track piece during a test
         // this is to prevent counting special tracks multiple times
-        RCT12xy8 CurTestTrackLocation; // 0x10C
+        RCT12xy8 curTestTrackLocation; // 0x10C
         // Next 3 variables are related (XXXX XYYY ZZZa aaaa)
-        uint16_t TurnCountDefault; // 0x10E X = current turn count
-        uint16_t TurnCountBanked;  // 0x110
-        uint16_t TurnCountSloped;  // 0x112 X = number turns > 3 elements
+        uint16_t turnCountDefault; // 0x10E X = current turn count
+        uint16_t turnCountBanked;  // 0x110
+        uint16_t turnCountSloped;  // 0x112 X = number turns > 3 elements
         union
         {
-            uint8_t Inversions; // 0x114 (???X XXXX)
-            uint8_t Holes;      // 0x114 (???X XXXX)
+            uint8_t inversions; // 0x114 (???X XXXX)
+            uint8_t holes;      // 0x114 (???X XXXX)
             // This is a very rough approximation of how much of the ride is undercover.
             // It reaches the maximum value of 7 at about 50% undercover and doesn't increase beyond that.
-            uint8_t ShelteredEighths; // 0x114 (XXX?-????)
+            uint8_t shelteredEighths; // 0x114 (XXX?-????)
         };
         // Y is number of powered lifts, X is drops
-        uint8_t Drops;             // 0x115 (YYXX XXXX)
-        uint8_t StartDropHeight;   // 0x116
-        uint8_t HighestDropHeight; // 0x117
-        int32_t ShelteredLength;   // 0x118
+        uint8_t drops;             // 0x115 (YYXX XXXX)
+        uint8_t startDropHeight;   // 0x116
+        uint8_t highestDropHeight; // 0x117
+        int32_t shelteredLength;   // 0x118
         // Unused always 0? Should affect nausea
-        uint16_t Var11C;              // 0x11C
-        uint8_t NumShelteredSections; // 0x11E (?abY YYYY)
+        uint16_t var11C;              // 0x11C
+        uint8_t numShelteredSections; // 0x11E (?abY YYYY)
         // see CurTestTrackLocation
-        uint8_t CurTestTrackZ; // 0x11F
+        uint8_t curTestTrackZ; // 0x11F
         // Customer counter in the current 960 game tick (about 30 seconds) interval
-        uint16_t CurNumCustomers; // 0x120
+        uint16_t curNumCustomers; // 0x120
         // Counts ticks to update customer intervals, resets each 960 game ticks.
-        uint16_t NumCustomersTimeout; // 0x122
+        uint16_t numCustomersTimeout; // 0x122
         // Customer count in the last 10 * 960 game ticks (sliding window)
-        uint16_t NumCustomers[Limits::kCustomerHistorySize]; // 0x124
-        money16 Price;                                       // 0x138
-        RCT12xy8 ChairliftBullwheelLocation[2];              // 0x13A
-        uint8_t ChairliftBullwheelZ[2];                      // 0x13E
+        uint16_t numCustomers[Limits::kCustomerHistorySize]; // 0x124
+        money16 price;                                       // 0x138
+        RCT12xy8 chairliftBullwheelLocation[2];              // 0x13A
+        uint8_t chairliftBullwheelZ[2];                      // 0x13E
         RatingTuple ratings;                                 // 0x140
-        money16 Value;                                       // 0x146
-        uint16_t ChairliftBullwheelRotation;                 // 0x148
-        uint8_t Satisfaction;                                // 0x14A
-        uint8_t SatisfactionTimeOut;                         // 0x14B
-        uint8_t SatisfactionNext;                            // 0x14C
+        money16 value;                                       // 0x146
+        uint16_t chairliftBullwheelRotation;                 // 0x148
+        uint8_t satisfaction;                                // 0x14A
+        uint8_t satisfactionTimeOut;                         // 0x14B
+        uint8_t satisfactionNext;                            // 0x14C
         // Various flags stating whether a window needs to be refreshed
-        uint8_t WindowInvalidateFlags; // 0x14D
-        uint8_t Pad14E[0x02];          // 0x14E
-        uint32_t TotalCustomers;       // 0x150
-        money32 TotalProfit;           // 0x154
-        uint8_t Popularity;            // 0x158
-        uint8_t PopularityTimeOut;     // 0x159 Updated every purchase and ?possibly by time?
-        uint8_t PopularityNext;        // 0x15A When timeout reached this will be the next popularity
-        uint8_t NumRiders;             // 0x15B
-        uint8_t MusicTuneId;           // 0x15C
-        uint8_t SlideInUse;            // 0x15D
+        uint8_t windowInvalidateFlags; // 0x14D
+        uint8_t pad14E[0x02];          // 0x14E
+        uint32_t totalCustomers;       // 0x150
+        money32 totalProfit;           // 0x154
+        uint8_t popularity;            // 0x158
+        uint8_t popularityTimeOut;     // 0x159 Updated every purchase and ?possibly by time?
+        uint8_t popularityNext;        // 0x15A When timeout reached this will be the next popularity
+        uint8_t numRiders;             // 0x15B
+        uint8_t musicTuneId;           // 0x15C
+        uint8_t slideInUse;            // 0x15D
         union
         {
-            uint16_t SlidePeep; // 0x15E
-            uint16_t MazeTiles; // 0x15E
+            uint16_t slidePeep; // 0x15E
+            uint16_t mazeTiles; // 0x15E
         };
-        uint8_t Pad160[0xE];            // 0x160
-        uint8_t SlidePeepTShirtColour;  // 0x16E
-        uint8_t Pad16F[0x7];            // 0x16F
-        uint8_t SpiralSlideProgress;    // 0x176
-        uint8_t Pad177[0x9];            // 0x177
-        int16_t BuildDate;              // 0x180
-        money16 UpkeepCost;             // 0x182
-        uint16_t RaceWinner;            // 0x184
-        uint8_t Pad186[0x02];           // 0x186
-        uint32_t MusicPosition;         // 0x188
-        uint8_t BreakdownReasonPending; // 0x18C
-        uint8_t MechanicStatus;         // 0x18D
-        uint16_t Mechanic;              // 0x18E
-        uint8_t InspectionStation;      // 0x190
-        uint8_t BrokenVehicle;          // 0x191
-        uint8_t BrokenCar;              // 0x192
-        uint8_t BreakdownReason;        // 0x193
-        money16 PriceSecondary;         // 0x194
+        uint8_t pad160[0xE];            // 0x160
+        uint8_t slidePeepTShirtColour;  // 0x16E
+        uint8_t pad16F[0x7];            // 0x16F
+        uint8_t spiralSlideProgress;    // 0x176
+        uint8_t pad177[0x9];            // 0x177
+        int16_t buildDate;              // 0x180
+        money16 upkeepCost;             // 0x182
+        uint16_t raceWinner;            // 0x184
+        uint8_t pad186[0x02];           // 0x186
+        uint32_t musicPosition;         // 0x188
+        uint8_t breakdownReasonPending; // 0x18C
+        uint8_t mechanicStatus;         // 0x18D
+        uint16_t mechanic;              // 0x18E
+        uint8_t inspectionStation;      // 0x190
+        uint8_t brokenTrain;            // 0x191
+        uint8_t brokenCar;              // 0x192
+        uint8_t breakdownReason;        // 0x193
+        money16 priceSecondary;         // 0x194
         union
         {
             struct
             {
-                uint8_t ReliabilitySubvalue;   // 0x196, 0 - 255, acts like the decimals for reliabilityPercentage
-                uint8_t ReliabilityPercentage; // 0x197, Starts at 100 and decreases from there.
+                uint8_t reliabilitySubvalue;   // 0x196, 0 - 255, acts like the decimals for reliabilityPercentage
+                uint8_t reliabilityPercentage; // 0x197, Starts at 100 and decreases from there.
             };
-            uint16_t Reliability; // 0x196
+            uint16_t reliability; // 0x196
         };
         // Small constant used to increase the unreliability as the game continues,
         // making breakdowns more and more likely.
-        uint8_t UnreliabilityFactor; // 0x198
+        uint8_t unreliabilityFactor; // 0x198
         // Range from [0, 100]
-        uint8_t Downtime;                                      // 0x199
-        uint8_t InspectionInterval;                            // 0x19A
-        uint8_t LastInspection;                                // 0x19B
-        uint8_t DowntimeHistory[Limits::kDowntimeHistorySize]; // 0x19C
-        uint32_t NoPrimaryItemsSold;                           // 0x1A4
-        uint32_t NoSecondaryItemsSold;                         // 0x1A8
-        uint8_t BreakdownSoundModifier;                        // 0x1AC
+        uint8_t downtime;                                      // 0x199
+        uint8_t inspectionInterval;                            // 0x19A
+        uint8_t lastInspection;                                // 0x19B
+        uint8_t downtimeHistory[Limits::kDowntimeHistorySize]; // 0x19C
+        uint32_t numPrimaryItemsSold;                          // 0x1A4
+        uint32_t numSecondaryItemsSold;                        // 0x1A8
+        uint8_t breakdownSoundModifier;                        // 0x1AC
         // Used to oscillate the sound when ride breaks down.
         // 0 = no change, 255 = max change
-        uint8_t NotFixedTimeout;                                    // 0x1AD
-        uint8_t LastCrashType;                                      // 0x1AE
-        uint8_t ConnectedMessageThrottle;                           // 0x1AF
-        money32 IncomePerHour;                                      // 0x1B0
-        money32 Profit;                                             // 0x1B4
-        uint8_t QueueTime[Limits::kMaxStationsPerRide];             // 0x1B8
-        uint8_t TrackColourMain[Limits::kNumColourSchemes];         // 0x1BC
-        uint8_t TrackColourAdditional[Limits::kNumColourSchemes];   // 0x1C0
-        uint8_t TrackColourSupports[Limits::kNumColourSchemes];     // 0x1C4
-        uint8_t Music;                                              // 0x1C8
-        uint8_t EntranceStyle;                                      // 0x1C9
-        uint16_t VehicleChangeTimeout;                              // 0x1CA
-        uint8_t NumBlockBrakes;                                     // 0x1CC
-        uint8_t LiftHillSpeed;                                      // 0x1CD
-        uint16_t GuestsFavourite;                                   // 0x1CE
-        uint32_t LifecycleFlags;                                    // 0x1D0
-        uint8_t VehicleColoursExtended[Limits::kMaxVehicleColours]; // 0x1D4
-        uint16_t TotalAirTime;                                      // 0x1F4
-        uint8_t CurrentTestStation;                                 // 0x1F6
-        uint8_t NumCircuits;                                        // 0x1F7
-        int16_t CableLiftX;                                         // 0x1F8
-        int16_t CableLiftY;                                         // 0x1FA
-        uint8_t CableLiftZ;                                         // 0x1FC
-        uint8_t Pad1FD;                                             // 0x1FD
-        uint16_t CableLift;                                         // 0x1FE
-        uint16_t QueueLength[Limits::kMaxStationsPerRide];          // 0x200
-        uint8_t Pad208[0x58];                                       // 0x208
+        uint8_t notFixedTimeout;                                    // 0x1AD
+        uint8_t lastCrashType;                                      // 0x1AE
+        uint8_t connectedMessageThrottle;                           // 0x1AF
+        money32 incomePerHour;                                      // 0x1B0
+        money32 profit;                                             // 0x1B4
+        uint8_t queueTime[Limits::kMaxStationsPerRide];             // 0x1B8
+        uint8_t trackColourMain[Limits::kNumColourSchemes];         // 0x1BC
+        uint8_t trackColourAdditional[Limits::kNumColourSchemes];   // 0x1C0
+        uint8_t trackColourSupports[Limits::kNumColourSchemes];     // 0x1C4
+        uint8_t music;                                              // 0x1C8
+        uint8_t entranceStyle;                                      // 0x1C9
+        uint16_t vehicleChangeTimeout;                              // 0x1CA
+        uint8_t numBlockBrakes;                                     // 0x1CC
+        uint8_t liftHillSpeed;                                      // 0x1CD
+        uint16_t guestsFavourite;                                   // 0x1CE
+        uint32_t lifecycleFlags;                                    // 0x1D0
+        uint8_t vehicleColoursExtended[Limits::kMaxVehicleColours]; // 0x1D4
+        uint16_t totalAirTime;                                      // 0x1F4
+        uint8_t currentTestStation;                                 // 0x1F6
+        uint8_t numCircuits;                                        // 0x1F7
+        int16_t cableLiftX;                                         // 0x1F8
+        int16_t cableLiftY;                                         // 0x1FA
+        uint8_t cableLiftZ;                                         // 0x1FC
+        uint8_t pad1FD;                                             // 0x1FD
+        uint16_t cableLift;                                         // 0x1FE
+        uint16_t queueLength[Limits::kMaxStationsPerRide];          // 0x200
+        uint8_t pad208[0x58];                                       // 0x208
 
-        uint8_t GetMinCarsPerTrain() const;
-        uint8_t GetMaxCarsPerTrain() const;
+        uint8_t getMinCarsPerTrain() const;
+        uint8_t getMaxCarsPerTrain() const;
     };
     static_assert(sizeof(Ride) == 0x260);
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -644,7 +644,7 @@ namespace OpenRCT2::RCT2
             for (uint8_t index = 0; index < Limits::kMaxRidesInPark; index++)
             {
                 auto src = &_s6.Rides[index];
-                if (src->Type != kRideTypeNull)
+                if (src->type != kRideTypeNull)
                 {
                     const auto rideId = RideId::FromUnderlying(index);
                     auto dst = RideAllocateAtIndex(rideId);
@@ -670,13 +670,13 @@ namespace OpenRCT2::RCT2
             for (uint8_t index = 0; index < Limits::kMaxRidesInPark; index++)
             {
                 auto src = &_s6.Rides[index];
-                if (src->Type == kRideTypeNull)
+                if (src->type == kRideTypeNull)
                     continue;
 
-                auto subtype = RCTEntryIndexToOpenRCT2EntryIndex(src->Subtype);
+                auto subtype = RCTEntryIndexToOpenRCT2EntryIndex(src->subtype);
                 auto* rideEntry = GetRideEntryByIndex(subtype);
                 // If the ride is tracked, we don’t need to check the vehicle any more.
-                if (!GetRideTypeDescriptor(src->Type).HasFlag(RtdFlag::isFlatRide))
+                if (!GetRideTypeDescriptor(src->type).HasFlag(RtdFlag::isFlatRide))
                 {
                     _isFlatRide[index] = false;
                     continue;
@@ -684,7 +684,7 @@ namespace OpenRCT2::RCT2
 
                 // We have established the ride type is a flat ride, which means the vehicle now determines whether it is a
                 // true flat ride (scenario 4) or a tracked ride with an invisibility hack (scenario 2).
-                ObjectEntryIndex originalRideType = src->Type;
+                ObjectEntryIndex originalRideType = src->type;
                 if (rideEntry != nullptr)
                 {
                     originalRideType = rideEntry->GetFirstNonNullRideType();
@@ -706,14 +706,14 @@ namespace OpenRCT2::RCT2
             *dst = {};
             dst->id = rideIndex;
 
-            auto rideType = src->Type;
-            auto subtype = RCTEntryIndexToOpenRCT2EntryIndex(src->Subtype);
-            if (RCT2RideTypeNeedsConversion(src->Type))
+            auto rideType = src->type;
+            auto subtype = RCTEntryIndexToOpenRCT2EntryIndex(src->subtype);
+            if (RCT2RideTypeNeedsConversion(src->type))
             {
                 auto* rideEntry = GetRideEntryByIndex(subtype);
                 if (rideEntry != nullptr)
                 {
-                    rideType = RCT2RideTypeToOpenRCT2RideType(src->Type, *rideEntry);
+                    rideType = RCT2RideTypeToOpenRCT2RideType(src->type, *rideEntry);
                 }
             }
 
@@ -725,35 +725,35 @@ namespace OpenRCT2::RCT2
             dst->type = rideType;
             dst->subtype = subtype;
             // Pad002;
-            dst->mode = static_cast<RideMode>(src->Mode);
+            dst->mode = static_cast<RideMode>(src->mode);
             dst->vehicleColourSettings = src->vehicleColourSettings;
 
             for (uint8_t i = 0; i < Limits::kMaxVehicleColours; i++)
             {
-                dst->vehicleColours[i].Body = src->VehicleColours[i].BodyColour;
-                dst->vehicleColours[i].Trim = src->VehicleColours[i].TrimColour;
+                dst->vehicleColours[i].Body = src->vehicleColours[i].BodyColour;
+                dst->vehicleColours[i].Trim = src->vehicleColours[i].TrimColour;
             }
 
             // Pad046;
-            dst->status = static_cast<RideStatus>(src->Status);
+            dst->status = static_cast<RideStatus>(src->status);
 
-            dst->defaultNameNumber = src->NameArgumentsNumber;
-            if (IsUserStringID(src->Name))
+            dst->defaultNameNumber = src->nameArgumentsNumber;
+            if (IsUserStringID(src->name))
             {
-                dst->customName = GetUserString(src->Name);
+                dst->customName = GetUserString(src->name);
             }
             else
             {
-                dst->defaultNameNumber = src->NameArgumentsNumber;
+                dst->defaultNameNumber = src->nameArgumentsNumber;
             }
 
-            if (src->OverallView.IsNull())
+            if (src->overallView.IsNull())
             {
                 dst->overallView.SetNull();
             }
             else
             {
-                auto tileLoc = TileCoordsXY(src->OverallView.x, src->OverallView.y);
+                auto tileLoc = TileCoordsXY(src->overallView.x, src->overallView.y);
                 dst->overallView = tileLoc.ToCoordsXY();
             }
 
@@ -762,39 +762,39 @@ namespace OpenRCT2::RCT2
                 StationIndex stationIndex = StationIndex::FromUnderlying(i);
                 auto& destStation = dst->getStation(stationIndex);
 
-                if (src->StationStarts[i].IsNull())
+                if (src->stationStarts[i].IsNull())
                 {
                     destStation.Start.SetNull();
                 }
                 else
                 {
-                    auto tileStartLoc = TileCoordsXY(src->StationStarts[i].x, src->StationStarts[i].y);
+                    auto tileStartLoc = TileCoordsXY(src->stationStarts[i].x, src->stationStarts[i].y);
                     destStation.Start = tileStartLoc.ToCoordsXY();
                 }
-                destStation.Height = src->StationHeights[i];
-                destStation.Length = src->StationLength[i];
-                destStation.Depart = src->StationDepart[i];
-                destStation.TrainAtStation = src->TrainAtStation[i];
+                destStation.Height = src->stationHeights[i];
+                destStation.Length = src->stationLength[i];
+                destStation.Depart = src->stationDepart[i];
+                destStation.TrainAtStation = src->trainAtStation[i];
                 // Direction is fixed later.
 
-                if (src->Entrances[i].IsNull())
+                if (src->entrances[i].IsNull())
                     destStation.Entrance.SetNull();
                 else
-                    destStation.Entrance = { src->Entrances[i].x, src->Entrances[i].y, src->StationHeights[i], 0 };
+                    destStation.Entrance = { src->entrances[i].x, src->entrances[i].y, src->stationHeights[i], 0 };
 
-                if (src->Exits[i].IsNull())
+                if (src->exits[i].IsNull())
                     destStation.Exit.SetNull();
                 else
-                    destStation.Exit = { src->Exits[i].x, src->Exits[i].y, src->StationHeights[i], 0 };
+                    destStation.Exit = { src->exits[i].x, src->exits[i].y, src->stationHeights[i], 0 };
 
-                destStation.LastPeepInQueue = EntityId::FromUnderlying(src->LastPeepInQueue[i]);
+                destStation.LastPeepInQueue = EntityId::FromUnderlying(src->lastPeepInQueue[i]);
 
-                destStation.SegmentLength = src->Length[i];
-                destStation.SegmentTime = src->Time[i];
+                destStation.SegmentLength = src->length[i];
+                destStation.SegmentTime = src->time[i];
 
-                destStation.QueueTime = src->QueueTime[i];
+                destStation.QueueTime = src->queueTime[i];
 
-                destStation.QueueLength = src->QueueLength[i];
+                destStation.QueueLength = src->queueLength[i];
             }
             // All other values take 0 as their default. Since they're already memset to that, no need to do it again.
             for (int32_t i = Limits::kMaxStationsPerRide; i < OpenRCT2::Limits::kMaxStationsPerRide; i++)
@@ -811,161 +811,161 @@ namespace OpenRCT2::RCT2
 
             for (int32_t i = 0; i < Limits::kMaxTrainsPerRide; i++)
             {
-                dst->vehicles[i] = EntityId::FromUnderlying(src->Vehicles[i]);
+                dst->vehicles[i] = EntityId::FromUnderlying(src->vehicles[i]);
             }
             for (int32_t i = Limits::kMaxTrainsPerRide - 1; i <= OpenRCT2::Limits::kMaxTrainsPerRide; i++)
             {
                 dst->vehicles[i] = EntityId::GetNull();
             }
 
-            dst->departFlags = src->DepartFlags;
+            dst->departFlags = src->departFlags;
 
-            dst->numStations = src->NumStations;
-            dst->numTrains = src->NumTrains;
-            dst->numCarsPerTrain = src->NumCarsPerTrain;
-            dst->proposedNumTrains = src->ProposedNumTrains;
-            dst->proposedNumCarsPerTrain = src->ProposedNumCarsPerTrain;
-            dst->maxTrains = src->MaxTrains;
-            dst->minCarsPerTrain = src->GetMinCarsPerTrain();
-            dst->maxCarsPerTrain = src->GetMaxCarsPerTrain();
-            dst->minWaitingTime = src->MinWaitingTime;
-            dst->maxWaitingTime = src->MaxWaitingTime;
+            dst->numStations = src->numStations;
+            dst->numTrains = src->numTrains;
+            dst->numCarsPerTrain = src->numCarsPerTrain;
+            dst->proposedNumTrains = src->proposedNumTrains;
+            dst->proposedNumCarsPerTrain = src->proposedNumCarsPerTrain;
+            dst->maxTrains = src->maxTrains;
+            dst->minCarsPerTrain = src->getMinCarsPerTrain();
+            dst->maxCarsPerTrain = src->getMaxCarsPerTrain();
+            dst->minWaitingTime = src->minWaitingTime;
+            dst->maxWaitingTime = src->maxWaitingTime;
 
             // Includes timeLimit, NumLaps, launchSpeed, speed, rotations
-            dst->operationOption = src->OperationOption;
+            dst->operationOption = src->operationOption;
 
-            dst->boatHireReturnDirection = src->BoatHireReturnDirection;
-            dst->boatHireReturnPosition = { src->BoatHireReturnPosition.x, src->BoatHireReturnPosition.y };
+            dst->boatHireReturnDirection = src->boatHireReturnDirection;
+            dst->boatHireReturnPosition = { src->boatHireReturnPosition.x, src->boatHireReturnPosition.y };
 
-            dst->specialTrackElements = src->SpecialTrackElements;
+            dst->specialTrackElements = src->specialTrackElements;
             // Pad0D6[2];
 
-            dst->maxSpeed = src->MaxSpeed;
-            dst->averageSpeed = src->AverageSpeed;
-            dst->currentTestSegment = src->CurrentTestSegment;
-            dst->averageSpeedTestTimeout = src->AverageSpeedTestTimeout;
+            dst->maxSpeed = src->maxSpeed;
+            dst->averageSpeed = src->averageSpeed;
+            dst->currentTestSegment = src->currentTestSegment;
+            dst->averageSpeedTestTimeout = src->averageSpeedTestTimeout;
             // Pad0E2[0x2];
 
-            dst->maxPositiveVerticalG = src->MaxPositiveVerticalG;
-            dst->maxNegativeVerticalG = src->MaxNegativeVerticalG;
-            dst->maxLateralG = src->MaxLateralG;
-            dst->previousVerticalG = src->PreviousVerticalG;
-            dst->previousLateralG = src->PreviousLateralG;
+            dst->maxPositiveVerticalG = src->maxPositiveVerticalG;
+            dst->maxNegativeVerticalG = src->maxNegativeVerticalG;
+            dst->maxLateralG = src->maxLateralG;
+            dst->previousVerticalG = src->previousVerticalG;
+            dst->previousLateralG = src->previousLateralG;
             // Pad106[0x2];
-            dst->testingFlags = src->TestingFlags;
+            dst->testingFlags = src->testingFlags;
 
-            if (src->CurTestTrackLocation.IsNull())
+            if (src->curTestTrackLocation.IsNull())
             {
                 dst->curTestTrackLocation.SetNull();
             }
             else
             {
-                dst->curTestTrackLocation = { src->CurTestTrackLocation.x, src->CurTestTrackLocation.y, src->CurTestTrackZ };
+                dst->curTestTrackLocation = { src->curTestTrackLocation.x, src->curTestTrackLocation.y, src->curTestTrackZ };
             }
 
-            dst->turnCountDefault = src->TurnCountDefault;
-            dst->turnCountBanked = src->TurnCountBanked;
-            dst->turnCountSloped = src->TurnCountSloped;
-            if (src->Type == RIDE_TYPE_MINI_GOLF)
-                dst->holes = src->Inversions & kRCT12InversionAndHoleMask;
+            dst->turnCountDefault = src->turnCountDefault;
+            dst->turnCountBanked = src->turnCountBanked;
+            dst->turnCountSloped = src->turnCountSloped;
+            if (src->type == RIDE_TYPE_MINI_GOLF)
+                dst->holes = src->inversions & kRCT12InversionAndHoleMask;
             else
-                dst->inversions = src->Inversions & kRCT12InversionAndHoleMask;
-            dst->shelteredEighths = src->Inversions >> 5;
-            dst->dropsPoweredLifts = src->Drops;
-            dst->startDropHeight = src->StartDropHeight;
-            dst->highestDropHeight = src->HighestDropHeight;
-            dst->shelteredLength = src->ShelteredLength;
-            dst->var11C = src->Var11C;
-            dst->numShelteredSections = src->NumShelteredSections;
+                dst->inversions = src->inversions & kRCT12InversionAndHoleMask;
+            dst->shelteredEighths = src->inversions >> 5;
+            dst->dropsPoweredLifts = src->drops;
+            dst->startDropHeight = src->startDropHeight;
+            dst->highestDropHeight = src->highestDropHeight;
+            dst->shelteredLength = src->shelteredLength;
+            dst->var11C = src->var11C;
+            dst->numShelteredSections = src->numShelteredSections;
 
-            dst->curNumCustomers = src->CurNumCustomers;
-            dst->numCustomersTimeout = src->NumCustomersTimeout;
+            dst->curNumCustomers = src->curNumCustomers;
+            dst->numCustomersTimeout = src->numCustomersTimeout;
 
             for (uint8_t i = 0; i < Limits::kCustomerHistorySize; i++)
             {
-                dst->numCustomers[i] = src->NumCustomers[i];
+                dst->numCustomers[i] = src->numCustomers[i];
             }
 
-            dst->price[0] = src->Price;
+            dst->price[0] = src->price;
 
             for (uint8_t i = 0; i < 2; i++)
             {
-                dst->chairliftBullwheelLocation[i] = { src->ChairliftBullwheelLocation[i].x,
-                                                       src->ChairliftBullwheelLocation[i].y, src->ChairliftBullwheelZ[i] };
+                dst->chairliftBullwheelLocation[i] = { src->chairliftBullwheelLocation[i].x,
+                                                       src->chairliftBullwheelLocation[i].y, src->chairliftBullwheelZ[i] };
             }
 
             dst->ratings = src->ratings;
-            dst->value = ToMoney64(src->Value);
+            dst->value = ToMoney64(src->value);
 
-            dst->chairliftBullwheelRotation = src->ChairliftBullwheelRotation;
+            dst->chairliftBullwheelRotation = src->chairliftBullwheelRotation;
 
-            dst->satisfaction = src->Satisfaction;
-            dst->satisfactionTimeout = src->SatisfactionTimeOut;
-            dst->satisfactionNext = src->SatisfactionNext;
+            dst->satisfaction = src->satisfaction;
+            dst->satisfactionTimeout = src->satisfactionTimeOut;
+            dst->satisfactionNext = src->satisfactionNext;
 
-            dst->windowInvalidateFlags = src->WindowInvalidateFlags;
+            dst->windowInvalidateFlags = src->windowInvalidateFlags;
             // Pad14E[0x02];
 
-            dst->totalCustomers = src->TotalCustomers;
-            dst->totalProfit = ToMoney64(src->TotalProfit);
-            dst->popularity = src->Popularity;
-            dst->popularityTimeout = src->PopularityTimeOut;
-            dst->popularityNext = src->PopularityNext;
+            dst->totalCustomers = src->totalCustomers;
+            dst->totalProfit = ToMoney64(src->totalProfit);
+            dst->popularity = src->popularity;
+            dst->popularityTimeout = src->popularityTimeOut;
+            dst->popularityNext = src->popularityNext;
 
             ImportNumRiders(dst, rideIndex);
 
-            dst->musicTuneId = src->MusicTuneId;
-            dst->slideInUse = src->SlideInUse;
+            dst->musicTuneId = src->musicTuneId;
+            dst->slideInUse = src->slideInUse;
             // Includes mazeTiles
-            dst->slidePeep = EntityId::FromUnderlying(src->SlidePeep);
+            dst->slidePeep = EntityId::FromUnderlying(src->slidePeep);
             // Pad160[0xE];
-            dst->slidePeepTShirtColour = src->SlidePeepTShirtColour;
+            dst->slidePeepTShirtColour = src->slidePeepTShirtColour;
             // Pad16F[0x7];
-            dst->spiralSlideProgress = src->SpiralSlideProgress;
+            dst->spiralSlideProgress = src->spiralSlideProgress;
             // Pad177[0x9];
-            dst->buildDate = static_cast<int32_t>(src->BuildDate);
-            dst->upkeepCost = ToMoney64(src->UpkeepCost);
-            dst->raceWinner = EntityId::FromUnderlying(src->RaceWinner);
+            dst->buildDate = static_cast<int32_t>(src->buildDate);
+            dst->upkeepCost = ToMoney64(src->upkeepCost);
+            dst->raceWinner = EntityId::FromUnderlying(src->raceWinner);
             // Pad186[0x02];
-            dst->musicPosition = src->MusicPosition;
+            dst->musicPosition = src->musicPosition;
 
-            dst->breakdownReasonPending = src->BreakdownReasonPending;
-            dst->mechanicStatus = src->MechanicStatus;
-            dst->mechanic = EntityId::FromUnderlying(src->Mechanic);
-            dst->inspectionStation = StationIndex::FromUnderlying(src->InspectionStation);
-            dst->brokenTrain = src->BrokenVehicle;
-            dst->brokenCar = src->BrokenCar;
-            dst->breakdownReason = src->BreakdownReason;
+            dst->breakdownReasonPending = src->breakdownReasonPending;
+            dst->mechanicStatus = src->mechanicStatus;
+            dst->mechanic = EntityId::FromUnderlying(src->mechanic);
+            dst->inspectionStation = StationIndex::FromUnderlying(src->inspectionStation);
+            dst->brokenTrain = src->brokenTrain;
+            dst->brokenCar = src->brokenCar;
+            dst->breakdownReason = src->breakdownReason;
 
-            dst->price[1] = src->PriceSecondary;
+            dst->price[1] = src->priceSecondary;
 
-            dst->reliability = src->Reliability;
-            dst->unreliabilityFactor = src->UnreliabilityFactor;
-            dst->downtime = src->Downtime;
-            dst->inspectionInterval = src->InspectionInterval;
-            dst->lastInspection = src->LastInspection;
+            dst->reliability = src->reliability;
+            dst->unreliabilityFactor = src->unreliabilityFactor;
+            dst->downtime = src->downtime;
+            dst->inspectionInterval = src->inspectionInterval;
+            dst->lastInspection = src->lastInspection;
 
             for (uint8_t i = 0; i < Limits::kDowntimeHistorySize; i++)
             {
-                dst->downtimeHistory[i] = src->DowntimeHistory[i];
+                dst->downtimeHistory[i] = src->downtimeHistory[i];
             }
 
-            dst->numPrimaryItemsSold = src->NoPrimaryItemsSold;
-            dst->numSecondaryItemsSold = src->NoSecondaryItemsSold;
+            dst->numPrimaryItemsSold = src->numPrimaryItemsSold;
+            dst->numSecondaryItemsSold = src->numSecondaryItemsSold;
 
-            dst->breakdownSoundModifier = src->BreakdownSoundModifier;
-            dst->notFixedTimeout = src->NotFixedTimeout;
-            dst->lastCrashType = src->LastCrashType;
-            dst->connectedMessageThrottle = src->ConnectedMessageThrottle;
+            dst->breakdownSoundModifier = src->breakdownSoundModifier;
+            dst->notFixedTimeout = src->notFixedTimeout;
+            dst->lastCrashType = src->lastCrashType;
+            dst->connectedMessageThrottle = src->connectedMessageThrottle;
 
-            dst->incomePerHour = ToMoney64(src->IncomePerHour);
-            dst->profit = ToMoney64(src->Profit);
+            dst->incomePerHour = ToMoney64(src->incomePerHour);
+            dst->profit = ToMoney64(src->profit);
 
             for (uint8_t i = 0; i < Limits::kNumColourSchemes; i++)
             {
-                dst->trackColours[i].main = src->TrackColourMain[i];
-                dst->trackColours[i].additional = src->TrackColourAdditional[i];
-                dst->trackColours[i].supports = src->TrackColourSupports[i];
+                dst->trackColours[i].main = src->trackColourMain[i];
+                dst->trackColours[i].additional = src->trackColourAdditional[i];
+                dst->trackColours[i].supports = src->trackColourSupports[i];
             }
             // This stall was not colourable in RCT2.
             if (dst->type == RIDE_TYPE_FOOD_STALL)
@@ -980,7 +980,7 @@ namespace OpenRCT2::RCT2
             auto musicStyle = kObjectEntryIndexNull;
             if (GetRideTypeDescriptor(dst->type).HasFlag(RtdFlag::allowMusic))
             {
-                musicStyle = src->Music;
+                musicStyle = src->music;
             }
             dst->music = musicStyle;
 
@@ -988,27 +988,27 @@ namespace OpenRCT2::RCT2
             auto entranceStyle = kObjectEntryIndexNull;
             if (!_isSV7 && GetRideTypeDescriptor(dst->type).HasFlag(RtdFlag::hasEntranceAndExit))
             {
-                entranceStyle = src->EntranceStyle;
+                entranceStyle = src->entranceStyle;
             }
             dst->entranceStyle = entranceStyle;
 
-            dst->vehicleChangeTimeout = src->VehicleChangeTimeout;
-            dst->numBlockBrakes = src->NumBlockBrakes;
-            dst->liftHillSpeed = src->LiftHillSpeed;
-            dst->guestsFavourite = src->GuestsFavourite;
-            dst->lifecycleFlags = src->LifecycleFlags;
+            dst->vehicleChangeTimeout = src->vehicleChangeTimeout;
+            dst->numBlockBrakes = src->numBlockBrakes;
+            dst->liftHillSpeed = src->liftHillSpeed;
+            dst->guestsFavourite = src->guestsFavourite;
+            dst->lifecycleFlags = src->lifecycleFlags;
 
             for (uint8_t i = 0; i < Limits::kMaxTrainsPerRide; i++)
             {
-                dst->vehicleColours[i].Tertiary = src->VehicleColoursExtended[i];
+                dst->vehicleColours[i].Tertiary = src->vehicleColoursExtended[i];
             }
 
-            dst->totalAirTime = src->TotalAirTime;
-            dst->currentTestStation = StationIndex::FromUnderlying(src->CurrentTestStation);
-            dst->numCircuits = src->NumCircuits;
-            dst->cableLiftLoc = { src->CableLiftX, src->CableLiftY, src->CableLiftZ * kCoordsZStep };
+            dst->totalAirTime = src->totalAirTime;
+            dst->currentTestStation = StationIndex::FromUnderlying(src->currentTestStation);
+            dst->numCircuits = src->numCircuits;
+            dst->cableLiftLoc = { src->cableLiftX, src->cableLiftY, src->cableLiftZ * kCoordsZStep };
             // Pad1FD;
-            dst->cableLift = EntityId::FromUnderlying(src->CableLift);
+            dst->cableLift = EntityId::FromUnderlying(src->cableLift);
 
             // Pad208[0x58];
         }
@@ -1025,10 +1025,10 @@ namespace OpenRCT2::RCT2
             dst.ProximityStart = { src.ProximityStartX, src.ProximityStartY, src.ProximityStartZ };
             dst.CurrentRide = RCT12RideIdToOpenRCT2RideId(src.CurrentRide);
             dst.State = src.State;
-            if (src.CurrentRide < Limits::kMaxRidesInPark && _s6.Rides[src.CurrentRide].Type < std::size(kRideTypeDescriptors))
+            if (src.CurrentRide < Limits::kMaxRidesInPark && _s6.Rides[src.CurrentRide].type < std::size(kRideTypeDescriptors))
             {
                 dst.ProximityTrackType = RCT2TrackTypeToOpenRCT2(
-                    src.ProximityTrackType, _s6.Rides[src.CurrentRide].Type, IsFlatRide(src.CurrentRide));
+                    src.ProximityTrackType, _s6.Rides[src.CurrentRide].type, IsFlatRide(src.CurrentRide));
             }
             else
             {
@@ -1351,7 +1351,7 @@ namespace OpenRCT2::RCT2
                     auto dst2 = dst->AsTrack();
                     auto src2 = src->AsTrack();
 
-                    auto rideType = _s6.Rides[src2->GetRideIndex()].Type;
+                    auto rideType = _s6.Rides[src2->GetRideIndex()].type;
                     auto oldTrackType = src2->GetTrackType();
                     OpenRCT2::TrackElemType trackType = RCT2TrackTypeToOpenRCT2(
                         oldTrackType, rideType, IsFlatRide(src2->GetRideIndex()));
@@ -1940,7 +1940,7 @@ namespace OpenRCT2::RCT2
         dst->colours.Tertiary = src->ColoursExtended;
         dst->track_progress = src->TrackProgress;
         dst->TrackLocation = { src->TrackX, src->TrackY, src->TrackZ };
-        if (src->BoatLocation.IsNull() || static_cast<RideMode>(ride.Mode) != RideMode::boatHire
+        if (src->BoatLocation.IsNull() || static_cast<RideMode>(ride.mode) != RideMode::boatHire
             || src->Status != static_cast<uint8_t>(::Vehicle::Status::TravellingBoat))
         {
             dst->BoatLocation.SetNull();


### PR DESCRIPTION
Bringing them in line with the OpenRCT2 Ride struct. Thankfully (though predictably) much less intrusive than the former.