### PR TITLE
Fix #23889 and refactor news items import

### DIFF
--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -438,7 +438,7 @@ namespace OpenRCT2::Title
             auto intent = Intent(INTENT_ACTION_REFRESH_NEW_RIDES);
             ContextBroadcastIntent(&intent);
             Ui::Windows::WindowScenerySetDefaultPlacementConfiguration();
-            News::InitQueue();
+            News::InitQueue(gameState);
             LoadPalette();
             gScreenAge = 0;
             gGamePaused = false;

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -311,7 +311,7 @@ namespace OpenRCT2::Editor
 
         ClimateReset();
 
-        News::InitQueue();
+        News::InitQueue(gameState);
     }
 
     /**

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -65,7 +65,7 @@ namespace OpenRCT2
         UpdateConsolidatedPatrolAreas();
         ResetDate();
         ClimateReset();
-        News::InitQueue();
+        News::InitQueue(gameState);
 
         gInMapInitCode = false;
 

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -485,7 +485,7 @@ void News::RemoveItem(int32_t index)
 }
 
 void News::importNewsItems(
-    GameState_t& gameState, const std::vector<News::Item>& recent, const std::vector<News::Item>& archived)
+    GameState_t& gameState, const std::span<const News::Item> recent, const std::span<const News::Item> archived)
 {
     gameState.NewsItems.Clear();
 

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -104,9 +104,8 @@ void News::ItemQueues::Clear()
     Archived.clear();
 }
 
-void News::InitQueue()
+void News::InitQueue(GameState_t& gameState)
 {
-    auto& gameState = GetGameState();
     gameState.NewsItems.Clear();
     assert(gameState.NewsItems.IsEmpty());
 
@@ -494,13 +493,8 @@ void News::importNewsItems(
     {
         gameState.NewsItems[i] = recent[i];
     }
-    size_t offset = News::ItemHistoryStart;
     for (size_t i = 0; i < std::min<size_t>(archived.size(), News::MaxItemsArchive); i++)
     {
-        gameState.NewsItems[offset + i] = archived[i];
+        gameState.NewsItems[News::ItemHistoryStart + i] = archived[i];
     }
-
-    // Still need to set the correct type to properly terminate the queue
-    if (archived.size() < News::MaxItemsArchive)
-        gameState.NewsItems[offset + archived.size()].Type = News::ItemType::Null;
 }

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -484,3 +484,23 @@ void News::RemoveItem(int32_t index)
     }
     gameState.NewsItems[newsBoundary - 1].Type = News::ItemType::Null;
 }
+
+void News::importNewsItems(
+    GameState_t& gameState, const std::vector<News::Item>& recent, const std::vector<News::Item>& archived)
+{
+    gameState.NewsItems.Clear();
+
+    for (size_t i = 0; i < std::min<size_t>(recent.size(), News::ItemHistoryStart); i++)
+    {
+        gameState.NewsItems[i] = recent[i];
+    }
+    size_t offset = News::ItemHistoryStart;
+    for (size_t i = 0; i < std::min<size_t>(archived.size(), News::MaxItemsArchive); i++)
+    {
+        gameState.NewsItems[offset + i] = archived[i];
+    }
+
+    // Still need to set the correct type to properly terminate the queue
+    if (archived.size() < News::MaxItemsArchive)
+        gameState.NewsItems[offset + archived.size()].Type = News::ItemType::Null;
+}

--- a/src/openrct2/management/NewsItem.h
+++ b/src/openrct2/management/NewsItem.h
@@ -18,9 +18,15 @@
 #include <iterator>
 #include <optional>
 #include <string>
+#include <vector>
 
 struct CoordsXYZ;
 class Formatter;
+
+namespace OpenRCT2
+{
+    struct GameState_t;
+}
 
 namespace OpenRCT2::News
 {
@@ -315,4 +321,7 @@ namespace OpenRCT2::News
 
     void AddItemToQueue(News::Item* newNewsItem);
     void RemoveItem(int32_t index);
+
+    void importNewsItems(
+        GameState_t& gameState, const std::vector<News::Item>& recent, const std::vector<News::Item>& archived);
 } // namespace OpenRCT2::News

--- a/src/openrct2/management/NewsItem.h
+++ b/src/openrct2/management/NewsItem.h
@@ -17,8 +17,8 @@
 #include <array>
 #include <iterator>
 #include <optional>
+#include <span>
 #include <string>
-#include <vector>
 
 struct CoordsXYZ;
 class Formatter;
@@ -64,13 +64,13 @@ namespace OpenRCT2::News
      */
     struct Item
     {
-        News::ItemType Type;
-        uint8_t Flags;
-        uint32_t Assoc;
-        uint16_t Ticks;
-        uint16_t MonthYear;
-        uint8_t Day;
-        std::string Text;
+        News::ItemType Type = News::ItemType::Null;
+        uint8_t Flags{};
+        uint32_t Assoc{};
+        uint16_t Ticks{};
+        uint16_t MonthYear{};
+        uint8_t Day{};
+        std::string Text{};
 
         constexpr bool IsEmpty() const noexcept
         {
@@ -241,10 +241,7 @@ namespace OpenRCT2::News
 
         void clear() noexcept
         {
-            for (size_t i = 0; i < N; i++)
-            {
-                Queue[i].Type = News::ItemType::Null;
-            }
+            std::fill(Queue.begin(), Queue.end(), News::Item{});
         }
 
     private:
@@ -326,5 +323,5 @@ namespace OpenRCT2::News
     void RemoveItem(int32_t index);
 
     void importNewsItems(
-        GameState_t& gameState, const std::vector<News::Item>& recent, const std::vector<News::Item>& archived);
+        GameState_t& gameState, const std::span<const News::Item> recent, const std::span<const News::Item> archived);
 } // namespace OpenRCT2::News

