### PR TITLE
Fix s4 and s6 importer convertNewsQueue msvc build error

### DIFF
--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2192,7 +2192,7 @@ namespace OpenRCT2::RCT1
             park.Name = std::move(parkName);
         }
 
-        std::vector<OpenRCT2::News::Item> convertNewsQueue(const RCT12NewsItem* queue, uint8_t size)
+        std::vector<OpenRCT2::News::Item> convertNewsQueue(const RCT12NewsItem* queue, size_t size)
         {
             std::vector<OpenRCT2::News::Item> output{};
             const RCT12NewsItem* src = queue;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -320,7 +320,7 @@ namespace OpenRCT2::RCT2
             return {};
         }
 
-        std::vector<OpenRCT2::News::Item> convertNewsQueue(const RCT12NewsItem* queue, uint8_t size)
+        std::vector<OpenRCT2::News::Item> convertNewsQueue(const RCT12NewsItem* queue, size_t size)
         {
             std::vector<OpenRCT2::News::Item> output{};
             const RCT12NewsItem* src = queue;


### PR DESCRIPTION
Fixes this warning and build error in MSVC:

```
src\openrct2\rct1\S4Importer.cpp(2284,81): warning C4267: 'argument': conversion from 'size_t' to 'uint8_t', possible loss of data
src\openrct2\rct1\S4Importer.cpp(2285,85): warning C4267: 'argument': conversion from 'size_t' to 'uint8_t', possible loss of data
src\openrct2\rct2\S6Importer.cpp(608,81): warning C4267: 'argument': conversion from 'size_t' to 'uint8_t', possible loss of data
src\openrct2\rct2\S6Importer.cpp(609,85): warning C4267: 'argument': conversion from 'size_t' to 'uint8_t', possible loss of data
```

https://github.com/OpenRCT2/OpenRCT2/blob/94be70f8a8d252dbcceb7ef71381e92df30ea126/src/openrct2/rct1/S4Importer.cpp#L2284-L2285

https://github.com/OpenRCT2/OpenRCT2/blob/94be70f8a8d252dbcceb7ef71381e92df30ea126/src/openrct2/rct2/S6Importer.cpp#L608-L609