### PR TITLE
Bump kNetworkStreamVersion

### DIFF
--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -49,7 +49,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kNetworkStreamVersion = 0;
+constexpr uint8_t kNetworkStreamVersion = 1;
 
 const std::string kNetworkStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kNetworkStreamVersion);
 


### PR DESCRIPTION
When we merged the climate objects (#23774), we also removed the old `ClimateSetAction` game command. We didn't bump the network version, however, which now appears to lead to problems.