--- a/src/openrct2/management/NewsItem.h
+++ b/src/openrct2/management/NewsItem.h
@@ -299,7 +299,7 @@ namespace OpenRCT2::News
         News::ItemQueue<News::MaxItemsArchive> Archived;
     };
 
-    void InitQueue();
+    void InitQueue(GameState_t& gameState);
 
     void UpdateCurrentItem();
     void CloseCurrentItem();

--- a/src/openrct2/management/NewsItem.h
+++ b/src/openrct2/management/NewsItem.h
@@ -241,7 +241,10 @@ namespace OpenRCT2::News
 
         void clear() noexcept
         {
-            front().Type = News::ItemType::Null;
+            for (size_t i = 0; i < N; i++)
+            {
+                Queue[i].Type = News::ItemType::Null;
+            }
         }
 
     private:

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1129,26 +1129,13 @@ namespace OpenRCT2
             os.ReadWriteChunk(ParkFileChunkType::NOTIFICATIONS, [&gameState](OrcaStream::ChunkStream& cs) {
                 if (cs.GetMode() == OrcaStream::Mode::READING)
                 {
-                    gameState.NewsItems.Clear();
-
                     std::vector<News::Item> recent;
                     cs.ReadWriteVector(recent, [&cs](News::Item& item) { ReadWriteNewsItem(cs, item); });
-                    for (size_t i = 0; i < std::min<size_t>(recent.size(), News::ItemHistoryStart); i++)
-                    {
-                        gameState.NewsItems[i] = recent[i];
-                    }
 
                     std::vector<News::Item> archived;
                     cs.ReadWriteVector(archived, [&cs](News::Item& item) { ReadWriteNewsItem(cs, item); });
-                    size_t offset = News::ItemHistoryStart;
-                    for (size_t i = 0; i < std::min<size_t>(archived.size(), News::MaxItemsArchive); i++)
-                    {
-                        gameState.NewsItems[offset + i] = archived[i];
-                    }
 
-                    // Still need to set the correct type to properly terminate the queue
-                    if (archived.size() < News::MaxItemsArchive)
-                        gameState.NewsItems[offset + archived.size()].Type = News::ItemType::Null;
+                    News::importNewsItems(gameState, recent, archived);
                 }
                 else
                 {

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -889,7 +889,8 @@ namespace OpenRCT2::RCT1
         uint8_t TargetWeatherGloom;
         uint8_t Rain;
         uint8_t TargetRain;
-        RCT12NewsItem Messages[Limits::MaxNewsItems];
+        RCT12NewsItem recentMessages[Limits::kMaxRecentNewsItems];
+        RCT12NewsItem archivedMessages[Limits::kMaxArchivedNewsItems];
         char ScenarioName[62];
         uint16_t ScenarioSlotIndex;
         uint32_t ScenarioFlags;

--- a/src/openrct2/rct12/Limits.h
+++ b/src/openrct2/rct12/Limits.h
@@ -16,7 +16,8 @@ namespace OpenRCT2::RCT12::Limits
 
     constexpr uint8_t kMaxRidesInPark = 255;
     constexpr uint8_t kMaxAwards = 4;
-    constexpr uint8_t MaxNewsItems = 61;
+    constexpr uint8_t kMaxRecentNewsItems = 11;
+    constexpr uint8_t kMaxArchivedNewsItems = 50;
     constexpr uint8_t kMaxStationsPerRide = 4;
     constexpr uint8_t kMaxPeepSpawns = 2;
     constexpr uint8_t kMaxParkEntrances = 4;

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -990,7 +990,8 @@ namespace OpenRCT2::RCT2
         uint8_t NextWeatherGloom;
         uint8_t CurrentWeatherLevel;
         uint8_t NextWeatherLevel;
-        RCT12NewsItem NewsItems[Limits::MaxNewsItems];
+        RCT12NewsItem recentMessages[Limits::kMaxRecentNewsItems];
+        RCT12NewsItem archivedMessages[Limits::kMaxArchivedNewsItems];
         char RCT1ScenarioName[62];      // Unused in RCT2
         uint16_t RCT1ScenarioSlotIndex; // Unused in RCT2
         uint32_t RCT1ScenarioFlags;     // Unused in RCT2

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -320,6 +320,38 @@ namespace OpenRCT2::RCT2
             return {};
         }
 
+        std::vector<OpenRCT2::News::Item> convertNewsQueue(const RCT12NewsItem* queue, uint8_t size)
+        {
+            std::vector<OpenRCT2::News::Item> output{};
+            const RCT12NewsItem* src = queue;
+
+            for (uint8_t i = 0; i < size; i++)
+            {
+                if (src->Type == 0)
+                    break;
+
+                if (src->Type >= News::ItemTypeCount)
+                {
+                    LOG_ERROR("Invalid news type 0x%x for news item %d, ignoring remaining news items", src->Type, i);
+                    break;
+                }
+
+                News::Item dst{};
+                dst.Type = static_cast<News::ItemType>(src->Type);
+                dst.Flags = src->Flags;
+                dst.Assoc = src->Assoc;
+                dst.Ticks = src->Ticks;
+                dst.MonthYear = src->MonthYear;
+                dst.Day = src->Day;
+                dst.Text = ConvertFormattedStringToOpenRCT2(std::string_view(src->Text, sizeof(src->Text)));
+
+                output.emplace_back(dst);
+                src++;
+            }
+
+            return output;
+        }
+
         void Import(GameState_t& gameState) override
         {
             Initialise(gameState);
@@ -573,30 +605,9 @@ namespace OpenRCT2::RCT2
             };
 
             // News items
-            News::InitQueue();
-            for (size_t i = 0; i < Limits::MaxNewsItems; i++)
-            {
-                const RCT12NewsItem* src = &_s6.NewsItems[i];
-                News::Item* dst = &gameState.NewsItems[i];
-                if (src->Type < News::ItemTypeCount)
-                {
-                    dst->Type = static_cast<News::ItemType>(src->Type);
-                    dst->Flags = src->Flags;
-                    dst->Assoc = src->Assoc;
-                    dst->Ticks = src->Ticks;
-                    dst->MonthYear = src->MonthYear;
-                    dst->Day = src->Day;
-                    dst->Text = ConvertFormattedStringToOpenRCT2(std::string_view(src->Text, sizeof(src->Text)));
-                }
-                else
-                {
-                    // In case where news item type is broken, consider all remaining news items invalid.
-                    LOG_ERROR("Invalid news type 0x%x for news item %d, ignoring remaining news items", src->Type, i);
-                    // Still need to set the correct type to properly terminate the queue
-                    dst->Type = News::ItemType::Null;
-                    break;
-                }
-            }
+            auto recentMessages = convertNewsQueue(_s6.recentMessages, std::size(_s6.recentMessages));
+            auto archivedMessages = convertNewsQueue(_s6.archivedMessages, std::size(_s6.archivedMessages));
+            News::importNewsItems(gameState, recentMessages, archivedMessages);
 
             // Pad13CE730
             // rct1_scenario_flags

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -103,7 +103,7 @@ void ScenarioReset(GameState_t& gameState)
     auto intent = Intent(INTENT_ACTION_SET_DEFAULT_SCENERY_CONFIG);
     ContextBroadcastIntent(&intent);
 
-    News::InitQueue();
+    News::InitQueue(gameState);
 
     gameState.Park.Rating = Park::CalculateParkRating();
     gameState.Park.Value = Park::CalculateParkValue();


### PR DESCRIPTION
I’m seriously questioning the seemingly overengineered ItemQueues and ItemQueue struct. It seems a pair of static vectors (or even regular ones) would do the job better. We should also get rid of accessing both queues as if they are one - I expect this is only because a single 61-item queue looks the same in assembly as an 11-item queue followed by a 50-item one.

I haven’t changed it in this PR though. Rather, I concentrated on 1) fixing the bug at hand, and 2) making sure no garbage/null data is imported in the first place.

Problems include the three park types handling import differently, the Clear() function not actually clearing all items, and S4/S6 parks importing both queues wholly, instead of stopping on encountering a null item. Changing the S4/S6 structs to properly split the two makes it far easier to see what is going on - and it also fixes a hidden bug that would have manifested itself if we ever changed the maximum number of recent news items from 11 (again due to accessing the queue as if it was a single 61-item thing, which is an additional reason to nuke it from orbit).

Needs testing, obviously. Preferably, this includes at least one save that shows a message upon opening.

@James103 Could you verify the scenario you uploaded now correctly opens?

@ZeeMaji Could you test this?