### PR TITLE
Fix offset type B metal supports, refactor type A and B metal support paint functions in to single function

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Improved: [#24921] The command line sprite build command now prints out the images table entry for the compiled sprite file.
 - Improved: [#24953] Opening the Scenario Editor, Track Designer or Track Designs Manager now display the progress bar.
 - Fix: [#16988] AppImage version does not show changelog.
+- Fix: [#24001] Sloped diagonal metal supports that are offset with a crossbeam draw incorrectly.
 - Fix: [#24173] Allow all game speeds between 1 and 8 if developer mode is on.
 - Fix: [#24745] Potential crash when lighting effects are enabled and loading a save or a new scenario.
 - Fix: [#24915] LIM Launched (original bug), Corkscrew and Twister Roller Coaster inline twists have some incorrect tunnels.

--- a/src/openrct2/paint/support/MetalSupports.cpp
+++ b/src/openrct2/paint/support/MetalSupports.cpp
@@ -282,25 +282,25 @@ constexpr MetalSupportGraphic kMetalSupportGraphicRotated[kMetalSupportTypeCount
 };
 
 static bool MetalASupportsPaintSetup(
-    PaintSession& session, MetalSupportGraphic supportTypeMember, MetalSupportPlace placement, int32_t special, int32_t height,
-    ImageId imageTemplate);
+    PaintSession& session, MetalSupportGraphic supportTypeMember, MetalSupportPlace placement, int32_t heightExtra,
+    int32_t height, ImageId imageTemplate);
 static bool MetalBSupportsPaintSetup(
-    PaintSession& session, MetalSupportGraphic supportTypeMember, MetalSupportPlace placement, int32_t special, int32_t height,
-    ImageId imageTemplate);
+    PaintSession& session, MetalSupportGraphic supportTypeMember, MetalSupportPlace placement, int32_t heightExtra,
+    int32_t height, ImageId imageTemplate);
 static inline MetalSupportGraphic RotateMetalSupportGraphic(MetalSupportType supportType, Direction direction);
 
 /**
  * Metal pole supports
  * @param supportType (edi)
  * @param segment (ebx)
- * @param special (ax)
+ * @param heightExtra (ax)
  * @param height (edx)
  * @param imageTemplate (ebp)
  *  rct2: 0x00663105
  */
 static bool MetalASupportsPaintSetup(
-    PaintSession& session, MetalSupportGraphic supportTypeMember, MetalSupportPlace placement, int32_t special, int32_t height,
-    ImageId imageTemplate)
+    PaintSession& session, MetalSupportGraphic supportTypeMember, MetalSupportPlace placement, int32_t heightExtra,
+    int32_t height, ImageId imageTemplate)
 {
     if (!(session.Flags & PaintSessionFlags::PassedSurface))
     {
@@ -444,17 +444,17 @@ static bool MetalASupportsPaintSetup(
 
     height = originalHeight;
     segment = originalSegment;
-    if (special == 0)
+    if (heightExtra == 0)
         return true;
 
-    if (special < 0)
+    if (heightExtra < 0)
     {
-        special = -special;
+        heightExtra = -heightExtra;
         height--;
     }
 
     CoordsXYZ boundBoxOffset = CoordsXYZ(kMetalSupportBoundBoxOffsets[segment], height);
-    const auto combinedHeight = height + special;
+    const auto combinedHeight = height + heightExtra;
 
     while (1)
     {
@@ -484,20 +484,20 @@ static bool MetalASupportsPaintSetup(
 }
 
 bool MetalASupportsPaintSetup(
-    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, int32_t special, int32_t height,
+    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, int32_t heightExtra, int32_t height,
     ImageId imageTemplate)
 {
     auto supportGraphic = RotateMetalSupportGraphic(supportType, 0);
-    return MetalASupportsPaintSetup(session, supportGraphic, placement, special, height, imageTemplate);
+    return MetalASupportsPaintSetup(session, supportGraphic, placement, heightExtra, height, imageTemplate);
 }
 
 bool MetalASupportsPaintSetupRotated(
-    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, Direction direction, int32_t special,
+    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, Direction direction, int32_t heightExtra,
     int32_t height, ImageId imageTemplate)
 {
     auto supportGraphic = RotateMetalSupportGraphic(supportType, direction);
     placement = kMetalSupportPlacementRotated[EnumValue(placement)][direction];
-    return MetalASupportsPaintSetup(session, supportGraphic, placement, special, height, imageTemplate);
+    return MetalASupportsPaintSetup(session, supportGraphic, placement, heightExtra, height, imageTemplate);
 }
 
 /**
@@ -506,15 +506,15 @@ bool MetalASupportsPaintSetupRotated(
  *
  * @param supportType (edi)
  * @param segment (ebx)
- * @param special (ax)
+ * @param heightExtra (ax)
  * @param height (edx)
  * @param imageTemplate (ebp)
  *
  * @return (Carry Flag)
  */
 static bool MetalBSupportsPaintSetup(
-    PaintSession& session, MetalSupportGraphic supportTypeMember, MetalSupportPlace placement, int32_t special, int32_t height,
-    ImageId imageTemplate)
+    PaintSession& session, MetalSupportGraphic supportTypeMember, MetalSupportPlace placement, int32_t heightExtra,
+    int32_t height, ImageId imageTemplate)
 {
     if (!(session.Flags & PaintSessionFlags::PassedSurface))
     {
@@ -656,10 +656,10 @@ static bool MetalBSupportsPaintSetup(
     supportSegments[segment].height = unk9E3294;
     supportSegments[segment].slope = kTileSlopeAboveTrackOrScenery;
 
-    if (special != 0)
+    if (heightExtra != 0)
     {
         baseHeight = height;
-        const auto si2 = height + special;
+        const auto si2 = height + heightExtra;
         while (true)
         {
             endHeight = baseHeight + 16;
@@ -686,20 +686,20 @@ static bool MetalBSupportsPaintSetup(
 }
 
 bool MetalBSupportsPaintSetup(
-    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, int32_t special, int32_t height,
+    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, int32_t heightExtra, int32_t height,
     ImageId imageTemplate)
 {
     auto supportGraphic = RotateMetalSupportGraphic(supportType, 0);
-    return MetalBSupportsPaintSetup(session, supportGraphic, placement, special, height, imageTemplate);
+    return MetalBSupportsPaintSetup(session, supportGraphic, placement, heightExtra, height, imageTemplate);
 }
 
 bool MetalBSupportsPaintSetupRotated(
-    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, Direction direction, int32_t special,
+    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, Direction direction, int32_t heightExtra,
     int32_t height, ImageId imageTemplate)
 {
     auto supportGraphic = RotateMetalSupportGraphic(supportType, direction);
     placement = kMetalSupportPlacementRotated[EnumValue(placement)][direction];
-    return MetalBSupportsPaintSetup(session, supportGraphic, placement, special, height, imageTemplate);
+    return MetalBSupportsPaintSetup(session, supportGraphic, placement, heightExtra, height, imageTemplate);
 }
 
 static inline MetalSupportGraphic RotateMetalSupportGraphic(MetalSupportType supportType, Direction direction)
@@ -709,19 +709,20 @@ static inline MetalSupportGraphic RotateMetalSupportGraphic(MetalSupportType sup
 }
 
 void DrawSupportsSideBySide(
-    PaintSession& session, Direction direction, uint16_t height, ImageId colour, MetalSupportType supportType, int32_t special)
+    PaintSession& session, Direction direction, uint16_t height, ImageId colour, MetalSupportType supportType,
+    int32_t heightExtra)
 {
     auto graphic = RotateMetalSupportGraphic(supportType, direction);
 
     if (direction & 1)
     {
-        MetalASupportsPaintSetup(session, graphic, MetalSupportPlace::topRightSide, special, height, colour);
-        MetalASupportsPaintSetup(session, graphic, MetalSupportPlace::bottomLeftSide, special, height, colour);
+        MetalASupportsPaintSetup(session, graphic, MetalSupportPlace::topRightSide, heightExtra, height, colour);
+        MetalASupportsPaintSetup(session, graphic, MetalSupportPlace::bottomLeftSide, heightExtra, height, colour);
     }
     else
     {
-        MetalASupportsPaintSetup(session, graphic, MetalSupportPlace::topLeftSide, special, height, colour);
-        MetalASupportsPaintSetup(session, graphic, MetalSupportPlace::bottomRightSide, special, height, colour);
+        MetalASupportsPaintSetup(session, graphic, MetalSupportPlace::topLeftSide, heightExtra, height, colour);
+        MetalASupportsPaintSetup(session, graphic, MetalSupportPlace::bottomRightSide, heightExtra, height, colour);
     }
 }
 
@@ -730,7 +731,7 @@ void DrawSupportsSideBySide(
  *  rct2: 0x006A326B
  *
  * @param segment (ebx)
- * @param special (ax)
+ * @param heightExtra (ax)
  * @param height (dx)
  * @param imageTemplate (ebp)
  * @param railingsDescriptor (0x00F3EF6C)

--- a/src/openrct2/paint/support/MetalSupports.cpp
+++ b/src/openrct2/paint/support/MetalSupports.cpp
@@ -385,31 +385,18 @@ static bool MetalASupportsPaintSetup(
         currentHeight = supportSegments[segment].height + 6;
     }
 
-    // Work out if a small support segment required to bring support to normal
-    // size (aka floor2(x, 16))
-    int16_t heightDiff = floor2(currentHeight + 16, 16);
-    if (heightDiff > crossbeamHeight)
-    {
-        heightDiff = crossbeamHeight;
-    }
+    const auto supportBeamImageIndex = kSupportBasesAndBeams[supportType].beamUncapped;
 
-    heightDiff -= currentHeight;
-
+    // Draw an initial support segment to get the main segment height to a multiple of 16
+    const int16_t heightDiff = std::min<int16_t>(floor2(currentHeight + 16, 16), crossbeamHeight) - currentHeight;
     if (heightDiff > 0)
     {
-        int8_t xOffset = kMetalSupportBoundBoxOffsets[segment].x;
-        int8_t yOffset = kMetalSupportBoundBoxOffsets[segment].y;
-
-        uint32_t imageIndex = kSupportBasesAndBeams[supportType].beamUncapped;
-        imageIndex += heightDiff - 1;
-        auto image_id = imageTemplate.WithIndex(imageIndex);
-
-        PaintAddImageAsParent(session, image_id, { xOffset, yOffset, currentHeight }, { 0, 0, heightDiff - 1 });
+        PaintAddImageAsParent(
+            session, imageTemplate.WithIndex(supportBeamImageIndex + heightDiff - 1),
+            { kMetalSupportBoundBoxOffsets[segment], currentHeight }, { 0, 0, heightDiff - 1 });
     }
 
     currentHeight += heightDiff;
-
-    const auto supportBeamImageIndex = kSupportBasesAndBeams[supportType].beamUncapped;
 
     // Draw main support segments
     for (uint8_t count = 1;; count++)
@@ -570,23 +557,18 @@ static bool MetalBSupportsPaintSetup(
         currentHeight = supportSegments[segment].height + 6;
     }
 
-    int16_t heightDiff = floor2(currentHeight + 16, 16);
-    if (heightDiff > crossbeamHeight)
-    {
-        heightDiff = crossbeamHeight;
-    }
+    const auto supportBeamImageIndex = kSupportBasesAndBeams[supportType].beamUncapped;
 
-    heightDiff -= currentHeight;
+    // Draw an initial support segment to get the main segment height to a multiple of 16
+    const int16_t heightDiff = std::min<int16_t>(floor2(currentHeight + 16, 16), crossbeamHeight) - currentHeight;
     if (heightDiff > 0)
     {
         PaintAddImageAsParent(
-            session, imageTemplate.WithIndex(kSupportBasesAndBeams[supportType].beamUncapped + (heightDiff - 1)),
+            session, imageTemplate.WithIndex(supportBeamImageIndex + heightDiff - 1),
             { kMetalSupportBoundBoxOffsets[segment], currentHeight }, { 0, 0, heightDiff - 1 });
     }
 
     currentHeight += heightDiff;
-
-    const auto supportBeamImageIndex = kSupportBasesAndBeams[supportType].beamUncapped;
 
     // Draw main support segments
     for (uint8_t count = 1;; count++)

--- a/src/openrct2/paint/support/MetalSupports.cpp
+++ b/src/openrct2/paint/support/MetalSupports.cpp
@@ -284,6 +284,7 @@ constexpr MetalSupportGraphic kMetalSupportGraphicRotated[kMetalSupportTypeCount
 constexpr const int32_t kMetalSupportBaseHeight = 6;
 constexpr const int32_t kMetalSupportMaxSectionHeight = 16;
 constexpr const int32_t kMetalSupportJointInterval = 4;
+constexpr const int32_t kMetalSupportCrossbeamTwoSegmentOffsetIndex = 4;
 
 static inline MetalSupportGraphic RotateMetalSupportGraphic(MetalSupportType supportType, Direction direction);
 
@@ -347,7 +348,7 @@ static bool MetalSupportsPaintSetupCommon(
         const uint8_t crossBeamIndex = kMetalSupportSegmentOffsets[baseIndex + segment * 8 + 1];
         if constexpr (typeB)
         {
-            if (crossBeamIndex >= 4)
+            if (crossBeamIndex >= kMetalSupportCrossbeamTwoSegmentOffsetIndex)
                 return false;
         }
 

--- a/src/openrct2/paint/support/MetalSupports.cpp
+++ b/src/openrct2/paint/support/MetalSupports.cpp
@@ -322,10 +322,10 @@ static bool MetalASupportsPaintSetup(
     int16_t originalHeight = height;
     const auto originalSegment = segment;
 
-    uint16_t unk9E3294 = 0xFFFF;
+    uint16_t segmentHeight = 0xFFFF;
     if (height < supportSegments[segment].height)
     {
-        unk9E3294 = height;
+        segmentHeight = height;
 
         height -= kMetalSupportTypeToHeight[supportType];
         if (height < 0)
@@ -439,7 +439,7 @@ static bool MetalASupportsPaintSetup(
         height += beamLength;
     }
 
-    supportSegments[segment].height = unk9E3294;
+    supportSegments[segment].height = segmentHeight;
     supportSegments[segment].slope = kTileSlopeAboveTrackOrScenery;
 
     height = originalHeight;
@@ -533,12 +533,12 @@ static bool MetalBSupportsPaintSetup(
     const uint8_t segment = EnumValue(placement);
     auto supportType = EnumValue(supportTypeMember);
     SupportHeight* supportSegments = session.SupportSegments;
-    uint16_t unk9E3294 = 0xFFFF;
+    uint16_t segmentHeight = 0xFFFF;
     int32_t baseHeight = height;
 
     if (height < supportSegments[segment].height)
     {
-        unk9E3294 = height;
+        segmentHeight = height;
 
         baseHeight -= kMetalSupportTypeToHeight[supportType];
         if (baseHeight < 0)
@@ -653,7 +653,7 @@ static bool MetalBSupportsPaintSetup(
         i++;
     }
 
-    supportSegments[segment].height = unk9E3294;
+    supportSegments[segment].height = segmentHeight;
     supportSegments[segment].slope = kTileSlopeAboveTrackOrScenery;
 
     if (heightExtra != 0)

--- a/src/openrct2/paint/support/MetalSupports.cpp
+++ b/src/openrct2/paint/support/MetalSupports.cpp
@@ -408,34 +408,23 @@ static bool MetalASupportsPaintSetup(
     }
 
     currentHeight += heightDiff;
-    // 6632e6
 
-    for (uint8_t count = 0;; count++)
+    const auto supportBeamImageIndex = kSupportBasesAndBeams[supportType].beamUncapped;
+
+    // Draw main support segments
+    for (uint8_t count = 1;; count++)
     {
-        if (count >= 4)
-            count = 0;
-
-        int16_t beamLength = currentHeight + 16;
-        if (beamLength > crossbeamHeight)
-        {
-            beamLength = crossbeamHeight;
-        }
-
-        beamLength -= currentHeight;
+        const int16_t beamLength = std::min<int16_t>(currentHeight + 16, crossbeamHeight) - currentHeight;
         if (beamLength <= 0)
             break;
 
-        int8_t xOffset = kMetalSupportBoundBoxOffsets[segment].x;
-        int8_t yOffset = kMetalSupportBoundBoxOffsets[segment].y;
-
-        uint32_t imageIndex = kSupportBasesAndBeams[supportType].beamUncapped;
-        imageIndex += beamLength - 1;
-
-        if (count == 3 && beamLength == 0x10)
+        uint32_t imageIndex = supportBeamImageIndex + beamLength - 1;
+        if (count % 4 == 0 && beamLength == 16)
             imageIndex++;
 
-        auto image_id = imageTemplate.WithIndex(imageIndex);
-        PaintAddImageAsParent(session, image_id, { xOffset, yOffset, currentHeight }, { 0, 0, beamLength - 1 });
+        PaintAddImageAsParent(
+            session, imageTemplate.WithIndex(imageIndex), { kMetalSupportBoundBoxOffsets[segment], currentHeight },
+            { 0, 0, beamLength - 1 });
 
         currentHeight += beamLength;
     }
@@ -597,41 +586,24 @@ static bool MetalBSupportsPaintSetup(
 
     currentHeight += heightDiff;
 
-    int16_t endHeight;
+    const auto supportBeamImageIndex = kSupportBasesAndBeams[supportType].beamUncapped;
 
-    int32_t i = 1;
-    while (true)
+    // Draw main support segments
+    for (uint8_t count = 1;; count++)
     {
-        endHeight = currentHeight + 16;
-        if (endHeight > crossbeamHeight)
-        {
-            endHeight = crossbeamHeight;
-        }
-
-        int16_t beamLength = endHeight - currentHeight;
-
+        const int16_t beamLength = std::min<int16_t>(currentHeight + 16, crossbeamHeight) - currentHeight;
         if (beamLength <= 0)
-        {
             break;
-        }
 
-        uint32_t imageId = kSupportBasesAndBeams[supportType].beamUncapped + (beamLength - 1);
-
-        if (i % 4 == 0)
-        {
-            // Each fourth run, draw a special image
-            if (beamLength == 16)
-            {
-                imageId += 1;
-            }
-        }
+        uint32_t imageIndex = supportBeamImageIndex + beamLength - 1;
+        if (count % 4 == 0 && beamLength == 16)
+            imageIndex++;
 
         PaintAddImageAsParent(
-            session, imageTemplate.WithIndex(imageId), { kMetalSupportBoundBoxOffsets[segment], currentHeight },
+            session, imageTemplate.WithIndex(imageIndex), { kMetalSupportBoundBoxOffsets[segment], currentHeight },
             { 0, 0, beamLength - 1 });
 
         currentHeight += beamLength;
-        i++;
     }
 
     supportSegments[segment].height = segmentHeight;

--- a/src/openrct2/paint/support/MetalSupports.cpp
+++ b/src/openrct2/paint/support/MetalSupports.cpp
@@ -282,6 +282,7 @@ constexpr MetalSupportGraphic kMetalSupportGraphicRotated[kMetalSupportTypeCount
 };
 
 constexpr const int32_t kMetalSupportBaseHeight = 6;
+constexpr const int32_t kMetalSupportMaxSectionHeight = 16;
 
 static inline MetalSupportGraphic RotateMetalSupportGraphic(MetalSupportType supportType, Direction direction);
 
@@ -379,8 +380,11 @@ static bool MetalSupportsPaintSetupCommon(
 
     const auto supportBeamImageIndex = kSupportBasesAndBeams[supportType].beamUncapped;
 
-    // Draw an initial support segment to get the main segment height to a multiple of 16
-    const int16_t heightDiff = std::min<int16_t>(floor2(currentHeight + 16, 16), crossbeamHeight) - currentHeight;
+    // Draw an initial support segment to get the main segment height to a multiple of kMetalSupportMaxSectionHeight
+    const int16_t heightDiff = std::min<int16_t>(
+                                   floor2(currentHeight + kMetalSupportMaxSectionHeight, kMetalSupportMaxSectionHeight),
+                                   crossbeamHeight)
+        - currentHeight;
     if (heightDiff > 0)
     {
         PaintAddImageAsParent(
@@ -393,12 +397,13 @@ static bool MetalSupportsPaintSetupCommon(
     // Draw main support segments
     for (uint8_t count = 1;; count++)
     {
-        const int16_t beamLength = std::min<int16_t>(currentHeight + 16, crossbeamHeight) - currentHeight;
+        const int16_t beamLength = std::min<int16_t>(currentHeight + kMetalSupportMaxSectionHeight, crossbeamHeight)
+            - currentHeight;
         if (beamLength <= 0)
             break;
 
         uint32_t imageIndex = supportBeamImageIndex + beamLength - 1;
-        if (count % 4 == 0 && beamLength == 16)
+        if (count % 4 == 0 && beamLength == kMetalSupportMaxSectionHeight)
             imageIndex++;
 
         PaintAddImageAsParent(
@@ -419,7 +424,7 @@ static bool MetalSupportsPaintSetupCommon(
     const CoordsXYZ boundBoxOffset = CoordsXYZ(kMetalSupportBoundBoxOffsets[originalSegment], currentHeight);
     while (true)
     {
-        const int16_t beamLength = std::min(currentHeight + 16, totalHeightExtra) - currentHeight;
+        const int16_t beamLength = std::min(currentHeight + kMetalSupportMaxSectionHeight, totalHeightExtra) - currentHeight;
         if (beamLength <= 0)
             break;
 
@@ -551,7 +556,7 @@ bool PathPoleSupportsPaintSetup(
     // si = height
     // dx = baseHeight
 
-    int16_t heightDiff = floor2(baseHeight + 16, 16);
+    int16_t heightDiff = floor2(baseHeight + kMetalSupportMaxSectionHeight, kMetalSupportMaxSectionHeight);
     if (heightDiff > height)
     {
         heightDiff = height;
@@ -575,7 +580,7 @@ bool PathPoleSupportsPaintSetup(
 
         for (int32_t i = 0; i < 4; ++i)
         {
-            z = baseHeight + 16;
+            z = baseHeight + kMetalSupportMaxSectionHeight;
             if (z > height)
             {
                 z = height;
@@ -607,7 +612,7 @@ bool PathPoleSupportsPaintSetup(
         }
 
         ImageIndex imageIndex = pathPaintInfo.BridgeImageId + 20 + (z - 1);
-        if (z == 16)
+        if (z == kMetalSupportMaxSectionHeight)
         {
             imageIndex += 1;
         }

--- a/src/openrct2/paint/support/MetalSupports.cpp
+++ b/src/openrct2/paint/support/MetalSupports.cpp
@@ -189,8 +189,8 @@ static constexpr uint8_t kMetalSupportTypeToHeight[] = {
 
 struct MetalSupportsImages {
     ImageIndex base;
-    ImageIndex beamA;
-    ImageIndex beamB;
+    ImageIndex beamUncapped;
+    ImageIndex beamCapped;
 };
 
 /** rct2: 0x0097B15C, 0x0097B190 */
@@ -400,7 +400,7 @@ static bool MetalASupportsPaintSetup(
         int8_t xOffset = kMetalSupportBoundBoxOffsets[segment].x;
         int8_t yOffset = kMetalSupportBoundBoxOffsets[segment].y;
 
-        uint32_t imageIndex = kSupportBasesAndBeams[supportType].beamA;
+        uint32_t imageIndex = kSupportBasesAndBeams[supportType].beamUncapped;
         imageIndex += heightDiff - 1;
         auto image_id = imageTemplate.WithIndex(imageIndex);
 
@@ -428,7 +428,7 @@ static bool MetalASupportsPaintSetup(
         int8_t xOffset = kMetalSupportBoundBoxOffsets[segment].x;
         int8_t yOffset = kMetalSupportBoundBoxOffsets[segment].y;
 
-        uint32_t imageIndex = kSupportBasesAndBeams[supportType].beamA;
+        uint32_t imageIndex = kSupportBasesAndBeams[supportType].beamUncapped;
         imageIndex += beamLength - 1;
 
         if (count == 3 && beamLength == 0x10)
@@ -472,7 +472,7 @@ static bool MetalASupportsPaintSetup(
         int8_t xOffset = kMetalSupportBoundBoxOffsets[segment].x;
         int8_t yOffset = kMetalSupportBoundBoxOffsets[segment].y;
 
-        auto imageIndex = kSupportBasesAndBeams[supportType].beamB;
+        auto imageIndex = kSupportBasesAndBeams[supportType].beamCapped;
         imageIndex += beamLength - 1;
         auto image_id = imageTemplate.WithIndex(imageIndex);
 
@@ -612,7 +612,7 @@ static bool MetalBSupportsPaintSetup(
     if (heightDiff > 0)
     {
         PaintAddImageAsParent(
-            session, imageTemplate.WithIndex(kSupportBasesAndBeams[supportType].beamA + (heightDiff - 1)),
+            session, imageTemplate.WithIndex(kSupportBasesAndBeams[supportType].beamUncapped + (heightDiff - 1)),
             { kMetalSupportBoundBoxOffsets[segment], currentHeight }, { 0, 0, heightDiff - 1 });
     }
 
@@ -636,7 +636,7 @@ static bool MetalBSupportsPaintSetup(
             break;
         }
 
-        uint32_t imageId = kSupportBasesAndBeams[supportType].beamA + (beamLength - 1);
+        uint32_t imageId = kSupportBasesAndBeams[supportType].beamUncapped + (beamLength - 1);
 
         if (i % 4 == 0)
         {
@@ -676,7 +676,7 @@ static bool MetalBSupportsPaintSetup(
                 break;
             }
 
-            uint32_t imageId = kSupportBasesAndBeams[supportType].beamA + (beamLength - 1);
+            uint32_t imageId = kSupportBasesAndBeams[supportType].beamUncapped + (beamLength - 1);
             PaintAddImageAsParent(
                 session, imageTemplate.WithIndex(imageId), { kMetalSupportBoundBoxOffsets[segment], currentHeight },
                 { { kMetalSupportBoundBoxOffsets[segment], height }, { 0, 0, 0 } });

--- a/src/openrct2/paint/support/MetalSupports.cpp
+++ b/src/openrct2/paint/support/MetalSupports.cpp
@@ -283,6 +283,7 @@ constexpr MetalSupportGraphic kMetalSupportGraphicRotated[kMetalSupportTypeCount
 
 constexpr const int32_t kMetalSupportBaseHeight = 6;
 constexpr const int32_t kMetalSupportMaxSectionHeight = 16;
+constexpr const int32_t kMetalSupportJointInterval = 4;
 
 static inline MetalSupportGraphic RotateMetalSupportGraphic(MetalSupportType supportType, Direction direction);
 
@@ -403,7 +404,7 @@ static bool MetalSupportsPaintSetupCommon(
             break;
 
         uint32_t imageIndex = supportBeamImageIndex + beamLength - 1;
-        if (count % 4 == 0 && beamLength == kMetalSupportMaxSectionHeight)
+        if (count % kMetalSupportJointInterval == 0 && beamLength == kMetalSupportMaxSectionHeight)
             imageIndex++;
 
         PaintAddImageAsParent(

--- a/src/openrct2/paint/support/MetalSupports.cpp
+++ b/src/openrct2/paint/support/MetalSupports.cpp
@@ -281,6 +281,8 @@ constexpr MetalSupportGraphic kMetalSupportGraphicRotated[kMetalSupportTypeCount
       MetalSupportGraphic::boxedCoated },
 };
 
+constexpr const int32_t kMetalSupportBaseHeight = 6;
+
 static bool MetalASupportsPaintSetup(
     PaintSession& session, MetalSupportGraphic supportTypeMember, MetalSupportPlace placement, int32_t heightExtra,
     int32_t height, ImageId imageTemplate);
@@ -366,23 +368,23 @@ static bool MetalASupportsPaintSetup(
         segment = newSegment;
     }
     const int16_t crossbeamHeight = currentHeight;
-    if (supportSegments[segment].slope & kTileSlopeAboveTrackOrScenery || currentHeight - supportSegments[segment].height < 6
+
+    // Draw support bases
+    if (supportSegments[segment].slope & kTileSlopeAboveTrackOrScenery
+        || currentHeight - supportSegments[segment].height < kMetalSupportBaseHeight
         || kSupportBasesAndBeams[supportType].base == kImageIndexUndefined)
     {
         currentHeight = supportSegments[segment].height;
     }
     else
     {
-        int8_t xOffset = kMetalSupportBoundBoxOffsets[segment].x;
-        int8_t yOffset = kMetalSupportBoundBoxOffsets[segment].y;
+        const auto imageIndex = kSupportBasesAndBeams[supportType].base
+            + kMetalSupportsSlopeImageOffsetMap[supportSegments[segment].slope & kTileSlopeMask];
+        PaintAddImageAsParent(
+            session, imageTemplate.WithIndex(imageIndex),
+            { kMetalSupportBoundBoxOffsets[segment], supportSegments[segment].height }, { 0, 0, kMetalSupportBaseHeight - 1 });
 
-        auto imageIndex = kSupportBasesAndBeams[supportType].base;
-        imageIndex += kMetalSupportsSlopeImageOffsetMap[supportSegments[segment].slope & kTileSlopeMask];
-        auto image_id = imageTemplate.WithIndex(imageIndex);
-
-        PaintAddImageAsParent(session, image_id, { xOffset, yOffset, supportSegments[segment].height }, { 0, 0, 5 });
-
-        currentHeight = supportSegments[segment].height + 6;
+        currentHeight = supportSegments[segment].height + kMetalSupportBaseHeight;
     }
 
     const auto supportBeamImageIndex = kSupportBasesAndBeams[supportType].beamUncapped;
@@ -539,22 +541,22 @@ static bool MetalBSupportsPaintSetup(
 
     const int32_t crossbeamHeight = currentHeight;
 
-    if ((supportSegments[segment].slope & kTileSlopeAboveTrackOrScenery)
-        || (currentHeight - supportSegments[segment].height < 6)
-        || (kSupportBasesAndBeams[supportType].base == kImageIndexUndefined))
+    // Draw support bases
+    if (supportSegments[segment].slope & kTileSlopeAboveTrackOrScenery
+        || currentHeight - supportSegments[segment].height < kMetalSupportBaseHeight
+        || kSupportBasesAndBeams[supportType].base == kImageIndexUndefined)
     {
         currentHeight = supportSegments[segment].height;
     }
     else
     {
-        uint32_t imageOffset = kMetalSupportsSlopeImageOffsetMap[supportSegments[segment].slope & kTileSlopeMask];
-        uint32_t imageId = kSupportBasesAndBeams[supportType].base + imageOffset;
-
+        const auto imageIndex = kSupportBasesAndBeams[supportType].base
+            + kMetalSupportsSlopeImageOffsetMap[supportSegments[segment].slope & kTileSlopeMask];
         PaintAddImageAsParent(
-            session, imageTemplate.WithIndex(imageId),
-            { kMetalSupportBoundBoxOffsets[segment], supportSegments[segment].height }, { 0, 0, 5 });
+            session, imageTemplate.WithIndex(imageIndex),
+            { kMetalSupportBoundBoxOffsets[segment], supportSegments[segment].height }, { 0, 0, kMetalSupportBaseHeight - 1 });
 
-        currentHeight = supportSegments[segment].height + 6;
+        currentHeight = supportSegments[segment].height + kMetalSupportBaseHeight;
     }
 
     const auto supportBeamImageIndex = kSupportBasesAndBeams[supportType].beamUncapped;

--- a/src/openrct2/paint/support/MetalSupports.cpp
+++ b/src/openrct2/paint/support/MetalSupports.cpp
@@ -318,13 +318,13 @@ static bool MetalASupportsPaintSetup(
         imageTemplate = ImageId(0).WithTransparency(FilterPaletteID::PaletteDarken1);
     }
 
-    uint8_t segment = EnumValue(placement);
-    auto supportType = EnumValue(supportTypeMember);
-    SupportHeight* supportSegments = session.SupportSegments;
     int32_t currentHeight = height;
-    const auto originalSegment = segment;
+    const uint32_t supportType = EnumValue(supportTypeMember);
 
+    const uint8_t originalSegment = EnumValue(placement);
+    uint8_t segment = originalSegment;
     uint16_t segmentHeight = 0xFFFF;
+    SupportHeight* const supportSegments = session.SupportSegments;
     if (currentHeight < supportSegments[segment].height)
     {
         segmentHeight = currentHeight;
@@ -476,7 +476,7 @@ static bool MetalBSupportsPaintSetup(
 {
     if (!(session.Flags & PaintSessionFlags::PassedSurface))
     {
-        return false; // AND
+        return false;
     }
 
     if (session.ViewFlags & VIEWPORT_FLAG_HIDE_SUPPORTS)
@@ -488,12 +488,13 @@ static bool MetalBSupportsPaintSetup(
         imageTemplate = ImageId(0).WithTransparency(FilterPaletteID::PaletteDarken1);
     }
 
-    const uint8_t segment = EnumValue(placement);
-    auto supportType = EnumValue(supportTypeMember);
-    SupportHeight* supportSegments = session.SupportSegments;
-    uint16_t segmentHeight = 0xFFFF;
     int32_t currentHeight = height;
+    const uint32_t supportType = EnumValue(supportTypeMember);
 
+    const uint8_t originalSegment = EnumValue(placement);
+    uint8_t segment = originalSegment;
+    uint16_t segmentHeight = 0xFFFF;
+    SupportHeight* const supportSegments = session.SupportSegments;
     if (height < supportSegments[segment].height)
     {
         segmentHeight = height;

--- a/src/openrct2/paint/support/MetalSupports.cpp
+++ b/src/openrct2/paint/support/MetalSupports.cpp
@@ -299,7 +299,7 @@ static inline MetalSupportGraphic RotateMetalSupportGraphic(MetalSupportType sup
  *  rct2: 0x00663105
  */
 static bool MetalASupportsPaintSetup(
-    PaintSession& session, MetalSupportGraphic supportTypeMember, MetalSupportPlace placement, int32_t heightExtra,
+    PaintSession& session, const MetalSupportGraphic supportTypeMember, const MetalSupportPlace placement, int32_t heightExtra,
     int32_t height, ImageId imageTemplate)
 {
     if (!(session.Flags & PaintSessionFlags::PassedSurface))
@@ -484,7 +484,7 @@ static bool MetalASupportsPaintSetup(
 }
 
 bool MetalASupportsPaintSetup(
-    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, int32_t heightExtra, int32_t height,
+    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, const int32_t heightExtra, int32_t height,
     ImageId imageTemplate)
 {
     auto supportGraphic = RotateMetalSupportGraphic(supportType, 0);
@@ -492,8 +492,8 @@ bool MetalASupportsPaintSetup(
 }
 
 bool MetalASupportsPaintSetupRotated(
-    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, Direction direction, int32_t heightExtra,
-    int32_t height, ImageId imageTemplate)
+    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, Direction direction,
+    const int32_t heightExtra, int32_t height, ImageId imageTemplate)
 {
     auto supportGraphic = RotateMetalSupportGraphic(supportType, direction);
     placement = kMetalSupportPlacementRotated[EnumValue(placement)][direction];
@@ -513,8 +513,8 @@ bool MetalASupportsPaintSetupRotated(
  * @return (Carry Flag)
  */
 static bool MetalBSupportsPaintSetup(
-    PaintSession& session, MetalSupportGraphic supportTypeMember, MetalSupportPlace placement, int32_t heightExtra,
-    int32_t height, ImageId imageTemplate)
+    PaintSession& session, const MetalSupportGraphic supportTypeMember, const MetalSupportPlace placement,
+    const int32_t heightExtra, const int32_t height, ImageId imageTemplate)
 {
     if (!(session.Flags & PaintSessionFlags::PassedSurface))
     {
@@ -686,31 +686,31 @@ static bool MetalBSupportsPaintSetup(
 }
 
 bool MetalBSupportsPaintSetup(
-    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, int32_t heightExtra, int32_t height,
-    ImageId imageTemplate)
+    PaintSession& session, const MetalSupportType supportType, const MetalSupportPlace placement, const int32_t heightExtra,
+    int32_t height, const ImageId imageTemplate)
 {
     auto supportGraphic = RotateMetalSupportGraphic(supportType, 0);
     return MetalBSupportsPaintSetup(session, supportGraphic, placement, heightExtra, height, imageTemplate);
 }
 
 bool MetalBSupportsPaintSetupRotated(
-    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, Direction direction, int32_t heightExtra,
-    int32_t height, ImageId imageTemplate)
+    PaintSession& session, const MetalSupportType supportType, const MetalSupportPlace placement, const Direction direction,
+    const int32_t heightExtra, const int32_t height, const ImageId imageTemplate)
 {
     auto supportGraphic = RotateMetalSupportGraphic(supportType, direction);
-    placement = kMetalSupportPlacementRotated[EnumValue(placement)][direction];
-    return MetalBSupportsPaintSetup(session, supportGraphic, placement, heightExtra, height, imageTemplate);
+    const auto rotatedPlacement = kMetalSupportPlacementRotated[EnumValue(placement)][direction];
+    return MetalBSupportsPaintSetup(session, supportGraphic, rotatedPlacement, heightExtra, height, imageTemplate);
 }
 
-static inline MetalSupportGraphic RotateMetalSupportGraphic(MetalSupportType supportType, Direction direction)
+static inline MetalSupportGraphic RotateMetalSupportGraphic(const MetalSupportType supportType, const Direction direction)
 {
     assert(direction < kNumOrthogonalDirections);
     return kMetalSupportGraphicRotated[EnumValue(supportType)][direction];
 }
 
 void DrawSupportsSideBySide(
-    PaintSession& session, Direction direction, uint16_t height, ImageId colour, MetalSupportType supportType,
-    int32_t heightExtra)
+    PaintSession& session, const Direction direction, const uint16_t height, const ImageId colour,
+    const MetalSupportType supportType, const int32_t heightExtra)
 {
     auto graphic = RotateMetalSupportGraphic(supportType, direction);
 
@@ -739,8 +739,8 @@ void DrawSupportsSideBySide(
  * @return Whether supports were drawn
  */
 bool PathPoleSupportsPaintSetup(
-    PaintSession& session, MetalSupportPlace supportPlace, bool isSloped, int32_t height, ImageId imageTemplate,
-    const FootpathPaintInfo& pathPaintInfo)
+    PaintSession& session, const MetalSupportPlace supportPlace, const bool isSloped, const int32_t height,
+    ImageId imageTemplate, const FootpathPaintInfo& pathPaintInfo)
 {
     auto segment = EnumValue(supportPlace);
 

--- a/src/openrct2/paint/support/MetalSupports.cpp
+++ b/src/openrct2/paint/support/MetalSupports.cpp
@@ -365,7 +365,7 @@ static bool MetalASupportsPaintSetup(
 
         segment = newSegment;
     }
-    int16_t si = currentHeight;
+    const int16_t crossbeamHeight = currentHeight;
     if (supportSegments[segment].slope & kTileSlopeAboveTrackOrScenery || currentHeight - supportSegments[segment].height < 6
         || kSupportBasesAndBeams[supportType].base == kImageIndexUndefined)
     {
@@ -388,9 +388,9 @@ static bool MetalASupportsPaintSetup(
     // Work out if a small support segment required to bring support to normal
     // size (aka floor2(x, 16))
     int16_t heightDiff = floor2(currentHeight + 16, 16);
-    if (heightDiff > si)
+    if (heightDiff > crossbeamHeight)
     {
-        heightDiff = si;
+        heightDiff = crossbeamHeight;
     }
 
     heightDiff -= currentHeight;
@@ -416,9 +416,9 @@ static bool MetalASupportsPaintSetup(
             count = 0;
 
         int16_t beamLength = currentHeight + 16;
-        if (beamLength > si)
+        if (beamLength > crossbeamHeight)
         {
-            beamLength = si;
+            beamLength = crossbeamHeight;
         }
 
         beamLength -= currentHeight;
@@ -561,7 +561,7 @@ static bool MetalBSupportsPaintSetup(
             { kMetalSupportCrossBeamBoundBoxLengths[ebp], 1 });
     }
 
-    int32_t si = currentHeight;
+    const int32_t crossbeamHeight = currentHeight;
 
     if ((supportSegments[segment].slope & kTileSlopeAboveTrackOrScenery)
         || (currentHeight - supportSegments[segment].height < 6)
@@ -582,9 +582,9 @@ static bool MetalBSupportsPaintSetup(
     }
 
     int16_t heightDiff = floor2(currentHeight + 16, 16);
-    if (heightDiff > si)
+    if (heightDiff > crossbeamHeight)
     {
-        heightDiff = si;
+        heightDiff = crossbeamHeight;
     }
 
     heightDiff -= currentHeight;
@@ -603,9 +603,9 @@ static bool MetalBSupportsPaintSetup(
     while (true)
     {
         endHeight = currentHeight + 16;
-        if (endHeight > si)
+        if (endHeight > crossbeamHeight)
         {
-            endHeight = si;
+            endHeight = crossbeamHeight;
         }
 
         int16_t beamLength = endHeight - currentHeight;

--- a/src/openrct2/paint/support/MetalSupports.h
+++ b/src/openrct2/paint/support/MetalSupports.h
@@ -91,20 +91,21 @@ struct PaintSession;
 
 /** @deprecated */
 bool MetalASupportsPaintSetup(
-    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, int32_t special, int32_t height,
+    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, int32_t heightExtra, int32_t height,
     ImageId imageTemplate);
 bool MetalASupportsPaintSetupRotated(
-    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, Direction direction, int32_t special,
+    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, Direction direction, int32_t heightExtra,
     int32_t height, ImageId imageTemplate);
 /** @deprecated */
 bool MetalBSupportsPaintSetup(
-    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, int32_t special, int32_t height,
+    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, int32_t heightExtra, int32_t height,
     ImageId imageTemplate);
 bool MetalBSupportsPaintSetupRotated(
-    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, Direction direction, int32_t special,
+    PaintSession& session, MetalSupportType supportType, MetalSupportPlace placement, Direction direction, int32_t heightExtra,
     int32_t height, ImageId imageTemplate);
 void DrawSupportsSideBySide(
-    PaintSession& session, Direction direction, uint16_t height, ImageId colour, MetalSupportType type, int32_t special = 0);
+    PaintSession& session, Direction direction, uint16_t height, ImageId colour, MetalSupportType type,
+    int32_t heightExtra = 0);
 bool PathPoleSupportsPaintSetup(
     PaintSession& session, MetalSupportPlace supportPlace, bool isSloped, int32_t height, ImageId imageTemplate,
     const FootpathPaintInfo& pathPaintInfo);


### PR DESCRIPTION
This refactors the type A and B metal support paint functions in to a single function and generally cleans them up. They seem to have been decompiled separately but they are really the same function with minor differences. Type B supports only offset a support one segment away and use the uncapped sprite for the `extraHeight` section.

The only difference between them now is this: 

https://github.com/OpenRCT2/OpenRCT2/blob/2c1e838844dece036ce171acca2dd698492e46cd/src/openrct2/paint/support/MetalSupports.cpp#L349-L353
https://github.com/OpenRCT2/OpenRCT2/blob/2c1e838844dece036ce171acca2dd698492e46cd/src/openrct2/paint/support/MetalSupports.cpp#L423-L424

This fixes type B supports drawing the main beam glitchy or missing when they are offset (RCT2 - current - fix):

<img width="269" height="345" alt="typebsupportsrct2" src="https://github.com/user-attachments/assets/bf5758f6-9708-4b48-9572-7c681cf66717" />
<img width="269" height="345" alt="typebsupportsbug" src="https://github.com/user-attachments/assets/98788287-292b-4011-a827-008a9a5c2785" />
<img width="269" height="345" alt="typebsupportsfix" src="https://github.com/user-attachments/assets/5c5ce1be-240f-4a9e-8cc2-6b6bc37d6265" />

Save:
[type b supports bug.zip](https://github.com/user-attachments/files/21736820/type.b.supports.bug.zip)
