### PR TITLE
Fix #23985: Crash when opening New Ride menu

### DIFF
--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -281,9 +281,9 @@ namespace OpenRCT2::Ui::Windows
         RideSelection _windowNewRideListItems[RideListItemsMax]{};
         struct NewRideVariables
         {
-            RideSelection SelectedRide;
-            RideSelection HighlightedRide;
-            uint16_t SelectedRideCountdown;
+            RideSelection SelectedRide{};
+            RideSelection HighlightedRide{};
+            uint16_t SelectedRideCountdown{};
         } _newRideVars{};
 
     public:

--- a/src/openrct2/ride/RideEntry.h
+++ b/src/openrct2/ride/RideEntry.h
@@ -20,7 +20,6 @@
 
 // Set to 255 on all tracked ride entries
 static uint8_t constexpr kNoFlatRideCars = 0xFF;
-static ride_type_t constexpr kRideTypeNull = 0xFF;
 
 struct RideNaming
 {

--- a/src/openrct2/ride/RideTypes.h
+++ b/src/openrct2/ride/RideTypes.h
@@ -19,14 +19,15 @@
 struct Ride;
 
 using ride_type_t = uint16_t;
+static ride_type_t constexpr kRideTypeNull = 0xFF;
 
 /**
  * Couples a ride type and subtype together.
  */
 struct RideSelection
 {
-    ride_type_t Type;
-    ObjectEntryIndex EntryIndex;
+    ride_type_t Type = kRideTypeNull;
+    ObjectEntryIndex EntryIndex = kObjectEntryIndexNull;
 
     bool operator==(const RideSelection& other) const
     {


### PR DESCRIPTION
SetPage re-initialises `SelectedRide` and `HighlightedRide`. It turns out that these variables, as well as the `RideSelection` struct they use, were never properly default-initialised.