### PR TITLE
Add missing ctime include to FileBrowser.h

### DIFF
--- a/src/openrct2-ui/interface/FileBrowser.h
+++ b/src/openrct2-ui/interface/FileBrowser.h
@@ -13,6 +13,7 @@
 #include <functional>
 #include <openrct2/core/StringTypes.h>
 #include <openrct2/localisation/StringIdType.h>
+#include <ctime>
 #include <string>
 
 enum class LoadSaveAction : uint8_t;

--- a/src/openrct2-ui/interface/FileBrowser.h
+++ b/src/openrct2-ui/interface/FileBrowser.h
@@ -10,10 +10,10 @@
 #pragma once
 
 #include <cstdint>
+#include <ctime>
 #include <functional>
 #include <openrct2/core/StringTypes.h>
 #include <openrct2/localisation/StringIdType.h>
-#include <ctime>
 #include <string>
 
 enum class LoadSaveAction : uint8_t;


### PR DESCRIPTION
time_t is used which is defined in ctime. At least on musl libc systems this header is not implicitly included and needs to be includex explicitly.