### PR TITLE
Fix #18309: Flying and Multi Dim trains glitch when moving between inverted and uninverted track when uncap fps is on

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#5281] Missing supports on miniature railways built backwards.
 - Fix: [#10379] Banners outside the park can be renamed and modified (original bug).
 - Fix: [#10582] Low clearance tunnels below water are drawn incorrectly (original bug).
+- Fix: [#18309] Flying and Multi Dimension trains glitch when changing between inverted and uninverted track when uncap fps is on.
 - Fix: [#23486] Object selection minimum requirements can be bypassed with close window hotkey.
 - Fix: [#23743] Parks with guest goals over 32767 do not appear in the scenario list.
 - Fix: [#23844] Sound effects keep playing when loading another save.

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -26,6 +26,7 @@
 #include "../core/Speed.hpp"
 #include "../entity/EntityList.h"
 #include "../entity/EntityRegistry.h"
+#include "../entity/EntityTweener.h"
 #include "../entity/Particle.h"
 #include "../entity/Yaw.hpp"
 #include "../interface/Viewport.h"
@@ -7003,6 +7004,7 @@ bool Vehicle::UpdateTrackMotionForwardsGetNewTrack(
         }
 
         // Update VehicleFlags::CarIsInverted flag
+        const auto previousCarIsInverted = HasFlag(VehicleFlags::CarIsInverted);
         ClearFlag(VehicleFlags::CarIsInverted);
         {
             auto rideType = ::GetRide(tileElement->AsTrack()->GetRideIndex())->type;
@@ -7012,6 +7014,10 @@ bool Vehicle::UpdateTrackMotionForwardsGetNewTrack(
                 {
                     SetFlag(VehicleFlags::CarIsInverted);
                 }
+            }
+            if (previousCarIsInverted != HasFlag(VehicleFlags::CarIsInverted))
+            {
+                EntityTweener::Get().RemoveEntity(this);
             }
         }
     }
@@ -7392,12 +7398,17 @@ bool Vehicle::UpdateTrackMotionBackwardsGetNewTrack(TrackElemType trackType, con
         }
 
         // Update VehicleFlags::CarIsInverted
+        const auto previousCarIsInverted = HasFlag(VehicleFlags::CarIsInverted);
         ClearFlag(VehicleFlags::CarIsInverted);
         if (GetRideTypeDescriptor(curRide.type).HasFlag(RtdFlag::hasInvertedVariant))
         {
             if (tileElement->AsTrack()->IsInverted())
             {
                 SetFlag(VehicleFlags::CarIsInverted);
+            }
+            if (previousCarIsInverted != HasFlag(VehicleFlags::CarIsInverted))
+            {
+                EntityTweener::Get().RemoveEntity(this);
             }
         }
 


### PR DESCRIPTION
Fixes #18309 Flying and Multi Dim trains glitching when moving between inverted and uninverted track when uncap fps is on.

This happens because the underlying position of the vehicle changes even though visually it looks the same. It now stops the vehicle from being tweened when it changes from invert to uninverted.


https://github.com/user-attachments/assets/ec49ea5f-212c-4d05-a623-145dcc8cf48f


https://github.com/user-attachments/assets/cfa8a58a-4339-4fe7-bf76-7d101f34fa9f


Thanks ZehMatt for pointing out my stupid mistake 😆.