### PR TITLE
Fix #23983: Ordering files by size not working and potentially crashing

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -18,6 +18,7 @@
 - Fix: [#23941] Underflow in “Repay loan and achieve a certain park value” objective when using Japanese.
 - Fix: [#23949] Walls draw over sloped rear water edges and those edge sprites are misaligned (original bug).
 - Fix: [#23960] Corner path fences can draw over adjacent sloped land (original bug).
+- Fix: [#23983] Ordering files by size not working and also potentially crashing the game.
 
 0.4.20 (2025-02-25)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/interface/FileBrowser.cpp
+++ b/src/openrct2-ui/interface/FileBrowser.cpp
@@ -74,9 +74,9 @@ namespace OpenRCT2::Ui::FileBrowser
             case FileBrowserSort::DateAscending:
                 return difftime(a.dateModified, b.dateModified) < 0;
             case FileBrowserSort::SizeDescending:
-                return a.fileSizeBytes - b.fileSizeBytes;
+                return a.fileSizeBytes > b.fileSizeBytes;
             case FileBrowserSort::SizeAscending:
-                return b.fileSizeBytes - a.fileSizeBytes;
+                return a.fileSizeBytes < b.fileSizeBytes;
         }
         return String::logicalCmp(a.name.c_str(), b.name.c_str()) < 0;
     }


### PR DESCRIPTION
Close #23983