### PR TITLE
Add Guard::Assert function with std::source_location default parameter

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -249,6 +249,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Brendan Heinonen (staticinvocation)
 * (QuestionableDeer)
 * David Sungaila (sungaila)
+* Garrett Leach (GarrettLeach)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2/core/Guard.cpp
+++ b/src/openrct2/core/Guard.cpp
@@ -61,7 +61,7 @@ namespace OpenRCT2::Guard
             return;
 
         std::stringstream messageStream;
-        messageStream << "Assertion failed in " << location.function_name() << ":" << location.line();
+        messageStream << "Assertion failed in " << location.file_name() << ":" << location.line();
 
         std::string message = messageStream.str();
 

--- a/src/openrct2/core/Guard.cpp
+++ b/src/openrct2/core/Guard.cpp
@@ -23,7 +23,7 @@
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
-#include <format>
+#include <sstream>
 
 namespace OpenRCT2::Guard
 {
@@ -60,7 +60,11 @@ namespace OpenRCT2::Guard
         if (expression)
             return;
 
-        std::string message = std::format("Assertion failed in {}:{}", location.function_name(), location.line());
+        std::stringstream messageStream;
+        messageStream << "Assertion failed in " << location.function_name() << ":" << location.line();
+
+        std::string message = messageStream.str();
+
         Assert(expression, message.c_str());
     }
 

--- a/src/openrct2/core/Guard.cpp
+++ b/src/openrct2/core/Guard.cpp
@@ -23,6 +23,7 @@
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
+#include <format>
 
 namespace OpenRCT2::Guard
 {
@@ -52,6 +53,15 @@ namespace OpenRCT2::Guard
     void SetAssertBehaviour(ASSERT_BEHAVIOUR behaviour)
     {
         _assertBehaviour = behaviour;
+    }
+
+    void Assert(bool expression, const std::source_location& location)
+    {
+        if (expression)
+            return;
+
+        std::string message = std::format("Assertion failed in {}:{}", location.function_name(), location.line());
+        Assert(expression, message.c_str());
     }
 
     void Assert(bool expression, const char* message, ...)

--- a/src/openrct2/core/Guard.hpp
+++ b/src/openrct2/core/Guard.hpp
@@ -11,6 +11,7 @@
 
 #include <memory>
 #include <optional>
+#include <source_location>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <string>
@@ -30,7 +31,8 @@ namespace OpenRCT2::Guard
     ASSERT_BEHAVIOUR GetAssertBehaviour();
     void SetAssertBehaviour(ASSERT_BEHAVIOUR behaviour);
 
-    void Assert(bool expression, const char* message = nullptr, ...);
+    void Assert(bool expression, const std::source_location& location = std::source_location::current());
+    void Assert(bool expression, const char* message, ...);
     void Assert_VA(bool expression, const char* message, va_list args);
     void Fail(const char* message = nullptr, ...);
     void Fail_VA(const char* message, va_list args);


### PR DESCRIPTION
Takes a step on #12489 by adding an overload. `Guard::Assert` calls without a message will now have a message of the format `Assertion failed in {function_name}:{line}`. This doesn't affect calls with a message because we can't add a default parameter value after the variadic params. In my testing of a debug build from MSVC the function name includes the full parameters (which can be very long).