### PR TITLE
Reduce Map.h includes

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -35,7 +35,6 @@
 #include <openrct2/ui/UiContext.h>
 #include <openrct2/ui/WindowManager.h>
 #include <openrct2/world/Banner.h>
-#include <openrct2/world/Map.h>
 #include <openrct2/world/Scenery.h>
 #include <optional>
 

--- a/src/openrct2-ui/interface/LandTool.cpp
+++ b/src/openrct2-ui/interface/LandTool.cpp
@@ -19,7 +19,6 @@
 #include <openrct2/object/ObjectManager.h>
 #include <openrct2/object/TerrainEdgeObject.h>
 #include <openrct2/object/TerrainSurfaceObject.h>
-#include <openrct2/world/Map.h>
 
 using namespace OpenRCT2;
 using namespace OpenRCT2::Ui::Windows;

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -49,7 +49,6 @@
 #include <openrct2/windows/Intent.h>
 #include <openrct2/world/Banner.h>
 #include <openrct2/world/Footpath.h>
-#include <openrct2/world/Map.h>
 #include <openrct2/world/Park.h>
 #include <openrct2/world/Scenery.h>
 #include <openrct2/world/tile_element/BannerElement.h>

--- a/src/openrct2-ui/scripting/CustomMenu.cpp
+++ b/src/openrct2-ui/scripting/CustomMenu.cpp
@@ -18,7 +18,6 @@
     #include <openrct2/Input.h>
     #include <openrct2/ui/UiContext.h>
     #include <openrct2/ui/WindowManager.h>
-    #include <openrct2/world/Map.h>
 
 using namespace OpenRCT2;
 using namespace OpenRCT2::Ui;

--- a/src/openrct2-ui/scripting/ScViewport.hpp
+++ b/src/openrct2-ui/scripting/ScViewport.hpp
@@ -19,7 +19,6 @@
     #include <openrct2/scripting/Duktape.hpp>
     #include <openrct2/scripting/ScriptEngine.h>
     #include <openrct2/ui/WindowManager.h>
-    #include <openrct2/world/Map.h>
 
 namespace OpenRCT2::Scripting
 {

--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -36,7 +36,6 @@
 #include <openrct2/scenes/title/TitleSequencePlayer.h>
 #include <openrct2/ui/WindowManager.h>
 #include <openrct2/windows/Intent.h>
-#include <openrct2/world/Map.h>
 #include <openrct2/world/MapAnimation.h>
 #include <openrct2/world/Scenery.h>
 #include <stdexcept>

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -50,7 +50,6 @@
 #include <openrct2/windows/Intent.h>
 #include <openrct2/world/ConstructionClearance.h>
 #include <openrct2/world/Entrance.h>
-#include <openrct2/world/Map.h>
 #include <openrct2/world/Park.h>
 #include <openrct2/world/tile_element/EntranceElement.h>
 #include <openrct2/world/tile_element/PathElement.h>

--- a/src/openrct2/world/Banner.cpp
+++ b/src/openrct2/world/Banner.cpp
@@ -27,7 +27,6 @@
 #include "../ride/RideManager.hpp"
 #include "../ride/Track.h"
 #include "../windows/Intent.h"
-#include "Map.h"
 #include "MapAnimation.h"
 #include "Park.h"
 #include "Scenery.h"

--- a/src/openrct2/world/ConstructionClearance.h
+++ b/src/openrct2/world/ConstructionClearance.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "../actions/GameActionResult.h"
-#include "Map.h"
+#include "Location.hpp"
 
 #include <cstdint>
 

--- a/src/openrct2/world/Entrance.cpp
+++ b/src/openrct2/world/Entrance.cpp
@@ -27,7 +27,6 @@
 #include "../ride/Station.h"
 #include "../ride/Track.h"
 #include "Footpath.h"
-#include "Map.h"
 #include "MapAnimation.h"
 #include "Park.h"
 #include "tile_element/EntranceElement.h"

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -34,7 +34,6 @@
 #include "../ride/Track.h"
 #include "../ride/TrackData.h"
 #include "Location.hpp"
-#include "Map.h"
 #include "MapAnimation.h"
 #include "tile_element/BannerElement.h"
 #include "tile_element/EntranceElement.h"

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -26,7 +26,6 @@
 #include "../ride/Track.h"
 #include "Banner.h"
 #include "Footpath.h"
-#include "Map.h"
 #include "Scenery.h"
 #include "tile_element/EntranceElement.h"
 #include "tile_element/LargeSceneryElement.h"

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -38,7 +38,6 @@
 #include "../util/Util.h"
 #include "../windows/Intent.h"
 #include "Entrance.h"
-#include "Map.h"
 #include "tile_element/EntranceElement.h"
 #include "tile_element/SurfaceElement.h"
 

--- a/src/openrct2/world/Park.h
+++ b/src/openrct2/world/Park.h
@@ -13,6 +13,7 @@
 #include "Location.hpp"
 
 #include <string>
+#include <vector>
 
 constexpr auto kMaxEntranceFee = 999.00_GBP;
 

--- a/src/openrct2/world/Park.h
+++ b/src/openrct2/world/Park.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "../management/Finance.h"
-#include "Map.h"
+#include "Location.hpp"
 
 #include <string>
 

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -34,7 +34,6 @@
 #include "../object/SmallSceneryEntry.h"
 #include "../object/WallSceneryEntry.h"
 #include "Footpath.h"
-#include "Map.h"
 #include "Park.h"
 #include "tile_element/PathElement.h"
 #include "tile_element/SmallSceneryElement.h"

--- a/src/openrct2/world/TileElementsView.h
+++ b/src/openrct2/world/TileElementsView.h
@@ -10,7 +10,6 @@
 #pragma once
 
 #include "Location.hpp"
-#include "Map.h"
 
 #include <iterator>
 

--- a/src/openrct2/world/TileElementsView.h
+++ b/src/openrct2/world/TileElementsView.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "Location.hpp"
+#include "Map.h"
 
 #include <iterator>
 

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -20,7 +20,6 @@
 #include "Banner.h"
 #include "Footpath.h"
 #include "Location.hpp"
-#include "Map.h"
 #include "MapAnimation.h"
 #include "Park.h"
 #include "Scenery.h"

--- a/src/openrct2/world/TileInspector.h
+++ b/src/openrct2/world/TileInspector.h
@@ -9,9 +9,10 @@
 
 #pragma once
 
-#include "Map.h"
+#include "Location.hpp"
 
 struct Banner;
+struct TileElement;
 
 namespace OpenRCT2::GameActions
 {


### PR DESCRIPTION
Fairly straightforward. Changing Map.h would lead to many recompiles through unnecessary includes in Park.h in particular.