### PR TITLE
Improve performance of OpenGL transparency depth algorithm

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/TransparencyDepth.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/TransparencyDepth.cpp
@@ -13,8 +13,8 @@
 
     #include <algorithm>
     #include <cassert>
-    #include <map>
-    #include <vector>
+    #include <sfl/small_map.hpp>
+    #include <sfl/small_vector.hpp>
 
 namespace OpenRCT2::Ui
 {
@@ -23,11 +23,18 @@ namespace OpenRCT2::Ui
      */
     struct XData
     {
-        int32_t xposition;
+        int16_t xposition;
+        int16_t top;
+        int16_t bottom;
         bool begin;
-        int32_t top, bottom;
     };
-    using SweepLine = std::vector<XData>;
+
+    #ifdef _DEBUG
+    // Debug builds use a lot of stack so we have to keep it small.
+    using SweepLine = sfl::small_vector<XData, 4096>;
+    #else
+    using SweepLine = sfl::small_vector<XData, 8192>;
+    #endif
 
     /*
      * Creates a list of vertical bounding box edges, stored as xdata and sorted
@@ -41,10 +48,10 @@ namespace OpenRCT2::Ui
 
         for (const DrawRectCommand& command : transparent)
         {
-            int32_t left = std::min(std::max(command.bounds.x, command.clip.x), command.clip.z);
-            int32_t top = std::min(std::max(command.bounds.y, command.clip.y), command.clip.w);
-            int32_t right = std::min(std::max(command.bounds.z, command.clip.x), command.clip.z);
-            int32_t bottom = std::min(std::max(command.bounds.w, command.clip.y), command.clip.w);
+            int16_t left = std::min(std::max(command.bounds.x, command.clip.x), command.clip.z);
+            int16_t top = std::min(std::max(command.bounds.y, command.clip.y), command.clip.w);
+            int16_t right = std::min(std::max(command.bounds.z, command.clip.x), command.clip.z);
+            int16_t bottom = std::min(std::max(command.bounds.w, command.clip.y), command.clip.w);
 
             assert(left <= right);
             assert(top <= bottom);
@@ -53,8 +60,8 @@ namespace OpenRCT2::Ui
             if (top == bottom)
                 continue;
 
-            x_sweep.push_back({ left, true, top, bottom });
-            x_sweep.push_back({ right, false, top, bottom });
+            x_sweep.emplace_back(left, top, bottom, true);
+            x_sweep.emplace_back(right, top, bottom, false);
         }
 
         std::sort(x_sweep.begin(), x_sweep.end(), [](const XData& a, const XData& b) -> bool {
@@ -77,9 +84,10 @@ namespace OpenRCT2::Ui
      */
     struct YData
     {
-        int32_t count, depth;
+        int32_t count;
+        int32_t depth;
     };
-    using IntervalTree = std::map<int32_t, YData>;
+    using IntervalTree = sfl::small_map<int32_t, YData, 2048>;
 
     /*
      * Inserts the interval's top endpoint into the interval tree. If the endpoint
@@ -87,7 +95,7 @@ namespace OpenRCT2::Ui
      */
     static inline IntervalTree::iterator InsertTopEndpoint(IntervalTree& y_intersect, int32_t top)
     {
-        auto top_in = y_intersect.insert({ top, { 1, 0 } });
+        auto top_in = y_intersect.emplace(top, YData{ 1, 0 });
         IntervalTree::iterator top_it = top_in.first;
         if (top_in.second)
         {
@@ -111,7 +119,7 @@ namespace OpenRCT2::Ui
      */
     static inline IntervalTree::iterator InsertBottomEndpoint(IntervalTree& y_intersect, int32_t bottom)
     {
-        auto bottom_in = y_intersect.insert({ bottom, { 1, 1 } });
+        auto bottom_in = y_intersect.emplace(bottom, YData{ 1, 1 });
         IntervalTree::iterator bottom_it = bottom_in.first;
         if (bottom_in.second)
         {

--- a/src/thirdparty/sfl/compact_vector.hpp
+++ b/src/thirdparty/sfl/compact_vector.hpp
@@ -1,0 +1,1795 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_COMPACT_VECTOR_HPP_INCLUDED
+#define SFL_COMPACT_VECTOR_HPP_INCLUDED
+
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/exceptions.hpp>
+#include <sfl/detail/initialized_memory_algorithms.hpp>
+#include <sfl/detail/normal_iterator.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/to_address.hpp>
+#include <sfl/detail/type_traits.hpp>
+#include <sfl/detail/uninitialized_memory_algorithms.hpp>
+
+#include <algorithm>        // copy, move, swap, swap_ranges
+#include <initializer_list> // initializer_list
+#include <iterator>         // distance, next, reverse_iterator
+#include <limits>           // numeric_limits
+#include <memory>           // allocator, allocator_traits, pointer_traits
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+namespace sfl
+{
+
+template <typename T, typename Allocator = std::allocator<T>>
+class compact_vector
+{
+public:
+
+    using allocator_type         = Allocator;
+    using allocator_traits       = std::allocator_traits<Allocator>;
+    using value_type             = T;
+    using size_type              = typename allocator_traits::size_type;
+    using difference_type        = typename allocator_traits::difference_type;
+    using reference              = T&;
+    using const_reference        = const T&;
+    using pointer                = typename allocator_traits::pointer;
+    using const_pointer          = typename allocator_traits::const_pointer;
+    using iterator               = sfl::dtl::normal_iterator<pointer, compact_vector>;
+    using const_iterator         = sfl::dtl::normal_iterator<const_pointer, compact_vector>;
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    static_assert
+    (
+        std::is_same<typename Allocator::value_type, value_type>::value,
+        "Allocator::value_type must be same as sfl::compact_vector::value_type."
+    );
+
+private:
+
+    class data_base
+    {
+    public:
+
+        pointer first_;
+        pointer last_;
+
+        data_base() noexcept
+            : first_(nullptr)
+            , last_(nullptr)
+        {}
+    };
+
+    class data : public data_base , public allocator_type
+    {
+    public:
+
+        data() noexcept(std::is_nothrow_default_constructible<allocator_type>::value)
+            : allocator_type()
+        {}
+
+        data(const allocator_type& alloc) noexcept(std::is_nothrow_copy_constructible<allocator_type>::value)
+            : allocator_type(alloc)
+        {}
+
+        data(allocator_type&& other) noexcept(std::is_nothrow_move_constructible<allocator_type>::value)
+            : allocator_type(std::move(other))
+        {}
+
+        allocator_type& ref_to_alloc() noexcept
+        {
+            return *this;
+        }
+
+        const allocator_type& ref_to_alloc() const noexcept
+        {
+            return *this;
+        }
+    };
+
+    data data_;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    compact_vector() noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value
+    )
+        : data_()
+    {}
+
+    explicit compact_vector(const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value
+    )
+        : data_(alloc)
+    {}
+
+    explicit compact_vector(size_type n)
+        : data_()
+    {
+        initialize_default_n(n);
+    }
+
+    explicit compact_vector(size_type n, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_default_n(n);
+    }
+
+    compact_vector(size_type n, const T& value)
+        : data_()
+    {
+        initialize_fill_n(n, value);
+    }
+
+    compact_vector(size_type n, const T& value, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_fill_n(n, value);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    compact_vector(InputIt first, InputIt last)
+        : data_()
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    compact_vector(InputIt first, InputIt last, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(first, last);
+    }
+
+    compact_vector(std::initializer_list<T> ilist)
+        : compact_vector(ilist.begin(), ilist.end())
+    {}
+
+    compact_vector(std::initializer_list<T> ilist, const Allocator& alloc)
+        : compact_vector(ilist.begin(), ilist.end(), alloc)
+    {}
+
+    compact_vector(const compact_vector& other)
+        : data_
+        (
+            allocator_traits::select_on_container_copy_construction
+            (
+                other.data_.ref_to_alloc()
+            )
+        )
+    {
+        initialize_copy(other);
+    }
+
+    compact_vector(const compact_vector& other, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_copy(other);
+    }
+
+    compact_vector(compact_vector&& other)
+        : data_(std::move(other.data_.ref_to_alloc()))
+    {
+        initialize_move(other);
+    }
+
+    compact_vector(compact_vector&& other, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_move(other);
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    compact_vector(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    compact_vector(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    compact_vector(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    compact_vector(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~compact_vector()
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        sfl::dtl::deallocate
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_ - data_.first_
+        );
+    }
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    void assign(size_type n, const T& value)
+    {
+        assign_fill_n(n, value);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void assign(InputIt first, InputIt last)
+    {
+        assign_range(first, last);
+    }
+
+    void assign(std::initializer_list<T> ilist)
+    {
+        assign_range(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void assign_range(Range&& range)
+    {
+        if constexpr (std::ranges::forward_range<Range>)
+        {
+            assign_range(std::ranges::begin(range), std::ranges::end(range), std::forward_iterator_tag());
+        }
+        else
+        {
+            assign_range(std::ranges::begin(range), std::ranges::end(range), std::input_iterator_tag());
+        }
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void assign_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        assign_range(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    compact_vector& operator=(const compact_vector& other)
+    {
+        assign_copy(other);
+        return *this;
+    }
+
+    compact_vector& operator=(compact_vector&& other)
+    {
+        assign_move(other);
+        return *this;
+    }
+
+    compact_vector& operator=(std::initializer_list<T> ilist)
+    {
+        assign_range(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- ALLOCATOR ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    allocator_type get_allocator() const noexcept
+    {
+        return data_.ref_to_alloc();
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    iterator nth(size_type pos) noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_iterator nth(size_type pos) const noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return const_iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    size_type index_of(const_iterator pos) const noexcept
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return std::distance(cbegin(), pos);
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return data_.first_ == data_.last_;
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return std::distance(data_.first_, data_.last_);
+    }
+
+    SFL_NODISCARD
+    size_type max_size() const noexcept
+    {
+        return std::min<size_type>
+        (
+            allocator_traits::max_size(data_.ref_to_alloc()),
+            std::numeric_limits<difference_type>::max() / sizeof(value_type)
+        );
+    }
+
+    SFL_NODISCARD
+    size_type capacity() const noexcept
+    {
+        return size();
+    }
+
+    SFL_NODISCARD
+    size_type available() const noexcept
+    {
+        return 0;
+    }
+
+    //
+    // ---- ELEMENT ACCESS ----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    reference at(size_type pos)
+    {
+        if (pos >= size())
+        {
+            sfl::dtl::throw_out_of_range("sfl::compact_vector::at");
+        }
+
+        return *(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_reference at(size_type pos) const
+    {
+        if (pos >= size())
+        {
+            sfl::dtl::throw_out_of_range("sfl::compact_vector::at");
+        }
+
+        return *(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    reference operator[](size_type pos) noexcept
+    {
+        SFL_ASSERT(pos < size());
+        return *(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_reference operator[](size_type pos) const noexcept
+    {
+        SFL_ASSERT(pos < size());
+        return *(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    reference front() noexcept
+    {
+        SFL_ASSERT(!empty());
+        return *data_.first_;
+    }
+
+    SFL_NODISCARD
+    const_reference front() const noexcept
+    {
+        SFL_ASSERT(!empty());
+        return *data_.first_;
+    }
+
+    SFL_NODISCARD
+    reference back() noexcept
+    {
+        SFL_ASSERT(!empty());
+        return *(data_.last_ - 1);
+    }
+
+    SFL_NODISCARD
+    const_reference back() const noexcept
+    {
+        SFL_ASSERT(!empty());
+        return *(data_.last_ - 1);
+    }
+
+    SFL_NODISCARD
+    T* data() noexcept
+    {
+        return sfl::dtl::to_address(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const T* data() const noexcept
+    {
+        return sfl::dtl::to_address(data_.first_);
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear() noexcept
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        sfl::dtl::deallocate
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_ - data_.first_
+        );
+
+        data_.first_ = nullptr;
+        data_.last_  = nullptr;
+    }
+
+    template <typename... Args>
+    iterator emplace(const_iterator pos, Args&&... args)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+
+        const difference_type offset = std::distance(cbegin(), pos);
+
+        const size_type new_size = size() + 1;
+
+        if (new_size < size() || new_size > max_size())
+        {
+            sfl::dtl::throw_length_error("sfl::compact_vector::emplace");
+        }
+
+        pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_size);
+        pointer new_last  = new_first;
+
+        SFL_TRY
+        {
+            // The order of operations is critical. First we will construct
+            // new element in new storage because arguments `args...` can
+            // contain reference to element in this container and after
+            // that we will move elements from old to new storage.
+
+            sfl::dtl::construct_at_a
+            (
+                data_.ref_to_alloc(),
+                new_first + offset,
+                std::forward<Args>(args)...
+            );
+
+            new_last = nullptr;
+
+            new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.first_ + offset,
+                new_first
+            );
+
+            ++new_last;
+
+            new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_ + offset,
+                data_.last_,
+                new_last
+            );
+        }
+        SFL_CATCH (...)
+        {
+            if (new_last == nullptr)
+            {
+                sfl::dtl::destroy_at_a
+                (
+                    data_.ref_to_alloc(),
+                    new_first + offset
+                );
+            }
+            else
+            {
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    new_first,
+                    new_last
+                );
+            }
+
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                new_first,
+                new_size
+            );
+
+            SFL_RETHROW;
+        }
+
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        sfl::dtl::deallocate
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_ - data_.first_
+        );
+
+        data_.first_ = new_first;
+        data_.last_  = new_last;
+
+        return begin() + offset;
+    }
+
+    iterator insert(const_iterator pos, const T& value)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return emplace(pos, value);
+    }
+
+    iterator insert(const_iterator pos, T&& value)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return emplace(pos, std::move(value));
+    }
+
+    iterator insert(const_iterator pos, size_type n, const T& value)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return insert_fill_n(pos, n, value);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    iterator insert(const_iterator pos, InputIt first, InputIt last)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return insert_range(pos, first, last);
+    }
+
+    iterator insert(const_iterator pos, std::initializer_list<T> ilist)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return insert_range(pos, ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    iterator insert_range(const_iterator pos, Range&& range)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        if constexpr (std::ranges::forward_range<Range>)
+        {
+            return insert_range(pos, std::ranges::begin(range), std::ranges::end(range), std::forward_iterator_tag());
+        }
+        else
+        {
+            return insert_range(pos, std::ranges::begin(range), std::ranges::end(range), std::input_iterator_tag());
+        }
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    iterator insert_range(const_iterator pos, Range&& range)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        using std::begin;
+        using std::end;
+        return insert_range(pos, begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    template <typename... Args>
+    reference emplace_back(Args&&... args)
+    {
+        return *emplace(cend(), std::forward<Args>(args)...);
+    }
+
+    void push_back(const T& value)
+    {
+        emplace(cend(), value);
+    }
+
+    void push_back(T&& value)
+    {
+        emplace(cend(), std::move(value));
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void append_range(Range&& range)
+    {
+        insert_range(end(), std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void append_range(Range&& range)
+    {
+        insert_range(end(), std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    void pop_back()
+    {
+        SFL_ASSERT(!empty());
+        erase(const_iterator(data_.last_ - 1));
+    }
+
+    iterator erase(const_iterator pos)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos < cend());
+        return erase(pos, pos + 1);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        SFL_ASSERT(cbegin() <= first && first <= last && last <= cend());
+
+        if (first == last)
+        {
+            return begin() + std::distance(cbegin(), first);
+        }
+
+        const difference_type offset1 = std::distance(cbegin(), first);
+        const difference_type offset2 = std::distance(cbegin(), last);
+
+        const size_type new_size = size() - std::distance(first, last);
+
+        pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_size);
+        pointer new_last  = new_first;
+
+        SFL_TRY
+        {
+            new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.first_ + offset1,
+                new_first
+            );
+
+            new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_ + offset2,
+                data_.last_,
+                new_last
+            );
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                new_first,
+                new_last
+            );
+
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                new_first,
+                new_size
+            );
+
+            SFL_RETHROW;
+        }
+
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        sfl::dtl::deallocate
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_ - data_.first_
+        );
+
+        data_.first_ = new_first;
+        data_.last_  = new_last;
+
+        return begin() + offset1;
+    }
+
+    void resize(size_type n)
+    {
+        if (n == size())
+        {
+            return;
+        }
+
+        if (n > max_size())
+        {
+            sfl::dtl::throw_length_error("sfl::compact_vector::resize");
+        }
+
+        pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+        pointer new_last  = new_first;
+
+        SFL_TRY
+        {
+            if (n > size())
+            {
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_,
+                    new_first
+                );
+
+                new_last = sfl::dtl::uninitialized_default_construct_n_a
+                (
+                    data_.ref_to_alloc(),
+                    new_last,
+                    n - size()
+                );
+            }
+            else if (n < size())
+            {
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.first_ + n,
+                    new_first
+                );
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                new_first,
+                new_last
+            );
+
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                new_first,
+                n
+            );
+
+            SFL_RETHROW;
+        }
+
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        sfl::dtl::deallocate
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_ - data_.first_
+        );
+
+        data_.first_ = new_first;
+        data_.last_  = new_last;
+    }
+
+    void resize(size_type n, const T& value)
+    {
+        if (n == size())
+        {
+            return;
+        }
+
+        if (n > max_size())
+        {
+            sfl::dtl::throw_length_error("sfl::compact_vector::resize");
+        }
+
+        pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+        pointer new_last  = new_first;
+
+        SFL_TRY
+        {
+            if (n > size())
+            {
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_,
+                    new_first
+                );
+
+                new_last = sfl::dtl::uninitialized_fill_n_a
+                (
+                    data_.ref_to_alloc(),
+                    new_last,
+                    n - size(),
+                    value
+                );
+            }
+            else if (n < size())
+            {
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.first_ + n,
+                    new_first
+                );
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                new_first,
+                new_last
+            );
+
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                new_first,
+                n
+            );
+
+            SFL_RETHROW;
+        }
+
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        sfl::dtl::deallocate
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_ - data_.first_
+        );
+
+        data_.first_ = new_first;
+        data_.last_  = new_last;
+    }
+
+    void swap(compact_vector& other)
+    {
+        if (this == &other)
+        {
+            return;
+        }
+
+        using std::swap;
+
+        SFL_ASSERT
+        (
+            allocator_traits::propagate_on_container_swap::value ||
+            this->data_.ref_to_alloc() == other.data_.ref_to_alloc()
+        );
+
+        // If this and other allocator compares equal then one allocator
+        // can deallocate memory allocated by another allocator.
+        // One allocator can safely destroy_a elements constructed by other
+        // allocator regardless the two allocators compare equal or not.
+
+        if (allocator_traits::propagate_on_container_swap::value)
+        {
+            swap(this->data_.ref_to_alloc(), other.data_.ref_to_alloc());
+        }
+
+        swap(this->data_.first_, other.data_.first_);
+        swap(this->data_.last_,  other.data_.last_);
+    }
+
+private:
+
+    void initialize_default_n(size_type n)
+    {
+        if (n > max_size())
+        {
+            sfl::dtl::throw_length_error
+            (
+                "sfl::compact_vector::initialize_default_n"
+            );
+        }
+
+        data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+        data_.last_  = data_.first_;
+
+        SFL_TRY
+        {
+            data_.last_ = sfl::dtl::uninitialized_default_construct_n_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                n
+            );
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                n
+            );
+
+            SFL_RETHROW;
+        }
+    }
+
+    void initialize_fill_n(size_type n, const T& value)
+    {
+        if (n > max_size())
+        {
+            sfl::dtl::throw_length_error
+            (
+                "sfl::compact_vector::initialize_fill_n"
+            );
+        }
+
+        data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+        data_.last_  = data_.first_;
+
+        SFL_TRY
+        {
+            data_.last_ = sfl::dtl::uninitialized_fill_n_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                n,
+                value
+            );
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                n
+            );
+
+            SFL_RETHROW;
+        }
+    }
+
+    template <typename InputIt>
+    void initialize_range(InputIt first, InputIt last)
+    {
+        initialize_range(first, last, typename std::iterator_traits<InputIt>::iterator_category());
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void initialize_range(InputIt first, Sentinel last, std::input_iterator_tag)
+    {
+        SFL_TRY
+        {
+            while (first != last)
+            {
+                emplace_back(*first);
+                ++first;
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_ - data_.first_
+            );
+
+            SFL_RETHROW;
+        }
+    }
+
+    template <typename ForwardIt, typename Sentinel>
+    void initialize_range(ForwardIt first, Sentinel last, std::forward_iterator_tag)
+    {
+        const size_type n = std::distance(first, last);
+
+        if (n > max_size())
+        {
+            sfl::dtl::throw_length_error
+            (
+                "sfl::compact_vector::initialize_range"
+            );
+        }
+
+        data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+        data_.last_  = data_.first_;
+
+        SFL_TRY
+        {
+            data_.last_ = sfl::dtl::uninitialized_copy_a
+            (
+                data_.ref_to_alloc(),
+                first,
+                last,
+                data_.first_
+            );
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                n
+            );
+
+            SFL_RETHROW;
+        }
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void initialize_range(Range&& range)
+    {
+        if constexpr (std::ranges::forward_range<Range>)
+        {
+            initialize_range(std::ranges::begin(range), std::ranges::end(range), std::forward_iterator_tag());
+        }
+        else
+        {
+            initialize_range(std::ranges::begin(range), std::ranges::end(range), std::input_iterator_tag());
+        }
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void initialize_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        initialize_range(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    void initialize_copy(const compact_vector& other)
+    {
+        const size_type n = other.size();
+
+        if (n > max_size())
+        {
+            sfl::dtl::throw_length_error
+            (
+                "sfl::compact_vector::initialize_copy"
+            );
+        }
+
+        data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+        data_.last_  = data_.first_;
+
+        SFL_TRY
+        {
+            data_.last_ = sfl::dtl::uninitialized_copy_a
+            (
+                data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                data_.first_
+            );
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                n
+            );
+
+            SFL_RETHROW;
+        }
+    }
+
+    void initialize_move(compact_vector& other)
+    {
+        if (data_.ref_to_alloc() == other.data_.ref_to_alloc())
+        {
+            data_.first_ = other.data_.first_;
+            data_.last_  = other.data_.last_;
+
+            other.data_.first_ = nullptr;
+            other.data_.last_  = nullptr;
+        }
+        else
+        {
+            const size_type n = other.size();
+
+            if (n > max_size())
+            {
+                sfl::dtl::throw_length_error
+                (
+                    "sfl::compact_vector::initialize_move"
+                );
+            }
+
+            data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+            data_.last_  = data_.first_;
+
+            SFL_TRY
+            {
+                data_.last_ = sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    other.data_.first_,
+                    other.data_.last_,
+                    data_.first_
+                );
+            }
+            SFL_CATCH (...)
+            {
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    n
+                );
+
+                SFL_RETHROW;
+            }
+        }
+    }
+
+    void assign_fill_n(size_type n, const T& value)
+    {
+        if (n > max_size())
+        {
+            sfl::dtl::throw_length_error
+            (
+                "sfl::compact_vector::assign_fill_n"
+            );
+        }
+
+        if (n == size())
+        {
+            sfl::dtl::fill
+            (
+                data_.first_,
+                data_.last_,
+                value
+            );
+        }
+        else
+        {
+            clear();
+
+            data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+            data_.last_  = data_.first_;
+
+            SFL_TRY
+            {
+                data_.last_ = sfl::dtl::uninitialized_fill_n_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    n,
+                    value
+                );
+            }
+            SFL_CATCH (...)
+            {
+                clear();
+                SFL_RETHROW;
+            }
+        }
+    }
+
+    template <typename InputIt>
+    void assign_range(InputIt first, InputIt last)
+    {
+        assign_range(first, last, typename std::iterator_traits<InputIt>::iterator_category());
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void assign_range(InputIt first, Sentinel last, std::input_iterator_tag)
+    {
+        clear();
+
+        while (first != last)
+        {
+            emplace_back(*first);
+            ++first;
+        }
+    }
+
+    template <typename ForwardIt, typename Sentinel>
+    void assign_range(ForwardIt first, Sentinel last, std::forward_iterator_tag)
+    {
+        const size_type n = std::distance(first, last);
+
+        if (n > max_size())
+        {
+            sfl::dtl::throw_length_error
+            (
+                "sfl::compact_vector::assign_fill_n"
+            );
+        }
+
+        if (n == size())
+        {
+            sfl::dtl::copy
+            (
+                first,
+                last,
+                data_.first_
+            );
+        }
+        else
+        {
+            clear();
+
+            data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+            data_.last_  = data_.first_;
+
+            SFL_TRY
+            {
+                data_.last_ = sfl::dtl::uninitialized_copy_a
+                (
+                    data_.ref_to_alloc(),
+                    first,
+                    last,
+                    data_.first_
+                );
+            }
+            SFL_CATCH (...)
+            {
+                clear();
+                SFL_RETHROW;
+            }
+        }
+    }
+
+    void assign_copy(const compact_vector& other)
+    {
+        if (this != &other)
+        {
+            if (allocator_traits::propagate_on_container_copy_assignment::value)
+            {
+                if (data_.ref_to_alloc() != other.data_.ref_to_alloc())
+                {
+                    clear();
+                }
+
+                data_.ref_to_alloc() = other.data_.ref_to_alloc();
+            }
+
+            assign_range
+            (
+                other.data_.first_,
+                other.data_.last_
+            );
+        }
+    }
+
+    void assign_move(compact_vector& other)
+    {
+        if (allocator_traits::propagate_on_container_move_assignment::value)
+        {
+            if (data_.ref_to_alloc() != other.data_.ref_to_alloc())
+            {
+                clear();
+            }
+
+            data_.ref_to_alloc() = std::move(other.data_.ref_to_alloc());
+        }
+
+        if (data_.ref_to_alloc() == other.data_.ref_to_alloc())
+        {
+            clear();
+
+            data_.first_ = other.data_.first_;
+            data_.last_  = other.data_.last_;
+
+            other.data_.first_ = nullptr;
+            other.data_.last_  = nullptr;
+        }
+        else
+        {
+            assign_range
+            (
+                std::make_move_iterator(other.data_.first_),
+                std::make_move_iterator(other.data_.last_)
+            );
+        }
+    }
+
+    iterator insert_fill_n(const_iterator pos, size_type n, const T& value)
+    {
+        const difference_type offset = std::distance(cbegin(), pos);
+
+        if (n != 0)
+        {
+            const size_type new_size = size() + n;
+
+            if (new_size < size() || new_size > max_size())
+            {
+                sfl::dtl::throw_length_error
+                (
+                    "sfl::compact_vector::insert_fill_n"
+                );
+            }
+
+            pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_size);
+            pointer new_last  = new_first;
+
+            SFL_TRY
+            {
+                // `value` can be a reference to an element in this
+                // container. First we will create `n` copies of `value`
+                // and after that we can move elements.
+
+                sfl::dtl::uninitialized_fill_n_a
+                (
+                    data_.ref_to_alloc(),
+                    new_first + offset,
+                    n,
+                    value
+                );
+
+                new_last = nullptr;
+
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.first_ + offset,
+                    new_first
+                );
+
+                new_last += n;
+
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_ + offset,
+                    data_.last_,
+                    new_last
+                );
+            }
+            SFL_CATCH (...)
+            {
+                if (new_last == nullptr)
+                {
+                    sfl::dtl::destroy_n_a
+                    (
+                        data_.ref_to_alloc(),
+                        new_first + offset,
+                        n
+                    );
+                }
+                else
+                {
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_last
+                    );
+                }
+
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    new_first,
+                    new_size
+                );
+
+                SFL_RETHROW;
+            }
+
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_ - data_.first_
+            );
+
+            data_.first_ = new_first;
+            data_.last_  = new_last;
+        }
+
+        return begin() + offset;
+    }
+
+    template <typename InputIt>
+    iterator insert_range(const_iterator pos, InputIt first, InputIt last)
+    {
+        return insert_range(pos, first, last, typename std::iterator_traits<InputIt>::iterator_category());
+    }
+
+    template <typename InputIt, typename Sentinel>
+    iterator insert_range(const_iterator pos, InputIt first, Sentinel last, std::input_iterator_tag)
+    {
+        const difference_type offset = std::distance(cbegin(), pos);
+
+        while (first != last)
+        {
+            pos = insert(pos, *first);
+            ++pos;
+            ++first;
+        }
+
+        return begin() + offset;
+    }
+
+    template <typename ForwardIt, typename Sentinel>
+    iterator insert_range(const_iterator pos, ForwardIt first, Sentinel last, std::forward_iterator_tag)
+    {
+        const difference_type offset = std::distance(cbegin(), pos);
+
+        if (first != last)
+        {
+            const size_type new_size = size() + std::distance(first, last);
+
+            if (new_size < size() || new_size > max_size())
+            {
+                sfl::dtl::throw_length_error
+                (
+                    "sfl::compact_vector::insert_range"
+                );
+            }
+
+            pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_size);
+            pointer new_last  = new_first;
+
+            SFL_TRY
+            {
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.first_ + offset,
+                    new_first
+                );
+
+                new_last = sfl::dtl::uninitialized_copy_a
+                (
+                    data_.ref_to_alloc(),
+                    first,
+                    last,
+                    new_last
+                );
+
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_ + offset,
+                    data_.last_,
+                    new_last
+                );
+            }
+            SFL_CATCH (...)
+            {
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    new_first,
+                    new_last
+                );
+
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    new_first,
+                    new_size
+                );
+
+                SFL_RETHROW;
+            }
+
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_ - data_.first_
+            );
+
+            data_.first_ = new_first;
+            data_.last_  = new_last;
+        }
+
+        return begin() + offset;
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename T, typename A>
+SFL_NODISCARD
+bool operator==
+(
+    const compact_vector<T, A>& x,
+    const compact_vector<T, A>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename T, typename A>
+SFL_NODISCARD
+bool operator!=
+(
+    const compact_vector<T, A>& x,
+    const compact_vector<T, A>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename T, typename A>
+SFL_NODISCARD
+bool operator<
+(
+    const compact_vector<T, A>& x,
+    const compact_vector<T, A>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename T, typename A>
+SFL_NODISCARD
+bool operator>
+(
+    const compact_vector<T, A>& x,
+    const compact_vector<T, A>& y
+)
+{
+    return y < x;
+}
+
+template <typename T, typename A>
+SFL_NODISCARD
+bool operator<=
+(
+    const compact_vector<T, A>& x,
+    const compact_vector<T, A>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename T, typename A>
+SFL_NODISCARD
+bool operator>=
+(
+    const compact_vector<T, A>& x,
+    const compact_vector<T, A>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename T, typename A>
+void swap
+(
+    compact_vector<T, A>& x,
+    compact_vector<T, A>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename T, typename A, typename U>
+typename compact_vector<T, A>::size_type
+    erase(compact_vector<T, A>& c, const U& value)
+{
+    auto it = std::remove(c.begin(), c.end(), value);
+    auto r = std::distance(it, c.end());
+    c.erase(it, c.end());
+    return r;
+}
+
+template <typename T, typename A, typename Predicate>
+typename compact_vector<T, A>::size_type
+    erase_if(compact_vector<T, A>& c, Predicate pred)
+{
+    auto it = std::remove_if(c.begin(), c.end(), pred);
+    auto r = std::distance(it, c.end());
+    c.erase(it, c.end());
+    return r;
+}
+
+} // namespace sfl
+
+#endif // SFL_COMPACT_VECTOR_HPP_INCLUDED

--- a/src/thirdparty/sfl/detail/allocator_traits.hpp
+++ b/src/thirdparty/sfl/detail/allocator_traits.hpp
@@ -1,0 +1,277 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_DETAIL_ALLOCATOR_TRAITS_HPP_INCLUDED
+#define SFL_DETAIL_ALLOCATOR_TRAITS_HPP_INCLUDED
+
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/ignore_unused.hpp>
+#include <sfl/detail/type_traits.hpp>
+
+#include <limits>       // numeric_limits
+#include <memory>       // pointer_traits
+#include <type_traits>  // true_type, false_type
+#include <utility>      // declval
+
+#ifdef _MSC_VER // Visual C++
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+
+namespace sfl
+{
+
+namespace dtl
+{
+
+template <typename Allocator>
+class allocator_traits
+{
+private:
+
+    template <typename Alloc, typename T>
+    struct has_rebind
+    {
+    private:
+        template <typename Alloc2, typename T2>
+        static std::true_type test(typename Alloc2::template rebind<T2>*);
+
+        template <typename Alloc2, typename T2>
+        static std::false_type test(...);
+
+    public:
+        using type = decltype(test<Alloc, T>(nullptr));
+    };
+
+    template <typename Alloc, typename T, typename = typename has_rebind<Alloc, T>::type>
+    struct rebind_alloc_aux;
+
+    template <typename Alloc, typename T>
+    struct rebind_alloc_aux<Alloc, T, std::true_type>
+    {
+        using type = typename Alloc::template rebind<T>::other;
+    };
+
+    template <template <typename, typename...> class Alloc, typename T, typename U, typename... Args>
+    struct rebind_alloc_aux<Alloc<T, Args...>, U, std::false_type>
+    {
+        using type = Alloc<U, Args...>;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    template <typename Alloc, typename SizeType, typename ConstVoidPointer>
+    struct has_allocate_hint
+    {
+    private:
+        template <typename Alloc2, typename SizeType2, typename ConstVoidPointer2,
+                  sfl::dtl::void_t<decltype(std::declval<Alloc2>().allocate(std::declval<SizeType2>(),
+                                                                            std::declval<ConstVoidPointer2>()))>* = nullptr>
+        static std::true_type test(int);
+
+        template <typename Alloc2, typename SizeType2, typename ConstVoidPointer2>
+        static std::false_type test(...);
+
+    public:
+        using type = decltype(test<Alloc, SizeType, ConstVoidPointer>(0));
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    template <typename Alloc>
+    struct has_max_size
+    {
+    private:
+        template <typename Alloc2>
+        static std::true_type test(decltype(&Alloc2::max_size));
+
+        template <typename Alloc2>
+        static std::false_type test(...);
+
+    public:
+        using type = decltype(test<Alloc>(nullptr));
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    template <typename Alloc>
+    struct has_select_on_container_copy_construction
+    {
+    private:
+        template <typename Alloc2>
+        static std::true_type test(decltype(&Alloc2::select_on_container_copy_construction));
+
+        template <typename Alloc2>
+        static std::false_type test(...);
+
+    public:
+        using type = decltype(test<Alloc>(nullptr));
+    };
+
+public:
+
+    using allocator_type = Allocator;
+
+    using value_type = typename Allocator::value_type;
+
+    ///////////////////////////////////////////////////////////////////////////
+    #define SFL_NESTED_TYPE_OR_ALTERNATIVE(TNAME, ALTERNATIVE)              \
+    private:                                                                \
+        template <typename T> static typename T::TNAME test_##TNAME(T*);    \
+        template <typename T> static ALTERNATIVE       test_##TNAME(...);   \
+        using priv_##TNAME = decltype(test_##TNAME<Allocator>(nullptr));    \
+    public:                                                                 \
+    ///////////////////////////////////////////////////////////////////////////
+
+    SFL_NESTED_TYPE_OR_ALTERNATIVE(pointer, value_type*)
+    using pointer = priv_pointer;
+
+    SFL_NESTED_TYPE_OR_ALTERNATIVE(const_pointer, typename std::pointer_traits<pointer>::template rebind<const value_type>)
+    using const_pointer = priv_const_pointer;
+
+    SFL_NESTED_TYPE_OR_ALTERNATIVE(void_pointer, typename std::pointer_traits<pointer>::template rebind<void>)
+    using void_pointer = priv_void_pointer;
+
+    SFL_NESTED_TYPE_OR_ALTERNATIVE(const_void_pointer, typename std::pointer_traits<pointer>::template rebind<const void>)
+    using const_void_pointer = priv_const_void_pointer;
+
+    SFL_NESTED_TYPE_OR_ALTERNATIVE(difference_type, typename std::pointer_traits<pointer>::difference_type)
+    using difference_type = priv_difference_type;
+
+    SFL_NESTED_TYPE_OR_ALTERNATIVE(size_type, typename std::make_unsigned<difference_type>::type)
+    using size_type = priv_size_type;
+
+    SFL_NESTED_TYPE_OR_ALTERNATIVE(propagate_on_container_copy_assignment, std::false_type)
+    using propagate_on_container_copy_assignment = priv_propagate_on_container_copy_assignment;
+
+    SFL_NESTED_TYPE_OR_ALTERNATIVE(propagate_on_container_move_assignment, std::false_type)
+    using propagate_on_container_move_assignment = priv_propagate_on_container_move_assignment;
+
+    SFL_NESTED_TYPE_OR_ALTERNATIVE(propagate_on_container_swap, std::false_type)
+    using propagate_on_container_swap = priv_propagate_on_container_swap;
+
+    SFL_NESTED_TYPE_OR_ALTERNATIVE(is_always_equal, typename std::is_empty<Allocator>::type)
+    using is_always_equal = priv_is_always_equal;
+
+    SFL_NESTED_TYPE_OR_ALTERNATIVE(is_partially_propagable, std::false_type)
+    using is_partially_propagable = priv_is_partially_propagable;
+
+    ///////////////////////////////////////////////////////////////////////////
+    #undef SFL_NESTED_TYPE_OR_ALTERNATIVE
+    ///////////////////////////////////////////////////////////////////////////
+
+    template <typename T>
+    using rebind_alloc = typename rebind_alloc_aux<Allocator, T>::type;
+
+    template <typename T>
+    using rebind_traits = allocator_traits<rebind_alloc<T>>;
+
+public:
+
+    SFL_NODISCARD
+    static pointer allocate(Allocator& a, size_type n)
+    {
+        return a.allocate(n);
+    }
+
+    SFL_NODISCARD
+    static pointer allocate(Allocator& a, size_type n, const_void_pointer hint)
+    {
+        return priv_allocate(a, n, hint, typename has_allocate_hint<Allocator, size_type, const_void_pointer>::type());
+    }
+
+    static void deallocate(Allocator& a, pointer p, size_type n)
+    {
+        a.deallocate(p, n);
+    }
+
+    SFL_NODISCARD
+    static size_type max_size(const Allocator& a) noexcept
+    {
+        return priv_max_size(a, typename has_max_size<Allocator>::type());
+    }
+
+    SFL_NODISCARD
+    static Allocator select_on_container_copy_construction(const Allocator& a)
+    {
+        return priv_select_on_container_copy_construction(a, typename has_select_on_container_copy_construction<Allocator>::type());
+    }
+
+    SFL_NODISCARD
+    static bool is_storage_unpropagable(const Allocator& a, pointer p) noexcept
+    {
+        return priv_is_storage_unpropagable(a, p, is_partially_propagable());
+    }
+
+private:
+
+    static pointer priv_allocate(Allocator& a, size_type n, const_void_pointer hint, std::true_type)
+    {
+        return a.allocate(n, hint);
+    }
+
+    static pointer priv_allocate(Allocator& a, size_type n, const_void_pointer hint, std::false_type)
+    {
+        sfl::dtl::ignore_unused(hint);
+        return a.allocate(n);
+    }
+
+    static size_type priv_max_size(const Allocator& a, std::true_type)
+    {
+        return a.max_size();
+    }
+
+    static size_type priv_max_size(const Allocator& a, std::false_type)
+    {
+        sfl::dtl::ignore_unused(a);
+        return std::numeric_limits<size_type>::max() / sizeof(value_type);
+    }
+
+    static Allocator priv_select_on_container_copy_construction(const Allocator& a, std::true_type)
+    {
+        return a.select_on_container_copy_construction(a);
+    }
+
+    static Allocator priv_select_on_container_copy_construction(const Allocator& a, std::false_type)
+    {
+        return a;
+    }
+
+    static bool priv_is_storage_unpropagable(const Allocator& a, pointer p, std::true_type) noexcept
+    {
+        return a.is_storage_unpropagable(p);
+    }
+
+    static bool priv_is_storage_unpropagable(const Allocator& a, pointer p, std::false_type) noexcept
+    {
+        sfl::dtl::ignore_unused(a, p);
+        return false;
+    }
+};
+
+} // namespace dtl
+
+} // namespace sfl
+
+#ifdef _MSC_VER // Visual C++
+#pragma warning(pop)
+#endif
+
+#endif // SFL_DETAIL_ALLOCATOR_TRAITS_HPP_INCLUDED

--- a/src/thirdparty/sfl/detail/container_compatible_range.hpp
+++ b/src/thirdparty/sfl/detail/container_compatible_range.hpp
@@ -1,0 +1,48 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_DETAIL_CONTAINER_COMPATIBLE_RANGE_HPP_INCLUDED
+#define SFL_DETAIL_CONTAINER_COMPATIBLE_RANGE_HPP_INCLUDED
+
+#include <sfl/detail/cpp.hpp>
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+#include <concepts>
+#include <ranges>
+#endif
+
+namespace sfl
+{
+
+namespace dtl
+{
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+template <typename Range, typename T>
+concept container_compatible_range =
+    std::ranges::input_range<Range> &&
+    std::convertible_to<std::ranges::range_reference_t<Range>, T>;
+#endif
+
+} // namespace dtl
+
+} // namespace sfl
+
+#endif // SFL_DETAIL_CONTAINER_COMPATIBLE_RANGE_HPP_INCLUDED

--- a/src/thirdparty/sfl/detail/cpp.hpp
+++ b/src/thirdparty/sfl/detail/cpp.hpp
@@ -1,0 +1,60 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_DETAIL_CPP_HPP_INCLUDED
+#define SFL_DETAIL_CPP_HPP_INCLUDED
+
+#include <cassert>
+
+#define SFL_ASSERT(x) assert(x)
+
+#define SFL_CPP_14 201402L
+#define SFL_CPP_17 201703L
+#define SFL_CPP_20 202002L
+
+#if defined(_MSC_VER) && defined(_MSVC_LANG)
+    #define SFL_CPP_VERSION _MSVC_LANG
+#else
+    #define SFL_CPP_VERSION __cplusplus
+#endif
+
+#if SFL_CPP_VERSION >= SFL_CPP_14
+    #define SFL_CONSTEXPR_14 constexpr
+#else
+    #define SFL_CONSTEXPR_14
+#endif
+
+#if SFL_CPP_VERSION >= SFL_CPP_17
+    #define SFL_NODISCARD [[nodiscard]]
+#else
+    #define SFL_NODISCARD
+#endif
+
+#ifdef SFL_NO_EXCEPTIONS
+    #define SFL_TRY      if (true)
+    #define SFL_CATCH(x) if (false)
+    #define SFL_RETHROW
+#else
+    #define SFL_TRY      try
+    #define SFL_CATCH(x) catch (x)
+    #define SFL_RETHROW  throw
+#endif
+
+#endif // SFL_DETAIL_CPP_HPP_INCLUDED

--- a/src/thirdparty/sfl/detail/exceptions.hpp
+++ b/src/thirdparty/sfl/detail/exceptions.hpp
@@ -1,0 +1,64 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_DETAIL_EXCEPTIONS_HPP_INCLUDED
+#define SFL_DETAIL_EXCEPTIONS_HPP_INCLUDED
+
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/ignore_unused.hpp>
+
+#include <cstdlib>      // abort
+#include <stdexcept>    // length_error, out_of_range
+
+namespace sfl
+{
+
+namespace dtl
+{
+
+[[noreturn]]
+inline void throw_length_error(const char* msg)
+{
+    #ifdef SFL_NO_EXCEPTIONS
+    sfl::dtl::ignore_unused(msg);
+    SFL_ASSERT(!"std::length_error thrown");
+    std::abort();
+    #else
+    throw std::length_error(msg);
+    #endif
+}
+
+[[noreturn]]
+inline void throw_out_of_range(const char* msg)
+{
+    #ifdef SFL_NO_EXCEPTIONS
+    sfl::dtl::ignore_unused(msg);
+    SFL_ASSERT(!"std::out_of_range thrown");
+    std::abort();
+    #else
+    throw std::out_of_range(msg);
+    #endif
+}
+
+} // namespace dtl
+
+} // namespace sfl
+
+#endif // SFL_DETAIL_EXCEPTIONS_HPP_INCLUDED

--- a/src/thirdparty/sfl/detail/functional.hpp
+++ b/src/thirdparty/sfl/detail/functional.hpp
@@ -1,0 +1,72 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_DETAIL_FUNCTIONAL_HPP_INCLUDED
+#define SFL_DETAIL_FUNCTIONAL_HPP_INCLUDED
+
+#include <sfl/detail/cpp.hpp>
+
+namespace sfl
+{
+
+namespace dtl
+{
+
+// Function object type whose operator() returns its argument unchanged.
+struct identity
+{
+    template <typename T>
+    SFL_NODISCARD
+    T& operator()(T& t) const noexcept
+    {
+        return t;
+    }
+
+    template <typename T>
+    SFL_NODISCARD
+    const T& operator()(const T& t) const noexcept
+    {
+        return t;
+    }
+};
+
+// Function object type whose operator() returns first element of pair unchanged.
+struct first
+{
+    template <typename Pair>
+    SFL_NODISCARD
+    typename Pair::first_type& operator()(Pair& p) const noexcept
+    {
+        return p.first;
+    }
+
+    template <typename Pair>
+    SFL_NODISCARD
+    const typename Pair::first_type& operator()(const Pair& p) const noexcept
+    {
+        return p.first;
+    }
+};
+
+} // namespace dtl
+
+} // namespace sfl
+
+#endif // SFL_DETAIL_FUNCTIONAL_HPP_INCLUDED

--- a/src/thirdparty/sfl/detail/ignore_unused.hpp
+++ b/src/thirdparty/sfl/detail/ignore_unused.hpp
@@ -1,0 +1,46 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_DETAIL_IGNORE_UNUSED_HPP_INCLUDED
+#define SFL_DETAIL_IGNORE_UNUSED_HPP_INCLUDED
+
+#include <sfl/detail/cpp.hpp>
+
+namespace sfl
+{
+
+namespace dtl
+{
+
+//
+// This function is used for silencing warnings about unused variables.
+//
+template <typename... Args>
+SFL_CONSTEXPR_14
+void ignore_unused(Args&&...)
+{
+    // Do nothing.
+}
+
+} // namespace dtl
+
+} // namespace sfl
+
+#endif // SFL_DETAIL_IGNORE_UNUSED_HPP_INCLUDED

--- a/src/thirdparty/sfl/detail/index_sequence.hpp
+++ b/src/thirdparty/sfl/detail/index_sequence.hpp
@@ -1,0 +1,68 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_DETAIL_INDEX_SEQUENCE_HPP_INCLUDED
+#define SFL_DETAIL_INDEX_SEQUENCE_HPP_INCLUDED
+
+#include <cstddef> // size_t
+
+namespace sfl
+{
+
+namespace dtl
+{
+
+template <std::size_t... Ints>
+struct index_sequence
+{
+    using type = index_sequence;
+};
+
+template <typename IndexSequence1, typename IndexSequence2>
+struct index_sequence_concat;
+
+template <std::size_t... Ints1, std::size_t... Ints2>
+struct index_sequence_concat< sfl::dtl::index_sequence<Ints1...>,
+                              sfl::dtl::index_sequence<Ints2...> >
+    : sfl::dtl::index_sequence<Ints1..., (sizeof...(Ints1) + Ints2)...>
+{};
+
+template <std::size_t N>
+struct make_index_sequence
+    : sfl::dtl::index_sequence_concat< typename sfl::dtl::make_index_sequence<N/2>::type,
+                                       typename sfl::dtl::make_index_sequence<N - N/2>::type >::type
+{};
+
+template <>
+struct make_index_sequence<0> : sfl::dtl::index_sequence<>
+{};
+
+template <>
+struct make_index_sequence<1> : sfl::dtl::index_sequence<0>
+{};
+
+template <typename... T>
+using index_sequence_for = sfl::dtl::make_index_sequence<sizeof...(T)>;
+
+} // namespace dtl
+
+} // namespace sfl
+
+#endif // SFL_DETAIL_INDEX_SEQUENCE_HPP_INCLUDED

--- a/src/thirdparty/sfl/detail/initialized_memory_algorithms.hpp
+++ b/src/thirdparty/sfl/detail/initialized_memory_algorithms.hpp
@@ -1,0 +1,573 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_DETAIL_INITIALIZED_MEMORY_ALGORITHMS_HPP_INCLUDED
+#define SFL_DETAIL_INITIALIZED_MEMORY_ALGORITHMS_HPP_INCLUDED
+
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/type_traits.hpp>
+
+#include <algorithm>
+#include <iterator>
+
+namespace sfl
+{
+
+namespace dtl
+{
+
+template <typename InputIt, typename OutputIt,
+          sfl::dtl::enable_if_t< (!sfl::dtl::is_segmented_iterator<InputIt>::value &&
+                                  !sfl::dtl::is_segmented_iterator<OutputIt>::value) ||
+                                 (!sfl::dtl::is_segmented_iterator<InputIt>::value &&
+                                   sfl::dtl::is_segmented_iterator<OutputIt>::value &&
+                                  !sfl::dtl::is_random_access_iterator<InputIt>::value) >* = nullptr>
+OutputIt copy(InputIt first, InputIt last, OutputIt d_first)
+{
+    return std::copy(first, last, d_first);
+}
+
+template <typename InputIt, typename OutputIt,
+          sfl::dtl::enable_if_t< !sfl::dtl::is_segmented_iterator<InputIt>::value &&
+                                  sfl::dtl::is_segmented_iterator<OutputIt>::value &&
+                                  sfl::dtl::is_random_access_iterator<InputIt>::value >* = nullptr>
+OutputIt copy(InputIt first, InputIt last, OutputIt d_first)
+{
+    using traits = sfl::dtl::segmented_iterator_traits<OutputIt>;
+
+    if (first == last)
+    {
+        return d_first;
+    }
+    else
+    {
+        auto curr = first;
+
+        auto d_local = traits::local(d_first);
+        auto d_seg   = traits::segment(d_first);
+
+        while (true)
+        {
+            using difference_type =
+                typename std::iterator_traits<InputIt>::difference_type;
+
+            const auto count = std::min<difference_type>
+            (
+                std::distance(curr, last),
+                std::distance(d_local, traits::end(d_seg))
+            );
+
+            const auto next = curr + count;
+
+            d_local = sfl::dtl::copy
+            (
+                curr,
+                next,
+                d_local
+            );
+
+            curr = next;
+
+            if (curr == last)
+            {
+                return traits::compose(d_seg, d_local);
+            }
+
+            ++d_seg;
+
+            d_local = traits::begin(d_seg);
+        }
+    }
+}
+
+template <typename InputIt, typename OutputIt,
+          sfl::dtl::enable_if_t< sfl::dtl::is_segmented_iterator<InputIt>::value >* = nullptr>
+OutputIt copy(InputIt first, InputIt last, OutputIt d_first)
+{
+    using traits = sfl::dtl::segmented_iterator_traits<InputIt>;
+
+    auto first_seg = traits::segment(first);
+    auto last_seg  = traits::segment(last);
+
+    if (first_seg == last_seg)
+    {
+        return sfl::dtl::copy
+        (
+            traits::local(first),
+            traits::local(last),
+            d_first
+        );
+    }
+    else
+    {
+        d_first = sfl::dtl::copy
+        (
+            traits::local(first),
+            traits::end(first_seg),
+            d_first
+        );
+
+        ++first_seg;
+
+        while (first_seg != last_seg)
+        {
+            d_first = sfl::dtl::copy
+            (
+                traits::begin(first_seg),
+                traits::end(first_seg),
+                d_first
+            );
+
+            ++first_seg;
+        }
+
+        d_first = sfl::dtl::copy
+        (
+            traits::begin(last_seg),
+            traits::local(last),
+            d_first
+        );
+
+        return d_first;
+    }
+}
+
+template <typename InputIt, typename Size, typename OutputIt>
+OutputIt copy_n(InputIt first, Size count, OutputIt d_first)
+{
+    return std::copy_n(first, count, d_first);
+}
+
+template <typename BidirIt1, typename BidirIt2,
+          sfl::dtl::enable_if_t< (!sfl::dtl::is_segmented_iterator<BidirIt1>::value &&
+                                  !sfl::dtl::is_segmented_iterator<BidirIt2>::value) ||
+                                 (!sfl::dtl::is_segmented_iterator<BidirIt1>::value &&
+                                   sfl::dtl::is_segmented_iterator<BidirIt2>::value &&
+                                  !sfl::dtl::is_random_access_iterator<BidirIt1>::value) >* = nullptr>
+BidirIt2 copy_backward(BidirIt1 first, BidirIt1 last, BidirIt2 d_last)
+{
+    return std::copy_backward(first, last, d_last);
+}
+
+template <typename BidirIt1, typename BidirIt2,
+          sfl::dtl::enable_if_t< !sfl::dtl::is_segmented_iterator<BidirIt1>::value &&
+                                  sfl::dtl::is_segmented_iterator<BidirIt2>::value &&
+                                  sfl::dtl::is_random_access_iterator<BidirIt1>::value>* = nullptr>
+BidirIt2 copy_backward(BidirIt1 first, BidirIt1 last, BidirIt2 d_last)
+{
+    using traits = sfl::dtl::segmented_iterator_traits<BidirIt2>;
+
+    if (first == last)
+    {
+        return d_last;
+    }
+    else
+    {
+        auto curr = last;
+
+        auto d_local = traits::local(d_last);
+        auto d_seg   = traits::segment(d_last);
+
+        while (true)
+        {
+            using difference_type =
+                typename std::iterator_traits<BidirIt1>::difference_type;
+
+            const auto count = std::min<difference_type>
+            (
+                std::distance(first, curr),
+                std::distance(traits::begin(d_seg), d_local)
+            );
+
+            const auto prev = curr - count;
+
+            d_local = sfl::dtl::copy_backward
+            (
+                prev,
+                curr,
+                d_local
+            );
+
+            curr = prev;
+
+            if (curr == first)
+            {
+                return traits::compose(d_seg, d_local);
+            }
+
+            --d_seg;
+
+            d_local = traits::end(d_seg);
+        }
+    }
+}
+
+template <typename BidirIt1, typename BidirIt2,
+          sfl::dtl::enable_if_t< sfl::dtl::is_segmented_iterator<BidirIt1>::value >* = nullptr>
+BidirIt2 copy_backward(BidirIt1 first, BidirIt1 last, BidirIt2 d_last)
+{
+    using traits = sfl::dtl::segmented_iterator_traits<BidirIt1>;
+
+    auto first_seg = traits::segment(first);
+    auto last_seg  = traits::segment(last);
+
+    if (first_seg == last_seg)
+    {
+        return sfl::dtl::copy_backward
+        (
+            traits::local(first),
+            traits::local(last),
+            d_last
+        );
+    }
+    else
+    {
+        d_last = sfl::dtl::copy_backward
+        (
+            traits::begin(last_seg),
+            traits::local(last),
+            d_last
+        );
+
+        --last_seg;
+
+        while (first_seg != last_seg)
+        {
+            d_last = sfl::dtl::copy_backward
+            (
+                traits::begin(last_seg),
+                traits::end(last_seg),
+                d_last
+            );
+
+            --last_seg;
+        }
+
+        d_last = sfl::dtl::copy_backward
+        (
+            traits::local(first),
+            traits::end(last_seg),
+            d_last
+        );
+
+        return d_last;
+    }
+}
+
+template <typename InputIt, typename OutputIt,
+          sfl::dtl::enable_if_t< (!sfl::dtl::is_segmented_iterator<InputIt>::value &&
+                                  !sfl::dtl::is_segmented_iterator<OutputIt>::value) ||
+                                 (!sfl::dtl::is_segmented_iterator<InputIt>::value &&
+                                   sfl::dtl::is_segmented_iterator<OutputIt>::value &&
+                                  !sfl::dtl::is_random_access_iterator<InputIt>::value) >* = nullptr>
+OutputIt move(InputIt first, InputIt last, OutputIt d_first)
+{
+    return std::move(first, last, d_first);
+}
+
+template <typename InputIt, typename OutputIt,
+          sfl::dtl::enable_if_t< !sfl::dtl::is_segmented_iterator<InputIt>::value &&
+                                  sfl::dtl::is_segmented_iterator<OutputIt>::value &&
+                                  sfl::dtl::is_random_access_iterator<InputIt>::value >* = nullptr>
+OutputIt move(InputIt first, InputIt last, OutputIt d_first)
+{
+    using traits = sfl::dtl::segmented_iterator_traits<OutputIt>;
+
+    if (first == last)
+    {
+        return d_first;
+    }
+    else
+    {
+        auto curr = first;
+
+        auto d_local = traits::local(d_first);
+        auto d_seg   = traits::segment(d_first);
+
+        while (true)
+        {
+            using difference_type =
+                typename std::iterator_traits<InputIt>::difference_type;
+
+            const auto count = std::min<difference_type>
+            (
+                std::distance(curr, last),
+                std::distance(d_local, traits::end(d_seg))
+            );
+
+            const auto next = curr + count;
+
+            d_local = sfl::dtl::move
+            (
+                curr,
+                next,
+                d_local
+            );
+
+            curr = next;
+
+            if (curr == last)
+            {
+                return traits::compose(d_seg, d_local);
+            }
+
+            ++d_seg;
+
+            d_local = traits::begin(d_seg);
+        }
+    }
+}
+
+template <typename InputIt, typename OutputIt,
+          sfl::dtl::enable_if_t< sfl::dtl::is_segmented_iterator<InputIt>::value >* = nullptr>
+OutputIt move(InputIt first, InputIt last, OutputIt d_first)
+{
+    using traits = sfl::dtl::segmented_iterator_traits<InputIt>;
+
+    auto first_seg = traits::segment(first);
+    auto last_seg  = traits::segment(last);
+
+    if (first_seg == last_seg)
+    {
+        return sfl::dtl::move
+        (
+            traits::local(first),
+            traits::local(last),
+            d_first
+        );
+    }
+    else
+    {
+        d_first = sfl::dtl::move
+        (
+            traits::local(first),
+            traits::end(first_seg),
+            d_first
+        );
+
+        ++first_seg;
+
+        while (first_seg != last_seg)
+        {
+            d_first = sfl::dtl::move
+            (
+                traits::begin(first_seg),
+                traits::end(first_seg),
+                d_first
+            );
+
+            ++first_seg;
+        }
+
+        d_first = sfl::dtl::move
+        (
+            traits::begin(last_seg),
+            traits::local(last),
+            d_first
+        );
+
+        return d_first;
+    }
+}
+
+template <typename BidirIt1, typename BidirIt2,
+          sfl::dtl::enable_if_t< (!sfl::dtl::is_segmented_iterator<BidirIt1>::value &&
+                                  !sfl::dtl::is_segmented_iterator<BidirIt2>::value) ||
+                                 (!sfl::dtl::is_segmented_iterator<BidirIt1>::value &&
+                                   sfl::dtl::is_segmented_iterator<BidirIt2>::value &&
+                                  !sfl::dtl::is_random_access_iterator<BidirIt1>::value) >* = nullptr>
+BidirIt2 move_backward(BidirIt1 first, BidirIt1 last, BidirIt2 d_last)
+{
+    return std::move_backward(first, last, d_last);
+}
+
+template <typename BidirIt1, typename BidirIt2,
+          sfl::dtl::enable_if_t< !sfl::dtl::is_segmented_iterator<BidirIt1>::value &&
+                                  sfl::dtl::is_segmented_iterator<BidirIt2>::value &&
+                                  sfl::dtl::is_random_access_iterator<BidirIt1>::value >* = nullptr>
+BidirIt2 move_backward(BidirIt1 first, BidirIt1 last, BidirIt2 d_last)
+{
+    using traits = sfl::dtl::segmented_iterator_traits<BidirIt2>;
+
+    if (first == last)
+    {
+        return d_last;
+    }
+    else
+    {
+        auto curr = last;
+
+        auto d_local = traits::local(d_last);
+        auto d_seg   = traits::segment(d_last);
+
+        while (true)
+        {
+            using difference_type =
+                typename std::iterator_traits<BidirIt1>::difference_type;
+
+            const auto count = std::min<difference_type>
+            (
+                std::distance(first, curr),
+                std::distance(traits::begin(d_seg), d_local)
+            );
+
+            const auto prev = curr - count;
+
+            d_local = sfl::dtl::move_backward
+            (
+                prev,
+                curr,
+                d_local
+            );
+
+            curr = prev;
+
+            if (curr == first)
+            {
+                return traits::compose(d_seg, d_local);
+            }
+
+            --d_seg;
+
+            d_local = traits::end(d_seg);
+        }
+    }
+}
+
+template <typename BidirIt1, typename BidirIt2,
+          sfl::dtl::enable_if_t< sfl::dtl::is_segmented_iterator<BidirIt1>::value >* = nullptr>
+BidirIt2 move_backward(BidirIt1 first, BidirIt1 last, BidirIt2 d_last)
+{
+    using traits = sfl::dtl::segmented_iterator_traits<BidirIt1>;
+
+    auto first_seg = traits::segment(first);
+    auto last_seg  = traits::segment(last);
+
+    if (first_seg == last_seg)
+    {
+        return sfl::dtl::move_backward
+        (
+            traits::local(first),
+            traits::local(last),
+            d_last
+        );
+    }
+    else
+    {
+        d_last = sfl::dtl::move_backward
+        (
+            traits::begin(last_seg),
+            traits::local(last),
+            d_last
+        );
+
+        --last_seg;
+
+        while (first_seg != last_seg)
+        {
+            d_last = sfl::dtl::move_backward
+            (
+                traits::begin(last_seg),
+                traits::end(last_seg),
+                d_last
+            );
+
+            --last_seg;
+        }
+
+        d_last = sfl::dtl::move_backward
+        (
+            traits::local(first),
+            traits::end(last_seg),
+            d_last
+        );
+
+        return d_last;
+    }
+}
+
+template <typename ForwardIt, typename T,
+          sfl::dtl::enable_if_t< !sfl::dtl::is_segmented_iterator<ForwardIt>::value >* = nullptr>
+void fill(ForwardIt first, ForwardIt last, const T& value)
+{
+    std::fill(first, last, value);
+}
+
+template <typename ForwardIt, typename T,
+          sfl::dtl::enable_if_t< sfl::dtl::is_segmented_iterator<ForwardIt>::value >* = nullptr>
+void fill(ForwardIt first, ForwardIt last, const T& value)
+{
+    using traits = sfl::dtl::segmented_iterator_traits<ForwardIt>;
+
+    auto first_seg = traits::segment(first);
+    auto last_seg  = traits::segment(last);
+
+    if (first_seg == last_seg)
+    {
+        sfl::dtl::fill
+        (
+            traits::local(first),
+            traits::local(last),
+            value
+        );
+    }
+    else
+    {
+        sfl::dtl::fill
+        (
+            traits::local(first),
+            traits::end(first_seg),
+            value
+        );
+
+        ++first_seg;
+
+        while (first_seg != last_seg)
+        {
+            sfl::dtl::fill
+            (
+                traits::begin(first_seg),
+                traits::end(first_seg),
+                value
+            );
+
+            ++first_seg;
+        }
+
+        sfl::dtl::fill
+        (
+            traits::begin(last_seg),
+            traits::local(last),
+            value
+        );
+    }
+}
+
+template <typename OutputIt, typename Size, typename T>
+OutputIt fill_n(OutputIt first, Size count, const T& value)
+{
+    return std::fill_n(first, count, value);
+}
+
+} // namespace dtl
+
+} // namespace sfl
+
+#endif // SFL_DETAIL_INITIALIZED_MEMORY_ALGORITHMS_HPP_INCLUDED

--- a/src/thirdparty/sfl/detail/node_small_allocator.hpp
+++ b/src/thirdparty/sfl/detail/node_small_allocator.hpp
@@ -1,0 +1,398 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_DETAIL_NODE_SMALL_ALLOCATOR_HPP_INCLUDED
+#define SFL_DETAIL_NODE_SMALL_ALLOCATOR_HPP_INCLUDED
+
+#include <sfl/detail/allocator_traits.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/ignore_unused.hpp>
+#include <sfl/detail/static_pool.hpp>
+#include <sfl/detail/to_address.hpp>
+
+#include <cstddef>      // size_t, ptrdiff_t
+#include <memory>       // allocator, allocator_traits, pointer_traits
+#include <utility>      // move
+#include <type_traits>  // is_xxxxx, true_type, false_type
+
+namespace sfl
+{
+
+namespace dtl
+{
+
+template <typename T, std::size_t N, typename BaseAllocator = std::allocator<T>>
+class node_small_allocator : public BaseAllocator
+{
+    static_assert
+    (
+        std::is_same<typename BaseAllocator::value_type, T>::value,
+        "BaseAllocator::value_type must be same as T."
+    );
+
+    template <typename, std::size_t, typename>
+    friend class node_small_allocator;
+
+private:
+
+    using base_allocator_type = BaseAllocator;
+
+    using static_pool_type = sfl::dtl::static_pool<T, N>;
+
+public:
+
+    using value_type         = T;
+    using pointer            = typename sfl::dtl::allocator_traits<base_allocator_type>::pointer;
+    using const_pointer      = typename sfl::dtl::allocator_traits<base_allocator_type>::const_pointer;
+    using void_pointer       = typename sfl::dtl::allocator_traits<base_allocator_type>::void_pointer;
+    using const_void_pointer = typename sfl::dtl::allocator_traits<base_allocator_type>::const_void_pointer;
+    using reference          = T&;
+    using const_reference    = const T&;
+    using size_type          = std::size_t;
+    using difference_type    = std::ptrdiff_t;
+
+    using propagate_on_container_copy_assignment = typename sfl::dtl::allocator_traits<base_allocator_type>::propagate_on_container_copy_assignment;
+    using propagate_on_container_move_assignment = typename sfl::dtl::allocator_traits<base_allocator_type>::propagate_on_container_move_assignment;
+    using propagate_on_container_swap            = typename sfl::dtl::allocator_traits<base_allocator_type>::propagate_on_container_swap;
+    using is_always_equal                        = typename sfl::dtl::allocator_traits<base_allocator_type>::is_always_equal;
+    using is_partially_propagable                = std::true_type;
+
+    template <typename U>
+    struct rebind
+    {
+        using other = node_small_allocator
+        <
+            U,
+            N,
+            typename sfl::dtl::allocator_traits<base_allocator_type>::template rebind_alloc<U>
+        >;
+    };
+
+private:
+
+    SFL_NODISCARD
+    base_allocator_type& base() noexcept
+    {
+        return *static_cast<base_allocator_type*>(this);
+    }
+
+    SFL_NODISCARD
+    const base_allocator_type& base() const noexcept
+    {
+        return *static_cast<const base_allocator_type*>(this);
+    }
+
+private:
+
+    static_pool_type pool_;
+
+public:
+
+    node_small_allocator() noexcept
+    (
+        std::is_nothrow_default_constructible<base_allocator_type>::value &&
+        std::is_nothrow_default_constructible<static_pool_type>::value
+    )
+    {}
+
+    node_small_allocator(const node_small_allocator& other) noexcept
+        : base_allocator_type(other.base())
+    {}
+
+    node_small_allocator(node_small_allocator&& other) noexcept
+        : base_allocator_type(std::move(other.base()))
+    {}
+
+    template <typename T2, std::size_t N2, typename Allocator2>
+    node_small_allocator(const node_small_allocator<T2, N2, Allocator2>& other) noexcept
+        : base_allocator_type(other.base())
+    {}
+
+    template <typename T2, std::size_t N2, typename Allocator2>
+    node_small_allocator(node_small_allocator<T2, N2, Allocator2>&& other) noexcept
+        : base_allocator_type(std::move(other.base()))
+    {}
+
+    explicit node_small_allocator(const base_allocator_type& other) noexcept
+        : base_allocator_type(other)
+    {}
+
+    explicit node_small_allocator(base_allocator_type&& other) noexcept
+        : base_allocator_type(std::move(other))
+    {}
+
+    node_small_allocator& operator=(const node_small_allocator& other) noexcept
+    {
+        base_allocator_type::operator=(other.base());
+        return *this;
+    }
+
+    node_small_allocator& operator=(node_small_allocator&& other) noexcept
+    {
+        base_allocator_type::operator=(std::move(other.base()));
+        return *this;
+    }
+
+    template <typename T2, std::size_t N2, typename Allocator2>
+    node_small_allocator& operator=(const node_small_allocator<T2, N2, Allocator2>& other) noexcept
+    {
+        base_allocator_type::operator=(other.base());
+        return *this;
+    }
+
+    template <typename T2, std::size_t N2, typename Allocator2>
+    node_small_allocator& operator=(node_small_allocator<T2, N2, Allocator2>&& other) noexcept
+    {
+        base_allocator_type::operator=(std::move(other.base()));
+        return *this;
+    }
+
+    node_small_allocator& operator=(const base_allocator_type& other) noexcept
+    {
+        base_allocator_type::operator=(other);
+        return *this;
+    }
+
+    node_small_allocator& operator=(base_allocator_type&& other) noexcept
+    {
+        base_allocator_type::operator=(std::move(other));
+        return *this;
+    }
+
+    SFL_NODISCARD
+    pointer allocate(size_type n)
+    {
+        SFL_ASSERT(n == 1);
+
+        sfl::dtl::ignore_unused(n);
+
+        if (!pool_.full())
+        {
+            return std::pointer_traits<pointer>::pointer_to(*pool_.allocate());
+        }
+        else
+        {
+            return sfl::dtl::allocator_traits<base_allocator_type>::allocate(base(), 1);
+        }
+    }
+
+    SFL_NODISCARD
+    pointer allocate(size_type n, const void* hint)
+    {
+        SFL_ASSERT(n == 1);
+
+        sfl::dtl::ignore_unused(n);
+
+        if (!pool_.full())
+        {
+            return std::pointer_traits<pointer>::pointer_to(*pool_.allocate());
+        }
+        else
+        {
+            return sfl::dtl::allocator_traits<base_allocator_type>::allocate(base(), 1, hint);
+        }
+    }
+
+    void deallocate(pointer p, std::size_t n) noexcept
+    {
+        SFL_ASSERT(n == 1);
+
+        sfl::dtl::ignore_unused(n);
+
+        if (pool_.contains(sfl::dtl::to_address(p)))
+        {
+            pool_.deallocate(sfl::dtl::to_address(p));
+        }
+        else
+        {
+            sfl::dtl::allocator_traits<base_allocator_type>::deallocate(base(), p, 1);
+        }
+    }
+
+    SFL_NODISCARD
+    bool is_storage_unpropagable(pointer p) const noexcept
+    {
+        return pool_.contains(sfl::dtl::to_address(p));
+    }
+};
+
+template <typename T, typename BaseAllocator>
+class node_small_allocator<T, 0, BaseAllocator> : public BaseAllocator
+{
+    static_assert
+    (
+        std::is_same<typename BaseAllocator::value_type, T>::value,
+        "BaseAllocator::value_type must be same as T."
+    );
+
+    template <typename, std::size_t, typename>
+    friend class node_small_allocator;
+
+private:
+
+    using base_allocator_type = BaseAllocator;
+
+public:
+
+    using value_type         = T;
+    using pointer            = typename sfl::dtl::allocator_traits<base_allocator_type>::pointer;
+    using const_pointer      = typename sfl::dtl::allocator_traits<base_allocator_type>::const_pointer;
+    using void_pointer       = typename sfl::dtl::allocator_traits<base_allocator_type>::void_pointer;
+    using const_void_pointer = typename sfl::dtl::allocator_traits<base_allocator_type>::const_void_pointer;
+    using reference          = T&;
+    using const_reference    = const T&;
+    using size_type          = std::size_t;
+    using difference_type    = std::ptrdiff_t;
+
+    using propagate_on_container_copy_assignment = typename sfl::dtl::allocator_traits<base_allocator_type>::propagate_on_container_copy_assignment;
+    using propagate_on_container_move_assignment = typename sfl::dtl::allocator_traits<base_allocator_type>::propagate_on_container_move_assignment;
+    using propagate_on_container_swap            = typename sfl::dtl::allocator_traits<base_allocator_type>::propagate_on_container_swap;
+    using is_always_equal                        = typename sfl::dtl::allocator_traits<base_allocator_type>::is_always_equal;
+    using is_partially_propagable                = std::false_type;
+
+    template <typename U>
+    struct rebind
+    {
+        using other = node_small_allocator
+        <
+            U,
+            0,
+            typename sfl::dtl::allocator_traits<base_allocator_type>::template rebind_alloc<U>
+        >;
+    };
+
+private:
+
+    SFL_NODISCARD
+    base_allocator_type& base() noexcept
+    {
+        return *static_cast<base_allocator_type*>(this);
+    }
+
+    SFL_NODISCARD
+    const base_allocator_type& base() const noexcept
+    {
+        return *static_cast<const base_allocator_type*>(this);
+    }
+
+public:
+
+    node_small_allocator() noexcept(std::is_nothrow_default_constructible<base_allocator_type>::value)
+    {}
+
+    node_small_allocator(const node_small_allocator& other) noexcept
+        : base_allocator_type(other.base())
+    {}
+
+    node_small_allocator(node_small_allocator&& other) noexcept
+        : base_allocator_type(std::move(other.base()))
+    {}
+
+    template <typename T2, std::size_t N2, typename Allocator2>
+    node_small_allocator(const node_small_allocator<T2, N2, Allocator2>& other) noexcept
+        : base_allocator_type(other.base())
+    {}
+
+    template <typename T2, std::size_t N2, typename Allocator2>
+    node_small_allocator(node_small_allocator<T2, N2, Allocator2>&& other) noexcept
+        : base_allocator_type(std::move(other.base()))
+    {}
+
+    explicit node_small_allocator(const base_allocator_type& other) noexcept
+        : base_allocator_type(other)
+    {}
+
+    explicit node_small_allocator(base_allocator_type&& other) noexcept
+        : base_allocator_type(std::move(other))
+    {}
+
+    node_small_allocator& operator=(const node_small_allocator& other) noexcept
+    {
+        base_allocator_type::operator=(other.base());
+        return *this;
+    }
+
+    node_small_allocator& operator=(node_small_allocator&& other) noexcept
+    {
+        base_allocator_type::operator=(std::move(other.base()));
+        return *this;
+    }
+
+    template <typename T2, std::size_t N2, typename Allocator2>
+    node_small_allocator& operator=(const node_small_allocator<T2, N2, Allocator2>& other) noexcept
+    {
+        base_allocator_type::operator=(other.base());
+        return *this;
+    }
+
+    template <typename T2, std::size_t N2, typename Allocator2>
+    node_small_allocator& operator=(node_small_allocator<T2, N2, Allocator2>&& other) noexcept
+    {
+        base_allocator_type::operator=(std::move(other.base()));
+        return *this;
+    }
+
+    node_small_allocator& operator=(const base_allocator_type& other) noexcept
+    {
+        base_allocator_type::operator=(other);
+        return *this;
+    }
+
+    node_small_allocator& operator=(base_allocator_type&& other) noexcept
+    {
+        base_allocator_type::operator=(std::move(other));
+        return *this;
+    }
+
+    SFL_NODISCARD
+    pointer allocate(size_type n)
+    {
+        SFL_ASSERT(n == 1);
+
+        sfl::dtl::ignore_unused(n);
+
+        return sfl::dtl::allocator_traits<base_allocator_type>::allocate(base(), 1);
+    }
+
+    SFL_NODISCARD
+    pointer allocate(size_type n, const void* hint)
+    {
+        SFL_ASSERT(n == 1);
+
+        sfl::dtl::ignore_unused(n);
+
+        return sfl::dtl::allocator_traits<base_allocator_type>::allocate(base(), 1, hint);
+    }
+
+    void deallocate(pointer p, std::size_t n) noexcept
+    {
+        SFL_ASSERT(n == 1);
+
+        sfl::dtl::ignore_unused(n);
+
+        sfl::dtl::allocator_traits<base_allocator_type>::deallocate(base(), p, 1);
+    }
+};
+
+} // namespace dtl
+
+} // namespace sfl
+
+#endif // SFL_DETAIL_NODE_SMALL_ALLOCATOR_HPP_INCLUDED

--- a/src/thirdparty/sfl/detail/node_static_allocator.hpp
+++ b/src/thirdparty/sfl/detail/node_static_allocator.hpp
@@ -1,0 +1,172 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_DETAIL_NODE_STATIC_ALLOCATOR_HPP_INCLUDED
+#define SFL_DETAIL_NODE_STATIC_ALLOCATOR_HPP_INCLUDED
+
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/ignore_unused.hpp>
+#include <sfl/detail/static_pool.hpp>
+
+#include <cstddef>      // size_t, ptrdiff_t
+#include <utility>      // move
+#include <type_traits>  // is_xxxxx, true_type, false_type
+
+namespace sfl
+{
+
+namespace dtl
+{
+
+template <typename T, std::size_t N>
+class node_static_allocator
+{
+private:
+
+    using static_pool_type = sfl::dtl::static_pool<T, N>;
+
+public:
+
+    using value_type      = T;
+    using pointer         = T*;
+    using const_pointer   = const T*;
+    using reference       = T&;
+    using const_reference = const T&;
+    using size_type       = std::size_t;
+    using difference_type = std::ptrdiff_t;
+
+    using propagate_on_container_copy_assignment = std::false_type;
+    using propagate_on_container_move_assignment = std::false_type;
+    using propagate_on_container_swap            = std::false_type;
+    using is_always_equal                        = std::false_type;
+    using is_partially_propagable                = std::true_type;
+
+    template <typename U>
+    struct rebind
+    {
+        using other = node_static_allocator<U, N>;
+    };
+
+private:
+
+    sfl::dtl::static_pool<T, N> pool_;
+
+public:
+
+    node_static_allocator() noexcept(std::is_nothrow_default_constructible<static_pool_type>::value)
+    {}
+
+    node_static_allocator(const node_static_allocator& /*other*/) noexcept
+    {}
+
+    node_static_allocator(node_static_allocator&& /*other*/) noexcept
+    {}
+
+    template <typename Node2, std::size_t N2>
+    node_static_allocator(const node_static_allocator<Node2, N2>& /*other*/) noexcept
+    {}
+
+    template <typename Node2, std::size_t N2>
+    node_static_allocator(node_static_allocator<Node2, N2>&& /*other*/) noexcept
+    {}
+
+    node_static_allocator& operator=(const node_static_allocator& /*other*/) noexcept
+    {
+        return *this;
+    }
+
+    node_static_allocator& operator=(node_static_allocator&& /*other*/) noexcept
+    {
+        return *this;
+    }
+
+    template <typename Node2, std::size_t N2>
+    node_static_allocator& operator=(const node_static_allocator<Node2, N2>& /*other*/) noexcept
+    {
+        return *this;
+    }
+
+    template <typename Node2, std::size_t N2>
+    node_static_allocator& operator=(node_static_allocator<Node2, N2>&& /*other*/) noexcept
+    {
+        return *this;
+    }
+
+    SFL_NODISCARD
+    pointer allocate(size_type n)
+    {
+        SFL_ASSERT(n == 1);
+
+        sfl::dtl::ignore_unused(n);
+
+        return pool_.allocate();
+    }
+
+    void deallocate(pointer p, std::size_t n) noexcept
+    {
+        SFL_ASSERT(n == 1);
+
+        sfl::dtl::ignore_unused(n);
+
+        pool_.deallocate(p);
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type max_size() noexcept
+    {
+        return static_pool_type::max_size();
+    }
+
+    SFL_NODISCARD
+    bool is_storage_unpropagable(pointer p) const noexcept
+    {
+        sfl::dtl::ignore_unused(p);
+        return true;
+    }
+};
+
+template <typename T1, typename T2, std::size_t N>
+SFL_NODISCARD
+bool operator==
+(
+    const node_static_allocator<T1, N>& x,
+    const node_static_allocator<T2, N>& y
+) noexcept
+{
+    sfl::dtl::ignore_unused(x, y);
+    return false;
+}
+
+template <typename T1, typename T2, std::size_t N>
+SFL_NODISCARD
+bool operator!=
+(
+    const node_static_allocator<T1, N>& x,
+    const node_static_allocator<T2, N>& y
+) noexcept
+{
+    return !(x == y);
+}
+
+} // namespace dtl
+
+} // namespace sfl
+
+#endif // SFL_DETAIL_NODE_STATIC_ALLOCATOR_HPP_INCLUDED

--- a/src/thirdparty/sfl/detail/normal_iterator.hpp
+++ b/src/thirdparty/sfl/detail/normal_iterator.hpp
@@ -1,0 +1,213 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_DETAIL_NORMAL_ITERATOR_HPP_INCLUDED
+#define SFL_DETAIL_NORMAL_ITERATOR_HPP_INCLUDED
+
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/to_address.hpp>
+#include <sfl/detail/type_traits.hpp>
+
+#include <iterator>
+#include <type_traits>
+
+namespace sfl
+{
+
+namespace dtl
+{
+
+template <typename Iterator, typename Container>
+class normal_iterator
+{
+    template <typename, typename>
+    friend class normal_iterator;
+
+    friend Container;
+
+private:
+
+    Iterator it_;
+
+public:
+
+    using difference_type   = typename std::iterator_traits<Iterator>::difference_type;
+    using value_type        = typename std::iterator_traits<Iterator>::value_type;
+    using pointer           = typename std::iterator_traits<Iterator>::pointer;
+    using reference         = typename std::iterator_traits<Iterator>::reference;
+    using iterator_category = typename std::iterator_traits<Iterator>::iterator_category;
+#if SFL_CPP_VERSION >= SFL_CPP_20
+    using iterator_concept  = std::contiguous_iterator_tag;
+#endif
+
+private:
+
+    explicit normal_iterator(const Iterator& it) noexcept
+        : it_(it)
+    {}
+
+public:
+
+    // Default constructor
+    normal_iterator() noexcept
+        : it_()
+    {}
+
+    // Copy constructor
+    normal_iterator(const normal_iterator& other) noexcept
+        : it_(other.it_)
+    {}
+
+    // Converting constructor (from iterator to const_iterator)
+    template <typename OtherIterator,
+              sfl::dtl::enable_if_t<std::is_convertible<OtherIterator, Iterator>::value>* = nullptr>
+    normal_iterator(const normal_iterator<OtherIterator, Container>& other) noexcept
+        : it_(other.it_)
+    {}
+
+    // Copy assignment operator
+    normal_iterator& operator=(const normal_iterator& other) noexcept
+    {
+        it_ = other.it_;
+        return *this;
+    }
+
+    SFL_NODISCARD
+    reference operator*() const noexcept
+    {
+        return *it_;
+    }
+
+    SFL_NODISCARD
+    pointer operator->() const noexcept
+    {
+        return sfl::dtl::to_address(it_);
+    }
+
+    normal_iterator& operator++() noexcept
+    {
+        ++it_;
+        return *this;
+    }
+
+    normal_iterator operator++(int) noexcept
+    {
+        auto temp = *this;
+        ++it_;
+        return temp;
+    }
+
+    normal_iterator& operator--() noexcept
+    {
+        --it_;
+        return *this;
+    }
+
+    normal_iterator operator--(int) noexcept
+    {
+        auto temp = *this;
+        --it_;
+        return temp;
+    }
+
+    normal_iterator& operator+=(difference_type n) noexcept
+    {
+        it_ += n;
+        return *this;
+    }
+
+    normal_iterator& operator-=(difference_type n) noexcept
+    {
+        it_ -= n;
+        return *this;
+    }
+
+    SFL_NODISCARD
+    normal_iterator operator+(difference_type n) const noexcept
+    {
+        return normal_iterator(it_ + n);
+    }
+
+    SFL_NODISCARD
+    normal_iterator operator-(difference_type n) const noexcept
+    {
+        return normal_iterator(it_ - n);
+    }
+
+    SFL_NODISCARD
+    reference operator[](difference_type n) const noexcept
+    {
+        return it_[n];
+    }
+
+    SFL_NODISCARD
+    friend normal_iterator operator+(difference_type n, const normal_iterator& it) noexcept
+    {
+        return it + n;
+    }
+
+    SFL_NODISCARD
+    friend difference_type operator-(const normal_iterator& x, const normal_iterator& y) noexcept
+    {
+        return x.it_ - y.it_;
+    }
+
+    SFL_NODISCARD
+    friend bool operator==(const normal_iterator& x, const normal_iterator& y) noexcept
+    {
+        return x.it_ == y.it_;
+    }
+
+    SFL_NODISCARD
+    friend bool operator!=(const normal_iterator& x, const normal_iterator& y) noexcept
+    {
+        return !(x == y);
+    }
+
+    SFL_NODISCARD
+    friend bool operator<(const normal_iterator& x, const normal_iterator& y) noexcept
+    {
+        return x.it_ < y.it_;
+    }
+
+    SFL_NODISCARD
+    friend bool operator>(const normal_iterator& x, const normal_iterator& y) noexcept
+    {
+        return y < x;
+    }
+
+    SFL_NODISCARD
+    friend bool operator<=(const normal_iterator& x, const normal_iterator& y) noexcept
+    {
+        return !(y < x);
+    }
+
+    SFL_NODISCARD
+    friend bool operator>=(const normal_iterator& x, const normal_iterator& y) noexcept
+    {
+        return !(x < y);
+    }
+};
+
+} // namespace dtl
+
+} // namespace sfl
+
+#endif // SFL_DETAIL_NORMAL_ITERATOR_HPP_INCLUDED

--- a/src/thirdparty/sfl/detail/rb_tree.hpp
+++ b/src/thirdparty/sfl/detail/rb_tree.hpp
@@ -1,0 +1,2782 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_DETAIL_RB_TREE_HPP_INCLUDED
+#define SFL_DETAIL_RB_TREE_HPP_INCLUDED
+
+#include <sfl/detail/allocator_traits.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/to_address.hpp>
+#include <sfl/detail/type_traits.hpp>
+#include <sfl/detail/uninitialized_memory_algorithms.hpp>
+
+#include <algorithm>    // equal, lexicographical_compare
+#include <cstddef>      // size_t, ptrdiff_t
+#include <iterator>     // iterator_traits, xxxxx_iterator_tag, reverse_iterator
+#include <memory>       // pointer_traits
+#include <type_traits>  // is_xxxxx
+#include <utility>      // forward, move, pair
+
+#ifdef SFL_TEST_RB_TREE
+template <int>
+void test_rb_tree();
+#endif
+
+namespace sfl
+{
+
+namespace dtl
+{
+
+enum class rb_tree_node_color
+{
+    red,
+    black
+};
+
+template <typename VoidPointer>
+struct rb_tree_node_base
+{
+    using base_node_pointer = typename std::pointer_traits<VoidPointer>::template rebind<rb_tree_node_base>;
+
+    rb_tree_node_color color_;
+    base_node_pointer parent_;
+    base_node_pointer left_;
+    base_node_pointer right_;
+};
+
+template <typename Value, typename Allocator, typename VoidPointer>
+struct rb_tree_node : rb_tree_node_base<VoidPointer>
+{
+    static_assert
+    (
+        std::is_same<typename Allocator::value_type, Value>::value,
+        "Allocator::value_type must be Value."
+    );
+
+    using typename rb_tree_node_base<VoidPointer>::base_node_pointer;
+
+    using node_pointer = typename std::pointer_traits<VoidPointer>::template rebind<rb_tree_node>;
+
+    union
+    {
+        Value value_;
+    };
+
+    rb_tree_node() noexcept
+    {}
+
+    rb_tree_node(const rb_tree_node& other) = delete;
+
+    rb_tree_node(rb_tree_node&& other) = delete;
+
+    rb_tree_node& operator=(const rb_tree_node& other) = delete;
+
+    rb_tree_node& operator=(rb_tree_node&& other) = delete;
+
+    #if defined(__clang__) && (__clang_major__ == 3) // For CentOS 7
+    ~rb_tree_node()
+    {}
+    #else
+    ~rb_tree_node() noexcept
+    {}
+    #endif
+};
+
+template < typename Key,
+           typename Value,
+           typename KeyOfValue,
+           typename KeyCompare,
+           typename Allocator,
+           typename UpperLevelContainer >
+class rb_tree
+{
+    static_assert
+    (
+        std::is_same<typename Allocator::value_type, Value>::value,
+        "Allocator::value_type must be Value."
+    );
+
+    #ifdef SFL_TEST_RB_TREE
+    template <int>
+    friend void ::test_rb_tree();
+    #endif
+
+    friend UpperLevelContainer;
+
+public:
+
+    using allocator_type  = Allocator;
+    using key_type        = Key;
+    using value_type      = Value;
+    using size_type       = typename sfl::dtl::allocator_traits<allocator_type>::size_type;
+    using difference_type = typename sfl::dtl::allocator_traits<allocator_type>::difference_type;
+    using key_compare     = KeyCompare;
+    using reference       = value_type&;
+    using const_reference = const value_type&;
+    using pointer         = typename sfl::dtl::allocator_traits<allocator_type>::pointer;
+    using const_pointer   = typename sfl::dtl::allocator_traits<allocator_type>::const_pointer;
+
+private:
+
+    using void_pointer = typename sfl::dtl::allocator_traits<allocator_type>::void_pointer;
+
+    using base_node_type = rb_tree_node_base<void_pointer>;
+
+    using node_type = rb_tree_node<value_type, allocator_type, void_pointer>;
+
+    using node_allocator_type = typename sfl::dtl::allocator_traits<allocator_type>::template rebind_alloc<node_type>;
+
+    using base_node_pointer = typename base_node_type::base_node_pointer;
+
+    using node_pointer = typename node_type::node_pointer;
+
+public:
+
+    class iterator
+    {
+        #ifdef SFL_TEST_RB_TREE
+        template <int>
+        friend void ::test_rb_tree();
+        #endif
+
+        friend class rb_tree;
+
+        friend UpperLevelContainer;
+
+    public:
+
+        using difference_type   = std::ptrdiff_t;
+        using value_type        = Value;
+        using pointer           = Value*;
+        using reference         = Value&;
+        using iterator_category = std::bidirectional_iterator_tag;
+
+    private:
+
+        base_node_pointer node_;
+
+    private:
+
+        explicit iterator(base_node_pointer x) noexcept
+            : node_(x)
+        {}
+
+    public:
+
+        // Default constructor
+        iterator() noexcept
+            : node_()
+        {}
+
+        // Copy constructor
+        iterator(const iterator& other) noexcept
+            : node_(other.node_)
+        {}
+
+        // Copy assignment operator
+        iterator& operator=(const iterator& other) noexcept
+        {
+            node_ = other.node_;
+            return *this;
+        }
+
+        SFL_NODISCARD
+        reference operator*() const noexcept
+        {
+            return static_cast<node_pointer>(node_)->value_;
+        }
+
+        SFL_NODISCARD
+        pointer operator->() const noexcept
+        {
+            return std::addressof(static_cast<node_pointer>(node_)->value_);
+        }
+
+        iterator& operator++() noexcept
+        {
+            node_ = rb_tree::next(node_);
+            return *this;
+        }
+
+        iterator operator++(int) noexcept
+        {
+            auto temp = *this;
+            node_ = rb_tree::next(node_);
+            return temp;
+        }
+
+        iterator& operator--() noexcept
+        {
+            node_ = rb_tree::prev(node_);
+            return *this;
+        }
+
+        iterator operator--(int) noexcept
+        {
+            auto temp = *this;
+            node_ = rb_tree::prev(node_);
+            return temp;
+        }
+
+        SFL_NODISCARD
+        friend bool operator==(const iterator& x, const iterator& y) noexcept
+        {
+            return x.node_ == y.node_;
+        }
+
+        SFL_NODISCARD
+        friend bool operator!=(const iterator& x, const iterator& y) noexcept
+        {
+            return !(x == y);
+        }
+    };
+
+    class const_iterator
+    {
+        #ifdef SFL_TEST_RB_TREE
+        template <int>
+        friend void ::test_rb_tree();
+        #endif
+
+        friend class rb_tree;
+
+        friend UpperLevelContainer;
+
+    public:
+
+        using difference_type   = std::ptrdiff_t;
+        using value_type        = Value;
+        using pointer           = const Value*;
+        using reference         = const Value&;
+        using iterator_category = std::bidirectional_iterator_tag;
+
+    private:
+
+        base_node_pointer node_;
+
+    private:
+
+        explicit const_iterator(base_node_pointer x) noexcept
+            : node_(x)
+        {}
+
+    public:
+
+        // Default constructor
+        const_iterator() noexcept
+            : node_()
+        {}
+
+        // Copy constructor
+        const_iterator(const const_iterator& other) noexcept
+            : node_(other.node_)
+        {}
+
+        // Converting constructor (from iterator to const_iterator)
+        const_iterator(const iterator& other) noexcept
+            : node_(other.node_)
+        {}
+
+        // Copy assignment operator
+        const_iterator& operator=(const const_iterator& other) noexcept
+        {
+            node_ = other.node_;
+            return *this;
+        }
+
+        SFL_NODISCARD
+        reference operator*() const noexcept
+        {
+            return static_cast<node_pointer>(node_)->value_;
+        }
+
+        SFL_NODISCARD
+        pointer operator->() const noexcept
+        {
+            return std::addressof(static_cast<node_pointer>(node_)->value_);
+        }
+
+        const_iterator& operator++() noexcept
+        {
+            node_ = rb_tree::next(node_);
+            return *this;
+        }
+
+        const_iterator operator++(int) noexcept
+        {
+            auto temp = *this;
+            node_ = rb_tree::next(node_);
+            return temp;
+        }
+
+        const_iterator& operator--() noexcept
+        {
+            node_ = rb_tree::prev(node_);
+            return *this;
+        }
+
+        const_iterator operator--(int) noexcept
+        {
+            auto temp = *this;
+            node_ = rb_tree::prev(node_);
+            return temp;
+        }
+
+        SFL_NODISCARD
+        friend bool operator==(const const_iterator& x, const const_iterator& y) noexcept
+        {
+            return x.node_ == y.node_;
+        }
+
+        SFL_NODISCARD
+        friend bool operator!=(const const_iterator& x, const const_iterator& y) noexcept
+        {
+            return !(x == y);
+        }
+    };
+
+    using reverse_iterator = std::reverse_iterator<iterator>;
+
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+private:
+
+    class data_base
+    {
+    public:
+
+        base_node_type header_;
+
+        size_type size_;
+
+        SFL_NODISCARD
+        base_node_pointer header() noexcept
+        {
+            return std::pointer_traits<base_node_pointer>::pointer_to(header_);
+        }
+
+        SFL_NODISCARD
+        base_node_pointer& root() noexcept
+        {
+            return header_.left_;
+        }
+
+        SFL_NODISCARD
+        base_node_pointer& minimum() noexcept
+        {
+            return header_.parent_;
+        }
+
+        void reset() noexcept
+        {
+            header_.color_  = rb_tree_node_color::red;
+            header_.parent_ = std::pointer_traits<base_node_pointer>::pointer_to(header_); // minimum
+            header_.left_   = nullptr;  // root
+            header_.right_  = nullptr;  // unused
+            size_ = 0;
+        }
+
+        data_base() noexcept
+        {
+            reset();
+        }
+
+        data_base(const data_base& other) = delete;
+
+        data_base(data_base&& other) = delete;
+
+        data_base& operator=(const data_base& other) = delete;
+
+        data_base& operator=(data_base&& other) = delete;
+
+        ~data_base() noexcept
+        {};
+    };
+
+    class data : public data_base, public node_allocator_type, public key_compare
+    {
+    public:
+
+        data() noexcept
+        (
+            std::is_nothrow_default_constructible<node_allocator_type>::value &&
+            std::is_nothrow_default_constructible<key_compare>::value
+        )
+            : node_allocator_type()
+            , key_compare()
+        {}
+
+        template <typename Allocator2>
+        data(const Allocator2& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<node_allocator_type>::value &&
+            std::is_nothrow_default_constructible<key_compare>::value
+        )
+            : node_allocator_type(alloc)
+            , key_compare()
+        {}
+
+        data(const key_compare& comp) noexcept
+        (
+            std::is_nothrow_default_constructible<node_allocator_type>::value &&
+            std::is_nothrow_copy_constructible<key_compare>::value
+        )
+            : node_allocator_type()
+            , key_compare(comp)
+        {}
+
+        template <typename Allocator2>
+        data(const key_compare& comp, const Allocator2& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<node_allocator_type>::value &&
+            std::is_nothrow_copy_constructible<key_compare>::value
+        )
+            : node_allocator_type(alloc)
+            , key_compare(comp)
+        {}
+
+        template <typename Allocator2>
+        data(key_compare&& comp, const Allocator2& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<node_allocator_type>::value &&
+            std::is_nothrow_move_constructible<key_compare>::value
+        )
+            : node_allocator_type(alloc)
+            , key_compare(std::move(comp))
+        {}
+
+        template <typename Allocator2>
+        data(key_compare&& comp, Allocator2&& alloc) noexcept
+        (
+            std::is_nothrow_move_constructible<node_allocator_type>::value &&
+            std::is_nothrow_move_constructible<key_compare>::value
+        )
+            : node_allocator_type(std::move(alloc))
+            , key_compare(std::move(comp))
+        {}
+    };
+
+    mutable data data_;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    rb_tree() noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<KeyCompare>::value
+    )
+    {}
+
+    explicit rb_tree(const KeyCompare& comp) noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<KeyCompare>::value
+    )
+        : data_(comp)
+    {}
+
+    template <typename Allocator2>
+    explicit rb_tree(const Allocator2& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<KeyCompare>::value
+    )
+        : data_(alloc)
+    {}
+
+    template <typename Allocator2>
+    explicit rb_tree(const KeyCompare& comp, const Allocator2& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<KeyCompare>::value
+    )
+        : data_(comp, alloc)
+    {}
+
+    rb_tree(const rb_tree& other)
+        : data_
+        (
+            other.ref_to_comp(),
+            sfl::dtl::allocator_traits<node_allocator_type>::select_on_container_copy_construction(other.ref_to_node_alloc())
+        )
+    {
+        initialize_copy(other);
+    }
+
+    template <typename Allocator2>
+    rb_tree(const rb_tree& other, const Allocator2& alloc)
+        : data_(other.ref_to_comp(), alloc)
+    {
+        initialize_copy(other);
+    }
+
+    rb_tree(rb_tree&& other)
+        : data_
+        (
+            std::move(other.ref_to_comp()),
+            std::move(other.ref_to_node_alloc())
+        )
+    {
+        initialize_move(other);
+    }
+
+    template <typename Allocator2>
+    rb_tree(rb_tree&& other, const Allocator2& alloc)
+        : data_
+        (
+            std::move(other.ref_to_comp()),
+            alloc
+        )
+    {
+        initialize_move(other);
+    }
+
+    ~rb_tree() noexcept
+    {
+        if (data_.root() != nullptr)
+        {
+            clear(data_.root());
+        }
+    }
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    rb_tree& operator=(const rb_tree& other)
+    {
+        assign_copy(other);
+        return *this;
+    }
+
+    rb_tree& operator=(rb_tree&& other)
+    {
+        assign_move(other);
+        return *this;
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void assign_range_equal(InputIt first, InputIt last)
+    {
+        make_node_with_recycling_functor make_node(*this);
+
+        while (first != last)
+        {
+            insert_equal(*first, make_node);
+            ++first;
+        }
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void assign_range_unique(InputIt first, InputIt last)
+    {
+        make_node_with_recycling_functor make_node(*this);
+
+        while (first != last)
+        {
+            insert_unique(*first, make_node);
+            ++first;
+        }
+    }
+
+    //
+    // ---- ALLOCATOR ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    node_allocator_type& ref_to_node_alloc() noexcept
+    {
+        return data_;
+    }
+
+    SFL_NODISCARD
+    const node_allocator_type& ref_to_node_alloc() const noexcept
+    {
+        return data_;
+    }
+
+    SFL_NODISCARD
+    allocator_type get_allocator() const
+    {
+        return allocator_type(ref_to_node_alloc());
+    }
+
+    //
+    // ---- KEY COMPARE -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_compare& ref_to_comp() noexcept
+    {
+        return data_;
+    }
+
+    SFL_NODISCARD
+    const key_compare& ref_to_comp() const noexcept
+    {
+        return data_;
+    }
+
+    SFL_NODISCARD
+    key_compare key_comp() const
+    {
+        return ref_to_comp();
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return iterator(data_.minimum());
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return const_iterator(data_.minimum());
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(data_.minimum());
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return iterator(data_.header());
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return const_iterator(data_.header());
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return const_iterator(data_.header());
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return data_.size_ == 0;
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return data_.size_;
+    }
+
+    SFL_NODISCARD
+    size_type max_size() const noexcept
+    {
+        return sfl::dtl::allocator_traits<node_allocator_type>::max_size(ref_to_node_alloc());
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear()
+    {
+        if (data_.root() != nullptr)
+        {
+            clear(data_.root());
+        }
+
+        data_.reset();
+    }
+
+    template <typename... Args>
+    iterator emplace_equal(Args&&... args)
+    {
+        make_node_functor make_node(*this);
+        node_pointer x = make_node(std::forward<Args>(args)...);
+        auto res = calculate_position_for_insert_equal(key(x));
+        insert(x, res.pos, res.left, data_.root(), data_.minimum());
+        ++data_.size_;
+        return iterator(x);
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace_unique(Args&&... args)
+    {
+        make_node_functor make_node(*this);
+        node_pointer x = make_node(std::forward<Args>(args)...);
+        auto res = calculate_position_for_insert_unique(key(x));
+        if (res.status)
+        {
+            insert(x, res.pos, res.left, data_.root(), data_.minimum());
+            ++data_.size_;
+            return std::make_pair(iterator(x), true);
+        }
+        else
+        {
+            drop_node(x);
+            return std::make_pair(iterator(res.pos), false);
+        }
+    }
+
+    template <typename... Args>
+    iterator emplace_hint_equal(const_iterator hint, Args&&... args)
+    {
+        make_node_functor make_node(*this);
+        node_pointer x = make_node(std::forward<Args>(args)...);
+        auto res = calculate_position_for_insert_hint_equal(hint, key(x));
+        insert(x, res.pos, res.left, data_.root(), data_.minimum());
+        ++data_.size_;
+        return iterator(x);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint_unique(const_iterator hint, Args&&... args)
+    {
+        make_node_functor make_node(*this);
+        node_pointer x = make_node(std::forward<Args>(args)...);
+        auto res = calculate_position_for_insert_hint_unique(hint, key(x));
+        if (res.status)
+        {
+            insert(x, res.pos, res.left, data_.root(), data_.minimum());
+            ++data_.size_;
+            return iterator(x);
+        }
+        else
+        {
+            drop_node(x);
+            return iterator(res.pos);
+        }
+    }
+
+private:
+
+    template <typename V, typename MakeNodeFunctor>
+    iterator insert_equal(V&& value, MakeNodeFunctor& make_node)
+    {
+        auto res = calculate_position_for_insert_equal(KeyOfValue()(value));
+        node_pointer x = make_node(std::forward<V>(value));
+        insert(x, res.pos, res.left, data_.root(), data_.minimum());
+        ++data_.size_;
+        return iterator(x);
+    }
+
+    template <typename V, typename MakeNodeFunctor>
+    std::pair<iterator, bool> insert_unique(V&& value, MakeNodeFunctor& make_node)
+    {
+        auto res = calculate_position_for_insert_unique(KeyOfValue()(value));
+        if (res.status)
+        {
+            node_pointer x = make_node(std::forward<V>(value));
+            insert(x, res.pos, res.left, data_.root(), data_.minimum());
+            ++data_.size_;
+            return std::make_pair(iterator(x), true);
+        }
+        else
+        {
+            return std::make_pair(iterator(res.pos), false);
+        }
+    }
+
+public:
+
+    template <typename V>
+    iterator insert_equal(V&& value)
+    {
+        make_node_functor make_node(*this);
+        return insert_equal(std::forward<V>(value), make_node);
+    }
+
+    template <typename V>
+    std::pair<iterator, bool> insert_unique(V&& value)
+    {
+        make_node_functor make_node(*this);
+        return insert_unique(std::forward<V>(value), make_node);
+    }
+
+    template <typename V>
+    iterator insert_hint_equal(const_iterator hint, V&& value)
+    {
+        auto res = calculate_position_for_insert_hint_equal(hint, KeyOfValue()(value));
+        make_node_functor make_node(*this);
+        node_pointer x = make_node(std::forward<V>(value));
+        insert(x, res.pos, res.left, data_.root(), data_.minimum());
+        ++data_.size_;
+        return iterator(x);
+    }
+
+    template <typename V>
+    iterator insert_hint_unique(const_iterator hint, V&& value)
+    {
+        auto res = calculate_position_for_insert_hint_unique(hint, KeyOfValue()(value));
+        if (res.status)
+        {
+            make_node_functor make_node(*this);
+            node_pointer x = make_node(std::forward<V>(value));
+            insert(x, res.pos, res.left, data_.root(), data_.minimum());
+            ++data_.size_;
+            return iterator(x);
+        }
+        else
+        {
+            return iterator(res.pos);
+        }
+    }
+
+    iterator erase(iterator pos)
+    {
+        base_node_pointer x = pos.node_;
+        base_node_pointer y = next(x);
+        --data_.size_;
+        remove(x, data_.root(), data_.minimum());
+        drop_node(static_cast<node_pointer>(x));
+        return iterator(y);
+    }
+
+    iterator erase(const_iterator pos)
+    {
+        base_node_pointer x = pos.node_;
+        base_node_pointer y = next(x);
+        --data_.size_;
+        remove(x, data_.root(), data_.minimum());
+        drop_node(static_cast<node_pointer>(x));
+        return iterator(y);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        iterator it(first.node_);
+        while (it != last)
+        {
+            it = erase(it);
+        }
+        return it;
+    }
+
+    template <typename K>
+    size_type erase(const K& k)
+    {
+        const auto er = equal_range(k);
+        const auto sz = std::distance(er.first, er.second);
+        erase(er.first, er.second);
+        return sz;
+    }
+
+    void swap(rb_tree& other)
+    {
+        swap(other, typename sfl::dtl::allocator_traits<node_allocator_type>::is_partially_propagable());
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    template <typename K>
+    SFL_NODISCARD
+    iterator lower_bound(const K& k) noexcept
+    {
+        base_node_pointer x = data_.root();
+        base_node_pointer y = data_.header();
+
+        while (x != nullptr)
+        {
+            if (!ref_to_comp()(key(x), k))
+            {
+                y = x;
+                x = x->left_;
+            }
+            else
+            {
+                x = x->right_;
+            }
+        }
+
+        return iterator(y);
+    }
+
+    template <typename K>
+    SFL_NODISCARD
+    const_iterator lower_bound(const K& k) const noexcept
+    {
+        base_node_pointer x = data_.root();
+        base_node_pointer y = data_.header();
+
+        while (x != nullptr)
+        {
+            if (!ref_to_comp()(key(x), k))
+            {
+                y = x;
+                x = x->left_;
+            }
+            else
+            {
+                x = x->right_;
+            }
+        }
+
+        return const_iterator(y);
+    }
+
+    template <typename K>
+    SFL_NODISCARD
+    iterator upper_bound(const K& k) noexcept
+    {
+        base_node_pointer x = data_.root();
+        base_node_pointer y = data_.header();
+
+        while (x != nullptr)
+        {
+            if (ref_to_comp()(k, key(x)))
+            {
+                y = x;
+                x = x->left_;
+            }
+            else
+            {
+                x = x->right_;
+            }
+        }
+
+        return iterator(y);
+    }
+
+    template <typename K>
+    SFL_NODISCARD
+    const_iterator upper_bound(const K& k) const noexcept
+    {
+        base_node_pointer x = data_.root();
+        base_node_pointer y = data_.header();
+
+        while (x != nullptr)
+        {
+            if (ref_to_comp()(k, key(x)))
+            {
+                y = x;
+                x = x->left_;
+            }
+            else
+            {
+                x = x->right_;
+            }
+        }
+
+        return const_iterator(y);
+    }
+
+    template <typename K>
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const K& k) noexcept
+    {
+        base_node_pointer x = data_.root();
+        base_node_pointer y = data_.header();
+
+        while (x != nullptr)
+        {
+            if (ref_to_comp()(key(x), k))
+            {
+                x = x->right_;
+            }
+            else if (ref_to_comp()(k, key(x)))
+            {
+                y = x;
+                x = x->left_;
+            }
+            else
+            {
+                // lower bound
+                base_node_pointer x_lower = x->left_;
+                base_node_pointer y_lower = x;
+                while (x_lower != nullptr)
+                {
+                    if (!ref_to_comp()(key(x_lower), k))
+                    {
+                        y_lower = x_lower;
+                        x_lower = x_lower->left_;
+                    }
+                    else
+                    {
+                        x_lower = x_lower->right_;
+                    }
+                }
+
+                // upper bound
+                base_node_pointer x_upper = x->right_;
+                base_node_pointer y_upper = y;
+                while (x_upper != nullptr)
+                {
+                    if (ref_to_comp()(k, key(x_upper)))
+                    {
+                        y_upper = x_upper;
+                        x_upper = x_upper->left_;
+                    }
+                    else
+                    {
+                        x_upper = x_upper->right_;
+                    }
+                }
+
+                return std::make_pair(iterator(y_lower), iterator(y_upper));
+            }
+        }
+
+        return std::make_pair(iterator(y), iterator(y));
+    }
+
+    template <typename K>
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const K& k) const noexcept
+    {
+        base_node_pointer x = data_.root();
+        base_node_pointer y = data_.header();
+
+        while (x != nullptr)
+        {
+            if (ref_to_comp()(key(x), k))
+            {
+                x = x->right_;
+            }
+            else if (ref_to_comp()(k, key(x)))
+            {
+                y = x;
+                x = x->left_;
+            }
+            else
+            {
+                // lower bound
+                base_node_pointer x_lower = x->left_;
+                base_node_pointer y_lower = x;
+                while (x_lower != nullptr)
+                {
+                    if (!ref_to_comp()(key(x_lower), k))
+                    {
+                        y_lower = x_lower;
+                        x_lower = x_lower->left_;
+                    }
+                    else
+                    {
+                        x_lower = x_lower->right_;
+                    }
+                }
+
+                // upper bound
+                base_node_pointer x_upper = x->right_;
+                base_node_pointer y_upper = y;
+                while (x_upper != nullptr)
+                {
+                    if (ref_to_comp()(k, key(x_upper)))
+                    {
+                        y_upper = x_upper;
+                        x_upper = x_upper->left_;
+                    }
+                    else
+                    {
+                        x_upper = x_upper->right_;
+                    }
+                }
+
+                return std::make_pair(const_iterator(y_lower), const_iterator(y_upper));
+            }
+        }
+
+        return std::make_pair(const_iterator(y), const_iterator(y));
+    }
+
+    template <typename K>
+    SFL_NODISCARD
+    iterator find(const K& k) noexcept
+    {
+        auto it = lower_bound(k);
+
+        if (it != end() && ref_to_comp()(k, key(it.node_)))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    template <typename K>
+    SFL_NODISCARD
+    const_iterator find(const K& k) const noexcept
+    {
+        auto it = lower_bound(k);
+
+        if (it != end() && ref_to_comp()(k, key(it.node_)))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    template <typename K>
+    SFL_NODISCARD
+    size_type count(const K& k) const noexcept
+    {
+        const auto er = equal_range(k);
+        return std::distance(er.first, er.second);
+    }
+
+    template <typename K>
+    SFL_NODISCARD
+    bool contains(const K& k) const noexcept
+    {
+        return find(k) != end();
+    }
+
+private:
+
+    static base_node_pointer minimum(base_node_pointer x) noexcept
+    {
+        SFL_ASSERT(x != nullptr);
+
+        while (x->left_ != nullptr)
+        {
+            x = x->left_;
+        }
+
+        return x;
+    }
+
+    static base_node_pointer maximum(base_node_pointer x) noexcept
+    {
+        SFL_ASSERT(x != nullptr);
+
+        while (x->right_ != nullptr)
+        {
+            x = x->right_;
+        }
+
+        return x;
+    }
+
+    static base_node_pointer next(base_node_pointer x) noexcept
+    {
+        SFL_ASSERT(x != nullptr);
+
+        if (x->right_ != nullptr)
+        {
+            return minimum(x->right_);
+        }
+        else
+        {
+            base_node_pointer y = x->parent_;
+
+            while (x == y->right_)
+            {
+                x = y;
+                y = y->parent_;
+            }
+
+            return y;
+        }
+    }
+
+    static base_node_pointer prev(base_node_pointer x) noexcept
+    {
+        SFL_ASSERT(x != nullptr);
+
+        if (x->left_ != nullptr)
+        {
+            return maximum(x->left_);
+        }
+        else
+        {
+            base_node_pointer y = x->parent_;
+
+            while (x == y->left_)
+            {
+                x = y;
+                y = y->parent_;
+            }
+
+            return y;
+        }
+    }
+
+    static void rotate_left(base_node_pointer x) noexcept
+    {
+        /*
+         *    |                       |
+         *    x         left          y
+         *   / \       rotate        / \
+         *  a   y     -------->     x   c
+         *     / \    @ node x     / \
+         *    b   c               a   b
+         */
+
+        SFL_ASSERT(x != nullptr);
+        SFL_ASSERT(x->right_ != nullptr);
+
+        base_node_pointer y = x->right_;
+
+        x->right_ = y->left_;
+
+        if (y->left_ != nullptr)
+        {
+            y->left_->parent_ = x;
+        }
+
+        y->parent_ = x->parent_;
+
+        if (x == x->parent_->left_)
+        {
+            x->parent_->left_ = y;
+        }
+        else
+        {
+            x->parent_->right_ = y;
+        }
+
+        y->left_ = x;
+
+        x->parent_ = y;
+    }
+
+    static void rotate_right(base_node_pointer x) noexcept
+    {
+        /*
+         *      |                   |
+         *      x      right        y
+         *     / \     rotate      / \
+         *    y   c   -------->   a   x
+         *   / \      @ node x       / \
+         *  a   b                   b   c
+         */
+
+        SFL_ASSERT(x != nullptr);
+        SFL_ASSERT(x->left_ != nullptr);
+
+        base_node_pointer y = x->left_;
+
+        x->left_ = y->right_;
+
+        if (y->right_ != nullptr)
+        {
+            y->right_->parent_ = x;
+        }
+
+        y->parent_ = x->parent_;
+
+        if (x == x->parent_->right_)
+        {
+            x->parent_->right_ = y;
+        }
+        else
+        {
+            x->parent_->left_ = y;
+        }
+
+        y->right_ = x;
+
+        x->parent_ = y;
+    }
+
+    static void insert(base_node_pointer x,
+                       base_node_pointer parent,
+                       bool insert_left,
+                       base_node_pointer& root,
+                       base_node_pointer& minimum) noexcept
+    {
+        SFL_ASSERT(x != nullptr);
+        SFL_ASSERT(parent != nullptr);
+        SFL_ASSERT(x != parent);
+
+        x->parent_ = parent;
+        x->left_   = nullptr;
+        x->right_  = nullptr;
+        x->color_  = rb_tree_node_color::red;
+
+        if (insert_left)
+        {
+            parent->left_ = x; // If tree is empty, then this also updates root.
+
+            if (parent == minimum)
+            {
+                minimum = x;
+            }
+        }
+        else
+        {
+            parent->right_ = x;
+        }
+
+        insert_fixup(x, root);
+    }
+
+    static void insert_fixup(base_node_pointer x, base_node_pointer& root) noexcept
+    {
+        while (x != root && x->parent_->color_ == rb_tree_node_color::red)
+        {
+            if (x->parent_ == x->parent_->parent_->left_) // is z's parent a left child?
+            {
+                base_node_pointer y = x->parent_->parent_->right_; // y is z's uncle
+
+                if (y != nullptr && y->color_ == rb_tree_node_color::red) // are z's parent and uncle both red?
+                {
+                    // Case 1
+                    x->parent_->color_ = rb_tree_node_color::black;
+                    y->color_ = rb_tree_node_color::black;
+                    x->parent_->parent_->color_ = rb_tree_node_color::red;
+                    x = x->parent_->parent_;
+                }
+                else
+                {
+                    if (x == x->parent_->right_)
+                    {
+                        // Case 2
+                        x = x->parent_;
+                        rotate_left(x);
+                    }
+
+                    // Case 3
+                    x->parent_->color_ = rb_tree_node_color::black;
+                    x->parent_->parent_->color_ = rb_tree_node_color::red;
+                    rotate_right(x->parent_->parent_);
+                }
+            }
+            else // same as block above, but with "right" and "left" exchanged
+            {
+                base_node_pointer y = x->parent_->parent_->left_;
+
+                if (y != nullptr && y->color_ == rb_tree_node_color::red)
+                {
+                    x->parent_->color_ = rb_tree_node_color::black;
+                    y->color_ = rb_tree_node_color::black;
+                    x->parent_->parent_->color_ = rb_tree_node_color::red;
+                    x = x->parent_->parent_;
+                }
+                else
+                {
+                    if (x == x->parent_->left_)
+                    {
+                        x = x->parent_;
+                        rotate_right(x);
+                    }
+
+                    x->parent_->color_ = rb_tree_node_color::black;
+                    x->parent_->parent_->color_ = rb_tree_node_color::red;
+                    rotate_left(x->parent_->parent_);
+                }
+            }
+        }
+
+        root->color_ = rb_tree_node_color::black;
+    }
+
+    static void transplant(base_node_pointer x, base_node_pointer y)
+    {
+        SFL_ASSERT(x != nullptr);
+        SFL_ASSERT(x->parent_ != nullptr);
+
+        if (x == x->parent_->left_)
+        {
+            x->parent_->left_ = y;
+        }
+        else
+        {
+            x->parent_->right_ = y;
+        }
+
+        if (y != nullptr)
+        {
+            y->parent_ = x->parent_;
+        }
+    }
+
+    static void remove(base_node_pointer z, base_node_pointer& root, base_node_pointer& minimum)
+    {
+        SFL_ASSERT(z != nullptr);
+
+        if (z == minimum)
+        {
+            minimum = next(z);
+        }
+
+        base_node_pointer x;
+        base_node_pointer x_parent;
+        base_node_pointer y = z;
+        rb_tree_node_color y_original_color = y->color_;
+
+        if (z->left_ == nullptr) // if z has at most one child
+        {
+            x = z->right_; // z->right_ could be null pointer
+            transplant(z, z->right_);
+            x_parent = z->parent_;
+        }
+        else if (z->right_ == nullptr) // if z has exactly one child
+        {
+            x = z->left_; // z->left_ is not null pointer
+            transplant(z, z->left_);
+            x_parent = z->parent_;
+        }
+        else // if z has two children
+        {
+            y = rb_tree::minimum(z->right_);
+            y_original_color = y->color_;
+            x = y->right_; // y->right_ could be null pointer
+
+            if (y != z->right_) // if y is farther down the tree
+            {
+                transplant(y, y->right_); // replace y by its right child
+                x_parent = y->parent_;
+                y->right_ = z->right_; // z's right child becomes y's right child
+                y->right_->parent_ = y;
+            }
+            else
+            {
+                x_parent = y; // in case x is NIL
+            }
+
+            transplant(z, y); // replace z by its successor y
+            y->left_ = z->left_; // give z's left child to y, which had not left child
+            y->left_->parent_ = y;
+            y->color_ = z->color_;
+        }
+
+        if (y_original_color == rb_tree_node_color::black)
+        {
+            remove_fixup(x, x_parent, root);
+        }
+    }
+
+    static void remove_fixup(base_node_pointer x, base_node_pointer x_parent, base_node_pointer& root)
+    {
+        while (x != root && (x == nullptr || x->color_ == rb_tree_node_color::black))
+        {
+            if (x == x_parent->left_) // is x a left child?
+            {
+                base_node_pointer w = x_parent->right_; // w is x's sibling
+
+                if (w->color_ == rb_tree_node_color::red)
+                {
+                    // Case 1
+                    w->color_ = rb_tree_node_color::black;
+                    x_parent->color_ = rb_tree_node_color::red;
+                    rotate_left(x_parent);
+                    w = x_parent->right_;
+                }
+
+                if
+                (
+                    (w->left_  == nullptr || w->left_->color_  == rb_tree_node_color::black) &&
+                    (w->right_ == nullptr || w->right_->color_ == rb_tree_node_color::black)
+                )
+                {
+                    // Case 2
+                    w->color_ = rb_tree_node_color::red;
+                    x = x_parent;
+                    x_parent = x_parent->parent_;
+                }
+                else
+                {
+                    if (w->right_ == nullptr || w->right_->color_ == rb_tree_node_color::black)
+                    {
+                        // Case 3
+                        w->left_->color_ = rb_tree_node_color::black;
+                        w->color_ = rb_tree_node_color::red;
+                        rotate_right(w);
+                        w = x_parent->right_;
+                    }
+
+                    // Case 4
+                    w->color_ = x_parent->color_;
+                    x_parent->color_ = rb_tree_node_color::black;
+                    if (w->right_ != nullptr)
+                    {
+                        w->right_->color_ = rb_tree_node_color::black;
+                    }
+                    rotate_left(x_parent);
+                    break;
+                }
+            }
+            else // same as block above, but with "right" and "left" exchanged
+            {
+                base_node_pointer w = x_parent->left_;
+
+                if (w->color_ == rb_tree_node_color::red)
+                {
+                    w->color_ = rb_tree_node_color::black;
+                    x_parent->color_ = rb_tree_node_color::red;
+                    rotate_right(x_parent);
+                    w = x_parent->left_;
+                }
+
+                if
+                (
+                    (w->right_ == nullptr || w->right_->color_ == rb_tree_node_color::black) &&
+                    (w->left_  == nullptr || w->left_->color_  == rb_tree_node_color::black)
+                )
+                {
+                    w->color_ = rb_tree_node_color::red;
+                    x = x_parent;
+                    x_parent = x_parent->parent_;
+                }
+                else
+                {
+                    if (w->left_ == nullptr || w->left_->color_ == rb_tree_node_color::black)
+                    {
+                        w->right_->color_ = rb_tree_node_color::black;
+                        w->color_ = rb_tree_node_color::red;
+                        rotate_left(w);
+                        w = x_parent->left_;
+                    }
+
+                    w->color_ = x_parent->color_;
+                    x_parent->color_ = rb_tree_node_color::black;
+                    if (w->left_)
+                    {
+                        w->left_->color_ = rb_tree_node_color::black;
+                    }
+                    rotate_right(x_parent);
+                    break;
+                }
+            }
+        }
+
+        if (x != nullptr)
+        {
+            x->color_ = rb_tree_node_color::black;
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    static const Key& key(node_pointer x) noexcept
+    {
+        return KeyOfValue()(x->value_);
+    }
+
+    static const Key& key(base_node_pointer x) noexcept
+    {
+        return KeyOfValue()(static_cast<node_pointer>(x)->value_);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    node_pointer allocate_node()
+    {
+        return sfl::dtl::allocate(ref_to_node_alloc(), 1);
+    }
+
+    void deallocate_node(node_pointer p) noexcept
+    {
+        sfl::dtl::deallocate(ref_to_node_alloc(), p, 1);
+    }
+
+    template <typename... Args>
+    void construct_node(node_pointer p, Args&&... args)
+    {
+        sfl::dtl::construct_at_a(ref_to_node_alloc(), p);
+
+        SFL_TRY
+        {
+            sfl::dtl::construct_at_a
+            (
+                ref_to_node_alloc(),
+                std::addressof(p->value_),
+                std::forward<Args>(args)...
+            );
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_at_a(ref_to_node_alloc(), p);
+            SFL_RETHROW;
+        }
+    }
+
+    void destroy_node(node_pointer p) noexcept
+    {
+        sfl::dtl::destroy_at_a(ref_to_node_alloc(), std::addressof(p->value_));
+        sfl::dtl::destroy_at_a(ref_to_node_alloc(), p);
+    }
+
+    class make_node_functor
+    {
+    private:
+
+        rb_tree& tree_;
+
+    public:
+
+        make_node_functor(rb_tree& tree)
+            : tree_(tree)
+        {}
+
+        template <typename... Args>
+        node_pointer operator()(Args&&... args)
+        {
+            node_pointer p = tree_.allocate_node();
+
+            SFL_TRY
+            {
+                tree_.construct_node(p, std::forward<Args>(args)...);
+            }
+            SFL_CATCH (...)
+            {
+                tree_.deallocate_node(p);
+                SFL_RETHROW;
+            }
+
+            return p;
+        }
+    };
+
+    class make_node_with_recycling_functor
+    {
+    private:
+
+        rb_tree& tree_;
+
+        base_node_pointer root_;
+
+    public:
+
+        make_node_with_recycling_functor(rb_tree& tree)
+            : tree_(tree)
+            , root_(tree.data_.root())
+        {
+            tree.data_.reset();
+        }
+
+        ~make_node_with_recycling_functor()
+        {
+            if (root_ != nullptr)
+            {
+                tree_.clear(root_);
+            }
+        }
+
+        template <typename... Args>
+        node_pointer operator()(Args&&... args)
+        {
+            node_pointer p = this->allocate_node();
+
+            SFL_TRY
+            {
+                tree_.construct_node(p, std::forward<Args>(args)...);
+            }
+            SFL_CATCH (...)
+            {
+                tree_.deallocate_node(p);
+                SFL_RETHROW;
+            }
+
+            return p;
+        }
+
+    private:
+
+        node_pointer allocate_node()
+        {
+            if (root_ == nullptr)
+            {
+                return tree_.allocate_node();
+            }
+            else
+            {
+                base_node_pointer node = tree_.minimum(root_);
+
+                if (node != root_)
+                {
+                    node->parent_->left_ = node->right_;
+
+                    if (node->right_ != nullptr)
+                    {
+                        node->right_->parent_ = node->parent_;
+                    }
+                }
+                else
+                {
+                    root_ = node->right_;
+
+                    if (node->right_ != nullptr)
+                    {
+                        node->right_->parent_ = nullptr;
+                    }
+                }
+
+                tree_.destroy_node(static_cast<node_pointer>(node));
+
+                return static_cast<node_pointer>(node);
+            }
+        }
+    };
+
+    void drop_node(node_pointer p) noexcept
+    {
+        destroy_node(p);
+        deallocate_node(p);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    struct position_for_insert_equal
+    {
+        base_node_pointer pos;
+        bool               left;
+    };
+
+    struct position_for_insert_unique
+    {
+        base_node_pointer pos;
+        bool               left;
+        bool               status;
+    };
+
+    template <typename K>
+    position_for_insert_equal calculate_position_for_insert_equal(const K& k)
+    {
+        base_node_pointer x = data_.root();
+        base_node_pointer y = data_.header();
+
+        bool comp = true;
+
+        while (x != nullptr)
+        {
+            y = x;
+
+            comp = ref_to_comp()(k, key(x));
+
+            if (comp)
+            {
+                x = x->left_;
+            }
+            else
+            {
+                x = x->right_;
+            }
+        }
+
+        return position_for_insert_equal{y, comp};
+    }
+
+    template <typename K>
+    position_for_insert_unique calculate_position_for_insert_unique(const K& k)
+    {
+        base_node_pointer x = data_.root();
+        base_node_pointer y = data_.header();
+
+        bool comp = true;
+
+        while (x != nullptr)
+        {
+            y = x;
+
+            comp = ref_to_comp()(k, key(x));
+
+            if (comp)
+            {
+                x = x->left_;
+            }
+            else
+            {
+                x = x->right_;
+            }
+        }
+
+        if (comp && y == data_.minimum())
+        {
+            return position_for_insert_unique{y, comp, true};
+        }
+
+        base_node_pointer z = comp ? prev(y) : y;
+
+        if (z != data_.header() && !ref_to_comp()(key(z), k))
+        {
+            return position_for_insert_unique{z, comp, false};
+        }
+
+        return position_for_insert_unique{y, comp, true};
+    }
+
+    template <typename K>
+    position_for_insert_equal calculate_position_for_insert_hint_equal(const_iterator hint, const K& k)
+    {
+        if (hint == cend())
+        {
+            if (empty())
+            {
+                return calculate_position_for_insert_equal(k);
+            }
+            else
+            {
+                const_iterator maximum = std::prev(hint);
+
+                if (!ref_to_comp()(k, key(maximum.node_))) // k >= maximum
+                {
+                    return position_for_insert_equal{maximum.node_, false};
+                }
+                else
+                {
+                    return calculate_position_for_insert_equal(k);
+                }
+            }
+        }
+        else if (!ref_to_comp()(key(hint.node_), k)) // k <= hint
+        {
+            if (hint == cbegin()) // hint == minimum
+            {
+                return position_for_insert_equal{hint.node_, true};
+            }
+            else
+            {
+                const_iterator prev = std::prev(hint);
+
+                if (!ref_to_comp()(k, key(prev.node_))) // prev <= k
+                {
+                    if (prev.node_->right_ == nullptr)
+                    {
+                        return position_for_insert_equal{prev.node_, false};
+                    }
+                    else
+                    {
+                        return position_for_insert_equal{hint.node_, true};
+                    }
+                }
+                else // prev > k
+                {
+                    return calculate_position_for_insert_equal(k);
+                }
+            }
+        }
+        else // hint < k
+        {
+            if (hint == std::prev(cend())) // hint == maximum
+            {
+                return position_for_insert_equal{hint.node_, false};
+            }
+            else
+            {
+                const_iterator next = std::next(hint);
+
+                if (!ref_to_comp()(key(next.node_), k)) // k <= next
+                {
+                    if (next.node_->left_ == nullptr)
+                    {
+                        return position_for_insert_equal{next.node_, true};
+                    }
+                    else
+                    {
+                        return position_for_insert_equal{hint.node_, false};
+                    }
+                }
+                else // k > next
+                {
+                    return calculate_position_for_insert_equal(k);
+                }
+            }
+        }
+    }
+
+    template <typename K>
+    position_for_insert_unique calculate_position_for_insert_hint_unique(const_iterator hint, const K& k)
+    {
+        if (hint == cend())
+        {
+            if (empty())
+            {
+                return calculate_position_for_insert_unique(k);
+            }
+            else
+            {
+                const_iterator maximum = std::prev(hint);
+
+                if (ref_to_comp()(key(maximum.node_), k)) // maximum < k
+                {
+                    return position_for_insert_unique{maximum.node_, false, true};
+                }
+                else
+                {
+                    return calculate_position_for_insert_unique(k);
+                }
+            }
+        }
+        else if (ref_to_comp()(k, key(hint.node_))) // k < hint
+        {
+            if (hint == cbegin()) // hint == minimum
+            {
+                return position_for_insert_unique{hint.node_, true, true};
+            }
+            else
+            {
+                const_iterator prev = std::prev(hint);
+
+                if (ref_to_comp()(key(prev.node_), k)) // prev < k
+                {
+                    if (prev.node_->right_ == nullptr)
+                    {
+                        return position_for_insert_unique{prev.node_, false, true};
+                    }
+                    else
+                    {
+                        return position_for_insert_unique{hint.node_, true, true};
+                    }
+                }
+                else // prev >= k
+                {
+                    return calculate_position_for_insert_unique(k);
+                }
+            }
+        }
+        else if (ref_to_comp()(key(hint.node_), k)) // hint < k
+        {
+            if (hint == std::prev(cend())) // hint == maximum
+            {
+                return position_for_insert_unique{hint.node_, false, true};
+            }
+            else
+            {
+                const_iterator next = std::next(hint);
+
+                if (ref_to_comp()(k, key(next.node_))) // k < next
+                {
+                    if (next.node_->left_ == nullptr)
+                    {
+                        return position_for_insert_unique{next.node_, true, true};
+                    }
+                    else
+                    {
+                        return position_for_insert_unique{hint.node_, false, true};
+                    }
+                }
+                else // k >= next
+                {
+                    return calculate_position_for_insert_unique(k);
+                }
+            }
+        }
+        else // k == hint
+        {
+            return position_for_insert_unique{hint.node_, false, false};
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    template <typename MakeNodeFunctor>
+    base_node_pointer copy(base_node_pointer x, MakeNodeFunctor& make_node)
+    {
+        SFL_ASSERT(x != nullptr);
+
+        base_node_pointer y = make_node(static_cast<node_pointer>(x)->value_);
+
+        y->color_ = x->color_;
+        y->left_  = nullptr;
+        y->right_ = nullptr;
+
+        SFL_TRY
+        {
+            if (x->left_ != nullptr)
+            {
+                y->left_ = copy(x->left_, make_node);
+                y->left_->parent_ = y;
+            }
+
+            if (x->right_ != nullptr)
+            {
+                y->right_ = copy(x->right_, make_node);
+                y->right_->parent_ = y;
+            }
+        }
+        SFL_CATCH (...)
+        {
+            drop_node(static_cast<node_pointer>(y));
+            SFL_RETHROW;
+        }
+
+        return y;
+    }
+
+    template <typename MakeNodeFunctor>
+    base_node_pointer move(base_node_pointer x, MakeNodeFunctor& make_node)
+    {
+        SFL_ASSERT(x != nullptr);
+
+        base_node_pointer y = make_node(std::move(static_cast<node_pointer>(x)->value_));
+
+        y->color_ = x->color_;
+        y->left_  = nullptr;
+        y->right_ = nullptr;
+
+        SFL_TRY
+        {
+            if (x->left_ != nullptr)
+            {
+                y->left_ = move(x->left_, make_node);
+                y->left_->parent_ = y;
+            }
+
+            if (x->right_ != nullptr)
+            {
+                y->right_ = move(x->right_, make_node);
+                y->right_->parent_ = y;
+            }
+        }
+        SFL_CATCH (...)
+        {
+            drop_node(static_cast<node_pointer>(y));
+            SFL_RETHROW;
+        }
+
+        return y;
+    }
+
+    void clear(base_node_pointer x)
+    {
+        SFL_ASSERT(x != nullptr);
+
+        if (x->left_ != nullptr)
+        {
+            clear(x->left_);
+        }
+
+        if (x->right_ != nullptr)
+        {
+            clear(x->right_);
+        }
+
+        drop_node(static_cast<node_pointer>(x));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    void initialize_copy(const rb_tree& other)
+    {
+        if (other.data_.root() != nullptr)
+        {
+            make_node_functor make_node(*this);
+            data_.root() = copy(other.data_.root(), make_node);
+            data_.minimum() = minimum(data_.root());
+            data_.size_ = other.data_.size_;
+        }
+    }
+
+    void initialize_move(rb_tree& other)
+    {
+        initialize_move(other, typename sfl::dtl::allocator_traits<node_allocator_type>::is_partially_propagable());
+    }
+
+    void initialize_move(rb_tree& other, std::true_type)
+    {
+        if (other.data_.root() != nullptr)
+        {
+            make_node_functor make_node(*this);
+            data_.root() = move(other.data_.root(), make_node);
+            data_.minimum() = minimum(data_.root());
+            data_.size_ = other.data_.size_;
+        }
+    }
+
+    void initialize_move(rb_tree& other, std::false_type)
+    {
+        initialize_move(other, std::false_type(), typename sfl::dtl::allocator_traits<node_allocator_type>::is_always_equal());
+    }
+
+    void initialize_move(rb_tree& other, std::false_type, std::true_type)
+    {
+        data_.root() = other.data_.root();
+        data_.minimum() = other.data_.minimum();
+        data_.size_ = other.data_.size_;
+        other.data_.reset();
+    }
+
+    void initialize_move(rb_tree& other, std::false_type, std::false_type)
+    {
+        if (ref_to_node_alloc() == other.ref_to_node_alloc())
+        {
+            initialize_move(other, std::false_type(), std::true_type());
+        }
+        else
+        {
+            initialize_move(other, std::true_type());
+        }
+    }
+
+    void assign_copy(const rb_tree& other)
+    {
+        if (this != &other)
+        {
+            if (sfl::dtl::allocator_traits<node_allocator_type>::propagate_on_container_copy_assignment::value)
+            {
+                if (ref_to_node_alloc() != other.ref_to_node_alloc())
+                {
+                    clear();
+                }
+
+                ref_to_node_alloc() = other.ref_to_node_alloc();
+            }
+
+            ref_to_comp() = other.ref_to_comp();
+
+            make_node_with_recycling_functor make_node(*this);
+
+            if (other.data_.root() != nullptr)
+            {
+                data_.root() = copy(other.data_.root(), make_node);
+                data_.minimum() = minimum(data_.root());
+                data_.size_ = other.data_.size_;
+            }
+        }
+    }
+
+    void assign_move(rb_tree& other)
+    {
+        assign_move(other, typename sfl::dtl::allocator_traits<node_allocator_type>::is_partially_propagable());
+    }
+
+    void assign_move(rb_tree& other, std::true_type)
+    {
+        if (sfl::dtl::allocator_traits<node_allocator_type>::propagate_on_container_move_assignment::value)
+        {
+            if (ref_to_node_alloc() != other.ref_to_node_alloc())
+            {
+                clear();
+            }
+
+            ref_to_node_alloc() = std::move(other.ref_to_node_alloc());
+        }
+
+        ref_to_comp() = std::move(other.ref_to_comp());
+
+        make_node_with_recycling_functor make_node(*this);
+
+        if (other.data_.root() != nullptr)
+        {
+            data_.root() = move(other.data_.root(), make_node);
+            data_.minimum() = minimum(data_.root());
+            data_.size_ = other.data_.size_;
+        }
+    }
+
+    void assign_move(rb_tree& other, std::false_type)
+    {
+        assign_move(other, std::false_type(), typename sfl::dtl::allocator_traits<node_allocator_type>::is_always_equal());
+    }
+
+    void assign_move(rb_tree& other, std::false_type, std::true_type)
+    {
+        if (sfl::dtl::allocator_traits<node_allocator_type>::propagate_on_container_move_assignment::value)
+        {
+            ref_to_node_alloc() = std::move(other.ref_to_node_alloc());
+        }
+
+        ref_to_comp() = std::move(other.ref_to_comp());
+
+        clear();
+
+        data_.root() = other.data_.root();
+        data_.minimum() = other.data_.minimum();
+        data_.size_ = other.data_.size_;
+
+        other.data_.reset();
+    }
+
+    void assign_move(rb_tree& other, std::false_type, std::false_type)
+    {
+        if (ref_to_node_alloc() == other.ref_to_node_alloc())
+        {
+            assign_move(other, std::false_type(), std::true_type());
+        }
+        else
+        {
+            assign_move(other, std::true_type());
+        }
+    }
+
+    void swap(rb_tree& other, std::true_type)
+    {
+        SFL_ASSERT(this->size() < this->max_size());
+        SFL_ASSERT(other.size() < other.max_size());
+
+        using std::swap;
+
+        base_node_pointer old_this = this->data_.root();
+        base_node_pointer old_other = other.data_.root();
+
+        if (old_this != nullptr)
+        {
+            old_this->parent_ = nullptr;
+        }
+        if (old_other != nullptr)
+        {
+            old_other->parent_ = nullptr;
+        }
+
+        this->data_.reset();
+        other.data_.reset();
+
+        if (sfl::dtl::allocator_traits<node_allocator_type>::propagate_on_container_swap::value)
+        {
+            swap(ref_to_node_alloc(), other.ref_to_node_alloc()); // noexcept
+        }
+
+        SFL_TRY
+        {
+            struct help
+            {
+                static base_node_pointer next_to_swap(base_node_pointer x)
+                {
+                    SFL_ASSERT(x != nullptr);
+
+                    if (x->left_ != nullptr)
+                    {
+                        return next_to_swap(x->left_);
+                    }
+                    else if (x->right_ != nullptr)
+                    {
+                        return next_to_swap(x->right_);
+                    }
+                    else
+                    {
+                        return x;
+                    }
+                }
+
+                static base_node_pointer detach(base_node_pointer x)
+                {
+                    SFL_ASSERT(x != nullptr);
+                    SFL_ASSERT(x->left_ == nullptr);
+                    SFL_ASSERT(x->right_ == nullptr);
+
+                    base_node_pointer parent = x->parent_;
+
+                    if (parent != nullptr)
+                    {
+                        if (x == parent->left_)
+                        {
+                            parent->left_ = nullptr;
+                        }
+                        else
+                        {
+                            parent->right_ = nullptr;
+                        }
+                    }
+
+                    return parent;
+                }
+            };
+
+            base_node_pointer p_this = old_this;
+            base_node_pointer p_other = old_other;
+
+            while (true)
+            {
+                bool done = true;
+
+                if (p_this != nullptr)
+                {
+                    done = false;
+
+                    p_this = help::next_to_swap(p_this);
+
+                    if
+                    (
+                        sfl::dtl::allocator_traits<node_allocator_type>::is_storage_unpropagable
+                        (
+                            this->ref_to_node_alloc(),
+                            static_cast<node_pointer>(p_this)
+                        )
+                        ||
+                        (
+                            !sfl::dtl::allocator_traits<node_allocator_type>::propagate_on_container_swap::value
+                            &&
+                            this->ref_to_node_alloc() != other.ref_to_node_alloc()
+                        )
+                    )
+                    {
+                        other.insert_equal(std::move(static_cast<node_pointer>(p_this)->value_)); // may throw exception
+
+                        base_node_pointer p_this_parent = help::detach(p_this);
+
+                        this->drop_node(static_cast<node_pointer>(p_this));
+
+                        p_this = p_this_parent;
+                    }
+                    else
+                    {
+                        auto res = other.calculate_position_for_insert_equal(key(p_this));
+
+                        base_node_pointer p_this_parent = help::detach(p_this);
+
+                        insert(p_this, res.pos, res.left, other.data_.root(), other.data_.minimum());
+
+                        ++other.data_.size_;
+
+                        p_this = p_this_parent;
+                    }
+                }
+
+                if (p_other != nullptr)
+                {
+                    done = false;
+
+                    p_other = help::next_to_swap(p_other);
+
+                    if
+                    (
+                        sfl::dtl::allocator_traits<node_allocator_type>::is_storage_unpropagable
+                        (
+                            other.ref_to_node_alloc(),
+                            static_cast<node_pointer>(p_other)
+                        )
+                        ||
+                        (
+                            !sfl::dtl::allocator_traits<node_allocator_type>::propagate_on_container_swap::value
+                            &&
+                            this->ref_to_node_alloc() != other.ref_to_node_alloc()
+                        )
+                    )
+                    {
+                        this->insert_equal(std::move(static_cast<node_pointer>(p_other)->value_)); // may throw exception
+
+                        base_node_pointer p_other_parent = help::detach(p_other);
+
+                        other.drop_node(static_cast<node_pointer>(p_other));
+
+                        p_other = p_other_parent;
+                    }
+                    else
+                    {
+                        auto res = this->calculate_position_for_insert_equal(key(p_other));
+
+                        base_node_pointer p_other_parent = help::detach(p_other);
+
+                        insert(p_other, res.pos, res.left, this->data_.root(), this->data_.minimum());
+
+                        ++this->data_.size_;
+
+                        p_other = p_other_parent;
+                    }
+                }
+
+                if (done)
+                {
+                    break;
+                }
+            }
+        }
+        SFL_CATCH (...)
+        {
+            struct help
+            {
+                static base_node_pointer next_to_remove(base_node_pointer x)
+                {
+                    SFL_ASSERT(x != nullptr);
+
+                    if (x->left_ != nullptr)
+                    {
+                        return next_to_remove(x->left_);
+                    }
+                    else if (x->right_ != nullptr)
+                    {
+                        return next_to_remove(x->right_);
+                    }
+                    else
+                    {
+                        return x;
+                    }
+                }
+
+                static base_node_pointer detach(base_node_pointer x)
+                {
+                    SFL_ASSERT(x != nullptr);
+                    SFL_ASSERT(x->left_ == nullptr);
+                    SFL_ASSERT(x->right_ == nullptr);
+
+                    base_node_pointer parent = x->parent_;
+
+                    if (parent != nullptr)
+                    {
+                        if (x == parent->left_)
+                        {
+                            parent->left_ = nullptr;
+                        }
+                        else
+                        {
+                            parent->right_ = nullptr;
+                        }
+                    }
+
+                    return parent;
+                }
+            };
+
+            base_node_pointer p_this = old_this;
+            base_node_pointer p_other = old_other;
+
+            while (p_this != nullptr)
+            {
+                p_this = help::next_to_remove(p_this);
+
+                base_node_pointer p_this_parent = help::detach(p_this);
+
+                if
+                (
+                    sfl::dtl::allocator_traits<node_allocator_type>::is_storage_unpropagable
+                    (
+                        this->ref_to_node_alloc(),
+                        static_cast<node_pointer>(p_this)
+                    )
+                )
+                {
+                    this->drop_node(static_cast<node_pointer>(p_this));
+                }
+                else
+                {
+                    if (sfl::dtl::allocator_traits<node_allocator_type>::propagate_on_container_swap::value)
+                    {
+                        other.drop_node(static_cast<node_pointer>(p_this));
+                    }
+                    else
+                    {
+                        this->drop_node(static_cast<node_pointer>(p_this));
+                    }
+                }
+
+                p_this = p_this_parent;
+            }
+
+            while (p_other != nullptr)
+            {
+                p_other = help::next_to_remove(p_other);
+
+                base_node_pointer p_other_parent = help::detach(p_other);
+
+                if
+                (
+                    sfl::dtl::allocator_traits<node_allocator_type>::is_storage_unpropagable
+                    (
+                        other.ref_to_node_alloc(),
+                        static_cast<node_pointer>(p_other)
+                    )
+                )
+                {
+                    other.drop_node(static_cast<node_pointer>(p_other));
+                }
+                else
+                {
+                    if (sfl::dtl::allocator_traits<node_allocator_type>::propagate_on_container_swap::value)
+                    {
+                        this->drop_node(static_cast<node_pointer>(p_other));
+                    }
+                    else
+                    {
+                        other.drop_node(static_cast<node_pointer>(p_other));
+                    }
+                }
+
+                p_other = p_other_parent;
+            }
+
+            SFL_RETHROW;
+        }
+    }
+
+    void swap(rb_tree& other, std::false_type)
+    {
+        swap(other, std::false_type(), typename sfl::dtl::allocator_traits<node_allocator_type>::is_always_equal());
+    }
+
+    void swap(rb_tree& other, std::false_type, std::true_type)
+    {
+        using std::swap;
+
+        if (sfl::dtl::allocator_traits<node_allocator_type>::propagate_on_container_swap::value)
+        {
+            swap(ref_to_node_alloc(), other.ref_to_node_alloc());
+        }
+
+        swap(ref_to_comp(), other.ref_to_comp());
+
+        swap(data_.root(), other.data_.root());
+        swap(data_.minimum(), other.data_.minimum());
+        swap(data_.size_, other.data_.size_);
+    }
+
+    void swap(rb_tree& other, std::false_type, std::false_type)
+    {
+        if (ref_to_node_alloc() == other.ref_to_node_alloc())
+        {
+            swap(other, std::false_type(), std::true_type());
+        }
+        else
+        {
+            swap(other, std::true_type());
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    std::size_t verify_black_count(base_node_pointer x, base_node_pointer root) const
+    {
+        if (x == nullptr)
+        {
+            return 0;
+        }
+
+        std::size_t count = 0;
+
+        while (true)
+        {
+            if (x->color_ == rb_tree_node_color::black)
+            {
+                ++count;
+            }
+
+            if (x == root)
+            {
+                break;
+            }
+
+            x = x->parent_;
+        }
+
+        return count;
+    }
+
+    bool verify() const
+    {
+        if (data_.size_ == 0 || begin() == end())
+        {
+            return data_.size_ == 0
+                && begin() == end()
+                && data_.header_.parent_ == std::pointer_traits<base_node_pointer>::pointer_to(data_.header_)
+                && data_.header_.left_ == nullptr;
+        }
+
+        const std::size_t len = verify_black_count(data_.minimum(), data_.root());
+
+        for (auto it = begin(); it != end(); ++it)
+        {
+            node_pointer x = static_cast<node_pointer>(it.node_);
+            node_pointer l = static_cast<node_pointer>(x->left_);
+            node_pointer r = static_cast<node_pointer>(x->right_);
+
+            if (x->color_ == rb_tree_node_color::red)
+            {
+                if
+                (
+                    (l != nullptr && l->color_ == rb_tree_node_color::red) ||
+                    (r != nullptr && r->color_ == rb_tree_node_color::red)
+                )
+                {
+                    return false;
+                }
+            }
+
+            if (l != nullptr && ref_to_comp()(key(x), key(l)))
+            {
+                return false;
+            }
+
+            if (r != nullptr && ref_to_comp()(key(r), key(x)))
+            {
+                return false;
+            }
+
+            if (l == nullptr && r == nullptr && verify_black_count(x, data_.root()) != len)
+            {
+                return false;
+            }
+        }
+
+        if (data_.minimum() != minimum(data_.root()))
+        {
+            return false;
+        }
+
+        return true;
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template < typename Key,
+           typename Value,
+           typename KeyOfValue,
+           typename KeyCompare,
+           typename Allocator,
+           typename UpperLevelContainer >
+SFL_NODISCARD
+bool operator==
+(
+    const rb_tree<Key, Value, KeyOfValue, KeyCompare, Allocator, UpperLevelContainer>& x,
+    const rb_tree<Key, Value, KeyOfValue, KeyCompare, Allocator, UpperLevelContainer>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template < typename Key,
+           typename Value,
+           typename KeyOfValue,
+           typename KeyCompare,
+           typename Allocator,
+           typename UpperLevelContainer >
+SFL_NODISCARD
+bool operator!=
+(
+    const rb_tree<Key, Value, KeyOfValue, KeyCompare, Allocator, UpperLevelContainer>& x,
+    const rb_tree<Key, Value, KeyOfValue, KeyCompare, Allocator, UpperLevelContainer>& y
+)
+{
+    return !(x == y);
+}
+
+template < typename Key,
+           typename Value,
+           typename KeyOfValue,
+           typename KeyCompare,
+           typename Allocator,
+           typename UpperLevelContainer >
+SFL_NODISCARD
+bool operator<
+(
+    const rb_tree<Key, Value, KeyOfValue, KeyCompare, Allocator, UpperLevelContainer>& x,
+    const rb_tree<Key, Value, KeyOfValue, KeyCompare, Allocator, UpperLevelContainer>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template < typename Key,
+           typename Value,
+           typename KeyOfValue,
+           typename KeyCompare,
+           typename Allocator,
+           typename UpperLevelContainer >
+SFL_NODISCARD
+bool operator>
+(
+    const rb_tree<Key, Value, KeyOfValue, KeyCompare, Allocator, UpperLevelContainer>& x,
+    const rb_tree<Key, Value, KeyOfValue, KeyCompare, Allocator, UpperLevelContainer>& y
+)
+{
+    return y < x;
+}
+
+template < typename Key,
+           typename Value,
+           typename KeyOfValue,
+           typename KeyCompare,
+           typename Allocator,
+           typename UpperLevelContainer >
+SFL_NODISCARD
+bool operator<=
+(
+    const rb_tree<Key, Value, KeyOfValue, KeyCompare, Allocator, UpperLevelContainer>& x,
+    const rb_tree<Key, Value, KeyOfValue, KeyCompare, Allocator, UpperLevelContainer>& y
+)
+{
+    return !(y < x);
+}
+
+template < typename Key,
+           typename Value,
+           typename KeyOfValue,
+           typename KeyCompare,
+           typename Allocator,
+           typename UpperLevelContainer >
+SFL_NODISCARD
+bool operator>=
+(
+    const rb_tree<Key, Value, KeyOfValue, KeyCompare, Allocator, UpperLevelContainer>& x,
+    const rb_tree<Key, Value, KeyOfValue, KeyCompare, Allocator, UpperLevelContainer>& y
+)
+{
+    return !(x < y);
+}
+
+template < typename Key,
+           typename Value,
+           typename KeyOfValue,
+           typename KeyCompare,
+           typename Allocator,
+           typename UpperLevelContainer >
+void swap
+(
+    rb_tree<Key, Value, KeyOfValue, KeyCompare, Allocator, UpperLevelContainer>& x,
+    rb_tree<Key, Value, KeyOfValue, KeyCompare, Allocator, UpperLevelContainer>& y
+)
+{
+    x.swap(y);
+}
+
+} //namespace dtl
+
+} // namespace sfl
+
+#endif // SFL_DETAIL_RB_TREE_HPP_INCLUDED

--- a/src/thirdparty/sfl/detail/scope_guard.hpp
+++ b/src/thirdparty/sfl/detail/scope_guard.hpp
@@ -1,0 +1,90 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_DETAIL_SCOPE_GUARD_HPP_INCLUDED
+#define SFL_DETAIL_SCOPE_GUARD_HPP_INCLUDED
+
+#include <utility> // forward, move
+
+namespace sfl
+{
+
+namespace dtl
+{
+
+template <typename Lambda>
+class scope_guard
+{
+private:
+
+    mutable bool dismissed_;
+
+    Lambda lambda_;
+
+public:
+
+    scope_guard(Lambda&& lambda)
+        : dismissed_(false)
+        , lambda_(std::forward<Lambda>(lambda))
+    {}
+
+    scope_guard(const scope_guard& other) = delete;
+
+    scope_guard(scope_guard&& other)
+        : dismissed_(other.dismissed_)
+        , lambda_(std::move(other.lambda_))
+    {
+        other.dismissed_ = true;
+    }
+
+    scope_guard& operator=(const scope_guard& other) = delete;
+
+    scope_guard& operator=(scope_guard&& other)
+    {
+        dismissed_ = other.dismissed_;
+        lambda_ = std::move(other.lambda_);
+        other.dismissed_ = true;
+    }
+
+    ~scope_guard()
+    {
+        if (!dismissed_)
+        {
+            lambda_();
+        }
+    }
+
+    void dismiss() const noexcept
+    {
+        dismissed_ = true;
+    }
+};
+
+template <typename Lambda>
+scope_guard<Lambda> make_scope_guard(Lambda&& lambda)
+{
+    return scope_guard<Lambda>(std::forward<Lambda>(lambda));
+}
+
+} // namespace dtl
+
+} // namespace sfl
+
+#endif // SFL_DETAIL_SCOPE_GUARD_HPP_INCLUDED

--- a/src/thirdparty/sfl/detail/segmented_iterator.hpp
+++ b/src/thirdparty/sfl/detail/segmented_iterator.hpp
@@ -1,0 +1,303 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_DETAIL_SEGMENTED_ITERATOR_HPP_INCLUDED
+#define SFL_DETAIL_SEGMENTED_ITERATOR_HPP_INCLUDED
+
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/to_address.hpp>
+#include <sfl/detail/type_traits.hpp>
+
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+
+namespace sfl
+{
+
+namespace dtl
+{
+
+template <typename SegmentIterator, typename LocalIterator, std::size_t SegmentSize, typename Container>
+class segmented_iterator
+{
+    template <typename, typename, std::size_t, typename>
+    friend class segmented_iterator;
+
+    friend Container;
+
+    template <typename>
+    friend struct sfl::dtl::segmented_iterator_traits;
+
+private:
+
+    SegmentIterator segment_;
+    LocalIterator   local_;
+
+public:
+
+    using difference_type   = typename std::iterator_traits<LocalIterator>::difference_type;
+    using value_type        = typename std::iterator_traits<LocalIterator>::value_type;
+    using pointer           = typename std::iterator_traits<LocalIterator>::pointer;
+    using reference         = typename std::iterator_traits<LocalIterator>::reference;
+    using iterator_category = typename std::iterator_traits<LocalIterator>::iterator_category;
+
+private:
+
+    explicit segmented_iterator(const SegmentIterator& segment, const LocalIterator& local) noexcept
+        : segment_(segment)
+        , local_(local)
+    {}
+
+public:
+
+    // Default constructor
+    segmented_iterator() noexcept
+        : segment_()
+        , local_()
+    {}
+
+    // Copy constructor
+    segmented_iterator(const segmented_iterator& other) noexcept
+        : segment_(other.segment_)
+        , local_(other.local_)
+    {}
+
+    // Converting constructor (from iterator to const_iterator)
+    template <typename OtherSegmentIterator, typename OtherLocalIterator,
+              sfl::dtl::enable_if_t< std::is_convertible<OtherSegmentIterator, SegmentIterator>::value &&
+                                     std::is_convertible<OtherLocalIterator, LocalIterator>::value >* = nullptr >
+    segmented_iterator(const segmented_iterator<OtherSegmentIterator, OtherLocalIterator, SegmentSize, Container>& other) noexcept
+        : segment_(other.segment_)
+        , local_(other.local_)
+    {}
+
+    // Copy assignment operator
+    segmented_iterator& operator=(const segmented_iterator& other) noexcept
+    {
+        segment_ = other.segment_;
+        local_ = other.local_;
+        return *this;
+    }
+
+    SFL_NODISCARD
+    reference operator*() const noexcept
+    {
+        return *local_;
+    }
+
+    SFL_NODISCARD
+    pointer operator->() const noexcept
+    {
+        return sfl::dtl::to_address(local_);
+    }
+
+    segmented_iterator& operator++() noexcept
+    {
+        ++local_;
+
+        if (local_ == *segment_ + SegmentSize)
+        {
+            ++segment_;
+            local_ = *segment_;
+        }
+
+        return *this;
+    }
+
+    segmented_iterator operator++(int) noexcept
+    {
+        auto temp = *this;
+        this->operator++();
+        return temp;
+    }
+
+    segmented_iterator& operator--() noexcept
+    {
+        if (local_ == *segment_)
+        {
+            --segment_;
+            local_ = *segment_ + SegmentSize;
+        }
+
+        --local_;
+
+        return *this;
+    }
+
+    segmented_iterator operator--(int) noexcept
+    {
+        auto temp = *this;
+        this->operator--();
+        return temp;
+    }
+
+    segmented_iterator& operator+=(difference_type n) noexcept
+    {
+        const difference_type offset = std::distance(LocalIterator(*segment_), local_) + n;
+
+        if (offset >= 0 && offset < difference_type(SegmentSize))
+        {
+            local_ += n;
+        }
+        else
+        {
+            const difference_type segment_offset =
+                offset > 0
+                    ? offset / difference_type(SegmentSize)
+                    : -difference_type((-offset - 1) / SegmentSize) - 1;
+
+            segment_ += segment_offset;
+
+            local_ = *segment_ + (offset - segment_offset * difference_type(SegmentSize));
+        }
+
+        return *this;
+    }
+
+    segmented_iterator& operator-=(difference_type n) noexcept
+    {
+        return this->operator+=(-n);
+    }
+
+    SFL_NODISCARD
+    segmented_iterator operator+(difference_type n) const noexcept
+    {
+        auto temp = *this;
+        temp += n;
+        return temp;
+    }
+
+    SFL_NODISCARD
+    segmented_iterator operator-(difference_type n) const noexcept
+    {
+        auto temp = *this;
+        temp -= n;
+        return temp;
+    }
+
+    SFL_NODISCARD
+    reference operator[](difference_type n) const noexcept
+    {
+        auto temp = *this;
+        temp += n;
+        return *temp;
+    }
+
+    SFL_NODISCARD
+    friend segmented_iterator operator+(difference_type n, const segmented_iterator& it) noexcept
+    {
+        return it + n;
+    }
+
+    SFL_NODISCARD
+    friend difference_type operator-(const segmented_iterator& x, const segmented_iterator& y) noexcept
+    {
+        return (x.segment_ - y.segment_) * difference_type(SegmentSize)
+             + (x.local_ - *x.segment_) - (y.local_ - *y.segment_);
+    }
+
+    SFL_NODISCARD
+    friend bool operator==(const segmented_iterator& x, const segmented_iterator& y) noexcept
+    {
+        return x.local_ == y.local_;
+    }
+
+    SFL_NODISCARD
+    friend bool operator!=(const segmented_iterator& x, const segmented_iterator& y) noexcept
+    {
+        return !(x == y);
+    }
+
+    SFL_NODISCARD
+    friend bool operator<(const segmented_iterator& x, const segmented_iterator& y) noexcept
+    {
+        return (x.segment_ == y.segment_) ? (x.local_ < y.local_) : (x.segment_ < y.segment_);
+    }
+
+    SFL_NODISCARD
+    friend bool operator>(const segmented_iterator& x, const segmented_iterator& y) noexcept
+    {
+        return y < x;
+    }
+
+    SFL_NODISCARD
+    friend bool operator<=(const segmented_iterator& x, const segmented_iterator& y) noexcept
+    {
+        return !(y < x);
+    }
+
+    SFL_NODISCARD
+    friend bool operator>=(const segmented_iterator& x, const segmented_iterator& y) noexcept
+    {
+        return !(x < y);
+    }
+};
+
+template <typename SegmentIterator, typename LocalIterator, std::size_t SegmentSize, typename Container>
+struct segmented_iterator_traits<sfl::dtl::segmented_iterator<SegmentIterator, LocalIterator, SegmentSize, Container>>
+{
+    using is_segmented_iterator = std::true_type;
+
+    using iterator = sfl::dtl::segmented_iterator<SegmentIterator, LocalIterator, SegmentSize, Container>;
+
+    using segment_iterator = SegmentIterator;
+
+    using local_iterator = LocalIterator;
+
+    static segment_iterator segment(iterator it) noexcept
+    {
+        return it.segment_;
+    }
+
+    static local_iterator local(iterator it) noexcept
+    {
+        return it.local_;
+    }
+
+    static local_iterator begin(segment_iterator it) noexcept
+    {
+        return *it;
+    }
+
+    static local_iterator end(segment_iterator it) noexcept
+    {
+        return *it + SegmentSize;
+    }
+
+    static iterator compose(segment_iterator segment, local_iterator local) noexcept
+    {
+        SFL_ASSERT(begin(segment) <= local && local <= end(segment));
+
+        if (local == end(segment))
+        {
+            ++segment;
+            local = begin(segment);
+        }
+
+        return iterator(segment, local);
+    }
+};
+
+} // namespace dtl
+
+} // namespace sfl
+
+#endif // SFL_DETAIL_SEGMENTED_ITERATOR_HPP_INCLUDED

--- a/src/thirdparty/sfl/detail/static_pool.hpp
+++ b/src/thirdparty/sfl/detail/static_pool.hpp
@@ -1,0 +1,172 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_DETAIL_STATIC_POOL_HPP_INCLUDED
+#define SFL_DETAIL_STATIC_POOL_HPP_INCLUDED
+
+#include <sfl/detail/cpp.hpp>
+
+#include <cstddef> // size_t, ptrdiff_t
+#include <memory>  // addressof
+
+namespace sfl
+{
+
+namespace dtl
+{
+
+template <typename T, std::size_t N>
+class static_pool
+{
+    static_assert(N > 0, "N must be greater than zero.");
+
+public:
+
+    using value_type      = T;
+    using size_type       = std::size_t;
+    using difference_type = std::ptrdiff_t;
+
+private:
+
+    union element
+    {
+    public:
+
+        element* next_;
+
+        T value_;
+
+    public:
+
+        element() noexcept
+        {}
+
+        element(const element& other) = delete;
+
+        element(element&& other) = delete;
+
+        element& operator=(const element& other) = delete;
+
+        element& operator=(element&& other) = delete;
+
+        ~element() noexcept
+        {}
+    };
+
+    element storage_[N];
+
+    size_type n_allocated = 0;
+
+    size_type n_initialized = 0;
+
+    element* next_ = nullptr;
+
+public:
+
+    static_pool() noexcept
+    {}
+
+    static_pool(const static_pool& other) = delete;
+
+    static_pool(static_pool&& other) = delete;
+
+    static_pool& operator=(const static_pool& other) = delete;
+
+    static_pool& operator=(static_pool&& other) = delete;
+
+    ~static_pool() noexcept
+    {
+        SFL_ASSERT(empty());
+    }
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return n_allocated == 0;
+    }
+
+    SFL_NODISCARD
+    bool full() const noexcept
+    {
+        return n_allocated == N;
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type max_size() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    bool contains(const T* p) const noexcept
+    {
+        const element* q = reinterpret_cast<const element*>(p);
+        return storage_ <= q && q < storage_ + N;
+    }
+
+    SFL_NODISCARD
+    T* allocate() noexcept
+    {
+        SFL_ASSERT(n_allocated < N);
+
+        if (n_allocated < n_initialized)
+        {
+            // Nothing to do.
+        }
+        else
+        {
+            SFL_ASSERT(n_initialized < N);
+
+            element* p = std::addressof(storage_[n_initialized++]);
+
+            p->next_ = nullptr;
+
+            next_ = p;
+        }
+
+        element* p = next_;
+
+        next_ = p->next_;
+
+        ++n_allocated;
+
+        return std::addressof(p->value_);
+    }
+
+    void deallocate(T* p) noexcept
+    {
+        SFL_ASSERT(n_allocated > 0);
+        SFL_ASSERT(contains(p));
+
+        element* q = reinterpret_cast<element*>(p);
+
+        q->next_ = next_;
+
+        next_ = q;
+
+        --n_allocated;
+    }
+};
+
+} // namespace dtl
+
+} // namespace sfl
+
+#endif // SFL_DETAIL_STATIC_POOL_HPP_INCLUDED

--- a/src/thirdparty/sfl/detail/tags.hpp
+++ b/src/thirdparty/sfl/detail/tags.hpp
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_DETAIL_TAGS_HPP_INCLUDED
+#define SFL_DETAIL_TAGS_HPP_INCLUDED
+
+namespace sfl
+{
+
+// Type used to tag that the inserted values should be default initialized.
+struct default_init_t { };
+
+// Type used to tag that container is constructed from range.
+struct from_range_t { };
+
+} // namespace sfl
+
+#endif // SFL_DETAIL_TAGS_HPP_INCLUDED

--- a/src/thirdparty/sfl/detail/to_address.hpp
+++ b/src/thirdparty/sfl/detail/to_address.hpp
@@ -1,0 +1,60 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_DETAIL_TO_ADDRESS_HPP_INCLUDED
+#define SFL_DETAIL_TO_ADDRESS_HPP_INCLUDED
+
+#include <memory>       // pointer traits
+#include <type_traits>  // type traits
+
+namespace sfl
+{
+
+namespace dtl
+{
+
+//
+// Raw pointer overload.
+// Obtains a dereferenceable pointer to its argument.
+//
+template <typename T>
+constexpr
+T* to_address(T* p) noexcept
+{
+    static_assert(!std::is_function<T>::value, "not a function pointer");
+    return p;
+}
+
+//
+// Fancy pointer overload.
+// Obtains a raw pointer from a fancy pointer.
+//
+template <typename Pointer>
+constexpr
+auto to_address(const Pointer& p) noexcept -> typename std::pointer_traits<Pointer>::element_type*
+{
+    return sfl::dtl::to_address(p.operator->());
+}
+
+} // namespace dtl
+
+} // namespace sfl
+
+#endif // SFL_DETAIL_TO_ADDRESS_HPP_INCLUDED

--- a/src/thirdparty/sfl/detail/type_traits.hpp
+++ b/src/thirdparty/sfl/detail/type_traits.hpp
@@ -1,0 +1,165 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_DETAIL_TYPE_TRAITS_HPP_INCLUDED
+#define SFL_DETAIL_TYPE_TRAITS_HPP_INCLUDED
+
+#include <iterator>
+#include <type_traits>
+
+namespace sfl
+{
+
+namespace dtl
+{
+
+template <typename...>
+using void_t = void;
+
+template <bool B, typename T = void>
+using enable_if_t = typename std::enable_if<B, T>::type;
+
+template <typename T>
+using remove_cvref_t = typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+
+//
+// This struct provides information about segmented iterators.
+//
+// The architecture about segmented iterator traits is based on this article:
+// "Segmented Iterators and Hierarchical Algorithms", Matthew H. Austern.
+//
+template <typename T>
+struct segmented_iterator_traits
+{
+    using is_segmented_iterator = std::false_type;
+
+    //
+    // Specialized struct must define the following types and functions:
+    //
+    // using iterator         = xxxxx; (it is usually `T`)
+    // using segment_iterator = xxxxx;
+    // using local_iterator   = xxxxx;
+    //
+    // static segment_iterator segment(iterator);
+    // static local_iterator   local(iterator);
+    //
+    // static local_iterator begin(segment_iterator);
+    // static local_iterator end(segment_iterator);
+    //
+    // static iterator compose(segment_iterator, local_iterator);
+    //
+};
+
+//
+// Checks if `T` is segmented iterator.
+//
+template <typename T>
+struct is_segmented_iterator :
+    sfl::dtl::segmented_iterator_traits<T>::is_segmented_iterator {};
+
+//
+// Checks if `T` is input iterator.
+//
+template <typename Iterator, typename = void>
+struct is_input_iterator : std::false_type {};
+
+template <typename Iterator>
+struct is_input_iterator<
+    Iterator,
+    sfl::dtl::enable_if_t<
+        std::is_convertible<
+            typename std::iterator_traits<Iterator>::iterator_category,
+            std::input_iterator_tag
+        >::value
+    >
+> : std::true_type {};
+
+//
+// Checks if `T` is exactly input iterator.
+//
+template <typename T, typename = void>
+struct is_exactly_input_iterator : std::false_type {};
+
+template <typename T>
+struct is_exactly_input_iterator<
+    T,
+    sfl::dtl::enable_if_t<
+        std::is_convertible<
+            typename std::iterator_traits<T>::iterator_category,
+            std::input_iterator_tag
+        >::value
+        &&
+       !std::is_convertible<
+            typename std::iterator_traits<T>::iterator_category,
+            std::forward_iterator_tag
+        >::value
+    >
+> : std::true_type {};
+
+//
+// Checks if `T` is forward iterator.
+//
+template <typename T, typename = void>
+struct is_forward_iterator : std::false_type {};
+
+template <typename T>
+struct is_forward_iterator<
+    T,
+    sfl::dtl::enable_if_t<
+        std::is_convertible<
+            typename std::iterator_traits<T>::iterator_category,
+            std::forward_iterator_tag
+        >::value
+    >
+> : std::true_type {};
+
+//
+// Checks if `T` is random access iterator.
+//
+template <typename T, typename = void>
+struct is_random_access_iterator : std::false_type {};
+
+template <typename T>
+struct is_random_access_iterator<
+    T,
+    sfl::dtl::enable_if_t<
+        std::is_convertible<
+            typename std::iterator_traits<T>::iterator_category,
+            std::random_access_iterator_tag
+        >::value
+    >
+> : std::true_type {};
+
+//
+// Checks if `Type` has member `is_transparent`.
+//
+template <typename Type, typename SfinaeType, typename = void>
+struct has_is_transparent : std::false_type {};
+
+template <typename Type, typename SfinaeType>
+struct has_is_transparent<
+    Type, SfinaeType, sfl::dtl::void_t<typename Type::is_transparent>
+> : std::true_type {};
+
+} // namespace dtl
+
+} // namespace sfl
+
+#endif // SFL_DETAIL_TYPE_TRAITS_HPP_INCLUDED

--- a/src/thirdparty/sfl/detail/uninitialized_memory_algorithms.hpp
+++ b/src/thirdparty/sfl/detail/uninitialized_memory_algorithms.hpp
@@ -1,0 +1,1175 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_DETAIL_UNINITIALIZED_MEMORY_ALGORITHMS_HPP_INCLUDED
+#define SFL_DETAIL_UNINITIALIZED_MEMORY_ALGORITHMS_HPP_INCLUDED
+
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/to_address.hpp>
+#include <sfl/detail/type_traits.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <memory>
+#include <utility>
+
+namespace sfl
+{
+
+namespace dtl
+{
+
+template <typename Allocator, typename Size>
+auto allocate(Allocator& a, Size n) -> typename std::allocator_traits<Allocator>::pointer
+{
+    if (n != 0)
+    {
+        return std::allocator_traits<Allocator>::allocate(a, n);
+    }
+    return nullptr;
+}
+
+template <typename Allocator, typename Pointer, typename Size>
+void deallocate(Allocator& a, Pointer p, Size n) noexcept
+{
+    if (p != nullptr)
+    {
+        std::allocator_traits<Allocator>::deallocate(a, p, n);
+    }
+}
+
+template <typename Allocator, typename Pointer, typename... Args>
+void construct_at_a(Allocator& a, Pointer p, Args&&... args)
+{
+    std::allocator_traits<Allocator>::construct
+    (
+        a,
+        sfl::dtl::to_address(p),
+        std::forward<Args>(args)...
+    );
+}
+
+template <typename Allocator, typename Pointer>
+void destroy_at_a(Allocator& a, Pointer p) noexcept
+{
+    std::allocator_traits<Allocator>::destroy
+    (
+        a,
+        sfl::dtl::to_address(p)
+    );
+}
+
+template <typename Allocator, typename ForwardIt,
+          sfl::dtl::enable_if_t< !sfl::dtl::is_segmented_iterator<ForwardIt>::value >* = nullptr>
+void destroy_a(Allocator& a, ForwardIt first, ForwardIt last) noexcept
+{
+    while (first != last)
+    {
+        sfl::dtl::destroy_at_a(a, std::addressof(*first));
+        ++first;
+    }
+}
+
+template <typename Allocator, typename ForwardIt,
+          sfl::dtl::enable_if_t< sfl::dtl::is_segmented_iterator<ForwardIt>::value >* = nullptr>
+void destroy_a(Allocator& a, ForwardIt first, ForwardIt last) noexcept
+{
+    using traits = sfl::dtl::segmented_iterator_traits<ForwardIt>;
+
+    auto first_seg = traits::segment(first);
+    auto last_seg  = traits::segment(last);
+
+    if (first_seg == last_seg)
+    {
+        sfl::dtl::destroy_a
+        (
+            a,
+            traits::local(first),
+            traits::local(last)
+        );
+    }
+    else
+    {
+        sfl::dtl::destroy_a
+        (
+            a,
+            traits::local(first),
+            traits::end(first_seg)
+        );
+
+        ++first_seg;
+
+        while (first_seg != last_seg)
+        {
+            sfl::dtl::destroy_a
+            (
+                a,
+                traits::begin(first_seg),
+                traits::end(first_seg)
+            );
+
+            ++first_seg;
+        }
+
+        sfl::dtl::destroy_a
+        (
+            a,
+            traits::begin(last_seg),
+            traits::local(last)
+        );
+    }
+}
+
+template <typename Allocator, typename ForwardIt, typename Size,
+          sfl::dtl::enable_if_t< !sfl::dtl::is_segmented_iterator<ForwardIt>::value >* = nullptr>
+ForwardIt destroy_n_a(Allocator& a, ForwardIt first, Size n) noexcept
+{
+    while (n > 0)
+    {
+        sfl::dtl::destroy_at_a(a, std::addressof(*first));
+        ++first;
+        --n;
+    }
+    return first;
+}
+
+template <typename Allocator, typename ForwardIt, typename Size,
+          sfl::dtl::enable_if_t< sfl::dtl::is_segmented_iterator<ForwardIt>::value >* = nullptr>
+ForwardIt destroy_n_a(Allocator& a, ForwardIt first, Size n) noexcept
+{
+    using traits = sfl::dtl::segmented_iterator_traits<ForwardIt>;
+
+    auto curr_local = traits::local(first);
+    auto curr_seg   = traits::segment(first);
+
+    auto remainining = n;
+
+    while (true)
+    {
+        using difference_type =
+            typename std::iterator_traits<typename traits::local_iterator>::difference_type;
+
+        const auto count = std::min<difference_type>
+        (
+            remainining,
+            std::distance(curr_local, traits::end(curr_seg))
+        );
+
+        curr_local = sfl::dtl::destroy_n_a
+        (
+            a,
+            curr_local,
+            count
+        );
+
+        remainining -= count;
+
+        SFL_ASSERT(remainining <= n && "Bug in algorithm. Please report it.");
+
+        if (remainining == 0)
+        {
+            return traits::compose(curr_seg, curr_local);
+        }
+
+        ++curr_seg;
+
+        curr_local = traits::begin(curr_seg);
+    }
+}
+
+template <typename Allocator, typename ForwardIt,
+          sfl::dtl::enable_if_t< !sfl::dtl::is_segmented_iterator<ForwardIt>::value >* = nullptr>
+void uninitialized_default_construct_a(Allocator& a, ForwardIt first, ForwardIt last)
+{
+    ForwardIt curr = first;
+    SFL_TRY
+    {
+        while (curr != last)
+        {
+            sfl::dtl::construct_at_a(a, std::addressof(*curr));
+            ++curr;
+        }
+    }
+    SFL_CATCH (...)
+    {
+        sfl::dtl::destroy_a(a, first, curr);
+        SFL_RETHROW;
+    }
+}
+
+template <typename Allocator, typename ForwardIt,
+          sfl::dtl::enable_if_t< sfl::dtl::is_segmented_iterator<ForwardIt>::value >* = nullptr>
+void uninitialized_default_construct_a(Allocator& a, ForwardIt first, ForwardIt last)
+{
+    using traits = sfl::dtl::segmented_iterator_traits<ForwardIt>;
+
+    auto first_seg = traits::segment(first);
+    auto last_seg  = traits::segment(last);
+
+    if (first_seg == last_seg)
+    {
+        sfl::dtl::uninitialized_default_construct_a
+        (
+            a,
+            traits::local(first),
+            traits::local(last)
+        );
+    }
+    else
+    {
+        sfl::dtl::uninitialized_default_construct_a
+        (
+            a,
+            traits::local(first),
+            traits::end(first_seg)
+        );
+
+        ++first_seg;
+
+        SFL_TRY
+        {
+            while (first_seg != last_seg)
+            {
+                sfl::dtl::uninitialized_default_construct_a
+                (
+                    a,
+                    traits::begin(first_seg),
+                    traits::end(first_seg)
+                );
+
+                ++first_seg;
+            }
+
+            sfl::dtl::uninitialized_default_construct_a
+            (
+                a,
+                traits::begin(last_seg),
+                traits::local(last)
+            );
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                a,
+                first,
+                traits::compose(first_seg, traits::begin(first_seg))
+            );
+
+            SFL_RETHROW;
+        }
+    }
+}
+
+template <typename Allocator, typename ForwardIt, typename Size,
+          sfl::dtl::enable_if_t< !sfl::dtl::is_segmented_iterator<ForwardIt>::value >* = nullptr>
+ForwardIt uninitialized_default_construct_n_a(Allocator& a, ForwardIt first, Size n)
+{
+    ForwardIt curr = first;
+    SFL_TRY
+    {
+        while (n > 0)
+        {
+            sfl::dtl::construct_at_a(a, std::addressof(*curr));
+            ++curr;
+            --n;
+        }
+        return curr;
+    }
+    SFL_CATCH (...)
+    {
+        sfl::dtl::destroy_a(a, first, curr);
+        SFL_RETHROW;
+    }
+}
+
+template <typename Allocator, typename ForwardIt, typename Size,
+          sfl::dtl::enable_if_t< sfl::dtl::is_segmented_iterator<ForwardIt>::value >* = nullptr>
+ForwardIt uninitialized_default_construct_n_a(Allocator& a, ForwardIt first, Size n)
+{
+    using traits = sfl::dtl::segmented_iterator_traits<ForwardIt>;
+
+    auto curr_local = traits::local(first);
+    auto curr_seg   = traits::segment(first);
+
+    auto remainining = n;
+
+    SFL_TRY
+    {
+        while (true)
+        {
+            using difference_type =
+                typename std::iterator_traits<typename traits::local_iterator>::difference_type;
+
+            const auto count = std::min<difference_type>
+            (
+                remainining,
+                std::distance(curr_local, traits::end(curr_seg))
+            );
+
+            curr_local = sfl::dtl::uninitialized_default_construct_n_a
+            (
+                a,
+                curr_local,
+                count
+            );
+
+            remainining -= count;
+
+            SFL_ASSERT(remainining <= n && "Bug in algorithm. Please report it.");
+
+            if (remainining == 0)
+            {
+                return traits::compose(curr_seg, curr_local);
+            }
+
+            ++curr_seg;
+
+            curr_local = traits::begin(curr_seg);
+        }
+    }
+    SFL_CATCH (...)
+    {
+        sfl::dtl::destroy_n_a(a, first, n - remainining);
+        SFL_RETHROW;
+    }
+}
+
+template <typename Allocator, typename ForwardIt, typename T,
+          sfl::dtl::enable_if_t< !sfl::dtl::is_segmented_iterator<ForwardIt>::value >* = nullptr>
+void uninitialized_fill_a(Allocator& a, ForwardIt first, ForwardIt last, const T& value)
+{
+    ForwardIt curr = first;
+    SFL_TRY
+    {
+        while (curr != last)
+        {
+            sfl::dtl::construct_at_a(a, std::addressof(*curr), value);
+            ++curr;
+        }
+    }
+    SFL_CATCH (...)
+    {
+        sfl::dtl::destroy_a(a, first, curr);
+        SFL_RETHROW;
+    }
+}
+
+template <typename Allocator, typename ForwardIt, typename T,
+          sfl::dtl::enable_if_t< sfl::dtl::is_segmented_iterator<ForwardIt>::value >* = nullptr>
+void uninitialized_fill_a(Allocator& a, ForwardIt first, ForwardIt last, const T& value)
+{
+    using traits = sfl::dtl::segmented_iterator_traits<ForwardIt>;
+
+    auto first_seg = traits::segment(first);
+    auto last_seg  = traits::segment(last);
+
+    if (first_seg == last_seg)
+    {
+        sfl::dtl::uninitialized_fill_a
+        (
+            a,
+            traits::local(first),
+            traits::local(last),
+            value
+        );
+    }
+    else
+    {
+        sfl::dtl::uninitialized_fill_a
+        (
+            a,
+            traits::local(first),
+            traits::end(first_seg),
+            value
+        );
+
+        ++first_seg;
+
+        SFL_TRY
+        {
+            while (first_seg != last_seg)
+            {
+                sfl::dtl::uninitialized_fill_a
+                (
+                    a,
+                    traits::begin(first_seg),
+                    traits::end(first_seg),
+                    value
+                );
+
+                ++first_seg;
+            }
+
+            sfl::dtl::uninitialized_fill_a
+            (
+                a,
+                traits::begin(last_seg),
+                traits::local(last),
+                value
+            );
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                a,
+                first,
+                traits::compose(first_seg, traits::begin(first_seg))
+            );
+
+            SFL_RETHROW;
+        }
+    }
+}
+
+template <typename Allocator, typename ForwardIt, typename Size, typename T,
+          sfl::dtl::enable_if_t< !sfl::dtl::is_segmented_iterator<ForwardIt>::value >* = nullptr>
+ForwardIt uninitialized_fill_n_a(Allocator& a, ForwardIt first, Size n, const T& value)
+{
+    ForwardIt curr = first;
+    SFL_TRY
+    {
+        while (n > 0)
+        {
+            sfl::dtl::construct_at_a(a, std::addressof(*curr), value);
+            ++curr;
+            --n;
+        }
+        return curr;
+    }
+    SFL_CATCH (...)
+    {
+        sfl::dtl::destroy_a(a, first, curr);
+        SFL_RETHROW;
+    }
+}
+
+template <typename Allocator, typename ForwardIt, typename Size, typename T,
+          sfl::dtl::enable_if_t< sfl::dtl::is_segmented_iterator<ForwardIt>::value >* = nullptr>
+ForwardIt uninitialized_fill_n_a(Allocator& a, ForwardIt first, Size n, const T& value)
+{
+    using traits = sfl::dtl::segmented_iterator_traits<ForwardIt>;
+
+    auto curr_local = traits::local(first);
+    auto curr_seg   = traits::segment(first);
+
+    auto remainining = n;
+
+    SFL_TRY
+    {
+        while (true)
+        {
+            using difference_type =
+                typename std::iterator_traits<typename traits::local_iterator>::difference_type;
+
+            const auto count = std::min<difference_type>
+            (
+                remainining,
+                std::distance(curr_local, traits::end(curr_seg))
+            );
+
+            curr_local = sfl::dtl::uninitialized_fill_n_a
+            (
+                a,
+                curr_local,
+                count,
+                value
+            );
+
+            remainining -= count;
+
+            SFL_ASSERT(remainining <= n && "Bug in algorithm. Please report it.");
+
+            if (remainining == 0)
+            {
+                return traits::compose(curr_seg, curr_local);
+            }
+
+            ++curr_seg;
+
+            curr_local = traits::begin(curr_seg);
+        }
+    }
+    SFL_CATCH (...)
+    {
+        sfl::dtl::destroy_n_a(a, first, n - remainining);
+        SFL_RETHROW;
+    }
+}
+
+template <typename Allocator, typename InputIt, typename ForwardIt,
+          sfl::dtl::enable_if_t< (!sfl::dtl::is_segmented_iterator<InputIt>::value &&
+                                  !sfl::dtl::is_segmented_iterator<ForwardIt>::value) ||
+                                 (!sfl::dtl::is_segmented_iterator<InputIt>::value &&
+                                   sfl::dtl::is_segmented_iterator<ForwardIt>::value &&
+                                  !sfl::dtl::is_random_access_iterator<InputIt>::value) >* = nullptr>
+ForwardIt uninitialized_copy_a(Allocator& a, InputIt first, InputIt last, ForwardIt d_first)
+{
+    ForwardIt d_curr = d_first;
+    SFL_TRY
+    {
+        while (first != last)
+        {
+            sfl::dtl::construct_at_a(a, std::addressof(*d_curr), *first);
+            ++d_curr;
+            ++first;
+        }
+        return d_curr;
+    }
+    SFL_CATCH (...)
+    {
+        sfl::dtl::destroy_a(a, d_first, d_curr);
+        SFL_RETHROW;
+    }
+}
+
+template <typename Allocator, typename InputIt, typename ForwardIt,
+          sfl::dtl::enable_if_t< !sfl::dtl::is_segmented_iterator<InputIt>::value &&
+                                  sfl::dtl::is_segmented_iterator<ForwardIt>::value &&
+                                  sfl::dtl::is_random_access_iterator<InputIt>::value >* = nullptr>
+ForwardIt uninitialized_copy_a(Allocator& a, InputIt first, InputIt last, ForwardIt d_first)
+{
+    using traits = sfl::dtl::segmented_iterator_traits<ForwardIt>;
+
+    if (first == last)
+    {
+        return d_first;
+    }
+    else
+    {
+        auto curr = first;
+
+        auto d_local = traits::local(d_first);
+        auto d_seg   = traits::segment(d_first);
+
+        SFL_TRY
+        {
+            while (true)
+            {
+                using difference_type =
+                    typename std::iterator_traits<InputIt>::difference_type;
+
+                const auto count = std::min<difference_type>
+                (
+                    std::distance(curr, last),
+                    std::distance(d_local, traits::end(d_seg))
+                );
+
+                const auto next = curr + count;
+
+                d_local = sfl::dtl::uninitialized_copy_a
+                (
+                    a,
+                    curr,
+                    next,
+                    d_local
+                );
+
+                curr = next;
+
+                if (curr == last)
+                {
+                    return traits::compose(d_seg, d_local);
+                }
+
+                ++d_seg;
+
+                d_local = traits::begin(d_seg);
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                a,
+                d_first,
+                traits::compose(d_seg, d_local)
+            );
+            SFL_RETHROW;
+        }
+    }
+}
+
+template <typename Allocator, typename InputIt, typename ForwardIt,
+          sfl::dtl::enable_if_t< sfl::dtl::is_segmented_iterator<InputIt>::value >* = nullptr>
+ForwardIt uninitialized_copy_a(Allocator& a, InputIt first, InputIt last, ForwardIt d_first)
+{
+    using traits = sfl::dtl::segmented_iterator_traits<InputIt>;
+
+    auto first_seg = traits::segment(first);
+    auto last_seg  = traits::segment(last);
+
+    if (first_seg == last_seg)
+    {
+        return sfl::dtl::uninitialized_copy_a
+        (
+            a,
+            traits::local(first),
+            traits::local(last),
+            d_first
+        );
+    }
+    else
+    {
+        auto d_curr = d_first;
+
+        d_curr = sfl::dtl::uninitialized_copy_a
+        (
+            a,
+            traits::local(first),
+            traits::end(first_seg),
+            d_curr
+        );
+
+        ++first_seg;
+
+        SFL_TRY
+        {
+            while (first_seg != last_seg)
+            {
+                d_curr = sfl::dtl::uninitialized_copy_a
+                (
+                    a,
+                    traits::begin(first_seg),
+                    traits::end(first_seg),
+                    d_curr
+                );
+
+                ++first_seg;
+            }
+
+            d_curr = sfl::dtl::uninitialized_copy_a
+            (
+                a,
+                traits::begin(last_seg),
+                traits::local(last),
+                d_curr
+            );
+
+            return d_curr;
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                a,
+                d_first,
+                d_curr
+            );
+            SFL_RETHROW;
+        }
+    }
+}
+
+template <typename Allocator, typename InputIt, typename ForwardIt,
+          sfl::dtl::enable_if_t< (!sfl::dtl::is_segmented_iterator<InputIt>::value &&
+                                  !sfl::dtl::is_segmented_iterator<ForwardIt>::value) ||
+                                 (!sfl::dtl::is_segmented_iterator<InputIt>::value &&
+                                   sfl::dtl::is_segmented_iterator<ForwardIt>::value &&
+                                  !sfl::dtl::is_random_access_iterator<InputIt>::value) >* = nullptr>
+ForwardIt uninitialized_move_a(Allocator& a, InputIt first, InputIt last, ForwardIt d_first)
+{
+    ForwardIt d_curr = d_first;
+    SFL_TRY
+    {
+        while (first != last)
+        {
+            sfl::dtl::construct_at_a(a, std::addressof(*d_curr), std::move(*first));
+            ++d_curr;
+            ++first;
+        }
+        return d_curr;
+    }
+    SFL_CATCH (...)
+    {
+        sfl::dtl::destroy_a(a, d_first, d_curr);
+        SFL_RETHROW;
+    }
+}
+
+template <typename Allocator, typename InputIt, typename ForwardIt,
+          sfl::dtl::enable_if_t< !sfl::dtl::is_segmented_iterator<InputIt>::value &&
+                                  sfl::dtl::is_segmented_iterator<ForwardIt>::value &&
+                                  sfl::dtl::is_random_access_iterator<InputIt>::value >* = nullptr>
+ForwardIt uninitialized_move_a(Allocator& a, InputIt first, InputIt last, ForwardIt d_first)
+{
+    using traits = sfl::dtl::segmented_iterator_traits<ForwardIt>;
+
+    if (first == last)
+    {
+        return d_first;
+    }
+    else
+    {
+        auto curr = first;
+
+        auto d_local = traits::local(d_first);
+        auto d_seg   = traits::segment(d_first);
+
+        SFL_TRY
+        {
+            while (true)
+            {
+                using difference_type =
+                    typename std::iterator_traits<InputIt>::difference_type;
+
+                const auto count = std::min<difference_type>
+                (
+                    std::distance(curr, last),
+                    std::distance(d_local, traits::end(d_seg))
+                );
+
+                const auto next = curr + count;
+
+                d_local = sfl::dtl::uninitialized_move_a
+                (
+                    a,
+                    curr,
+                    next,
+                    d_local
+                );
+
+                curr = next;
+
+                if (curr == last)
+                {
+                    return traits::compose(d_seg, d_local);
+                }
+
+                ++d_seg;
+
+                d_local = traits::begin(d_seg);
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                a,
+                d_first,
+                traits::compose(d_seg, d_local)
+            );
+            SFL_RETHROW;
+        }
+    }
+}
+
+template <typename Allocator, typename InputIt, typename ForwardIt,
+          sfl::dtl::enable_if_t< sfl::dtl::is_segmented_iterator<InputIt>::value >* = nullptr>
+ForwardIt uninitialized_move_a(Allocator& a, InputIt first, InputIt last, ForwardIt d_first)
+{
+    using traits = sfl::dtl::segmented_iterator_traits<InputIt>;
+
+    auto first_seg = traits::segment(first);
+    auto last_seg  = traits::segment(last);
+
+    if (first_seg == last_seg)
+    {
+        return sfl::dtl::uninitialized_move_a
+        (
+            a,
+            traits::local(first),
+            traits::local(last),
+            d_first
+        );
+    }
+    else
+    {
+        auto d_curr = d_first;
+
+        d_curr = sfl::dtl::uninitialized_move_a
+        (
+            a,
+            traits::local(first),
+            traits::end(first_seg),
+            d_curr
+        );
+
+        ++first_seg;
+
+        SFL_TRY
+        {
+            while (first_seg != last_seg)
+            {
+                d_curr = sfl::dtl::uninitialized_move_a
+                (
+                    a,
+                    traits::begin(first_seg),
+                    traits::end(first_seg),
+                    d_curr
+                );
+
+                ++first_seg;
+            }
+
+            d_curr = sfl::dtl::uninitialized_move_a
+            (
+                a,
+                traits::begin(last_seg),
+                traits::local(last),
+                d_curr
+            );
+
+            return d_curr;
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                a,
+                d_first,
+                d_curr
+            );
+            SFL_RETHROW;
+        }
+    }
+}
+
+template <typename Allocator, typename InputIt, typename ForwardIt,
+          sfl::dtl::enable_if_t< (!sfl::dtl::is_segmented_iterator<InputIt>::value &&
+                                  !sfl::dtl::is_segmented_iterator<ForwardIt>::value) ||
+                                 (!sfl::dtl::is_segmented_iterator<InputIt>::value &&
+                                   sfl::dtl::is_segmented_iterator<ForwardIt>::value &&
+                                  !sfl::dtl::is_random_access_iterator<InputIt>::value) >* = nullptr>
+ForwardIt uninitialized_move_if_noexcept_a(Allocator& a, InputIt first, InputIt last, ForwardIt d_first)
+{
+    ForwardIt d_curr = d_first;
+    SFL_TRY
+    {
+        while (first != last)
+        {
+            sfl::dtl::construct_at_a(a, std::addressof(*d_curr), std::move_if_noexcept(*first));
+            ++d_curr;
+            ++first;
+        }
+        return d_curr;
+    }
+    SFL_CATCH (...)
+    {
+        sfl::dtl::destroy_a(a, d_first, d_curr);
+        SFL_RETHROW;
+    }
+}
+
+template <typename Allocator, typename InputIt, typename ForwardIt,
+          sfl::dtl::enable_if_t< !sfl::dtl::is_segmented_iterator<InputIt>::value &&
+                                  sfl::dtl::is_segmented_iterator<ForwardIt>::value &&
+                                  sfl::dtl::is_random_access_iterator<InputIt>::value >* = nullptr>
+ForwardIt uninitialized_move_if_noexcept_a(Allocator& a, InputIt first, InputIt last, ForwardIt d_first)
+{
+    using traits = sfl::dtl::segmented_iterator_traits<ForwardIt>;
+
+    if (first == last)
+    {
+        return d_first;
+    }
+    else
+    {
+        auto curr = first;
+
+        auto d_local = traits::local(d_first);
+        auto d_seg   = traits::segment(d_first);
+
+        SFL_TRY
+        {
+            while (true)
+            {
+                using difference_type =
+                    typename std::iterator_traits<InputIt>::difference_type;
+
+                const auto count = std::min<difference_type>
+                (
+                    std::distance(curr, last),
+                    std::distance(d_local, traits::end(d_seg))
+                );
+
+                const auto next = curr + count;
+
+                d_local = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    a,
+                    curr,
+                    next,
+                    d_local
+                );
+
+                curr = next;
+
+                if (curr == last)
+                {
+                    return traits::compose(d_seg, d_local);
+                }
+
+                ++d_seg;
+
+                d_local = traits::begin(d_seg);
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                a,
+                d_first,
+                traits::compose(d_seg, d_local)
+            );
+            SFL_RETHROW;
+        }
+    }
+}
+
+template <typename Allocator, typename InputIt, typename ForwardIt,
+          sfl::dtl::enable_if_t< sfl::dtl::is_segmented_iterator<InputIt>::value >* = nullptr>
+ForwardIt uninitialized_move_if_noexcept_a(Allocator& a, InputIt first, InputIt last, ForwardIt d_first)
+{
+    using traits = sfl::dtl::segmented_iterator_traits<InputIt>;
+
+    auto first_seg = traits::segment(first);
+    auto last_seg  = traits::segment(last);
+
+    if (first_seg == last_seg)
+    {
+        return sfl::dtl::uninitialized_move_if_noexcept_a
+        (
+            a,
+            traits::local(first),
+            traits::local(last),
+            d_first
+        );
+    }
+    else
+    {
+        auto d_curr = d_first;
+
+        d_curr = sfl::dtl::uninitialized_move_if_noexcept_a
+        (
+            a,
+            traits::local(first),
+            traits::end(first_seg),
+            d_curr
+        );
+
+        ++first_seg;
+
+        SFL_TRY
+        {
+            while (first_seg != last_seg)
+            {
+                d_curr = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    a,
+                    traits::begin(first_seg),
+                    traits::end(first_seg),
+                    d_curr
+                );
+
+                ++first_seg;
+            }
+
+            d_curr = sfl::dtl::uninitialized_move_if_noexcept_a
+            (
+                a,
+                traits::begin(last_seg),
+                traits::local(last),
+                d_curr
+            );
+
+            return d_curr;
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                a,
+                d_first,
+                d_curr
+            );
+            SFL_RETHROW;
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename T>
+void default_construct_at(T* p)
+{
+    ::new (static_cast<void*>(p)) T;
+}
+
+template <typename T>
+void value_construct_at(T* p)
+{
+    ::new (static_cast<void*>(p)) T();
+}
+
+template <typename T, typename... Args>
+void construct_at(T* p, Args&&... args)
+{
+    ::new (static_cast<void*>(p)) T(std::forward<Args>(args)...);
+}
+
+template <typename T>
+void destroy_at(T* p) noexcept
+{
+    p->~T();
+}
+
+template <typename ForwardIt>
+void destroy(ForwardIt first, ForwardIt last) noexcept
+{
+    while (first != last)
+    {
+        sfl::dtl::destroy_at(std::addressof(*first));
+        ++first;
+    }
+}
+
+template <typename ForwardIt, typename Size>
+ForwardIt uninitialized_default_construct_n(ForwardIt first, Size n)
+{
+    ForwardIt curr = first;
+    SFL_TRY
+    {
+        while (n > 0)
+        {
+            sfl::dtl::default_construct_at(std::addressof(*curr));
+            ++curr;
+            --n;
+        }
+        return curr;
+    }
+    SFL_CATCH (...)
+    {
+        sfl::dtl::destroy(first, curr);
+        SFL_RETHROW;
+    }
+}
+
+template <typename ForwardIt, typename Size>
+ForwardIt uninitialized_value_construct_n(ForwardIt first, Size n)
+{
+    ForwardIt curr = first;
+    SFL_TRY
+    {
+        while (n > 0)
+        {
+            sfl::dtl::value_construct_at(std::addressof(*curr));
+            ++curr;
+            --n;
+        }
+        return curr;
+    }
+    SFL_CATCH (...)
+    {
+        sfl::dtl::destroy(first, curr);
+        SFL_RETHROW;
+    }
+}
+
+template <typename ForwardIt, typename T>
+void uninitialized_fill(ForwardIt first, ForwardIt last, const T& value)
+{
+    ForwardIt curr = first;
+    SFL_TRY
+    {
+        while (curr != last)
+        {
+            sfl::dtl::construct_at(std::addressof(*curr), value);
+            ++curr;
+        }
+    }
+    SFL_CATCH (...)
+    {
+        sfl::dtl::destroy(first, curr);
+        SFL_RETHROW;
+    }
+}
+
+template <typename ForwardIt, typename Size, typename T>
+ForwardIt uninitialized_fill_n(ForwardIt first, Size n, const T& value)
+{
+    ForwardIt curr = first;
+    SFL_TRY
+    {
+        while (n > 0)
+        {
+            sfl::dtl::construct_at(std::addressof(*curr), value);
+            ++curr;
+            --n;
+        }
+        return curr;
+    }
+    SFL_CATCH (...)
+    {
+        sfl::dtl::destroy(first, curr);
+        SFL_RETHROW;
+    }
+}
+
+template <typename InputIt, typename ForwardIt>
+ForwardIt uninitialized_copy(InputIt first, InputIt last, ForwardIt d_first)
+{
+    ForwardIt d_curr = d_first;
+    SFL_TRY
+    {
+        while (first != last)
+        {
+            sfl::dtl::construct_at(std::addressof(*d_curr), *first);
+            ++d_curr;
+            ++first;
+        }
+        return d_curr;
+    }
+    SFL_CATCH (...)
+    {
+        sfl::dtl::destroy(d_first, d_curr);
+        SFL_RETHROW;
+    }
+}
+
+template <typename InputIt, typename ForwardIt>
+ForwardIt uninitialized_move(InputIt first, InputIt last, ForwardIt d_first)
+{
+    ForwardIt d_curr = d_first;
+    SFL_TRY
+    {
+        while (first != last)
+        {
+            sfl::dtl::construct_at(std::addressof(*d_curr), std::move(*first));
+            ++d_curr;
+            ++first;
+        }
+        return d_curr;
+    }
+    SFL_CATCH (...)
+    {
+        sfl::dtl::destroy(d_first, d_curr);
+        SFL_RETHROW;
+    }
+}
+
+} // namespace dtl
+
+} // namespace sfl
+
+#endif // SFL_DETAIL_UNINITIALIZED_MEMORY_ALGORITHMS_HPP_INCLUDED

--- a/src/thirdparty/sfl/devector.hpp
+++ b/src/thirdparty/sfl/devector.hpp
@@ -1,0 +1,4367 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_DEVECTOR_HPP_INCLUDED
+#define SFL_DEVECTOR_HPP_INCLUDED
+
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/exceptions.hpp>
+#include <sfl/detail/index_sequence.hpp>
+#include <sfl/detail/initialized_memory_algorithms.hpp>
+#include <sfl/detail/normal_iterator.hpp>
+#include <sfl/detail/scope_guard.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/to_address.hpp>
+#include <sfl/detail/type_traits.hpp>
+#include <sfl/detail/uninitialized_memory_algorithms.hpp>
+
+#include <algorithm>        // copy, move, swap, swap_ranges
+#include <cstddef>          // size_t
+#include <initializer_list> // initializer_list
+#include <iterator>         // distance, next, reverse_iterator
+#include <limits>           // numeric_limits
+#include <memory>           // allocator, allocator_traits, pointer_traits
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <tuple>            // tuple
+#include <utility>          // forward, move, pair
+
+#ifdef SFL_TEST_DEVECTOR
+template <int>
+void test_devector();
+#endif
+
+namespace sfl
+{
+
+template <typename T, typename Allocator = std::allocator<T>>
+class devector
+{
+    #ifdef SFL_TEST_DEVECTOR
+    template <int>
+    friend void ::test_devector();
+    #endif
+
+public:
+
+    using allocator_type         = Allocator;
+    using allocator_traits       = std::allocator_traits<Allocator>;
+    using value_type             = T;
+    using size_type              = typename allocator_traits::size_type;
+    using difference_type        = typename allocator_traits::difference_type;
+    using reference              = T&;
+    using const_reference        = const T&;
+    using pointer                = typename allocator_traits::pointer;
+    using const_pointer          = typename allocator_traits::const_pointer;
+    using iterator               = sfl::dtl::normal_iterator<pointer, devector>;
+    using const_iterator         = sfl::dtl::normal_iterator<const_pointer, devector>;
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    static_assert
+    (
+        std::is_same<typename Allocator::value_type, value_type>::value,
+        "Allocator::value_type must be same as sfl::devector::value_type."
+    );
+
+private:
+
+    class data_base
+    {
+    public:
+
+        pointer bos_;   // Begin of storage
+        pointer first_; // First element in vector
+        pointer last_;  // One-past-last element in vector
+        pointer eos_;   // End of storage
+
+        data_base() noexcept
+            : bos_(nullptr)
+            , first_(nullptr)
+            , last_(nullptr)
+            , eos_(nullptr)
+        {}
+    };
+
+    class data : public data_base, public allocator_type
+    {
+    public:
+
+        data() noexcept(std::is_nothrow_default_constructible<allocator_type>::value)
+            : allocator_type()
+        {}
+
+        data(const allocator_type& alloc) noexcept(std::is_nothrow_copy_constructible<allocator_type>::value)
+            : allocator_type(alloc)
+        {}
+
+        data(allocator_type&& other) noexcept(std::is_nothrow_move_constructible<allocator_type>::value)
+            : allocator_type(std::move(other))
+        {}
+
+        allocator_type& ref_to_alloc() noexcept
+        {
+            return *this;
+        }
+
+        const allocator_type& ref_to_alloc() const noexcept
+        {
+            return *this;
+        }
+    };
+
+    data data_;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    devector() noexcept(std::is_nothrow_default_constructible<Allocator>::value)
+        : data_()
+    {}
+
+    explicit devector(const Allocator& alloc) noexcept(std::is_nothrow_copy_constructible<Allocator>::value)
+        : data_(alloc)
+    {}
+
+    devector(size_type n)
+        : data_()
+    {
+        initialize_default_n(n);
+    }
+
+    explicit devector(size_type n, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_default_n(n);
+    }
+
+    devector(size_type n, const T& value)
+        : data_()
+    {
+        initialize_fill_n(n, value);
+    }
+
+    devector(size_type n, const T& value, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_fill_n(n, value);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    devector(InputIt first, InputIt last)
+        : data_()
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    devector(InputIt first, InputIt last, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(first, last);
+    }
+
+    devector(std::initializer_list<T> ilist)
+        : devector(ilist.begin(), ilist.end())
+    {}
+
+    devector(std::initializer_list<T> ilist, const Allocator& alloc)
+        : devector(ilist.begin(), ilist.end(), alloc)
+    {}
+
+    devector(const devector& other)
+        : data_
+        (
+            allocator_traits::select_on_container_copy_construction
+            (
+                other.data_.ref_to_alloc()
+            )
+        )
+    {
+        initialize_copy(other);
+    }
+
+    devector(const devector& other, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_copy(other);
+    }
+
+    devector(devector&& other)
+        : data_(std::move(other.data_.ref_to_alloc()))
+    {
+        initialize_move(other);
+    }
+
+    devector(devector&& other, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_move(other);
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    devector(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    devector(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    devector(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    devector(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~devector()
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        sfl::dtl::deallocate
+        (
+            data_.ref_to_alloc(),
+            data_.bos_,
+            std::distance(data_.bos_, data_.eos_)
+        );
+    }
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    void assign(size_type n, const T& value)
+    {
+        assign_fill_n(n, value);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void assign(InputIt first, InputIt last)
+    {
+        assign_range(first, last);
+    }
+
+    void assign(std::initializer_list<T> ilist)
+    {
+        assign_range(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void assign_range(Range&& range)
+    {
+        if constexpr (std::ranges::forward_range<Range>)
+        {
+            assign_range(std::ranges::begin(range), std::ranges::end(range), std::forward_iterator_tag());
+        }
+        else
+        {
+            assign_range(std::ranges::begin(range), std::ranges::end(range), std::input_iterator_tag());
+        }
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void assign_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        assign_range(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    devector& operator=(const devector& other)
+    {
+        assign_copy(other);
+        return *this;
+    }
+
+    devector& operator=(devector&& other)
+    {
+        assign_move(other);
+        return *this;
+    }
+
+    devector& operator=(std::initializer_list<T> ilist)
+    {
+        assign_range(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- ALLOCATOR ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    allocator_type get_allocator() const noexcept
+    {
+        return data_.ref_to_alloc();
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    iterator nth(size_type pos) noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_iterator nth(size_type pos) const noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return const_iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    size_type index_of(const_iterator pos) const noexcept
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return std::distance(cbegin(), pos);
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return data_.first_ == data_.last_;
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return std::distance(data_.first_, data_.last_);
+    }
+
+    SFL_NODISCARD
+    size_type max_size() const noexcept
+    {
+        return std::min<size_type>
+        (
+            allocator_traits::max_size(data_.ref_to_alloc()),
+            std::numeric_limits<difference_type>::max() / sizeof(value_type)
+        );
+    }
+
+    SFL_NODISCARD
+    size_type capacity() const noexcept
+    {
+        return std::distance(data_.bos_, data_.eos_);
+    }
+
+    SFL_NODISCARD
+    size_type available_front() const noexcept
+    {
+        return std::distance(data_.bos_, data_.first_);
+    }
+
+    SFL_NODISCARD
+    size_type available_back() const noexcept
+    {
+        return std::distance(data_.last_, data_.eos_);
+    }
+
+    void reserve_front(size_type new_capacity)
+    {
+        const size_type max_size = this->max_size();
+        const size_type available_back = this->available_back();
+
+        if (new_capacity > max_size - available_back)
+        {
+            sfl::dtl::throw_length_error("sfl::devector::reserve_front");
+        }
+
+        const size_type size = this->size();
+        const size_type available_front = this->available_front();
+
+        if (new_capacity > size + available_front)
+        {
+            const size_type n = available_back + new_capacity;
+
+            pointer new_bos   = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+            pointer new_eos   = new_bos + n;
+            pointer new_first = new_eos - std::distance(data_.first_, data_.eos_);
+            pointer new_last  = new_first;
+
+            SFL_TRY
+            {
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_,
+                    new_first
+                );
+            }
+            SFL_CATCH (...)
+            {
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    new_bos,
+                    n
+                );
+
+                SFL_RETHROW;
+            }
+
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.bos_,
+                std::distance(data_.bos_, data_.eos_)
+            );
+
+            data_.bos_   = new_bos;
+            data_.first_ = new_first;
+            data_.last_  = new_last;
+            data_.eos_   = new_eos;
+        }
+    }
+
+    void reserve_back(size_type new_capacity)
+    {
+        const size_type max_size = this->max_size();
+        const size_type available_front = this->available_front();
+
+        if (new_capacity > max_size - available_front)
+        {
+            sfl::dtl::throw_length_error("sfl::devector::reserve_back");
+        }
+
+        const size_type size = this->size();
+        const size_type available_back = this->available_back();
+
+        if (new_capacity > size + available_back)
+        {
+            const size_type n = available_front + new_capacity;
+
+            pointer new_bos   = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+            pointer new_eos   = new_bos + n;
+            pointer new_first = new_bos + std::distance(data_.bos_, data_.first_);
+            pointer new_last  = new_first;
+
+            SFL_TRY
+            {
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_,
+                    new_first
+                );
+            }
+            SFL_CATCH (...)
+            {
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    new_bos,
+                    n
+                );
+
+                SFL_RETHROW;
+            }
+
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.bos_,
+                std::distance(data_.bos_, data_.eos_)
+            );
+
+            data_.bos_   = new_bos;
+            data_.first_ = new_first;
+            data_.last_  = new_last;
+            data_.eos_   = new_eos;
+        }
+    }
+
+    void shrink_to_fit()
+    {
+        const size_type new_cap = size();
+
+        if (new_cap < capacity())
+        {
+            pointer new_bos   = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+            pointer new_first = new_bos;
+            pointer new_last  = new_first;
+            pointer new_eos   = new_first + new_cap;
+
+            SFL_TRY
+            {
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_,
+                    new_first
+                );
+            }
+            SFL_CATCH (...)
+            {
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    new_bos,
+                    new_cap
+                );
+
+                SFL_RETHROW;
+            }
+
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.bos_,
+                std::distance(data_.bos_, data_.eos_)
+            );
+
+            data_.bos_   = new_bos;
+            data_.first_ = new_first;
+            data_.last_  = new_last;
+            data_.eos_   = new_eos;
+        }
+    }
+
+    //
+    // ---- ELEMENT ACCESS ----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    reference at(size_type pos)
+    {
+        if (pos >= size())
+        {
+            sfl::dtl::throw_out_of_range("sfl::devector::at");
+        }
+
+        return *(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_reference at(size_type pos) const
+    {
+        if (pos >= size())
+        {
+            sfl::dtl::throw_out_of_range("sfl::devector::at");
+        }
+
+        return *(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    reference operator[](size_type pos) noexcept
+    {
+        SFL_ASSERT(pos < size());
+        return *(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_reference operator[](size_type pos) const noexcept
+    {
+        SFL_ASSERT(pos < size());
+        return *(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    reference front() noexcept
+    {
+        SFL_ASSERT(!empty());
+        return *data_.first_;
+    }
+
+    SFL_NODISCARD
+    const_reference front() const noexcept
+    {
+        SFL_ASSERT(!empty());
+        return *data_.first_;
+    }
+
+    SFL_NODISCARD
+    reference back() noexcept
+    {
+        SFL_ASSERT(!empty());
+        return *(data_.last_ - 1);
+    }
+
+    SFL_NODISCARD
+    const_reference back() const noexcept
+    {
+        SFL_ASSERT(!empty());
+        return *(data_.last_ - 1);
+    }
+
+    SFL_NODISCARD
+    T* data() noexcept
+    {
+        return sfl::dtl::to_address(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const T* data() const noexcept
+    {
+        return sfl::dtl::to_address(data_.first_);
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear() noexcept
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        data_.last_ = data_.first_;
+    }
+
+    template <typename... Args>
+    iterator emplace(const_iterator pos, Args&&... args)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+
+        if (pos == cbegin())
+        {
+            return emplace_front_aux(std::forward<Args>(args)...);
+        }
+        else if (pos == cend())
+        {
+            return emplace_back_aux(std::forward<Args>(args)...);
+        }
+        else
+        {
+            value_type tmp(std::forward<Args>(args)...);
+
+            emplace_proxy<value_type&&> proxy(std::move(tmp));
+
+            return insert_aux(pos, 1, proxy);
+        }
+    }
+
+    iterator insert(const_iterator pos, const T& value)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return emplace(pos, value);
+    }
+
+    iterator insert(const_iterator pos, T&& value)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return emplace(pos, std::move(value));
+    }
+
+    iterator insert(const_iterator pos, size_type n, const T& value)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return insert_fill_n(pos, n, value);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    iterator insert(const_iterator pos, InputIt first, InputIt last)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return insert_range(pos, first, last);
+    }
+
+    iterator insert(const_iterator pos, std::initializer_list<T> ilist)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return insert_range(pos, ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    iterator insert_range(const_iterator pos, Range&& range)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        if constexpr (std::ranges::forward_range<Range>)
+        {
+            return insert_range(pos, std::ranges::begin(range), std::ranges::end(range), std::forward_iterator_tag());
+        }
+        else
+        {
+            return insert_range(pos, std::ranges::begin(range), std::ranges::end(range), std::input_iterator_tag());
+        }
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    iterator insert_range(const_iterator pos, Range&& range)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        using std::begin;
+        using std::end;
+        return insert_range(pos, begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    template <typename... Args>
+    reference emplace_front(Args&&... args)
+    {
+        return *emplace_front_aux(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    reference emplace_back(Args&&... args)
+    {
+        return *emplace_back_aux(std::forward<Args>(args)...);
+    }
+
+    void push_front(const T& value)
+    {
+        emplace_front(value);
+    }
+
+    void push_front(T&& value)
+    {
+        emplace_front(std::move(value));
+    }
+
+    void push_back(const T& value)
+    {
+        emplace_back(value);
+    }
+
+    void push_back(T&& value)
+    {
+        emplace_back(std::move(value));
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void prepend_range(Range&& range)
+    {
+        insert_range(begin(), std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void append_range(Range&& range)
+    {
+        insert_range(end(), std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void prepend_range(Range&& range)
+    {
+        insert_range(begin(), std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    void append_range(Range&& range)
+    {
+        insert_range(end(), std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    void pop_front()
+    {
+        SFL_ASSERT(!empty());
+
+        sfl::dtl::destroy_at_a(data_.ref_to_alloc(), std::addressof(*data_.first_));
+
+        ++data_.first_;
+    }
+
+    void pop_back()
+    {
+        SFL_ASSERT(!empty());
+
+        --data_.last_;
+
+        sfl::dtl::destroy_at_a(data_.ref_to_alloc(), std::addressof(*data_.last_));
+    }
+
+    iterator erase(const_iterator pos)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos < cend());
+
+        const size_type dist_to_begin = std::distance(cbegin(), pos);
+        const size_type dist_to_end   = std::distance(pos, cend());
+
+        const pointer p1 = data_.first_ + std::distance(cbegin(), pos);
+        const pointer p2 = p1 + 1;
+
+        if (dist_to_begin < dist_to_end)
+        {
+            const pointer old_first = data_.first_;
+
+            data_.first_ = sfl::dtl::move_backward(data_.first_, p1, p2);
+
+            sfl::dtl::destroy_at_a(data_.ref_to_alloc(), old_first);
+
+            return iterator(p2);
+        }
+        else
+        {
+            data_.last_ = sfl::dtl::move(p2, data_.last_, p1);
+
+            sfl::dtl::destroy_at_a(data_.ref_to_alloc(), data_.last_);
+
+            return iterator(p1);
+        }
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        SFL_ASSERT(cbegin() <= first && first <= last && last <= cend());
+
+        if (first == last)
+        {
+            return begin() + std::distance(cbegin(), first);
+        }
+
+        const size_type dist_to_begin = std::distance(cbegin(), first);
+        const size_type dist_to_end   = std::distance(last, cend());
+
+        if (dist_to_begin < dist_to_end)
+        {
+            const pointer p1 = data_.first_ + std::distance(cbegin(), first);
+            const pointer p2 = data_.first_ + std::distance(cbegin(), last);
+
+            const pointer new_first = sfl::dtl::move_backward(data_.first_, p1, p2);
+
+            sfl::dtl::destroy_a(data_.ref_to_alloc(), data_.first_, new_first);
+
+            data_.first_ = new_first;
+
+            return iterator(p2);
+        }
+        else
+        {
+            const pointer p1 = data_.first_ + std::distance(cbegin(), first);
+            const pointer p2 = data_.first_ + std::distance(cbegin(), last);
+
+            const pointer new_last = sfl::dtl::move(p2, data_.last_, p1);
+
+            sfl::dtl::destroy_a(data_.ref_to_alloc(), new_last, data_.last_);
+
+            data_.last_ = new_last;
+
+            return iterator(p1);
+        }
+    }
+
+    void resize(size_type n)
+    {
+        const size_type size = this->size();
+
+        if (n <= size)
+        {
+            const pointer new_last = data_.first_ + n;
+
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                new_last,
+                data_.last_
+            );
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const size_type available_back = this->available_back();
+
+            if (n <= size + available_back)
+            {
+                data_.last_ = sfl::dtl::uninitialized_default_construct_n_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.last_,
+                    n - size
+                );
+            }
+            else
+            {
+                const size_type available_front = this->available_front();
+
+                if (n <= available_front + size + available_back)
+                {
+                    sfl::dtl::uninitialized_default_construct_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.last_,
+                        data_.eos_
+                    );
+
+                    data_.last_ = data_.eos_;
+
+                    const pointer new_first = data_.first_ - (n - (size + available_back));
+
+                    sfl::dtl::uninitialized_default_construct_a
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        data_.first_
+                    );
+
+                    data_.first_ = new_first;
+                }
+                else
+                {
+                    grow_storage_back(n - (available_front + size + available_back));
+
+                    data_.last_ = sfl::dtl::uninitialized_default_construct_n_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.last_,
+                        n - (size + available_front)
+                    );
+
+                    sfl::dtl::uninitialized_default_construct_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.bos_,
+                        data_.first_
+                    );
+
+                    data_.first_ = data_.bos_;
+                }
+            }
+        }
+    }
+
+    void resize(size_type n, const T& value)
+    {
+        const size_type size = this->size();
+
+        if (n <= size)
+        {
+            const pointer new_last = data_.first_ + n;
+
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                new_last,
+                data_.last_
+            );
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const size_type available_back = this->available_back();
+
+            if (n <= size + available_back)
+            {
+                data_.last_ = sfl::dtl::uninitialized_fill_n_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.last_,
+                    n - size,
+                    value
+                );
+            }
+            else
+            {
+                const size_type available_front = this->available_front();
+
+                if (n <= available_front + size + available_back)
+                {
+                    sfl::dtl::uninitialized_fill_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.last_,
+                        data_.eos_,
+                        value
+                    );
+
+                    data_.last_ = data_.eos_;
+
+                    const pointer new_first = data_.first_ - (n - (size + available_back));
+
+                    sfl::dtl::uninitialized_fill_a
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        data_.first_,
+                        value
+                    );
+
+                    data_.first_ = new_first;
+                }
+                else
+                {
+                    grow_storage_back(n - (available_front + size + available_back));
+
+                    data_.last_ = sfl::dtl::uninitialized_fill_n_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.last_,
+                        n - (size + available_front),
+                        value
+                    );
+
+                    sfl::dtl::uninitialized_fill_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.bos_,
+                        data_.first_,
+                        value
+                    );
+
+                    data_.first_ = data_.bos_;
+                }
+            }
+        }
+    }
+
+    void resize_front(size_type n)
+    {
+        const size_type size = this->size();
+
+        if (n <= size)
+        {
+            const pointer new_first = data_.first_ + (size - n);
+
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                new_first
+            );
+
+            data_.first_ = new_first;
+        }
+        else
+        {
+            const size_type available_front = this->available_front();
+
+            if (n > size + available_front)
+            {
+                grow_storage_front(n - (size + available_front));
+            }
+
+            const pointer new_first = data_.first_ - (n - size);
+
+            sfl::dtl::uninitialized_default_construct_a
+            (
+                data_.ref_to_alloc(),
+                new_first,
+                data_.first_
+            );
+
+            data_.first_ = new_first;
+        }
+    }
+
+    void resize_front(size_type n, const T& value)
+    {
+        const size_type size = this->size();
+
+        if (n <= size)
+        {
+            const pointer new_first = data_.first_ + (size - n);
+
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                new_first
+            );
+
+            data_.first_ = new_first;
+        }
+        else
+        {
+            const size_type available_front = this->available_front();
+
+            if (n > size + available_front)
+            {
+                grow_storage_front(n - (size + available_front));
+            }
+
+            const pointer new_first = data_.first_ - (n - size);
+
+            sfl::dtl::uninitialized_fill_a
+            (
+                data_.ref_to_alloc(),
+                new_first,
+                data_.first_,
+                value
+            );
+
+            data_.first_ = new_first;
+        }
+    }
+
+    void resize_back(size_type n)
+    {
+        const size_type size = this->size();
+
+        if (n <= size)
+        {
+            const pointer new_last = data_.first_ + n;
+
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                new_last,
+                data_.last_
+            );
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const size_type available_back = this->available_back();
+
+            if (n > size + available_back)
+            {
+                grow_storage_back(n - (size + available_back));
+            }
+
+            data_.last_ = sfl::dtl::uninitialized_default_construct_n_a
+            (
+                data_.ref_to_alloc(),
+                data_.last_,
+                n - size
+            );
+        }
+    }
+
+    void resize_back(size_type n, const T& value)
+    {
+        const size_type size = this->size();
+
+        if (n <= size)
+        {
+            const pointer new_last = data_.first_ + n;
+
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                new_last,
+                data_.last_
+            );
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const size_type available_back = this->available_back();
+
+            if (n > size + available_back)
+            {
+                grow_storage_back(n - (size + available_back));
+            }
+
+            data_.last_ = sfl::dtl::uninitialized_fill_n_a
+            (
+                data_.ref_to_alloc(),
+                data_.last_,
+                n - size,
+                value
+            );
+        }
+    }
+
+    void swap(devector& other)
+    {
+        if (this == &other)
+        {
+            return;
+        }
+
+        using std::swap;
+
+        SFL_ASSERT
+        (
+            allocator_traits::propagate_on_container_swap::value ||
+            this->data_.ref_to_alloc() == other.data_.ref_to_alloc()
+        );
+
+        // If this and other allocator compares equal then one allocator
+        // can deallocate memory allocated by another allocator.
+        // One allocator can safely destroy_a elements constructed by other
+        // allocator regardless the two allocators compare equal or not.
+
+        if (allocator_traits::propagate_on_container_swap::value)
+        {
+            swap(this->data_.ref_to_alloc(), other.data_.ref_to_alloc());
+        }
+
+        swap(this->data_.bos_,   other.data_.bos_);
+        swap(this->data_.first_, other.data_.first_);
+        swap(this->data_.last_,  other.data_.last_);
+        swap(this->data_.eos_,   other.data_.eos_);
+    }
+
+private:
+
+    template <typename... Args>
+    class emplace_proxy
+    {
+    private:
+
+        std::tuple<Args&...> args_;
+
+    private:
+
+        template <std::size_t... Ints>
+        pointer aux_uninitialized_insert_n(allocator_type& alloc, pointer dest, std::size_t n, const sfl::dtl::index_sequence<Ints...>&)
+        {
+            if (n == 0)
+            {
+                return dest;
+            }
+            else
+            {
+                SFL_ASSERT(n == 1);
+                sfl::dtl::construct_at_a(alloc, dest, std::forward<Args>(std::get<Ints>(args_))...);
+                return dest + 1;
+            }
+        }
+
+        template <std::size_t... Ints>
+        pointer aux_insert_n(pointer dest, std::size_t n, const sfl::dtl::index_sequence<Ints...>&)
+        {
+            if (n == 0)
+            {
+                return dest;
+            }
+            else
+            {
+                SFL_ASSERT(n == 1);
+                *dest = value_type(std::forward<Args>(std::get<Ints>(args_))...);
+                return dest + 1;
+            }
+        }
+
+    public:
+
+        explicit emplace_proxy(Args&&... args)
+            : args_(args...)
+        {}
+
+        pointer uninitialized_insert_n(allocator_type& alloc, pointer dest, std::size_t n)
+        {
+            return aux_uninitialized_insert_n(alloc, dest, n, sfl::dtl::index_sequence_for<Args...>());
+        }
+
+        pointer insert_n(pointer dest, std::size_t n)
+        {
+            return aux_insert_n(dest, n, sfl::dtl::index_sequence_for<Args...>());
+        }
+    };
+
+    template <typename ForwardIt>
+    class insert_range_proxy
+    {
+    private:
+
+        ForwardIt first_;
+
+    public:
+
+        explicit insert_range_proxy(ForwardIt first)
+            : first_(first)
+        {}
+
+        pointer uninitialized_insert_n(allocator_type& alloc, pointer dest, std::size_t n)
+        {
+            const ForwardIt last = std::next(first_, n);
+            const pointer result = sfl::dtl::uninitialized_copy_a(alloc, first_, last, dest);
+            first_ = last;
+            return result;
+        }
+
+        pointer insert_n(pointer dest, std::size_t n)
+        {
+            const ForwardIt last = std::next(first_, n);
+            const pointer result = sfl::dtl::copy(first_, last, dest);
+            first_ = last;
+            return result;
+        }
+    };
+
+    class insert_fill_n_proxy
+    {
+    private:
+
+        const value_type& value_;
+
+    public:
+
+        explicit insert_fill_n_proxy(const value_type& value)
+            : value_(value)
+        {}
+
+        pointer uninitialized_insert_n(allocator_type& alloc, pointer dest, std::size_t n)
+        {
+            const pointer last = dest + n;
+            sfl::dtl::uninitialized_fill_a(alloc, dest, dest + n, value_);
+            return last;
+        }
+
+        pointer insert_n(pointer dest, std::size_t n)
+        {
+            const pointer last = dest + n;
+            sfl::dtl::fill(dest, dest + n, value_);
+            return last;
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    void check_size(size_type n, const char* msg)
+    {
+        if (n > max_size())
+        {
+            sfl::dtl::throw_length_error(msg);
+        }
+    }
+
+    size_type calculate_additional_capacity_for_grow_storage_front(size_type num_additional_elements)
+    {
+        const size_type capacity_front  = std::distance(data_.bos_, data_.last_);
+        const size_type available_front = std::distance(data_.bos_, data_.first_);
+
+        if (num_additional_elements >= available_front)
+        {
+            return std::max
+            (
+                num_additional_elements - available_front,
+                capacity_front / 2
+            );
+        }
+        else
+        {
+            return capacity_front / 2;
+        }
+    }
+
+    size_type calculate_additional_capacity_for_grow_storage_back(size_type num_additional_elements)
+    {
+        const size_type capacity_back  = std::distance(data_.first_, data_.eos_);
+        const size_type available_back = std::distance(data_.last_,  data_.eos_);
+
+        if (num_additional_elements >= available_back)
+        {
+            return std::max
+            (
+                num_additional_elements - available_back,
+                capacity_back / 2
+            );
+        }
+        else
+        {
+            return capacity_back / 2;
+        }
+    }
+
+    void reset(size_type new_cap = 0)
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        sfl::dtl::deallocate
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            std::distance(data_.bos_, data_.eos_)
+        );
+
+        // First set pointers to null ...
+        data_.bos_   = nullptr;
+        data_.first_ = nullptr;
+        data_.last_  = nullptr;
+        data_.eos_   = nullptr;
+
+        // ... and then allocate new storage. If allocation fails,
+        // first_, last_ and eos_ won't be dangling pointers.
+        if (new_cap > 0)
+        {
+            data_.bos_   = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+            data_.first_ = data_.bos_;
+            data_.last_  = data_.bos_;
+            data_.eos_   = data_.bos_ + new_cap;
+        }
+    }
+
+    void grow_storage_front(size_type additional_capacity)
+    {
+        const size_type capacity = this->capacity();
+        const size_type max_size = this->max_size();
+
+        if (additional_capacity > max_size - capacity)
+        {
+            sfl::dtl::throw_length_error("sfl::devector::grow_storage_front");
+        }
+
+        const size_type n = capacity + additional_capacity;
+
+        pointer new_bos   = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+        pointer new_eos   = new_bos + n;
+        pointer new_first = new_eos - std::distance(data_.first_, data_.eos_);
+        pointer new_last  = new_first;
+
+        SFL_TRY
+        {
+            new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_,
+                new_first
+            );
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                new_bos,
+                n
+            );
+
+            SFL_RETHROW;
+        }
+
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        sfl::dtl::deallocate
+        (
+            data_.ref_to_alloc(),
+            data_.bos_,
+            std::distance(data_.bos_, data_.eos_)
+        );
+
+        data_.bos_   = new_bos;
+        data_.first_ = new_first;
+        data_.last_  = new_last;
+        data_.eos_   = new_eos;
+    }
+
+    void grow_storage_back(size_type additional_capacity)
+    {
+        const size_type capacity = this->capacity();
+        const size_type max_size = this->max_size();
+
+        if (additional_capacity > max_size - capacity)
+        {
+            sfl::dtl::throw_length_error("sfl::devector::grow_storage_back");
+        }
+
+        const size_type n = capacity + additional_capacity;
+
+        pointer new_bos   = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+        pointer new_eos   = new_bos + n;
+        pointer new_first = new_bos + std::distance(data_.bos_, data_.first_);
+        pointer new_last  = new_first;
+
+        SFL_TRY
+        {
+            new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_,
+                new_first
+            );
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                new_bos,
+                n
+            );
+
+            SFL_RETHROW;
+        }
+
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        sfl::dtl::deallocate
+        (
+            data_.ref_to_alloc(),
+            data_.bos_,
+            std::distance(data_.bos_, data_.eos_)
+        );
+
+        data_.bos_   = new_bos;
+        data_.first_ = new_first;
+        data_.last_  = new_last;
+        data_.eos_   = new_eos;
+    }
+
+    void initialize_default_n(size_type n)
+    {
+        check_size(n, "sfl::devector::initialize_default_n");
+
+        data_.bos_   = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+        data_.first_ = data_.bos_;
+        data_.last_  = data_.first_;
+        data_.eos_   = data_.bos_ + n;
+
+        SFL_TRY
+        {
+            data_.last_ = sfl::dtl::uninitialized_default_construct_n_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                n
+            );
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::deallocate(data_.ref_to_alloc(), data_.bos_, n);
+            SFL_RETHROW;
+        }
+    }
+
+    void initialize_fill_n(size_type n, const T& value)
+    {
+        check_size(n, "sfl::devector::initialize_fill_n");
+
+        data_.bos_   = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+        data_.first_ = data_.bos_;
+        data_.last_  = data_.first_;
+        data_.eos_   = data_.bos_ + n;
+
+        SFL_TRY
+        {
+            data_.last_ = sfl::dtl::uninitialized_fill_n_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                n,
+                value
+            );
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::deallocate(data_.ref_to_alloc(), data_.bos_, n);
+            SFL_RETHROW;
+        }
+    }
+
+    template <typename InputIt>
+    void initialize_range(InputIt first, InputIt last)
+    {
+        initialize_range(first, last, typename std::iterator_traits<InputIt>::iterator_category());
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void initialize_range(InputIt first, Sentinel last, std::input_iterator_tag)
+    {
+        SFL_TRY
+        {
+            while (first != last)
+            {
+                emplace_back(*first);
+                ++first;
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.bos_,
+                std::distance(data_.bos_, data_.eos_)
+            );
+
+            SFL_RETHROW;
+        }
+    }
+
+    template <typename ForwardIt, typename Sentinel>
+    void initialize_range(ForwardIt first, Sentinel last, std::forward_iterator_tag)
+    {
+        const size_type n = std::distance(first, last);
+
+        check_size(n, "sfl::devector::initialize_range");
+
+        data_.bos_   = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+        data_.first_ = data_.bos_;
+        data_.last_  = data_.first_;
+        data_.eos_   = data_.bos_ + n;
+
+        SFL_TRY
+        {
+            data_.last_ = sfl::dtl::uninitialized_copy_a
+            (
+                data_.ref_to_alloc(),
+                first,
+                last,
+                data_.first_
+            );
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::deallocate(data_.ref_to_alloc(), data_.bos_, n);
+            SFL_RETHROW;
+        }
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void initialize_range(Range&& range)
+    {
+        if constexpr (std::ranges::forward_range<Range>)
+        {
+            initialize_range(std::ranges::begin(range), std::ranges::end(range), std::forward_iterator_tag());
+        }
+        else
+        {
+            initialize_range(std::ranges::begin(range), std::ranges::end(range), std::input_iterator_tag());
+        }
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void initialize_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        initialize_range(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    void initialize_copy(const devector& other)
+    {
+        const size_type n = other.size();
+
+        check_size(n, "sfl::devector::initialize_copy");
+
+        data_.bos_   = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+        data_.first_ = data_.bos_;
+        data_.last_  = data_.first_;
+        data_.eos_   = data_.bos_ + n;
+
+        SFL_TRY
+        {
+            data_.last_ = sfl::dtl::uninitialized_copy_a
+            (
+                data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                data_.first_
+            );
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::deallocate(data_.ref_to_alloc(), data_.bos_, n);
+            SFL_RETHROW;
+        }
+    }
+
+    void initialize_move(devector& other)
+    {
+        if (data_.ref_to_alloc() == other.data_.ref_to_alloc())
+        {
+            data_.bos_   = other.data_.bos_;
+            data_.first_ = other.data_.first_;
+            data_.last_  = other.data_.last_;
+            data_.eos_   = other.data_.eos_;
+
+            other.data_.bos_   = nullptr;
+            other.data_.first_ = nullptr;
+            other.data_.last_  = nullptr;
+            other.data_.eos_   = nullptr;
+        }
+        else
+        {
+            const size_type n = other.size();
+
+            check_size(n, "sfl::devector::initialize_move");
+
+            data_.bos_   = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+            data_.first_ = data_.bos_;
+            data_.last_  = data_.first_;
+            data_.eos_   = data_.bos_ + n;
+
+            SFL_TRY
+            {
+                data_.last_ = sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    other.data_.first_,
+                    other.data_.last_,
+                    data_.first_
+                );
+            }
+            SFL_CATCH (...)
+            {
+                sfl::dtl::deallocate(data_.ref_to_alloc(), data_.bos_, n);
+                SFL_RETHROW;
+            }
+        }
+    }
+
+    void assign_fill_n(size_type n, const T& value)
+    {
+        const size_type size = this->size();
+
+        if (n <= size)
+        {
+            const pointer new_last = data_.first_ + n;
+
+            sfl::dtl::fill
+            (
+                data_.first_,
+                new_last,
+                value
+            );
+
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                new_last,
+                data_.last_
+            );
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const size_type available_back = this->available_back();
+
+            if (n <= size + available_back)
+            {
+                sfl::dtl::fill
+                (
+                    data_.first_,
+                    data_.last_,
+                    value
+                );
+
+                data_.last_ = sfl::dtl::uninitialized_fill_n_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.last_,
+                    n - size,
+                    value
+                );
+            }
+            else
+            {
+                const size_type available_front = this->available_front();
+
+                if (n <= available_front + size + available_back)
+                {
+                    sfl::dtl::fill
+                    (
+                        data_.first_,
+                        data_.last_,
+                        value
+                    );
+
+                    sfl::dtl::uninitialized_fill_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.last_,
+                        data_.eos_,
+                        value
+                    );
+
+                    data_.last_ = data_.eos_;
+
+                    const pointer new_first = data_.first_ - (n - (size + available_back));
+
+                    sfl::dtl::uninitialized_fill_a
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        data_.first_,
+                        value
+                    );
+
+                    data_.first_ = new_first;
+                }
+                else
+                {
+                    grow_storage_back(n - (available_front + size + available_back));
+
+                    sfl::dtl::fill
+                    (
+                        data_.first_,
+                        data_.last_,
+                        value
+                    );
+
+                    data_.last_ = sfl::dtl::uninitialized_fill_n_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.last_,
+                        n - (size + available_front),
+                        value
+                    );
+
+                    sfl::dtl::uninitialized_fill_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.bos_,
+                        data_.first_,
+                        value
+                    );
+
+                    data_.first_ = data_.bos_;
+                }
+            }
+        }
+    }
+
+    template <typename InputIt>
+    void assign_range(InputIt first, InputIt last)
+    {
+        assign_range(first, last, typename std::iterator_traits<InputIt>::iterator_category());
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void assign_range(InputIt first, Sentinel last, std::input_iterator_tag)
+    {
+        pointer curr = data_.first_;
+
+        while (first != last && curr != data_.last_)
+        {
+            *curr = *first;
+            ++curr;
+            ++first;
+        }
+
+        if (first != last)
+        {
+            do
+            {
+                emplace_back(*first);
+                ++first;
+            }
+            while (first != last);
+        }
+        else if (curr < data_.last_)
+        {
+            sfl::dtl::destroy_a(data_.ref_to_alloc(), curr, data_.last_);
+            data_.last_ = curr;
+        }
+    }
+
+    template <typename ForwardIt, typename Sentinel>
+    void assign_range(ForwardIt first, Sentinel last, std::forward_iterator_tag)
+    {
+        const size_type n = std::distance(first, last);
+
+        const size_type size = this->size();
+
+        if (n <= size)
+        {
+            const pointer new_last = sfl::dtl::copy
+            (
+                first,
+                last,
+                data_.first_
+            );
+
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                new_last,
+                data_.last_
+            );
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const size_type available_back = this->available_back();
+
+            if (n <= size + available_back)
+            {
+                const ForwardIt mid = std::next(first, size);
+
+                sfl::dtl::copy
+                (
+                    first,
+                    mid,
+                    data_.first_
+                );
+
+                data_.last_ = sfl::dtl::uninitialized_copy_a
+                (
+                    data_.ref_to_alloc(),
+                    mid,
+                    last,
+                    data_.last_
+                );
+            }
+            else
+            {
+                const size_type available_front = this->available_front();
+
+                if (n <= available_front + size + available_back)
+                {
+                    const ForwardIt mid1 = std::next(first, n - (size + available_back));
+                    const ForwardIt mid2 = std::next(mid1, size);
+
+                    sfl::dtl::copy
+                    (
+                        mid1,
+                        mid2,
+                        data_.first_
+                    );
+
+                    data_.last_ = sfl::dtl::uninitialized_copy_a
+                    (
+                        data_.ref_to_alloc(),
+                        mid2,
+                        last,
+                        data_.last_
+                    );
+
+                    const pointer new_first = data_.first_ - (n - (size + available_back));
+
+                    sfl::dtl::uninitialized_copy_a
+                    (
+                        data_.ref_to_alloc(),
+                        first,
+                        mid1,
+                        new_first
+                    );
+
+                    data_.first_ = new_first;
+                }
+                else
+                {
+                    grow_storage_back(n - (available_front + size + available_back));
+
+                    const ForwardIt mid1 = std::next(first, available_front);
+                    const ForwardIt mid2 = std::next(mid1, size);
+
+                    sfl::dtl::copy
+                    (
+                        mid1,
+                        mid2,
+                        data_.first_
+                    );
+
+                    data_.last_ = sfl::dtl::uninitialized_copy_a
+                    (
+                        data_.ref_to_alloc(),
+                        mid2,
+                        last,
+                        data_.last_
+                    );
+
+                    sfl::dtl::uninitialized_copy_a
+                    (
+                        data_.ref_to_alloc(),
+                        first,
+                        mid1,
+                        data_.bos_
+                    );
+
+                    data_.first_ = data_.bos_;
+                }
+            }
+        }
+    }
+
+    void assign_copy(const devector& other)
+    {
+        if (this != &other)
+        {
+            if (allocator_traits::propagate_on_container_copy_assignment::value)
+            {
+                if (data_.ref_to_alloc() != other.data_.ref_to_alloc())
+                {
+                    reset();
+                }
+
+                data_.ref_to_alloc() = other.data_.ref_to_alloc();
+            }
+
+            assign_range
+            (
+                other.data_.first_,
+                other.data_.last_
+            );
+        }
+    }
+
+    void assign_move(devector& other)
+    {
+        if (allocator_traits::propagate_on_container_move_assignment::value)
+        {
+            if (data_.ref_to_alloc() != other.data_.ref_to_alloc())
+            {
+                reset();
+            }
+
+            data_.ref_to_alloc() = std::move(other.data_.ref_to_alloc());
+        }
+
+        if (data_.ref_to_alloc() == other.data_.ref_to_alloc())
+        {
+            reset();
+
+            data_.bos_   = other.data_.bos_;
+            data_.first_ = other.data_.first_;
+            data_.last_  = other.data_.last_;
+            data_.eos_   = other.data_.eos_;
+
+            other.data_.bos_   = nullptr;
+            other.data_.first_ = nullptr;
+            other.data_.last_  = nullptr;
+            other.data_.eos_   = nullptr;
+        }
+        else
+        {
+            assign_range
+            (
+                std::make_move_iterator(other.data_.first_),
+                std::make_move_iterator(other.data_.last_)
+            );
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    template <typename... Args>
+    iterator emplace_front_aux(Args&&... args)
+    {
+        if (data_.first_ != data_.bos_)
+        {
+            const pointer new_first = data_.first_ - 1;
+
+            sfl::dtl::construct_at_a
+            (
+                data_.ref_to_alloc(),
+                new_first,
+                std::forward<Args>(args)...
+            );
+
+            data_.first_ = new_first;
+
+            return iterator(new_first);
+        }
+        else
+        {
+            value_type tmp(std::forward<Args>(args)...);
+
+            emplace_proxy<value_type&&> proxy(std::move(tmp));
+
+            const size_type additional_capacity = calculate_additional_capacity_for_grow_storage_front(1);
+
+            if (available_back() > additional_capacity)
+            {
+                return insert_aux_shift_to_back(additional_capacity, cbegin(), 1, proxy);
+            }
+            else
+            {
+                return insert_aux_grow_storage_front(additional_capacity, cbegin(), 1, proxy);
+            }
+        }
+    }
+
+    template <typename... Args>
+    iterator emplace_back_aux(Args&&... args)
+    {
+        if (data_.last_ != data_.eos_)
+        {
+            const pointer old_last = data_.last_;
+
+            sfl::dtl::construct_at_a
+            (
+                data_.ref_to_alloc(),
+                data_.last_,
+                std::forward<Args>(args)...
+            );
+
+            ++data_.last_;
+
+            return iterator(old_last);
+        }
+        else
+        {
+            value_type tmp(std::forward<Args>(args)...);
+
+            emplace_proxy<value_type&&> proxy(std::move(tmp));
+
+            const size_type additional_capacity = calculate_additional_capacity_for_grow_storage_back(1);
+
+            if (available_front() > additional_capacity)
+            {
+                return insert_aux_shift_to_front(additional_capacity, cend(), 1, proxy);
+            }
+            else
+            {
+                return insert_aux_grow_storage_back(additional_capacity, cend(), 1, proxy);
+            }
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    template <typename InsertionProxy>
+    iterator insert_aux
+    (
+        const_iterator insert_pos,
+        size_type insert_size,
+        InsertionProxy& proxy
+    )
+    {
+        SFL_ASSERT(cbegin() <= insert_pos && insert_pos <= cend());
+
+        if (insert_size == 0)
+        {
+            return begin() + std::distance(cbegin(), insert_pos);
+        }
+
+        const size_type dist_to_begin = std::distance(cbegin(), insert_pos);
+        const size_type dist_to_end   = std::distance(insert_pos, cend());
+
+        if (dist_to_begin < dist_to_end)
+        {
+            if (available_front() >= insert_size)
+            {
+                if (dist_to_begin > insert_size)
+                {
+                    //                      p11
+                    //                 p10  |   p20          p30
+                    // ................[aaaabbbb|zzzzzzzzzzzz].................
+                    // ...........[aaaabbbb|....|zzzzzzzzzzzz].................
+                    //            q10  |   q20  q30          q40
+                    //                 q11
+
+                    const pointer& q10 = data_.first_ - insert_size;
+                    const pointer& q11 = data_.first_;
+                    const pointer& q20 = q10 + dist_to_begin;
+                    const pointer& q30 = data_.first_ + dist_to_begin;
+
+                    const pointer& p10 = data_.first_;
+                    const pointer& p11 = p10 + std::distance(q10, q11);
+                    const pointer& p20 = q30;
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p10,
+                        p11,
+                        q10
+                    );
+
+                    const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q10, q11);
+                    });
+
+                    if (p11 != q11)
+                    {
+                        sfl::dtl::move
+                        (
+                            p11,
+                            p20,
+                            q11
+                        );
+                    }
+
+                    proxy.insert_n
+                    (
+                        q20,
+                        insert_size
+                    );
+
+                    sg1.dismiss();
+
+                    data_.first_ = q10;
+
+                    return iterator(q20);
+                }
+                else
+                {
+                    //                     p10      p20          p30
+                    // ....................[aaaaaaaa|zzzzzzzzzzzz].............
+                    // .......[aaaaaaaa|............|zzzzzzzzzzzz].............
+                    //        q10      q20 |        q30          q40
+                    //                     q21
+
+                    const pointer& q10 = data_.first_ - insert_size;
+                    const pointer& q20 = q10 + dist_to_begin;
+                    const pointer& q21 = data_.first_;
+                    const pointer& q30 = data_.first_ + dist_to_begin;
+
+                    const pointer& p10 = data_.first_;
+                    const pointer& p20 = q30;
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p10,
+                        p20,
+                        q10
+                    );
+
+                    const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q10, q20);
+                    });
+
+                    proxy.uninitialized_insert_n
+                    (
+                        data_.ref_to_alloc(),
+                        q20,
+                        std::distance(q20, q21)
+                    );
+
+                    const auto sg2 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q20, q21);
+                    });
+
+                    proxy.insert_n
+                    (
+                        q21,
+                        std::distance(q21, q30)
+                    );
+
+                    sg1.dismiss();
+                    sg2.dismiss();
+
+                    data_.first_ = q10;
+
+                    return iterator(q20);
+                }
+            }
+            else
+            {
+                const size_type additional_capacity = calculate_additional_capacity_for_grow_storage_front(insert_size);
+
+                if (available_back() > additional_capacity)
+                {
+                    return insert_aux_shift_to_back(additional_capacity, insert_pos, insert_size, proxy);
+                }
+                else
+                {
+                    return insert_aux_grow_storage_front(additional_capacity, insert_pos, insert_size, proxy);
+                }
+            }
+        }
+        else
+        {
+            if (available_back() >= insert_size)
+            {
+                if (dist_to_end > insert_size)
+                {
+                    //                              p21
+                    //        p10          p20      |     p30
+                    // .......[aaaaaaaaaaaa|yyyyyyyyzzzzzz]....................
+                    // .......[aaaaaaaaaaaa|.....|yyyyyyyyzzzzzz]..............
+                    //        q10          q20   q30      |   q40
+                    //                                    q31
+
+                    const pointer& q20 = data_.first_ + dist_to_begin;
+                    const pointer& q30 = q20 + insert_size;
+                    const pointer& q31 = data_.last_;
+                    const pointer& q40 = q30 + dist_to_end;
+
+                    const pointer& p20 = q20;
+                    const pointer& p21 = p20 + std::distance(q30, q31);
+                    const pointer& p30 = q31;
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p21,
+                        p30,
+                        q31
+                    );
+
+                    const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q31, q40);
+                    });
+
+                    if (p21 != q31)
+                    {
+                        sfl::dtl::move_backward
+                        (
+                            p20,
+                            p21,
+                            q31
+                        );
+                    }
+
+                    proxy.insert_n
+                    (
+                        q20,
+                        insert_size
+                    );
+
+                    sg1.dismiss();
+
+                    data_.last_ = q40;
+
+                    return iterator(q20);
+                }
+                else
+                {
+                    //        p10          p20      p30
+                    // .......[aaaaaaaaaaaa|zzzzzzzz]..........................
+                    // .......[aaaaaaaaaaaa|............|zzzzzzzz].............
+                    //        q10          q20      |   q30      q40
+                    //                              q21
+
+                    const pointer& q20 = data_.first_ + dist_to_begin;
+                    const pointer& q21 = data_.last_;
+                    const pointer& q30 = q20 + insert_size;
+                    const pointer& q40 = q30 + dist_to_end;
+
+                    const pointer& p20 = q20;
+                    const pointer& p30 = q21;
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p20,
+                        p30,
+                        q30
+                    );
+
+                    const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q30, q40);
+                    });
+
+                    proxy.insert_n
+                    (
+                        q20,
+                        dist_to_end
+                    );
+
+                    proxy.uninitialized_insert_n
+                    (
+                        data_.ref_to_alloc(),
+                        q21,
+                        std::distance(q21, q30)
+                    );
+
+                    sg1.dismiss();
+
+                    data_.last_ = q40;
+
+                    return iterator(q20);
+                }
+            }
+            else
+            {
+                const size_type additional_capacity = calculate_additional_capacity_for_grow_storage_back(insert_size);
+
+                if (available_front() > additional_capacity)
+                {
+                    return insert_aux_shift_to_front(additional_capacity, insert_pos, insert_size, proxy);
+                }
+                else
+                {
+                    return insert_aux_grow_storage_back(additional_capacity, insert_pos, insert_size, proxy);
+                }
+            }
+        }
+    }
+
+    template <typename InsertionProxy>
+    iterator insert_aux_shift_to_back
+    (
+        size_type shift_size,
+        const_iterator insert_pos,
+        size_type insert_size,
+        InsertionProxy& proxy
+    )
+    {
+        SFL_ASSERT(shift_size > 0);
+        SFL_ASSERT(cbegin() <= insert_pos && insert_pos <= cend());
+        SFL_ASSERT(insert_size > 0);
+
+        const pointer& p10 = data_.first_;
+        const pointer& p20 = p10 + std::distance(cbegin(), insert_pos);
+        const pointer& p30 = data_.last_;
+
+        const pointer& q10 = data_.first_ + shift_size - insert_size;
+        const pointer& q20 = q10 + std::distance(cbegin(), insert_pos);
+        const pointer& q30 = q20 + insert_size;
+        const pointer& q40 = q30 + std::distance(insert_pos, cend());
+
+        if (q30 >= p30)
+        {
+            if (q20 >= p30)
+            {
+                if (q10 >= p30)
+                {
+                    //     p10     p20     p30
+                    // ....[aaaaaaa|zzzzzzz]...................................
+                    // .........................[aaaaaaa|.......|zzzzzzz]......
+                    //                          q10     q20     q30     q40
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p10,
+                        p20,
+                        q10
+                    );
+
+                    const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q10, q20);
+                    });
+
+                    proxy.uninitialized_insert_n
+                    (
+                        data_.ref_to_alloc(),
+                        q20,
+                        insert_size
+                    );
+
+                    const auto sg2 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q20, q30);
+                    });
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p20,
+                        p30,
+                        q30
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        p10,
+                        p30
+                    );
+
+                    sg1.dismiss();
+                    sg2.dismiss();
+                }
+                else if (q10 >= p20)
+                {
+                    //         p11     p21
+                    //     p10 |   p20 |   p30
+                    // ....[aaabbbb|zzzzzzz]...................................
+                    // ................[aaabbbb|.......|zzzzzzz]...............
+                    //                 q10 |   q20     q30     q40
+                    //                     q11
+
+                    const pointer& q11 = p30;
+                    const pointer& p11 = p10 + std::distance(q10, q11);
+                    const pointer& p21 = q10;
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p20,
+                        p30,
+                        q30
+                    );
+
+                    const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q30, q40);
+                    });
+
+                    proxy.uninitialized_insert_n
+                    (
+                        data_.ref_to_alloc(),
+                        q20,
+                        insert_size
+                    );
+
+                    const auto sg2 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q20, q30);
+                    });
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p11,
+                        p20,
+                        q11
+                    );
+
+                    const auto sg3 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q11, q20);
+                    });
+
+                    sfl::dtl::move
+                    (
+                        p10,
+                        p11,
+                        q10
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        p10,
+                        p21
+                    );
+
+                    sg1.dismiss();
+                    sg2.dismiss();
+                    sg3.dismiss();
+                }
+                else if (q10 >= p10)
+                {
+                    //                p11 p12
+                    //     p10        |   |    p20   p30
+                    // ....[aaaaaaaaaaaaaabbbbb|zzzzz]...........................
+                    // ...............[aaaaaaaaaaaaaabbbbb|.......|zzzzz]......
+                    //                q10            |    q20     q30   q40
+                    //                               q11
+
+                    const pointer& q11 = p30;
+                    const pointer& p11 = q10;
+                    const pointer& p12 = p10 + std::distance(q10, q11);
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p20,
+                        p30,
+                        q30
+                    );
+
+                    const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q30, q40);
+                    });
+
+                    proxy.uninitialized_insert_n
+                    (
+                        data_.ref_to_alloc(),
+                        q20,
+                        insert_size
+                    );
+
+                    const auto sg2 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q20, q30);
+                    });
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p12,
+                        p20,
+                        q11
+                    );
+
+                    const auto sg3 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q11, q20);
+                    });
+
+                    if (p12 != q11)
+                    {
+                        sfl::dtl::move_backward
+                        (
+                            p10,
+                            p12,
+                            q11
+                        );
+                    }
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        p10,
+                        p11
+                    );
+
+                    sg1.dismiss();
+                    sg2.dismiss();
+                    sg3.dismiss();
+                }
+                else //  q10 < p10
+                {
+                    // Impossible case
+                    SFL_ASSERT(false);
+                }
+            }
+            else if (q20 >= p20)
+            {
+                if (q10 >= p20)
+                {
+                    //                  p21
+                    //     p10     p20  |           p30
+                    // ....[aaaaaaa|zzzzzzzzzzzzzzzz]..........................
+                    // .................[aaaaaaa|.......|zzzzzzzzzzzzzzzz].....
+                    //                  q10     q20 |   q30              q40
+                    //                              q21
+
+                    const pointer& q21 = p30;
+                    const pointer& p21 = q10;
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p20,
+                        p30,
+                        q30
+                    );
+
+                    const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q30, q40);
+                    });
+
+                    sfl::dtl::move
+                    (
+                        p10,
+                        p20,
+                        q10
+                    );
+
+                    proxy.insert_n
+                    (
+                        q20,
+                        std::distance(q20, q21)
+                    );
+
+                    proxy.uninitialized_insert_n
+                    (
+                        data_.ref_to_alloc(),
+                        q21,
+                        std::distance(q21, q30)
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        p10,
+                        p21
+                    );
+
+                    sg1.dismiss();
+                }
+                else if (q10 >= p10)
+                {
+                    //         p11
+                    //     p10 |   p20             p30
+                    // ....[aaaaaaa|zzzzzzzzzzzzzzz]...........................
+                    // ........[aaaaaaa|................|zzzzzzzzzzzzzzz]......
+                    //         q10     q20         |    q30             q40
+                    //                             q21
+
+                    const pointer& q21 = p30;
+                    const pointer& p11 = q10;
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p20,
+                        p30,
+                        q30
+                    );
+
+                    const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q30, q40);
+                    });
+
+                    if (p20 != q20)
+                    {
+                        sfl::dtl::move_backward
+                        (
+                            p10,
+                            p20,
+                            q20
+                        );
+                    }
+
+                    proxy.insert_n
+                    (
+                        q20,
+                        std::distance(q20, q21)
+                    );
+
+                    proxy.uninitialized_insert_n
+                    (
+                        data_.ref_to_alloc(),
+                        q21,
+                        std::distance(q21, q30)
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        p10,
+                        p11
+                    );
+
+                    sg1.dismiss();
+                }
+                else // q10 < p10
+                {
+                    // Impossible case
+                    SFL_ASSERT(false);
+                }
+            }
+            else if (q20 >= p10)
+            {
+                //              p11
+                //         p10  |       p20      p30
+                // ........[aaaabbbbbbbb|zzzzzzzz].............................
+                // ...[aaaabbbbbbbb|....................|zzzzzzzz].............
+                //    q10  |       q20           |      q30      q40
+                //         q11                   q21
+
+                const pointer& q11 = p10;
+                const pointer& q21 = p30;
+                const pointer& p11 = p10 + std::distance(q10, q11);
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    p20,
+                    p30,
+                    q30
+                );
+
+                const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                    sfl::dtl::destroy_a(data_.ref_to_alloc(), q30, q40);
+                });
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    p10,
+                    p11,
+                    q10
+                );
+
+                const auto sg2 = sfl::dtl::make_scope_guard([&](){
+                    sfl::dtl::destroy_a(data_.ref_to_alloc(), q10, q10);
+                });
+
+                if (p11 != q11)
+                {
+                    sfl::dtl::move
+                    (
+                        p11,
+                        p20,
+                        q11
+                    );
+                }
+
+                proxy.insert_n
+                (
+                    q20,
+                    std::distance(q20, q21)
+                );
+
+                proxy.uninitialized_insert_n
+                (
+                    data_.ref_to_alloc(),
+                    q21,
+                    std::distance(q21, q30)
+                );
+
+                sg1.dismiss();
+                sg2.dismiss();
+            }
+            else // q20 < p10
+            {
+                //                 p10     p20     p30
+                // ................[aaaaaaa|zzzzzzz]...........................
+                // ...[aaaaaaa|........................|zzzzzzz]...............
+                //    q10     q20  |               |   q30     q40
+                //                 q21             q22
+
+                const pointer& q21 = p10;
+                const pointer& q22 = p30;
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    p10,
+                    p20,
+                    q10
+                );
+
+                const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                    sfl::dtl::destroy_a(data_.ref_to_alloc(), q10, q20);
+                });
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    p20,
+                    p30,
+                    q30
+                );
+
+                const auto sg2 = sfl::dtl::make_scope_guard([&](){
+                    sfl::dtl::destroy_a(data_.ref_to_alloc(), q30, q40);
+                });
+
+                proxy.uninitialized_insert_n
+                (
+                    data_.ref_to_alloc(),
+                    q20,
+                    std::distance(q20, q21)
+                );
+
+                const auto sg3 = sfl::dtl::make_scope_guard([&](){
+                    sfl::dtl::destroy_a(data_.ref_to_alloc(), q20, q21);
+                });
+
+                proxy.insert_n
+                (
+                    q21,
+                    std::distance(q21, q22)
+                );
+
+                proxy.uninitialized_insert_n
+                (
+                    data_.ref_to_alloc(),
+                    q22,
+                    std::distance(q22, q30)
+                );
+
+                sg1.dismiss();
+                sg2.dismiss();
+                sg3.dismiss();
+            }
+        }
+        else // q30 < p30
+        {
+            if (q20 >= p20)
+            {
+                if (q10 >= p20)
+                {
+                    //               p21 p22
+                    //    p10    p20 |   |               p30
+                    // ...[aaaaaa|yyyyyyyzzzzzzzzzzzzzzzz].....................
+                    // ..............[aaaaaa|....|yyyyyyyzzzzzzzzzzzzzzzz].....
+                    //               q10    q20  q30     |               q40
+                    //                                   q31
+
+                    const pointer& q31 = p30;
+                    const pointer& p21 = q10;
+                    const pointer& p22 = p20 + std::distance(q30, q31);
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p22,
+                        p30,
+                        q31
+                    );
+
+                    const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q31, q40);
+                    });
+
+                    if (p22 != q31)
+                    {
+                        sfl::dtl::move_backward
+                        (
+                            p20,
+                            p22,
+                            q31
+                        );
+                    }
+
+                    sfl::dtl::move
+                    (
+                        p10,
+                        p20,
+                        q10
+                    );
+
+                    proxy.insert_n
+                    (
+                        q20,
+                        insert_size
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        p10,
+                        p21
+                    );
+
+                    sg1.dismiss();
+                }
+                else if (q10 >= p10)
+                {
+                    //        p11        p21
+                    //    p10 |  p20     |               p30
+                    // ...[aaaaaa|yyyyyyyzzzzzzzzzzzzzzzz].....................
+                    // .......[aaaaaa|...........|yyyyyyyzzzzzzzzzzzzzzzz].....
+                    //        q10    q20         q30     |               q40
+                    //                                   q31
+
+                    const pointer& q31 = p30;
+                    const pointer& p11 = q10;
+                    const pointer& p21 = p20 + std::distance(q30, q31);
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p21,
+                        p30,
+                        q31
+                    );
+
+                    const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q31, q40);
+                    });
+
+                    if (p21 != q31)
+                    {
+                        sfl::dtl::move_backward
+                        (
+                            p20,
+                            p21,
+                            q31
+                        );
+                    }
+
+                    if (p20 != q20)
+                    {
+                        sfl::dtl::move_backward
+                        (
+                            p10,
+                            p20,
+                            q20
+                        );
+                    }
+
+                    proxy.insert_n
+                    (
+                        q20,
+                        insert_size
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        p10,
+                        p11
+                    );
+
+                    sg1.dismiss();
+                }
+                else // q10 < p10
+                {
+                    // Impossible case
+                    SFL_ASSERT(false);
+                }
+            }
+            else if (q20 >= p10)
+            {
+                //                            p11    p21
+                //                   p10      |  p20 |       p30
+                // ..................[aaaaaaaabbb|yyyzzzzzzzz].................
+                // .........[aaaaaaaabbb|................|yyyzzzzzzzz].........
+                //          q10      |  q20              q30 |       q40
+                //                   q11                     q31
+
+                const pointer& q11 = p10;
+                const pointer& q31 = p30;
+                const pointer& p11 = p10 + std::distance(q10, q11);
+                const pointer& p21 = p20 + std::distance(q30, q31);
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    p10,
+                    p11,
+                    q10
+                );
+
+                const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                    sfl::dtl::destroy_a(data_.ref_to_alloc(), q10, q11);
+                });
+
+                if (p11 != q11)
+                {
+                    sfl::dtl::move
+                    (
+                        p11,
+                        p20,
+                        q11
+                    );
+                }
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    p21,
+                    p30,
+                    q31
+                );
+
+                const auto sg2 = sfl::dtl::make_scope_guard([&](){
+                    sfl::dtl::destroy_a(data_.ref_to_alloc(), q31, q40);
+                });
+
+                if (p21 != q31)
+                {
+                    sfl::dtl::move_backward
+                    (
+                        p20,
+                        p21,
+                        q31
+                    );
+                }
+
+                proxy.insert_n
+                (
+                    q20,
+                    insert_size
+                );
+
+                sg1.dismiss();
+                sg2.dismiss();
+            }
+            else // q20 < p10
+            {
+                //                                    p21
+                //                  p10      p20      |    p30
+                // .................[aaaaaaaa|zzzzzzzzyyyyy]...................
+                // ...[aaaaaaaa|..................|zzzzzzzzyyyyy]..............
+                //    q10      q20  |             q30      |    q40
+                //                  q21                    q31
+
+                const pointer& q21 = p10;
+                const pointer& q31 = p30;
+                const pointer& p21 = p20 + std::distance(q30, q31);
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    p10,
+                    p20,
+                    q10
+                );
+
+                const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                    sfl::dtl::destroy_a(data_.ref_to_alloc(), q10, q20);
+                });
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    p21,
+                    p30,
+                    q31
+                );
+
+                const auto sg2 = sfl::dtl::make_scope_guard([&](){
+                    sfl::dtl::destroy_a(data_.ref_to_alloc(), q31, q40);
+                });
+
+                if (p21 != q31)
+                {
+                    sfl::dtl::move_backward
+                    (
+                        p20,
+                        p21,
+                        q31
+                    );
+                }
+
+                proxy.uninitialized_insert_n
+                (
+                    data_.ref_to_alloc(),
+                    q20,
+                    std::distance(q20, q21)
+                );
+
+                const auto sg3 = sfl::dtl::make_scope_guard([&](){
+                    sfl::dtl::destroy_a(data_.ref_to_alloc(), q20, q21);
+                });
+
+                proxy.insert_n
+                (
+                    q21,
+                    std::distance(q21, q30)
+                );
+
+                sg1.dismiss();
+                sg2.dismiss();
+                sg3.dismiss();
+            }
+        }
+
+        data_.first_ = q10;
+        data_.last_  = q40;
+
+        return iterator(q20);
+    }
+
+    template <typename InsertionProxy>
+    iterator insert_aux_shift_to_front
+    (
+        size_type shift_size,
+        const_iterator insert_pos,
+        size_type insert_size,
+        InsertionProxy& proxy
+    )
+    {
+        SFL_ASSERT(shift_size > 0);
+        SFL_ASSERT(cbegin() <= insert_pos && insert_pos <= cend());
+        SFL_ASSERT(insert_size > 0);
+
+        const pointer& p10 = data_.first_;
+        const pointer& p20 = p10 + std::distance(cbegin(), insert_pos);
+        const pointer& p30 = data_.last_;
+
+        const pointer& q10 = data_.first_ - shift_size;
+        const pointer& q20 = q10 + std::distance(cbegin(), insert_pos);
+        const pointer& q30 = q20 + insert_size;
+        const pointer& q40 = q30 + std::distance(insert_pos, cend());
+
+        if (q20 <= p10)
+        {
+            if (q30 <= p10)
+            {
+                if (q40 <= p10)
+                {
+                    //                                  p10     p20     p30
+                    // .................................[aaaaaaa|zzzzzzz]......
+                    // ....[aaaaaaa|.......|zzzzzzz]...........................
+                    //     q10     q20     q30     q40
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p10,
+                        p20,
+                        q10
+                    );
+
+                    const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q10, q20);
+                    });
+
+                    proxy.uninitialized_insert_n
+                    (
+                        data_.ref_to_alloc(),
+                        q20,
+                        insert_size
+                    );
+
+                    const auto sg2 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_n_a(data_.ref_to_alloc(), q20, insert_size);
+                    });
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p20,
+                        p30,
+                        q30
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        p10,
+                        p30
+                    );
+
+                    sg1.dismiss();
+                    sg2.dismiss();
+                }
+                else if (q40 <= p20)
+                {
+                    //                                               p21
+                    //                                  p10     p20  |  p30
+                    // .................................[aaaaaaa|yyyyzzzz].....
+                    // ....[aaaaaaa|...............|yyyyzzzz]..................
+                    //     q10     q20             q30  |   q40
+                    //                                  q31
+
+                    const pointer& q31 = p10;
+                    const pointer& p21 = p20 + std::distance(q30, q31);
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p10,
+                        p20,
+                        q10
+                    );
+
+                    const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q10, q20);
+                    });
+
+                    proxy.uninitialized_insert_n
+                    (
+                        data_.ref_to_alloc(),
+                        q20,
+                        insert_size
+                    );
+
+                    const auto sg2 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_n_a(data_.ref_to_alloc(), q20, insert_size);
+                    });
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p20,
+                        p21,
+                        q30
+                    );
+
+                    const auto sg3 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q30, q31);
+                    });
+
+                    if (p21 != q31) // To avoid moving elements into themselves.
+                    {
+                        sfl::dtl::move
+                        (
+                            p21,
+                            p30,
+                            q31
+                        );
+                    }
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        q40,
+                        p30
+                    );
+
+                    sg1.dismiss();
+                    sg2.dismiss();
+                    sg3.dismiss();
+                }
+                else if (q40 <= p30)
+                {
+                    //                                     p21
+                    //                            p10  p20 |            p30
+                    // ...........................[aaaa|yyyyzzzzzzzzzzzz]......
+                    // ....[aaaa|............|yyyyzzzzzzzzzzzz]................
+                    //     q10  q20          q30  |           q40
+                    //                            q31
+
+                    const pointer& q31 = p10;
+                    const pointer& p21 = p20 + std::distance(q30, q31);
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p10,
+                        p20,
+                        q10
+                    );
+
+                    const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q10, q20);
+                    });
+
+                    proxy.uninitialized_insert_n
+                    (
+                        data_.ref_to_alloc(),
+                        q20,
+                        insert_size
+                    );
+
+                    const auto sg2 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_n_a(data_.ref_to_alloc(), q20, insert_size);
+                    });
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p20,
+                        p21,
+                        q30
+                    );
+
+                    const auto sg3 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q30, q31);
+                    });
+
+                    if (p21 != q31) // To avoid moving elements into themselves.
+                    {
+                        sfl::dtl::move
+                        (
+                            p21,
+                            p30,
+                            q31
+                        );
+                    }
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        q40,
+                        p30
+                    );
+
+                    sg1.dismiss();
+                    sg2.dismiss();
+                    sg3.dismiss();
+                }
+                else // q40 > p30
+                {
+                    // Impossible case
+                    SFL_ASSERT(false);
+                }
+            }
+            else if (q30 <= p20)
+            {
+                if (q40 <= p20)
+                {
+                    //                                  p11
+                    //                        p10       |    p20  p30
+                    // .......................[aaaaaaaaaaaaaa|zzzz]............
+                    // ...[aaaaaaaaaaaaaa|.........|zzzz]......................
+                    //    q10            q20  |    q30  q40
+                    //                        q21
+
+                    const pointer& q21 = p10;
+                    const pointer& p11 = q40;
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p10,
+                        p20,
+                        q10
+                    );
+
+                    const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q10, q20);
+                    });
+
+                    proxy.uninitialized_insert_n
+                    (
+                        data_.ref_to_alloc(),
+                        q20,
+                        std::distance(q20, q21)
+                    );
+
+                    const auto sg2 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q20, q21);
+                    });
+
+                    proxy.insert_n
+                    (
+                        q21,
+                        std::distance(q21, q30)
+                    );
+
+                    if (p20 != q30) // To avoid moving elements into themselves.
+                    {
+                        sfl::dtl::move
+                        (
+                            p20,
+                            p30,
+                            q30
+                        );
+                    }
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        p11,
+                        p30
+                    );
+
+                    sg1.dismiss();
+                    sg2.dismiss();
+                }
+                else if (q40 <= p30)
+                {
+                    //
+                    //                        p10            p20           p30
+                    // .......................[aaaaaaaaaaaaaa|zzzzzzzzzzzzzz]...
+                    // ...[aaaaaaaaaaaaaa|.........|zzzzzzzzzzzzzz].............
+                    //    q10            q20  |    q30           q40
+                    //                        q21
+
+                    const pointer& q21 = p10;
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p10,
+                        p20,
+                        q10
+                    );
+
+                    const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q10, q20);
+                    });
+
+                    proxy.uninitialized_insert_n
+                    (
+                        data_.ref_to_alloc(),
+                        q20,
+                        std::distance(q20, q21)
+                    );
+
+                    const auto sg2 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q20, q21);
+                    });
+
+                    proxy.insert_n
+                    (
+                        q21,
+                        std::distance(q21, q30)
+                    );
+
+                    if (p20 != q30) // To avoid moving elements into themselves.
+                    {
+                        std::move
+                        (
+                            p20,
+                            p30,
+                            q30
+                        );
+                    }
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        q40,
+                        p30
+                    );
+
+                    sg1.dismiss();
+                    sg2.dismiss();
+                }
+                else // q40 > p30
+                {
+                    // Impossible case
+                    SFL_ASSERT(false);
+                }
+            }
+            else if (q30 <= p30)
+            {
+                //                                              p21
+                //                              p10     p20     |   p30
+                // .............................[aaaaaaa|yyyyyyyzzzz]..........
+                // ....[aaaaaaa|............................|yyyyyyyzzzz]......
+                //     q10     q20              |           q30     |   q40
+                //                              q21                 q31
+
+                const pointer& q21 = p10;
+                const pointer& q31 = p30;
+                const pointer& p21 = p20 + std::distance(q30, q31);
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    p10,
+                    p20,
+                    q10
+                );
+
+                const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                    sfl::dtl::destroy_a(data_.ref_to_alloc(), q10, q20);
+                });
+
+                proxy.uninitialized_insert_n
+                (
+                    data_.ref_to_alloc(),
+                    q20,
+                    std::distance(q20, q21)
+                );
+
+                const auto sg2 = sfl::dtl::make_scope_guard([&](){
+                    sfl::dtl::destroy_a(data_.ref_to_alloc(), q20, q21);
+                });
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    p21,
+                    p30,
+                    q31
+                );
+
+                const auto sg3 = sfl::dtl::make_scope_guard([&](){
+                    sfl::dtl::destroy_a(data_.ref_to_alloc(), q31, q40);
+                });
+
+                if (p21 != q31) // To avoid moving elements into themselves.
+                {
+                    sfl::dtl::move_backward
+                    (
+                        p20,
+                        p21,
+                        q31
+                    );
+                }
+
+                proxy.insert_n
+                (
+                    q21,
+                    std::distance(q21, q30)
+                );
+
+                sg1.dismiss();
+                sg2.dismiss();
+                sg3.dismiss();
+            }
+            else // q30 > p30
+            {
+                //
+                //                        p10     p20    p30
+                // .......................[aaaaaaa|zzzzzz].....................
+                // ....[aaaaaaa|.............................|zzzzzz]..........
+                //     q10     q20        |              |   q30    q40
+                //                        q21            q22
+
+                const pointer& q21 = p10;
+                const pointer& q22 = p30;
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    p10,
+                    p20,
+                    q10
+                );
+
+                const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                    sfl::dtl::destroy_a(data_.ref_to_alloc(), q10, q20);
+                });
+
+                proxy.uninitialized_insert_n
+                (
+                    data_.ref_to_alloc(),
+                    q20,
+                    std::distance(q20, q21)
+                );
+
+                const auto sg2 = sfl::dtl::make_scope_guard([&](){
+                    sfl::dtl::destroy_a(data_.ref_to_alloc(), q20, q21);
+                });
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    p20,
+                    p30,
+                    q30
+                );
+
+                const auto sg3 = sfl::dtl::make_scope_guard([&](){
+                    sfl::dtl::destroy_a(data_.ref_to_alloc(), q30, q40);
+                });
+
+                proxy.insert_n
+                (
+                    q21,
+                    std::distance(q21, q22)
+                );
+
+                proxy.uninitialized_insert_n
+                (
+                    data_.ref_to_alloc(),
+                    q22,
+                    std::distance(q22, q30)
+                );
+
+                const auto sg4 = sfl::dtl::make_scope_guard([&](){
+                    sfl::dtl::destroy_a(data_.ref_to_alloc(), q22, q30);
+                });
+
+                sg1.dismiss();
+                sg2.dismiss();
+                sg3.dismiss();
+                sg4.dismiss();
+            }
+        }
+        else // q20 > p10
+        {
+            if (q30 <= p20)
+            {
+                if (q40 <= p20)
+                {
+                    //                                p11
+                    //                  p10           |   p20   p30
+                    // .................[aaaaaaaaaaaaabbbb|zzzzz]..............
+                    // ...[aaaaaaaaaaaaabbbb|.....|zzzzz]......................
+                    //    q10           |   q20   q30   q40
+                    //                  q11
+
+                    const pointer& q11 = p10;
+                    const pointer& p11 = p10 + std::distance(q10, q11);
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p10,
+                        p11,
+                        q10
+                    );
+
+                    const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q10, q11);
+                    });
+
+                    if (p11 != q11) // To avoid moving elements into themselves.
+                    {
+                        sfl::dtl::move
+                        (
+                            p11,
+                            p20,
+                            q11
+                        );
+                    }
+
+                    proxy.insert_n
+                    (
+                        q20,
+                        insert_size
+                    );
+
+                    if (p20 != q30) // To avoid moving elements into themselves.
+                    {
+                        sfl::dtl::move
+                        (
+                            p20,
+                            p30,
+                            q30
+                        );
+                    }
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        q40,
+                        p30
+                    );
+
+                    sg1.dismiss();
+                }
+                else if (q40 <= p30)
+                {
+                    //                                p11
+                    //                  p10           |   p20        p30
+                    // .................[aaaaaaaaaaaaabbbb|zzzzzzzzzz].........
+                    // ...[aaaaaaaaaaaaabbbb|.....|zzzzzzzzzz].................
+                    //    q10           |   q20   q30        q40
+                    //                  q11
+
+                    const pointer& q11 = p10;
+                    const pointer& p11 = p10 + std::distance(q10, q11);
+
+                    sfl::dtl::uninitialized_move_a
+                    (
+                        data_.ref_to_alloc(),
+                        p10,
+                        p11,
+                        q10
+                    );
+
+                    const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                        sfl::dtl::destroy_a(data_.ref_to_alloc(), q10, q20);
+                    });
+
+                    if (p11 != q11) // To avoid moving elements into themselves.
+                    {
+                        sfl::dtl::move
+                        (
+                            p11,
+                            p20,
+                            q11
+                        );
+                    }
+
+                    proxy.insert_n
+                    (
+                        q20,
+                        insert_size
+                    );
+
+                    if (p20 != q30) // To avoid moving elements into themselves.
+                    {
+                        sfl::dtl::move
+                        (
+                            p20,
+                            p30,
+                            q30
+                        );
+                    }
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        q40,
+                        p30
+                    );
+
+                    sg1.dismiss();
+                }
+                else // q40 > p30
+                {
+                    // Impossible case
+                    SFL_ASSERT(false);
+                }
+            }
+            else if (q30 <= p30)
+            {
+                //                                p11        p21
+                //                  p10           |   p20    |   p30
+                // .................[aaaaaaaaaaaaabbbb|yyyyyyzzzz].............
+                // ...[aaaaaaaaaaaaabbbb|.................|yyyyyyzzzz]........
+                //    q10           |   q20               q30    |   q40
+                //                  q11                          q31
+
+                const pointer& q11 = p10;
+                const pointer& q31 = p30;
+                const pointer& p11 = p10 + std::distance(q10, q11);
+                const pointer& p21 = p20 + std::distance(q30, q31);
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    p10,
+                    p11,
+                    q10
+                );
+
+                const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                    sfl::dtl::destroy_a(data_.ref_to_alloc(), q10, q11);
+                });
+
+                if (p11 != q11) // To avoid moving elements into themselves.
+                {
+                    sfl::dtl::move
+                    (
+                        p11,
+                        p20,
+                        q11
+                    );
+                }
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    p21,
+                    p30,
+                    q31
+                );
+
+                const auto sg2 = sfl::dtl::make_scope_guard([&](){
+                    sfl::dtl::destroy_a(data_.ref_to_alloc(), q31, q40);
+                });
+
+                if (p21 != q31) // To avoid moving elements into themselves.
+                {
+                    sfl::dtl::move_backward
+                    (
+                        p20,
+                        p21,
+                        q31
+                    );
+                }
+
+                proxy.insert_n
+                (
+                    q20,
+                    insert_size
+                );
+
+                sg1.dismiss();
+                sg2.dismiss();
+            }
+            else // q30 > p30
+            {
+                //                                p11
+                //                  p10           |   p20   p30
+                // .................[aaaaaaaaaaaaabbbb|zzzzz]..................
+                // ...[aaaaaaaaaaaaabbbb|........................|zzzzz].......
+                //    q10           |   q20                 |    q30   q40
+                //                  q11                     q21
+
+                const pointer& q11 = p10;
+                const pointer& q21 = p30;
+                const pointer& p11 = p10 + std::distance(q10, q11);
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    p10,
+                    p11,
+                    q10
+                );
+
+                const auto sg1 = sfl::dtl::make_scope_guard([&](){
+                    sfl::dtl::destroy_a(data_.ref_to_alloc(), q10, q11);
+                });
+
+                if (p11 != q11) // To avoid moving elements into themselves.
+                {
+                    sfl::dtl::move
+                    (
+                        p11,
+                        p20,
+                        q11
+                    );
+                }
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    p20,
+                    p30,
+                    q30
+                );
+
+                const auto sg2 = sfl::dtl::make_scope_guard([&](){
+                    sfl::dtl::destroy_a(data_.ref_to_alloc(), q30, q40);
+                });
+
+                proxy.insert_n
+                (
+                    q20,
+                    std::distance(q20, q21)
+                );
+
+                proxy.uninitialized_insert_n
+                (
+                    data_.ref_to_alloc(),
+                    q21,
+                    std::distance(q21, q30)
+                );
+
+                sg1.dismiss();
+                sg2.dismiss();
+            }
+        }
+
+        data_.first_ = q10;
+        data_.last_  = q40;
+
+        return iterator(q20);
+    }
+
+    template <typename InsertionProxy>
+    iterator insert_aux_grow_storage_front
+    (
+        size_type additional_capacity,
+        const_iterator insert_pos,
+        size_type insert_size,
+        InsertionProxy& proxy
+    )
+    {
+        SFL_ASSERT(additional_capacity > 0);
+        SFL_ASSERT(cbegin() <= insert_pos && insert_pos <= cend());
+        SFL_ASSERT(insert_size > 0);
+
+        if (additional_capacity > max_size() - capacity())
+        {
+            sfl::dtl::throw_length_error("sfl::devector::insert_aux_grow_storage_front");
+        }
+
+        const size_type offset = std::distance(cbegin(), insert_pos);
+
+        const size_type new_cap = capacity() + additional_capacity;
+
+        pointer new_bos   = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+        pointer new_eos   = new_bos + new_cap;
+        pointer new_first = new_eos - std::distance(data_.last_, data_.eos_) - size() - insert_size;
+        pointer new_last  = new_first;
+
+        const pointer p = new_first + offset;
+
+        SFL_TRY
+        {
+            new_last = sfl::dtl::uninitialized_move_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.first_ + offset,
+                new_first
+            );
+
+            new_last = proxy.uninitialized_insert_n
+            (
+                data_.ref_to_alloc(),
+                new_last,
+                insert_size
+            );
+
+            new_last = sfl::dtl::uninitialized_move_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_ + offset,
+                data_.last_,
+                new_last
+            );
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                new_first,
+                new_last
+            );
+
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                new_bos,
+                new_cap
+            );
+
+            SFL_RETHROW;
+        }
+
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        sfl::dtl::deallocate
+        (
+            data_.ref_to_alloc(),
+            data_.bos_,
+            std::distance(data_.bos_, data_.eos_)
+        );
+
+        data_.bos_   = new_bos;
+        data_.first_ = new_first;
+        data_.last_  = new_last;
+        data_.eos_   = new_eos;
+
+        return iterator(p);
+    }
+
+    template <typename InsertionProxy>
+    iterator insert_aux_grow_storage_back
+    (
+        size_type additional_capacity,
+        const_iterator insert_pos,
+        size_type insert_size,
+        InsertionProxy& proxy
+    )
+    {
+        SFL_ASSERT(additional_capacity > 0);
+        SFL_ASSERT(cbegin() <= insert_pos && insert_pos <= cend());
+        SFL_ASSERT(insert_size > 0);
+
+        if (additional_capacity > max_size() - capacity())
+        {
+            sfl::dtl::throw_length_error("sfl::devector::insert_aux_grow_storage_back");
+        }
+
+        const size_type offset = std::distance(cbegin(), insert_pos);
+
+        const size_type new_cap = capacity() + additional_capacity;
+
+        pointer new_bos   = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+        pointer new_eos   = new_bos + new_cap;
+        pointer new_first = new_bos + std::distance(data_.bos_, data_.first_);
+        pointer new_last  = new_first;
+
+        const pointer p = new_first + offset;
+
+        SFL_TRY
+        {
+            new_last = sfl::dtl::uninitialized_move_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.first_ + offset,
+                new_first
+            );
+
+            new_last = proxy.uninitialized_insert_n
+            (
+                data_.ref_to_alloc(),
+                new_last,
+                insert_size
+            );
+
+            new_last = sfl::dtl::uninitialized_move_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_ + offset,
+                data_.last_,
+                new_last
+            );
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                new_first,
+                new_last
+            );
+
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                new_bos,
+                new_cap
+            );
+
+            SFL_RETHROW;
+        }
+
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        sfl::dtl::deallocate
+        (
+            data_.ref_to_alloc(),
+            data_.bos_,
+            std::distance(data_.bos_, data_.eos_)
+        );
+
+        data_.bos_   = new_bos;
+        data_.first_ = new_first;
+        data_.last_  = new_last;
+        data_.eos_   = new_eos;
+
+        return iterator(p);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    iterator insert_fill_n(const_iterator pos, size_type n, const T& value)
+    {
+        insert_fill_n_proxy proxy(value);
+        return insert_aux(pos, n, proxy);
+    }
+
+    template <typename InputIt>
+    iterator insert_range(const_iterator pos, InputIt first, InputIt last)
+    {
+        return insert_range(pos, first, last, typename std::iterator_traits<InputIt>::iterator_category());
+    }
+
+    template <typename InputIt, typename Sentinel>
+    iterator insert_range(const_iterator pos, InputIt first, Sentinel last, std::input_iterator_tag)
+    {
+        const difference_type offset = std::distance(cbegin(), pos);
+
+        while (first != last)
+        {
+            pos = insert(pos, *first);
+            ++pos;
+            ++first;
+        }
+
+        return begin() + offset;
+    }
+
+    template <typename ForwardIt, typename Sentinel>
+    iterator insert_range(const_iterator pos, ForwardIt first, Sentinel last, std::forward_iterator_tag)
+    {
+        const size_type n = std::distance(first, last);
+        insert_range_proxy<ForwardIt> proxy(first);
+        return insert_aux(pos, n, proxy);
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename T, typename A>
+SFL_NODISCARD
+bool operator==
+(
+    const devector<T, A>& x,
+    const devector<T, A>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename T, typename A>
+SFL_NODISCARD
+bool operator!=
+(
+    const devector<T, A>& x,
+    const devector<T, A>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename T, typename A>
+SFL_NODISCARD
+bool operator<
+(
+    const devector<T, A>& x,
+    const devector<T, A>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename T, typename A>
+SFL_NODISCARD
+bool operator>
+(
+    const devector<T, A>& x,
+    const devector<T, A>& y
+)
+{
+    return y < x;
+}
+
+template <typename T, typename A>
+SFL_NODISCARD
+bool operator<=
+(
+    const devector<T, A>& x,
+    const devector<T, A>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename T, typename A>
+SFL_NODISCARD
+bool operator>=
+(
+    const devector<T, A>& x,
+    const devector<T, A>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename T, typename A>
+void swap
+(
+    devector<T, A>& x,
+    devector<T, A>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename T, typename A, typename U>
+typename devector<T, A>::size_type
+    erase(devector<T, A>& c, const U& value)
+{
+    auto it = std::remove(c.begin(), c.end(), value);
+    auto r = std::distance(it, c.end());
+    c.erase(it, c.end());
+    return r;
+}
+
+template <typename T, typename A, typename Predicate>
+typename devector<T, A>::size_type
+    erase_if(devector<T, A>& c, Predicate pred)
+{
+    auto it = std::remove_if(c.begin(), c.end(), pred);
+    auto r = std::distance(it, c.end());
+    c.erase(it, c.end());
+    return r;
+}
+
+//
+// ---- DEDUCTION GUIDES ------------------------------------------------------
+//
+
+#if SFL_CPP_VERSION >= SFL_CPP_17
+
+template < typename InputIt,
+           typename Allocator = std::allocator<typename std::iterator_traits<InputIt>::value_type>,
+           sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr >
+devector(InputIt, InputIt, Allocator = Allocator())
+    -> devector<typename std::iterator_traits<InputIt>::value_type, Allocator>;
+
+#endif
+
+} // namespace sfl
+
+#endif // SFL_DEVECTOR_HPP_INCLUDED

--- a/src/thirdparty/sfl/map.hpp
+++ b/src/thirdparty/sfl/map.hpp
@@ -1,0 +1,1075 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_MAP_HPP_INCLUDED
+#define SFL_MAP_HPP_INCLUDED
+
+#include <sfl/detail/allocator_traits.hpp>
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/exceptions.hpp>
+#include <sfl/detail/functional.hpp>
+#include <sfl/detail/rb_tree.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/type_traits.hpp>
+
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <memory>           // allocator
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+namespace sfl
+{
+
+template < typename Key,
+           typename T,
+           typename Compare = std::less<Key>,
+           typename Allocator = std::allocator<std::pair<const Key, T>> >
+class map
+{
+    static_assert
+    (
+        std::is_same<typename Allocator::value_type, std::pair<const Key, T>>::value,
+        "Allocator::value_type must be std::pair<const Key, T>."
+    );
+
+public:
+
+    using allocator_type = Allocator;
+    using key_type       = Key;
+    using mapped_type    = T;
+    using value_type     = std::pair<const Key, T>;
+    using key_compare    = Compare;
+
+    class value_compare : protected key_compare
+    {
+        friend class map;
+
+    private:
+
+        value_compare(const key_compare& c) : key_compare(c)
+        {}
+
+    public:
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_compare::operator()(x.first, y.first);
+        }
+    };
+
+private:
+
+    using tree_type = sfl::dtl::rb_tree
+    <
+        key_type,
+        value_type,
+        sfl::dtl::first,
+        key_compare,
+        typename sfl::dtl::allocator_traits<allocator_type>::template rebind_alloc<value_type>,
+        map
+    >;
+
+    tree_type tree_;
+
+public:
+
+    using size_type              = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::size_type;
+    using difference_type        = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::difference_type;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using pointer                = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::pointer;
+    using const_pointer          = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::const_pointer;
+    using iterator               = typename tree_type::iterator;
+    using const_iterator         = typename tree_type::const_iterator;
+    using reverse_iterator       = typename tree_type::reverse_iterator;
+    using const_reverse_iterator = typename tree_type::const_reverse_iterator;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    map() noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : tree_()
+    {}
+
+    explicit map(const Compare& comp) noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : tree_(comp)
+    {}
+
+    explicit map(const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : tree_(alloc)
+    {}
+
+    explicit map(const Compare& comp, const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : tree_(comp, alloc)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    map(InputIt first, InputIt last)
+        : tree_()
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    map(InputIt first, InputIt last, const Compare& comp)
+        : tree_(comp)
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    map(InputIt first, InputIt last, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    map(InputIt first, InputIt last, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert(first, last);
+    }
+
+    map(std::initializer_list<value_type> ilist)
+        : map(ilist.begin(), ilist.end())
+    {}
+
+    map(std::initializer_list<value_type> ilist, const Compare& comp)
+        : map(ilist.begin(), ilist.end(), comp)
+    {}
+
+    map(std::initializer_list<value_type> ilist, const Allocator& alloc)
+        : map(ilist.begin(), ilist.end(), alloc)
+    {}
+
+    map(std::initializer_list<value_type> ilist, const Compare& comp, const Allocator& alloc)
+        : map(ilist.begin(), ilist.end(), comp, alloc)
+    {}
+
+    map(const map& other)
+        : tree_(other.tree_)
+    {}
+
+    map(const map& other, const Allocator& alloc)
+        : tree_(other.tree_, alloc)
+    {}
+
+    map(map&& other)
+        : tree_(std::move(other.tree_))
+    {}
+
+    map(map&& other, const Allocator& alloc)
+        : tree_(std::move(other.tree_), alloc)
+    {}
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    map(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    map(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    map(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    map(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    map(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    map(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    map(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    map(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~map()
+    {}
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    map& operator=(const map& other)
+    {
+        tree_.operator=(other.tree_);
+        return *this;
+    }
+
+    map& operator=(map&& other)
+    {
+        tree_.operator=(std::move(other.tree_));
+        return *this;
+    }
+
+    map& operator=(std::initializer_list<value_type> ilist)
+    {
+        tree_.assign_range_unique(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- ALLOCATOR ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    allocator_type get_allocator() const noexcept
+    {
+        return allocator_type(tree_.ref_to_node_alloc());
+    }
+
+    //
+    // ---- KEY COMPARE -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_compare key_comp() const
+    {
+        return key_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- VALUE COMPARE -----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_compare value_comp() const
+    {
+        return value_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return tree_.cbegin();
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return tree_.cend();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return tree_.crbegin();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return tree_.crend();
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return tree_.empty();
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return tree_.size();
+    }
+
+    SFL_NODISCARD
+    size_type max_size() const noexcept
+    {
+        return tree_.max_size();
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear()
+    {
+        tree_.clear();
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace(Args&&... args)
+    {
+        return tree_.emplace_unique(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        return tree_.emplace_hint_unique(hint, std::forward<Args>(args)...);
+    }
+
+    std::pair<iterator, bool> insert(const value_type& value)
+    {
+        return tree_.insert_unique(value);
+    }
+
+    std::pair<iterator, bool> insert(value_type&& value)
+    {
+        return tree_.insert_unique(std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P&&>::value>* = nullptr>
+    std::pair<iterator, bool> insert(P&& value)
+    {
+        return tree_.insert_unique(std::forward<P>(value));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        return tree_.insert_hint_unique(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        return tree_.insert_hint_unique(hint, std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P>::value>* = nullptr>
+    iterator insert(const_iterator hint, P&& value)
+    {
+        return tree_.insert_hint_unique(hint, std::forward<P>(value));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    std::pair<iterator, bool> insert_or_assign(const Key& key, M&& obj)
+    {
+        return insert_or_assign_aux(key, std::forward<M>(obj));
+    }
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    std::pair<iterator, bool> insert_or_assign(Key&& key, M&& obj)
+    {
+        return insert_or_assign_aux(std::move(key), std::forward<M>(obj));
+    }
+
+    template <typename K, typename M,
+              sfl::dtl::enable_if_t< sfl::dtl::has_is_transparent<Compare, K>::value &&
+                                     std::is_assignable<mapped_type&, M&&>::value >* = nullptr>
+    std::pair<iterator, bool> insert_or_assign(K&& key, M&& obj)
+    {
+        return insert_or_assign_aux(std::forward<K>(key), std::forward<M>(obj));
+    }
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    iterator insert_or_assign(const_iterator hint, const Key& key, M&& obj)
+    {
+        return insert_or_assign_aux(hint, key, std::forward<M>(obj));
+    }
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    iterator insert_or_assign(const_iterator hint, Key&& key, M&& obj)
+    {
+        return insert_or_assign_aux(hint, std::move(key), std::forward<M>(obj));
+    }
+
+    template <typename K, typename M,
+              sfl::dtl::enable_if_t< sfl::dtl::has_is_transparent<Compare, K>::value &&
+                                     std::is_assignable<mapped_type&, M&&>::value >* = nullptr>
+    iterator insert_or_assign(const_iterator hint, K&& key, M&& obj)
+    {
+        return insert_or_assign_aux(hint, std::forward<K>(key), std::forward<M>(obj));
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(const Key& key, Args&&... args)
+    {
+        return try_emplace_aux(key, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(Key&& key, Args&&... args)
+    {
+        return try_emplace_aux(std::move(key), std::forward<Args>(args)...);
+    }
+
+    template <typename K, typename... Args,
+              sfl::dtl::enable_if_t<
+                #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 7)
+                // This is workaround for GCC 4 bug on CentOS 7.
+                !std::is_same<sfl::dtl::remove_cvref_t<Key>, sfl::dtl::remove_cvref_t<K>>::value &&
+                #endif
+                sfl::dtl::has_is_transparent<Compare, K>::value &&
+                !std::is_convertible<K&&, const_iterator>::value &&
+                !std::is_convertible<K&&, iterator>::value
+              >* = nullptr>
+    std::pair<iterator, bool> try_emplace(K&& key, Args&&... args)
+    {
+        return try_emplace_aux(std::forward<K>(key), std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator try_emplace(const_iterator hint, const Key& key, Args&&... args)
+    {
+        return try_emplace_aux(hint, key, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator try_emplace(const_iterator hint, Key&& key, Args&&... args)
+    {
+        return try_emplace_aux(hint, std::move(key), std::forward<Args>(args)...);
+    }
+
+    template <typename K, typename... Args,
+              sfl::dtl::enable_if_t<
+                #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 7)
+                // This is workaround for GCC 4 bug on CentOS 7.
+                !std::is_same<sfl::dtl::remove_cvref_t<Key>, sfl::dtl::remove_cvref_t<K>>::value &&
+                #endif
+                sfl::dtl::has_is_transparent<Compare, K>::value
+              >* = nullptr>
+    iterator try_emplace(const_iterator hint, K&& key, Args&&... args)
+    {
+        return try_emplace_aux(hint, std::forward<K>(key), std::forward<Args>(args)...);
+    }
+
+    iterator erase(iterator pos)
+    {
+        return tree_.erase(pos);
+    }
+
+    iterator erase(const_iterator pos)
+    {
+        return tree_.erase(pos);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        return tree_.erase(first, last);
+    }
+
+    size_type erase(const Key& key)
+    {
+        return tree_.erase(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        return tree_.erase(x);
+    }
+
+    void swap(map& other)
+    {
+        tree_.swap(other.tree_);
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator lower_bound(const Key& key)
+    {
+        return tree_.lower_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator lower_bound(const Key& key) const
+    {
+        return tree_.lower_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator lower_bound(const K& x)
+    {
+        return tree_.lower_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator lower_bound(const K& x) const
+    {
+        return tree_.lower_bound(x);
+    }
+
+    SFL_NODISCARD
+    iterator upper_bound(const Key& key)
+    {
+        return tree_.upper_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator upper_bound(const Key& key) const
+    {
+        return tree_.upper_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator upper_bound(const K& x)
+    {
+        return tree_.upper_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator upper_bound(const K& x) const
+    {
+        return tree_.upper_bound(x);
+    }
+
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const Key& key)
+    {
+        return tree_.equal_range(key);
+    }
+
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const
+    {
+        return tree_.equal_range(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const K& x)
+    {
+        return tree_.equal_range(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const K& x) const
+    {
+        return tree_.equal_range(x);
+    }
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        return tree_.find(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        return tree_.find(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        return tree_.find(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        return tree_.find(x);
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        return tree_.count(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        return tree_.count(x);
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return tree_.contains(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return tree_.contains(x);
+    }
+
+    //
+    // ---- ELEMENT ACCESS ----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    T& at(const Key& key)
+    {
+        auto it = find(key);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::map::at");
+        }
+
+        return it->second;
+    }
+
+    SFL_NODISCARD
+    const T& at(const Key& key) const
+    {
+        auto it = find(key);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::map::at");
+        }
+
+        return it->second;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    T& at(const K& x)
+    {
+        auto it = find(x);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::map::at");
+        }
+
+        return it->second;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const T& at(const K& x) const
+    {
+        auto it = find(x);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::map::at");
+        }
+
+        return it->second;
+    }
+
+    SFL_NODISCARD
+    T& operator[](const Key& key)
+    {
+        return try_emplace(key).first->second;
+    }
+
+    SFL_NODISCARD
+    T& operator[](Key&& key)
+    {
+        return try_emplace(std::move(key)).first->second;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    T& operator[](K&& key)
+    {
+        return try_emplace(std::forward<K>(key)).first->second;
+    }
+
+private:
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+
+    template <typename K, typename M>
+    std::pair<iterator, bool> insert_or_assign_aux(K&& key, M&& obj)
+    {
+        auto res = tree_.calculate_position_for_insert_unique(key);
+        if (res.status)
+        {
+            typename tree_type::make_node_functor make_node(tree_);
+            typename tree_type::node_pointer x = make_node
+            (
+                std::piecewise_construct,
+                std::forward_as_tuple(std::forward<K>(key)),
+                std::forward_as_tuple(std::forward<M>(obj))
+            );
+            tree_.insert(x, res.pos, res.left, tree_.data_.root(), tree_.data_.minimum());
+            ++tree_.data_.size_;
+            return std::make_pair(iterator(x), true);
+        }
+        else
+        {
+            iterator it(res.pos);
+            it->second = std::forward<M>(obj);
+            return std::make_pair(it, false);
+        }
+    }
+
+    template <typename K, typename M>
+    iterator insert_or_assign_aux(const_iterator hint, K&& key, M&& obj)
+    {
+        auto res = tree_.calculate_position_for_insert_hint_unique(hint, key);
+        if (res.status)
+        {
+            typename tree_type::make_node_functor make_node(tree_);
+            typename tree_type::node_pointer x = make_node
+            (
+                std::piecewise_construct,
+                std::forward_as_tuple(std::forward<K>(key)),
+                std::forward_as_tuple(std::forward<M>(obj))
+            );
+            tree_.insert(x, res.pos, res.left, tree_.data_.root(), tree_.data_.minimum());
+            ++tree_.data_.size_;
+            return iterator(x);
+        }
+        else
+        {
+            iterator it(res.pos);
+            it->second = std::forward<M>(obj);
+            return it;
+        }
+    }
+
+    template <typename K, typename... Args>
+    std::pair<iterator, bool> try_emplace_aux(K&& key, Args&&... args)
+    {
+        auto res = tree_.calculate_position_for_insert_unique(key);
+        if (res.status)
+        {
+            typename tree_type::make_node_functor make_node(tree_);
+            typename tree_type::node_pointer x = make_node
+            (
+                std::piecewise_construct,
+                std::forward_as_tuple(std::forward<K>(key)),
+                std::forward_as_tuple(std::forward<Args>(args)...)
+            );
+            tree_.insert(x, res.pos, res.left, tree_.data_.root(), tree_.data_.minimum());
+            ++tree_.data_.size_;
+            return std::make_pair(iterator(x), true);
+        }
+        else
+        {
+            return std::make_pair(iterator(res.pos), false);
+        }
+    }
+
+    template <typename K, typename... Args>
+    iterator try_emplace_aux(const_iterator hint, K&& key, Args&&... args)
+    {
+        auto res = tree_.calculate_position_for_insert_hint_unique(hint, key);
+        if (res.status)
+        {
+            typename tree_type::make_node_functor make_node(tree_);
+            typename tree_type::node_pointer x = make_node
+            (
+                std::piecewise_construct,
+                std::forward_as_tuple(std::forward<K>(key)),
+                std::forward_as_tuple(std::forward<Args>(args)...)
+            );
+            tree_.insert(x, res.pos, res.left, tree_.data_.root(), tree_.data_.minimum());
+            ++tree_.data_.size_;
+            return iterator(x);
+        }
+        else
+        {
+            return iterator(res.pos);
+        }
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, typename T, typename C, typename A>
+SFL_NODISCARD
+bool operator==
+(
+    const map<K, T, C, A>& x,
+    const map<K, T, C, A>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, typename T, typename C, typename A>
+SFL_NODISCARD
+bool operator!=
+(
+    const map<K, T, C, A>& x,
+    const map<K, T, C, A>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, typename T, typename C, typename A>
+SFL_NODISCARD
+bool operator<
+(
+    const map<K, T, C, A>& x,
+    const map<K, T, C, A>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename K, typename T, typename C, typename A>
+SFL_NODISCARD
+bool operator>
+(
+    const map<K, T, C, A>& x,
+    const map<K, T, C, A>& y
+)
+{
+    return y < x;
+}
+
+template <typename K, typename T, typename C, typename A>
+SFL_NODISCARD
+bool operator<=
+(
+    const map<K, T, C, A>& x,
+    const map<K, T, C, A>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename K, typename T, typename C, typename A>
+SFL_NODISCARD
+bool operator>=
+(
+    const map<K, T, C, A>& x,
+    const map<K, T, C, A>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename K, typename T, typename C, typename A>
+void swap
+(
+    map<K, T, C, A>& x,
+    map<K, T, C, A>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, typename T, typename C, typename A, typename Predicate>
+typename map<K, T, C, A>::size_type
+    erase_if(map<K, T, C, A>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_MAP_HPP_INCLUDED

--- a/src/thirdparty/sfl/multimap.hpp
+++ b/src/thirdparty/sfl/multimap.hpp
@@ -1,0 +1,802 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_MULTIMAP_HPP_INCLUDED
+#define SFL_MULTIMAP_HPP_INCLUDED
+
+#include <sfl/detail/allocator_traits.hpp>
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/functional.hpp>
+#include <sfl/detail/rb_tree.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/type_traits.hpp>
+
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <memory>           // allocator
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+namespace sfl
+{
+
+template < typename Key,
+           typename T,
+           typename Compare = std::less<Key>,
+           typename Allocator = std::allocator<std::pair<const Key, T>> >
+class multimap
+{
+    static_assert
+    (
+        std::is_same<typename Allocator::value_type, std::pair<const Key, T>>::value,
+        "Allocator::value_type must be std::pair<const Key, T>."
+    );
+
+public:
+
+    using allocator_type = Allocator;
+    using key_type       = Key;
+    using mapped_type    = T;
+    using value_type     = std::pair<const Key, T>;
+    using key_compare    = Compare;
+
+    class value_compare : protected key_compare
+    {
+        friend class multimap;
+
+    private:
+
+        value_compare(const key_compare& c) : key_compare(c)
+        {}
+
+    public:
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_compare::operator()(x.first, y.first);
+        }
+    };
+
+private:
+
+    using tree_type = sfl::dtl::rb_tree
+    <
+        key_type,
+        value_type,
+        sfl::dtl::first,
+        key_compare,
+        typename sfl::dtl::allocator_traits<allocator_type>::template rebind_alloc<value_type>,
+        multimap
+    >;
+
+    tree_type tree_;
+
+public:
+
+    using size_type              = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::size_type;
+    using difference_type        = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::difference_type;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using pointer                = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::pointer;
+    using const_pointer          = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::const_pointer;
+    using iterator               = typename tree_type::iterator;
+    using const_iterator         = typename tree_type::const_iterator;
+    using reverse_iterator       = typename tree_type::reverse_iterator;
+    using const_reverse_iterator = typename tree_type::const_reverse_iterator;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    multimap() noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : tree_()
+    {}
+
+    explicit multimap(const Compare& comp) noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : tree_(comp)
+    {}
+
+    explicit multimap(const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : tree_(alloc)
+    {}
+
+    explicit multimap(const Compare& comp, const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : tree_(comp, alloc)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    multimap(InputIt first, InputIt last)
+        : tree_()
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    multimap(InputIt first, InputIt last, const Compare& comp)
+        : tree_(comp)
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    multimap(InputIt first, InputIt last, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    multimap(InputIt first, InputIt last, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert(first, last);
+    }
+
+    multimap(std::initializer_list<value_type> ilist)
+        : multimap(ilist.begin(), ilist.end())
+    {}
+
+    multimap(std::initializer_list<value_type> ilist, const Compare& comp)
+        : multimap(ilist.begin(), ilist.end(), comp)
+    {}
+
+    multimap(std::initializer_list<value_type> ilist, const Allocator& alloc)
+        : multimap(ilist.begin(), ilist.end(), alloc)
+    {}
+
+    multimap(std::initializer_list<value_type> ilist, const Compare& comp, const Allocator& alloc)
+        : multimap(ilist.begin(), ilist.end(), comp, alloc)
+    {}
+
+    multimap(const multimap& other)
+        : tree_(other.tree_)
+    {}
+
+    multimap(const multimap& other, const Allocator& alloc)
+        : tree_(other.tree_, alloc)
+    {}
+
+    multimap(multimap&& other)
+        : tree_(std::move(other.tree_))
+    {}
+
+    multimap(multimap&& other, const Allocator& alloc)
+        : tree_(std::move(other.tree_), alloc)
+    {}
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    multimap(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    multimap(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    multimap(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    multimap(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    multimap(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    multimap(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    multimap(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    multimap(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~multimap()
+    {}
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    multimap& operator=(const multimap& other)
+    {
+        tree_.operator=(other.tree_);
+        return *this;
+    }
+
+    multimap& operator=(multimap&& other)
+    {
+        tree_.operator=(std::move(other.tree_));
+        return *this;
+    }
+
+    multimap& operator=(std::initializer_list<value_type> ilist)
+    {
+        tree_.assign_range_equal(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- ALLOCATOR ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    allocator_type get_allocator() const noexcept
+    {
+        return allocator_type(tree_.ref_to_node_alloc());
+    }
+
+    //
+    // ---- KEY COMPARE -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_compare key_comp() const
+    {
+        return key_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- VALUE COMPARE -----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_compare value_comp() const
+    {
+        return value_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return tree_.cbegin();
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return tree_.cend();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return tree_.crbegin();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return tree_.crend();
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return tree_.empty();
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return tree_.size();
+    }
+
+    SFL_NODISCARD
+    size_type max_size() const noexcept
+    {
+        return tree_.max_size();
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear()
+    {
+        tree_.clear();
+    }
+
+    template <typename... Args>
+    iterator emplace(Args&&... args)
+    {
+        return tree_.emplace_equal(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        return tree_.emplace_hint_equal(hint, std::forward<Args>(args)...);
+    }
+
+    iterator insert(const value_type& value)
+    {
+        return tree_.insert_equal(value);
+    }
+
+    iterator insert(value_type&& value)
+    {
+        return tree_.insert_equal(std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P&&>::value>* = nullptr>
+    iterator insert(P&& value)
+    {
+        return tree_.insert_equal(std::forward<P>(value));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        return tree_.insert_hint_equal(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        return tree_.insert_hint_equal(hint, std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P>::value>* = nullptr>
+    iterator insert(const_iterator hint, P&& value)
+    {
+        return tree_.insert_hint_equal(hint, std::forward<P>(value));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    iterator erase(iterator pos)
+    {
+        return tree_.erase(pos);
+    }
+
+    iterator erase(const_iterator pos)
+    {
+        return tree_.erase(pos);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        return tree_.erase(first, last);
+    }
+
+    size_type erase(const Key& key)
+    {
+        return tree_.erase(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        return tree_.erase(x);
+    }
+
+    void swap(multimap& other)
+    {
+        tree_.swap(other.tree_);
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator lower_bound(const Key& key)
+    {
+        return tree_.lower_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator lower_bound(const Key& key) const
+    {
+        return tree_.lower_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator lower_bound(const K& x)
+    {
+        return tree_.lower_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator lower_bound(const K& x) const
+    {
+        return tree_.lower_bound(x);
+    }
+
+    SFL_NODISCARD
+    iterator upper_bound(const Key& key)
+    {
+        return tree_.upper_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator upper_bound(const Key& key) const
+    {
+        return tree_.upper_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator upper_bound(const K& x)
+    {
+        return tree_.upper_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator upper_bound(const K& x) const
+    {
+        return tree_.upper_bound(x);
+    }
+
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const Key& key)
+    {
+        return tree_.equal_range(key);
+    }
+
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const
+    {
+        return tree_.equal_range(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const K& x)
+    {
+        return tree_.equal_range(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const K& x) const
+    {
+        return tree_.equal_range(x);
+    }
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        return tree_.find(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        return tree_.find(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        return tree_.find(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        return tree_.find(x);
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        return tree_.count(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        return tree_.count(x);
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return tree_.contains(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return tree_.contains(x);
+    }
+
+private:
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, typename T, typename C, typename A>
+SFL_NODISCARD
+bool operator==
+(
+    const multimap<K, T, C, A>& x,
+    const multimap<K, T, C, A>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, typename T, typename C, typename A>
+SFL_NODISCARD
+bool operator!=
+(
+    const multimap<K, T, C, A>& x,
+    const multimap<K, T, C, A>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, typename T, typename C, typename A>
+SFL_NODISCARD
+bool operator<
+(
+    const multimap<K, T, C, A>& x,
+    const multimap<K, T, C, A>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename K, typename T, typename C, typename A>
+SFL_NODISCARD
+bool operator>
+(
+    const multimap<K, T, C, A>& x,
+    const multimap<K, T, C, A>& y
+)
+{
+    return y < x;
+}
+
+template <typename K, typename T, typename C, typename A>
+SFL_NODISCARD
+bool operator<=
+(
+    const multimap<K, T, C, A>& x,
+    const multimap<K, T, C, A>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename K, typename T, typename C, typename A>
+SFL_NODISCARD
+bool operator>=
+(
+    const multimap<K, T, C, A>& x,
+    const multimap<K, T, C, A>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename K, typename T, typename C, typename A>
+void swap
+(
+    multimap<K, T, C, A>& x,
+    multimap<K, T, C, A>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, typename T, typename C, typename A, typename Predicate>
+typename multimap<K, T, C, A>::size_type
+    erase_if(multimap<K, T, C, A>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_MULTIMAP_HPP_INCLUDED

--- a/src/thirdparty/sfl/multiset.hpp
+++ b/src/thirdparty/sfl/multiset.hpp
@@ -1,0 +1,765 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_MULTISET_HPP_INCLUDED
+#define SFL_MULTISET_HPP_INCLUDED
+
+#include <sfl/detail/allocator_traits.hpp>
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/functional.hpp>
+#include <sfl/detail/rb_tree.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/type_traits.hpp>
+
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <memory>           // allocator
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+namespace sfl
+{
+
+template < typename Key,
+           typename Compare = std::less<Key>,
+           typename Allocator = std::allocator<Key> >
+class multiset
+{
+    static_assert
+    (
+        std::is_same<typename Allocator::value_type, Key>::value,
+        "Allocator::value_type must be Key."
+    );
+
+public:
+
+    using allocator_type = Allocator;
+    using key_type       = Key;
+    using value_type     = Key;
+    using key_compare    = Compare;
+    using value_compare  = Compare;
+
+private:
+
+    using tree_type = sfl::dtl::rb_tree
+    <
+        key_type,
+        value_type,
+        sfl::dtl::identity,
+        key_compare,
+        typename sfl::dtl::allocator_traits<allocator_type>::template rebind_alloc<value_type>,
+        multiset
+    >;
+
+    tree_type tree_;
+
+public:
+
+    using size_type              = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::size_type;
+    using difference_type        = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::difference_type;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using pointer                = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::pointer;
+    using const_pointer          = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::const_pointer;
+    using iterator               = typename tree_type::const_iterator; // MUST BE const
+    using const_iterator         = typename tree_type::const_iterator;
+    using reverse_iterator       = typename tree_type::const_reverse_iterator; // MUST BE const
+    using const_reverse_iterator = typename tree_type::const_reverse_iterator;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    multiset() noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : tree_()
+    {}
+
+    explicit multiset(const Compare& comp) noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : tree_(comp)
+    {}
+
+    explicit multiset(const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : tree_(alloc)
+    {}
+
+    explicit multiset(const Compare& comp, const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : tree_(comp, alloc)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    multiset(InputIt first, InputIt last)
+        : tree_()
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    multiset(InputIt first, InputIt last, const Compare& comp)
+        : tree_(comp)
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    multiset(InputIt first, InputIt last, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    multiset(InputIt first, InputIt last, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert(first, last);
+    }
+
+    multiset(std::initializer_list<value_type> ilist)
+        : multiset(ilist.begin(), ilist.end())
+    {}
+
+    multiset(std::initializer_list<value_type> ilist, const Compare& comp)
+        : multiset(ilist.begin(), ilist.end(), comp)
+    {}
+
+    multiset(std::initializer_list<value_type> ilist, const Allocator& alloc)
+        : multiset(ilist.begin(), ilist.end(), alloc)
+    {}
+
+    multiset(std::initializer_list<value_type> ilist, const Compare& comp, const Allocator& alloc)
+        : multiset(ilist.begin(), ilist.end(), comp, alloc)
+    {}
+
+    multiset(const multiset& other)
+        : tree_(other.tree_)
+    {}
+
+    multiset(const multiset& other, const Allocator& alloc)
+        : tree_(other.tree_, alloc)
+    {}
+
+    multiset(multiset&& other)
+        : tree_(std::move(other.tree_))
+    {}
+
+    multiset(multiset&& other, const Allocator& alloc)
+        : tree_(std::move(other.tree_), alloc)
+    {}
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    multiset(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    multiset(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    multiset(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    multiset(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    multiset(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    multiset(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    multiset(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    multiset(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~multiset()
+    {}
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    multiset& operator=(const multiset& other)
+    {
+        tree_.operator=(other.tree_);
+        return *this;
+    }
+
+    multiset& operator=(multiset&& other)
+    {
+        tree_.operator=(std::move(other.tree_));
+        return *this;
+    }
+
+    multiset& operator=(std::initializer_list<value_type> ilist)
+    {
+        tree_.assign_range_equal(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- ALLOCATOR ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    allocator_type get_allocator() const noexcept
+    {
+        return allocator_type(tree_.ref_to_node_alloc());
+    }
+
+    //
+    // ---- KEY COMPARE -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_compare key_comp() const
+    {
+        return key_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- VALUE COMPARE -----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_compare value_comp() const
+    {
+        return value_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return tree_.cbegin();
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return tree_.cend();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return tree_.crbegin();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return tree_.crend();
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return tree_.empty();
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return tree_.size();
+    }
+
+    SFL_NODISCARD
+    size_type max_size() const noexcept
+    {
+        return tree_.max_size();
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear()
+    {
+        tree_.clear();
+    }
+
+    template <typename... Args>
+    iterator emplace(Args&&... args)
+    {
+        return tree_.emplace_equal(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        return tree_.emplace_hint_equal(hint, std::forward<Args>(args)...);
+    }
+
+    iterator insert(const value_type& value)
+    {
+        return tree_.insert_equal(value);
+    }
+
+    iterator insert(value_type&& value)
+    {
+        return tree_.insert_equal(std::move(value));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        return tree_.insert_hint_equal(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        return tree_.insert_hint_equal(hint, std::move(value));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    iterator erase(const_iterator pos)
+    {
+        return tree_.erase(pos);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        return tree_.erase(first, last);
+    }
+
+    size_type erase(const Key& key)
+    {
+        return tree_.erase(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        return tree_.erase(x);
+    }
+
+    void swap(multiset& other)
+    {
+        tree_.swap(other.tree_);
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator lower_bound(const Key& key)
+    {
+        return tree_.lower_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator lower_bound(const Key& key) const
+    {
+        return tree_.lower_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator lower_bound(const K& x)
+    {
+        return tree_.lower_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator lower_bound(const K& x) const
+    {
+        return tree_.lower_bound(x);
+    }
+
+    SFL_NODISCARD
+    iterator upper_bound(const Key& key)
+    {
+        return tree_.upper_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator upper_bound(const Key& key) const
+    {
+        return tree_.upper_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator upper_bound(const K& x)
+    {
+        return tree_.upper_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator upper_bound(const K& x) const
+    {
+        return tree_.upper_bound(x);
+    }
+
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const Key& key)
+    {
+        return tree_.equal_range(key);
+    }
+
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const
+    {
+        return tree_.equal_range(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const K& x)
+    {
+        return tree_.equal_range(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const K& x) const
+    {
+        return tree_.equal_range(x);
+    }
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        return tree_.find(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        return tree_.find(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        return tree_.find(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        return tree_.find(x);
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        return tree_.count(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        return tree_.count(x);
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return tree_.contains(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return tree_.contains(x);
+    }
+
+private:
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, typename C, typename A>
+SFL_NODISCARD
+bool operator==
+(
+    const multiset<K, C, A>& x,
+    const multiset<K, C, A>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, typename C, typename A>
+SFL_NODISCARD
+bool operator!=
+(
+    const multiset<K, C, A>& x,
+    const multiset<K, C, A>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, typename C, typename A>
+SFL_NODISCARD
+bool operator<
+(
+    const multiset<K, C, A>& x,
+    const multiset<K, C, A>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename K, typename C, typename A>
+SFL_NODISCARD
+bool operator>
+(
+    const multiset<K, C, A>& x,
+    const multiset<K, C, A>& y
+)
+{
+    return y < x;
+}
+
+template <typename K, typename C, typename A>
+SFL_NODISCARD
+bool operator<=
+(
+    const multiset<K, C, A>& x,
+    const multiset<K, C, A>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename K, typename C, typename A>
+SFL_NODISCARD
+bool operator>=
+(
+    const multiset<K, C, A>& x,
+    const multiset<K, C, A>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename K, typename C, typename A>
+void swap
+(
+    multiset<K, C, A>& x,
+    multiset<K, C, A>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, typename C, typename A, typename Predicate>
+typename multiset<K, C, A>::size_type
+    erase_if(multiset<K, C, A>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_MULTISET_HPP_INCLUDED

--- a/src/thirdparty/sfl/segmented_vector.hpp
+++ b/src/thirdparty/sfl/segmented_vector.hpp
@@ -21,7 +21,14 @@
 #ifndef SFL_SEGMENTED_VECTOR_HPP_INCLUDED
 #define SFL_SEGMENTED_VECTOR_HPP_INCLUDED
 
-#include "private.hpp"
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/exceptions.hpp>
+#include <sfl/detail/initialized_memory_algorithms.hpp>
+#include <sfl/detail/segmented_iterator.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/type_traits.hpp>
+#include <sfl/detail/uninitialized_memory_algorithms.hpp>
 
 #include <algorithm>        // copy, move, swap, swap_ranges
 #include <cstddef>          // size_t
@@ -220,6 +227,40 @@ public:
         initialize_move(other);
     }
 
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    segmented_vector(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    segmented_vector(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    segmented_vector(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    segmented_vector(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
     ~segmented_vector()
     {
         sfl::dtl::destroy_a
@@ -252,6 +293,33 @@ public:
     {
         assign_range(ilist.begin(), ilist.end());
     }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void assign_range(Range&& range)
+    {
+        if constexpr (std::ranges::forward_range<Range>)
+        {
+            assign_range(std::ranges::begin(range), std::ranges::end(range), std::forward_iterator_tag());
+        }
+        else
+        {
+            assign_range(std::ranges::begin(range), std::ranges::end(range), std::input_iterator_tag());
+        }
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void assign_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        assign_range(begin(range), end(range));
+    }
+
+#endif // before C++20
 
     segmented_vector& operator=(const segmented_vector& other)
     {
@@ -635,6 +703,35 @@ public:
         return insert_range(pos, ilist.begin(), ilist.end());
     }
 
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    iterator insert_range(const_iterator pos, Range&& range)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        if constexpr (std::ranges::forward_range<Range>)
+        {
+            return insert_range(pos, std::ranges::begin(range), std::ranges::end(range), std::forward_iterator_tag());
+        }
+        else
+        {
+            return insert_range(pos, std::ranges::begin(range), std::ranges::end(range), std::input_iterator_tag());
+        }
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    iterator insert_range(const_iterator pos, Range&& range)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        using std::begin;
+        using std::end;
+        return insert_range(pos, begin(range), end(range));
+    }
+
+#endif // before C++20
+
     template <typename... Args>
     reference emplace_back(Args&&... args)
     {
@@ -666,6 +763,24 @@ public:
     {
         emplace_back(std::move(value));
     }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void append_range(Range&& range)
+    {
+        insert_range(end(), std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void append_range(Range&& range)
+    {
+        insert_range(end(), std::forward<Range>(range));
+    }
+
+#endif // before C++20
 
     void pop_back()
     {
@@ -1140,9 +1255,14 @@ private:
         }
     }
 
-    template <typename InputIt,
-              sfl::dtl::enable_if_t<sfl::dtl::is_exactly_input_iterator<InputIt>::value>* = nullptr>
+    template <typename InputIt>
     void initialize_range(InputIt first, InputIt last)
+    {
+        initialize_range(first, last, typename std::iterator_traits<InputIt>::iterator_category());
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void initialize_range(InputIt first, Sentinel last, std::input_iterator_tag)
     {
         allocate_storage(0);
 
@@ -1162,9 +1282,8 @@ private:
         }
     }
 
-    template <typename ForwardIt,
-              sfl::dtl::enable_if_t<sfl::dtl::is_forward_iterator<ForwardIt>::value>* = nullptr>
-    void initialize_range(ForwardIt first, ForwardIt last)
+    template <typename ForwardIt, typename Sentinel>
+    void initialize_range(ForwardIt first, Sentinel last, std::forward_iterator_tag)
     {
         allocate_storage(std::distance(first, last));
 
@@ -1184,6 +1303,33 @@ private:
             SFL_RETHROW;
         }
     }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void initialize_range(Range&& range)
+    {
+        if constexpr (std::ranges::forward_range<Range>)
+        {
+            initialize_range(std::ranges::begin(range), std::ranges::end(range), std::forward_iterator_tag());
+        }
+        else
+        {
+            initialize_range(std::ranges::begin(range), std::ranges::end(range), std::input_iterator_tag());
+        }
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void initialize_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        initialize_range(begin(range), end(range));
+    }
+
+#endif // before C++20
 
     void initialize_copy(const segmented_vector& other)
     {
@@ -1286,9 +1432,14 @@ private:
         }
     }
 
-    template <typename InputIt,
-              sfl::dtl::enable_if_t<sfl::dtl::is_exactly_input_iterator<InputIt>::value>* = nullptr>
+    template <typename InputIt>
     void assign_range(InputIt first, InputIt last)
+    {
+        assign_range(first, last, typename std::iterator_traits<InputIt>::iterator_category());
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void assign_range(InputIt first, Sentinel last, std::input_iterator_tag)
     {
         iterator curr = data_.first_;
 
@@ -1315,9 +1466,8 @@ private:
         }
     }
 
-    template <typename ForwardIt,
-              sfl::dtl::enable_if_t<sfl::dtl::is_forward_iterator<ForwardIt>::value>* = nullptr>
-    void assign_range(ForwardIt first, ForwardIt last)
+    template <typename ForwardIt, typename Sentinel>
+    void assign_range(ForwardIt first, Sentinel last, std::forward_iterator_tag)
     {
         const size_type n = std::distance(first, last);
 
@@ -1601,9 +1751,14 @@ private:
         return p1;
     }
 
-    template <typename InputIt,
-              sfl::dtl::enable_if_t<sfl::dtl::is_exactly_input_iterator<InputIt>::value>* = nullptr>
+    template <typename InputIt>
     iterator insert_range(const_iterator pos, InputIt first, InputIt last)
+    {
+        return insert_range(pos, first, last, typename std::iterator_traits<InputIt>::iterator_category());
+    }
+
+    template <typename InputIt, typename Sentinel>
+    iterator insert_range(const_iterator pos, InputIt first, Sentinel last, std::input_iterator_tag)
     {
         const size_type offset = std::distance(cbegin(), pos);
 
@@ -1617,9 +1772,8 @@ private:
         return nth(offset);
     }
 
-    template <typename ForwardIt,
-              sfl::dtl::enable_if_t<sfl::dtl::is_forward_iterator<ForwardIt>::value>* = nullptr>
-    iterator insert_range(const_iterator pos, ForwardIt first, ForwardIt last)
+    template <typename ForwardIt, typename Sentinel>
+    iterator insert_range(const_iterator pos, ForwardIt first, Sentinel last, std::forward_iterator_tag)
     {
         if (first == last)
         {

--- a/src/thirdparty/sfl/set.hpp
+++ b/src/thirdparty/sfl/set.hpp
@@ -1,0 +1,765 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_SET_HPP_INCLUDED
+#define SFL_SET_HPP_INCLUDED
+
+#include <sfl/detail/allocator_traits.hpp>
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/functional.hpp>
+#include <sfl/detail/rb_tree.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/type_traits.hpp>
+
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <memory>           // allocator
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+namespace sfl
+{
+
+template < typename Key,
+           typename Compare = std::less<Key>,
+           typename Allocator = std::allocator<Key> >
+class set
+{
+    static_assert
+    (
+        std::is_same<typename Allocator::value_type, Key>::value,
+        "Allocator::value_type must be Key."
+    );
+
+public:
+
+    using allocator_type = Allocator;
+    using key_type       = Key;
+    using value_type     = Key;
+    using key_compare    = Compare;
+    using value_compare  = Compare;
+
+private:
+
+    using tree_type = sfl::dtl::rb_tree
+    <
+        key_type,
+        value_type,
+        sfl::dtl::identity,
+        key_compare,
+        typename sfl::dtl::allocator_traits<allocator_type>::template rebind_alloc<value_type>,
+        set
+    >;
+
+    tree_type tree_;
+
+public:
+
+    using size_type              = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::size_type;
+    using difference_type        = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::difference_type;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using pointer                = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::pointer;
+    using const_pointer          = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::const_pointer;
+    using iterator               = typename tree_type::const_iterator; // MUST BE const
+    using const_iterator         = typename tree_type::const_iterator;
+    using reverse_iterator       = typename tree_type::const_reverse_iterator; // MUST BE const
+    using const_reverse_iterator = typename tree_type::const_reverse_iterator;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    set() noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : tree_()
+    {}
+
+    explicit set(const Compare& comp) noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : tree_(comp)
+    {}
+
+    explicit set(const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : tree_(alloc)
+    {}
+
+    explicit set(const Compare& comp, const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : tree_(comp, alloc)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    set(InputIt first, InputIt last)
+        : tree_()
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    set(InputIt first, InputIt last, const Compare& comp)
+        : tree_(comp)
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    set(InputIt first, InputIt last, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    set(InputIt first, InputIt last, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert(first, last);
+    }
+
+    set(std::initializer_list<value_type> ilist)
+        : set(ilist.begin(), ilist.end())
+    {}
+
+    set(std::initializer_list<value_type> ilist, const Compare& comp)
+        : set(ilist.begin(), ilist.end(), comp)
+    {}
+
+    set(std::initializer_list<value_type> ilist, const Allocator& alloc)
+        : set(ilist.begin(), ilist.end(), alloc)
+    {}
+
+    set(std::initializer_list<value_type> ilist, const Compare& comp, const Allocator& alloc)
+        : set(ilist.begin(), ilist.end(), comp, alloc)
+    {}
+
+    set(const set& other)
+        : tree_(other.tree_)
+    {}
+
+    set(const set& other, const Allocator& alloc)
+        : tree_(other.tree_, alloc)
+    {}
+
+    set(set&& other)
+        : tree_(std::move(other.tree_))
+    {}
+
+    set(set&& other, const Allocator& alloc)
+        : tree_(std::move(other.tree_), alloc)
+    {}
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    set(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    set(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    set(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    set(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    set(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    set(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    set(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    set(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~set()
+    {}
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    set& operator=(const set& other)
+    {
+        tree_.operator=(other.tree_);
+        return *this;
+    }
+
+    set& operator=(set&& other)
+    {
+        tree_.operator=(std::move(other.tree_));
+        return *this;
+    }
+
+    set& operator=(std::initializer_list<value_type> ilist)
+    {
+        tree_.assign_range_unique(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- ALLOCATOR ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    allocator_type get_allocator() const noexcept
+    {
+        return allocator_type(tree_.ref_to_node_alloc());
+    }
+
+    //
+    // ---- KEY COMPARE -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_compare key_comp() const
+    {
+        return key_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- VALUE COMPARE -----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_compare value_comp() const
+    {
+        return value_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return tree_.cbegin();
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return tree_.cend();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return tree_.crbegin();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return tree_.crend();
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return tree_.empty();
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return tree_.size();
+    }
+
+    SFL_NODISCARD
+    size_type max_size() const noexcept
+    {
+        return tree_.max_size();
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear()
+    {
+        tree_.clear();
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace(Args&&... args)
+    {
+        return tree_.emplace_unique(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        return tree_.emplace_hint_unique(hint, std::forward<Args>(args)...);
+    }
+
+    std::pair<iterator, bool> insert(const value_type& value)
+    {
+        return tree_.insert_unique(value);
+    }
+
+    std::pair<iterator, bool> insert(value_type&& value)
+    {
+        return tree_.insert_unique(std::move(value));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        return tree_.insert_hint_unique(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        return tree_.insert_hint_unique(hint, std::move(value));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    iterator erase(const_iterator pos)
+    {
+        return tree_.erase(pos);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        return tree_.erase(first, last);
+    }
+
+    size_type erase(const Key& key)
+    {
+        return tree_.erase(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        return tree_.erase(x);
+    }
+
+    void swap(set& other)
+    {
+        tree_.swap(other.tree_);
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator lower_bound(const Key& key)
+    {
+        return tree_.lower_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator lower_bound(const Key& key) const
+    {
+        return tree_.lower_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator lower_bound(const K& x)
+    {
+        return tree_.lower_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator lower_bound(const K& x) const
+    {
+        return tree_.lower_bound(x);
+    }
+
+    SFL_NODISCARD
+    iterator upper_bound(const Key& key)
+    {
+        return tree_.upper_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator upper_bound(const Key& key) const
+    {
+        return tree_.upper_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator upper_bound(const K& x)
+    {
+        return tree_.upper_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator upper_bound(const K& x) const
+    {
+        return tree_.upper_bound(x);
+    }
+
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const Key& key)
+    {
+        return tree_.equal_range(key);
+    }
+
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const
+    {
+        return tree_.equal_range(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const K& x)
+    {
+        return tree_.equal_range(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const K& x) const
+    {
+        return tree_.equal_range(x);
+    }
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        return tree_.find(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        return tree_.find(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        return tree_.find(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        return tree_.find(x);
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        return tree_.count(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        return tree_.count(x);
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return tree_.contains(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return tree_.contains(x);
+    }
+
+private:
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, typename C, typename A>
+SFL_NODISCARD
+bool operator==
+(
+    const set<K, C, A>& x,
+    const set<K, C, A>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, typename C, typename A>
+SFL_NODISCARD
+bool operator!=
+(
+    const set<K, C, A>& x,
+    const set<K, C, A>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, typename C, typename A>
+SFL_NODISCARD
+bool operator<
+(
+    const set<K, C, A>& x,
+    const set<K, C, A>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename K, typename C, typename A>
+SFL_NODISCARD
+bool operator>
+(
+    const set<K, C, A>& x,
+    const set<K, C, A>& y
+)
+{
+    return y < x;
+}
+
+template <typename K, typename C, typename A>
+SFL_NODISCARD
+bool operator<=
+(
+    const set<K, C, A>& x,
+    const set<K, C, A>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename K, typename C, typename A>
+SFL_NODISCARD
+bool operator>=
+(
+    const set<K, C, A>& x,
+    const set<K, C, A>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename K, typename C, typename A>
+void swap
+(
+    set<K, C, A>& x,
+    set<K, C, A>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, typename C, typename A, typename Predicate>
+typename set<K, C, A>::size_type
+    erase_if(set<K, C, A>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_SET_HPP_INCLUDED

--- a/src/thirdparty/sfl/small_flat_map.hpp
+++ b/src/thirdparty/sfl/small_flat_map.hpp
@@ -1,0 +1,2319 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_SMALL_FLAT_MAP_HPP_INCLUDED
+#define SFL_SMALL_FLAT_MAP_HPP_INCLUDED
+
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/exceptions.hpp>
+#include <sfl/detail/initialized_memory_algorithms.hpp>
+#include <sfl/detail/normal_iterator.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/to_address.hpp>
+#include <sfl/detail/type_traits.hpp>
+#include <sfl/detail/uninitialized_memory_algorithms.hpp>
+
+#include <algorithm>        // copy, move, lower_bound, swap, swap_ranges
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <iterator>         // distance, next, reverse_iterator
+#include <limits>           // numeric_limits
+#include <memory>           // allocator, allocator_traits, pointer_traits
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+#ifdef SFL_TEST_SMALL_FLAT_MAP
+template <int>
+void test_small_flat_map();
+#endif
+
+namespace sfl
+{
+
+template < typename Key,
+           typename T,
+           std::size_t N,
+           typename Compare = std::less<Key>,
+           typename Allocator = std::allocator<std::pair<Key, T>> >
+class small_flat_map
+{
+    #ifdef SFL_TEST_SMALL_FLAT_MAP
+    template <int>
+    friend void ::test_small_flat_map();
+    #endif
+
+public:
+
+    using allocator_type         = Allocator;
+    using allocator_traits       = std::allocator_traits<allocator_type>;
+    using key_type               = Key;
+    using mapped_type            = T;
+    using value_type             = std::pair<Key, T>;
+    using size_type              = typename allocator_traits::size_type;
+    using difference_type        = typename allocator_traits::difference_type;
+    using key_compare            = Compare;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using pointer                = typename allocator_traits::pointer;
+    using const_pointer          = typename allocator_traits::const_pointer;
+    using iterator               = sfl::dtl::normal_iterator<pointer, small_flat_map>;
+    using const_iterator         = sfl::dtl::normal_iterator<const_pointer, small_flat_map>;
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    class value_compare : protected key_compare
+    {
+        friend class small_flat_map;
+
+    private:
+
+        value_compare(const key_compare& c) : key_compare(c)
+        {}
+
+    public:
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_compare::operator()(x.first, y.first);
+        }
+    };
+
+    static_assert
+    (
+        std::is_same<typename Allocator::value_type, value_type>::value,
+        "Allocator::value_type must be same as sfl::small_flat_map::value_type."
+    );
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+private:
+
+    // Like `value_compare` but with additional operators.
+    // For internal use only.
+    class ultra_compare : public key_compare
+    {
+    public:
+
+        ultra_compare() noexcept(std::is_nothrow_default_constructible<key_compare>::value)
+        {}
+
+        ultra_compare(const key_compare& c) noexcept(std::is_nothrow_copy_constructible<key_compare>::value)
+            : key_compare(c)
+        {}
+
+        ultra_compare(key_compare&& c) noexcept(std::is_nothrow_move_constructible<key_compare>::value)
+            : key_compare(std::move(c))
+        {}
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_compare::operator()(x.first, y.first);
+        }
+
+        template <typename K>
+        bool operator()(const value_type& x, const K& y) const
+        {
+            return key_compare::operator()(x.first, y);
+        }
+
+        template <typename K>
+        bool operator()(const K& x, const value_type& y) const
+        {
+            return key_compare::operator()(x, y.first);
+        }
+    };
+
+    template <bool WithInternalStorage = true, typename = void>
+    class data_base
+    {
+    private:
+
+        union
+        {
+            value_type internal_storage_[N];
+        };
+
+    public:
+
+        pointer first_;
+        pointer last_;
+        pointer eos_;
+
+        data_base() noexcept
+            : first_(std::pointer_traits<pointer>::pointer_to(*internal_storage_))
+            , last_(first_)
+            , eos_(first_ + N)
+        {}
+
+        #if defined(__clang__) && (__clang_major__ == 3) // For CentOS 7
+        ~data_base()
+        {}
+        #else
+        ~data_base() noexcept
+        {}
+        #endif
+
+        pointer internal_storage() noexcept
+        {
+            return std::pointer_traits<pointer>::pointer_to(*internal_storage_);
+        }
+    };
+
+    template <typename Dummy>
+    class data_base<false, Dummy>
+    {
+    public:
+
+        pointer first_;
+        pointer last_;
+        pointer eos_;
+
+        data_base() noexcept
+            : first_(nullptr)
+            , last_(nullptr)
+            , eos_(nullptr)
+        {}
+
+        pointer internal_storage() noexcept
+        {
+            return nullptr;
+        }
+    };
+
+    class data : public data_base<(N > 0)>, public allocator_type, public ultra_compare
+    {
+    public:
+
+        data() noexcept
+        (
+            std::is_nothrow_default_constructible<allocator_type>::value &&
+            std::is_nothrow_default_constructible<ultra_compare>::value
+        )
+            : allocator_type()
+            , ultra_compare()
+        {}
+
+        data(const ultra_compare& comp) noexcept
+        (
+            std::is_nothrow_default_constructible<allocator_type>::value &&
+            std::is_nothrow_copy_constructible<ultra_compare>::value
+        )
+            : allocator_type()
+            , ultra_compare(comp)
+        {}
+
+        data(const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_default_constructible<ultra_compare>::value
+        )
+            : allocator_type(alloc)
+            , ultra_compare()
+        {}
+
+        data(const ultra_compare& comp, const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_copy_constructible<ultra_compare>::value
+        )
+            : allocator_type(alloc)
+            , ultra_compare(comp)
+        {}
+
+        data(ultra_compare&& comp, allocator_type&& alloc) noexcept
+        (
+            std::is_nothrow_move_constructible<allocator_type>::value &&
+            std::is_nothrow_move_constructible<ultra_compare>::value
+        )
+            : allocator_type(std::move(alloc))
+            , ultra_compare(std::move(comp))
+        {}
+
+        data(ultra_compare&& comp, const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_move_constructible<ultra_compare>::value
+        )
+            : allocator_type(alloc)
+            , ultra_compare(std::move(comp))
+        {}
+
+        allocator_type& ref_to_alloc() noexcept
+        {
+            return *this;
+        }
+
+        const allocator_type& ref_to_alloc() const noexcept
+        {
+            return *this;
+        }
+
+        ultra_compare& ref_to_comp() noexcept
+        {
+            return *this;
+        }
+
+        const ultra_compare& ref_to_comp() const noexcept
+        {
+            return *this;
+        }
+    };
+
+    data data_;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    small_flat_map() noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : data_()
+    {}
+
+    explicit small_flat_map(const Compare& comp) noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : data_(comp)
+    {}
+
+    explicit small_flat_map(const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : data_(alloc)
+    {}
+
+    explicit small_flat_map(const Compare& comp, const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : data_(comp, alloc)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_flat_map(InputIt first, InputIt last)
+        : data_()
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_flat_map(InputIt first, InputIt last, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_flat_map(InputIt first, InputIt last, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_flat_map(InputIt first, InputIt last, const Compare& comp,
+                                                const Allocator& alloc)
+        : data_(comp, alloc)
+    {
+        initialize_range(first, last);
+    }
+
+    small_flat_map(std::initializer_list<value_type> ilist)
+        : small_flat_map(ilist.begin(), ilist.end())
+    {}
+
+    small_flat_map(std::initializer_list<value_type> ilist,
+                   const Compare& comp)
+        : small_flat_map(ilist.begin(), ilist.end(), comp)
+    {}
+
+    small_flat_map(std::initializer_list<value_type> ilist,
+                   const Allocator& alloc)
+        : small_flat_map(ilist.begin(), ilist.end(), alloc)
+    {}
+
+    small_flat_map(std::initializer_list<value_type> ilist,
+                   const Compare& comp, const Allocator& alloc)
+        : small_flat_map(ilist.begin(), ilist.end(), comp, alloc)
+    {}
+
+    small_flat_map(const small_flat_map& other)
+        : data_
+        (
+            other.data_.ref_to_comp(),
+            allocator_traits::select_on_container_copy_construction
+            (
+                other.data_.ref_to_alloc()
+            )
+        )
+    {
+        initialize_copy(other);
+    }
+
+    small_flat_map(const small_flat_map& other, const Allocator& alloc)
+        : data_
+        (
+            other.data_.ref_to_comp(),
+            alloc
+        )
+    {
+        initialize_copy(other);
+    }
+
+    small_flat_map(small_flat_map&& other)
+        : data_
+        (
+            std::move(other.data_.ref_to_comp()),
+            std::move(other.data_.ref_to_alloc())
+        )
+    {
+        initialize_move(other);
+    }
+
+    small_flat_map(small_flat_map&& other, const Allocator& alloc)
+        : data_
+        (
+            std::move(other.data_.ref_to_comp()),
+            alloc
+        )
+    {
+        initialize_move(other);
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_flat_map(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_flat_map(sfl::from_range_t, Range&& range, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_flat_map(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_flat_map(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : data_(comp, alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    small_flat_map(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_flat_map(sfl::from_range_t, Range&& range, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_flat_map(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_flat_map(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : data_(comp, alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~small_flat_map()
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        if (data_.first_ != data_.internal_storage())
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                std::distance(data_.first_, data_.eos_)
+            );
+        }
+    }
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    small_flat_map& operator=(const small_flat_map& other)
+    {
+        assign_copy(other);
+        return *this;
+    }
+
+    small_flat_map& operator=(small_flat_map&& other)
+    {
+        assign_move(other);
+        return *this;
+    }
+
+    small_flat_map& operator=(std::initializer_list<value_type> ilist)
+    {
+        clear();
+        insert(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- ALLOCATOR ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    allocator_type get_allocator() const noexcept
+    {
+        return data_.ref_to_alloc();
+    }
+
+    //
+    // ---- KEY COMPARE -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_compare key_comp() const
+    {
+        return data_.ref_to_comp();
+    }
+
+    //
+    // ---- VALUE COMPARE -----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_compare value_comp() const
+    {
+        return value_compare(data_.ref_to_comp());
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    iterator nth(size_type pos) noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_iterator nth(size_type pos) const noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return const_iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    size_type index_of(const_iterator pos) const noexcept
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return std::distance(cbegin(), pos);
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return data_.first_ == data_.last_;
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return std::distance(data_.first_, data_.last_);
+    }
+
+    SFL_NODISCARD
+    size_type max_size() const noexcept
+    {
+        return std::min<size_type>
+        (
+            allocator_traits::max_size(data_.ref_to_alloc()),
+            std::numeric_limits<difference_type>::max() / sizeof(value_type)
+        );
+    }
+
+    SFL_NODISCARD
+    size_type capacity() const noexcept
+    {
+        return std::distance(data_.first_, data_.eos_);
+    }
+
+    SFL_NODISCARD
+    size_type available() const noexcept
+    {
+        return std::distance(data_.last_, data_.eos_);
+    }
+
+    void reserve(size_type new_cap)
+    {
+        check_size(new_cap, "sfl::small_flat_map::reserve");
+
+        if (new_cap > capacity())
+        {
+            if (new_cap <= N)
+            {
+                if (data_.first_ == data_.internal_storage())
+                {
+                    // Do nothing. We are already using internal storage.
+                }
+                else
+                {
+                    // We are not using internal storage but new capacity
+                    // can fit in internal storage.
+
+                    pointer new_first = data_.internal_storage();
+                    pointer new_last  = new_first;
+                    pointer new_eos   = new_first + N;
+
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_
+                    );
+
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+
+                    data_.first_ = new_first;
+                    data_.last_  = new_last;
+                    data_.eos_   = new_eos;
+                }
+            }
+            else
+            {
+                pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                pointer new_last  = new_first;
+                pointer new_eos   = new_first + new_cap;
+
+                SFL_TRY
+                {
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+                }
+                SFL_CATCH (...)
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+
+                    SFL_RETHROW;
+                }
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_
+                );
+
+                if (data_.first_ != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+                }
+
+                data_.first_ = new_first;
+                data_.last_  = new_last;
+                data_.eos_   = new_eos;
+            }
+        }
+    }
+
+    void shrink_to_fit()
+    {
+        const size_type new_cap = size();
+
+        if (new_cap < capacity())
+        {
+            if (new_cap <= N)
+            {
+                if (data_.first_ == data_.internal_storage())
+                {
+                    // Do nothing. We are already using internal storage.
+                }
+                else
+                {
+                    // We are not using internal storage but new capacity
+                    // can fit in internal storage.
+
+                    pointer new_first = data_.internal_storage();
+                    pointer new_last  = new_first;
+                    pointer new_eos   = new_first + N;
+
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_
+                    );
+
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+
+                    data_.first_ = new_first;
+                    data_.last_  = new_last;
+                    data_.eos_   = new_eos;
+                }
+            }
+            else
+            {
+                pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                pointer new_last  = new_first;
+                pointer new_eos   = new_first + new_cap;
+
+                SFL_TRY
+                {
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+                }
+                SFL_CATCH (...)
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+
+                    SFL_RETHROW;
+                }
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_
+                );
+
+                if (data_.first_ != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+                }
+
+                data_.first_ = new_first;
+                data_.last_  = new_last;
+                data_.eos_   = new_eos;
+            }
+        }
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear() noexcept
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        data_.last_ = data_.first_;
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace(Args&&... args)
+    {
+        return insert_aux(value_type(std::forward<Args>(args)...));
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value_type(std::forward<Args>(args)...));
+    }
+
+    std::pair<iterator, bool> insert(const value_type& value)
+    {
+        return insert_aux(value);
+    }
+
+    std::pair<iterator, bool> insert(value_type&& value)
+    {
+        return insert_aux(std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P&&>::value>* = nullptr>
+    std::pair<iterator, bool> insert(P&& value)
+    {
+        return insert_aux(value_type(std::forward<P>(value)));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P>::value>* = nullptr>
+    iterator insert(const_iterator hint, P&& value)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value_type(std::forward<P>(value)));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    std::pair<iterator, bool> insert_or_assign(const Key& key, M&& obj)
+    {
+        return insert_or_assign_aux(key, std::forward<M>(obj));
+    }
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    std::pair<iterator, bool> insert_or_assign(Key&& key, M&& obj)
+    {
+        return insert_or_assign_aux(std::move(key), std::forward<M>(obj));
+    }
+
+    template <typename K, typename M,
+              sfl::dtl::enable_if_t< sfl::dtl::has_is_transparent<Compare, K>::value &&
+                                     std::is_assignable<mapped_type&, M&&>::value >* = nullptr>
+    std::pair<iterator, bool> insert_or_assign(K&& key, M&& obj)
+    {
+        return insert_or_assign_aux(std::forward<K>(key), std::forward<M>(obj));
+    }
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    iterator insert_or_assign(const_iterator hint, const Key& key, M&& obj)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_or_assign_aux(hint, key, std::forward<M>(obj));
+    }
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    iterator insert_or_assign(const_iterator hint, Key&& key, M&& obj)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_or_assign_aux(hint, std::move(key), std::forward<M>(obj));
+    }
+
+    template <typename K, typename M,
+              sfl::dtl::enable_if_t< sfl::dtl::has_is_transparent<Compare, K>::value &&
+                                     std::is_assignable<mapped_type&, M&&>::value >* = nullptr>
+    iterator insert_or_assign(const_iterator hint, K&& key, M&& obj)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_or_assign_aux(hint, std::forward<K>(key), std::forward<M>(obj));
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(const Key& key, Args&&... args)
+    {
+        return try_emplace_aux(key, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(Key&& key, Args&&... args)
+    {
+        return try_emplace_aux(std::move(key), std::forward<Args>(args)...);
+    }
+
+    template <typename K, typename... Args,
+              sfl::dtl::enable_if_t<
+                #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 7)
+                // This is workaround for GCC 4 bug on CentOS 7.
+                !std::is_same<sfl::dtl::remove_cvref_t<Key>, sfl::dtl::remove_cvref_t<K>>::value &&
+                #endif
+                sfl::dtl::has_is_transparent<Compare, K>::value &&
+                !std::is_convertible<K&&, const_iterator>::value &&
+                !std::is_convertible<K&&, iterator>::value
+              >* = nullptr>
+    std::pair<iterator, bool> try_emplace(K&& key, Args&&... args)
+    {
+        return try_emplace_aux(std::forward<K>(key), std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator try_emplace(const_iterator hint, const Key& key, Args&&... args)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return try_emplace_aux(hint, key, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator try_emplace(const_iterator hint, Key&& key, Args&&... args)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return try_emplace_aux(hint, std::move(key), std::forward<Args>(args)...);
+    }
+
+    template <typename K, typename... Args,
+              sfl::dtl::enable_if_t<
+                #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 7)
+                // This is workaround for GCC 4 bug on CentOS 7.
+                !std::is_same<sfl::dtl::remove_cvref_t<Key>, sfl::dtl::remove_cvref_t<K>>::value &&
+                #endif
+                sfl::dtl::has_is_transparent<Compare, K>::value
+              >* = nullptr>
+    iterator try_emplace(const_iterator hint, K&& key, Args&&... args)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return try_emplace_aux(hint, std::forward<K>(key), std::forward<Args>(args)...);
+    }
+
+    iterator erase(iterator pos)
+    {
+        return erase(const_iterator(pos));
+    }
+
+    iterator erase(const_iterator pos)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos < cend());
+
+        const pointer p = data_.first_ + std::distance(cbegin(), pos);
+
+        data_.last_ = sfl::dtl::move(p + 1, data_.last_, p);
+
+        sfl::dtl::destroy_at_a(data_.ref_to_alloc(), data_.last_);
+
+        return iterator(p);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        SFL_ASSERT(cbegin() <= first && first <= last && last <= cend());
+
+        if (first == last)
+        {
+            return begin() + std::distance(cbegin(), first);
+        }
+
+        const pointer p1 = data_.first_ + std::distance(cbegin(), first);
+        const pointer p2 = data_.first_ + std::distance(cbegin(), last);
+
+        const pointer new_last = sfl::dtl::move(p2, data_.last_, p1);
+
+        sfl::dtl::destroy_a(data_.ref_to_alloc(), new_last, data_.last_);
+
+        data_.last_ = new_last;
+
+        return iterator(p1);
+    }
+
+    size_type erase(const Key& key)
+    {
+        auto it = find(key);
+        if (it == cend())
+        {
+            return 0;
+        }
+        erase(it);
+        return 1;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        auto it = find(x);
+        if (it == cend())
+        {
+            return 0;
+        }
+        erase(it);
+        return 1;
+    }
+
+    void swap(small_flat_map& other)
+    {
+        if (this == &other)
+        {
+            return;
+        }
+
+        using std::swap;
+
+        SFL_ASSERT
+        (
+            allocator_traits::propagate_on_container_swap::value ||
+            this->data_.ref_to_alloc() == other.data_.ref_to_alloc()
+        );
+
+        // If this and other allocator compares equal then one allocator
+        // can deallocate memory allocated by another allocator.
+        // One allocator can safely destroy_a elements constructed by other
+        // allocator regardless the two allocators compare equal or not.
+
+        if (allocator_traits::propagate_on_container_swap::value)
+        {
+            swap(this->data_.ref_to_alloc(), other.data_.ref_to_alloc());
+        }
+
+        swap(this->data_.ref_to_comp(), other.data_.ref_to_comp());
+
+        if
+        (
+            this->data_.first_ == this->data_.internal_storage() &&
+            other.data_.first_ == other.data_.internal_storage()
+        )
+        {
+            const size_type this_size  = this->size();
+            const size_type other_size = other.size();
+
+            if (this_size <= other_size)
+            {
+                std::swap_ranges
+                (
+                    this->data_.first_,
+                    this->data_.first_ + this_size,
+                    other.data_.first_
+                );
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    this->data_.ref_to_alloc(),
+                    other.data_.first_ + this_size,
+                    other.data_.first_ + other_size,
+                    this->data_.first_ + this_size
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    other.data_.ref_to_alloc(),
+                    other.data_.first_ + this_size,
+                    other.data_.first_ + other_size
+                );
+            }
+            else
+            {
+                std::swap_ranges
+                (
+                    other.data_.first_,
+                    other.data_.first_ + other_size,
+                    this->data_.first_
+                );
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    other.data_.ref_to_alloc(),
+                    this->data_.first_ + other_size,
+                    this->data_.first_ + this_size,
+                    other.data_.first_ + other_size
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    this->data_.ref_to_alloc(),
+                    this->data_.first_ + other_size,
+                    this->data_.first_ + this_size
+                );
+            }
+
+            this->data_.last_ = this->data_.first_ + other_size;
+            other.data_.last_ = other.data_.first_ + this_size;
+        }
+        else if
+        (
+            this->data_.first_ == this->data_.internal_storage() &&
+            other.data_.first_ != other.data_.internal_storage()
+        )
+        {
+            pointer new_other_first = other.data_.internal_storage();
+            pointer new_other_last  = new_other_first;
+            pointer new_other_eos   = new_other_first + N;
+
+            new_other_last = sfl::dtl::uninitialized_move_a
+            (
+                other.data_.ref_to_alloc(),
+                this->data_.first_,
+                this->data_.last_,
+                new_other_first
+            );
+
+            sfl::dtl::destroy_a
+            (
+                this->data_.ref_to_alloc(),
+                this->data_.first_,
+                this->data_.last_
+            );
+
+            this->data_.first_ = other.data_.first_;
+            this->data_.last_  = other.data_.last_;
+            this->data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = new_other_first;
+            other.data_.last_  = new_other_last;
+            other.data_.eos_   = new_other_eos;
+        }
+        else if
+        (
+            this->data_.first_ != this->data_.internal_storage() &&
+            other.data_.first_ == other.data_.internal_storage()
+        )
+        {
+            pointer new_this_first = this->data_.internal_storage();
+            pointer new_this_last  = new_this_first;
+            pointer new_this_eos   = new_this_first + N;
+
+            new_this_last = sfl::dtl::uninitialized_move_a
+            (
+                this->data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                new_this_first
+            );
+
+            sfl::dtl::destroy_a
+            (
+                other.data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_
+            );
+
+            other.data_.first_ = this->data_.first_;
+            other.data_.last_  = this->data_.last_;
+            other.data_.eos_   = this->data_.eos_;
+
+            this->data_.first_ = new_this_first;
+            this->data_.last_  = new_this_last;
+            this->data_.eos_   = new_this_eos;
+        }
+        else
+        {
+            swap(this->data_.first_, other.data_.first_);
+            swap(this->data_.last_,  other.data_.last_);
+            swap(this->data_.eos_,   other.data_.eos_);
+        }
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator lower_bound(const Key& key)
+    {
+        return std::lower_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    const_iterator lower_bound(const Key& key) const
+    {
+        return std::lower_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator lower_bound(const K& x)
+    {
+        return std::lower_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator lower_bound(const K& x) const
+    {
+        return std::lower_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    iterator upper_bound(const Key& key)
+    {
+        return std::upper_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    const_iterator upper_bound(const Key& key) const
+    {
+        return std::upper_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator upper_bound(const K& x)
+    {
+        return std::upper_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator upper_bound(const K& x) const
+    {
+        return std::upper_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const Key& key)
+    {
+        return std::equal_range(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const
+    {
+        return std::equal_range(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const K& x)
+    {
+        return std::equal_range(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const K& x) const
+    {
+        return std::equal_range(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        auto it = lower_bound(key);
+
+        if (it != end() && data_.ref_to_comp()(key, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        auto it = lower_bound(key);
+
+        if (it != end() && data_.ref_to_comp()(key, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        auto it = lower_bound(x);
+
+        if (it != end() && data_.ref_to_comp()(x, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        auto it = lower_bound(x);
+
+        if (it != end() && data_.ref_to_comp()(x, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    //
+    // ---- ELEMENT ACCESS ----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    T& at(const Key& key)
+    {
+        auto it = find(key);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::small_flat_map::at");
+        }
+
+        return it->second;
+    }
+
+    SFL_NODISCARD
+    const T& at(const Key& key) const
+    {
+        auto it = find(key);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::small_flat_map::at");
+        }
+
+        return it->second;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    T& at(const K& x)
+    {
+        auto it = find(x);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::small_flat_map::at");
+        }
+
+        return it->second;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const T& at(const K& x) const
+    {
+        auto it = find(x);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::small_flat_map::at");
+        }
+
+        return it->second;
+    }
+
+    SFL_NODISCARD
+    T& operator[](const Key& key)
+    {
+        return try_emplace(key).first->second;
+    }
+
+    SFL_NODISCARD
+    T& operator[](Key&& key)
+    {
+        return try_emplace(std::move(key)).first->second;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    T& operator[](K&& key)
+    {
+        return try_emplace(std::forward<K>(key)).first->second;
+    }
+
+    SFL_NODISCARD
+    value_type* data() noexcept
+    {
+        return sfl::dtl::to_address(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const value_type* data() const noexcept
+    {
+        return sfl::dtl::to_address(data_.first_);
+    }
+
+private:
+
+    void check_size(size_type n, const char* msg)
+    {
+        if (n > max_size())
+        {
+            sfl::dtl::throw_length_error(msg);
+        }
+    }
+
+    size_type calculate_new_capacity(size_type num_additional_elements, const char* msg)
+    {
+        const size_type size = this->size();
+        const size_type capacity = this->capacity();
+        const size_type max_size = this->max_size();
+
+        if (max_size - size < num_additional_elements)
+        {
+            sfl::dtl::throw_length_error(msg);
+        }
+        else if (max_size - capacity < capacity / 2)
+        {
+            return max_size;
+        }
+        else if (size + num_additional_elements < capacity + capacity / 2)
+        {
+            return std::max(N, capacity + capacity / 2);
+        }
+        else
+        {
+            return std::max(N, size + num_additional_elements);
+        }
+    }
+
+    void reset(size_type new_cap = N)
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        if (data_.first_ != data_.internal_storage())
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                std::distance(data_.first_, data_.eos_)
+            );
+        }
+
+        data_.first_ = data_.internal_storage();
+        data_.last_  = data_.first_;
+        data_.eos_   = data_.first_ + N;
+
+        if (new_cap > N)
+        {
+            data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+            data_.last_  = data_.first_;
+            data_.eos_   = data_.first_ + new_cap;
+
+            // If allocation throws, first_, last_ and eos_ will be valid
+            // (they will be pointing to internal_storage).
+        }
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void initialize_range(InputIt first, Sentinel last)
+    {
+        SFL_TRY
+        {
+            while (first != last)
+            {
+                insert(*first);
+                ++first;
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            if (data_.first_ != data_.internal_storage())
+            {
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    std::distance(data_.first_, data_.eos_)
+                );
+            }
+
+            SFL_RETHROW;
+        }
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void initialize_range(Range&& range)
+    {
+        initialize_range(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void initialize_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        initialize_range(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    void initialize_copy(const small_flat_map& other)
+    {
+        const size_type n = other.size();
+
+        check_size(n, "sfl::small_flat_map::initialize_copy");
+
+        if (n > N)
+        {
+            data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+            data_.last_  = data_.first_;
+            data_.eos_   = data_.first_ + n;
+        }
+
+        SFL_TRY
+        {
+            data_.last_ = sfl::dtl::uninitialized_copy_a
+            (
+                data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                data_.first_
+            );
+        }
+        SFL_CATCH (...)
+        {
+            if (n > N)
+            {
+                sfl::dtl::deallocate(data_.ref_to_alloc(), data_.first_, n);
+            }
+
+            SFL_RETHROW;
+        }
+    }
+
+    void initialize_move(small_flat_map& other)
+    {
+        if (other.data_.first_ == other.data_.internal_storage())
+        {
+            data_.last_ = sfl::dtl::uninitialized_move_a
+            (
+                data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                data_.first_
+            );
+        }
+        else if (data_.ref_to_alloc() == other.data_.ref_to_alloc())
+        {
+            data_.first_ = other.data_.first_;
+            data_.last_  = other.data_.last_;
+            data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = nullptr;
+            other.data_.last_  = nullptr;
+            other.data_.eos_   = nullptr;
+        }
+        else
+        {
+            const size_type n = other.size();
+
+            check_size(n, "sfl::small_flat_map::initialize_move");
+
+            if (n > N)
+            {
+                data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+                data_.last_  = data_.first_;
+                data_.eos_   = data_.first_ + n;
+            }
+
+            SFL_TRY
+            {
+                data_.last_ = sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    other.data_.first_,
+                    other.data_.last_,
+                    data_.first_
+                );
+            }
+            SFL_CATCH (...)
+            {
+                if (n > N)
+                {
+                    sfl::dtl::deallocate(data_.ref_to_alloc(), data_.first_, n);
+                }
+
+                SFL_RETHROW;
+            }
+        }
+    }
+
+    template <typename ForwardIt>
+    void assign_range(ForwardIt first, ForwardIt last)
+    {
+        const size_type n = std::distance(first, last);
+
+        check_size(n, "sfl::small_flat_map::assign_range");
+
+        if (n <= capacity())
+        {
+            const size_type s = size();
+
+            if (n <= s)
+            {
+                pointer new_last = sfl::dtl::copy
+                (
+                    first,
+                    last,
+                    data_.first_
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    new_last,
+                    data_.last_
+                );
+
+                data_.last_ = new_last;
+            }
+            else
+            {
+                ForwardIt mid = std::next(first, s);
+
+                sfl::dtl::copy
+                (
+                    first,
+                    mid,
+                    data_.first_
+                );
+
+                data_.last_ = sfl::dtl::uninitialized_copy_a
+                (
+                    data_.ref_to_alloc(),
+                    mid,
+                    last,
+                    data_.last_
+                );
+            }
+        }
+        else
+        {
+            reset(n);
+
+            data_.last_ = sfl::dtl::uninitialized_copy_a
+            (
+                data_.ref_to_alloc(),
+                first,
+                last,
+                data_.first_
+            );
+        }
+    }
+
+    void assign_copy(const small_flat_map& other)
+    {
+        if (this != &other)
+        {
+            if (allocator_traits::propagate_on_container_copy_assignment::value)
+            {
+                if (data_.ref_to_alloc() != other.data_.ref_to_alloc())
+                {
+                    reset();
+                }
+
+                data_.ref_to_alloc() = other.data_.ref_to_alloc();
+            }
+
+            data_.ref_to_comp() = other.data_.ref_to_comp();
+
+            assign_range(other.data_.first_, other.data_.last_);
+        }
+    }
+
+    void assign_move(small_flat_map& other)
+    {
+        if (allocator_traits::propagate_on_container_move_assignment::value)
+        {
+            if (data_.ref_to_alloc() != other.data_.ref_to_alloc())
+            {
+                reset();
+            }
+
+            data_.ref_to_alloc() = std::move(other.data_.ref_to_alloc());
+        }
+
+        data_.ref_to_comp() = other.data_.ref_to_comp();
+
+        if (other.data_.first_ == other.data_.internal_storage())
+        {
+            assign_range
+            (
+                std::make_move_iterator(other.data_.first_),
+                std::make_move_iterator(other.data_.last_)
+            );
+        }
+        else if (data_.ref_to_alloc() == other.data_.ref_to_alloc())
+        {
+            reset();
+
+            data_.first_ = other.data_.first_;
+            data_.last_  = other.data_.last_;
+            data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = nullptr;
+            other.data_.last_  = nullptr;
+            other.data_.eos_   = nullptr;
+        }
+        else
+        {
+            assign_range
+            (
+                std::make_move_iterator(other.data_.first_),
+                std::make_move_iterator(other.data_.last_)
+            );
+        }
+    }
+
+    template <typename Value>
+    std::pair<iterator, bool> insert_aux(Value&& value)
+    {
+        auto it = lower_bound(value.first);
+
+        if (it == end() || data_.ref_to_comp()(value, *it))
+        {
+            return std::make_pair(insert_exactly_at(it, std::forward<Value>(value)), true);
+        }
+
+        return std::make_pair(it, false);
+    }
+
+    template <typename Value>
+    iterator insert_aux(const_iterator hint, Value&& value)
+    {
+        if (is_insert_hint_good(hint, value))
+        {
+            return insert_exactly_at(hint, std::forward<Value>(value));
+        }
+
+        // Hint is not good. Use non-hinted function.
+        return insert_aux(std::forward<Value>(value)).first;
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+
+    template <typename K, typename M>
+    std::pair<iterator, bool> insert_or_assign_aux(K&& key, M&& obj)
+    {
+        auto it = lower_bound(key);
+
+        if (it == end() || data_.ref_to_comp()(key, *it))
+        {
+            return std::make_pair
+            (
+                insert_exactly_at
+                (
+                    it,
+                    value_type
+                    (
+                        std::piecewise_construct,
+                        std::forward_as_tuple(std::forward<K>(key)),
+                        std::forward_as_tuple(std::forward<M>(obj))
+                    )
+                ),
+                true
+            );
+        }
+
+        it->second = std::forward<M>(obj);
+        return std::make_pair(it, false);
+    }
+
+    template <typename K, typename M>
+    iterator insert_or_assign_aux(const_iterator hint, K&& key, M&& obj)
+    {
+        if (is_insert_hint_good(hint, key))
+        {
+            return insert_exactly_at
+            (
+                hint,
+                value_type
+                (
+                    std::piecewise_construct,
+                    std::forward_as_tuple(std::forward<K>(key)),
+                    std::forward_as_tuple(std::forward<M>(obj))
+                )
+            );
+        }
+
+        // Hint is not good. Use non-hinted function.
+        return insert_or_assign_aux(std::forward<K>(key), std::forward<M>(obj)).first;
+    }
+
+    template <typename K, typename... Args>
+    std::pair<iterator, bool> try_emplace_aux(K&& key, Args&&... args)
+    {
+        auto it = lower_bound(key);
+
+        if (it == end() || data_.ref_to_comp()(key, *it))
+        {
+            return std::make_pair
+            (
+                insert_exactly_at
+                (
+                    it,
+                    value_type
+                    (
+                        std::piecewise_construct,
+                        std::forward_as_tuple(std::forward<K>(key)),
+                        std::forward_as_tuple(std::forward<Args>(args)...)
+                    )
+                ),
+                true
+            );
+        }
+
+        return std::make_pair(it, false);
+    }
+
+    template <typename K, typename... Args>
+    iterator try_emplace_aux(const_iterator hint, K&& key, Args&&... args)
+    {
+        if (is_insert_hint_good(hint, key))
+        {
+            return insert_exactly_at
+            (
+                hint,
+                value_type
+                (
+                    std::piecewise_construct,
+                    std::forward_as_tuple(std::forward<K>(key)),
+                    std::forward_as_tuple(std::forward<Args>(args)...)
+                )
+            );
+        }
+
+        // Hint is not good. Use non-hinted function.
+        return try_emplace_aux(std::forward<K>(key), std::forward<Args>(args)...).first;
+    }
+
+    template <typename Value>
+    iterator insert_exactly_at(const_iterator pos, Value&& value)
+    {
+        if (data_.last_ != data_.eos_)
+        {
+            const pointer p1 = data_.first_ + std::distance(cbegin(), pos);
+
+            if (p1 == data_.last_)
+            {
+                sfl::dtl::construct_at_a
+                (
+                    data_.ref_to_alloc(),
+                    p1,
+                    std::forward<Value>(value)
+                );
+
+                ++data_.last_;
+            }
+            else
+            {
+                const pointer p2 = data_.last_ - 1;
+
+                const pointer old_last = data_.last_;
+
+                sfl::dtl::construct_at_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.last_,
+                    std::move(*p2)
+                );
+
+                ++data_.last_;
+
+                sfl::dtl::move_backward
+                (
+                    p1,
+                    p2,
+                    old_last
+                );
+
+                *p1 = std::forward<Value>(value);
+            }
+
+            return iterator(p1);
+        }
+        else
+        {
+            const difference_type offset = std::distance(cbegin(), pos);
+
+            const size_type new_cap =
+                calculate_new_capacity(1, "sfl::small_flat_map::insert_exactly_at");
+
+            pointer new_first;
+            pointer new_last;
+            pointer new_eos;
+
+            if (new_cap <= N && data_.first_ != data_.internal_storage())
+            {
+                new_first = data_.internal_storage();
+                new_last  = new_first;
+                new_eos   = new_first + N;
+            }
+            else
+            {
+                new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                new_last  = new_first;
+                new_eos   = new_first + new_cap;
+            }
+
+            const pointer p = new_first + offset;
+
+            SFL_TRY
+            {
+                sfl::dtl::construct_at_a
+                (
+                    data_.ref_to_alloc(),
+                    p,
+                    std::forward<Value>(value)
+                );
+
+                new_last = nullptr;
+
+                const pointer mid = data_.first_ + offset;
+
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    mid,
+                    new_first
+                );
+
+                ++new_last;
+
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    mid,
+                    data_.last_,
+                    new_last
+                );
+            }
+            SFL_CATCH (...)
+            {
+                if (new_last == nullptr)
+                {
+                    sfl::dtl::destroy_at_a
+                    (
+                        data_.ref_to_alloc(),
+                        p
+                    );
+                }
+                else
+                {
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_last
+                    );
+                }
+
+                if (new_first != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+                }
+
+                SFL_RETHROW;
+            }
+
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            if (data_.first_ != data_.internal_storage())
+            {
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    std::distance(data_.first_, data_.eos_)
+                );
+            }
+
+            data_.first_ = new_first;
+            data_.last_  = new_last;
+            data_.eos_   = new_eos;
+
+            return iterator(p);
+        }
+    }
+
+    template <typename Value>
+    bool is_insert_hint_good(const_iterator hint, const Value& value)
+    {
+        return (hint == begin() || data_.ref_to_comp()(*(hint - 1), value))
+            && (hint == end()   || data_.ref_to_comp()(value, *hint));
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator==
+(
+    const small_flat_map<K, T, N, C, A>& x,
+    const small_flat_map<K, T, N, C, A>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator!=
+(
+    const small_flat_map<K, T, N, C, A>& x,
+    const small_flat_map<K, T, N, C, A>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator<
+(
+    const small_flat_map<K, T, N, C, A>& x,
+    const small_flat_map<K, T, N, C, A>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator>
+(
+    const small_flat_map<K, T, N, C, A>& x,
+    const small_flat_map<K, T, N, C, A>& y
+)
+{
+    return y < x;
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator<=
+(
+    const small_flat_map<K, T, N, C, A>& x,
+    const small_flat_map<K, T, N, C, A>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator>=
+(
+    const small_flat_map<K, T, N, C, A>& x,
+    const small_flat_map<K, T, N, C, A>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+void swap
+(
+    small_flat_map<K, T, N, C, A>& x,
+    small_flat_map<K, T, N, C, A>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A,
+          typename Predicate>
+typename small_flat_map<K, T, N, C, A>::size_type
+    erase_if(small_flat_map<K, T, N, C, A>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_SMALL_FLAT_MAP_HPP_INCLUDED

--- a/src/thirdparty/sfl/small_flat_multimap.hpp
+++ b/src/thirdparty/sfl/small_flat_multimap.hpp
@@ -1,0 +1,2057 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_SMALL_FLAT_MULTIMAP_HPP_INCLUDED
+#define SFL_SMALL_FLAT_MULTIMAP_HPP_INCLUDED
+
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/exceptions.hpp>
+#include <sfl/detail/initialized_memory_algorithms.hpp>
+#include <sfl/detail/normal_iterator.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/to_address.hpp>
+#include <sfl/detail/type_traits.hpp>
+#include <sfl/detail/uninitialized_memory_algorithms.hpp>
+
+#include <algorithm>        // copy, move, lower_bound, swap, swap_ranges
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <iterator>         // distance, next, reverse_iterator
+#include <limits>           // numeric_limits
+#include <memory>           // allocator, allocator_traits, pointer_traits
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+#ifdef SFL_TEST_SMALL_FLAT_MULTIMAP
+template <int>
+void test_small_flat_multimap();
+#endif
+
+namespace sfl
+{
+
+template < typename Key,
+           typename T,
+           std::size_t N,
+           typename Compare = std::less<Key>,
+           typename Allocator = std::allocator<std::pair<Key, T>> >
+class small_flat_multimap
+{
+    #ifdef SFL_TEST_SMALL_FLAT_MULTIMAP
+    template <int>
+    friend void ::test_small_flat_multimap();
+    #endif
+
+public:
+
+    using allocator_type         = Allocator;
+    using allocator_traits       = std::allocator_traits<allocator_type>;
+    using key_type               = Key;
+    using mapped_type            = T;
+    using value_type             = std::pair<Key, T>;
+    using size_type              = typename allocator_traits::size_type;
+    using difference_type        = typename allocator_traits::difference_type;
+    using key_compare            = Compare;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using pointer                = typename allocator_traits::pointer;
+    using const_pointer          = typename allocator_traits::const_pointer;
+    using iterator               = sfl::dtl::normal_iterator<pointer, small_flat_multimap>;
+    using const_iterator         = sfl::dtl::normal_iterator<const_pointer, small_flat_multimap>;
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    class value_compare : protected key_compare
+    {
+        friend class small_flat_multimap;
+
+    private:
+
+        value_compare(const key_compare& c) : key_compare(c)
+        {}
+
+    public:
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_compare::operator()(x.first, y.first);
+        }
+    };
+
+    static_assert
+    (
+        std::is_same<typename Allocator::value_type, value_type>::value,
+        "Allocator::value_type must be same as sfl::small_flat_multimap::value_type."
+    );
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+private:
+
+    // Like `value_compare` but with additional operators.
+    // For internal use only.
+    class ultra_compare : public key_compare
+    {
+    public:
+
+        ultra_compare() noexcept(std::is_nothrow_default_constructible<key_compare>::value)
+        {}
+
+        ultra_compare(const key_compare& c) noexcept(std::is_nothrow_copy_constructible<key_compare>::value)
+            : key_compare(c)
+        {}
+
+        ultra_compare(key_compare&& c) noexcept(std::is_nothrow_move_constructible<key_compare>::value)
+            : key_compare(std::move(c))
+        {}
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_compare::operator()(x.first, y.first);
+        }
+
+        template <typename K>
+        bool operator()(const value_type& x, const K& y) const
+        {
+            return key_compare::operator()(x.first, y);
+        }
+
+        template <typename K>
+        bool operator()(const K& x, const value_type& y) const
+        {
+            return key_compare::operator()(x, y.first);
+        }
+    };
+
+    template <bool WithInternalStorage = true, typename = void>
+    class data_base
+    {
+    private:
+
+        union
+        {
+            value_type internal_storage_[N];
+        };
+
+    public:
+
+        pointer first_;
+        pointer last_;
+        pointer eos_;
+
+        data_base() noexcept
+            : first_(std::pointer_traits<pointer>::pointer_to(*internal_storage_))
+            , last_(first_)
+            , eos_(first_ + N)
+        {}
+
+        #if defined(__clang__) && (__clang_major__ == 3) // For CentOS 7
+        ~data_base()
+        {}
+        #else
+        ~data_base() noexcept
+        {}
+        #endif
+
+        pointer internal_storage() noexcept
+        {
+            return std::pointer_traits<pointer>::pointer_to(*internal_storage_);
+        }
+    };
+
+    template <typename Dummy>
+    class data_base<false, Dummy>
+    {
+    public:
+
+        pointer first_;
+        pointer last_;
+        pointer eos_;
+
+        data_base() noexcept
+            : first_(nullptr)
+            , last_(nullptr)
+            , eos_(nullptr)
+        {}
+
+        pointer internal_storage() noexcept
+        {
+            return nullptr;
+        }
+    };
+
+    class data : public data_base<(N > 0)>, public allocator_type, public ultra_compare
+    {
+    public:
+
+        data() noexcept
+        (
+            std::is_nothrow_default_constructible<allocator_type>::value &&
+            std::is_nothrow_default_constructible<ultra_compare>::value
+        )
+            : allocator_type()
+            , ultra_compare()
+        {}
+
+        data(const ultra_compare& comp) noexcept
+        (
+            std::is_nothrow_default_constructible<allocator_type>::value &&
+            std::is_nothrow_copy_constructible<ultra_compare>::value
+        )
+            : allocator_type()
+            , ultra_compare(comp)
+        {}
+
+        data(const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_default_constructible<ultra_compare>::value
+        )
+            : allocator_type(alloc)
+            , ultra_compare()
+        {}
+
+        data(const ultra_compare& comp, const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_copy_constructible<ultra_compare>::value
+        )
+            : allocator_type(alloc)
+            , ultra_compare(comp)
+        {}
+
+        data(ultra_compare&& comp, allocator_type&& alloc) noexcept
+        (
+            std::is_nothrow_move_constructible<allocator_type>::value &&
+            std::is_nothrow_move_constructible<ultra_compare>::value
+        )
+            : allocator_type(std::move(alloc))
+            , ultra_compare(std::move(comp))
+        {}
+
+        data(ultra_compare&& comp, const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_move_constructible<ultra_compare>::value
+        )
+            : allocator_type(alloc)
+            , ultra_compare(std::move(comp))
+        {}
+
+        allocator_type& ref_to_alloc() noexcept
+        {
+            return *this;
+        }
+
+        const allocator_type& ref_to_alloc() const noexcept
+        {
+            return *this;
+        }
+
+        ultra_compare& ref_to_comp() noexcept
+        {
+            return *this;
+        }
+
+        const ultra_compare& ref_to_comp() const noexcept
+        {
+            return *this;
+        }
+    };
+
+    data data_;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    small_flat_multimap() noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : data_()
+    {}
+
+    explicit small_flat_multimap(const Compare& comp) noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : data_(comp)
+    {}
+
+    explicit small_flat_multimap(const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : data_(alloc)
+    {}
+
+    explicit small_flat_multimap(const Compare& comp, const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : data_(comp, alloc)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_flat_multimap(InputIt first, InputIt last)
+        : data_()
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_flat_multimap(InputIt first, InputIt last, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_flat_multimap(InputIt first, InputIt last, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_flat_multimap(InputIt first, InputIt last, const Compare& comp,
+                                                     const Allocator& alloc)
+        : data_(comp, alloc)
+    {
+        initialize_range(first, last);
+    }
+
+    small_flat_multimap(std::initializer_list<value_type> ilist)
+        : small_flat_multimap(ilist.begin(), ilist.end())
+    {}
+
+    small_flat_multimap(std::initializer_list<value_type> ilist,
+                   const Compare& comp)
+        : small_flat_multimap(ilist.begin(), ilist.end(), comp)
+    {}
+
+    small_flat_multimap(std::initializer_list<value_type> ilist,
+                   const Allocator& alloc)
+        : small_flat_multimap(ilist.begin(), ilist.end(), alloc)
+    {}
+
+    small_flat_multimap(std::initializer_list<value_type> ilist,
+                        const Compare& comp, const Allocator& alloc)
+        : small_flat_multimap(ilist.begin(), ilist.end(), comp, alloc)
+    {}
+
+    small_flat_multimap(const small_flat_multimap& other)
+        : data_
+        (
+            other.data_.ref_to_comp(),
+            allocator_traits::select_on_container_copy_construction
+            (
+                other.data_.ref_to_alloc()
+            )
+        )
+    {
+        initialize_copy(other);
+    }
+
+    small_flat_multimap(const small_flat_multimap& other, const Allocator& alloc)
+        : data_
+        (
+            other.data_.ref_to_comp(),
+            alloc
+        )
+    {
+        initialize_copy(other);
+    }
+
+    small_flat_multimap(small_flat_multimap&& other)
+        : data_
+        (
+            std::move(other.data_.ref_to_comp()),
+            std::move(other.data_.ref_to_alloc())
+        )
+    {
+        initialize_move(other);
+    }
+
+    small_flat_multimap(small_flat_multimap&& other, const Allocator& alloc)
+        : data_
+        (
+            std::move(other.data_.ref_to_comp()),
+            alloc
+        )
+    {
+        initialize_move(other);
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_flat_multimap(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_flat_multimap(sfl::from_range_t, Range&& range, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_flat_multimap(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_flat_multimap(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : data_(comp, alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    small_flat_multimap(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_flat_multimap(sfl::from_range_t, Range&& range, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_flat_multimap(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_flat_multimap(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : data_(comp, alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~small_flat_multimap()
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        if (data_.first_ != data_.internal_storage())
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                std::distance(data_.first_, data_.eos_)
+            );
+        }
+    }
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    small_flat_multimap& operator=(const small_flat_multimap& other)
+    {
+        assign_copy(other);
+        return *this;
+    }
+
+    small_flat_multimap& operator=(small_flat_multimap&& other)
+    {
+        assign_move(other);
+        return *this;
+    }
+
+    small_flat_multimap& operator=(std::initializer_list<value_type> ilist)
+    {
+        clear();
+        insert(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- ALLOCATOR ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    allocator_type get_allocator() const noexcept
+    {
+        return data_.ref_to_alloc();
+    }
+
+    //
+    // ---- KEY COMPARE -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_compare key_comp() const
+    {
+        return data_.ref_to_comp();
+    }
+
+    //
+    // ---- VALUE COMPARE -----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_compare value_comp() const
+    {
+        return value_compare(data_.ref_to_comp());
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    iterator nth(size_type pos) noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_iterator nth(size_type pos) const noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return const_iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    size_type index_of(const_iterator pos) const noexcept
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return std::distance(cbegin(), pos);
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return data_.first_ == data_.last_;
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return std::distance(data_.first_, data_.last_);
+    }
+
+    SFL_NODISCARD
+    size_type max_size() const noexcept
+    {
+        return std::min<size_type>
+        (
+            allocator_traits::max_size(data_.ref_to_alloc()),
+            std::numeric_limits<difference_type>::max() / sizeof(value_type)
+        );
+    }
+
+    SFL_NODISCARD
+    size_type capacity() const noexcept
+    {
+        return std::distance(data_.first_, data_.eos_);
+    }
+
+    SFL_NODISCARD
+    size_type available() const noexcept
+    {
+        return std::distance(data_.last_, data_.eos_);
+    }
+
+    void reserve(size_type new_cap)
+    {
+        check_size(new_cap, "sfl::small_flat_multimap::reserve");
+
+        if (new_cap > capacity())
+        {
+            if (new_cap <= N)
+            {
+                if (data_.first_ == data_.internal_storage())
+                {
+                    // Do nothing. We are already using internal storage.
+                }
+                else
+                {
+                    // We are not using internal storage but new capacity
+                    // can fit in internal storage.
+
+                    pointer new_first = data_.internal_storage();
+                    pointer new_last  = new_first;
+                    pointer new_eos   = new_first + N;
+
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_
+                    );
+
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+
+                    data_.first_ = new_first;
+                    data_.last_  = new_last;
+                    data_.eos_   = new_eos;
+                }
+            }
+            else
+            {
+                pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                pointer new_last  = new_first;
+                pointer new_eos   = new_first + new_cap;
+
+                SFL_TRY
+                {
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+                }
+                SFL_CATCH (...)
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+
+                    SFL_RETHROW;
+                }
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_
+                );
+
+                if (data_.first_ != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+                }
+
+                data_.first_ = new_first;
+                data_.last_  = new_last;
+                data_.eos_   = new_eos;
+            }
+        }
+    }
+
+    void shrink_to_fit()
+    {
+        const size_type new_cap = size();
+
+        if (new_cap < capacity())
+        {
+            if (new_cap <= N)
+            {
+                if (data_.first_ == data_.internal_storage())
+                {
+                    // Do nothing. We are already using internal storage.
+                }
+                else
+                {
+                    // We are not using internal storage but new capacity
+                    // can fit in internal storage.
+
+                    pointer new_first = data_.internal_storage();
+                    pointer new_last  = new_first;
+                    pointer new_eos   = new_first + N;
+
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_
+                    );
+
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+
+                    data_.first_ = new_first;
+                    data_.last_  = new_last;
+                    data_.eos_   = new_eos;
+                }
+            }
+            else
+            {
+                pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                pointer new_last  = new_first;
+                pointer new_eos   = new_first + new_cap;
+
+                SFL_TRY
+                {
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+                }
+                SFL_CATCH (...)
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+
+                    SFL_RETHROW;
+                }
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_
+                );
+
+                if (data_.first_ != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+                }
+
+                data_.first_ = new_first;
+                data_.last_  = new_last;
+                data_.eos_   = new_eos;
+            }
+        }
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear() noexcept
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        data_.last_ = data_.first_;
+    }
+
+    template <typename... Args>
+    iterator emplace(Args&&... args)
+    {
+        return insert_aux(value_type(std::forward<Args>(args)...));
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value_type(std::forward<Args>(args)...));
+    }
+
+    iterator insert(const value_type& value)
+    {
+        return insert_aux(value);
+    }
+
+    iterator insert(value_type&& value)
+    {
+        return insert_aux(std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P&&>::value>* = nullptr>
+    iterator insert(P&& value)
+    {
+        return insert_aux(value_type(std::forward<P>(value)));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P&&>::value>* = nullptr>
+    iterator insert(const_iterator hint, P&& value)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value_type(std::forward<P>(value)));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    iterator erase(iterator pos)
+    {
+        return erase(const_iterator(pos));
+    }
+
+    iterator erase(const_iterator pos)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos < cend());
+
+        const pointer p = data_.first_ + std::distance(cbegin(), pos);
+
+        data_.last_ = sfl::dtl::move(p + 1, data_.last_, p);
+
+        sfl::dtl::destroy_at_a(data_.ref_to_alloc(), data_.last_);
+
+        return iterator(p);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        SFL_ASSERT(cbegin() <= first && first <= last && last <= cend());
+
+        if (first == last)
+        {
+            return begin() + std::distance(cbegin(), first);
+        }
+
+        const pointer p1 = data_.first_ + std::distance(cbegin(), first);
+        const pointer p2 = data_.first_ + std::distance(cbegin(), last);
+
+        const pointer new_last = sfl::dtl::move(p2, data_.last_, p1);
+
+        sfl::dtl::destroy_a(data_.ref_to_alloc(), new_last, data_.last_);
+
+        data_.last_ = new_last;
+
+        return iterator(p1);
+    }
+
+    size_type erase(const Key& key)
+    {
+        const auto er = equal_range(key);
+        const auto n = std::distance(er.first, er.second);
+        erase(er.first, er.second);
+        return n;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        const auto er = equal_range(x);
+        const auto n = std::distance(er.first, er.second);
+        erase(er.first, er.second);
+        return n;
+    }
+
+    void swap(small_flat_multimap& other)
+    {
+        if (this == &other)
+        {
+            return;
+        }
+
+        using std::swap;
+
+        SFL_ASSERT
+        (
+            allocator_traits::propagate_on_container_swap::value ||
+            this->data_.ref_to_alloc() == other.data_.ref_to_alloc()
+        );
+
+        // If this and other allocator compares equal then one allocator
+        // can deallocate memory allocated by another allocator.
+        // One allocator can safely destroy_a elements constructed by other
+        // allocator regardless the two allocators compare equal or not.
+
+        if (allocator_traits::propagate_on_container_swap::value)
+        {
+            swap(this->data_.ref_to_alloc(), other.data_.ref_to_alloc());
+        }
+
+        swap(this->data_.ref_to_comp(), other.data_.ref_to_comp());
+
+        if
+        (
+            this->data_.first_ == this->data_.internal_storage() &&
+            other.data_.first_ == other.data_.internal_storage()
+        )
+        {
+            const size_type this_size  = this->size();
+            const size_type other_size = other.size();
+
+            if (this_size <= other_size)
+            {
+                std::swap_ranges
+                (
+                    this->data_.first_,
+                    this->data_.first_ + this_size,
+                    other.data_.first_
+                );
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    this->data_.ref_to_alloc(),
+                    other.data_.first_ + this_size,
+                    other.data_.first_ + other_size,
+                    this->data_.first_ + this_size
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    other.data_.ref_to_alloc(),
+                    other.data_.first_ + this_size,
+                    other.data_.first_ + other_size
+                );
+            }
+            else
+            {
+                std::swap_ranges
+                (
+                    other.data_.first_,
+                    other.data_.first_ + other_size,
+                    this->data_.first_
+                );
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    other.data_.ref_to_alloc(),
+                    this->data_.first_ + other_size,
+                    this->data_.first_ + this_size,
+                    other.data_.first_ + other_size
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    this->data_.ref_to_alloc(),
+                    this->data_.first_ + other_size,
+                    this->data_.first_ + this_size
+                );
+            }
+
+            this->data_.last_ = this->data_.first_ + other_size;
+            other.data_.last_ = other.data_.first_ + this_size;
+        }
+        else if
+        (
+            this->data_.first_ == this->data_.internal_storage() &&
+            other.data_.first_ != other.data_.internal_storage()
+        )
+        {
+            pointer new_other_first = other.data_.internal_storage();
+            pointer new_other_last  = new_other_first;
+            pointer new_other_eos   = new_other_first + N;
+
+            new_other_last = sfl::dtl::uninitialized_move_a
+            (
+                other.data_.ref_to_alloc(),
+                this->data_.first_,
+                this->data_.last_,
+                new_other_first
+            );
+
+            sfl::dtl::destroy_a
+            (
+                this->data_.ref_to_alloc(),
+                this->data_.first_,
+                this->data_.last_
+            );
+
+            this->data_.first_ = other.data_.first_;
+            this->data_.last_  = other.data_.last_;
+            this->data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = new_other_first;
+            other.data_.last_  = new_other_last;
+            other.data_.eos_   = new_other_eos;
+        }
+        else if
+        (
+            this->data_.first_ != this->data_.internal_storage() &&
+            other.data_.first_ == other.data_.internal_storage()
+        )
+        {
+            pointer new_this_first = this->data_.internal_storage();
+            pointer new_this_last  = new_this_first;
+            pointer new_this_eos   = new_this_first + N;
+
+            new_this_last = sfl::dtl::uninitialized_move_a
+            (
+                this->data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                new_this_first
+            );
+
+            sfl::dtl::destroy_a
+            (
+                other.data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_
+            );
+
+            other.data_.first_ = this->data_.first_;
+            other.data_.last_  = this->data_.last_;
+            other.data_.eos_   = this->data_.eos_;
+
+            this->data_.first_ = new_this_first;
+            this->data_.last_  = new_this_last;
+            this->data_.eos_   = new_this_eos;
+        }
+        else
+        {
+            swap(this->data_.first_, other.data_.first_);
+            swap(this->data_.last_,  other.data_.last_);
+            swap(this->data_.eos_,   other.data_.eos_);
+        }
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator lower_bound(const Key& key)
+    {
+        return std::lower_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    const_iterator lower_bound(const Key& key) const
+    {
+        return std::lower_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator lower_bound(const K& x)
+    {
+        return std::lower_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator lower_bound(const K& x) const
+    {
+        return std::lower_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    iterator upper_bound(const Key& key)
+    {
+        return std::upper_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    const_iterator upper_bound(const Key& key) const
+    {
+        return std::upper_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator upper_bound(const K& x)
+    {
+        return std::upper_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator upper_bound(const K& x) const
+    {
+        return std::upper_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const Key& key)
+    {
+        return std::equal_range(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const
+    {
+        return std::equal_range(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const K& x)
+    {
+        return std::equal_range(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const K& x) const
+    {
+        return std::equal_range(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        auto it = lower_bound(key);
+
+        if (it != end() && data_.ref_to_comp()(key, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        auto it = lower_bound(key);
+
+        if (it != end() && data_.ref_to_comp()(key, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        auto it = lower_bound(x);
+
+        if (it != end() && data_.ref_to_comp()(x, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        auto it = lower_bound(x);
+
+        if (it != end() && data_.ref_to_comp()(x, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        const auto er = equal_range(key);
+        return std::distance(er.first, er.second);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        const auto er = equal_range(x);
+        return std::distance(er.first, er.second);
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    //
+    // ---- ELEMENT ACCESS ----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_type* data() noexcept
+    {
+        return sfl::dtl::to_address(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const value_type* data() const noexcept
+    {
+        return sfl::dtl::to_address(data_.first_);
+    }
+
+private:
+
+    void check_size(size_type n, const char* msg)
+    {
+        if (n > max_size())
+        {
+            sfl::dtl::throw_length_error(msg);
+        }
+    }
+
+    size_type calculate_new_capacity(size_type num_additional_elements, const char* msg)
+    {
+        const size_type size = this->size();
+        const size_type capacity = this->capacity();
+        const size_type max_size = this->max_size();
+
+        if (max_size - size < num_additional_elements)
+        {
+            sfl::dtl::throw_length_error(msg);
+        }
+        else if (max_size - capacity < capacity / 2)
+        {
+            return max_size;
+        }
+        else if (size + num_additional_elements < capacity + capacity / 2)
+        {
+            return std::max(N, capacity + capacity / 2);
+        }
+        else
+        {
+            return std::max(N, size + num_additional_elements);
+        }
+    }
+
+    void reset(size_type new_cap = N)
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        if (data_.first_ != data_.internal_storage())
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                std::distance(data_.first_, data_.eos_)
+            );
+        }
+
+        data_.first_ = data_.internal_storage();
+        data_.last_  = data_.first_;
+        data_.eos_   = data_.first_ + N;
+
+        if (new_cap > N)
+        {
+            data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+            data_.last_  = data_.first_;
+            data_.eos_   = data_.first_ + new_cap;
+
+            // If allocation throws, first_, last_ and eos_ will be valid
+            // (they will be pointing to internal_storage).
+        }
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void initialize_range(InputIt first, Sentinel last)
+    {
+        SFL_TRY
+        {
+            while (first != last)
+            {
+                insert(*first);
+                ++first;
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            if (data_.first_ != data_.internal_storage())
+            {
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    std::distance(data_.first_, data_.eos_)
+                );
+            }
+
+            SFL_RETHROW;
+        }
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void initialize_range(Range&& range)
+    {
+        initialize_range(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void initialize_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        initialize_range(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    void initialize_copy(const small_flat_multimap& other)
+    {
+        const size_type n = other.size();
+
+        check_size(n, "sfl::small_flat_multimap::initialize_copy");
+
+        if (n > N)
+        {
+            data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+            data_.last_  = data_.first_;
+            data_.eos_   = data_.first_ + n;
+        }
+
+        SFL_TRY
+        {
+            data_.last_ = sfl::dtl::uninitialized_copy_a
+            (
+                data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                data_.first_
+            );
+        }
+        SFL_CATCH (...)
+        {
+            if (n > N)
+            {
+                sfl::dtl::deallocate(data_.ref_to_alloc(), data_.first_, n);
+            }
+
+            SFL_RETHROW;
+        }
+    }
+
+    void initialize_move(small_flat_multimap& other)
+    {
+        if (other.data_.first_ == other.data_.internal_storage())
+        {
+            data_.last_ = sfl::dtl::uninitialized_move_a
+            (
+                data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                data_.first_
+            );
+        }
+        else if (data_.ref_to_alloc() == other.data_.ref_to_alloc())
+        {
+            data_.first_ = other.data_.first_;
+            data_.last_  = other.data_.last_;
+            data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = nullptr;
+            other.data_.last_  = nullptr;
+            other.data_.eos_   = nullptr;
+        }
+        else
+        {
+            const size_type n = other.size();
+
+            check_size(n, "sfl::small_flat_multimap::initialize_move");
+
+            if (n > N)
+            {
+                data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+                data_.last_  = data_.first_;
+                data_.eos_   = data_.first_ + n;
+            }
+
+            SFL_TRY
+            {
+                data_.last_ = sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    other.data_.first_,
+                    other.data_.last_,
+                    data_.first_
+                );
+            }
+            SFL_CATCH (...)
+            {
+                if (n > N)
+                {
+                    sfl::dtl::deallocate(data_.ref_to_alloc(), data_.first_, n);
+                }
+
+                SFL_RETHROW;
+            }
+        }
+    }
+
+    template <typename ForwardIt>
+    void assign_range(ForwardIt first, ForwardIt last)
+    {
+        const size_type n = std::distance(first, last);
+
+        check_size(n, "sfl::small_flat_multimap::assign_range");
+
+        if (n <= capacity())
+        {
+            const size_type s = size();
+
+            if (n <= s)
+            {
+                pointer new_last = sfl::dtl::copy
+                (
+                    first,
+                    last,
+                    data_.first_
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    new_last,
+                    data_.last_
+                );
+
+                data_.last_ = new_last;
+            }
+            else
+            {
+                ForwardIt mid = std::next(first, s);
+
+                sfl::dtl::copy
+                (
+                    first,
+                    mid,
+                    data_.first_
+                );
+
+                data_.last_ = sfl::dtl::uninitialized_copy_a
+                (
+                    data_.ref_to_alloc(),
+                    mid,
+                    last,
+                    data_.last_
+                );
+            }
+        }
+        else
+        {
+            reset(n);
+
+            data_.last_ = sfl::dtl::uninitialized_copy_a
+            (
+                data_.ref_to_alloc(),
+                first,
+                last,
+                data_.first_
+            );
+        }
+    }
+
+    void assign_copy(const small_flat_multimap& other)
+    {
+        if (this != &other)
+        {
+            if (allocator_traits::propagate_on_container_copy_assignment::value)
+            {
+                if (data_.ref_to_alloc() != other.data_.ref_to_alloc())
+                {
+                    reset();
+                }
+
+                data_.ref_to_alloc() = other.data_.ref_to_alloc();
+            }
+
+            data_.ref_to_comp() = other.data_.ref_to_comp();
+
+            assign_range(other.data_.first_, other.data_.last_);
+        }
+    }
+
+    void assign_move(small_flat_multimap& other)
+    {
+        if (allocator_traits::propagate_on_container_move_assignment::value)
+        {
+            if (data_.ref_to_alloc() != other.data_.ref_to_alloc())
+            {
+                reset();
+            }
+
+            data_.ref_to_alloc() = std::move(other.data_.ref_to_alloc());
+        }
+
+        data_.ref_to_comp() = other.data_.ref_to_comp();
+
+        if (other.data_.first_ == other.data_.internal_storage())
+        {
+            assign_range
+            (
+                std::make_move_iterator(other.data_.first_),
+                std::make_move_iterator(other.data_.last_)
+            );
+        }
+        else if (data_.ref_to_alloc() == other.data_.ref_to_alloc())
+        {
+            reset();
+
+            data_.first_ = other.data_.first_;
+            data_.last_  = other.data_.last_;
+            data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = nullptr;
+            other.data_.last_  = nullptr;
+            other.data_.eos_   = nullptr;
+        }
+        else
+        {
+            assign_range
+            (
+                std::make_move_iterator(other.data_.first_),
+                std::make_move_iterator(other.data_.last_)
+            );
+        }
+    }
+
+    template <typename Value>
+    iterator insert_aux(Value&& value)
+    {
+        return insert_exactly_at(lower_bound(value.first), std::forward<Value>(value));
+    }
+
+    template <typename Value>
+    iterator insert_aux(const_iterator hint, Value&& value)
+    {
+        if (is_insert_hint_good(hint, value))
+        {
+            return insert_exactly_at(hint, std::forward<Value>(value));
+        }
+
+        // Hint is not good. Use non-hinted function.
+        return insert_aux(std::forward<Value>(value));
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+
+    template <typename Value>
+    iterator insert_exactly_at(const_iterator pos, Value&& value)
+    {
+        if (data_.last_ != data_.eos_)
+        {
+            const pointer p1 = data_.first_ + std::distance(cbegin(), pos);
+
+            if (p1 == data_.last_)
+            {
+                sfl::dtl::construct_at_a
+                (
+                    data_.ref_to_alloc(),
+                    p1,
+                    std::forward<Value>(value)
+                );
+
+                ++data_.last_;
+            }
+            else
+            {
+                // This container can contain duplicates.
+                // Create temporary value before making place for new element.
+                value_type temp(std::forward<Value>(value));
+
+                const pointer p2 = data_.last_ - 1;
+
+                const pointer old_last = data_.last_;
+
+                sfl::dtl::construct_at_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.last_,
+                    std::move(*p2)
+                );
+
+                ++data_.last_;
+
+                sfl::dtl::move_backward
+                (
+                    p1,
+                    p2,
+                    old_last
+                );
+
+                *p1 = std::move(temp);
+            }
+
+            return iterator(p1);
+        }
+        else
+        {
+            const difference_type offset = std::distance(cbegin(), pos);
+
+            const size_type new_cap =
+                calculate_new_capacity(1, "sfl::small_flat_multimap::insert_exactly_at");
+
+            pointer new_first;
+            pointer new_last;
+            pointer new_eos;
+
+            if (new_cap <= N && data_.first_ != data_.internal_storage())
+            {
+                new_first = data_.internal_storage();
+                new_last  = new_first;
+                new_eos   = new_first + N;
+            }
+            else
+            {
+                new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                new_last  = new_first;
+                new_eos   = new_first + new_cap;
+            }
+
+            const pointer p = new_first + offset;
+
+            SFL_TRY
+            {
+                sfl::dtl::construct_at_a
+                (
+                    data_.ref_to_alloc(),
+                    p,
+                    std::forward<Value>(value)
+                );
+
+                new_last = nullptr;
+
+                const pointer mid = data_.first_ + offset;
+
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    mid,
+                    new_first
+                );
+
+                ++new_last;
+
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    mid,
+                    data_.last_,
+                    new_last
+                );
+            }
+            SFL_CATCH (...)
+            {
+                if (new_last == nullptr)
+                {
+                    sfl::dtl::destroy_at_a
+                    (
+                        data_.ref_to_alloc(),
+                        p
+                    );
+                }
+                else
+                {
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_last
+                    );
+                }
+
+                if (new_first != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+                }
+
+                SFL_RETHROW;
+            }
+
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            if (data_.first_ != data_.internal_storage())
+            {
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    std::distance(data_.first_, data_.eos_)
+                );
+            }
+
+            data_.first_ = new_first;
+            data_.last_  = new_last;
+            data_.eos_   = new_eos;
+
+            return iterator(p);
+        }
+    }
+
+    template <typename Value>
+    bool is_insert_hint_good(const_iterator hint, const Value& value)
+    {
+        return
+            // If `hint` == `value`
+            (
+                hint != end() &&
+                !data_.ref_to_comp()(*hint, value) &&
+                !data_.ref_to_comp()(value, *hint)
+            )
+            ||
+            // If `hint - 1` == `value`
+            (
+                hint != begin() &&
+                !data_.ref_to_comp()(*(hint - 1), value) &&
+                !data_.ref_to_comp()(value, *(hint - 1))
+            )
+            ||
+            // If `hint - 1` < `value` and `value` < `hint`
+            (
+                (hint == begin() || data_.ref_to_comp()(*(hint - 1), value)) &&
+                (hint == end()   || data_.ref_to_comp()(value, *hint))
+            );
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator==
+(
+    const small_flat_multimap<K, T, N, C, A>& x,
+    const small_flat_multimap<K, T, N, C, A>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator!=
+(
+    const small_flat_multimap<K, T, N, C, A>& x,
+    const small_flat_multimap<K, T, N, C, A>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator<
+(
+    const small_flat_multimap<K, T, N, C, A>& x,
+    const small_flat_multimap<K, T, N, C, A>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator>
+(
+    const small_flat_multimap<K, T, N, C, A>& x,
+    const small_flat_multimap<K, T, N, C, A>& y
+)
+{
+    return y < x;
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator<=
+(
+    const small_flat_multimap<K, T, N, C, A>& x,
+    const small_flat_multimap<K, T, N, C, A>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator>=
+(
+    const small_flat_multimap<K, T, N, C, A>& x,
+    const small_flat_multimap<K, T, N, C, A>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+void swap
+(
+    small_flat_multimap<K, T, N, C, A>& x,
+    small_flat_multimap<K, T, N, C, A>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A,
+          typename Predicate>
+typename small_flat_multimap<K, T, N, C, A>::size_type
+    erase_if(small_flat_multimap<K, T, N, C, A>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_SMALL_FLAT_MULTIMAP_HPP_INCLUDED

--- a/src/thirdparty/sfl/small_flat_multiset.hpp
+++ b/src/thirdparty/sfl/small_flat_multiset.hpp
@@ -1,0 +1,1983 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_SMALL_FLAT_MULTISET_HPP_INCLUDED
+#define SFL_SMALL_FLAT_MULTISET_HPP_INCLUDED
+
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/exceptions.hpp>
+#include <sfl/detail/initialized_memory_algorithms.hpp>
+#include <sfl/detail/normal_iterator.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/to_address.hpp>
+#include <sfl/detail/type_traits.hpp>
+#include <sfl/detail/uninitialized_memory_algorithms.hpp>
+
+#include <algorithm>        // copy, move, lower_bound, swap, swap_ranges
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <iterator>         // distance, next, reverse_iterator
+#include <limits>           // numeric_limits
+#include <memory>           // allocator, allocator_traits, pointer_traits
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+#ifdef SFL_TEST_SMALL_FLAT_MULTISET
+template <int>
+void test_small_flat_multiset();
+#endif
+
+namespace sfl
+{
+
+template < typename Key,
+           std::size_t N,
+           typename Compare = std::less<Key>,
+           typename Allocator = std::allocator<Key> >
+class small_flat_multiset
+{
+    #ifdef SFL_TEST_SMALL_FLAT_MULTISET
+    template <int>
+    friend void ::test_small_flat_multiset();
+    #endif
+
+public:
+
+    using allocator_type         = Allocator;
+    using allocator_traits       = std::allocator_traits<allocator_type>;
+    using key_type               = Key;
+    using value_type             = Key;
+    using size_type              = typename allocator_traits::size_type;
+    using difference_type        = typename allocator_traits::difference_type;
+    using key_compare            = Compare;
+    using value_compare          = Compare;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using pointer                = typename allocator_traits::pointer;
+    using const_pointer          = typename allocator_traits::const_pointer;
+    using iterator               = sfl::dtl::normal_iterator<const_pointer, small_flat_multiset>; // MUST BE const_pointer
+    using const_iterator         = sfl::dtl::normal_iterator<const_pointer, small_flat_multiset>;
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    static_assert
+    (
+        std::is_same<typename Allocator::value_type, value_type>::value,
+        "Allocator::value_type must be same as sfl::small_flat_multiset::value_type."
+    );
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+private:
+
+    template <bool WithInternalStorage = true, typename = void>
+    class data_base
+    {
+    private:
+
+        union
+        {
+            value_type internal_storage_[N];
+        };
+
+    public:
+
+        pointer first_;
+        pointer last_;
+        pointer eos_;
+
+        data_base() noexcept
+            : first_(std::pointer_traits<pointer>::pointer_to(*internal_storage_))
+            , last_(first_)
+            , eos_(first_ + N)
+        {}
+
+        #if defined(__clang__) && (__clang_major__ == 3) // For CentOS 7
+        ~data_base()
+        {}
+        #else
+        ~data_base() noexcept
+        {}
+        #endif
+
+        pointer internal_storage() noexcept
+        {
+            return std::pointer_traits<pointer>::pointer_to(*internal_storage_);
+        }
+    };
+
+    template <typename Dummy>
+    class data_base<false, Dummy>
+    {
+    public:
+
+        pointer first_;
+        pointer last_;
+        pointer eos_;
+
+        data_base() noexcept
+            : first_(nullptr)
+            , last_(nullptr)
+            , eos_(nullptr)
+        {}
+
+        pointer internal_storage() noexcept
+        {
+            return nullptr;
+        }
+    };
+
+    class data : public data_base<(N > 0)>, public allocator_type, public value_compare
+    {
+    public:
+
+        data() noexcept
+        (
+            std::is_nothrow_default_constructible<allocator_type>::value &&
+            std::is_nothrow_default_constructible<value_compare>::value
+        )
+            : allocator_type()
+            , value_compare()
+        {}
+
+        data(const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_default_constructible<value_compare>::value
+        )
+            : allocator_type(alloc)
+            , value_compare()
+        {}
+
+        data(const value_compare& comp) noexcept
+        (
+            std::is_nothrow_default_constructible<allocator_type>::value &&
+            std::is_nothrow_copy_constructible<value_compare>::value
+        )
+            : allocator_type()
+            , value_compare(comp)
+        {}
+
+        data(const value_compare& comp, const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_copy_constructible<value_compare>::value
+        )
+            : allocator_type(alloc)
+            , value_compare(comp)
+        {}
+
+        data(value_compare&& comp, allocator_type&& alloc) noexcept
+        (
+            std::is_nothrow_move_constructible<allocator_type>::value &&
+            std::is_nothrow_move_constructible<value_compare>::value
+        )
+            : allocator_type(std::move(alloc))
+            , value_compare(std::move(comp))
+        {}
+
+        data(value_compare&& comp, const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_move_constructible<value_compare>::value
+        )
+            : allocator_type(alloc)
+            , value_compare(std::move(comp))
+        {}
+
+        allocator_type& ref_to_alloc() noexcept
+        {
+            return *this;
+        }
+
+        const allocator_type& ref_to_alloc() const noexcept
+        {
+            return *this;
+        }
+
+        value_compare& ref_to_comp() noexcept
+        {
+            return *this;
+        }
+
+        const value_compare& ref_to_comp() const noexcept
+        {
+            return *this;
+        }
+    };
+
+    data data_;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    small_flat_multiset() noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : data_()
+    {}
+
+    explicit small_flat_multiset(const Compare& comp) noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : data_(comp)
+    {}
+
+    explicit small_flat_multiset(const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : data_(alloc)
+    {}
+
+    explicit small_flat_multiset(const Compare& comp, const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : data_(comp, alloc)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_flat_multiset(InputIt first, InputIt last)
+        : data_()
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_flat_multiset(InputIt first, InputIt last, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_flat_multiset(InputIt first, InputIt last, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_flat_multiset(InputIt first, InputIt last, const Compare& comp,
+                                                     const Allocator& alloc)
+        : data_(comp, alloc)
+    {
+        initialize_range(first, last);
+    }
+
+    small_flat_multiset(std::initializer_list<value_type> ilist)
+        : small_flat_multiset(ilist.begin(), ilist.end())
+    {}
+
+    small_flat_multiset(std::initializer_list<value_type> ilist,
+                        const Compare& comp)
+        : small_flat_multiset(ilist.begin(), ilist.end(), comp)
+    {}
+
+    small_flat_multiset(std::initializer_list<value_type> ilist,
+                        const Allocator& alloc)
+        : small_flat_multiset(ilist.begin(), ilist.end(), alloc)
+    {}
+
+    small_flat_multiset(std::initializer_list<value_type> ilist,
+                        const Compare& comp, const Allocator& alloc)
+        : small_flat_multiset(ilist.begin(), ilist.end(), comp, alloc)
+    {}
+
+    small_flat_multiset(const small_flat_multiset& other)
+        : data_
+        (
+            other.data_.ref_to_comp(),
+            allocator_traits::select_on_container_copy_construction
+            (
+                other.data_.ref_to_alloc()
+            )
+        )
+    {
+        initialize_copy(other);
+    }
+
+    small_flat_multiset(const small_flat_multiset& other, const Allocator& alloc)
+        : data_
+        (
+            other.data_.ref_to_comp(),
+            alloc
+        )
+    {
+        initialize_copy(other);
+    }
+
+    small_flat_multiset(small_flat_multiset&& other)
+        : data_
+        (
+            std::move(other.data_.ref_to_comp()),
+            std::move(other.data_.ref_to_alloc())
+        )
+    {
+        initialize_move(other);
+    }
+
+    small_flat_multiset(small_flat_multiset&& other, const Allocator& alloc)
+        : data_
+        (
+            std::move(other.data_.ref_to_comp()),
+            alloc
+        )
+    {
+        initialize_move(other);
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_flat_multiset(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_flat_multiset(sfl::from_range_t, Range&& range, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_flat_multiset(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_flat_multiset(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : data_(comp, alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    small_flat_multiset(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_flat_multiset(sfl::from_range_t, Range&& range, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_flat_multiset(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_flat_multiset(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : data_(comp, alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~small_flat_multiset()
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        if (data_.first_ != data_.internal_storage())
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                std::distance(data_.first_, data_.eos_)
+            );
+        }
+    }
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    small_flat_multiset& operator=(const small_flat_multiset& other)
+    {
+        assign_copy(other);
+        return *this;
+    }
+
+    small_flat_multiset& operator=(small_flat_multiset&& other)
+    {
+        assign_move(other);
+        return *this;
+    }
+
+    small_flat_multiset& operator=(std::initializer_list<Key> ilist)
+    {
+        clear();
+        insert(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- ALLOCATOR ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    allocator_type get_allocator() const noexcept
+    {
+        return data_.ref_to_alloc();
+    }
+
+    //
+    // ---- KEY COMPARE -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_compare key_comp() const
+    {
+        return data_.ref_to_comp();
+    }
+
+    //
+    // ---- VALUE COMPARE -----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_compare value_comp() const
+    {
+        return data_.ref_to_comp();
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    iterator nth(size_type pos) noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_iterator nth(size_type pos) const noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return const_iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    size_type index_of(const_iterator pos) const noexcept
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return std::distance(cbegin(), pos);
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return data_.first_ == data_.last_;
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return std::distance(data_.first_, data_.last_);
+    }
+
+    SFL_NODISCARD
+    size_type max_size() const noexcept
+    {
+        return std::min<size_type>
+        (
+            allocator_traits::max_size(data_.ref_to_alloc()),
+            std::numeric_limits<difference_type>::max() / sizeof(value_type)
+        );
+    }
+
+    SFL_NODISCARD
+    size_type capacity() const noexcept
+    {
+        return std::distance(data_.first_, data_.eos_);
+    }
+
+    SFL_NODISCARD
+    size_type available() const noexcept
+    {
+        return std::distance(data_.last_, data_.eos_);
+    }
+
+    void reserve(size_type new_cap)
+    {
+        check_size(new_cap, "sfl::small_flat_multiset::reserve");
+
+        if (new_cap > capacity())
+        {
+            if (new_cap <= N)
+            {
+                if (data_.first_ == data_.internal_storage())
+                {
+                    // Do nothing. We are already using internal storage.
+                }
+                else
+                {
+                    // We are not using internal storage but new capacity
+                    // can fit in internal storage.
+
+                    pointer new_first = data_.internal_storage();
+                    pointer new_last  = new_first;
+                    pointer new_eos   = new_first + N;
+
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_
+                    );
+
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+
+                    data_.first_ = new_first;
+                    data_.last_  = new_last;
+                    data_.eos_   = new_eos;
+                }
+            }
+            else
+            {
+                pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                pointer new_last  = new_first;
+                pointer new_eos   = new_first + new_cap;
+
+                SFL_TRY
+                {
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+                }
+                SFL_CATCH (...)
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+
+                    SFL_RETHROW;
+                }
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_
+                );
+
+                if (data_.first_ != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+                }
+
+                data_.first_ = new_first;
+                data_.last_  = new_last;
+                data_.eos_   = new_eos;
+            }
+        }
+    }
+
+    void shrink_to_fit()
+    {
+        const size_type new_cap = size();
+
+        if (new_cap < capacity())
+        {
+            if (new_cap <= N)
+            {
+                if (data_.first_ == data_.internal_storage())
+                {
+                    // Do nothing. We are already using internal storage.
+                }
+                else
+                {
+                    // We are not using internal storage but new capacity
+                    // can fit in internal storage.
+
+                    pointer new_first = data_.internal_storage();
+                    pointer new_last  = new_first;
+                    pointer new_eos   = new_first + N;
+
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_
+                    );
+
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+
+                    data_.first_ = new_first;
+                    data_.last_  = new_last;
+                    data_.eos_   = new_eos;
+                }
+            }
+            else
+            {
+                pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                pointer new_last  = new_first;
+                pointer new_eos   = new_first + new_cap;
+
+                SFL_TRY
+                {
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+                }
+                SFL_CATCH (...)
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+
+                    SFL_RETHROW;
+                }
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_
+                );
+
+                if (data_.first_ != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+                }
+
+                data_.first_ = new_first;
+                data_.last_  = new_last;
+                data_.eos_   = new_eos;
+            }
+        }
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear() noexcept
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        data_.last_ = data_.first_;
+    }
+
+    template <typename... Args>
+    iterator emplace(Args&&... args)
+    {
+        return insert_aux(value_type(std::forward<Args>(args)...));
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value_type(std::forward<Args>(args)...));
+    }
+
+    iterator insert(const value_type& value)
+    {
+        return insert_aux(value);
+    }
+
+    iterator insert(value_type&& value)
+    {
+        return insert_aux(std::move(value));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, std::move(value));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    iterator erase(const_iterator pos)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos < cend());
+
+        const pointer p = data_.first_ + std::distance(cbegin(), pos);
+
+        data_.last_ = sfl::dtl::move(p + 1, data_.last_, p);
+
+        sfl::dtl::destroy_at_a(data_.ref_to_alloc(), data_.last_);
+
+        return iterator(p);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        SFL_ASSERT(cbegin() <= first && first <= last && last <= cend());
+
+        if (first == last)
+        {
+            return begin() + std::distance(cbegin(), first);
+        }
+
+        const pointer p1 = data_.first_ + std::distance(cbegin(), first);
+        const pointer p2 = data_.first_ + std::distance(cbegin(), last);
+
+        const pointer new_last = sfl::dtl::move(p2, data_.last_, p1);
+
+        sfl::dtl::destroy_a(data_.ref_to_alloc(), new_last, data_.last_);
+
+        data_.last_ = new_last;
+
+        return iterator(p1);
+    }
+
+    size_type erase(const Key& key)
+    {
+        const auto er = equal_range(key);
+        const auto n = std::distance(er.first, er.second);
+        erase(er.first, er.second);
+        return n;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        const auto er = equal_range(x);
+        const auto n = std::distance(er.first, er.second);
+        erase(er.first, er.second);
+        return n;
+    }
+
+    void swap(small_flat_multiset& other)
+    {
+        if (this == &other)
+        {
+            return;
+        }
+
+        using std::swap;
+
+        SFL_ASSERT
+        (
+            allocator_traits::propagate_on_container_swap::value ||
+            this->data_.ref_to_alloc() == other.data_.ref_to_alloc()
+        );
+
+        // If this and other allocator compares equal then one allocator
+        // can deallocate memory allocated by another allocator.
+        // One allocator can safely destroy_a elements constructed by other
+        // allocator regardless the two allocators compare equal or not.
+
+        if (allocator_traits::propagate_on_container_swap::value)
+        {
+            swap(this->data_.ref_to_alloc(), other.data_.ref_to_alloc());
+        }
+
+        swap(this->data_.ref_to_comp(), other.data_.ref_to_comp());
+
+        if
+        (
+            this->data_.first_ == this->data_.internal_storage() &&
+            other.data_.first_ == other.data_.internal_storage()
+        )
+        {
+            const size_type this_size  = this->size();
+            const size_type other_size = other.size();
+
+            if (this_size <= other_size)
+            {
+                std::swap_ranges
+                (
+                    this->data_.first_,
+                    this->data_.first_ + this_size,
+                    other.data_.first_
+                );
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    this->data_.ref_to_alloc(),
+                    other.data_.first_ + this_size,
+                    other.data_.first_ + other_size,
+                    this->data_.first_ + this_size
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    other.data_.ref_to_alloc(),
+                    other.data_.first_ + this_size,
+                    other.data_.first_ + other_size
+                );
+            }
+            else
+            {
+                std::swap_ranges
+                (
+                    other.data_.first_,
+                    other.data_.first_ + other_size,
+                    this->data_.first_
+                );
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    other.data_.ref_to_alloc(),
+                    this->data_.first_ + other_size,
+                    this->data_.first_ + this_size,
+                    other.data_.first_ + other_size
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    this->data_.ref_to_alloc(),
+                    this->data_.first_ + other_size,
+                    this->data_.first_ + this_size
+                );
+            }
+
+            this->data_.last_ = this->data_.first_ + other_size;
+            other.data_.last_ = other.data_.first_ + this_size;
+        }
+        else if
+        (
+            this->data_.first_ == this->data_.internal_storage() &&
+            other.data_.first_ != other.data_.internal_storage()
+        )
+        {
+            pointer new_other_first = other.data_.internal_storage();
+            pointer new_other_last  = new_other_first;
+            pointer new_other_eos   = new_other_first + N;
+
+            new_other_last = sfl::dtl::uninitialized_move_a
+            (
+                other.data_.ref_to_alloc(),
+                this->data_.first_,
+                this->data_.last_,
+                new_other_first
+            );
+
+            sfl::dtl::destroy_a
+            (
+                this->data_.ref_to_alloc(),
+                this->data_.first_,
+                this->data_.last_
+            );
+
+            this->data_.first_ = other.data_.first_;
+            this->data_.last_  = other.data_.last_;
+            this->data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = new_other_first;
+            other.data_.last_  = new_other_last;
+            other.data_.eos_   = new_other_eos;
+        }
+        else if
+        (
+            this->data_.first_ != this->data_.internal_storage() &&
+            other.data_.first_ == other.data_.internal_storage()
+        )
+        {
+            pointer new_this_first = this->data_.internal_storage();
+            pointer new_this_last  = new_this_first;
+            pointer new_this_eos   = new_this_first + N;
+
+            new_this_last = sfl::dtl::uninitialized_move_a
+            (
+                this->data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                new_this_first
+            );
+
+            sfl::dtl::destroy_a
+            (
+                other.data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_
+            );
+
+            other.data_.first_ = this->data_.first_;
+            other.data_.last_  = this->data_.last_;
+            other.data_.eos_   = this->data_.eos_;
+
+            this->data_.first_ = new_this_first;
+            this->data_.last_  = new_this_last;
+            this->data_.eos_   = new_this_eos;
+        }
+        else
+        {
+            swap(this->data_.first_, other.data_.first_);
+            swap(this->data_.last_,  other.data_.last_);
+            swap(this->data_.eos_,   other.data_.eos_);
+        }
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator lower_bound(const Key& key)
+    {
+        return std::lower_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    const_iterator lower_bound(const Key& key) const
+    {
+        return std::lower_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator lower_bound(const K& x)
+    {
+        return std::lower_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator lower_bound(const K& x) const
+    {
+        return std::lower_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    iterator upper_bound(const Key& key)
+    {
+        return std::upper_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    const_iterator upper_bound(const Key& key) const
+    {
+        return std::upper_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator upper_bound(const K& x)
+    {
+        return std::upper_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator upper_bound(const K& x) const
+    {
+        return std::upper_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const Key& key)
+    {
+        return std::equal_range(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const
+    {
+        return std::equal_range(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const K& x)
+    {
+        return std::equal_range(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const K& x) const
+    {
+        return std::equal_range(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        auto it = lower_bound(key);
+
+        if (it != end() && data_.ref_to_comp()(key, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        auto it = lower_bound(key);
+
+        if (it != end() && data_.ref_to_comp()(key, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        auto it = lower_bound(x);
+
+        if (it != end() && data_.ref_to_comp()(x, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        auto it = lower_bound(x);
+
+        if (it != end() && data_.ref_to_comp()(x, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        const auto er = equal_range(key);
+        return std::distance(er.first, er.second);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        const auto er = equal_range(x);
+        return std::distance(er.first, er.second);
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    //
+    // ---- ELEMENT ACCESS ----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_type* data() noexcept
+    {
+        return sfl::dtl::to_address(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const value_type* data() const noexcept
+    {
+        return sfl::dtl::to_address(data_.first_);
+    }
+
+private:
+
+    void check_size(size_type n, const char* msg)
+    {
+        if (n > max_size())
+        {
+            sfl::dtl::throw_length_error(msg);
+        }
+    }
+
+    size_type calculate_new_capacity(size_type num_additional_elements, const char* msg)
+    {
+        const size_type size = this->size();
+        const size_type capacity = this->capacity();
+        const size_type max_size = this->max_size();
+
+        if (max_size - size < num_additional_elements)
+        {
+            sfl::dtl::throw_length_error(msg);
+        }
+        else if (max_size - capacity < capacity / 2)
+        {
+            return max_size;
+        }
+        else if (size + num_additional_elements < capacity + capacity / 2)
+        {
+            return std::max(N, capacity + capacity / 2);
+        }
+        else
+        {
+            return std::max(N, size + num_additional_elements);
+        }
+    }
+
+    void reset(size_type new_cap = N)
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        if (data_.first_ != data_.internal_storage())
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                std::distance(data_.first_, data_.eos_)
+            );
+        }
+
+        data_.first_ = data_.internal_storage();
+        data_.last_  = data_.first_;
+        data_.eos_   = data_.first_ + N;
+
+        if (new_cap > N)
+        {
+            data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+            data_.last_  = data_.first_;
+            data_.eos_   = data_.first_ + new_cap;
+
+            // If allocation throws, first_, last_ and eos_ will be valid
+            // (they will be pointing to internal_storage).
+        }
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void initialize_range(InputIt first, Sentinel last)
+    {
+        SFL_TRY
+        {
+            while (first != last)
+            {
+                insert(*first);
+                ++first;
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            if (data_.first_ != data_.internal_storage())
+            {
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    std::distance(data_.first_, data_.eos_)
+                );
+            }
+
+            SFL_RETHROW;
+        }
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void initialize_range(Range&& range)
+    {
+        initialize_range(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void initialize_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        initialize_range(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    void initialize_copy(const small_flat_multiset& other)
+    {
+        const size_type n = other.size();
+
+        check_size(n, "sfl::small_flat_multiset::initialize_copy");
+
+        if (n > N)
+        {
+            data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+            data_.last_  = data_.first_;
+            data_.eos_   = data_.first_ + n;
+        }
+
+        SFL_TRY
+        {
+            data_.last_ = sfl::dtl::uninitialized_copy_a
+            (
+                data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                data_.first_
+            );
+        }
+        SFL_CATCH (...)
+        {
+            if (n > N)
+            {
+                sfl::dtl::deallocate(data_.ref_to_alloc(), data_.first_, n);
+            }
+
+            SFL_RETHROW;
+        }
+    }
+
+    void initialize_move(small_flat_multiset& other)
+    {
+        if (other.data_.first_ == other.data_.internal_storage())
+        {
+            data_.last_ = sfl::dtl::uninitialized_move_a
+            (
+                data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                data_.first_
+            );
+        }
+        else if (data_.ref_to_alloc() == other.data_.ref_to_alloc())
+        {
+            data_.first_ = other.data_.first_;
+            data_.last_  = other.data_.last_;
+            data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = nullptr;
+            other.data_.last_  = nullptr;
+            other.data_.eos_   = nullptr;
+        }
+        else
+        {
+            const size_type n = other.size();
+
+            check_size(n, "sfl::small_flat_multiset::initialize_move");
+
+            if (n > N)
+            {
+                data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+                data_.last_  = data_.first_;
+                data_.eos_   = data_.first_ + n;
+            }
+
+            SFL_TRY
+            {
+                data_.last_ = sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    other.data_.first_,
+                    other.data_.last_,
+                    data_.first_
+                );
+            }
+            SFL_CATCH (...)
+            {
+                if (n > N)
+                {
+                    sfl::dtl::deallocate(data_.ref_to_alloc(), data_.first_, n);
+                }
+
+                SFL_RETHROW;
+            }
+        }
+    }
+
+    template <typename ForwardIt>
+    void assign_range(ForwardIt first, ForwardIt last)
+    {
+        const size_type n = std::distance(first, last);
+
+        check_size(n, "sfl::small_flat_multiset::assign_range");
+
+        if (n <= capacity())
+        {
+            const size_type s = size();
+
+            if (n <= s)
+            {
+                pointer new_last = sfl::dtl::copy
+                (
+                    first,
+                    last,
+                    data_.first_
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    new_last,
+                    data_.last_
+                );
+
+                data_.last_ = new_last;
+            }
+            else
+            {
+                ForwardIt mid = std::next(first, s);
+
+                sfl::dtl::copy
+                (
+                    first,
+                    mid,
+                    data_.first_
+                );
+
+                data_.last_ = sfl::dtl::uninitialized_copy_a
+                (
+                    data_.ref_to_alloc(),
+                    mid,
+                    last,
+                    data_.last_
+                );
+            }
+        }
+        else
+        {
+            reset(n);
+
+            data_.last_ = sfl::dtl::uninitialized_copy_a
+            (
+                data_.ref_to_alloc(),
+                first,
+                last,
+                data_.first_
+            );
+        }
+    }
+
+    void assign_copy(const small_flat_multiset& other)
+    {
+        if (this != &other)
+        {
+            if (allocator_traits::propagate_on_container_copy_assignment::value)
+            {
+                if (data_.ref_to_alloc() != other.data_.ref_to_alloc())
+                {
+                    reset();
+                }
+
+                data_.ref_to_alloc() = other.data_.ref_to_alloc();
+            }
+
+            data_.ref_to_comp() = other.data_.ref_to_comp();
+
+            assign_range(other.data_.first_, other.data_.last_);
+        }
+    }
+
+    void assign_move(small_flat_multiset& other)
+    {
+        if (allocator_traits::propagate_on_container_move_assignment::value)
+        {
+            if (data_.ref_to_alloc() != other.data_.ref_to_alloc())
+            {
+                reset();
+            }
+
+            data_.ref_to_alloc() = std::move(other.data_.ref_to_alloc());
+        }
+
+        data_.ref_to_comp() = other.data_.ref_to_comp();
+
+        if (other.data_.first_ == other.data_.internal_storage())
+        {
+            assign_range
+            (
+                std::make_move_iterator(other.data_.first_),
+                std::make_move_iterator(other.data_.last_)
+            );
+        }
+        else if (data_.ref_to_alloc() == other.data_.ref_to_alloc())
+        {
+            reset();
+
+            data_.first_ = other.data_.first_;
+            data_.last_  = other.data_.last_;
+            data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = nullptr;
+            other.data_.last_  = nullptr;
+            other.data_.eos_   = nullptr;
+        }
+        else
+        {
+            assign_range
+            (
+                std::make_move_iterator(other.data_.first_),
+                std::make_move_iterator(other.data_.last_)
+            );
+        }
+    }
+
+    template <typename Value>
+    iterator insert_aux(Value&& value)
+    {
+        return insert_exactly_at(lower_bound(value), std::forward<Value>(value));
+    }
+
+    template <typename Value>
+    iterator insert_aux(const_iterator hint, Value&& value)
+    {
+        if (is_insert_hint_good(hint, value))
+        {
+            return insert_exactly_at(hint, std::forward<Value>(value));
+        }
+
+        // Hint is not good. Use non-hinted function.
+        return insert_aux(std::forward<Value>(value));
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+
+    template <typename Value>
+    iterator insert_exactly_at(const_iterator pos, Value&& value)
+    {
+        if (data_.last_ != data_.eos_)
+        {
+            const pointer p1 = data_.first_ + std::distance(cbegin(), pos);
+
+            if (p1 == data_.last_)
+            {
+                sfl::dtl::construct_at_a
+                (
+                    data_.ref_to_alloc(),
+                    p1,
+                    std::forward<Value>(value)
+                );
+
+                ++data_.last_;
+            }
+            else
+            {
+                // This container can contain duplicates.
+                // Create temporary value before making place for new element.
+                value_type temp(std::forward<Value>(value));
+
+                const pointer p2 = data_.last_ - 1;
+
+                const pointer old_last = data_.last_;
+
+                sfl::dtl::construct_at_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.last_,
+                    std::move(*p2)
+                );
+
+                ++data_.last_;
+
+                sfl::dtl::move_backward
+                (
+                    p1,
+                    p2,
+                    old_last
+                );
+
+                *p1 = std::move(temp);
+            }
+
+            return iterator(p1);
+        }
+        else
+        {
+            const difference_type offset = std::distance(cbegin(), pos);
+
+            const size_type new_cap =
+                calculate_new_capacity(1, "sfl::small_flat_multiset::insert_exactly_at");
+
+            pointer new_first;
+            pointer new_last;
+            pointer new_eos;
+
+            if (new_cap <= N && data_.first_ != data_.internal_storage())
+            {
+                new_first = data_.internal_storage();
+                new_last  = new_first;
+                new_eos   = new_first + N;
+            }
+            else
+            {
+                new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                new_last  = new_first;
+                new_eos   = new_first + new_cap;
+            }
+
+            const pointer p = new_first + offset;
+
+            SFL_TRY
+            {
+                sfl::dtl::construct_at_a
+                (
+                    data_.ref_to_alloc(),
+                    p,
+                    std::forward<Value>(value)
+                );
+
+                new_last = nullptr;
+
+                const pointer mid = data_.first_ + offset;
+
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    mid,
+                    new_first
+                );
+
+                ++new_last;
+
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    mid,
+                    data_.last_,
+                    new_last
+                );
+            }
+            SFL_CATCH (...)
+            {
+                if (new_last == nullptr)
+                {
+                    sfl::dtl::destroy_at_a
+                    (
+                        data_.ref_to_alloc(),
+                        p
+                    );
+                }
+                else
+                {
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_last
+                    );
+                }
+
+                if (new_first != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+                }
+
+                SFL_RETHROW;
+            }
+
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            if (data_.first_ != data_.internal_storage())
+            {
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    std::distance(data_.first_, data_.eos_)
+                );
+            }
+
+            data_.first_ = new_first;
+            data_.last_  = new_last;
+            data_.eos_   = new_eos;
+
+            return iterator(p);
+        }
+    }
+
+    template <typename Value>
+    bool is_insert_hint_good(const_iterator hint, const Value& value)
+    {
+        return
+            // If `hint` == `value`
+            (
+                hint != end() &&
+                !data_.ref_to_comp()(*hint, value) &&
+                !data_.ref_to_comp()(value, *hint)
+            )
+            ||
+            // If `hint - 1` == `value`
+            (
+                hint != begin() &&
+                !data_.ref_to_comp()(*(hint - 1), value) &&
+                !data_.ref_to_comp()(value, *(hint - 1))
+            )
+            ||
+            // If `hint - 1` < `value` and `value` < `hint`
+            (
+                (hint == begin() || data_.ref_to_comp()(*(hint - 1), value)) &&
+                (hint == end()   || data_.ref_to_comp()(value, *hint))
+            );
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator==
+(
+    const small_flat_multiset<K, N, C, A>& x,
+    const small_flat_multiset<K, N, C, A>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator!=
+(
+    const small_flat_multiset<K, N, C, A>& x,
+    const small_flat_multiset<K, N, C, A>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator<
+(
+    const small_flat_multiset<K, N, C, A>& x,
+    const small_flat_multiset<K, N, C, A>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator>
+(
+    const small_flat_multiset<K, N, C, A>& x,
+    const small_flat_multiset<K, N, C, A>& y
+)
+{
+    return y < x;
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator<=
+(
+    const small_flat_multiset<K, N, C, A>& x,
+    const small_flat_multiset<K, N, C, A>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator>=
+(
+    const small_flat_multiset<K, N, C, A>& x,
+    const small_flat_multiset<K, N, C, A>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+void swap
+(
+    small_flat_multiset<K, N, C, A>& x,
+    small_flat_multiset<K, N, C, A>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, std::size_t N, typename C, typename A, typename Predicate>
+typename small_flat_multiset<K, N, C, A>::size_type
+erase_if(small_flat_multiset<K, N, C, A>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_SMALL_FLAT_MULTISET_HPP_INCLUDED

--- a/src/thirdparty/sfl/small_flat_set.hpp
+++ b/src/thirdparty/sfl/small_flat_set.hpp
@@ -1,0 +1,2015 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_SMALL_FLAT_SET_HPP_INCLUDED
+#define SFL_SMALL_FLAT_SET_HPP_INCLUDED
+
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/exceptions.hpp>
+#include <sfl/detail/initialized_memory_algorithms.hpp>
+#include <sfl/detail/normal_iterator.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/to_address.hpp>
+#include <sfl/detail/type_traits.hpp>
+#include <sfl/detail/uninitialized_memory_algorithms.hpp>
+
+#include <algorithm>        // copy, move, lower_bound, swap, swap_ranges
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <iterator>         // distance, next, reverse_iterator
+#include <limits>           // numeric_limits
+#include <memory>           // allocator, allocator_traits, pointer_traits
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+#ifdef SFL_TEST_SMALL_FLAT_SET
+template <int>
+void test_small_flat_set();
+#endif
+
+namespace sfl
+{
+
+template < typename Key,
+           std::size_t N,
+           typename Compare = std::less<Key>,
+           typename Allocator = std::allocator<Key> >
+class small_flat_set
+{
+    #ifdef SFL_TEST_SMALL_FLAT_SET
+    template <int>
+    friend void ::test_small_flat_set();
+    #endif
+
+public:
+
+    using allocator_type         = Allocator;
+    using allocator_traits       = std::allocator_traits<allocator_type>;
+    using key_type               = Key;
+    using value_type             = Key;
+    using size_type              = typename allocator_traits::size_type;
+    using difference_type        = typename allocator_traits::difference_type;
+    using key_compare            = Compare;
+    using value_compare          = Compare;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using pointer                = typename allocator_traits::pointer;
+    using const_pointer          = typename allocator_traits::const_pointer;
+    using iterator               = sfl::dtl::normal_iterator<const_pointer, small_flat_set>; // MUST BE const_pointer
+    using const_iterator         = sfl::dtl::normal_iterator<const_pointer, small_flat_set>;
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    static_assert
+    (
+        std::is_same<typename Allocator::value_type, value_type>::value,
+        "Allocator::value_type must be same as sfl::small_flat_set::value_type."
+    );
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+private:
+
+    template <bool WithInternalStorage = true, typename = void>
+    class data_base
+    {
+    private:
+
+        union
+        {
+            value_type internal_storage_[N];
+        };
+
+    public:
+
+        pointer first_;
+        pointer last_;
+        pointer eos_;
+
+        data_base() noexcept
+            : first_(std::pointer_traits<pointer>::pointer_to(*internal_storage_))
+            , last_(first_)
+            , eos_(first_ + N)
+        {}
+
+        #if defined(__clang__) && (__clang_major__ == 3) // For CentOS 7
+        ~data_base()
+        {}
+        #else
+        ~data_base() noexcept
+        {}
+        #endif
+
+        pointer internal_storage() noexcept
+        {
+            return std::pointer_traits<pointer>::pointer_to(*internal_storage_);
+        }
+    };
+
+    template <typename Dummy>
+    class data_base<false, Dummy>
+    {
+    public:
+
+        pointer first_;
+        pointer last_;
+        pointer eos_;
+
+        data_base() noexcept
+            : first_(nullptr)
+            , last_(nullptr)
+            , eos_(nullptr)
+        {}
+
+        pointer internal_storage() noexcept
+        {
+            return nullptr;
+        }
+    };
+
+    class data : public data_base<(N > 0)>, public allocator_type, public value_compare
+    {
+    public:
+
+        data() noexcept
+        (
+            std::is_nothrow_default_constructible<allocator_type>::value &&
+            std::is_nothrow_default_constructible<value_compare>::value
+        )
+            : allocator_type()
+            , value_compare()
+        {}
+
+        data(const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_default_constructible<value_compare>::value
+        )
+            : allocator_type(alloc)
+            , value_compare()
+        {}
+
+        data(const value_compare& comp) noexcept
+        (
+            std::is_nothrow_default_constructible<allocator_type>::value &&
+            std::is_nothrow_copy_constructible<value_compare>::value
+        )
+            : allocator_type()
+            , value_compare(comp)
+        {}
+
+        data(const value_compare& comp, const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_copy_constructible<value_compare>::value
+        )
+            : allocator_type(alloc)
+            , value_compare(comp)
+        {}
+
+        data(value_compare&& comp, allocator_type&& alloc) noexcept
+        (
+            std::is_nothrow_move_constructible<allocator_type>::value &&
+            std::is_nothrow_move_constructible<value_compare>::value
+        )
+            : allocator_type(std::move(alloc))
+            , value_compare(std::move(comp))
+        {}
+
+        data(value_compare&& comp, const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_move_constructible<value_compare>::value
+        )
+            : allocator_type(alloc)
+            , value_compare(std::move(comp))
+        {}
+
+        allocator_type& ref_to_alloc() noexcept
+        {
+            return *this;
+        }
+
+        const allocator_type& ref_to_alloc() const noexcept
+        {
+            return *this;
+        }
+
+        value_compare& ref_to_comp() noexcept
+        {
+            return *this;
+        }
+
+        const value_compare& ref_to_comp() const noexcept
+        {
+            return *this;
+        }
+    };
+
+    data data_;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    small_flat_set() noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : data_()
+    {}
+
+    explicit small_flat_set(const Compare& comp) noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : data_(comp)
+    {}
+
+    explicit small_flat_set(const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : data_(alloc)
+    {}
+
+    explicit small_flat_set(const Compare& comp, const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : data_(comp, alloc)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_flat_set(InputIt first, InputIt last)
+        : data_()
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_flat_set(InputIt first, InputIt last, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_flat_set(InputIt first, InputIt last, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_flat_set(InputIt first, InputIt last, const Compare& comp,
+                                                const Allocator& alloc)
+        : data_(comp, alloc)
+    {
+        initialize_range(first, last);
+    }
+
+    small_flat_set(std::initializer_list<value_type> ilist)
+        : small_flat_set(ilist.begin(), ilist.end())
+    {}
+
+    small_flat_set(std::initializer_list<value_type> ilist,
+                   const Compare& comp)
+        : small_flat_set(ilist.begin(), ilist.end(), comp)
+    {}
+
+    small_flat_set(std::initializer_list<value_type> ilist,
+                   const Allocator& alloc)
+        : small_flat_set(ilist.begin(), ilist.end(), alloc)
+    {}
+
+    small_flat_set(std::initializer_list<value_type> ilist,
+                   const Compare& comp, const Allocator& alloc)
+        : small_flat_set(ilist.begin(), ilist.end(), comp, alloc)
+    {}
+
+    small_flat_set(const small_flat_set& other)
+        : data_
+        (
+            other.data_.ref_to_comp(),
+            allocator_traits::select_on_container_copy_construction
+            (
+                other.data_.ref_to_alloc()
+            )
+        )
+    {
+        initialize_copy(other);
+    }
+
+    small_flat_set(const small_flat_set& other, const Allocator& alloc)
+        : data_
+        (
+            other.data_.ref_to_comp(),
+            alloc
+        )
+    {
+        initialize_copy(other);
+    }
+
+    small_flat_set(small_flat_set&& other)
+        : data_
+        (
+            std::move(other.data_.ref_to_comp()),
+            std::move(other.data_.ref_to_alloc())
+        )
+    {
+        initialize_move(other);
+    }
+
+    small_flat_set(small_flat_set&& other, const Allocator& alloc)
+        : data_
+        (
+            std::move(other.data_.ref_to_comp()),
+            alloc
+        )
+    {
+        initialize_move(other);
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_flat_set(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_flat_set(sfl::from_range_t, Range&& range, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_flat_set(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_flat_set(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : data_(comp, alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    small_flat_set(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_flat_set(sfl::from_range_t, Range&& range, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_flat_set(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_flat_set(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : data_(comp, alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~small_flat_set()
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        if (data_.first_ != data_.internal_storage())
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                std::distance(data_.first_, data_.eos_)
+            );
+        }
+    }
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    small_flat_set& operator=(const small_flat_set& other)
+    {
+        assign_copy(other);
+        return *this;
+    }
+
+    small_flat_set& operator=(small_flat_set&& other)
+    {
+        assign_move(other);
+        return *this;
+    }
+
+    small_flat_set& operator=(std::initializer_list<Key> ilist)
+    {
+        clear();
+        insert(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- ALLOCATOR ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    allocator_type get_allocator() const noexcept
+    {
+        return data_.ref_to_alloc();
+    }
+
+    //
+    // ---- KEY COMPARE -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_compare key_comp() const
+    {
+        return data_.ref_to_comp();
+    }
+
+    //
+    // ---- VALUE COMPARE -----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_compare value_comp() const
+    {
+        return data_.ref_to_comp();
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    iterator nth(size_type pos) noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_iterator nth(size_type pos) const noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return const_iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    size_type index_of(const_iterator pos) const noexcept
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return std::distance(cbegin(), pos);
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return data_.first_ == data_.last_;
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return std::distance(data_.first_, data_.last_);
+    }
+
+    SFL_NODISCARD
+    size_type max_size() const noexcept
+    {
+        return std::min<size_type>
+        (
+            allocator_traits::max_size(data_.ref_to_alloc()),
+            std::numeric_limits<difference_type>::max() / sizeof(value_type)
+        );
+    }
+
+    SFL_NODISCARD
+    size_type capacity() const noexcept
+    {
+        return std::distance(data_.first_, data_.eos_);
+    }
+
+    SFL_NODISCARD
+    size_type available() const noexcept
+    {
+        return std::distance(data_.last_, data_.eos_);
+    }
+
+    void reserve(size_type new_cap)
+    {
+        check_size(new_cap, "sfl::small_flat_set::reserve");
+
+        if (new_cap > capacity())
+        {
+            if (new_cap <= N)
+            {
+                if (data_.first_ == data_.internal_storage())
+                {
+                    // Do nothing. We are already using internal storage.
+                }
+                else
+                {
+                    // We are not using internal storage but new capacity
+                    // can fit in internal storage.
+
+                    pointer new_first = data_.internal_storage();
+                    pointer new_last  = new_first;
+                    pointer new_eos   = new_first + N;
+
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_
+                    );
+
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+
+                    data_.first_ = new_first;
+                    data_.last_  = new_last;
+                    data_.eos_   = new_eos;
+                }
+            }
+            else
+            {
+                pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                pointer new_last  = new_first;
+                pointer new_eos   = new_first + new_cap;
+
+                SFL_TRY
+                {
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+                }
+                SFL_CATCH (...)
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+
+                    SFL_RETHROW;
+                }
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_
+                );
+
+                if (data_.first_ != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+                }
+
+                data_.first_ = new_first;
+                data_.last_  = new_last;
+                data_.eos_   = new_eos;
+            }
+        }
+    }
+
+    void shrink_to_fit()
+    {
+        const size_type new_cap = size();
+
+        if (new_cap < capacity())
+        {
+            if (new_cap <= N)
+            {
+                if (data_.first_ == data_.internal_storage())
+                {
+                    // Do nothing. We are already using internal storage.
+                }
+                else
+                {
+                    // We are not using internal storage but new capacity
+                    // can fit in internal storage.
+
+                    pointer new_first = data_.internal_storage();
+                    pointer new_last  = new_first;
+                    pointer new_eos   = new_first + N;
+
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_
+                    );
+
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+
+                    data_.first_ = new_first;
+                    data_.last_  = new_last;
+                    data_.eos_   = new_eos;
+                }
+            }
+            else
+            {
+                pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                pointer new_last  = new_first;
+                pointer new_eos   = new_first + new_cap;
+
+                SFL_TRY
+                {
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+                }
+                SFL_CATCH (...)
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+
+                    SFL_RETHROW;
+                }
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_
+                );
+
+                if (data_.first_ != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+                }
+
+                data_.first_ = new_first;
+                data_.last_  = new_last;
+                data_.eos_   = new_eos;
+            }
+        }
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear() noexcept
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        data_.last_ = data_.first_;
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace(Args&&... args)
+    {
+        return insert_aux(value_type(std::forward<Args>(args)...));
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value_type(std::forward<Args>(args)...));
+    }
+
+    std::pair<iterator, bool> insert(const value_type& value)
+    {
+        return insert_aux(value);
+    }
+
+    std::pair<iterator, bool> insert(value_type&& value)
+    {
+        return insert_aux(std::move(value));
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    std::pair<iterator, bool> insert(K&& x)
+    {
+        return insert_aux_heterogeneous(std::forward<K>(x));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, std::move(value));
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t< sfl::dtl::has_is_transparent<Compare, K>::value &&
+                                    !std::is_convertible<K&&, const_iterator>::value &&
+                                    !std::is_convertible<K&&, iterator>::value >* = nullptr>
+    iterator insert(const_iterator hint, K&& x)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux_heterogeneous(hint, std::forward<K>(x));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    iterator erase(const_iterator pos)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos < cend());
+
+        const pointer p = data_.first_ + std::distance(cbegin(), pos);
+
+        data_.last_ = sfl::dtl::move(p + 1, data_.last_, p);
+
+        sfl::dtl::destroy_at_a(data_.ref_to_alloc(), data_.last_);
+
+        return iterator(p);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        SFL_ASSERT(cbegin() <= first && first <= last && last <= cend());
+
+        if (first == last)
+        {
+            return begin() + std::distance(cbegin(), first);
+        }
+
+        const pointer p1 = data_.first_ + std::distance(cbegin(), first);
+        const pointer p2 = data_.first_ + std::distance(cbegin(), last);
+
+        const pointer new_last = sfl::dtl::move(p2, data_.last_, p1);
+
+        sfl::dtl::destroy_a(data_.ref_to_alloc(), new_last, data_.last_);
+
+        data_.last_ = new_last;
+
+        return iterator(p1);
+    }
+
+    size_type erase(const Key& key)
+    {
+        auto it = find(key);
+        if (it == cend())
+        {
+            return 0;
+        }
+        erase(it);
+        return 1;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        auto it = find(x);
+        if (it == cend())
+        {
+            return 0;
+        }
+        erase(it);
+        return 1;
+    }
+
+    void swap(small_flat_set& other)
+    {
+        if (this == &other)
+        {
+            return;
+        }
+
+        using std::swap;
+
+        SFL_ASSERT
+        (
+            allocator_traits::propagate_on_container_swap::value ||
+            this->data_.ref_to_alloc() == other.data_.ref_to_alloc()
+        );
+
+        // If this and other allocator compares equal then one allocator
+        // can deallocate memory allocated by another allocator.
+        // One allocator can safely destroy_a elements constructed by other
+        // allocator regardless the two allocators compare equal or not.
+
+        if (allocator_traits::propagate_on_container_swap::value)
+        {
+            swap(this->data_.ref_to_alloc(), other.data_.ref_to_alloc());
+        }
+
+        swap(this->data_.ref_to_comp(), other.data_.ref_to_comp());
+
+        if
+        (
+            this->data_.first_ == this->data_.internal_storage() &&
+            other.data_.first_ == other.data_.internal_storage()
+        )
+        {
+            const size_type this_size  = this->size();
+            const size_type other_size = other.size();
+
+            if (this_size <= other_size)
+            {
+                std::swap_ranges
+                (
+                    this->data_.first_,
+                    this->data_.first_ + this_size,
+                    other.data_.first_
+                );
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    this->data_.ref_to_alloc(),
+                    other.data_.first_ + this_size,
+                    other.data_.first_ + other_size,
+                    this->data_.first_ + this_size
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    other.data_.ref_to_alloc(),
+                    other.data_.first_ + this_size,
+                    other.data_.first_ + other_size
+                );
+            }
+            else
+            {
+                std::swap_ranges
+                (
+                    other.data_.first_,
+                    other.data_.first_ + other_size,
+                    this->data_.first_
+                );
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    other.data_.ref_to_alloc(),
+                    this->data_.first_ + other_size,
+                    this->data_.first_ + this_size,
+                    other.data_.first_ + other_size
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    this->data_.ref_to_alloc(),
+                    this->data_.first_ + other_size,
+                    this->data_.first_ + this_size
+                );
+            }
+
+            this->data_.last_ = this->data_.first_ + other_size;
+            other.data_.last_ = other.data_.first_ + this_size;
+        }
+        else if
+        (
+            this->data_.first_ == this->data_.internal_storage() &&
+            other.data_.first_ != other.data_.internal_storage()
+        )
+        {
+            pointer new_other_first = other.data_.internal_storage();
+            pointer new_other_last  = new_other_first;
+            pointer new_other_eos   = new_other_first + N;
+
+            new_other_last = sfl::dtl::uninitialized_move_a
+            (
+                other.data_.ref_to_alloc(),
+                this->data_.first_,
+                this->data_.last_,
+                new_other_first
+            );
+
+            sfl::dtl::destroy_a
+            (
+                this->data_.ref_to_alloc(),
+                this->data_.first_,
+                this->data_.last_
+            );
+
+            this->data_.first_ = other.data_.first_;
+            this->data_.last_  = other.data_.last_;
+            this->data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = new_other_first;
+            other.data_.last_  = new_other_last;
+            other.data_.eos_   = new_other_eos;
+        }
+        else if
+        (
+            this->data_.first_ != this->data_.internal_storage() &&
+            other.data_.first_ == other.data_.internal_storage()
+        )
+        {
+            pointer new_this_first = this->data_.internal_storage();
+            pointer new_this_last  = new_this_first;
+            pointer new_this_eos   = new_this_first + N;
+
+            new_this_last = sfl::dtl::uninitialized_move_a
+            (
+                this->data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                new_this_first
+            );
+
+            sfl::dtl::destroy_a
+            (
+                other.data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_
+            );
+
+            other.data_.first_ = this->data_.first_;
+            other.data_.last_  = this->data_.last_;
+            other.data_.eos_   = this->data_.eos_;
+
+            this->data_.first_ = new_this_first;
+            this->data_.last_  = new_this_last;
+            this->data_.eos_   = new_this_eos;
+        }
+        else
+        {
+            swap(this->data_.first_, other.data_.first_);
+            swap(this->data_.last_,  other.data_.last_);
+            swap(this->data_.eos_,   other.data_.eos_);
+        }
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator lower_bound(const Key& key)
+    {
+        return std::lower_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    const_iterator lower_bound(const Key& key) const
+    {
+        return std::lower_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator lower_bound(const K& x)
+    {
+        return std::lower_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator lower_bound(const K& x) const
+    {
+        return std::lower_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    iterator upper_bound(const Key& key)
+    {
+        return std::upper_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    const_iterator upper_bound(const Key& key) const
+    {
+        return std::upper_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator upper_bound(const K& x)
+    {
+        return std::upper_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator upper_bound(const K& x) const
+    {
+        return std::upper_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const Key& key)
+    {
+        return std::equal_range(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const
+    {
+        return std::equal_range(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const K& x)
+    {
+        return std::equal_range(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const K& x) const
+    {
+        return std::equal_range(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        auto it = lower_bound(key);
+
+        if (it != end() && data_.ref_to_comp()(key, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        auto it = lower_bound(key);
+
+        if (it != end() && data_.ref_to_comp()(key, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        auto it = lower_bound(x);
+
+        if (it != end() && data_.ref_to_comp()(x, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        auto it = lower_bound(x);
+
+        if (it != end() && data_.ref_to_comp()(x, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    //
+    // ---- ELEMENT ACCESS ----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_type* data() noexcept
+    {
+        return sfl::dtl::to_address(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const value_type* data() const noexcept
+    {
+        return sfl::dtl::to_address(data_.first_);
+    }
+
+private:
+
+    void check_size(size_type n, const char* msg)
+    {
+        if (n > max_size())
+        {
+            sfl::dtl::throw_length_error(msg);
+        }
+    }
+
+    size_type calculate_new_capacity(size_type num_additional_elements, const char* msg)
+    {
+        const size_type size = this->size();
+        const size_type capacity = this->capacity();
+        const size_type max_size = this->max_size();
+
+        if (max_size - size < num_additional_elements)
+        {
+            sfl::dtl::throw_length_error(msg);
+        }
+        else if (max_size - capacity < capacity / 2)
+        {
+            return max_size;
+        }
+        else if (size + num_additional_elements < capacity + capacity / 2)
+        {
+            return std::max(N, capacity + capacity / 2);
+        }
+        else
+        {
+            return std::max(N, size + num_additional_elements);
+        }
+    }
+
+    void reset(size_type new_cap = N)
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        if (data_.first_ != data_.internal_storage())
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                std::distance(data_.first_, data_.eos_)
+            );
+        }
+
+        data_.first_ = data_.internal_storage();
+        data_.last_  = data_.first_;
+        data_.eos_   = data_.first_ + N;
+
+        if (new_cap > N)
+        {
+            data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+            data_.last_  = data_.first_;
+            data_.eos_   = data_.first_ + new_cap;
+
+            // If allocation throws, first_, last_ and eos_ will be valid
+            // (they will be pointing to internal_storage).
+        }
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void initialize_range(InputIt first, Sentinel last)
+    {
+        SFL_TRY
+        {
+            while (first != last)
+            {
+                insert(*first);
+                ++first;
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            if (data_.first_ != data_.internal_storage())
+            {
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    std::distance(data_.first_, data_.eos_)
+                );
+            }
+
+            SFL_RETHROW;
+        }
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void initialize_range(Range&& range)
+    {
+        initialize_range(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void initialize_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        initialize_range(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    void initialize_copy(const small_flat_set& other)
+    {
+        const size_type n = other.size();
+
+        check_size(n, "sfl::small_flat_set::initialize_copy");
+
+        if (n > N)
+        {
+            data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+            data_.last_  = data_.first_;
+            data_.eos_   = data_.first_ + n;
+        }
+
+        SFL_TRY
+        {
+            data_.last_ = sfl::dtl::uninitialized_copy_a
+            (
+                data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                data_.first_
+            );
+        }
+        SFL_CATCH (...)
+        {
+            if (n > N)
+            {
+                sfl::dtl::deallocate(data_.ref_to_alloc(), data_.first_, n);
+            }
+
+            SFL_RETHROW;
+        }
+    }
+
+    void initialize_move(small_flat_set& other)
+    {
+        if (other.data_.first_ == other.data_.internal_storage())
+        {
+            data_.last_ = sfl::dtl::uninitialized_move_a
+            (
+                data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                data_.first_
+            );
+        }
+        else if (data_.ref_to_alloc() == other.data_.ref_to_alloc())
+        {
+            data_.first_ = other.data_.first_;
+            data_.last_  = other.data_.last_;
+            data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = nullptr;
+            other.data_.last_  = nullptr;
+            other.data_.eos_   = nullptr;
+        }
+        else
+        {
+            const size_type n = other.size();
+
+            check_size(n, "sfl::small_flat_set::initialize_move");
+
+            if (n > N)
+            {
+                data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+                data_.last_  = data_.first_;
+                data_.eos_   = data_.first_ + n;
+            }
+
+            SFL_TRY
+            {
+                data_.last_ = sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    other.data_.first_,
+                    other.data_.last_,
+                    data_.first_
+                );
+            }
+            SFL_CATCH (...)
+            {
+                if (n > N)
+                {
+                    sfl::dtl::deallocate(data_.ref_to_alloc(), data_.first_, n);
+                }
+
+                SFL_RETHROW;
+            }
+        }
+    }
+
+    template <typename ForwardIt>
+    void assign_range(ForwardIt first, ForwardIt last)
+    {
+        const size_type n = std::distance(first, last);
+
+        check_size(n, "sfl::small_flat_set::assign_range");
+
+        if (n <= capacity())
+        {
+            const size_type s = size();
+
+            if (n <= s)
+            {
+                pointer new_last = sfl::dtl::copy
+                (
+                    first,
+                    last,
+                    data_.first_
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    new_last,
+                    data_.last_
+                );
+
+                data_.last_ = new_last;
+            }
+            else
+            {
+                ForwardIt mid = std::next(first, s);
+
+                sfl::dtl::copy
+                (
+                    first,
+                    mid,
+                    data_.first_
+                );
+
+                data_.last_ = sfl::dtl::uninitialized_copy_a
+                (
+                    data_.ref_to_alloc(),
+                    mid,
+                    last,
+                    data_.last_
+                );
+            }
+        }
+        else
+        {
+            reset(n);
+
+            data_.last_ = sfl::dtl::uninitialized_copy_a
+            (
+                data_.ref_to_alloc(),
+                first,
+                last,
+                data_.first_
+            );
+        }
+    }
+
+    void assign_copy(const small_flat_set& other)
+    {
+        if (this != &other)
+        {
+            if (allocator_traits::propagate_on_container_copy_assignment::value)
+            {
+                if (data_.ref_to_alloc() != other.data_.ref_to_alloc())
+                {
+                    reset();
+                }
+
+                data_.ref_to_alloc() = other.data_.ref_to_alloc();
+            }
+
+            data_.ref_to_comp() = other.data_.ref_to_comp();
+
+            assign_range(other.data_.first_, other.data_.last_);
+        }
+    }
+
+    void assign_move(small_flat_set& other)
+    {
+        if (allocator_traits::propagate_on_container_move_assignment::value)
+        {
+            if (data_.ref_to_alloc() != other.data_.ref_to_alloc())
+            {
+                reset();
+            }
+
+            data_.ref_to_alloc() = std::move(other.data_.ref_to_alloc());
+        }
+
+        data_.ref_to_comp() = other.data_.ref_to_comp();
+
+        if (other.data_.first_ == other.data_.internal_storage())
+        {
+            assign_range
+            (
+                std::make_move_iterator(other.data_.first_),
+                std::make_move_iterator(other.data_.last_)
+            );
+        }
+        else if (data_.ref_to_alloc() == other.data_.ref_to_alloc())
+        {
+            reset();
+
+            data_.first_ = other.data_.first_;
+            data_.last_  = other.data_.last_;
+            data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = nullptr;
+            other.data_.last_  = nullptr;
+            other.data_.eos_   = nullptr;
+        }
+        else
+        {
+            assign_range
+            (
+                std::make_move_iterator(other.data_.first_),
+                std::make_move_iterator(other.data_.last_)
+            );
+        }
+    }
+
+    template <typename Value>
+    std::pair<iterator, bool> insert_aux(Value&& value)
+    {
+        auto it = lower_bound(value);
+
+        if (it == end() || data_.ref_to_comp()(value, *it))
+        {
+            return std::make_pair(insert_exactly_at(it, std::forward<Value>(value)), true);
+        }
+
+        return std::make_pair(it, false);
+    }
+
+    template <typename Value>
+    iterator insert_aux(const_iterator hint, Value&& value)
+    {
+        if (is_insert_hint_good(hint, value))
+        {
+            return insert_exactly_at(hint, std::forward<Value>(value));
+        }
+
+        // Hint is not good. Use non-hinted function.
+        return insert_aux(std::forward<Value>(value)).first;
+    }
+
+    template <typename K>
+    std::pair<iterator, bool> insert_aux_heterogeneous(K&& x)
+    {
+        auto it = lower_bound(x);
+
+        if (it == end() || data_.ref_to_comp()(x, *it))
+        {
+            return std::make_pair(insert_exactly_at(it, value_type(std::forward<K>(x))), true);
+        }
+
+        return std::make_pair(it, false);
+    }
+
+    template <typename K>
+    iterator insert_aux_heterogeneous(const_iterator hint, K&& x)
+    {
+        if (is_insert_hint_good(hint, x))
+        {
+            return insert_exactly_at(hint, value_type(std::forward<K>(x)));
+        }
+
+        // Hint is not good. Use non-hinted function.
+        return insert_aux_heterogeneous(std::forward<K>(x)).first;
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+
+    template <typename Value>
+    iterator insert_exactly_at(const_iterator pos, Value&& value)
+    {
+        if (data_.last_ != data_.eos_)
+        {
+            const pointer p1 = data_.first_ + std::distance(cbegin(), pos);
+
+            if (p1 == data_.last_)
+            {
+                sfl::dtl::construct_at_a
+                (
+                    data_.ref_to_alloc(),
+                    p1,
+                    std::forward<Value>(value)
+                );
+
+                ++data_.last_;
+            }
+            else
+            {
+                const pointer p2 = data_.last_ - 1;
+
+                const pointer old_last = data_.last_;
+
+                sfl::dtl::construct_at_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.last_,
+                    std::move(*p2)
+                );
+
+                ++data_.last_;
+
+                sfl::dtl::move_backward
+                (
+                    p1,
+                    p2,
+                    old_last
+                );
+
+                *p1 = std::forward<Value>(value);
+            }
+
+            return iterator(p1);
+        }
+        else
+        {
+            const difference_type offset = std::distance(cbegin(), pos);
+
+            const size_type new_cap =
+                calculate_new_capacity(1, "sfl::small_flat_set::insert_exactly_at");
+
+            pointer new_first;
+            pointer new_last;
+            pointer new_eos;
+
+            if (new_cap <= N && data_.first_ != data_.internal_storage())
+            {
+                new_first = data_.internal_storage();
+                new_last  = new_first;
+                new_eos   = new_first + N;
+            }
+            else
+            {
+                new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                new_last  = new_first;
+                new_eos   = new_first + new_cap;
+            }
+
+            const pointer p = new_first + offset;
+
+            SFL_TRY
+            {
+                sfl::dtl::construct_at_a
+                (
+                    data_.ref_to_alloc(),
+                    p,
+                    std::forward<Value>(value)
+                );
+
+                new_last = nullptr;
+
+                const pointer mid = data_.first_ + offset;
+
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    mid,
+                    new_first
+                );
+
+                ++new_last;
+
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    mid,
+                    data_.last_,
+                    new_last
+                );
+            }
+            SFL_CATCH (...)
+            {
+                if (new_last == nullptr)
+                {
+                    sfl::dtl::destroy_at_a
+                    (
+                        data_.ref_to_alloc(),
+                        p
+                    );
+                }
+                else
+                {
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_last
+                    );
+                }
+
+                if (new_first != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+                }
+
+                SFL_RETHROW;
+            }
+
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            if (data_.first_ != data_.internal_storage())
+            {
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    std::distance(data_.first_, data_.eos_)
+                );
+            }
+
+            data_.first_ = new_first;
+            data_.last_  = new_last;
+            data_.eos_   = new_eos;
+
+            return iterator(p);
+        }
+    }
+
+    template <typename Value>
+    bool is_insert_hint_good(const_iterator hint, const Value& value)
+    {
+        return (hint == begin() || data_.ref_to_comp()(*(hint - 1), value))
+            && (hint == end()   || data_.ref_to_comp()(value, *hint));
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator==
+(
+    const small_flat_set<K, N, C, A>& x,
+    const small_flat_set<K, N, C, A>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator!=
+(
+    const small_flat_set<K, N, C, A>& x,
+    const small_flat_set<K, N, C, A>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator<
+(
+    const small_flat_set<K, N, C, A>& x,
+    const small_flat_set<K, N, C, A>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator>
+(
+    const small_flat_set<K, N, C, A>& x,
+    const small_flat_set<K, N, C, A>& y
+)
+{
+    return y < x;
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator<=
+(
+    const small_flat_set<K, N, C, A>& x,
+    const small_flat_set<K, N, C, A>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator>=
+(
+    const small_flat_set<K, N, C, A>& x,
+    const small_flat_set<K, N, C, A>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+void swap
+(
+    small_flat_set<K, N, C, A>& x,
+    small_flat_set<K, N, C, A>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, std::size_t N, typename C, typename A,
+          typename Predicate>
+typename small_flat_set<K, N, C, A>::size_type
+    erase_if(small_flat_set<K, N, C, A>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_SMALL_FLAT_SET_HPP_INCLUDED

--- a/src/thirdparty/sfl/small_map.hpp
+++ b/src/thirdparty/sfl/small_map.hpp
@@ -1,0 +1,1086 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_SMALL_MAP_HPP_INCLUDED
+#define SFL_SMALL_MAP_HPP_INCLUDED
+
+#include <sfl/detail/allocator_traits.hpp>
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/exceptions.hpp>
+#include <sfl/detail/functional.hpp>
+#include <sfl/detail/node_small_allocator.hpp>
+#include <sfl/detail/rb_tree.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/type_traits.hpp>
+
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <memory>           // allocator
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+namespace sfl
+{
+
+template < typename Key,
+           typename T,
+           std::size_t N,
+           typename Compare = std::less<Key>,
+           typename Allocator = std::allocator<std::pair<const Key, T>> >
+class small_map
+{
+    static_assert
+    (
+        std::is_same<typename Allocator::value_type, std::pair<const Key, T>>::value,
+        "Allocator::value_type must be std::pair<const Key, T>."
+    );
+
+public:
+
+    using allocator_type = Allocator;
+    using key_type       = Key;
+    using mapped_type    = T;
+    using value_type     = std::pair<const Key, T>;
+    using key_compare    = Compare;
+
+    class value_compare : protected key_compare
+    {
+        friend class small_map;
+
+    private:
+
+        value_compare(const key_compare& c) : key_compare(c)
+        {}
+
+    public:
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_compare::operator()(x.first, y.first);
+        }
+    };
+
+private:
+
+    using tree_type = sfl::dtl::rb_tree
+    <
+        key_type,
+        value_type,
+        sfl::dtl::first,
+        key_compare,
+        sfl::dtl::node_small_allocator
+        <
+            value_type,
+            N,
+            typename sfl::dtl::allocator_traits<allocator_type>::template rebind_alloc<value_type>
+        >,
+        small_map
+    >;
+
+    tree_type tree_;
+
+public:
+
+    using size_type              = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::size_type;
+    using difference_type        = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::difference_type;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using pointer                = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::pointer;
+    using const_pointer          = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::const_pointer;
+    using iterator               = typename tree_type::iterator;
+    using const_iterator         = typename tree_type::const_iterator;
+    using reverse_iterator       = typename tree_type::reverse_iterator;
+    using const_reverse_iterator = typename tree_type::const_reverse_iterator;
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    small_map() noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : tree_()
+    {}
+
+    explicit small_map(const Compare& comp) noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : tree_(comp)
+    {}
+
+    explicit small_map(const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : tree_(alloc)
+    {}
+
+    explicit small_map(const Compare& comp, const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : tree_(comp, alloc)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_map(InputIt first, InputIt last)
+        : tree_()
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_map(InputIt first, InputIt last, const Compare& comp)
+        : tree_(comp)
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_map(InputIt first, InputIt last, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_map(InputIt first, InputIt last, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert(first, last);
+    }
+
+    small_map(std::initializer_list<value_type> ilist)
+        : small_map(ilist.begin(), ilist.end())
+    {}
+
+    small_map(std::initializer_list<value_type> ilist, const Compare& comp)
+        : small_map(ilist.begin(), ilist.end(), comp)
+    {}
+
+    small_map(std::initializer_list<value_type> ilist, const Allocator& alloc)
+        : small_map(ilist.begin(), ilist.end(), alloc)
+    {}
+
+    small_map(std::initializer_list<value_type> ilist, const Compare& comp, const Allocator& alloc)
+        : small_map(ilist.begin(), ilist.end(), comp, alloc)
+    {}
+
+    small_map(const small_map& other)
+        : tree_(other.tree_)
+    {}
+
+    small_map(const small_map& other, const Allocator& alloc)
+        : tree_(other.tree_, alloc)
+    {}
+
+    small_map(small_map&& other)
+        : tree_(std::move(other.tree_))
+    {}
+
+    small_map(small_map&& other, const Allocator& alloc)
+        : tree_(std::move(other.tree_), alloc)
+    {}
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_map(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_map(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_map(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_map(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    small_map(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_map(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_map(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_map(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~small_map()
+    {}
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    small_map& operator=(const small_map& other)
+    {
+        tree_.operator=(other.tree_);
+        return *this;
+    }
+
+    small_map& operator=(small_map&& other)
+    {
+        tree_.operator=(std::move(other.tree_));
+        return *this;
+    }
+
+    small_map& operator=(std::initializer_list<value_type> ilist)
+    {
+        tree_.assign_range_unique(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- ALLOCATOR ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    allocator_type get_allocator() const noexcept
+    {
+        return allocator_type(tree_.ref_to_node_alloc());
+    }
+
+    //
+    // ---- KEY COMPARE -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_compare key_comp() const
+    {
+        return key_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- VALUE COMPARE -----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_compare value_comp() const
+    {
+        return value_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return tree_.cbegin();
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return tree_.cend();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return tree_.crbegin();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return tree_.crend();
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return tree_.empty();
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return tree_.size();
+    }
+
+    SFL_NODISCARD
+    size_type max_size() const noexcept
+    {
+        return tree_.max_size();
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear()
+    {
+        tree_.clear();
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace(Args&&... args)
+    {
+        return tree_.emplace_unique(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        return tree_.emplace_hint_unique(hint, std::forward<Args>(args)...);
+    }
+
+    std::pair<iterator, bool> insert(const value_type& value)
+    {
+        return tree_.insert_unique(value);
+    }
+
+    std::pair<iterator, bool> insert(value_type&& value)
+    {
+        return tree_.insert_unique(std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P&&>::value>* = nullptr>
+    std::pair<iterator, bool> insert(P&& value)
+    {
+        return tree_.insert_unique(std::forward<P>(value));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        return tree_.insert_hint_unique(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        return tree_.insert_hint_unique(hint, std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P>::value>* = nullptr>
+    iterator insert(const_iterator hint, P&& value)
+    {
+        return tree_.insert_hint_unique(hint, std::forward<P>(value));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    std::pair<iterator, bool> insert_or_assign(const Key& key, M&& obj)
+    {
+        return insert_or_assign_aux(key, std::forward<M>(obj));
+    }
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    std::pair<iterator, bool> insert_or_assign(Key&& key, M&& obj)
+    {
+        return insert_or_assign_aux(std::move(key), std::forward<M>(obj));
+    }
+
+    template <typename K, typename M,
+              sfl::dtl::enable_if_t< sfl::dtl::has_is_transparent<Compare, K>::value &&
+                                     std::is_assignable<mapped_type&, M&&>::value >* = nullptr>
+    std::pair<iterator, bool> insert_or_assign(K&& key, M&& obj)
+    {
+        return insert_or_assign_aux(std::forward<K>(key), std::forward<M>(obj));
+    }
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    iterator insert_or_assign(const_iterator hint, const Key& key, M&& obj)
+    {
+        return insert_or_assign_aux(hint, key, std::forward<M>(obj));
+    }
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    iterator insert_or_assign(const_iterator hint, Key&& key, M&& obj)
+    {
+        return insert_or_assign_aux(hint, std::move(key), std::forward<M>(obj));
+    }
+
+    template <typename K, typename M,
+              sfl::dtl::enable_if_t< sfl::dtl::has_is_transparent<Compare, K>::value &&
+                                     std::is_assignable<mapped_type&, M&&>::value >* = nullptr>
+    iterator insert_or_assign(const_iterator hint, K&& key, M&& obj)
+    {
+        return insert_or_assign_aux(hint, std::forward<K>(key), std::forward<M>(obj));
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(const Key& key, Args&&... args)
+    {
+        return try_emplace_aux(key, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(Key&& key, Args&&... args)
+    {
+        return try_emplace_aux(std::move(key), std::forward<Args>(args)...);
+    }
+
+    template <typename K, typename... Args,
+              sfl::dtl::enable_if_t<
+                #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 7)
+                // This is workaround for GCC 4 bug on CentOS 7.
+                !std::is_same<sfl::dtl::remove_cvref_t<Key>, sfl::dtl::remove_cvref_t<K>>::value &&
+                #endif
+                sfl::dtl::has_is_transparent<Compare, K>::value &&
+                !std::is_convertible<K&&, const_iterator>::value &&
+                !std::is_convertible<K&&, iterator>::value
+              >* = nullptr>
+    std::pair<iterator, bool> try_emplace(K&& key, Args&&... args)
+    {
+        return try_emplace_aux(std::forward<K>(key), std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator try_emplace(const_iterator hint, const Key& key, Args&&... args)
+    {
+        return try_emplace_aux(hint, key, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator try_emplace(const_iterator hint, Key&& key, Args&&... args)
+    {
+        return try_emplace_aux(hint, std::move(key), std::forward<Args>(args)...);
+    }
+
+    template <typename K, typename... Args,
+              sfl::dtl::enable_if_t<
+                #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 7)
+                // This is workaround for GCC 4 bug on CentOS 7.
+                !std::is_same<sfl::dtl::remove_cvref_t<Key>, sfl::dtl::remove_cvref_t<K>>::value &&
+                #endif
+                sfl::dtl::has_is_transparent<Compare, K>::value
+              >* = nullptr>
+    iterator try_emplace(const_iterator hint, K&& key, Args&&... args)
+    {
+        return try_emplace_aux(hint, std::forward<K>(key), std::forward<Args>(args)...);
+    }
+
+    iterator erase(iterator pos)
+    {
+        return tree_.erase(pos);
+    }
+
+    iterator erase(const_iterator pos)
+    {
+        return tree_.erase(pos);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        return tree_.erase(first, last);
+    }
+
+    size_type erase(const Key& key)
+    {
+        return tree_.erase(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        return tree_.erase(x);
+    }
+
+    void swap(small_map& other)
+    {
+        tree_.swap(other.tree_);
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator lower_bound(const Key& key)
+    {
+        return tree_.lower_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator lower_bound(const Key& key) const
+    {
+        return tree_.lower_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator lower_bound(const K& x)
+    {
+        return tree_.lower_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator lower_bound(const K& x) const
+    {
+        return tree_.lower_bound(x);
+    }
+
+    SFL_NODISCARD
+    iterator upper_bound(const Key& key)
+    {
+        return tree_.upper_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator upper_bound(const Key& key) const
+    {
+        return tree_.upper_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator upper_bound(const K& x)
+    {
+        return tree_.upper_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator upper_bound(const K& x) const
+    {
+        return tree_.upper_bound(x);
+    }
+
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const Key& key)
+    {
+        return tree_.equal_range(key);
+    }
+
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const
+    {
+        return tree_.equal_range(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const K& x)
+    {
+        return tree_.equal_range(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const K& x) const
+    {
+        return tree_.equal_range(x);
+    }
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        return tree_.find(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        return tree_.find(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        return tree_.find(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        return tree_.find(x);
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        return tree_.count(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        return tree_.count(x);
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return tree_.contains(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return tree_.contains(x);
+    }
+
+    //
+    // ---- ELEMENT ACCESS ----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    T& at(const Key& key)
+    {
+        auto it = find(key);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::small_map::at");
+        }
+
+        return it->second;
+    }
+
+    SFL_NODISCARD
+    const T& at(const Key& key) const
+    {
+        auto it = find(key);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::small_map::at");
+        }
+
+        return it->second;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    T& at(const K& x)
+    {
+        auto it = find(x);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::small_map::at");
+        }
+
+        return it->second;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const T& at(const K& x) const
+    {
+        auto it = find(x);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::small_map::at");
+        }
+
+        return it->second;
+    }
+
+    SFL_NODISCARD
+    T& operator[](const Key& key)
+    {
+        return try_emplace(key).first->second;
+    }
+
+    SFL_NODISCARD
+    T& operator[](Key&& key)
+    {
+        return try_emplace(std::move(key)).first->second;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    T& operator[](K&& key)
+    {
+        return try_emplace(std::forward<K>(key)).first->second;
+    }
+
+private:
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+
+    template <typename K, typename M>
+    std::pair<iterator, bool> insert_or_assign_aux(K&& key, M&& obj)
+    {
+        auto res = tree_.calculate_position_for_insert_unique(key);
+        if (res.status)
+        {
+            typename tree_type::make_node_functor make_node(tree_);
+            typename tree_type::node_pointer x = make_node
+            (
+                std::piecewise_construct,
+                std::forward_as_tuple(std::forward<K>(key)),
+                std::forward_as_tuple(std::forward<M>(obj))
+            );
+            tree_.insert(x, res.pos, res.left, tree_.data_.root(), tree_.data_.minimum());
+            ++tree_.data_.size_;
+            return std::make_pair(iterator(x), true);
+        }
+        else
+        {
+            iterator it(res.pos);
+            it->second = std::forward<M>(obj);
+            return std::make_pair(it, false);
+        }
+    }
+
+    template <typename K, typename M>
+    iterator insert_or_assign_aux(const_iterator hint, K&& key, M&& obj)
+    {
+        auto res = tree_.calculate_position_for_insert_hint_unique(hint, key);
+        if (res.status)
+        {
+            typename tree_type::make_node_functor make_node(tree_);
+            typename tree_type::node_pointer x = make_node
+            (
+                std::piecewise_construct,
+                std::forward_as_tuple(std::forward<K>(key)),
+                std::forward_as_tuple(std::forward<M>(obj))
+            );
+            tree_.insert(x, res.pos, res.left, tree_.data_.root(), tree_.data_.minimum());
+            ++tree_.data_.size_;
+            return iterator(x);
+        }
+        else
+        {
+            iterator it(res.pos);
+            it->second = std::forward<M>(obj);
+            return it;
+        }
+    }
+
+    template <typename K, typename... Args>
+    std::pair<iterator, bool> try_emplace_aux(K&& key, Args&&... args)
+    {
+        auto res = tree_.calculate_position_for_insert_unique(key);
+        if (res.status)
+        {
+            typename tree_type::make_node_functor make_node(tree_);
+            typename tree_type::node_pointer x = make_node
+            (
+                std::piecewise_construct,
+                std::forward_as_tuple(std::forward<K>(key)),
+                std::forward_as_tuple(std::forward<Args>(args)...)
+            );
+            tree_.insert(x, res.pos, res.left, tree_.data_.root(), tree_.data_.minimum());
+            ++tree_.data_.size_;
+            return std::make_pair(iterator(x), true);
+        }
+        else
+        {
+            return std::make_pair(iterator(res.pos), false);
+        }
+    }
+
+    template <typename K, typename... Args>
+    iterator try_emplace_aux(const_iterator hint, K&& key, Args&&... args)
+    {
+        auto res = tree_.calculate_position_for_insert_hint_unique(hint, key);
+        if (res.status)
+        {
+            typename tree_type::make_node_functor make_node(tree_);
+            typename tree_type::node_pointer x = make_node
+            (
+                std::piecewise_construct,
+                std::forward_as_tuple(std::forward<K>(key)),
+                std::forward_as_tuple(std::forward<Args>(args)...)
+            );
+            tree_.insert(x, res.pos, res.left, tree_.data_.root(), tree_.data_.minimum());
+            ++tree_.data_.size_;
+            return iterator(x);
+        }
+        else
+        {
+            return iterator(res.pos);
+        }
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator==
+(
+    const small_map<K, T, N, C, A>& x,
+    const small_map<K, T, N, C, A>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator!=
+(
+    const small_map<K, T, N, C, A>& x,
+    const small_map<K, T, N, C, A>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator<
+(
+    const small_map<K, T, N, C, A>& x,
+    const small_map<K, T, N, C, A>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator>
+(
+    const small_map<K, T, N, C, A>& x,
+    const small_map<K, T, N, C, A>& y
+)
+{
+    return y < x;
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator<=
+(
+    const small_map<K, T, N, C, A>& x,
+    const small_map<K, T, N, C, A>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator>=
+(
+    const small_map<K, T, N, C, A>& x,
+    const small_map<K, T, N, C, A>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+void swap
+(
+    small_map<K, T, N, C, A>& x,
+    small_map<K, T, N, C, A>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A, typename Predicate>
+typename small_map<K, T, N, C, A>::size_type
+    erase_if(small_map<K, T, N, C, A>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_SMALL_MAP_HPP_INCLUDED

--- a/src/thirdparty/sfl/small_multimap.hpp
+++ b/src/thirdparty/sfl/small_multimap.hpp
@@ -1,0 +1,813 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_SMALL_MULTIMAP_HPP_INCLUDED
+#define SFL_SMALL_MULTIMAP_HPP_INCLUDED
+
+#include <sfl/detail/allocator_traits.hpp>
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/functional.hpp>
+#include <sfl/detail/node_small_allocator.hpp>
+#include <sfl/detail/rb_tree.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/type_traits.hpp>
+
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <memory>           // allocator
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+namespace sfl
+{
+
+template < typename Key,
+           typename T,
+           std::size_t N,
+           typename Compare = std::less<Key>,
+           typename Allocator = std::allocator<std::pair<const Key, T>> >
+class small_multimap
+{
+    static_assert
+    (
+        std::is_same<typename Allocator::value_type, std::pair<const Key, T>>::value,
+        "Allocator::value_type must be std::pair<const Key, T>."
+    );
+
+public:
+
+    using allocator_type = Allocator;
+    using key_type       = Key;
+    using mapped_type    = T;
+    using value_type     = std::pair<const Key, T>;
+    using key_compare    = Compare;
+
+    class value_compare : protected key_compare
+    {
+        friend class small_multimap;
+
+    private:
+
+        value_compare(const key_compare& c) : key_compare(c)
+        {}
+
+    public:
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_compare::operator()(x.first, y.first);
+        }
+    };
+
+private:
+
+    using tree_type = sfl::dtl::rb_tree
+    <
+        key_type,
+        value_type,
+        sfl::dtl::first,
+        key_compare,
+        sfl::dtl::node_small_allocator
+        <
+            value_type,
+            N,
+            typename sfl::dtl::allocator_traits<allocator_type>::template rebind_alloc<value_type>
+        >,
+        small_multimap
+    >;
+
+    tree_type tree_;
+
+public:
+
+    using size_type              = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::size_type;
+    using difference_type        = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::difference_type;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using pointer                = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::pointer;
+    using const_pointer          = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::const_pointer;
+    using iterator               = typename tree_type::iterator;
+    using const_iterator         = typename tree_type::const_iterator;
+    using reverse_iterator       = typename tree_type::reverse_iterator;
+    using const_reverse_iterator = typename tree_type::const_reverse_iterator;
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    small_multimap() noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : tree_()
+    {}
+
+    explicit small_multimap(const Compare& comp) noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : tree_(comp)
+    {}
+
+    explicit small_multimap(const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : tree_(alloc)
+    {}
+
+    explicit small_multimap(const Compare& comp, const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : tree_(comp, alloc)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_multimap(InputIt first, InputIt last)
+        : tree_()
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_multimap(InputIt first, InputIt last, const Compare& comp)
+        : tree_(comp)
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_multimap(InputIt first, InputIt last, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_multimap(InputIt first, InputIt last, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert(first, last);
+    }
+
+    small_multimap(std::initializer_list<value_type> ilist)
+        : small_multimap(ilist.begin(), ilist.end())
+    {}
+
+    small_multimap(std::initializer_list<value_type> ilist, const Compare& comp)
+        : small_multimap(ilist.begin(), ilist.end(), comp)
+    {}
+
+    small_multimap(std::initializer_list<value_type> ilist, const Allocator& alloc)
+        : small_multimap(ilist.begin(), ilist.end(), alloc)
+    {}
+
+    small_multimap(std::initializer_list<value_type> ilist, const Compare& comp, const Allocator& alloc)
+        : small_multimap(ilist.begin(), ilist.end(), comp, alloc)
+    {}
+
+    small_multimap(const small_multimap& other)
+        : tree_(other.tree_)
+    {}
+
+    small_multimap(const small_multimap& other, const Allocator& alloc)
+        : tree_(other.tree_, alloc)
+    {}
+
+    small_multimap(small_multimap&& other)
+        : tree_(std::move(other.tree_))
+    {}
+
+    small_multimap(small_multimap&& other, const Allocator& alloc)
+        : tree_(std::move(other.tree_), alloc)
+    {}
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_multimap(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_multimap(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_multimap(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_multimap(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    small_multimap(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_multimap(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_multimap(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_multimap(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~small_multimap()
+    {}
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    small_multimap& operator=(const small_multimap& other)
+    {
+        tree_.operator=(other.tree_);
+        return *this;
+    }
+
+    small_multimap& operator=(small_multimap&& other)
+    {
+        tree_.operator=(std::move(other.tree_));
+        return *this;
+    }
+
+    small_multimap& operator=(std::initializer_list<value_type> ilist)
+    {
+        tree_.assign_range_equal(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- ALLOCATOR ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    allocator_type get_allocator() const noexcept
+    {
+        return allocator_type(tree_.ref_to_node_alloc());
+    }
+
+    //
+    // ---- KEY COMPARE -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_compare key_comp() const
+    {
+        return key_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- VALUE COMPARE -----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_compare value_comp() const
+    {
+        return value_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return tree_.cbegin();
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return tree_.cend();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return tree_.crbegin();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return tree_.crend();
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return tree_.empty();
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return tree_.size();
+    }
+
+    SFL_NODISCARD
+    size_type max_size() const noexcept
+    {
+        return tree_.max_size();
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear()
+    {
+        tree_.clear();
+    }
+
+    template <typename... Args>
+    iterator emplace(Args&&... args)
+    {
+        return tree_.emplace_equal(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        return tree_.emplace_hint_equal(hint, std::forward<Args>(args)...);
+    }
+
+    iterator insert(const value_type& value)
+    {
+        return tree_.insert_equal(value);
+    }
+
+    iterator insert(value_type&& value)
+    {
+        return tree_.insert_equal(std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P&&>::value>* = nullptr>
+    iterator insert(P&& value)
+    {
+        return tree_.insert_equal(std::forward<P>(value));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        return tree_.insert_hint_equal(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        return tree_.insert_hint_equal(hint, std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P>::value>* = nullptr>
+    iterator insert(const_iterator hint, P&& value)
+    {
+        return tree_.insert_hint_equal(hint, std::forward<P>(value));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    iterator erase(iterator pos)
+    {
+        return tree_.erase(pos);
+    }
+
+    iterator erase(const_iterator pos)
+    {
+        return tree_.erase(pos);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        return tree_.erase(first, last);
+    }
+
+    size_type erase(const Key& key)
+    {
+        return tree_.erase(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        return tree_.erase(x);
+    }
+
+    void swap(small_multimap& other)
+    {
+        tree_.swap(other.tree_);
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator lower_bound(const Key& key)
+    {
+        return tree_.lower_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator lower_bound(const Key& key) const
+    {
+        return tree_.lower_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator lower_bound(const K& x)
+    {
+        return tree_.lower_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator lower_bound(const K& x) const
+    {
+        return tree_.lower_bound(x);
+    }
+
+    SFL_NODISCARD
+    iterator upper_bound(const Key& key)
+    {
+        return tree_.upper_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator upper_bound(const Key& key) const
+    {
+        return tree_.upper_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator upper_bound(const K& x)
+    {
+        return tree_.upper_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator upper_bound(const K& x) const
+    {
+        return tree_.upper_bound(x);
+    }
+
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const Key& key)
+    {
+        return tree_.equal_range(key);
+    }
+
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const
+    {
+        return tree_.equal_range(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const K& x)
+    {
+        return tree_.equal_range(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const K& x) const
+    {
+        return tree_.equal_range(x);
+    }
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        return tree_.find(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        return tree_.find(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        return tree_.find(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        return tree_.find(x);
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        return tree_.count(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        return tree_.count(x);
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return tree_.contains(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return tree_.contains(x);
+    }
+
+private:
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator==
+(
+    const small_multimap<K, T, N, C, A>& x,
+    const small_multimap<K, T, N, C, A>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator!=
+(
+    const small_multimap<K, T, N, C, A>& x,
+    const small_multimap<K, T, N, C, A>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator<
+(
+    const small_multimap<K, T, N, C, A>& x,
+    const small_multimap<K, T, N, C, A>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator>
+(
+    const small_multimap<K, T, N, C, A>& x,
+    const small_multimap<K, T, N, C, A>& y
+)
+{
+    return y < x;
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator<=
+(
+    const small_multimap<K, T, N, C, A>& x,
+    const small_multimap<K, T, N, C, A>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator>=
+(
+    const small_multimap<K, T, N, C, A>& x,
+    const small_multimap<K, T, N, C, A>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A>
+void swap
+(
+    small_multimap<K, T, N, C, A>& x,
+    small_multimap<K, T, N, C, A>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename A, typename Predicate>
+typename small_multimap<K, T, N, C, A>::size_type
+    erase_if(small_multimap<K, T, N, C, A>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_SMALL_MULTIMAP_HPP_INCLUDED

--- a/src/thirdparty/sfl/small_multiset.hpp
+++ b/src/thirdparty/sfl/small_multiset.hpp
@@ -1,0 +1,776 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_SMALL_MULTISET_HPP_INCLUDED
+#define SFL_SMALL_MULTISET_HPP_INCLUDED
+
+#include <sfl/detail/allocator_traits.hpp>
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/functional.hpp>
+#include <sfl/detail/node_small_allocator.hpp>
+#include <sfl/detail/rb_tree.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/type_traits.hpp>
+
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <memory>           // allocator
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+namespace sfl
+{
+
+template < typename Key,
+           std::size_t N,
+           typename Compare = std::less<Key>,
+           typename Allocator = std::allocator<Key> >
+class small_multiset
+{
+    static_assert
+    (
+        std::is_same<typename Allocator::value_type, Key>::value,
+        "Allocator::value_type must be Key."
+    );
+
+public:
+
+    using allocator_type = Allocator;
+    using key_type       = Key;
+    using value_type     = Key;
+    using key_compare    = Compare;
+    using value_compare  = Compare;
+
+private:
+
+    using tree_type = sfl::dtl::rb_tree
+    <
+        key_type,
+        value_type,
+        sfl::dtl::identity,
+        key_compare,
+        sfl::dtl::node_small_allocator
+        <
+            value_type,
+            N,
+            typename sfl::dtl::allocator_traits<allocator_type>::template rebind_alloc<value_type>
+        >,
+        small_multiset
+    >;
+
+    tree_type tree_;
+
+public:
+
+    using size_type              = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::size_type;
+    using difference_type        = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::difference_type;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using pointer                = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::pointer;
+    using const_pointer          = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::const_pointer;
+    using iterator               = typename tree_type::const_iterator; // MUST BE const
+    using const_iterator         = typename tree_type::const_iterator;
+    using reverse_iterator       = typename tree_type::const_reverse_iterator; // MUST BE const
+    using const_reverse_iterator = typename tree_type::const_reverse_iterator;
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    small_multiset() noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : tree_()
+    {}
+
+    explicit small_multiset(const Compare& comp) noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : tree_(comp)
+    {}
+
+    explicit small_multiset(const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : tree_(alloc)
+    {}
+
+    explicit small_multiset(const Compare& comp, const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : tree_(comp, alloc)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_multiset(InputIt first, InputIt last)
+        : tree_()
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_multiset(InputIt first, InputIt last, const Compare& comp)
+        : tree_(comp)
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_multiset(InputIt first, InputIt last, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_multiset(InputIt first, InputIt last, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert(first, last);
+    }
+
+    small_multiset(std::initializer_list<value_type> ilist)
+        : small_multiset(ilist.begin(), ilist.end())
+    {}
+
+    small_multiset(std::initializer_list<value_type> ilist, const Compare& comp)
+        : small_multiset(ilist.begin(), ilist.end(), comp)
+    {}
+
+    small_multiset(std::initializer_list<value_type> ilist, const Allocator& alloc)
+        : small_multiset(ilist.begin(), ilist.end(), alloc)
+    {}
+
+    small_multiset(std::initializer_list<value_type> ilist, const Compare& comp, const Allocator& alloc)
+        : small_multiset(ilist.begin(), ilist.end(), comp, alloc)
+    {}
+
+    small_multiset(const small_multiset& other)
+        : tree_(other.tree_)
+    {}
+
+    small_multiset(const small_multiset& other, const Allocator& alloc)
+        : tree_(other.tree_, alloc)
+    {}
+
+    small_multiset(small_multiset&& other)
+        : tree_(std::move(other.tree_))
+    {}
+
+    small_multiset(small_multiset&& other, const Allocator& alloc)
+        : tree_(std::move(other.tree_), alloc)
+    {}
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_multiset(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_multiset(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_multiset(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_multiset(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    small_multiset(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_multiset(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_multiset(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_multiset(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~small_multiset()
+    {}
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    small_multiset& operator=(const small_multiset& other)
+    {
+        tree_.operator=(other.tree_);
+        return *this;
+    }
+
+    small_multiset& operator=(small_multiset&& other)
+    {
+        tree_.operator=(std::move(other.tree_));
+        return *this;
+    }
+
+    small_multiset& operator=(std::initializer_list<value_type> ilist)
+    {
+        tree_.assign_range_equal(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- ALLOCATOR ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    allocator_type get_allocator() const noexcept
+    {
+        return allocator_type(tree_.ref_to_node_alloc());
+    }
+
+    //
+    // ---- KEY COMPARE -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_compare key_comp() const
+    {
+        return key_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- VALUE COMPARE -----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_compare value_comp() const
+    {
+        return value_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return tree_.cbegin();
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return tree_.cend();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return tree_.crbegin();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return tree_.crend();
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return tree_.empty();
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return tree_.size();
+    }
+
+    SFL_NODISCARD
+    size_type max_size() const noexcept
+    {
+        return tree_.max_size();
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear()
+    {
+        tree_.clear();
+    }
+
+    template <typename... Args>
+    iterator emplace(Args&&... args)
+    {
+        return tree_.emplace_equal(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        return tree_.emplace_hint_equal(hint, std::forward<Args>(args)...);
+    }
+
+    iterator insert(const value_type& value)
+    {
+        return tree_.insert_equal(value);
+    }
+
+    iterator insert(value_type&& value)
+    {
+        return tree_.insert_equal(std::move(value));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        return tree_.insert_hint_equal(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        return tree_.insert_hint_equal(hint, std::move(value));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    iterator erase(const_iterator pos)
+    {
+        return tree_.erase(pos);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        return tree_.erase(first, last);
+    }
+
+    size_type erase(const Key& key)
+    {
+        return tree_.erase(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        return tree_.erase(x);
+    }
+
+    void swap(small_multiset& other)
+    {
+        tree_.swap(other.tree_);
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator lower_bound(const Key& key)
+    {
+        return tree_.lower_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator lower_bound(const Key& key) const
+    {
+        return tree_.lower_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator lower_bound(const K& x)
+    {
+        return tree_.lower_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator lower_bound(const K& x) const
+    {
+        return tree_.lower_bound(x);
+    }
+
+    SFL_NODISCARD
+    iterator upper_bound(const Key& key)
+    {
+        return tree_.upper_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator upper_bound(const Key& key) const
+    {
+        return tree_.upper_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator upper_bound(const K& x)
+    {
+        return tree_.upper_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator upper_bound(const K& x) const
+    {
+        return tree_.upper_bound(x);
+    }
+
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const Key& key)
+    {
+        return tree_.equal_range(key);
+    }
+
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const
+    {
+        return tree_.equal_range(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const K& x)
+    {
+        return tree_.equal_range(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const K& x) const
+    {
+        return tree_.equal_range(x);
+    }
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        return tree_.find(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        return tree_.find(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        return tree_.find(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        return tree_.find(x);
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        return tree_.count(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        return tree_.count(x);
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return tree_.contains(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return tree_.contains(x);
+    }
+
+private:
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator==
+(
+    const small_multiset<K, N, C, A>& x,
+    const small_multiset<K, N, C, A>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator!=
+(
+    const small_multiset<K, N, C, A>& x,
+    const small_multiset<K, N, C, A>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator<
+(
+    const small_multiset<K, N, C, A>& x,
+    const small_multiset<K, N, C, A>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator>
+(
+    const small_multiset<K, N, C, A>& x,
+    const small_multiset<K, N, C, A>& y
+)
+{
+    return y < x;
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator<=
+(
+    const small_multiset<K, N, C, A>& x,
+    const small_multiset<K, N, C, A>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator>=
+(
+    const small_multiset<K, N, C, A>& x,
+    const small_multiset<K, N, C, A>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+void swap
+(
+    small_multiset<K, N, C, A>& x,
+    small_multiset<K, N, C, A>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, std::size_t N, typename C, typename A, typename Predicate>
+typename small_multiset<K, N, C, A>::size_type
+    erase_if(small_multiset<K, N, C, A>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_SMALL_MULTISET_HPP_INCLUDED

--- a/src/thirdparty/sfl/small_set.hpp
+++ b/src/thirdparty/sfl/small_set.hpp
@@ -1,0 +1,776 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_SMALL_SET_HPP_INCLUDED
+#define SFL_SMALL_SET_HPP_INCLUDED
+
+#include <sfl/detail/allocator_traits.hpp>
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/functional.hpp>
+#include <sfl/detail/node_small_allocator.hpp>
+#include <sfl/detail/rb_tree.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/type_traits.hpp>
+
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <memory>           // allocator
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+namespace sfl
+{
+
+template < typename Key,
+           std::size_t N,
+           typename Compare = std::less<Key>,
+           typename Allocator = std::allocator<Key> >
+class small_set
+{
+    static_assert
+    (
+        std::is_same<typename Allocator::value_type, Key>::value,
+        "Allocator::value_type must be Key."
+    );
+
+public:
+
+    using allocator_type = Allocator;
+    using key_type       = Key;
+    using value_type     = Key;
+    using key_compare    = Compare;
+    using value_compare  = Compare;
+
+private:
+
+    using tree_type = sfl::dtl::rb_tree
+    <
+        key_type,
+        value_type,
+        sfl::dtl::identity,
+        key_compare,
+        sfl::dtl::node_small_allocator
+        <
+            value_type,
+            N,
+            typename sfl::dtl::allocator_traits<allocator_type>::template rebind_alloc<value_type>
+        >,
+        small_set
+    >;
+
+    tree_type tree_;
+
+public:
+
+    using size_type              = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::size_type;
+    using difference_type        = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::difference_type;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using pointer                = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::pointer;
+    using const_pointer          = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::const_pointer;
+    using iterator               = typename tree_type::const_iterator; // MUST BE const
+    using const_iterator         = typename tree_type::const_iterator;
+    using reverse_iterator       = typename tree_type::const_reverse_iterator; // MUST BE const
+    using const_reverse_iterator = typename tree_type::const_reverse_iterator;
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    small_set() noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : tree_()
+    {}
+
+    explicit small_set(const Compare& comp) noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : tree_(comp)
+    {}
+
+    explicit small_set(const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : tree_(alloc)
+    {}
+
+    explicit small_set(const Compare& comp, const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : tree_(comp, alloc)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_set(InputIt first, InputIt last)
+        : tree_()
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_set(InputIt first, InputIt last, const Compare& comp)
+        : tree_(comp)
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_set(InputIt first, InputIt last, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_set(InputIt first, InputIt last, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert(first, last);
+    }
+
+    small_set(std::initializer_list<value_type> ilist)
+        : small_set(ilist.begin(), ilist.end())
+    {}
+
+    small_set(std::initializer_list<value_type> ilist, const Compare& comp)
+        : small_set(ilist.begin(), ilist.end(), comp)
+    {}
+
+    small_set(std::initializer_list<value_type> ilist, const Allocator& alloc)
+        : small_set(ilist.begin(), ilist.end(), alloc)
+    {}
+
+    small_set(std::initializer_list<value_type> ilist, const Compare& comp, const Allocator& alloc)
+        : small_set(ilist.begin(), ilist.end(), comp, alloc)
+    {}
+
+    small_set(const small_set& other)
+        : tree_(other.tree_)
+    {}
+
+    small_set(const small_set& other, const Allocator& alloc)
+        : tree_(other.tree_, alloc)
+    {}
+
+    small_set(small_set&& other)
+        : tree_(std::move(other.tree_))
+    {}
+
+    small_set(small_set&& other, const Allocator& alloc)
+        : tree_(std::move(other.tree_), alloc)
+    {}
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_set(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_set(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_set(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_set(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    small_set(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_set(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_set(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : tree_(alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_set(sfl::from_range_t, Range&& range, const Compare& comp, const Allocator& alloc)
+        : tree_(comp, alloc)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~small_set()
+    {}
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    small_set& operator=(const small_set& other)
+    {
+        tree_.operator=(other.tree_);
+        return *this;
+    }
+
+    small_set& operator=(small_set&& other)
+    {
+        tree_.operator=(std::move(other.tree_));
+        return *this;
+    }
+
+    small_set& operator=(std::initializer_list<value_type> ilist)
+    {
+        tree_.assign_range_unique(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- ALLOCATOR ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    allocator_type get_allocator() const noexcept
+    {
+        return allocator_type(tree_.ref_to_node_alloc());
+    }
+
+    //
+    // ---- KEY COMPARE -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_compare key_comp() const
+    {
+        return key_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- VALUE COMPARE -----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_compare value_comp() const
+    {
+        return value_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return tree_.cbegin();
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return tree_.cend();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return tree_.crbegin();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return tree_.crend();
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return tree_.empty();
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return tree_.size();
+    }
+
+    SFL_NODISCARD
+    size_type max_size() const noexcept
+    {
+        return tree_.max_size();
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear()
+    {
+        tree_.clear();
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace(Args&&... args)
+    {
+        return tree_.emplace_unique(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        return tree_.emplace_hint_unique(hint, std::forward<Args>(args)...);
+    }
+
+    std::pair<iterator, bool> insert(const value_type& value)
+    {
+        return tree_.insert_unique(value);
+    }
+
+    std::pair<iterator, bool> insert(value_type&& value)
+    {
+        return tree_.insert_unique(std::move(value));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        return tree_.insert_hint_unique(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        return tree_.insert_hint_unique(hint, std::move(value));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    iterator erase(const_iterator pos)
+    {
+        return tree_.erase(pos);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        return tree_.erase(first, last);
+    }
+
+    size_type erase(const Key& key)
+    {
+        return tree_.erase(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        return tree_.erase(x);
+    }
+
+    void swap(small_set& other)
+    {
+        tree_.swap(other.tree_);
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator lower_bound(const Key& key)
+    {
+        return tree_.lower_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator lower_bound(const Key& key) const
+    {
+        return tree_.lower_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator lower_bound(const K& x)
+    {
+        return tree_.lower_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator lower_bound(const K& x) const
+    {
+        return tree_.lower_bound(x);
+    }
+
+    SFL_NODISCARD
+    iterator upper_bound(const Key& key)
+    {
+        return tree_.upper_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator upper_bound(const Key& key) const
+    {
+        return tree_.upper_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator upper_bound(const K& x)
+    {
+        return tree_.upper_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator upper_bound(const K& x) const
+    {
+        return tree_.upper_bound(x);
+    }
+
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const Key& key)
+    {
+        return tree_.equal_range(key);
+    }
+
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const
+    {
+        return tree_.equal_range(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const K& x)
+    {
+        return tree_.equal_range(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const K& x) const
+    {
+        return tree_.equal_range(x);
+    }
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        return tree_.find(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        return tree_.find(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        return tree_.find(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        return tree_.find(x);
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        return tree_.count(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        return tree_.count(x);
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return tree_.contains(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return tree_.contains(x);
+    }
+
+private:
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator==
+(
+    const small_set<K, N, C, A>& x,
+    const small_set<K, N, C, A>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator!=
+(
+    const small_set<K, N, C, A>& x,
+    const small_set<K, N, C, A>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator<
+(
+    const small_set<K, N, C, A>& x,
+    const small_set<K, N, C, A>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator>
+(
+    const small_set<K, N, C, A>& x,
+    const small_set<K, N, C, A>& y
+)
+{
+    return y < x;
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator<=
+(
+    const small_set<K, N, C, A>& x,
+    const small_set<K, N, C, A>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+SFL_NODISCARD
+bool operator>=
+(
+    const small_set<K, N, C, A>& x,
+    const small_set<K, N, C, A>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename K, std::size_t N, typename C, typename A>
+void swap
+(
+    small_set<K, N, C, A>& x,
+    small_set<K, N, C, A>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, std::size_t N, typename C, typename A, typename Predicate>
+typename small_set<K, N, C, A>::size_type
+    erase_if(small_set<K, N, C, A>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_SMALL_SET_HPP_INCLUDED

--- a/src/thirdparty/sfl/small_unordered_flat_map.hpp
+++ b/src/thirdparty/sfl/small_unordered_flat_map.hpp
@@ -1,0 +1,2137 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_SMALL_UNORDERED_FLAT_MAP_HPP_INCLUDED
+#define SFL_SMALL_UNORDERED_FLAT_MAP_HPP_INCLUDED
+
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/exceptions.hpp>
+#include <sfl/detail/ignore_unused.hpp>
+#include <sfl/detail/initialized_memory_algorithms.hpp>
+#include <sfl/detail/normal_iterator.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/to_address.hpp>
+#include <sfl/detail/type_traits.hpp>
+#include <sfl/detail/uninitialized_memory_algorithms.hpp>
+
+#include <algorithm>        // copy, move, lower_bound, swap, swap_ranges
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <iterator>         // distance, next, reverse_iterator
+#include <limits>           // numeric_limits
+#include <memory>           // allocator, allocator_traits, pointer_traits
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+#ifdef SFL_TEST_SMALL_UNORDERED_FLAT_MAP
+template <int>
+void test_small_unordered_flat_map();
+#endif
+
+namespace sfl
+{
+
+template < typename Key,
+           typename T,
+           std::size_t N,
+           typename KeyEqual = std::equal_to<Key>,
+           typename Allocator = std::allocator<std::pair<Key, T>> >
+class small_unordered_flat_map
+{
+    #ifdef SFL_TEST_SMALL_UNORDERED_FLAT_MAP
+    template <int>
+    friend void ::test_small_unordered_flat_map();
+    #endif
+
+public:
+
+    using allocator_type   = Allocator;
+    using allocator_traits = std::allocator_traits<allocator_type>;
+    using key_type         = Key;
+    using mapped_type      = T;
+    using value_type       = std::pair<Key, T>;
+    using size_type        = typename allocator_traits::size_type;
+    using difference_type  = typename allocator_traits::difference_type;
+    using key_equal        = KeyEqual;
+    using reference        = value_type&;
+    using const_reference  = const value_type&;
+    using pointer          = typename allocator_traits::pointer;
+    using const_pointer    = typename allocator_traits::const_pointer;
+    using iterator         = sfl::dtl::normal_iterator<pointer, small_unordered_flat_map>;
+    using const_iterator   = sfl::dtl::normal_iterator<const_pointer, small_unordered_flat_map>;
+
+    class value_equal : protected key_equal
+    {
+        friend class small_unordered_flat_map;
+
+    private:
+
+        value_equal(const key_equal& e) : key_equal(e)
+        {}
+
+    public:
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_equal::operator()(x.first, y.first);
+        }
+    };
+
+    static_assert
+    (
+        std::is_same<typename Allocator::value_type, value_type>::value,
+        "Allocator::value_type must be same as sfl::small_unordered_flat_map::value_type."
+    );
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+private:
+
+    // Like `value_equal` but with additional operators.
+    // For internal use only.
+    class ultra_equal : public key_equal
+    {
+    public:
+
+        ultra_equal() noexcept(std::is_nothrow_default_constructible<key_equal>::value)
+        {}
+
+        ultra_equal(const key_equal& e) noexcept(std::is_nothrow_copy_constructible<key_equal>::value)
+            : key_equal(e)
+        {}
+
+        ultra_equal(key_equal&& e) noexcept(std::is_nothrow_move_constructible<key_equal>::value)
+            : key_equal(std::move(e))
+        {}
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_equal::operator()(x.first, y.first);
+        }
+
+        template <typename K>
+        bool operator()(const value_type& x, const K& y) const
+        {
+            return key_equal::operator()(x.first, y);
+        }
+
+        template <typename K>
+        bool operator()(const K& x, const value_type& y) const
+        {
+            return key_equal::operator()(x, y.first);
+        }
+    };
+
+    template <bool WithInternalStorage = true, typename = void>
+    class data_base
+    {
+    private:
+
+        union
+        {
+            value_type internal_storage_[N];
+        };
+
+    public:
+
+        pointer first_;
+        pointer last_;
+        pointer eos_;
+
+        data_base() noexcept
+            : first_(std::pointer_traits<pointer>::pointer_to(*internal_storage_))
+            , last_(first_)
+            , eos_(first_ + N)
+        {}
+
+        #if defined(__clang__) && (__clang_major__ == 3) // For CentOS 7
+        ~data_base()
+        {}
+        #else
+        ~data_base() noexcept
+        {}
+        #endif
+
+        pointer internal_storage() noexcept
+        {
+            return std::pointer_traits<pointer>::pointer_to(*internal_storage_);
+        }
+    };
+
+    template <typename Dummy>
+    class data_base<false, Dummy>
+    {
+    public:
+
+        pointer first_;
+        pointer last_;
+        pointer eos_;
+
+        data_base() noexcept
+            : first_(nullptr)
+            , last_(nullptr)
+            , eos_(nullptr)
+        {}
+
+        pointer internal_storage() noexcept
+        {
+            return nullptr;
+        }
+    };
+
+    class data : public data_base<(N > 0)>, public allocator_type, public ultra_equal
+    {
+    public:
+
+        data() noexcept
+        (
+            std::is_nothrow_default_constructible<allocator_type>::value &&
+            std::is_nothrow_default_constructible<ultra_equal>::value
+        )
+            : allocator_type()
+            , ultra_equal()
+        {}
+
+        data(const ultra_equal& equal) noexcept
+        (
+            std::is_nothrow_default_constructible<allocator_type>::value &&
+            std::is_nothrow_copy_constructible<ultra_equal>::value
+        )
+            : allocator_type()
+            , ultra_equal(equal)
+        {}
+
+        data(const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_default_constructible<ultra_equal>::value
+        )
+            : allocator_type(alloc)
+            , ultra_equal()
+        {}
+
+        data(const ultra_equal& equal, const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_copy_constructible<ultra_equal>::value
+        )
+            : allocator_type(alloc)
+            , ultra_equal(equal)
+        {}
+
+        data(ultra_equal&& equal, allocator_type&& alloc) noexcept
+        (
+            std::is_nothrow_move_constructible<allocator_type>::value &&
+            std::is_nothrow_move_constructible<ultra_equal>::value
+        )
+            : allocator_type(std::move(alloc))
+            , ultra_equal(std::move(equal))
+        {}
+
+        data(ultra_equal&& equal, const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_move_constructible<ultra_equal>::value
+        )
+            : allocator_type(alloc)
+            , ultra_equal(std::move(equal))
+        {}
+
+        allocator_type& ref_to_alloc() noexcept
+        {
+            return *this;
+        }
+
+        const allocator_type& ref_to_alloc() const noexcept
+        {
+            return *this;
+        }
+
+        ultra_equal& ref_to_equal() noexcept
+        {
+            return *this;
+        }
+
+        const ultra_equal& ref_to_equal() const noexcept
+        {
+            return *this;
+        }
+    };
+
+    data data_;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    small_unordered_flat_map() noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<KeyEqual>::value
+    )
+        : data_()
+    {}
+
+    explicit small_unordered_flat_map(const KeyEqual& equal) noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<KeyEqual>::value
+    )
+        : data_(equal)
+    {}
+
+    explicit small_unordered_flat_map(const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<KeyEqual>::value
+    )
+        : data_(alloc)
+    {}
+
+    explicit small_unordered_flat_map(const KeyEqual& equal,
+                                      const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<KeyEqual>::value
+    )
+        : data_(equal, alloc)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_unordered_flat_map(InputIt first, InputIt last)
+        : data_()
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_unordered_flat_map(InputIt first, InputIt last,
+                             const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_unordered_flat_map(InputIt first, InputIt last,
+                             const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_unordered_flat_map(InputIt first, InputIt last,
+                             const KeyEqual& equal,
+                             const Allocator& alloc)
+        : data_(equal, alloc)
+    {
+        initialize_range(first, last);
+    }
+
+    small_unordered_flat_map(std::initializer_list<value_type> ilist)
+        : small_unordered_flat_map(ilist.begin(), ilist.end())
+    {}
+
+    small_unordered_flat_map(std::initializer_list<value_type> ilist,
+                             const KeyEqual& equal)
+        : small_unordered_flat_map(ilist.begin(), ilist.end(), equal)
+    {}
+
+    small_unordered_flat_map(std::initializer_list<value_type> ilist,
+                             const Allocator& alloc)
+        : small_unordered_flat_map(ilist.begin(), ilist.end(), alloc)
+    {}
+
+    small_unordered_flat_map(std::initializer_list<value_type> ilist,
+                             const KeyEqual& equal,
+                             const Allocator& alloc)
+        : small_unordered_flat_map(ilist.begin(), ilist.end(), equal, alloc)
+    {}
+
+    small_unordered_flat_map(const small_unordered_flat_map& other)
+        : data_
+        (
+            other.data_.ref_to_equal(),
+            allocator_traits::select_on_container_copy_construction
+            (
+                other.data_.ref_to_alloc()
+            )
+        )
+    {
+        initialize_copy(other);
+    }
+
+    small_unordered_flat_map(const small_unordered_flat_map& other,
+                             const Allocator& alloc)
+        : data_
+        (
+            other.data_.ref_to_equal(),
+            alloc
+        )
+    {
+        initialize_copy(other);
+    }
+
+    small_unordered_flat_map(small_unordered_flat_map&& other)
+        : data_
+        (
+            std::move(other.data_.ref_to_equal()),
+            std::move(other.data_.ref_to_alloc())
+        )
+    {
+        initialize_move(other);
+    }
+
+    small_unordered_flat_map(small_unordered_flat_map&& other,
+                             const Allocator& alloc)
+        : data_
+        (
+            std::move(other.data_.ref_to_equal()),
+            alloc
+        )
+    {
+        initialize_move(other);
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_unordered_flat_map(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_unordered_flat_map(sfl::from_range_t, Range&& range, const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_unordered_flat_map(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_unordered_flat_map(sfl::from_range_t, Range&& range, const KeyEqual& equal, const Allocator& alloc)
+        : data_(equal, alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    small_unordered_flat_map(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_unordered_flat_map(sfl::from_range_t, Range&& range, const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_unordered_flat_map(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_unordered_flat_map(sfl::from_range_t, Range&& range, const KeyEqual& equal, const Allocator& alloc)
+        : data_(equal, alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~small_unordered_flat_map()
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        if (data_.first_ != data_.internal_storage())
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                std::distance(data_.first_, data_.eos_)
+            );
+        }
+    }
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    small_unordered_flat_map& operator=(const small_unordered_flat_map& other)
+    {
+        assign_copy(other);
+        return *this;
+    }
+
+    small_unordered_flat_map& operator=(small_unordered_flat_map&& other)
+    {
+        assign_move(other);
+        return *this;
+    }
+
+    small_unordered_flat_map& operator=(std::initializer_list<value_type> ilist)
+    {
+        clear();
+        insert(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- ALLOCATOR ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    allocator_type get_allocator() const noexcept
+    {
+        return data_.ref_to_alloc();
+    }
+
+    //
+    // ---- KEY EQUAL ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_equal key_eq() const
+    {
+        return data_.ref_to_equal();
+    }
+
+    //
+    // ---- VALUE EQUAL -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_equal value_eq() const
+    {
+        return value_equal(data_.ref_to_equal());
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    iterator nth(size_type pos) noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_iterator nth(size_type pos) const noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return const_iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    size_type index_of(const_iterator pos) const noexcept
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return std::distance(cbegin(), pos);
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return data_.first_ == data_.last_;
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return std::distance(data_.first_, data_.last_);
+    }
+
+    SFL_NODISCARD
+    size_type max_size() const noexcept
+    {
+        return std::min<size_type>
+        (
+            allocator_traits::max_size(data_.ref_to_alloc()),
+            std::numeric_limits<difference_type>::max() / sizeof(value_type)
+        );
+    }
+
+    SFL_NODISCARD
+    size_type capacity() const noexcept
+    {
+        return std::distance(data_.first_, data_.eos_);
+    }
+
+    SFL_NODISCARD
+    size_type available() const noexcept
+    {
+        return std::distance(data_.last_, data_.eos_);
+    }
+
+    void reserve(size_type new_cap)
+    {
+        check_size(new_cap, "sfl::small_unordered_flat_map::reserve");
+
+        if (new_cap > capacity())
+        {
+            if (new_cap <= N)
+            {
+                if (data_.first_ == data_.internal_storage())
+                {
+                    // Do nothing. We are already using internal storage.
+                }
+                else
+                {
+                    // We are not using internal storage but new capacity
+                    // can fit in internal storage.
+
+                    pointer new_first = data_.internal_storage();
+                    pointer new_last  = new_first;
+                    pointer new_eos   = new_first + N;
+
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_
+                    );
+
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+
+                    data_.first_ = new_first;
+                    data_.last_  = new_last;
+                    data_.eos_   = new_eos;
+                }
+            }
+            else
+            {
+                pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                pointer new_last  = new_first;
+                pointer new_eos   = new_first + new_cap;
+
+                SFL_TRY
+                {
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+                }
+                SFL_CATCH (...)
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+
+                    SFL_RETHROW;
+                }
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_
+                );
+
+                if (data_.first_ != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+                }
+
+                data_.first_ = new_first;
+                data_.last_  = new_last;
+                data_.eos_   = new_eos;
+            }
+        }
+    }
+
+    void shrink_to_fit()
+    {
+        const size_type new_cap = size();
+
+        if (new_cap < capacity())
+        {
+            if (new_cap <= N)
+            {
+                if (data_.first_ == data_.internal_storage())
+                {
+                    // Do nothing. We are already using internal storage.
+                }
+                else
+                {
+                    // We are not using internal storage but new capacity
+                    // can fit in internal storage.
+
+                    pointer new_first = data_.internal_storage();
+                    pointer new_last  = new_first;
+                    pointer new_eos   = new_first + N;
+
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_
+                    );
+
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+
+                    data_.first_ = new_first;
+                    data_.last_  = new_last;
+                    data_.eos_   = new_eos;
+                }
+            }
+            else
+            {
+                pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                pointer new_last  = new_first;
+                pointer new_eos   = new_first + new_cap;
+
+                SFL_TRY
+                {
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+                }
+                SFL_CATCH (...)
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+
+                    SFL_RETHROW;
+                }
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_
+                );
+
+                if (data_.first_ != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+                }
+
+                data_.first_ = new_first;
+                data_.last_  = new_last;
+                data_.eos_   = new_eos;
+            }
+        }
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear() noexcept
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        data_.last_ = data_.first_;
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace(Args&&... args)
+    {
+        return emplace_aux(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return emplace_hint_aux(hint, std::forward<Args>(args)...);
+    }
+
+    std::pair<iterator, bool> insert(const value_type& value)
+    {
+        return insert_aux(value);
+    }
+
+    std::pair<iterator, bool> insert(value_type&& value)
+    {
+        return insert_aux(std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P&&>::value>* = nullptr>
+    std::pair<iterator, bool> insert(P&& value)
+    {
+        return insert_aux(value_type(std::forward<P>(value)));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P&&>::value>* = nullptr>
+    iterator insert(const_iterator hint, P&& value)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value_type(std::forward<P>(value)));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    std::pair<iterator, bool> insert_or_assign(const Key& key, M&& obj)
+    {
+        return insert_or_assign_aux(key, std::forward<M>(obj));
+    }
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    std::pair<iterator, bool> insert_or_assign(Key&& key, M&& obj)
+    {
+        return insert_or_assign_aux(std::move(key), std::forward<M>(obj));
+    }
+
+    template <typename K, typename M,
+              sfl::dtl::enable_if_t< sfl::dtl::has_is_transparent<KeyEqual, K>::value &&
+                                     std::is_assignable<mapped_type&, M&&>::value >* = nullptr>
+    std::pair<iterator, bool> insert_or_assign(K&& key, M&& obj)
+    {
+        return insert_or_assign_aux(std::forward<K>(key), std::forward<M>(obj));
+    }
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    iterator insert_or_assign(const_iterator hint, const Key& key, M&& obj)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_or_assign_aux(hint, key, std::forward<M>(obj));
+    }
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    iterator insert_or_assign(const_iterator hint, Key&& key, M&& obj)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_or_assign_aux(hint, std::move(key), std::forward<M>(obj));
+    }
+
+    template <typename K, typename M,
+              sfl::dtl::enable_if_t< sfl::dtl::has_is_transparent<KeyEqual, K>::value &&
+                                     std::is_assignable<mapped_type&, M&&>::value >* = nullptr>
+    iterator insert_or_assign(const_iterator hint, K&& key, M&& obj)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_or_assign_aux(hint, std::forward<K>(key), std::forward<M>(obj));
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(const Key& key, Args&&... args)
+    {
+        return try_emplace_aux(key, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(Key&& key, Args&&... args)
+    {
+        return try_emplace_aux(std::move(key), std::forward<Args>(args)...);
+    }
+
+    template <typename K, typename... Args,
+              sfl::dtl::enable_if_t<
+                #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 7)
+                // This is workaround for GCC 4 bug on CentOS 7.
+                !std::is_same<sfl::dtl::remove_cvref_t<Key>, sfl::dtl::remove_cvref_t<K>>::value &&
+                #endif
+                sfl::dtl::has_is_transparent<KeyEqual, K>::value &&
+                !std::is_convertible<K&&, const_iterator>::value &&
+                !std::is_convertible<K&&, iterator>::value
+              >* = nullptr>
+    std::pair<iterator, bool> try_emplace(K&& key, Args&&... args)
+    {
+        return try_emplace_aux(std::forward<K>(key), std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator try_emplace(const_iterator hint, const Key& key, Args&&... args)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return try_emplace_aux(hint, key, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator try_emplace(const_iterator hint, Key&& key, Args&&... args)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return try_emplace_aux(hint, std::move(key), std::forward<Args>(args)...);
+    }
+
+    template <typename K, typename... Args,
+              sfl::dtl::enable_if_t<
+                #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 7)
+                // This is workaround for GCC 4 bug on CentOS 7.
+                !std::is_same<sfl::dtl::remove_cvref_t<Key>, sfl::dtl::remove_cvref_t<K>>::value &&
+                #endif
+                sfl::dtl::has_is_transparent<KeyEqual, K>::value
+              >* = nullptr>
+    iterator try_emplace(const_iterator hint, K&& key, Args&&... args)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return try_emplace_aux(hint, std::forward<K>(key), std::forward<Args>(args)...);
+    }
+
+    iterator erase(iterator pos)
+    {
+        return erase(const_iterator(pos));
+    }
+
+    iterator erase(const_iterator pos)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos < cend());
+
+        const difference_type offset = std::distance(cbegin(), pos);
+
+        const pointer p = data_.first_ + offset;
+
+        if (p < data_.last_ - 1)
+        {
+            *p = std::move(*(data_.last_ - 1));
+        }
+
+        --data_.last_;
+
+        sfl::dtl::destroy_at_a(data_.ref_to_alloc(), data_.last_);
+
+        return iterator(p);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        SFL_ASSERT(cbegin() <= first && first <= last && last <= cend());
+
+        if (first == last)
+        {
+            return begin() + std::distance(cbegin(), first);
+        }
+
+        const difference_type count1 = std::distance(first, last);
+        const difference_type count2 = std::distance(last, cend());
+
+        const difference_type offset = std::distance(cbegin(), first);
+
+        const pointer p1 = data_.first_ + offset;
+
+        if (count1 >= count2)
+        {
+            const pointer p2 = p1 + count1;
+
+            const pointer new_last = sfl::dtl::move(p2, data_.last_, p1);
+
+            sfl::dtl::destroy_a(data_.ref_to_alloc(), new_last, data_.last_);
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const pointer p2 = p1 + count2;
+
+            sfl::dtl::move(p2, data_.last_, p1);
+
+            const pointer new_last = p2;
+
+            sfl::dtl::destroy_a(data_.ref_to_alloc(), new_last, data_.last_);
+
+            data_.last_ = new_last;
+        }
+
+        return iterator(p1);
+    }
+
+    size_type erase(const Key& key)
+    {
+        auto it = find(key);
+
+        if (it == cend())
+        {
+            return 0;
+        }
+
+        erase(it);
+        return 1;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        auto it = find(x);
+
+        if (it == cend())
+        {
+            return 0;
+        }
+
+        erase(it);
+        return 1;
+    }
+
+    void swap(small_unordered_flat_map& other)
+    {
+        if (this == &other)
+        {
+            return;
+        }
+
+        using std::swap;
+
+        SFL_ASSERT
+        (
+            allocator_traits::propagate_on_container_swap::value ||
+            this->data_.ref_to_alloc() == other.data_.ref_to_alloc()
+        );
+
+        // If this and other allocator compares equal then one allocator
+        // can deallocate memory allocated by another allocator.
+        // One allocator can safely destroy_a elements constructed by other
+        // allocator regardless the two allocators compare equal or not.
+
+        if (allocator_traits::propagate_on_container_swap::value)
+        {
+            swap(this->data_.ref_to_alloc(), other.data_.ref_to_alloc());
+        }
+
+        swap(this->data_.ref_to_equal(), other.data_.ref_to_equal());
+
+        if
+        (
+            this->data_.first_ == this->data_.internal_storage() &&
+            other.data_.first_ == other.data_.internal_storage()
+        )
+        {
+            const size_type this_size  = this->size();
+            const size_type other_size = other.size();
+
+            if (this_size <= other_size)
+            {
+                std::swap_ranges
+                (
+                    this->data_.first_,
+                    this->data_.first_ + this_size,
+                    other.data_.first_
+                );
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    this->data_.ref_to_alloc(),
+                    other.data_.first_ + this_size,
+                    other.data_.first_ + other_size,
+                    this->data_.first_ + this_size
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    other.data_.ref_to_alloc(),
+                    other.data_.first_ + this_size,
+                    other.data_.first_ + other_size
+                );
+            }
+            else
+            {
+                std::swap_ranges
+                (
+                    other.data_.first_,
+                    other.data_.first_ + other_size,
+                    this->data_.first_
+                );
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    other.data_.ref_to_alloc(),
+                    this->data_.first_ + other_size,
+                    this->data_.first_ + this_size,
+                    other.data_.first_ + other_size
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    this->data_.ref_to_alloc(),
+                    this->data_.first_ + other_size,
+                    this->data_.first_ + this_size
+                );
+            }
+
+            this->data_.last_ = this->data_.first_ + other_size;
+            other.data_.last_ = other.data_.first_ + this_size;
+        }
+        else if
+        (
+            this->data_.first_ == this->data_.internal_storage() &&
+            other.data_.first_ != other.data_.internal_storage()
+        )
+        {
+            pointer new_other_first = other.data_.internal_storage();
+            pointer new_other_last  = new_other_first;
+            pointer new_other_eos   = new_other_first + N;
+
+            new_other_last = sfl::dtl::uninitialized_move_a
+            (
+                other.data_.ref_to_alloc(),
+                this->data_.first_,
+                this->data_.last_,
+                new_other_first
+            );
+
+            sfl::dtl::destroy_a
+            (
+                this->data_.ref_to_alloc(),
+                this->data_.first_,
+                this->data_.last_
+            );
+
+            this->data_.first_ = other.data_.first_;
+            this->data_.last_  = other.data_.last_;
+            this->data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = new_other_first;
+            other.data_.last_  = new_other_last;
+            other.data_.eos_   = new_other_eos;
+        }
+        else if
+        (
+            this->data_.first_ != this->data_.internal_storage() &&
+            other.data_.first_ == other.data_.internal_storage()
+        )
+        {
+            pointer new_this_first = this->data_.internal_storage();
+            pointer new_this_last  = new_this_first;
+            pointer new_this_eos   = new_this_first + N;
+
+            new_this_last = sfl::dtl::uninitialized_move_a
+            (
+                this->data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                new_this_first
+            );
+
+            sfl::dtl::destroy_a
+            (
+                other.data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_
+            );
+
+            other.data_.first_ = this->data_.first_;
+            other.data_.last_  = this->data_.last_;
+            other.data_.eos_   = this->data_.eos_;
+
+            this->data_.first_ = new_this_first;
+            this->data_.last_  = new_this_last;
+            this->data_.eos_   = new_this_eos;
+        }
+        else
+        {
+            swap(this->data_.first_, other.data_.first_);
+            swap(this->data_.last_,  other.data_.last_);
+            swap(this->data_.eos_,   other.data_.eos_);
+        }
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    //
+    // ---- ELEMENT ACCESS ----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    T& at(const Key& key)
+    {
+        auto it = find(key);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::small_unordered_flat_map::at");
+        }
+
+        return it->second;
+    }
+
+    SFL_NODISCARD
+    const T& at(const Key& key) const
+    {
+        auto it = find(key);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::small_unordered_flat_map::at");
+        }
+
+        return it->second;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    T& at(const K& x)
+    {
+        auto it = find(x);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::small_unordered_flat_map::at");
+        }
+
+        return it->second;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const T& at(const K& x) const
+    {
+        auto it = find(x);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::small_unordered_flat_map::at");
+        }
+
+        return it->second;
+    }
+
+    SFL_NODISCARD
+    T& operator[](const Key& key)
+    {
+        return try_emplace(key).first->second;
+    }
+
+    SFL_NODISCARD
+    T& operator[](Key&& key)
+    {
+        return try_emplace(std::move(key)).first->second;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    T& operator[](K&& key)
+    {
+        return try_emplace(std::forward<K>(key)).first->second;
+    }
+
+    SFL_NODISCARD
+    value_type* data() noexcept
+    {
+        return sfl::dtl::to_address(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const value_type* data() const noexcept
+    {
+        return sfl::dtl::to_address(data_.first_);
+    }
+
+private:
+
+    void check_size(size_type n, const char* msg)
+    {
+        if (n > max_size())
+        {
+            sfl::dtl::throw_length_error(msg);
+        }
+    }
+
+    size_type calculate_new_capacity(size_type num_additional_elements, const char* msg)
+    {
+        const size_type size = this->size();
+        const size_type capacity = this->capacity();
+        const size_type max_size = this->max_size();
+
+        if (max_size - size < num_additional_elements)
+        {
+            sfl::dtl::throw_length_error(msg);
+        }
+        else if (max_size - capacity < capacity / 2)
+        {
+            return max_size;
+        }
+        else if (size + num_additional_elements < capacity + capacity / 2)
+        {
+            return std::max(N, capacity + capacity / 2);
+        }
+        else
+        {
+            return std::max(N, size + num_additional_elements);
+        }
+    }
+
+    void reset(size_type new_cap = N)
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        if (data_.first_ != data_.internal_storage())
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                std::distance(data_.first_, data_.eos_)
+            );
+        }
+
+        data_.first_ = data_.internal_storage();
+        data_.last_  = data_.first_;
+        data_.eos_   = data_.first_ + N;
+
+        if (new_cap > N)
+        {
+            data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+            data_.last_  = data_.first_;
+            data_.eos_   = data_.first_ + new_cap;
+
+            // If allocation throws, first_, last_ and eos_ will be valid
+            // (they will be pointing to internal_storage).
+        }
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void initialize_range(InputIt first, Sentinel last)
+    {
+        SFL_TRY
+        {
+            while (first != last)
+            {
+                insert(*first);
+                ++first;
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            if (data_.first_ != data_.internal_storage())
+            {
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    std::distance(data_.first_, data_.eos_)
+                );
+            }
+
+            SFL_RETHROW;
+        }
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void initialize_range(Range&& range)
+    {
+        initialize_range(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void initialize_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        initialize_range(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    void initialize_copy(const small_unordered_flat_map& other)
+    {
+        const size_type n = other.size();
+
+        check_size(n, "sfl::small_unordered_flat_map::initialize_copy");
+
+        if (n > N)
+        {
+            data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+            data_.last_  = data_.first_;
+            data_.eos_   = data_.first_ + n;
+        }
+
+        SFL_TRY
+        {
+            data_.last_ = sfl::dtl::uninitialized_copy_a
+            (
+                data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                data_.first_
+            );
+        }
+        SFL_CATCH (...)
+        {
+            if (n > N)
+            {
+                sfl::dtl::deallocate(data_.ref_to_alloc(), data_.first_, n);
+            }
+
+            SFL_RETHROW;
+        }
+    }
+
+    void initialize_move(small_unordered_flat_map& other)
+    {
+        if (other.data_.first_ == other.data_.internal_storage())
+        {
+            data_.last_ = sfl::dtl::uninitialized_move_a
+            (
+                data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                data_.first_
+            );
+        }
+        else if (data_.ref_to_alloc() == other.data_.ref_to_alloc())
+        {
+            data_.first_ = other.data_.first_;
+            data_.last_  = other.data_.last_;
+            data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = nullptr;
+            other.data_.last_  = nullptr;
+            other.data_.eos_   = nullptr;
+        }
+        else
+        {
+            const size_type n = other.size();
+
+            check_size(n, "sfl::small_unordered_flat_map::initialize_move");
+
+            if (n > N)
+            {
+                data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+                data_.last_  = data_.first_;
+                data_.eos_   = data_.first_ + n;
+            }
+
+            SFL_TRY
+            {
+                data_.last_ = sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    other.data_.first_,
+                    other.data_.last_,
+                    data_.first_
+                );
+            }
+            SFL_CATCH (...)
+            {
+                if (n > N)
+                {
+                    sfl::dtl::deallocate(data_.ref_to_alloc(), data_.first_, n);
+                }
+
+                SFL_RETHROW;
+            }
+        }
+    }
+
+    template <typename ForwardIt>
+    void assign_range(ForwardIt first, ForwardIt last)
+    {
+        const size_type n = std::distance(first, last);
+
+        check_size(n, "sfl::small_unordered_flat_map::assign_range");
+
+        if (n <= capacity())
+        {
+            const size_type s = size();
+
+            if (n <= s)
+            {
+                pointer new_last = sfl::dtl::copy
+                (
+                    first,
+                    last,
+                    data_.first_
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    new_last,
+                    data_.last_
+                );
+
+                data_.last_ = new_last;
+            }
+            else
+            {
+                ForwardIt mid = std::next(first, s);
+
+                sfl::dtl::copy
+                (
+                    first,
+                    mid,
+                    data_.first_
+                );
+
+                data_.last_ = sfl::dtl::uninitialized_copy_a
+                (
+                    data_.ref_to_alloc(),
+                    mid,
+                    last,
+                    data_.last_
+                );
+            }
+        }
+        else
+        {
+            reset(n);
+
+            data_.last_ = sfl::dtl::uninitialized_copy_a
+            (
+                data_.ref_to_alloc(),
+                first,
+                last,
+                data_.first_
+            );
+        }
+    }
+
+    void assign_copy(const small_unordered_flat_map& other)
+    {
+        if (this != &other)
+        {
+            if (allocator_traits::propagate_on_container_copy_assignment::value)
+            {
+                if (data_.ref_to_alloc() != other.data_.ref_to_alloc())
+                {
+                    reset();
+                }
+
+                data_.ref_to_alloc() = other.data_.ref_to_alloc();
+            }
+
+            data_.ref_to_equal() = other.data_.ref_to_equal();
+
+            assign_range(other.data_.first_, other.data_.last_);
+        }
+    }
+
+    void assign_move(small_unordered_flat_map& other)
+    {
+        if (allocator_traits::propagate_on_container_move_assignment::value)
+        {
+            if (data_.ref_to_alloc() != other.data_.ref_to_alloc())
+            {
+                reset();
+            }
+
+            data_.ref_to_alloc() = std::move(other.data_.ref_to_alloc());
+        }
+
+        data_.ref_to_equal() = other.data_.ref_to_equal();
+
+        if (other.data_.first_ == other.data_.internal_storage())
+        {
+            assign_range
+            (
+                std::make_move_iterator(other.data_.first_),
+                std::make_move_iterator(other.data_.last_)
+            );
+        }
+        else if (data_.ref_to_alloc() == other.data_.ref_to_alloc())
+        {
+            reset();
+
+            data_.first_ = other.data_.first_;
+            data_.last_  = other.data_.last_;
+            data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = nullptr;
+            other.data_.last_  = nullptr;
+            other.data_.eos_   = nullptr;
+        }
+        else
+        {
+            assign_range
+            (
+                std::make_move_iterator(other.data_.first_),
+                std::make_move_iterator(other.data_.last_)
+            );
+        }
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace_aux(Args&&... args)
+    {
+        const auto it1 = emplace_back(std::forward<Args>(args)...);
+        const auto it2 = find(it1->first);
+
+        const bool is_unique = it1 == it2;
+
+        if (!is_unique)
+        {
+            pop_back();
+        }
+
+        return std::make_pair(it2, is_unique);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint_aux(const_iterator hint, Args&&... args)
+    {
+        sfl::dtl::ignore_unused(hint);
+        return emplace_aux(std::forward<Args>(args)...).first;
+    }
+
+    template <typename Value>
+    std::pair<iterator, bool> insert_aux(Value&& value)
+    {
+        auto it = find(value.first);
+
+        if (it == end())
+        {
+            return std::make_pair(emplace_back(std::forward<Value>(value)), true);
+        }
+
+        return std::make_pair(it, false);
+    }
+
+    template <typename Value>
+    iterator insert_aux(const_iterator hint, Value&& value)
+    {
+        sfl::dtl::ignore_unused(hint);
+        return insert_aux(std::forward<Value>(value)).first;
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+
+    template <typename K, typename M>
+    std::pair<iterator, bool> insert_or_assign_aux(K&& key, M&& obj)
+    {
+        auto it = find(key);
+
+        if (it == end())
+        {
+            return std::make_pair
+            (
+                emplace_back
+                (
+                    std::piecewise_construct,
+                    std::forward_as_tuple(std::forward<K>(key)),
+                    std::forward_as_tuple(std::forward<M>(obj))
+                ),
+                true
+            );
+        }
+
+        it->second = std::forward<M>(obj);
+        return std::make_pair(it, false);
+    }
+
+    template <typename K, typename M>
+    iterator insert_or_assign_aux(const_iterator hint, K&& key, M&& obj)
+    {
+        sfl::dtl::ignore_unused(hint);
+        return insert_or_assign_aux(std::forward<K>(key), std::forward<M>(obj)).first;
+    }
+
+    template <typename K, typename... Args>
+    std::pair<iterator, bool> try_emplace_aux(K&& key, Args&&... args)
+    {
+        auto it = find(key);
+
+        if (it == end())
+        {
+            return std::make_pair
+            (
+                emplace_back
+                (
+                    std::piecewise_construct,
+                    std::forward_as_tuple(std::forward<K>(key)),
+                    std::forward_as_tuple(std::forward<Args>(args)...)
+                ),
+                true
+            );
+        }
+
+        return std::make_pair(it, false);
+    }
+
+    template <typename K, typename... Args>
+    iterator try_emplace_aux(const_iterator hint, K&& key, Args&&... args)
+    {
+        sfl::dtl::ignore_unused(hint);
+        return try_emplace_aux(std::forward<K>(key), std::forward<Args>(args)...).first;
+    }
+
+    template <typename... Args>
+    iterator emplace_back(Args&&... args)
+    {
+        if (data_.last_ != data_.eos_)
+        {
+            const pointer old_last = data_.last_;
+
+            sfl::dtl::construct_at_a
+            (
+                data_.ref_to_alloc(),
+                data_.last_,
+                std::forward<Args>(args)...
+            );
+
+            ++data_.last_;
+
+            return iterator(old_last);
+        }
+        else
+        {
+            const size_type new_cap =
+                calculate_new_capacity(1, "sfl::small_unordered_flat_map::emplace_back");
+
+            pointer new_first;
+            pointer new_last;
+            pointer new_eos;
+
+            if (new_cap <= N && data_.first_ != data_.internal_storage())
+            {
+                new_first = data_.internal_storage();
+                new_last  = new_first;
+                new_eos   = new_first + N;
+            }
+            else
+            {
+                new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                new_last  = new_first;
+                new_eos   = new_first + new_cap;
+            }
+
+            const pointer p = new_first + size();
+
+            SFL_TRY
+            {
+                sfl::dtl::construct_at_a
+                (
+                    data_.ref_to_alloc(),
+                    p,
+                    std::forward<Args>(args)...
+                );
+
+                new_last = nullptr;
+
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_,
+                    new_first
+                );
+
+                ++new_last;
+            }
+            SFL_CATCH (...)
+            {
+                if (new_last == nullptr)
+                {
+                    sfl::dtl::destroy_at_a
+                    (
+                        data_.ref_to_alloc(),
+                        p
+                    );
+                }
+                else
+                {
+                    // Nothing to do
+                }
+
+                if (new_first != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+                }
+
+                SFL_RETHROW;
+            }
+
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            if (data_.first_ != data_.internal_storage())
+            {
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    std::distance(data_.first_, data_.eos_)
+                );
+            }
+
+            data_.first_ = new_first;
+            data_.last_  = new_last;
+            data_.eos_   = new_eos;
+
+            return iterator(p);
+        }
+    }
+
+    void pop_back()
+    {
+        SFL_ASSERT(!empty());
+
+        --data_.last_;
+
+        sfl::dtl::destroy_at_a(data_.ref_to_alloc(), data_.last_);
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, typename T, std::size_t N, typename E, typename A>
+SFL_NODISCARD
+bool operator==
+(
+    const small_unordered_flat_map<K, T, N, E, A>& x,
+    const small_unordered_flat_map<K, T, N, E, A>& y
+)
+{
+    return x.size() == y.size() && std::is_permutation(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, typename T, std::size_t N, typename E, typename A>
+SFL_NODISCARD
+bool operator!=
+(
+    const small_unordered_flat_map<K, T, N, E, A>& x,
+    const small_unordered_flat_map<K, T, N, E, A>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, typename T, std::size_t N, typename E, typename A>
+void swap
+(
+    small_unordered_flat_map<K, T, N, E, A>& x,
+    small_unordered_flat_map<K, T, N, E, A>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, typename T, std::size_t N, typename E, typename A,
+          typename Predicate>
+typename small_unordered_flat_map<K, T, N, E, A>::size_type
+    erase_if(small_unordered_flat_map<K, T, N, E, A>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_SMALL_UNORDERED_FLAT_MAP_HPP_INCLUDED

--- a/src/thirdparty/sfl/small_unordered_flat_multimap.hpp
+++ b/src/thirdparty/sfl/small_unordered_flat_multimap.hpp
@@ -1,0 +1,1885 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_SMALL_UNORDERED_FLAT_MULTIMAP_HPP_INCLUDED
+#define SFL_SMALL_UNORDERED_FLAT_MULTIMAP_HPP_INCLUDED
+
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/exceptions.hpp>
+#include <sfl/detail/ignore_unused.hpp>
+#include <sfl/detail/initialized_memory_algorithms.hpp>
+#include <sfl/detail/normal_iterator.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/to_address.hpp>
+#include <sfl/detail/type_traits.hpp>
+#include <sfl/detail/uninitialized_memory_algorithms.hpp>
+
+#include <algorithm>        // copy, move, lower_bound, swap, swap_ranges
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <iterator>         // distance, next, reverse_iterator
+#include <limits>           // numeric_limits
+#include <memory>           // allocator, allocator_traits, pointer_traits
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+#ifdef SFL_TEST_SMALL_UNORDERED_FLAT_MULTIMAP
+template <int>
+void test_small_unordered_flat_multimap();
+#endif
+
+namespace sfl
+{
+
+template < typename Key,
+           typename T,
+           std::size_t N,
+           typename KeyEqual = std::equal_to<Key>,
+           typename Allocator = std::allocator<std::pair<Key, T>> >
+class small_unordered_flat_multimap
+{
+    #ifdef SFL_TEST_SMALL_UNORDERED_FLAT_MULTIMAP
+    template <int>
+    friend void ::test_small_unordered_flat_multimap();
+    #endif
+
+public:
+
+    using allocator_type   = Allocator;
+    using allocator_traits = std::allocator_traits<allocator_type>;
+    using key_type         = Key;
+    using mapped_type      = T;
+    using value_type       = std::pair<Key, T>;
+    using size_type        = typename allocator_traits::size_type;
+    using difference_type  = typename allocator_traits::difference_type;
+    using key_equal        = KeyEqual;
+    using reference        = value_type&;
+    using const_reference  = const value_type&;
+    using pointer          = typename allocator_traits::pointer;
+    using const_pointer    = typename allocator_traits::const_pointer;
+    using iterator         = sfl::dtl::normal_iterator<pointer, small_unordered_flat_multimap>;
+    using const_iterator   = sfl::dtl::normal_iterator<const_pointer, small_unordered_flat_multimap>;
+
+    class value_equal : protected key_equal
+    {
+        friend class small_unordered_flat_multimap;
+
+    private:
+
+        value_equal(const key_equal& e) : key_equal(e)
+        {}
+
+    public:
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_equal::operator()(x.first, y.first);
+        }
+    };
+
+    static_assert
+    (
+        std::is_same<typename Allocator::value_type, value_type>::value,
+        "Allocator::value_type must be same as sfl::small_unordered_flat_multimap::value_type."
+    );
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+private:
+
+    // Like `value_equal` but with additional operators.
+    // For internal use only.
+    class ultra_equal : public key_equal
+    {
+    public:
+
+        ultra_equal() noexcept(std::is_nothrow_default_constructible<key_equal>::value)
+        {}
+
+        ultra_equal(const key_equal& e) noexcept(std::is_nothrow_copy_constructible<key_equal>::value)
+            : key_equal(e)
+        {}
+
+        ultra_equal(key_equal&& e) noexcept(std::is_nothrow_move_constructible<key_equal>::value)
+            : key_equal(std::move(e))
+        {}
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_equal::operator()(x.first, y.first);
+        }
+
+        template <typename K>
+        bool operator()(const value_type& x, const K& y) const
+        {
+            return key_equal::operator()(x.first, y);
+        }
+
+        template <typename K>
+        bool operator()(const K& x, const value_type& y) const
+        {
+            return key_equal::operator()(x, y.first);
+        }
+    };
+
+    template <bool WithInternalStorage = true, typename = void>
+    class data_base
+    {
+    private:
+
+        union
+        {
+            value_type internal_storage_[N];
+        };
+
+    public:
+
+        pointer first_;
+        pointer last_;
+        pointer eos_;
+
+        data_base() noexcept
+            : first_(std::pointer_traits<pointer>::pointer_to(*internal_storage_))
+            , last_(first_)
+            , eos_(first_ + N)
+        {}
+
+        #if defined(__clang__) && (__clang_major__ == 3) // For CentOS 7
+        ~data_base()
+        {}
+        #else
+        ~data_base() noexcept
+        {}
+        #endif
+
+        pointer internal_storage() noexcept
+        {
+            return std::pointer_traits<pointer>::pointer_to(*internal_storage_);
+        }
+    };
+
+    template <typename Dummy>
+    class data_base<false, Dummy>
+    {
+    public:
+
+        pointer first_;
+        pointer last_;
+        pointer eos_;
+
+        data_base() noexcept
+            : first_(nullptr)
+            , last_(nullptr)
+            , eos_(nullptr)
+        {}
+
+        pointer internal_storage() noexcept
+        {
+            return nullptr;
+        }
+    };
+
+    class data : public data_base<(N > 0)>, public allocator_type, public ultra_equal
+    {
+    public:
+
+        data() noexcept
+        (
+            std::is_nothrow_default_constructible<allocator_type>::value &&
+            std::is_nothrow_default_constructible<ultra_equal>::value
+        )
+            : allocator_type()
+            , ultra_equal()
+        {}
+
+        data(const ultra_equal& equal) noexcept
+        (
+            std::is_nothrow_default_constructible<allocator_type>::value &&
+            std::is_nothrow_copy_constructible<ultra_equal>::value
+        )
+            : allocator_type()
+            , ultra_equal(equal)
+        {}
+
+        data(const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_default_constructible<ultra_equal>::value
+        )
+            : allocator_type(alloc)
+            , ultra_equal()
+        {}
+
+        data(const ultra_equal& equal, const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_copy_constructible<ultra_equal>::value
+        )
+            : allocator_type(alloc)
+            , ultra_equal(equal)
+        {}
+
+        data(ultra_equal&& equal, allocator_type&& alloc) noexcept
+        (
+            std::is_nothrow_move_constructible<allocator_type>::value &&
+            std::is_nothrow_move_constructible<ultra_equal>::value
+        )
+            : allocator_type(std::move(alloc))
+            , ultra_equal(std::move(equal))
+        {}
+
+        data(ultra_equal&& equal, const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_move_constructible<ultra_equal>::value
+        )
+            : allocator_type(alloc)
+            , ultra_equal(std::move(equal))
+        {}
+
+        allocator_type& ref_to_alloc() noexcept
+        {
+            return *this;
+        }
+
+        const allocator_type& ref_to_alloc() const noexcept
+        {
+            return *this;
+        }
+
+        ultra_equal& ref_to_equal() noexcept
+        {
+            return *this;
+        }
+
+        const ultra_equal& ref_to_equal() const noexcept
+        {
+            return *this;
+        }
+    };
+
+    data data_;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    small_unordered_flat_multimap() noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<KeyEqual>::value
+    )
+        : data_()
+    {}
+
+    explicit small_unordered_flat_multimap(const KeyEqual& equal) noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<KeyEqual>::value
+    )
+        : data_(equal)
+    {}
+
+    explicit small_unordered_flat_multimap(const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<KeyEqual>::value
+    )
+        : data_(alloc)
+    {}
+
+    explicit small_unordered_flat_multimap(const KeyEqual& equal,
+                                           const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<KeyEqual>::value
+    )
+        : data_(equal, alloc)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_unordered_flat_multimap(InputIt first, InputIt last)
+        : data_()
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_unordered_flat_multimap(InputIt first, InputIt last,
+                                  const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_unordered_flat_multimap(InputIt first, InputIt last,
+                                  const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_unordered_flat_multimap(InputIt first, InputIt last,
+                                  const KeyEqual& equal,
+                                  const Allocator& alloc)
+        : data_(equal, alloc)
+    {
+        initialize_range(first, last);
+    }
+
+    small_unordered_flat_multimap(std::initializer_list<value_type> ilist)
+        : small_unordered_flat_multimap(ilist.begin(), ilist.end())
+    {}
+
+    small_unordered_flat_multimap(std::initializer_list<value_type> ilist,
+                                  const KeyEqual& equal)
+        : small_unordered_flat_multimap(ilist.begin(), ilist.end(), equal)
+    {}
+
+    small_unordered_flat_multimap(std::initializer_list<value_type> ilist,
+                                  const Allocator& alloc)
+        : small_unordered_flat_multimap(ilist.begin(), ilist.end(), alloc)
+    {}
+
+    small_unordered_flat_multimap(std::initializer_list<value_type> ilist,
+                                  const KeyEqual& equal, const Allocator& alloc)
+        : small_unordered_flat_multimap(ilist.begin(), ilist.end(), equal, alloc)
+    {}
+
+    small_unordered_flat_multimap(const small_unordered_flat_multimap& other)
+        : data_
+        (
+            other.data_.ref_to_equal(),
+            allocator_traits::select_on_container_copy_construction
+            (
+                other.data_.ref_to_alloc()
+            )
+        )
+    {
+        initialize_copy(other);
+    }
+
+    small_unordered_flat_multimap(const small_unordered_flat_multimap& other,
+                                  const Allocator& alloc)
+        : data_
+        (
+            other.data_.ref_to_equal(),
+            alloc
+        )
+    {
+        initialize_copy(other);
+    }
+
+    small_unordered_flat_multimap(small_unordered_flat_multimap&& other)
+        : data_
+        (
+            std::move(other.data_.ref_to_equal()),
+            std::move(other.data_.ref_to_alloc())
+        )
+    {
+        initialize_move(other);
+    }
+
+    small_unordered_flat_multimap(small_unordered_flat_multimap&& other,
+                                  const Allocator& alloc)
+        : data_
+        (
+            std::move(other.data_.ref_to_equal()),
+            alloc
+        )
+    {
+        initialize_move(other);
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_unordered_flat_multimap(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_unordered_flat_multimap(sfl::from_range_t, Range&& range, const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_unordered_flat_multimap(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_unordered_flat_multimap(sfl::from_range_t, Range&& range, const KeyEqual& equal, const Allocator& alloc)
+        : data_(equal, alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    small_unordered_flat_multimap(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_unordered_flat_multimap(sfl::from_range_t, Range&& range, const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_unordered_flat_multimap(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_unordered_flat_multimap(sfl::from_range_t, Range&& range, const KeyEqual& equal, const Allocator& alloc)
+        : data_(equal, alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~small_unordered_flat_multimap()
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        if (data_.first_ != data_.internal_storage())
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                std::distance(data_.first_, data_.eos_)
+            );
+        }
+    }
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    small_unordered_flat_multimap& operator=(const small_unordered_flat_multimap& other)
+    {
+        assign_copy(other);
+        return *this;
+    }
+
+    small_unordered_flat_multimap& operator=(small_unordered_flat_multimap&& other)
+    {
+        assign_move(other);
+        return *this;
+    }
+
+    small_unordered_flat_multimap& operator=(std::initializer_list<value_type> ilist)
+    {
+        clear();
+        insert(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- ALLOCATOR ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    allocator_type get_allocator() const noexcept
+    {
+        return data_.ref_to_alloc();
+    }
+
+    //
+    // ---- KEY EQUAL ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_equal key_eq() const
+    {
+        return data_.ref_to_equal();
+    }
+
+    //
+    // ---- VALUE EQUAL -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_equal value_eq() const
+    {
+        return value_equal(data_.ref_to_equal());
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    iterator nth(size_type pos) noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_iterator nth(size_type pos) const noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return const_iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    size_type index_of(const_iterator pos) const noexcept
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return std::distance(cbegin(), pos);
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return data_.first_ == data_.last_;
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return std::distance(data_.first_, data_.last_);
+    }
+
+    SFL_NODISCARD
+    size_type max_size() const noexcept
+    {
+        return std::min<size_type>
+        (
+            allocator_traits::max_size(data_.ref_to_alloc()),
+            std::numeric_limits<difference_type>::max() / sizeof(value_type)
+        );
+    }
+
+    SFL_NODISCARD
+    size_type capacity() const noexcept
+    {
+        return std::distance(data_.first_, data_.eos_);
+    }
+
+    SFL_NODISCARD
+    size_type available() const noexcept
+    {
+        return std::distance(data_.last_, data_.eos_);
+    }
+
+    void reserve(size_type new_cap)
+    {
+        check_size(new_cap, "sfl::small_unordered_flat_multimap::reserve");
+
+        if (new_cap > capacity())
+        {
+            if (new_cap <= N)
+            {
+                if (data_.first_ == data_.internal_storage())
+                {
+                    // Do nothing. We are already using internal storage.
+                }
+                else
+                {
+                    // We are not using internal storage but new capacity
+                    // can fit in internal storage.
+
+                    pointer new_first = data_.internal_storage();
+                    pointer new_last  = new_first;
+                    pointer new_eos   = new_first + N;
+
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_
+                    );
+
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+
+                    data_.first_ = new_first;
+                    data_.last_  = new_last;
+                    data_.eos_   = new_eos;
+                }
+            }
+            else
+            {
+                pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                pointer new_last  = new_first;
+                pointer new_eos   = new_first + new_cap;
+
+                SFL_TRY
+                {
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+                }
+                SFL_CATCH (...)
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+
+                    SFL_RETHROW;
+                }
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_
+                );
+
+                if (data_.first_ != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+                }
+
+                data_.first_ = new_first;
+                data_.last_  = new_last;
+                data_.eos_   = new_eos;
+            }
+        }
+    }
+
+    void shrink_to_fit()
+    {
+        const size_type new_cap = size();
+
+        if (new_cap < capacity())
+        {
+            if (new_cap <= N)
+            {
+                if (data_.first_ == data_.internal_storage())
+                {
+                    // Do nothing. We are already using internal storage.
+                }
+                else
+                {
+                    // We are not using internal storage but new capacity
+                    // can fit in internal storage.
+
+                    pointer new_first = data_.internal_storage();
+                    pointer new_last  = new_first;
+                    pointer new_eos   = new_first + N;
+
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_
+                    );
+
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+
+                    data_.first_ = new_first;
+                    data_.last_  = new_last;
+                    data_.eos_   = new_eos;
+                }
+            }
+            else
+            {
+                pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                pointer new_last  = new_first;
+                pointer new_eos   = new_first + new_cap;
+
+                SFL_TRY
+                {
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+                }
+                SFL_CATCH (...)
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+
+                    SFL_RETHROW;
+                }
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_
+                );
+
+                if (data_.first_ != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+                }
+
+                data_.first_ = new_first;
+                data_.last_  = new_last;
+                data_.eos_   = new_eos;
+            }
+        }
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear() noexcept
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        data_.last_ = data_.first_;
+    }
+
+    template <typename... Args>
+    iterator emplace(Args&&... args)
+    {
+        return emplace_back(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        sfl::dtl::ignore_unused(hint);
+        return emplace_back(std::forward<Args>(args)...);
+    }
+
+    iterator insert(const value_type& value)
+    {
+        return emplace_back(value);
+    }
+
+    iterator insert(value_type&& value)
+    {
+        return emplace_back(std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P&&>::value>* = nullptr>
+    iterator insert(P&& value)
+    {
+        return emplace_back(std::forward<P>(value));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        sfl::dtl::ignore_unused(hint);
+        return emplace_back(value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        sfl::dtl::ignore_unused(hint);
+        return emplace_back(std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P&&>::value>* = nullptr>
+    iterator insert(const_iterator hint, P&& value)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        sfl::dtl::ignore_unused(hint);
+        return emplace_back(std::forward<P>(value));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    iterator erase(iterator pos)
+    {
+        return erase(const_iterator(pos));
+    }
+
+    iterator erase(const_iterator pos)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos < cend());
+
+        const difference_type offset = std::distance(cbegin(), pos);
+
+        const pointer p = data_.first_ + offset;
+
+        if (p < data_.last_ - 1)
+        {
+            *p = std::move(*(data_.last_ - 1));
+        }
+
+        --data_.last_;
+
+        sfl::dtl::destroy_at_a(data_.ref_to_alloc(), data_.last_);
+
+        return iterator(p);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        SFL_ASSERT(cbegin() <= first && first <= last && last <= cend());
+
+        if (first == last)
+        {
+            return begin() + std::distance(cbegin(), first);
+        }
+
+        const difference_type count1 = std::distance(first, last);
+        const difference_type count2 = std::distance(last, cend());
+
+        const difference_type offset = std::distance(cbegin(), first);
+
+        const pointer p1 = data_.first_ + offset;
+
+        if (count1 >= count2)
+        {
+            const pointer p2 = p1 + count1;
+
+            const pointer new_last = sfl::dtl::move(p2, data_.last_, p1);
+
+            sfl::dtl::destroy_a(data_.ref_to_alloc(), new_last, data_.last_);
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const pointer p2 = p1 + count2;
+
+            sfl::dtl::move(p2, data_.last_, p1);
+
+            const pointer new_last = p2;
+
+            sfl::dtl::destroy_a(data_.ref_to_alloc(), new_last, data_.last_);
+
+            data_.last_ = new_last;
+        }
+
+        return iterator(p1);
+    }
+
+    size_type erase(const Key& key)
+    {
+        size_type n = 0;
+
+        for (auto it = begin(); it != end();)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                it = erase(it);
+                ++n;
+            }
+            else
+            {
+                ++it;
+            }
+        }
+
+        return n;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        size_type n = 0;
+
+        for (auto it = begin(); it != end();)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                it = erase(it);
+                ++n;
+            }
+            else
+            {
+                ++it;
+            }
+        }
+
+        return n;
+    }
+
+    void swap(small_unordered_flat_multimap& other)
+    {
+        if (this == &other)
+        {
+            return;
+        }
+
+        using std::swap;
+
+        SFL_ASSERT
+        (
+            allocator_traits::propagate_on_container_swap::value ||
+            this->data_.ref_to_alloc() == other.data_.ref_to_alloc()
+        );
+
+        // If this and other allocator compares equal then one allocator
+        // can deallocate memory allocated by another allocator.
+        // One allocator can safely destroy_a elements constructed by other
+        // allocator regardless the two allocators compare equal or not.
+
+        if (allocator_traits::propagate_on_container_swap::value)
+        {
+            swap(this->data_.ref_to_alloc(), other.data_.ref_to_alloc());
+        }
+
+        swap(this->data_.ref_to_equal(), other.data_.ref_to_equal());
+
+        if
+        (
+            this->data_.first_ == this->data_.internal_storage() &&
+            other.data_.first_ == other.data_.internal_storage()
+        )
+        {
+            const size_type this_size  = this->size();
+            const size_type other_size = other.size();
+
+            if (this_size <= other_size)
+            {
+                std::swap_ranges
+                (
+                    this->data_.first_,
+                    this->data_.first_ + this_size,
+                    other.data_.first_
+                );
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    this->data_.ref_to_alloc(),
+                    other.data_.first_ + this_size,
+                    other.data_.first_ + other_size,
+                    this->data_.first_ + this_size
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    other.data_.ref_to_alloc(),
+                    other.data_.first_ + this_size,
+                    other.data_.first_ + other_size
+                );
+            }
+            else
+            {
+                std::swap_ranges
+                (
+                    other.data_.first_,
+                    other.data_.first_ + other_size,
+                    this->data_.first_
+                );
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    other.data_.ref_to_alloc(),
+                    this->data_.first_ + other_size,
+                    this->data_.first_ + this_size,
+                    other.data_.first_ + other_size
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    this->data_.ref_to_alloc(),
+                    this->data_.first_ + other_size,
+                    this->data_.first_ + this_size
+                );
+            }
+
+            this->data_.last_ = this->data_.first_ + other_size;
+            other.data_.last_ = other.data_.first_ + this_size;
+        }
+        else if
+        (
+            this->data_.first_ == this->data_.internal_storage() &&
+            other.data_.first_ != other.data_.internal_storage()
+        )
+        {
+            pointer new_other_first = other.data_.internal_storage();
+            pointer new_other_last  = new_other_first;
+            pointer new_other_eos   = new_other_first + N;
+
+            new_other_last = sfl::dtl::uninitialized_move_a
+            (
+                other.data_.ref_to_alloc(),
+                this->data_.first_,
+                this->data_.last_,
+                new_other_first
+            );
+
+            sfl::dtl::destroy_a
+            (
+                this->data_.ref_to_alloc(),
+                this->data_.first_,
+                this->data_.last_
+            );
+
+            this->data_.first_ = other.data_.first_;
+            this->data_.last_  = other.data_.last_;
+            this->data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = new_other_first;
+            other.data_.last_  = new_other_last;
+            other.data_.eos_   = new_other_eos;
+        }
+        else if
+        (
+            this->data_.first_ != this->data_.internal_storage() &&
+            other.data_.first_ == other.data_.internal_storage()
+        )
+        {
+            pointer new_this_first = this->data_.internal_storage();
+            pointer new_this_last  = new_this_first;
+            pointer new_this_eos   = new_this_first + N;
+
+            new_this_last = sfl::dtl::uninitialized_move_a
+            (
+                this->data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                new_this_first
+            );
+
+            sfl::dtl::destroy_a
+            (
+                other.data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_
+            );
+
+            other.data_.first_ = this->data_.first_;
+            other.data_.last_  = this->data_.last_;
+            other.data_.eos_   = this->data_.eos_;
+
+            this->data_.first_ = new_this_first;
+            this->data_.last_  = new_this_last;
+            this->data_.eos_   = new_this_eos;
+        }
+        else
+        {
+            swap(this->data_.first_, other.data_.first_);
+            swap(this->data_.last_,  other.data_.last_);
+            swap(this->data_.eos_,   other.data_.eos_);
+        }
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        size_type n = 0;
+
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                ++n;
+            }
+        }
+
+        return n;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        size_type n = 0;
+
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                ++n;
+            }
+        }
+
+        return n;
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    //
+    // ---- ELEMENT ACCESS ----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_type* data() noexcept
+    {
+        return sfl::dtl::to_address(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const value_type* data() const noexcept
+    {
+        return sfl::dtl::to_address(data_.first_);
+    }
+
+private:
+
+    void check_size(size_type n, const char* msg)
+    {
+        if (n > max_size())
+        {
+            sfl::dtl::throw_length_error(msg);
+        }
+    }
+
+    size_type calculate_new_capacity(size_type num_additional_elements, const char* msg)
+    {
+        const size_type size = this->size();
+        const size_type capacity = this->capacity();
+        const size_type max_size = this->max_size();
+
+        if (max_size - size < num_additional_elements)
+        {
+            sfl::dtl::throw_length_error(msg);
+        }
+        else if (max_size - capacity < capacity / 2)
+        {
+            return max_size;
+        }
+        else if (size + num_additional_elements < capacity + capacity / 2)
+        {
+            return std::max(N, capacity + capacity / 2);
+        }
+        else
+        {
+            return std::max(N, size + num_additional_elements);
+        }
+    }
+
+    void reset(size_type new_cap = N)
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        if (data_.first_ != data_.internal_storage())
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                std::distance(data_.first_, data_.eos_)
+            );
+        }
+
+        data_.first_ = data_.internal_storage();
+        data_.last_  = data_.first_;
+        data_.eos_   = data_.first_ + N;
+
+        if (new_cap > N)
+        {
+            data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+            data_.last_  = data_.first_;
+            data_.eos_   = data_.first_ + new_cap;
+
+            // If allocation throws, first_, last_ and eos_ will be valid
+            // (they will be pointing to internal_storage).
+        }
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void initialize_range(InputIt first, Sentinel last)
+    {
+        SFL_TRY
+        {
+            while (first != last)
+            {
+                insert(*first);
+                ++first;
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            if (data_.first_ != data_.internal_storage())
+            {
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    std::distance(data_.first_, data_.eos_)
+                );
+            }
+
+            SFL_RETHROW;
+        }
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void initialize_range(Range&& range)
+    {
+        initialize_range(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void initialize_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        initialize_range(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    void initialize_copy(const small_unordered_flat_multimap& other)
+    {
+        const size_type n = other.size();
+
+        check_size(n, "sfl::small_unordered_flat_multimap::initialize_copy");
+
+        if (n > N)
+        {
+            data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+            data_.last_  = data_.first_;
+            data_.eos_   = data_.first_ + n;
+        }
+
+        SFL_TRY
+        {
+            data_.last_ = sfl::dtl::uninitialized_copy_a
+            (
+                data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                data_.first_
+            );
+        }
+        SFL_CATCH (...)
+        {
+            if (n > N)
+            {
+                sfl::dtl::deallocate(data_.ref_to_alloc(), data_.first_, n);
+            }
+
+            SFL_RETHROW;
+        }
+    }
+
+    void initialize_move(small_unordered_flat_multimap& other)
+    {
+        if (other.data_.first_ == other.data_.internal_storage())
+        {
+            data_.last_ = sfl::dtl::uninitialized_move_a
+            (
+                data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                data_.first_
+            );
+        }
+        else if (data_.ref_to_alloc() == other.data_.ref_to_alloc())
+        {
+            data_.first_ = other.data_.first_;
+            data_.last_  = other.data_.last_;
+            data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = nullptr;
+            other.data_.last_  = nullptr;
+            other.data_.eos_   = nullptr;
+        }
+        else
+        {
+            const size_type n = other.size();
+
+            check_size(n, "sfl::small_unordered_flat_multimap::initialize_move");
+
+            if (n > N)
+            {
+                data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+                data_.last_  = data_.first_;
+                data_.eos_   = data_.first_ + n;
+            }
+
+            SFL_TRY
+            {
+                data_.last_ = sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    other.data_.first_,
+                    other.data_.last_,
+                    data_.first_
+                );
+            }
+            SFL_CATCH (...)
+            {
+                if (n > N)
+                {
+                    sfl::dtl::deallocate(data_.ref_to_alloc(), data_.first_, n);
+                }
+
+                SFL_RETHROW;
+            }
+        }
+    }
+
+    template <typename ForwardIt>
+    void assign_range(ForwardIt first, ForwardIt last)
+    {
+        const size_type n = std::distance(first, last);
+
+        check_size(n, "sfl::small_unordered_flat_multimap::assign_range");
+
+        if (n <= capacity())
+        {
+            const size_type s = size();
+
+            if (n <= s)
+            {
+                pointer new_last = sfl::dtl::copy
+                (
+                    first,
+                    last,
+                    data_.first_
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    new_last,
+                    data_.last_
+                );
+
+                data_.last_ = new_last;
+            }
+            else
+            {
+                ForwardIt mid = std::next(first, s);
+
+                sfl::dtl::copy
+                (
+                    first,
+                    mid,
+                    data_.first_
+                );
+
+                data_.last_ = sfl::dtl::uninitialized_copy_a
+                (
+                    data_.ref_to_alloc(),
+                    mid,
+                    last,
+                    data_.last_
+                );
+            }
+        }
+        else
+        {
+            reset(n);
+
+            data_.last_ = sfl::dtl::uninitialized_copy_a
+            (
+                data_.ref_to_alloc(),
+                first,
+                last,
+                data_.first_
+            );
+        }
+    }
+
+    void assign_copy(const small_unordered_flat_multimap& other)
+    {
+        if (this != &other)
+        {
+            if (allocator_traits::propagate_on_container_copy_assignment::value)
+            {
+                if (data_.ref_to_alloc() != other.data_.ref_to_alloc())
+                {
+                    reset();
+                }
+
+                data_.ref_to_alloc() = other.data_.ref_to_alloc();
+            }
+
+            data_.ref_to_equal() = other.data_.ref_to_equal();
+
+            assign_range(other.data_.first_, other.data_.last_);
+        }
+    }
+
+    void assign_move(small_unordered_flat_multimap& other)
+    {
+        if (allocator_traits::propagate_on_container_move_assignment::value)
+        {
+            if (data_.ref_to_alloc() != other.data_.ref_to_alloc())
+            {
+                reset();
+            }
+
+            data_.ref_to_alloc() = std::move(other.data_.ref_to_alloc());
+        }
+
+        data_.ref_to_equal() = other.data_.ref_to_equal();
+
+        if (other.data_.first_ == other.data_.internal_storage())
+        {
+            assign_range
+            (
+                std::make_move_iterator(other.data_.first_),
+                std::make_move_iterator(other.data_.last_)
+            );
+        }
+        else if (data_.ref_to_alloc() == other.data_.ref_to_alloc())
+        {
+            reset();
+
+            data_.first_ = other.data_.first_;
+            data_.last_  = other.data_.last_;
+            data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = nullptr;
+            other.data_.last_  = nullptr;
+            other.data_.eos_   = nullptr;
+        }
+        else
+        {
+            assign_range
+            (
+                std::make_move_iterator(other.data_.first_),
+                std::make_move_iterator(other.data_.last_)
+            );
+        }
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+
+    template <typename... Args>
+    iterator emplace_back(Args&&... args)
+    {
+        if (data_.last_ != data_.eos_)
+        {
+            const pointer old_last = data_.last_;
+
+            sfl::dtl::construct_at_a
+            (
+                data_.ref_to_alloc(),
+                data_.last_,
+                std::forward<Args>(args)...
+            );
+
+            ++data_.last_;
+
+            return iterator(old_last);
+        }
+        else
+        {
+            const size_type new_cap =
+                calculate_new_capacity(1, "sfl::small_unordered_flat_multimap::emplace_back");
+
+            pointer new_first;
+            pointer new_last;
+            pointer new_eos;
+
+            if (new_cap <= N && data_.first_ != data_.internal_storage())
+            {
+                new_first = data_.internal_storage();
+                new_last  = new_first;
+                new_eos   = new_first + N;
+            }
+            else
+            {
+                new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                new_last  = new_first;
+                new_eos   = new_first + new_cap;
+            }
+
+            const pointer p = new_first + size();
+
+            SFL_TRY
+            {
+                sfl::dtl::construct_at_a
+                (
+                    data_.ref_to_alloc(),
+                    p,
+                    std::forward<Args>(args)...
+                );
+
+                new_last = nullptr;
+
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_,
+                    new_first
+                );
+
+                ++new_last;
+            }
+            SFL_CATCH (...)
+            {
+                if (new_last == nullptr)
+                {
+                    sfl::dtl::destroy_at_a
+                    (
+                        data_.ref_to_alloc(),
+                        p
+                    );
+                }
+                else
+                {
+                    // Nothing to do
+                }
+
+                if (new_first != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+                }
+
+                SFL_RETHROW;
+            }
+
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            if (data_.first_ != data_.internal_storage())
+            {
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    std::distance(data_.first_, data_.eos_)
+                );
+            }
+
+            data_.first_ = new_first;
+            data_.last_  = new_last;
+            data_.eos_   = new_eos;
+
+            return iterator(p);
+        }
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, typename T, std::size_t N, typename E, typename A>
+SFL_NODISCARD
+bool operator==
+(
+    const small_unordered_flat_multimap<K, T, N, E, A>& x,
+    const small_unordered_flat_multimap<K, T, N, E, A>& y
+)
+{
+    return x.size() == y.size() && std::is_permutation(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, typename T, std::size_t N, typename E, typename A>
+SFL_NODISCARD
+bool operator!=
+(
+    const small_unordered_flat_multimap<K, T, N, E, A>& x,
+    const small_unordered_flat_multimap<K, T, N, E, A>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, typename T, std::size_t N, typename E, typename A>
+void swap
+(
+    small_unordered_flat_multimap<K, T, N, E, A>& x,
+    small_unordered_flat_multimap<K, T, N, E, A>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, typename T, std::size_t N, typename E, typename A,
+          typename Predicate>
+typename small_unordered_flat_multimap<K, T, N, E, A>::size_type
+    erase_if(small_unordered_flat_multimap<K, T, N, E, A>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_SMALL_UNORDERED_FLAT_MULTIMAP_HPP_INCLUDED

--- a/src/thirdparty/sfl/small_unordered_flat_multiset.hpp
+++ b/src/thirdparty/sfl/small_unordered_flat_multiset.hpp
@@ -1,0 +1,1799 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_SMALL_UNORDERED_FLAT_MULTISET_HPP_INCLUDED
+#define SFL_SMALL_UNORDERED_FLAT_MULTISET_HPP_INCLUDED
+
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/exceptions.hpp>
+#include <sfl/detail/ignore_unused.hpp>
+#include <sfl/detail/initialized_memory_algorithms.hpp>
+#include <sfl/detail/normal_iterator.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/to_address.hpp>
+#include <sfl/detail/type_traits.hpp>
+#include <sfl/detail/uninitialized_memory_algorithms.hpp>
+
+#include <algorithm>        // copy, move, lower_bound, swap, swap_ranges
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <iterator>         // distance, next, reverse_iterator
+#include <limits>           // numeric_limits
+#include <memory>           // allocator, allocator_traits, pointer_traits
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+#ifdef SFL_TEST_SMALL_UNORDERED_FLAT_MULTISET
+template <int>
+void test_small_unordered_flat_multiset();
+#endif
+
+namespace sfl
+{
+
+template < typename Key,
+           std::size_t N,
+           typename KeyEqual = std::equal_to<Key>,
+           typename Allocator = std::allocator<Key> >
+class small_unordered_flat_multiset
+{
+    #ifdef SFL_TEST_SMALL_UNORDERED_FLAT_MULTISET
+    template <int>
+    friend void ::test_small_unordered_flat_multiset();
+    #endif
+
+public:
+
+    using allocator_type   = Allocator;
+    using allocator_traits = std::allocator_traits<allocator_type>;
+    using key_type         = Key;
+    using value_type       = Key;
+    using size_type        = typename allocator_traits::size_type;
+    using difference_type  = typename allocator_traits::difference_type;
+    using key_equal        = KeyEqual;
+    using reference        = value_type&;
+    using const_reference  = const value_type&;
+    using pointer          = typename allocator_traits::pointer;
+    using const_pointer    = typename allocator_traits::const_pointer;
+    using iterator         = sfl::dtl::normal_iterator<const_pointer, small_unordered_flat_multiset>; // MUST BE const_pointer
+    using const_iterator   = sfl::dtl::normal_iterator<const_pointer, small_unordered_flat_multiset>;
+
+    static_assert
+    (
+        std::is_same<typename Allocator::value_type, value_type>::value,
+        "Allocator::value_type must be same as sfl::small_unordered_flat_multiset::value_type."
+    );
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+private:
+
+    template <bool WithInternalStorage = true, typename = void>
+    class data_base
+    {
+    private:
+
+        union
+        {
+            value_type internal_storage_[N];
+        };
+
+    public:
+
+        pointer first_;
+        pointer last_;
+        pointer eos_;
+
+        data_base() noexcept
+            : first_(std::pointer_traits<pointer>::pointer_to(*internal_storage_))
+            , last_(first_)
+            , eos_(first_ + N)
+        {}
+
+        #if defined(__clang__) && (__clang_major__ == 3) // For CentOS 7
+        ~data_base()
+        {}
+        #else
+        ~data_base() noexcept
+        {}
+        #endif
+
+        pointer internal_storage() noexcept
+        {
+            return std::pointer_traits<pointer>::pointer_to(*internal_storage_);
+        }
+    };
+
+    template <typename Dummy>
+    class data_base<false, Dummy>
+    {
+    public:
+
+        pointer first_;
+        pointer last_;
+        pointer eos_;
+
+        data_base() noexcept
+            : first_(nullptr)
+            , last_(nullptr)
+            , eos_(nullptr)
+        {}
+
+        pointer internal_storage() noexcept
+        {
+            return nullptr;
+        }
+    };
+
+    class data : public data_base<(N > 0)>, public allocator_type, public key_equal
+    {
+    public:
+
+        data() noexcept
+        (
+            std::is_nothrow_default_constructible<allocator_type>::value &&
+            std::is_nothrow_default_constructible<key_equal>::value
+        )
+            : allocator_type()
+            , key_equal()
+        {}
+
+        data(const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_default_constructible<key_equal>::value
+        )
+            : allocator_type(alloc)
+            , key_equal()
+        {}
+
+        data(const key_equal& equal) noexcept
+        (
+            std::is_nothrow_default_constructible<allocator_type>::value &&
+            std::is_nothrow_copy_constructible<key_equal>::value
+        )
+            : allocator_type()
+            , key_equal(equal)
+        {}
+
+        data(const key_equal& equal, const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_copy_constructible<key_equal>::value
+        )
+            : allocator_type(alloc)
+            , key_equal(equal)
+        {}
+
+        data(key_equal&& equal, allocator_type&& alloc) noexcept
+        (
+            std::is_nothrow_move_constructible<allocator_type>::value &&
+            std::is_nothrow_move_constructible<key_equal>::value
+        )
+            : allocator_type(std::move(alloc))
+            , key_equal(std::move(equal))
+        {}
+
+        data(key_equal&& equal, const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_move_constructible<key_equal>::value
+        )
+            : allocator_type(alloc)
+            , key_equal(std::move(equal))
+        {}
+
+        allocator_type& ref_to_alloc() noexcept
+        {
+            return *this;
+        }
+
+        const allocator_type& ref_to_alloc() const noexcept
+        {
+            return *this;
+        }
+
+        key_equal& ref_to_equal() noexcept
+        {
+            return *this;
+        }
+
+        const key_equal& ref_to_equal() const noexcept
+        {
+            return *this;
+        }
+    };
+
+    data data_;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    small_unordered_flat_multiset() noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<KeyEqual>::value
+    )
+        : data_()
+    {}
+
+    explicit small_unordered_flat_multiset(const KeyEqual& equal) noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<KeyEqual>::value
+    )
+        : data_(equal)
+    {}
+
+    explicit small_unordered_flat_multiset(const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<KeyEqual>::value
+    )
+        : data_(alloc)
+    {}
+
+    explicit small_unordered_flat_multiset(const KeyEqual& equal,
+                                      const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<KeyEqual>::value
+    )
+        : data_(equal, alloc)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_unordered_flat_multiset(InputIt first, InputIt last)
+        : data_()
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_unordered_flat_multiset(InputIt first, InputIt last,
+                             const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_unordered_flat_multiset(InputIt first, InputIt last,
+                             const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_unordered_flat_multiset(InputIt first, InputIt last,
+                             const KeyEqual& equal, const Allocator& alloc)
+        : data_(equal, alloc)
+    {
+        initialize_range(first, last);
+    }
+
+    small_unordered_flat_multiset(std::initializer_list<value_type> ilist)
+        : small_unordered_flat_multiset(ilist.begin(), ilist.end())
+    {}
+
+    small_unordered_flat_multiset(std::initializer_list<value_type> ilist,
+                             const KeyEqual& equal)
+        : small_unordered_flat_multiset(ilist.begin(), ilist.end(), equal)
+    {}
+
+    small_unordered_flat_multiset(std::initializer_list<value_type> ilist,
+                             const Allocator& alloc)
+        : small_unordered_flat_multiset(ilist.begin(), ilist.end(), alloc)
+    {}
+
+    small_unordered_flat_multiset(std::initializer_list<value_type> ilist,
+                             const KeyEqual& equal, const Allocator& alloc)
+        : small_unordered_flat_multiset(ilist.begin(), ilist.end(), equal, alloc)
+    {}
+
+    small_unordered_flat_multiset(const small_unordered_flat_multiset& other)
+        : data_
+        (
+            other.data_.ref_to_equal(),
+            allocator_traits::select_on_container_copy_construction
+            (
+                other.data_.ref_to_alloc()
+            )
+        )
+    {
+        initialize_copy(other);
+    }
+
+    small_unordered_flat_multiset(const small_unordered_flat_multiset& other,
+                             const Allocator& alloc)
+        : data_
+        (
+            other.data_.ref_to_equal(),
+            alloc
+        )
+    {
+        initialize_copy(other);
+    }
+
+    small_unordered_flat_multiset(small_unordered_flat_multiset&& other)
+        : data_
+        (
+            std::move(other.data_.ref_to_equal()),
+            std::move(other.data_.ref_to_alloc())
+        )
+    {
+        initialize_move(other);
+    }
+
+    small_unordered_flat_multiset(small_unordered_flat_multiset&& other,
+                             const Allocator& alloc)
+        : data_
+        (
+            std::move(other.data_.ref_to_equal()),
+            alloc
+        )
+    {
+        initialize_move(other);
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_unordered_flat_multiset(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_unordered_flat_multiset(sfl::from_range_t, Range&& range, const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_unordered_flat_multiset(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_unordered_flat_multiset(sfl::from_range_t, Range&& range, const KeyEqual& equal, const Allocator& alloc)
+        : data_(equal, alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    small_unordered_flat_multiset(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_unordered_flat_multiset(sfl::from_range_t, Range&& range, const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_unordered_flat_multiset(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_unordered_flat_multiset(sfl::from_range_t, Range&& range, const KeyEqual& equal, const Allocator& alloc)
+        : data_(equal, alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~small_unordered_flat_multiset()
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        if (data_.first_ != data_.internal_storage())
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                std::distance(data_.first_, data_.eos_)
+            );
+        }
+    }
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    small_unordered_flat_multiset& operator=(const small_unordered_flat_multiset& other)
+    {
+        assign_copy(other);
+        return *this;
+    }
+
+    small_unordered_flat_multiset& operator=(small_unordered_flat_multiset&& other)
+    {
+        assign_move(other);
+        return *this;
+    }
+
+    small_unordered_flat_multiset& operator=(std::initializer_list<Key> ilist)
+    {
+        clear();
+        insert(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- ALLOCATOR ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    allocator_type get_allocator() const noexcept
+    {
+        return data_.ref_to_alloc();
+    }
+
+    //
+    // ---- KEY EQUAL ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_equal key_eq() const
+    {
+        return data_.ref_to_equal();
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    iterator nth(size_type pos) noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_iterator nth(size_type pos) const noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return const_iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    size_type index_of(const_iterator pos) const noexcept
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return std::distance(cbegin(), pos);
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return data_.first_ == data_.last_;
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return std::distance(data_.first_, data_.last_);
+    }
+
+    SFL_NODISCARD
+    size_type max_size() const noexcept
+    {
+        return std::min<size_type>
+        (
+            allocator_traits::max_size(data_.ref_to_alloc()),
+            std::numeric_limits<difference_type>::max() / sizeof(value_type)
+        );
+    }
+
+    SFL_NODISCARD
+    size_type capacity() const noexcept
+    {
+        return std::distance(data_.first_, data_.eos_);
+    }
+
+    SFL_NODISCARD
+    size_type available() const noexcept
+    {
+        return std::distance(data_.last_, data_.eos_);
+    }
+
+    void reserve(size_type new_cap)
+    {
+        check_size(new_cap, "sfl::small_unordered_flat_multiset::reserve");
+
+        if (new_cap > capacity())
+        {
+            if (new_cap <= N)
+            {
+                if (data_.first_ == data_.internal_storage())
+                {
+                    // Do nothing. We are already using internal storage.
+                }
+                else
+                {
+                    // We are not using internal storage but new capacity
+                    // can fit in internal storage.
+
+                    pointer new_first = data_.internal_storage();
+                    pointer new_last  = new_first;
+                    pointer new_eos   = new_first + N;
+
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_
+                    );
+
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+
+                    data_.first_ = new_first;
+                    data_.last_  = new_last;
+                    data_.eos_   = new_eos;
+                }
+            }
+            else
+            {
+                pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                pointer new_last  = new_first;
+                pointer new_eos   = new_first + new_cap;
+
+                SFL_TRY
+                {
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+                }
+                SFL_CATCH (...)
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+
+                    SFL_RETHROW;
+                }
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_
+                );
+
+                if (data_.first_ != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+                }
+
+                data_.first_ = new_first;
+                data_.last_  = new_last;
+                data_.eos_   = new_eos;
+            }
+        }
+    }
+
+    void shrink_to_fit()
+    {
+        const size_type new_cap = size();
+
+        if (new_cap < capacity())
+        {
+            if (new_cap <= N)
+            {
+                if (data_.first_ == data_.internal_storage())
+                {
+                    // Do nothing. We are already using internal storage.
+                }
+                else
+                {
+                    // We are not using internal storage but new capacity
+                    // can fit in internal storage.
+
+                    pointer new_first = data_.internal_storage();
+                    pointer new_last  = new_first;
+                    pointer new_eos   = new_first + N;
+
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_
+                    );
+
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+
+                    data_.first_ = new_first;
+                    data_.last_  = new_last;
+                    data_.eos_   = new_eos;
+                }
+            }
+            else
+            {
+                pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                pointer new_last  = new_first;
+                pointer new_eos   = new_first + new_cap;
+
+                SFL_TRY
+                {
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+                }
+                SFL_CATCH (...)
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+
+                    SFL_RETHROW;
+                }
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_
+                );
+
+                if (data_.first_ != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+                }
+
+                data_.first_ = new_first;
+                data_.last_  = new_last;
+                data_.eos_   = new_eos;
+            }
+        }
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear() noexcept
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        data_.last_ = data_.first_;
+    }
+
+    template <typename... Args>
+    iterator emplace(Args&&... args)
+    {
+        return emplace_back(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        sfl::dtl::ignore_unused(hint);
+        return emplace_back(std::forward<Args>(args)...);
+    }
+
+    iterator insert(const value_type& value)
+    {
+        return emplace_back(value);
+    }
+
+    iterator insert(value_type&& value)
+    {
+        return emplace_back(std::move(value));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        sfl::dtl::ignore_unused(hint);
+        return emplace_back(value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        sfl::dtl::ignore_unused(hint);
+        return emplace_back(std::move(value));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    iterator erase(const_iterator pos)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos < cend());
+
+        const difference_type offset = std::distance(cbegin(), pos);
+
+        const pointer p = data_.first_ + offset;
+
+        if (p < data_.last_ - 1)
+        {
+            *p = std::move(*(data_.last_ - 1));
+        }
+
+        --data_.last_;
+
+        sfl::dtl::destroy_at_a(data_.ref_to_alloc(), data_.last_);
+
+        return iterator(p);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        SFL_ASSERT(cbegin() <= first && first <= last && last <= cend());
+
+        if (first == last)
+        {
+            return begin() + std::distance(cbegin(), first);
+        }
+
+        const difference_type count1 = std::distance(first, last);
+        const difference_type count2 = std::distance(last, cend());
+
+        const difference_type offset = std::distance(cbegin(), first);
+
+        const pointer p1 = data_.first_ + offset;
+
+        if (count1 >= count2)
+        {
+            const pointer p2 = p1 + count1;
+
+            const pointer new_last = sfl::dtl::move(p2, data_.last_, p1);
+
+            sfl::dtl::destroy_a(data_.ref_to_alloc(), new_last, data_.last_);
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const pointer p2 = p1 + count2;
+
+            sfl::dtl::move(p2, data_.last_, p1);
+
+            const pointer new_last = p2;
+
+            sfl::dtl::destroy_a(data_.ref_to_alloc(), new_last, data_.last_);
+
+            data_.last_ = new_last;
+        }
+
+        return iterator(p1);
+    }
+
+    size_type erase(const Key& key)
+    {
+        size_type n = 0;
+
+        for (auto it = begin(); it != end();)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                it = erase(it);
+                ++n;
+            }
+            else
+            {
+                ++it;
+            }
+        }
+
+        return n;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        size_type n = 0;
+
+        for (auto it = begin(); it != end();)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                it = erase(it);
+                ++n;
+            }
+            else
+            {
+                ++it;
+            }
+        }
+
+        return n;
+    }
+
+    void swap(small_unordered_flat_multiset& other)
+    {
+        if (this == &other)
+        {
+            return;
+        }
+
+        using std::swap;
+
+        SFL_ASSERT
+        (
+            allocator_traits::propagate_on_container_swap::value ||
+            this->data_.ref_to_alloc() == other.data_.ref_to_alloc()
+        );
+
+        // If this and other allocator compares equal then one allocator
+        // can deallocate memory allocated by another allocator.
+        // One allocator can safely destroy_a elements constructed by other
+        // allocator regardless the two allocators compare equal or not.
+
+        if (allocator_traits::propagate_on_container_swap::value)
+        {
+            swap(this->data_.ref_to_alloc(), other.data_.ref_to_alloc());
+        }
+
+        swap(this->data_.ref_to_equal(), other.data_.ref_to_equal());
+
+        if
+        (
+            this->data_.first_ == this->data_.internal_storage() &&
+            other.data_.first_ == other.data_.internal_storage()
+        )
+        {
+            const size_type this_size  = this->size();
+            const size_type other_size = other.size();
+
+            if (this_size <= other_size)
+            {
+                std::swap_ranges
+                (
+                    this->data_.first_,
+                    this->data_.first_ + this_size,
+                    other.data_.first_
+                );
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    this->data_.ref_to_alloc(),
+                    other.data_.first_ + this_size,
+                    other.data_.first_ + other_size,
+                    this->data_.first_ + this_size
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    other.data_.ref_to_alloc(),
+                    other.data_.first_ + this_size,
+                    other.data_.first_ + other_size
+                );
+            }
+            else
+            {
+                std::swap_ranges
+                (
+                    other.data_.first_,
+                    other.data_.first_ + other_size,
+                    this->data_.first_
+                );
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    other.data_.ref_to_alloc(),
+                    this->data_.first_ + other_size,
+                    this->data_.first_ + this_size,
+                    other.data_.first_ + other_size
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    this->data_.ref_to_alloc(),
+                    this->data_.first_ + other_size,
+                    this->data_.first_ + this_size
+                );
+            }
+
+            this->data_.last_ = this->data_.first_ + other_size;
+            other.data_.last_ = other.data_.first_ + this_size;
+        }
+        else if
+        (
+            this->data_.first_ == this->data_.internal_storage() &&
+            other.data_.first_ != other.data_.internal_storage()
+        )
+        {
+            pointer new_other_first = other.data_.internal_storage();
+            pointer new_other_last  = new_other_first;
+            pointer new_other_eos   = new_other_first + N;
+
+            new_other_last = sfl::dtl::uninitialized_move_a
+            (
+                other.data_.ref_to_alloc(),
+                this->data_.first_,
+                this->data_.last_,
+                new_other_first
+            );
+
+            sfl::dtl::destroy_a
+            (
+                this->data_.ref_to_alloc(),
+                this->data_.first_,
+                this->data_.last_
+            );
+
+            this->data_.first_ = other.data_.first_;
+            this->data_.last_  = other.data_.last_;
+            this->data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = new_other_first;
+            other.data_.last_  = new_other_last;
+            other.data_.eos_   = new_other_eos;
+        }
+        else if
+        (
+            this->data_.first_ != this->data_.internal_storage() &&
+            other.data_.first_ == other.data_.internal_storage()
+        )
+        {
+            pointer new_this_first = this->data_.internal_storage();
+            pointer new_this_last  = new_this_first;
+            pointer new_this_eos   = new_this_first + N;
+
+            new_this_last = sfl::dtl::uninitialized_move_a
+            (
+                this->data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                new_this_first
+            );
+
+            sfl::dtl::destroy_a
+            (
+                other.data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_
+            );
+
+            other.data_.first_ = this->data_.first_;
+            other.data_.last_  = this->data_.last_;
+            other.data_.eos_   = this->data_.eos_;
+
+            this->data_.first_ = new_this_first;
+            this->data_.last_  = new_this_last;
+            this->data_.eos_   = new_this_eos;
+        }
+        else
+        {
+            swap(this->data_.first_, other.data_.first_);
+            swap(this->data_.last_,  other.data_.last_);
+            swap(this->data_.eos_,   other.data_.eos_);
+        }
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        size_type n = 0;
+
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                ++n;
+            }
+        }
+
+        return n;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        size_type n = 0;
+
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                ++n;
+            }
+        }
+
+        return n;
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    //
+    // ---- ELEMENT ACCESS ----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_type* data() noexcept
+    {
+        return sfl::dtl::to_address(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const value_type* data() const noexcept
+    {
+        return sfl::dtl::to_address(data_.first_);
+    }
+
+private:
+
+    void check_size(size_type n, const char* msg)
+    {
+        if (n > max_size())
+        {
+            sfl::dtl::throw_length_error(msg);
+        }
+    }
+
+    size_type calculate_new_capacity(size_type num_additional_elements, const char* msg)
+    {
+        const size_type size = this->size();
+        const size_type capacity = this->capacity();
+        const size_type max_size = this->max_size();
+
+        if (max_size - size < num_additional_elements)
+        {
+            sfl::dtl::throw_length_error(msg);
+        }
+        else if (max_size - capacity < capacity / 2)
+        {
+            return max_size;
+        }
+        else if (size + num_additional_elements < capacity + capacity / 2)
+        {
+            return std::max(N, capacity + capacity / 2);
+        }
+        else
+        {
+            return std::max(N, size + num_additional_elements);
+        }
+    }
+
+    void reset(size_type new_cap = N)
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        if (data_.first_ != data_.internal_storage())
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                std::distance(data_.first_, data_.eos_)
+            );
+        }
+
+        data_.first_ = data_.internal_storage();
+        data_.last_  = data_.first_;
+        data_.eos_   = data_.first_ + N;
+
+        if (new_cap > N)
+        {
+            data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+            data_.last_  = data_.first_;
+            data_.eos_   = data_.first_ + new_cap;
+
+            // If allocation throws, first_, last_ and eos_ will be valid
+            // (they will be pointing to internal_storage).
+        }
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void initialize_range(InputIt first, Sentinel last)
+    {
+        SFL_TRY
+        {
+            while (first != last)
+            {
+                insert(*first);
+                ++first;
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            if (data_.first_ != data_.internal_storage())
+            {
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    std::distance(data_.first_, data_.eos_)
+                );
+            }
+
+            SFL_RETHROW;
+        }
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void initialize_range(Range&& range)
+    {
+        initialize_range(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void initialize_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        initialize_range(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    void initialize_copy(const small_unordered_flat_multiset& other)
+    {
+        const size_type n = other.size();
+
+        check_size(n, "sfl::small_unordered_flat_multiset::initialize_copy");
+
+        if (n > N)
+        {
+            data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+            data_.last_  = data_.first_;
+            data_.eos_   = data_.first_ + n;
+        }
+
+        SFL_TRY
+        {
+            data_.last_ = sfl::dtl::uninitialized_copy_a
+            (
+                data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                data_.first_
+            );
+        }
+        SFL_CATCH (...)
+        {
+            if (n > N)
+            {
+                sfl::dtl::deallocate(data_.ref_to_alloc(), data_.first_, n);
+            }
+
+            SFL_RETHROW;
+        }
+    }
+
+    void initialize_move(small_unordered_flat_multiset& other)
+    {
+        if (other.data_.first_ == other.data_.internal_storage())
+        {
+            data_.last_ = sfl::dtl::uninitialized_move_a
+            (
+                data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                data_.first_
+            );
+        }
+        else if (data_.ref_to_alloc() == other.data_.ref_to_alloc())
+        {
+            data_.first_ = other.data_.first_;
+            data_.last_  = other.data_.last_;
+            data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = nullptr;
+            other.data_.last_  = nullptr;
+            other.data_.eos_   = nullptr;
+        }
+        else
+        {
+            const size_type n = other.size();
+
+            check_size(n, "sfl::small_unordered_flat_multiset::initialize_move");
+
+            if (n > N)
+            {
+                data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+                data_.last_  = data_.first_;
+                data_.eos_   = data_.first_ + n;
+            }
+
+            SFL_TRY
+            {
+                data_.last_ = sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    other.data_.first_,
+                    other.data_.last_,
+                    data_.first_
+                );
+            }
+            SFL_CATCH (...)
+            {
+                if (n > N)
+                {
+                    sfl::dtl::deallocate(data_.ref_to_alloc(), data_.first_, n);
+                }
+
+                SFL_RETHROW;
+            }
+        }
+    }
+
+    template <typename ForwardIt>
+    void assign_range(ForwardIt first, ForwardIt last)
+    {
+        const size_type n = std::distance(first, last);
+
+        check_size(n, "sfl::small_unordered_flat_multiset::assign_range");
+
+        if (n <= capacity())
+        {
+            const size_type s = size();
+
+            if (n <= s)
+            {
+                pointer new_last = sfl::dtl::copy
+                (
+                    first,
+                    last,
+                    data_.first_
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    new_last,
+                    data_.last_
+                );
+
+                data_.last_ = new_last;
+            }
+            else
+            {
+                ForwardIt mid = std::next(first, s);
+
+                sfl::dtl::copy
+                (
+                    first,
+                    mid,
+                    data_.first_
+                );
+
+                data_.last_ = sfl::dtl::uninitialized_copy_a
+                (
+                    data_.ref_to_alloc(),
+                    mid,
+                    last,
+                    data_.last_
+                );
+            }
+        }
+        else
+        {
+            reset(n);
+
+            data_.last_ = sfl::dtl::uninitialized_copy_a
+            (
+                data_.ref_to_alloc(),
+                first,
+                last,
+                data_.first_
+            );
+        }
+    }
+
+    void assign_copy(const small_unordered_flat_multiset& other)
+    {
+        if (this != &other)
+        {
+            if (allocator_traits::propagate_on_container_copy_assignment::value)
+            {
+                if (data_.ref_to_alloc() != other.data_.ref_to_alloc())
+                {
+                    reset();
+                }
+
+                data_.ref_to_alloc() = other.data_.ref_to_alloc();
+            }
+
+            data_.ref_to_equal() = other.data_.ref_to_equal();
+
+            assign_range(other.data_.first_, other.data_.last_);
+        }
+    }
+
+    void assign_move(small_unordered_flat_multiset& other)
+    {
+        if (allocator_traits::propagate_on_container_move_assignment::value)
+        {
+            if (data_.ref_to_alloc() != other.data_.ref_to_alloc())
+            {
+                reset();
+            }
+
+            data_.ref_to_alloc() = std::move(other.data_.ref_to_alloc());
+        }
+
+        data_.ref_to_equal() = other.data_.ref_to_equal();
+
+        if (other.data_.first_ == other.data_.internal_storage())
+        {
+            assign_range
+            (
+                std::make_move_iterator(other.data_.first_),
+                std::make_move_iterator(other.data_.last_)
+            );
+        }
+        else if (data_.ref_to_alloc() == other.data_.ref_to_alloc())
+        {
+            reset();
+
+            data_.first_ = other.data_.first_;
+            data_.last_  = other.data_.last_;
+            data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = nullptr;
+            other.data_.last_  = nullptr;
+            other.data_.eos_   = nullptr;
+        }
+        else
+        {
+            assign_range
+            (
+                std::make_move_iterator(other.data_.first_),
+                std::make_move_iterator(other.data_.last_)
+            );
+        }
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+
+    template <typename... Args>
+    iterator emplace_back(Args&&... args)
+    {
+        if (data_.last_ != data_.eos_)
+        {
+            const pointer old_last = data_.last_;
+
+            sfl::dtl::construct_at_a
+            (
+                data_.ref_to_alloc(),
+                data_.last_,
+                std::forward<Args>(args)...
+            );
+
+            ++data_.last_;
+
+            return iterator(old_last);
+        }
+        else
+        {
+            const size_type new_cap =
+                calculate_new_capacity(1, "sfl::small_unordered_flat_multiset::emplace_back");
+
+            pointer new_first;
+            pointer new_last;
+            pointer new_eos;
+
+            if (new_cap <= N && data_.first_ != data_.internal_storage())
+            {
+                new_first = data_.internal_storage();
+                new_last  = new_first;
+                new_eos   = new_first + N;
+            }
+            else
+            {
+                new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                new_last  = new_first;
+                new_eos   = new_first + new_cap;
+            }
+
+            const pointer p = new_first + size();
+
+            SFL_TRY
+            {
+                sfl::dtl::construct_at_a
+                (
+                    data_.ref_to_alloc(),
+                    p,
+                    std::forward<Args>(args)...
+                );
+
+                new_last = nullptr;
+
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_,
+                    new_first
+                );
+
+                ++new_last;
+            }
+            SFL_CATCH (...)
+            {
+                if (new_last == nullptr)
+                {
+                    sfl::dtl::destroy_at_a
+                    (
+                        data_.ref_to_alloc(),
+                        p
+                    );
+                }
+                else
+                {
+                    // Nothing to do
+                }
+
+                if (new_first != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+                }
+
+                SFL_RETHROW;
+            }
+
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            if (data_.first_ != data_.internal_storage())
+            {
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    std::distance(data_.first_, data_.eos_)
+                );
+            }
+
+            data_.first_ = new_first;
+            data_.last_  = new_last;
+            data_.eos_   = new_eos;
+
+            return iterator(p);
+        }
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, std::size_t N, typename E, typename A>
+SFL_NODISCARD
+bool operator==
+(
+    const small_unordered_flat_multiset<K, N, E, A>& x,
+    const small_unordered_flat_multiset<K, N, E, A>& y
+)
+{
+    return x.size() == y.size() && std::is_permutation(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, std::size_t N, typename E, typename A>
+SFL_NODISCARD
+bool operator!=
+(
+    const small_unordered_flat_multiset<K, N, E, A>& x,
+    const small_unordered_flat_multiset<K, N, E, A>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, std::size_t N, typename E, typename A>
+void swap
+(
+    small_unordered_flat_multiset<K, N, E, A>& x,
+    small_unordered_flat_multiset<K, N, E, A>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, std::size_t N, typename E, typename A,
+          typename Predicate>
+typename small_unordered_flat_multiset<K, N, E, A>::size_type
+    erase_if(small_unordered_flat_multiset<K, N, E, A>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_SMALL_UNORDERED_FLAT_MULTISET_HPP_INCLUDED

--- a/src/thirdparty/sfl/small_unordered_flat_set.hpp
+++ b/src/thirdparty/sfl/small_unordered_flat_set.hpp
@@ -1,0 +1,1851 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_SMALL_UNORDERED_FLAT_SET_HPP_INCLUDED
+#define SFL_SMALL_UNORDERED_FLAT_SET_HPP_INCLUDED
+
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/exceptions.hpp>
+#include <sfl/detail/ignore_unused.hpp>
+#include <sfl/detail/initialized_memory_algorithms.hpp>
+#include <sfl/detail/normal_iterator.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/to_address.hpp>
+#include <sfl/detail/type_traits.hpp>
+#include <sfl/detail/uninitialized_memory_algorithms.hpp>
+
+#include <algorithm>        // copy, move, lower_bound, swap, swap_ranges
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <iterator>         // distance, next, reverse_iterator
+#include <limits>           // numeric_limits
+#include <memory>           // allocator, allocator_traits, pointer_traits
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+#ifdef SFL_TEST_SMALL_UNORDERED_FLAT_SET
+template <int>
+void test_small_unordered_flat_set();
+#endif
+
+namespace sfl
+{
+
+template < typename Key,
+           std::size_t N,
+           typename KeyEqual = std::equal_to<Key>,
+           typename Allocator = std::allocator<Key> >
+class small_unordered_flat_set
+{
+    #ifdef SFL_TEST_SMALL_UNORDERED_FLAT_SET
+    template <int>
+    friend void ::test_small_unordered_flat_set();
+    #endif
+
+public:
+
+    using allocator_type   = Allocator;
+    using allocator_traits = std::allocator_traits<allocator_type>;
+    using key_type         = Key;
+    using value_type       = Key;
+    using size_type        = typename allocator_traits::size_type;
+    using difference_type  = typename allocator_traits::difference_type;
+    using key_equal        = KeyEqual;
+    using reference        = value_type&;
+    using const_reference  = const value_type&;
+    using pointer          = typename allocator_traits::pointer;
+    using const_pointer    = typename allocator_traits::const_pointer;
+    using iterator         = sfl::dtl::normal_iterator<const_pointer, small_unordered_flat_set>; // MUST BE const_pointer
+    using const_iterator   = sfl::dtl::normal_iterator<const_pointer, small_unordered_flat_set>;
+
+    static_assert
+    (
+        std::is_same<typename Allocator::value_type, value_type>::value,
+        "Allocator::value_type must be same as sfl::small_unordered_flat_set::value_type."
+    );
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+private:
+
+    template <bool WithInternalStorage = true, typename = void>
+    class data_base
+    {
+    private:
+
+        union
+        {
+            value_type internal_storage_[N];
+        };
+
+    public:
+
+        pointer first_;
+        pointer last_;
+        pointer eos_;
+
+        data_base() noexcept
+            : first_(std::pointer_traits<pointer>::pointer_to(*internal_storage_))
+            , last_(first_)
+            , eos_(first_ + N)
+        {}
+
+        #if defined(__clang__) && (__clang_major__ == 3) // For CentOS 7
+        ~data_base()
+        {}
+        #else
+        ~data_base() noexcept
+        {}
+        #endif
+
+        pointer internal_storage() noexcept
+        {
+            return std::pointer_traits<pointer>::pointer_to(*internal_storage_);
+        }
+    };
+
+    template <typename Dummy>
+    class data_base<false, Dummy>
+    {
+    public:
+
+        pointer first_;
+        pointer last_;
+        pointer eos_;
+
+        data_base() noexcept
+            : first_(nullptr)
+            , last_(nullptr)
+            , eos_(nullptr)
+        {}
+
+        pointer internal_storage() noexcept
+        {
+            return nullptr;
+        }
+    };
+
+    class data : public data_base<(N > 0)>, public allocator_type, public key_equal
+    {
+    public:
+
+        data() noexcept
+        (
+            std::is_nothrow_default_constructible<allocator_type>::value &&
+            std::is_nothrow_default_constructible<key_equal>::value
+        )
+            : allocator_type()
+            , key_equal()
+        {}
+
+        data(const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_default_constructible<key_equal>::value
+        )
+            : allocator_type(alloc)
+            , key_equal()
+        {}
+
+        data(const key_equal& equal) noexcept
+        (
+            std::is_nothrow_default_constructible<allocator_type>::value &&
+            std::is_nothrow_copy_constructible<key_equal>::value
+        )
+            : allocator_type()
+            , key_equal(equal)
+        {}
+
+        data(const key_equal& equal, const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_copy_constructible<key_equal>::value
+        )
+            : allocator_type(alloc)
+            , key_equal(equal)
+        {}
+
+        data(key_equal&& equal, allocator_type&& alloc) noexcept
+        (
+            std::is_nothrow_move_constructible<allocator_type>::value &&
+            std::is_nothrow_move_constructible<key_equal>::value
+        )
+            : allocator_type(std::move(alloc))
+            , key_equal(std::move(equal))
+        {}
+
+        data(key_equal&& equal, const allocator_type& alloc) noexcept
+        (
+            std::is_nothrow_copy_constructible<allocator_type>::value &&
+            std::is_nothrow_move_constructible<key_equal>::value
+        )
+            : allocator_type(alloc)
+            , key_equal(std::move(equal))
+        {}
+
+        allocator_type& ref_to_alloc() noexcept
+        {
+            return *this;
+        }
+
+        const allocator_type& ref_to_alloc() const noexcept
+        {
+            return *this;
+        }
+
+        key_equal& ref_to_equal() noexcept
+        {
+            return *this;
+        }
+
+        const key_equal& ref_to_equal() const noexcept
+        {
+            return *this;
+        }
+    };
+
+    data data_;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    small_unordered_flat_set() noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<KeyEqual>::value
+    )
+        : data_()
+    {}
+
+    explicit small_unordered_flat_set(const KeyEqual& equal) noexcept
+    (
+        std::is_nothrow_default_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<KeyEqual>::value
+    )
+        : data_(equal)
+    {}
+
+    explicit small_unordered_flat_set(const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_default_constructible<KeyEqual>::value
+    )
+        : data_(alloc)
+    {}
+
+    explicit small_unordered_flat_set(const KeyEqual& equal,
+                                      const Allocator& alloc) noexcept
+    (
+        std::is_nothrow_copy_constructible<Allocator>::value &&
+        std::is_nothrow_copy_constructible<KeyEqual>::value
+    )
+        : data_(equal, alloc)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_unordered_flat_set(InputIt first, InputIt last)
+        : data_()
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_unordered_flat_set(InputIt first, InputIt last,
+                             const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_unordered_flat_set(InputIt first, InputIt last,
+                             const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    small_unordered_flat_set(InputIt first, InputIt last,
+                             const KeyEqual& equal, const Allocator& alloc)
+        : data_(equal, alloc)
+    {
+        initialize_range(first, last);
+    }
+
+    small_unordered_flat_set(std::initializer_list<value_type> ilist)
+        : small_unordered_flat_set(ilist.begin(), ilist.end())
+    {}
+
+    small_unordered_flat_set(std::initializer_list<value_type> ilist,
+                             const KeyEqual& equal)
+        : small_unordered_flat_set(ilist.begin(), ilist.end(), equal)
+    {}
+
+    small_unordered_flat_set(std::initializer_list<value_type> ilist,
+                             const Allocator& alloc)
+        : small_unordered_flat_set(ilist.begin(), ilist.end(), alloc)
+    {}
+
+    small_unordered_flat_set(std::initializer_list<value_type> ilist,
+                             const KeyEqual& equal, const Allocator& alloc)
+        : small_unordered_flat_set(ilist.begin(), ilist.end(), equal, alloc)
+    {}
+
+    small_unordered_flat_set(const small_unordered_flat_set& other)
+        : data_
+        (
+            other.data_.ref_to_equal(),
+            allocator_traits::select_on_container_copy_construction
+            (
+                other.data_.ref_to_alloc()
+            )
+        )
+    {
+        initialize_copy(other);
+    }
+
+    small_unordered_flat_set(const small_unordered_flat_set& other,
+                             const Allocator& alloc)
+        : data_
+        (
+            other.data_.ref_to_equal(),
+            alloc
+        )
+    {
+        initialize_copy(other);
+    }
+
+    small_unordered_flat_set(small_unordered_flat_set&& other)
+        : data_
+        (
+            std::move(other.data_.ref_to_equal()),
+            std::move(other.data_.ref_to_alloc())
+        )
+    {
+        initialize_move(other);
+    }
+
+    small_unordered_flat_set(small_unordered_flat_set&& other,
+                             const Allocator& alloc)
+        : data_
+        (
+            std::move(other.data_.ref_to_equal()),
+            alloc
+        )
+    {
+        initialize_move(other);
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_unordered_flat_set(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_unordered_flat_set(sfl::from_range_t, Range&& range, const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_unordered_flat_set(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    small_unordered_flat_set(sfl::from_range_t, Range&& range, const KeyEqual& equal, const Allocator& alloc)
+        : data_(equal, alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    small_unordered_flat_set(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_unordered_flat_set(sfl::from_range_t, Range&& range, const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_unordered_flat_set(sfl::from_range_t, Range&& range, const Allocator& alloc)
+        : data_(alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    small_unordered_flat_set(sfl::from_range_t, Range&& range, const KeyEqual& equal, const Allocator& alloc)
+        : data_(equal, alloc)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~small_unordered_flat_set()
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        if (data_.first_ != data_.internal_storage())
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                std::distance(data_.first_, data_.eos_)
+            );
+        }
+    }
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    small_unordered_flat_set& operator=(const small_unordered_flat_set& other)
+    {
+        assign_copy(other);
+        return *this;
+    }
+
+    small_unordered_flat_set& operator=(small_unordered_flat_set&& other)
+    {
+        assign_move(other);
+        return *this;
+    }
+
+    small_unordered_flat_set& operator=(std::initializer_list<Key> ilist)
+    {
+        clear();
+        insert(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- ALLOCATOR ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    allocator_type get_allocator() const noexcept
+    {
+        return data_.ref_to_alloc();
+    }
+
+    //
+    // ---- KEY EQUAL ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_equal key_eq() const
+    {
+        return data_.ref_to_equal();
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    iterator nth(size_type pos) noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_iterator nth(size_type pos) const noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return const_iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    size_type index_of(const_iterator pos) const noexcept
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return std::distance(cbegin(), pos);
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return data_.first_ == data_.last_;
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return std::distance(data_.first_, data_.last_);
+    }
+
+    SFL_NODISCARD
+    size_type max_size() const noexcept
+    {
+        return std::min<size_type>
+        (
+            allocator_traits::max_size(data_.ref_to_alloc()),
+            std::numeric_limits<difference_type>::max() / sizeof(value_type)
+        );
+    }
+
+    SFL_NODISCARD
+    size_type capacity() const noexcept
+    {
+        return std::distance(data_.first_, data_.eos_);
+    }
+
+    SFL_NODISCARD
+    size_type available() const noexcept
+    {
+        return std::distance(data_.last_, data_.eos_);
+    }
+
+    void reserve(size_type new_cap)
+    {
+        check_size(new_cap, "sfl::small_unordered_flat_set::reserve");
+
+        if (new_cap > capacity())
+        {
+            if (new_cap <= N)
+            {
+                if (data_.first_ == data_.internal_storage())
+                {
+                    // Do nothing. We are already using internal storage.
+                }
+                else
+                {
+                    // We are not using internal storage but new capacity
+                    // can fit in internal storage.
+
+                    pointer new_first = data_.internal_storage();
+                    pointer new_last  = new_first;
+                    pointer new_eos   = new_first + N;
+
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_
+                    );
+
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+
+                    data_.first_ = new_first;
+                    data_.last_  = new_last;
+                    data_.eos_   = new_eos;
+                }
+            }
+            else
+            {
+                pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                pointer new_last  = new_first;
+                pointer new_eos   = new_first + new_cap;
+
+                SFL_TRY
+                {
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+                }
+                SFL_CATCH (...)
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+
+                    SFL_RETHROW;
+                }
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_
+                );
+
+                if (data_.first_ != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+                }
+
+                data_.first_ = new_first;
+                data_.last_  = new_last;
+                data_.eos_   = new_eos;
+            }
+        }
+    }
+
+    void shrink_to_fit()
+    {
+        const size_type new_cap = size();
+
+        if (new_cap < capacity())
+        {
+            if (new_cap <= N)
+            {
+                if (data_.first_ == data_.internal_storage())
+                {
+                    // Do nothing. We are already using internal storage.
+                }
+                else
+                {
+                    // We are not using internal storage but new capacity
+                    // can fit in internal storage.
+
+                    pointer new_first = data_.internal_storage();
+                    pointer new_last  = new_first;
+                    pointer new_eos   = new_first + N;
+
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+
+                    sfl::dtl::destroy_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_
+                    );
+
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+
+                    data_.first_ = new_first;
+                    data_.last_  = new_last;
+                    data_.eos_   = new_eos;
+                }
+            }
+            else
+            {
+                pointer new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                pointer new_last  = new_first;
+                pointer new_eos   = new_first + new_cap;
+
+                SFL_TRY
+                {
+                    new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        data_.last_,
+                        new_first
+                    );
+                }
+                SFL_CATCH (...)
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+
+                    SFL_RETHROW;
+                }
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_
+                );
+
+                if (data_.first_ != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        data_.first_,
+                        std::distance(data_.first_, data_.eos_)
+                    );
+                }
+
+                data_.first_ = new_first;
+                data_.last_  = new_last;
+                data_.eos_   = new_eos;
+            }
+        }
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear() noexcept
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        data_.last_ = data_.first_;
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace(Args&&... args)
+    {
+        return insert_aux(value_type(std::forward<Args>(args)...));
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value_type(std::forward<Args>(args)...));
+    }
+
+    std::pair<iterator, bool> insert(const value_type& value)
+    {
+        return insert_aux(value);
+    }
+
+    std::pair<iterator, bool> insert(value_type&& value)
+    {
+        return insert_aux(std::move(value));
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    std::pair<iterator, bool> insert(K&& x)
+    {
+        return insert_aux_heterogeneous(std::forward<K>(x));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, std::move(value));
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t< sfl::dtl::has_is_transparent<KeyEqual, K>::value &&
+                                    !std::is_convertible<K&&, const_iterator>::value &&
+                                    !std::is_convertible<K&&, iterator>::value >* = nullptr>
+    iterator insert(const_iterator hint, K&& x)
+    {
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux_heterogeneous(hint, std::forward<K>(x));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    iterator erase(const_iterator pos)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos < cend());
+
+        const difference_type offset = std::distance(cbegin(), pos);
+
+        const pointer p = data_.first_ + offset;
+
+        if (p < data_.last_ - 1)
+        {
+            *p = std::move(*(data_.last_ - 1));
+        }
+
+        --data_.last_;
+
+        sfl::dtl::destroy_at_a(data_.ref_to_alloc(), data_.last_);
+
+        return iterator(p);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        SFL_ASSERT(cbegin() <= first && first <= last && last <= cend());
+
+        if (first == last)
+        {
+            return begin() + std::distance(cbegin(), first);
+        }
+
+        const difference_type count1 = std::distance(first, last);
+        const difference_type count2 = std::distance(last, cend());
+
+        const difference_type offset = std::distance(cbegin(), first);
+
+        const pointer p1 = data_.first_ + offset;
+
+        if (count1 >= count2)
+        {
+            const pointer p2 = p1 + count1;
+
+            const pointer new_last = sfl::dtl::move(p2, data_.last_, p1);
+
+            sfl::dtl::destroy_a(data_.ref_to_alloc(), new_last, data_.last_);
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const pointer p2 = p1 + count2;
+
+            sfl::dtl::move(p2, data_.last_, p1);
+
+            const pointer new_last = p2;
+
+            sfl::dtl::destroy_a(data_.ref_to_alloc(), new_last, data_.last_);
+
+            data_.last_ = new_last;
+        }
+
+        return iterator(p1);
+    }
+
+    size_type erase(const Key& key)
+    {
+        auto it = find(key);
+
+        if (it == cend())
+        {
+            return 0;
+        }
+
+        erase(it);
+        return 1;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        auto it = find(x);
+
+        if (it == cend())
+        {
+            return 0;
+        }
+
+        erase(it);
+        return 1;
+    }
+
+    void swap(small_unordered_flat_set& other)
+    {
+        if (this == &other)
+        {
+            return;
+        }
+
+        using std::swap;
+
+        SFL_ASSERT
+        (
+            allocator_traits::propagate_on_container_swap::value ||
+            this->data_.ref_to_alloc() == other.data_.ref_to_alloc()
+        );
+
+        // If this and other allocator compares equal then one allocator
+        // can deallocate memory allocated by another allocator.
+        // One allocator can safely destroy_a elements constructed by other
+        // allocator regardless the two allocators compare equal or not.
+
+        if (allocator_traits::propagate_on_container_swap::value)
+        {
+            swap(this->data_.ref_to_alloc(), other.data_.ref_to_alloc());
+        }
+
+        swap(this->data_.ref_to_equal(), other.data_.ref_to_equal());
+
+        if
+        (
+            this->data_.first_ == this->data_.internal_storage() &&
+            other.data_.first_ == other.data_.internal_storage()
+        )
+        {
+            const size_type this_size  = this->size();
+            const size_type other_size = other.size();
+
+            if (this_size <= other_size)
+            {
+                std::swap_ranges
+                (
+                    this->data_.first_,
+                    this->data_.first_ + this_size,
+                    other.data_.first_
+                );
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    this->data_.ref_to_alloc(),
+                    other.data_.first_ + this_size,
+                    other.data_.first_ + other_size,
+                    this->data_.first_ + this_size
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    other.data_.ref_to_alloc(),
+                    other.data_.first_ + this_size,
+                    other.data_.first_ + other_size
+                );
+            }
+            else
+            {
+                std::swap_ranges
+                (
+                    other.data_.first_,
+                    other.data_.first_ + other_size,
+                    this->data_.first_
+                );
+
+                sfl::dtl::uninitialized_move_a
+                (
+                    other.data_.ref_to_alloc(),
+                    this->data_.first_ + other_size,
+                    this->data_.first_ + this_size,
+                    other.data_.first_ + other_size
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    this->data_.ref_to_alloc(),
+                    this->data_.first_ + other_size,
+                    this->data_.first_ + this_size
+                );
+            }
+
+            this->data_.last_ = this->data_.first_ + other_size;
+            other.data_.last_ = other.data_.first_ + this_size;
+        }
+        else if
+        (
+            this->data_.first_ == this->data_.internal_storage() &&
+            other.data_.first_ != other.data_.internal_storage()
+        )
+        {
+            pointer new_other_first = other.data_.internal_storage();
+            pointer new_other_last  = new_other_first;
+            pointer new_other_eos   = new_other_first + N;
+
+            new_other_last = sfl::dtl::uninitialized_move_a
+            (
+                other.data_.ref_to_alloc(),
+                this->data_.first_,
+                this->data_.last_,
+                new_other_first
+            );
+
+            sfl::dtl::destroy_a
+            (
+                this->data_.ref_to_alloc(),
+                this->data_.first_,
+                this->data_.last_
+            );
+
+            this->data_.first_ = other.data_.first_;
+            this->data_.last_  = other.data_.last_;
+            this->data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = new_other_first;
+            other.data_.last_  = new_other_last;
+            other.data_.eos_   = new_other_eos;
+        }
+        else if
+        (
+            this->data_.first_ != this->data_.internal_storage() &&
+            other.data_.first_ == other.data_.internal_storage()
+        )
+        {
+            pointer new_this_first = this->data_.internal_storage();
+            pointer new_this_last  = new_this_first;
+            pointer new_this_eos   = new_this_first + N;
+
+            new_this_last = sfl::dtl::uninitialized_move_a
+            (
+                this->data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                new_this_first
+            );
+
+            sfl::dtl::destroy_a
+            (
+                other.data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_
+            );
+
+            other.data_.first_ = this->data_.first_;
+            other.data_.last_  = this->data_.last_;
+            other.data_.eos_   = this->data_.eos_;
+
+            this->data_.first_ = new_this_first;
+            this->data_.last_  = new_this_last;
+            this->data_.eos_   = new_this_eos;
+        }
+        else
+        {
+            swap(this->data_.first_, other.data_.first_);
+            swap(this->data_.last_,  other.data_.last_);
+            swap(this->data_.eos_,   other.data_.eos_);
+        }
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    //
+    // ---- ELEMENT ACCESS ----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_type* data() noexcept
+    {
+        return sfl::dtl::to_address(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const value_type* data() const noexcept
+    {
+        return sfl::dtl::to_address(data_.first_);
+    }
+
+private:
+
+    void check_size(size_type n, const char* msg)
+    {
+        if (n > max_size())
+        {
+            sfl::dtl::throw_length_error(msg);
+        }
+    }
+
+    size_type calculate_new_capacity(size_type num_additional_elements, const char* msg)
+    {
+        const size_type size = this->size();
+        const size_type capacity = this->capacity();
+        const size_type max_size = this->max_size();
+
+        if (max_size - size < num_additional_elements)
+        {
+            sfl::dtl::throw_length_error(msg);
+        }
+        else if (max_size - capacity < capacity / 2)
+        {
+            return max_size;
+        }
+        else if (size + num_additional_elements < capacity + capacity / 2)
+        {
+            return std::max(N, capacity + capacity / 2);
+        }
+        else
+        {
+            return std::max(N, size + num_additional_elements);
+        }
+    }
+
+    void reset(size_type new_cap = N)
+    {
+        sfl::dtl::destroy_a
+        (
+            data_.ref_to_alloc(),
+            data_.first_,
+            data_.last_
+        );
+
+        if (data_.first_ != data_.internal_storage())
+        {
+            sfl::dtl::deallocate
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                std::distance(data_.first_, data_.eos_)
+            );
+        }
+
+        data_.first_ = data_.internal_storage();
+        data_.last_  = data_.first_;
+        data_.eos_   = data_.first_ + N;
+
+        if (new_cap > N)
+        {
+            data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+            data_.last_  = data_.first_;
+            data_.eos_   = data_.first_ + new_cap;
+
+            // If allocation throws, first_, last_ and eos_ will be valid
+            // (they will be pointing to internal_storage).
+        }
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void initialize_range(InputIt first, Sentinel last)
+    {
+        SFL_TRY
+        {
+            while (first != last)
+            {
+                insert(*first);
+                ++first;
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            if (data_.first_ != data_.internal_storage())
+            {
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    std::distance(data_.first_, data_.eos_)
+                );
+            }
+
+            SFL_RETHROW;
+        }
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void initialize_range(Range&& range)
+    {
+        initialize_range(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void initialize_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        initialize_range(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    void initialize_copy(const small_unordered_flat_set& other)
+    {
+        const size_type n = other.size();
+
+        check_size(n, "sfl::small_unordered_flat_set::initialize_copy");
+
+        if (n > N)
+        {
+            data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+            data_.last_  = data_.first_;
+            data_.eos_   = data_.first_ + n;
+        }
+
+        SFL_TRY
+        {
+            data_.last_ = sfl::dtl::uninitialized_copy_a
+            (
+                data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                data_.first_
+            );
+        }
+        SFL_CATCH (...)
+        {
+            if (n > N)
+            {
+                sfl::dtl::deallocate(data_.ref_to_alloc(), data_.first_, n);
+            }
+
+            SFL_RETHROW;
+        }
+    }
+
+    void initialize_move(small_unordered_flat_set& other)
+    {
+        if (other.data_.first_ == other.data_.internal_storage())
+        {
+            data_.last_ = sfl::dtl::uninitialized_move_a
+            (
+                data_.ref_to_alloc(),
+                other.data_.first_,
+                other.data_.last_,
+                data_.first_
+            );
+        }
+        else if (data_.ref_to_alloc() == other.data_.ref_to_alloc())
+        {
+            data_.first_ = other.data_.first_;
+            data_.last_  = other.data_.last_;
+            data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = nullptr;
+            other.data_.last_  = nullptr;
+            other.data_.eos_   = nullptr;
+        }
+        else
+        {
+            const size_type n = other.size();
+
+            check_size(n, "sfl::small_unordered_flat_set::initialize_move");
+
+            if (n > N)
+            {
+                data_.first_ = sfl::dtl::allocate(data_.ref_to_alloc(), n);
+                data_.last_  = data_.first_;
+                data_.eos_   = data_.first_ + n;
+            }
+
+            SFL_TRY
+            {
+                data_.last_ = sfl::dtl::uninitialized_move_a
+                (
+                    data_.ref_to_alloc(),
+                    other.data_.first_,
+                    other.data_.last_,
+                    data_.first_
+                );
+            }
+            SFL_CATCH (...)
+            {
+                if (n > N)
+                {
+                    sfl::dtl::deallocate(data_.ref_to_alloc(), data_.first_, n);
+                }
+
+                SFL_RETHROW;
+            }
+        }
+    }
+
+    template <typename ForwardIt>
+    void assign_range(ForwardIt first, ForwardIt last)
+    {
+        const size_type n = std::distance(first, last);
+
+        check_size(n, "sfl::small_unordered_flat_set::assign_range");
+
+        if (n <= capacity())
+        {
+            const size_type s = size();
+
+            if (n <= s)
+            {
+                pointer new_last = sfl::dtl::copy
+                (
+                    first,
+                    last,
+                    data_.first_
+                );
+
+                sfl::dtl::destroy_a
+                (
+                    data_.ref_to_alloc(),
+                    new_last,
+                    data_.last_
+                );
+
+                data_.last_ = new_last;
+            }
+            else
+            {
+                ForwardIt mid = std::next(first, s);
+
+                sfl::dtl::copy
+                (
+                    first,
+                    mid,
+                    data_.first_
+                );
+
+                data_.last_ = sfl::dtl::uninitialized_copy_a
+                (
+                    data_.ref_to_alloc(),
+                    mid,
+                    last,
+                    data_.last_
+                );
+            }
+        }
+        else
+        {
+            reset(n);
+
+            data_.last_ = sfl::dtl::uninitialized_copy_a
+            (
+                data_.ref_to_alloc(),
+                first,
+                last,
+                data_.first_
+            );
+        }
+    }
+
+    void assign_copy(const small_unordered_flat_set& other)
+    {
+        if (this != &other)
+        {
+            if (allocator_traits::propagate_on_container_copy_assignment::value)
+            {
+                if (data_.ref_to_alloc() != other.data_.ref_to_alloc())
+                {
+                    reset();
+                }
+
+                data_.ref_to_alloc() = other.data_.ref_to_alloc();
+            }
+
+            data_.ref_to_equal() = other.data_.ref_to_equal();
+
+            assign_range(other.data_.first_, other.data_.last_);
+        }
+    }
+
+    void assign_move(small_unordered_flat_set& other)
+    {
+        if (allocator_traits::propagate_on_container_move_assignment::value)
+        {
+            if (data_.ref_to_alloc() != other.data_.ref_to_alloc())
+            {
+                reset();
+            }
+
+            data_.ref_to_alloc() = std::move(other.data_.ref_to_alloc());
+        }
+
+        data_.ref_to_equal() = other.data_.ref_to_equal();
+
+        if (other.data_.first_ == other.data_.internal_storage())
+        {
+            assign_range
+            (
+                std::make_move_iterator(other.data_.first_),
+                std::make_move_iterator(other.data_.last_)
+            );
+        }
+        else if (data_.ref_to_alloc() == other.data_.ref_to_alloc())
+        {
+            reset();
+
+            data_.first_ = other.data_.first_;
+            data_.last_  = other.data_.last_;
+            data_.eos_   = other.data_.eos_;
+
+            other.data_.first_ = nullptr;
+            other.data_.last_  = nullptr;
+            other.data_.eos_   = nullptr;
+        }
+        else
+        {
+            assign_range
+            (
+                std::make_move_iterator(other.data_.first_),
+                std::make_move_iterator(other.data_.last_)
+            );
+        }
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace_aux(Args&&... args)
+    {
+        const auto it1 = emplace_back(std::forward<Args>(args)...);
+        const auto it2 = find(*it1);
+
+        const bool is_unique = it1 == it2;
+
+        if (!is_unique)
+        {
+            pop_back();
+        }
+
+        return std::make_pair(it2, is_unique);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint_aux(const_iterator hint, Args&&... args)
+    {
+        sfl::dtl::ignore_unused(hint);
+        return emplace_aux(std::forward<Args>(args)...).first;
+    }
+
+    template <typename Value>
+    std::pair<iterator, bool> insert_aux(Value&& value)
+    {
+        auto it = find(value);
+
+        if (it == end())
+        {
+            return std::make_pair(emplace_back(std::forward<Value>(value)), true);
+        }
+
+        return std::make_pair(it, false);
+    }
+
+    template <typename Value>
+    iterator insert_aux(const_iterator hint, Value&& value)
+    {
+        sfl::dtl::ignore_unused(hint);
+        return insert_aux(std::forward<Value>(value)).first;
+    }
+
+    template <typename K>
+    std::pair<iterator, bool> insert_aux_heterogeneous(K&& x)
+    {
+        auto it = find(x);
+
+        if (it == end())
+        {
+            return std::make_pair(emplace_back(value_type(std::forward<K>(x))), true);
+        }
+
+        return std::make_pair(it, false);
+    }
+
+    template <typename K>
+    iterator insert_aux_heterogeneous(const_iterator hint, K&& x)
+    {
+        sfl::dtl::ignore_unused(hint);
+        return insert_aux_heterogeneous(std::forward<K>(x)).first;
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+
+    template <typename... Args>
+    iterator emplace_back(Args&&... args)
+    {
+        if (data_.last_ != data_.eos_)
+        {
+            const pointer old_last = data_.last_;
+
+            sfl::dtl::construct_at_a
+            (
+                data_.ref_to_alloc(),
+                data_.last_,
+                std::forward<Args>(args)...
+            );
+
+            ++data_.last_;
+
+            return iterator(old_last);
+        }
+        else
+        {
+            const size_type new_cap =
+                calculate_new_capacity(1, "sfl::small_unordered_flat_set::emplace_back");
+
+            pointer new_first;
+            pointer new_last;
+            pointer new_eos;
+
+            if (new_cap <= N && data_.first_ != data_.internal_storage())
+            {
+                new_first = data_.internal_storage();
+                new_last  = new_first;
+                new_eos   = new_first + N;
+            }
+            else
+            {
+                new_first = sfl::dtl::allocate(data_.ref_to_alloc(), new_cap);
+                new_last  = new_first;
+                new_eos   = new_first + new_cap;
+            }
+
+            const pointer p = new_first + size();
+
+            SFL_TRY
+            {
+                sfl::dtl::construct_at_a
+                (
+                    data_.ref_to_alloc(),
+                    p,
+                    std::forward<Args>(args)...
+                );
+
+                new_last = nullptr;
+
+                new_last = sfl::dtl::uninitialized_move_if_noexcept_a
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    data_.last_,
+                    new_first
+                );
+
+                ++new_last;
+            }
+            SFL_CATCH (...)
+            {
+                if (new_last == nullptr)
+                {
+                    sfl::dtl::destroy_at_a
+                    (
+                        data_.ref_to_alloc(),
+                        p
+                    );
+                }
+                else
+                {
+                    // Nothing to do
+                }
+
+                if (new_first != data_.internal_storage())
+                {
+                    sfl::dtl::deallocate
+                    (
+                        data_.ref_to_alloc(),
+                        new_first,
+                        new_cap
+                    );
+                }
+
+                SFL_RETHROW;
+            }
+
+            sfl::dtl::destroy_a
+            (
+                data_.ref_to_alloc(),
+                data_.first_,
+                data_.last_
+            );
+
+            if (data_.first_ != data_.internal_storage())
+            {
+                sfl::dtl::deallocate
+                (
+                    data_.ref_to_alloc(),
+                    data_.first_,
+                    std::distance(data_.first_, data_.eos_)
+                );
+            }
+
+            data_.first_ = new_first;
+            data_.last_  = new_last;
+            data_.eos_   = new_eos;
+
+            return iterator(p);
+        }
+    }
+
+    void pop_back()
+    {
+        SFL_ASSERT(!empty());
+
+        --data_.last_;
+
+        sfl::dtl::destroy_at_a(data_.ref_to_alloc(), data_.last_);
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, std::size_t N, typename E, typename A>
+SFL_NODISCARD
+bool operator==
+(
+    const small_unordered_flat_set<K, N, E, A>& x,
+    const small_unordered_flat_set<K, N, E, A>& y
+)
+{
+    return x.size() == y.size() && std::is_permutation(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, std::size_t N, typename E, typename A>
+SFL_NODISCARD
+bool operator!=
+(
+    const small_unordered_flat_set<K, N, E, A>& x,
+    const small_unordered_flat_set<K, N, E, A>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, std::size_t N, typename E, typename A>
+void swap
+(
+    small_unordered_flat_set<K, N, E, A>& x,
+    small_unordered_flat_set<K, N, E, A>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, std::size_t N, typename E, typename A,
+          typename Predicate>
+typename small_unordered_flat_set<K, N, E, A>::size_type
+    erase_if(small_unordered_flat_set<K, N, E, A>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_SMALL_UNORDERED_FLAT_SET_HPP_INCLUDED

--- a/src/thirdparty/sfl/static_flat_map.hpp
+++ b/src/thirdparty/sfl/static_flat_map.hpp
@@ -1,0 +1,1463 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_STATIC_FLAT_MAP_HPP_INCLUDED
+#define SFL_STATIC_FLAT_MAP_HPP_INCLUDED
+
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/exceptions.hpp>
+#include <sfl/detail/initialized_memory_algorithms.hpp>
+#include <sfl/detail/normal_iterator.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/type_traits.hpp>
+#include <sfl/detail/uninitialized_memory_algorithms.hpp>
+
+#include <algorithm>        // copy, move, lower_bound, swap, swap_ranges
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <iterator>         // distance, next, reverse_iterator
+#include <limits>           // numeric_limits
+#include <memory>           // allocator, allocator_traits, pointer_traits
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+#ifdef SFL_TEST_STATIC_FLAT_MAP
+void test_static_flat_map();
+#endif
+
+namespace sfl
+{
+
+template < typename Key,
+           typename T,
+           std::size_t N,
+           typename Compare = std::less<Key> >
+class static_flat_map
+{
+    #ifdef SFL_TEST_STATIC_FLAT_MAP
+    friend void ::test_static_flat_map();
+    #endif
+
+    static_assert(N > 0, "N must be greater than zero.");
+
+public:
+
+    using key_type               = Key;
+    using mapped_type            = T;
+    using value_type             = std::pair<Key, T>;
+    using size_type              = std::size_t;
+    using difference_type        = std::ptrdiff_t;
+    using key_compare            = Compare;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using pointer                = value_type*;
+    using const_pointer          = const value_type*;
+    using iterator               = sfl::dtl::normal_iterator<pointer, static_flat_map>;
+    using const_iterator         = sfl::dtl::normal_iterator<const_pointer, static_flat_map>;
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    class value_compare : protected key_compare
+    {
+        friend class static_flat_map;
+
+    private:
+
+        value_compare(const key_compare& c)
+            : key_compare(c)
+        {}
+
+    public:
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_compare::operator()(x.first, y.first);
+        }
+    };
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+private:
+
+    // Like `value_compare` but with additional operators.
+    // For internal use only.
+    class ultra_compare : public key_compare
+    {
+    public:
+
+        ultra_compare() noexcept(std::is_nothrow_default_constructible<key_compare>::value)
+        {}
+
+        ultra_compare(const key_compare& c) noexcept(std::is_nothrow_copy_constructible<key_compare>::value)
+            : key_compare(c)
+        {}
+
+        ultra_compare(key_compare&& c) noexcept(std::is_nothrow_move_constructible<key_compare>::value)
+            : key_compare(std::move(c))
+        {}
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_compare::operator()(x.first, y.first);
+        }
+
+        template <typename K>
+        bool operator()(const value_type& x, const K& y) const
+        {
+            return key_compare::operator()(x.first, y);
+        }
+
+        template <typename K>
+        bool operator()(const K& x, const value_type& y) const
+        {
+            return key_compare::operator()(x, y.first);
+        }
+    };
+
+    class data_base
+    {
+    public:
+
+        union
+        {
+            value_type first_[N];
+        };
+
+        pointer last_;
+
+        data_base() noexcept
+            : last_(first_)
+        {}
+
+        #if defined(__clang__) && (__clang_major__ == 3) // For CentOS 7
+        ~data_base()
+        {}
+        #else
+        ~data_base() noexcept
+        {}
+        #endif
+    };
+
+    class data : public data_base, public ultra_compare
+    {
+    public:
+
+        data() noexcept(std::is_nothrow_default_constructible<ultra_compare>::value)
+            : ultra_compare()
+        {}
+
+        data(const ultra_compare& comp) noexcept(std::is_nothrow_copy_constructible<ultra_compare>::value)
+            : ultra_compare(comp)
+        {}
+
+        data(ultra_compare&& comp) noexcept(std::is_nothrow_move_constructible<ultra_compare>::value)
+            : ultra_compare(std::move(comp))
+        {}
+
+        ultra_compare& ref_to_comp() noexcept
+        {
+            return *this;
+        }
+
+        const ultra_compare& ref_to_comp() const noexcept
+        {
+            return *this;
+        }
+    };
+
+    data data_;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    static_flat_map() noexcept(std::is_nothrow_default_constructible<Compare>::value)
+        : data_()
+    {}
+
+    explicit static_flat_map(const Compare& comp) noexcept(std::is_nothrow_copy_constructible<Compare>::value)
+        : data_(comp)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_flat_map(InputIt first, InputIt last)
+        : data_()
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_flat_map(InputIt first, InputIt last, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(first, last);
+    }
+
+    static_flat_map(std::initializer_list<value_type> ilist)
+        : static_flat_map(ilist.begin(), ilist.end())
+    {}
+
+    static_flat_map(std::initializer_list<value_type> ilist, const Compare& comp)
+        : static_flat_map(ilist.begin(), ilist.end(), comp)
+    {}
+
+    static_flat_map(const static_flat_map& other)
+        : data_(other.data_.ref_to_comp())
+    {
+        data_.last_ = sfl::dtl::uninitialized_copy
+        (
+            pointer(other.data_.first_),
+            pointer(other.data_.last_),
+            data_.first_
+        );
+    }
+
+    static_flat_map(static_flat_map&& other)
+        : data_(std::move(other.data_.ref_to_comp()))
+    {
+        data_.last_ = sfl::dtl::uninitialized_move
+        (
+            std::make_move_iterator(pointer(other.data_.first_)),
+            std::make_move_iterator(pointer(other.data_.last_)),
+            data_.first_
+        );
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_flat_map(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_flat_map(sfl::from_range_t, Range&& range, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    static_flat_map(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    static_flat_map(sfl::from_range_t, Range&& range, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~static_flat_map()
+    {
+        sfl::dtl::destroy(data_.first_, data_.last_);
+    }
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    static_flat_map& operator=(const static_flat_map& other)
+    {
+        if (this != &other)
+        {
+            data_.ref_to_comp() = other.data_.ref_to_comp();
+
+            assign_range
+            (
+                pointer(other.data_.first_),
+                pointer(other.data_.last_)
+            );
+        }
+
+        return *this;
+    }
+
+    static_flat_map& operator=(static_flat_map&& other)
+    {
+        data_.ref_to_comp() = other.data_.ref_to_comp();
+
+        assign_range
+        (
+            std::make_move_iterator(pointer(other.data_.first_)),
+            std::make_move_iterator(pointer(other.data_.last_))
+        );
+
+        return *this;
+    }
+
+    static_flat_map& operator=(std::initializer_list<value_type> ilist)
+    {
+        assign_range(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- KEY COMPARE -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_compare key_comp() const
+    {
+        return data_.ref_to_comp();
+    }
+
+    //
+    // ---- VALUE COMPARE -----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_compare value_comp() const
+    {
+        return value_compare(data_.ref_to_comp());
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    iterator nth(size_type pos) noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_iterator nth(size_type pos) const noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return const_iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    size_type index_of(const_iterator pos) const noexcept
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return std::distance(cbegin(), pos);
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return data_.first_ == data_.last_;
+    }
+
+    SFL_NODISCARD
+    bool full() const noexcept
+    {
+        return std::distance(begin(), end()) == N;
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return std::distance(begin(), end());
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type max_size() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type capacity() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    size_type available() const noexcept
+    {
+        return capacity() - size();
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear() noexcept
+    {
+        sfl::dtl::destroy(data_.first_, data_.last_);
+        data_.last_ = data_.first_;
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace(Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return insert_aux(value_type(std::forward<Args>(args)...));
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value_type(std::forward<Args>(args)...));
+    }
+
+    std::pair<iterator, bool> insert(const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        return insert_aux(value);
+    }
+
+    std::pair<iterator, bool> insert(value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        return insert_aux(std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P&&>::value>* = nullptr>
+    std::pair<iterator, bool> insert(P&& value)
+    {
+        SFL_ASSERT(!full());
+        return insert_aux(value_type(std::forward<P>(value)));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P>::value>* = nullptr>
+    iterator insert(const_iterator hint, P&& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value_type(std::forward<P>(value)));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    std::pair<iterator, bool> insert_or_assign(const Key& key, M&& obj)
+    {
+        SFL_ASSERT(!full());
+        return insert_or_assign_aux(key, std::forward<M>(obj));
+    }
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    std::pair<iterator, bool> insert_or_assign(Key&& key, M&& obj)
+    {
+        SFL_ASSERT(!full());
+        return insert_or_assign_aux(std::move(key), std::forward<M>(obj));
+    }
+
+    template <typename K, typename M,
+              sfl::dtl::enable_if_t< sfl::dtl::has_is_transparent<Compare, K>::value &&
+                                     std::is_assignable<mapped_type&, M&&>::value >* = nullptr>
+    std::pair<iterator, bool> insert_or_assign(K&& key, M&& obj)
+    {
+        SFL_ASSERT(!full());
+        return insert_or_assign_aux(std::forward<K>(key), std::forward<M>(obj));
+    }
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    iterator insert_or_assign(const_iterator hint, const Key& key, M&& obj)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_or_assign_aux(hint, key, std::forward<M>(obj));
+    }
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    iterator insert_or_assign(const_iterator hint, Key&& key, M&& obj)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_or_assign_aux(hint, std::move(key), std::forward<M>(obj));
+    }
+
+    template <typename K, typename M,
+              sfl::dtl::enable_if_t< sfl::dtl::has_is_transparent<Compare, K>::value &&
+                                     std::is_assignable<mapped_type&, M&&>::value >* = nullptr>
+    iterator insert_or_assign(const_iterator hint, K&& key, M&& obj)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_or_assign_aux(hint, std::forward<K>(key), std::forward<M>(obj));
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(const Key& key, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return try_emplace_aux(key, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(Key&& key, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return try_emplace_aux(std::move(key), std::forward<Args>(args)...);
+    }
+
+    template <typename K, typename... Args,
+              sfl::dtl::enable_if_t<
+                #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 7)
+                // This is workaround for GCC 4 bug on CentOS 7.
+                !std::is_same<sfl::dtl::remove_cvref_t<Key>, sfl::dtl::remove_cvref_t<K>>::value &&
+                #endif
+                sfl::dtl::has_is_transparent<Compare, K>::value &&
+                !std::is_convertible<K&&, const_iterator>::value &&
+                !std::is_convertible<K&&, iterator>::value
+              >* = nullptr>
+    std::pair<iterator, bool> try_emplace(K&& key, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return try_emplace_aux(std::forward<K>(key), std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator try_emplace(const_iterator hint, const Key& key, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return try_emplace_aux(hint, key, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator try_emplace(const_iterator hint, Key&& key, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return try_emplace_aux(hint, std::move(key), std::forward<Args>(args)...);
+    }
+
+    template <typename K, typename... Args,
+              sfl::dtl::enable_if_t<
+                #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 7)
+                // This is workaround for GCC 4 bug on CentOS 7.
+                !std::is_same<sfl::dtl::remove_cvref_t<Key>, sfl::dtl::remove_cvref_t<K>>::value &&
+                #endif
+                sfl::dtl::has_is_transparent<Compare, K>::value
+              >* = nullptr>
+    iterator try_emplace(const_iterator hint, K&& key, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return try_emplace_aux(hint, std::forward<K>(key), std::forward<Args>(args)...);
+    }
+
+    iterator erase(iterator pos)
+    {
+        return erase(const_iterator(pos));
+    }
+
+    iterator erase(const_iterator pos)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos < cend());
+
+        const pointer p = data_.first_ + std::distance(cbegin(), pos);
+
+        data_.last_ = sfl::dtl::move(p + 1, data_.last_, p);
+
+        sfl::dtl::destroy_at(data_.last_);
+
+        return iterator(p);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        SFL_ASSERT(cbegin() <= first && first <= last && last <= cend());
+
+        if (first == last)
+        {
+            return begin() + std::distance(cbegin(), first);
+        }
+
+        const pointer p1 = data_.first_ + std::distance(cbegin(), first);
+        const pointer p2 = data_.first_ + std::distance(cbegin(), last);
+
+        const pointer new_last = sfl::dtl::move(p2, data_.last_, p1);
+
+        sfl::dtl::destroy(new_last, data_.last_);
+
+        data_.last_ = new_last;
+
+        return iterator(p1);
+    }
+
+    size_type erase(const Key& key)
+    {
+        auto it = find(key);
+        if (it == cend())
+        {
+            return 0;
+        }
+        erase(it);
+        return 1;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        auto it = find(x);
+        if (it == cend())
+        {
+            return 0;
+        }
+        erase(it);
+        return 1;
+    }
+
+    void swap(static_flat_map& other)
+    {
+        if (this == &other)
+        {
+            return;
+        }
+
+        using std::swap;
+
+        swap(this->data_.ref_to_comp(), other.data_.ref_to_comp());
+
+        const size_type this_size  = this->size();
+        const size_type other_size = other.size();
+
+        if (this_size <= other_size)
+        {
+            std::swap_ranges
+            (
+                this->data_.first_,
+                this->data_.first_ + this_size,
+                other.data_.first_
+            );
+
+            sfl::dtl::uninitialized_move
+            (
+                other.data_.first_ + this_size,
+                other.data_.first_ + other_size,
+                this->data_.first_ + this_size
+            );
+
+            sfl::dtl::destroy
+            (
+                other.data_.first_ + this_size,
+                other.data_.first_ + other_size
+            );
+        }
+        else
+        {
+            std::swap_ranges
+            (
+                other.data_.first_,
+                other.data_.first_ + other_size,
+                this->data_.first_
+            );
+
+            sfl::dtl::uninitialized_move
+            (
+                this->data_.first_ + other_size,
+                this->data_.first_ + this_size,
+                other.data_.first_ + other_size
+            );
+
+            sfl::dtl::destroy
+            (
+                this->data_.first_ + other_size,
+                this->data_.first_ + this_size
+            );
+        }
+
+        this->data_.last_ = this->data_.first_ + other_size;
+        other.data_.last_ = other.data_.first_ + this_size;
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator lower_bound(const Key& key)
+    {
+        return std::lower_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    const_iterator lower_bound(const Key& key) const
+    {
+        return std::lower_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator lower_bound(const K& x)
+    {
+        return std::lower_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator lower_bound(const K& x) const
+    {
+        return std::lower_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    iterator upper_bound(const Key& key)
+    {
+        return std::upper_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    const_iterator upper_bound(const Key& key) const
+    {
+        return std::upper_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator upper_bound(const K& x)
+    {
+        return std::upper_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator upper_bound(const K& x) const
+    {
+        return std::upper_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const Key& key)
+    {
+        return std::equal_range(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const
+    {
+        return std::equal_range(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const K& x)
+    {
+        return std::equal_range(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const K& x) const
+    {
+        return std::equal_range(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        auto it = lower_bound(key);
+
+        if (it != end() && data_.ref_to_comp()(key, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        auto it = lower_bound(key);
+
+        if (it != end() && data_.ref_to_comp()(key, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        auto it = lower_bound(x);
+
+        if (it != end() && data_.ref_to_comp()(x, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        auto it = lower_bound(x);
+
+        if (it != end() && data_.ref_to_comp()(x, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    //
+    // ---- ELEMENT ACCESS ----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    T& at(const Key& key)
+    {
+        auto it = find(key);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::static_flat_map::at");
+        }
+
+        return it->second;
+    }
+
+    SFL_NODISCARD
+    const T& at(const Key& key) const
+    {
+        auto it = find(key);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::static_flat_map::at");
+        }
+
+        return it->second;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    T& at(const K& x)
+    {
+        auto it = find(x);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::static_flat_map::at");
+        }
+
+        return it->second;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const T& at(const K& x) const
+    {
+        auto it = find(x);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::static_flat_map::at");
+        }
+
+        return it->second;
+    }
+
+    SFL_NODISCARD
+    T& operator[](const Key& key)
+    {
+        return try_emplace(key).first->second;
+    }
+
+    SFL_NODISCARD
+    T& operator[](Key&& key)
+    {
+        return try_emplace(std::move(key)).first->second;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    T& operator[](K&& key)
+    {
+        return try_emplace(std::forward<K>(key)).first->second;
+    }
+
+    SFL_NODISCARD
+    value_type* data() noexcept
+    {
+        return data_.first_;
+    }
+
+    SFL_NODISCARD
+    const value_type* data() const noexcept
+    {
+        return data_.first_;
+    }
+
+private:
+
+    template <typename InputIt, typename Sentinel>
+    void initialize_range(InputIt first, Sentinel last)
+    {
+        SFL_TRY
+        {
+            while (first != last)
+            {
+                insert(*first);
+                ++first;
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy(data_.first_, data_.last_);
+            SFL_RETHROW;
+        }
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void initialize_range(Range&& range)
+    {
+        initialize_range(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void initialize_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        initialize_range(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    template <typename ForwardIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_forward_iterator<ForwardIt>::value>* = nullptr>
+    void assign_range(ForwardIt first, ForwardIt last)
+    {
+        SFL_ASSERT(size_type(std::distance(first, last)) <= capacity());
+
+        const size_type n = std::distance(first, last);
+
+        const size_type size = this->size();
+
+        if (n <= size)
+        {
+            const pointer new_last = sfl::dtl::copy
+            (
+                first,
+                last,
+                data_.first_
+            );
+
+            sfl::dtl::destroy
+            (
+                new_last,
+                data_.last_
+            );
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const ForwardIt mid = std::next(first, size);
+
+            sfl::dtl::copy
+            (
+                first,
+                mid,
+                data_.first_
+            );
+
+            data_.last_ = sfl::dtl::uninitialized_copy
+            (
+                mid,
+                last,
+                data_.last_
+            );
+        }
+    }
+
+    template <typename Value>
+    std::pair<iterator, bool> insert_aux(Value&& value)
+    {
+        auto it = lower_bound(value.first);
+
+        if (it == end() || data_.ref_to_comp()(value, *it))
+        {
+            return std::make_pair(insert_exactly_at(it, std::forward<Value>(value)), true);
+        }
+
+        return std::make_pair(it, false);
+    }
+
+    template <typename Value>
+    iterator insert_aux(const_iterator hint, Value&& value)
+    {
+        if (is_insert_hint_good(hint, value))
+        {
+            return insert_exactly_at(hint, std::forward<Value>(value));
+        }
+
+        // Hint is not good. Use non-hinted function.
+        return insert_aux(std::forward<Value>(value)).first;
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+
+    template <typename K, typename M>
+    std::pair<iterator, bool> insert_or_assign_aux(K&& key, M&& obj)
+    {
+        auto it = lower_bound(key);
+
+        if (it == end() || data_.ref_to_comp()(key, *it))
+        {
+            return std::make_pair
+            (
+                insert_exactly_at
+                (
+                    it,
+                    value_type
+                    (
+                        std::piecewise_construct,
+                        std::forward_as_tuple(std::forward<K>(key)),
+                        std::forward_as_tuple(std::forward<M>(obj))
+                    )
+                ),
+                true
+            );
+        }
+
+        it->second = std::forward<M>(obj);
+        return std::make_pair(it, false);
+    }
+
+    template <typename K, typename M>
+    iterator insert_or_assign_aux(const_iterator hint, K&& key, M&& obj)
+    {
+        if (is_insert_hint_good(hint, key))
+        {
+            return insert_exactly_at
+            (
+                hint,
+                value_type
+                (
+                    std::piecewise_construct,
+                    std::forward_as_tuple(std::forward<K>(key)),
+                    std::forward_as_tuple(std::forward<M>(obj))
+                )
+            );
+        }
+
+        // Hint is not good. Use non-hinted function.
+        return insert_or_assign_aux(std::forward<K>(key), std::forward<M>(obj)).first;
+    }
+
+    template <typename K, typename... Args>
+    std::pair<iterator, bool> try_emplace_aux(K&& key, Args&&... args)
+    {
+        auto it = lower_bound(key);
+
+        if (it == end() || data_.ref_to_comp()(key, *it))
+        {
+            return std::make_pair
+            (
+                insert_exactly_at
+                (
+                    it,
+                    value_type
+                    (
+                        std::piecewise_construct,
+                        std::forward_as_tuple(std::forward<K>(key)),
+                        std::forward_as_tuple(std::forward<Args>(args)...)
+                    )
+                ),
+                true
+            );
+        }
+
+        return std::make_pair(it, false);
+    }
+
+    template <typename K, typename... Args>
+    iterator try_emplace_aux(const_iterator hint, K&& key, Args&&... args)
+    {
+        if (is_insert_hint_good(hint, key))
+        {
+            return insert_exactly_at
+            (
+                hint,
+                value_type
+                (
+                    std::piecewise_construct,
+                    std::forward_as_tuple(std::forward<K>(key)),
+                    std::forward_as_tuple(std::forward<Args>(args)...)
+                )
+            );
+        }
+
+        // Hint is not good. Use non-hinted function.
+        return try_emplace_aux(std::forward<K>(key), std::forward<Args>(args)...).first;
+    }
+
+    template <typename Value>
+    iterator insert_exactly_at(const_iterator pos, Value&& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+
+        const pointer p1 = data_.first_ + std::distance(cbegin(), pos);
+
+        if (p1 == data_.last_)
+        {
+            sfl::dtl::construct_at
+            (
+                p1,
+                std::forward<Value>(value)
+            );
+
+            ++data_.last_;
+        }
+        else
+        {
+            const pointer p2 = data_.last_ - 1;
+
+            const pointer old_last = data_.last_;
+
+            sfl::dtl::construct_at
+            (
+                data_.last_,
+                std::move(*p2)
+            );
+
+            ++data_.last_;
+
+            sfl::dtl::move_backward
+            (
+                p1,
+                p2,
+                old_last
+            );
+
+            *p1 = std::forward<Value>(value);
+        }
+
+        return iterator(p1);
+    }
+
+    template <typename Value>
+    bool is_insert_hint_good(const_iterator hint, const Value& value)
+    {
+        return (hint == begin() || data_.ref_to_comp()(*(hint - 1), value))
+            && (hint == end()   || data_.ref_to_comp()(value, *hint));
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator==
+(
+    const static_flat_map<K, T, N, C>& x,
+    const static_flat_map<K, T, N, C>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator!=
+(
+    const static_flat_map<K, T, N, C>& x,
+    const static_flat_map<K, T, N, C>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator<
+(
+    const static_flat_map<K, T, N, C>& x,
+    const static_flat_map<K, T, N, C>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator>
+(
+    const static_flat_map<K, T, N, C>& x,
+    const static_flat_map<K, T, N, C>& y
+)
+{
+    return y < x;
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator<=
+(
+    const static_flat_map<K, T, N, C>& x,
+    const static_flat_map<K, T, N, C>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator>=
+(
+    const static_flat_map<K, T, N, C>& x,
+    const static_flat_map<K, T, N, C>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+void swap
+(
+    static_flat_map<K, T, N, C>& x,
+    static_flat_map<K, T, N, C>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename Predicate>
+typename static_flat_map<K, T, N, C>::size_type
+    erase_if(static_flat_map<K, T, N, C>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_STATIC_FLAT_MAP_HPP_INCLUDED

--- a/src/thirdparty/sfl/static_flat_multimap.hpp
+++ b/src/thirdparty/sfl/static_flat_multimap.hpp
@@ -1,0 +1,1188 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_STATIC_FLAT_MULTIMAP_HPP_INCLUDED
+#define SFL_STATIC_FLAT_MULTIMAP_HPP_INCLUDED
+
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/initialized_memory_algorithms.hpp>
+#include <sfl/detail/normal_iterator.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/type_traits.hpp>
+#include <sfl/detail/uninitialized_memory_algorithms.hpp>
+
+#include <algorithm>        // copy, move, lower_bound, swap, swap_ranges
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <iterator>         // distance, next, reverse_iterator
+#include <limits>           // numeric_limits
+#include <memory>           // allocator, allocator_traits, pointer_traits
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+#ifdef SFL_TEST_STATIC_FLAT_MULTIMAP
+void test_static_flat_multimap();
+#endif
+
+namespace sfl
+{
+
+template < typename Key,
+           typename T,
+           std::size_t N,
+           typename Compare = std::less<Key> >
+class static_flat_multimap
+{
+    #ifdef SFL_TEST_STATIC_FLAT_MULTIMAP
+    friend void ::test_static_flat_multimap();
+    #endif
+
+    static_assert(N > 0, "N must be greater than zero.");
+
+public:
+
+    using key_type               = Key;
+    using mapped_type            = T;
+    using value_type             = std::pair<Key, T>;
+    using size_type              = std::size_t;
+    using difference_type        = std::ptrdiff_t;
+    using key_compare            = Compare;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using pointer                = value_type*;
+    using const_pointer          = const value_type*;
+    using iterator               = sfl::dtl::normal_iterator<pointer, static_flat_multimap>;
+    using const_iterator         = sfl::dtl::normal_iterator<const_pointer, static_flat_multimap>;
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    class value_compare : protected key_compare
+    {
+        friend class static_flat_multimap;
+
+    private:
+
+        value_compare(const key_compare& c)
+            : key_compare(c)
+        {}
+
+    public:
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_compare::operator()(x.first, y.first);
+        }
+    };
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+private:
+
+    // Like `value_compare` but with additional operators.
+    // For internal use only.
+    class ultra_compare : public key_compare
+    {
+    public:
+
+        ultra_compare() noexcept(std::is_nothrow_default_constructible<key_compare>::value)
+        {}
+
+        ultra_compare(const key_compare& c) noexcept(std::is_nothrow_copy_constructible<key_compare>::value)
+            : key_compare(c)
+        {}
+
+        ultra_compare(key_compare&& c) noexcept(std::is_nothrow_move_constructible<key_compare>::value)
+            : key_compare(std::move(c))
+        {}
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_compare::operator()(x.first, y.first);
+        }
+
+        template <typename K>
+        bool operator()(const value_type& x, const K& y) const
+        {
+            return key_compare::operator()(x.first, y);
+        }
+
+        template <typename K>
+        bool operator()(const K& x, const value_type& y) const
+        {
+            return key_compare::operator()(x, y.first);
+        }
+    };
+
+    class data_base
+    {
+    public:
+
+        union
+        {
+            value_type first_[N];
+        };
+
+        pointer last_;
+
+        data_base() noexcept
+            : last_(first_)
+        {}
+
+        #if defined(__clang__) && (__clang_major__ == 3) // For CentOS 7
+        ~data_base()
+        {}
+        #else
+        ~data_base() noexcept
+        {}
+        #endif
+    };
+
+    class data : public data_base, public ultra_compare
+    {
+    public:
+
+        data() noexcept(std::is_nothrow_default_constructible<ultra_compare>::value)
+            : ultra_compare()
+        {}
+
+        data(const ultra_compare& comp) noexcept(std::is_nothrow_copy_constructible<ultra_compare>::value)
+            : ultra_compare(comp)
+        {}
+
+        data(ultra_compare&& comp) noexcept(std::is_nothrow_move_constructible<ultra_compare>::value)
+            : ultra_compare(std::move(comp))
+        {}
+
+        ultra_compare& ref_to_comp() noexcept
+        {
+            return *this;
+        }
+
+        const ultra_compare& ref_to_comp() const noexcept
+        {
+            return *this;
+        }
+    };
+
+    data data_;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    static_flat_multimap() noexcept(std::is_nothrow_default_constructible<Compare>::value)
+        : data_()
+    {}
+
+    explicit static_flat_multimap(const Compare& comp) noexcept(std::is_nothrow_copy_constructible<Compare>::value)
+        : data_(comp)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_flat_multimap(InputIt first, InputIt last)
+        : data_()
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_flat_multimap(InputIt first, InputIt last, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(first, last);
+    }
+
+    static_flat_multimap(std::initializer_list<value_type> ilist)
+        : static_flat_multimap(ilist.begin(), ilist.end())
+    {}
+
+    static_flat_multimap(std::initializer_list<value_type> ilist, const Compare& comp)
+        : static_flat_multimap(ilist.begin(), ilist.end(), comp)
+    {}
+
+    static_flat_multimap(const static_flat_multimap& other)
+        : data_(other.data_.ref_to_comp())
+    {
+        data_.last_ = sfl::dtl::uninitialized_copy
+        (
+            pointer(other.data_.first_),
+            pointer(other.data_.last_),
+            data_.first_
+        );
+    }
+
+    static_flat_multimap(static_flat_multimap&& other)
+        : data_(std::move(other.data_.ref_to_comp()))
+    {
+        data_.last_ = sfl::dtl::uninitialized_move
+        (
+            std::make_move_iterator(pointer(other.data_.first_)),
+            std::make_move_iterator(pointer(other.data_.last_)),
+            data_.first_
+        );
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_flat_multimap(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_flat_multimap(sfl::from_range_t, Range&& range, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    static_flat_multimap(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    static_flat_multimap(sfl::from_range_t, Range&& range, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~static_flat_multimap()
+    {
+        sfl::dtl::destroy(data_.first_, data_.last_);
+    }
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    static_flat_multimap& operator=(const static_flat_multimap& other)
+    {
+        if (this != &other)
+        {
+            data_.ref_to_comp() = other.data_.ref_to_comp();
+
+            assign_range
+            (
+                pointer(other.data_.first_),
+                pointer(other.data_.last_)
+            );
+        }
+
+        return *this;
+    }
+
+    static_flat_multimap& operator=(static_flat_multimap&& other)
+    {
+        data_.ref_to_comp() = other.data_.ref_to_comp();
+
+        assign_range
+        (
+            std::make_move_iterator(pointer(other.data_.first_)),
+            std::make_move_iterator(pointer(other.data_.last_))
+        );
+
+        return *this;
+    }
+
+    static_flat_multimap& operator=(std::initializer_list<value_type> ilist)
+    {
+        assign_range(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- KEY COMPARE -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_compare key_comp() const
+    {
+        return data_.ref_to_comp();
+    }
+
+    //
+    // ---- VALUE COMPARE -----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_compare value_comp() const
+    {
+        return value_compare(data_.ref_to_comp());
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    iterator nth(size_type pos) noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_iterator nth(size_type pos) const noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return const_iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    size_type index_of(const_iterator pos) const noexcept
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return std::distance(cbegin(), pos);
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return data_.first_ == data_.last_;
+    }
+
+    SFL_NODISCARD
+    bool full() const noexcept
+    {
+        return std::distance(begin(), end()) == N;
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return std::distance(begin(), end());
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type max_size() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type capacity() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    size_type available() const noexcept
+    {
+        return capacity() - size();
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear() noexcept
+    {
+        sfl::dtl::destroy(data_.first_, data_.last_);
+        data_.last_ = data_.first_;
+    }
+
+    template <typename... Args>
+    iterator emplace(Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return insert_aux(value_type(std::forward<Args>(args)...));
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value_type(std::forward<Args>(args)...));
+    }
+
+    iterator insert(const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        return insert_aux(value);
+    }
+
+    iterator insert(value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        return insert_aux(std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P&&>::value>* = nullptr>
+    iterator insert(P&& value)
+    {
+        SFL_ASSERT(!full());
+        return insert_aux(value_type(std::forward<P>(value)));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P>::value>* = nullptr>
+    iterator insert(const_iterator hint, P&& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value_type(std::forward<P>(value)));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    iterator erase(iterator pos)
+    {
+        return erase(const_iterator(pos));
+    }
+
+    iterator erase(const_iterator pos)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos < cend());
+
+        const pointer p = data_.first_ + std::distance(cbegin(), pos);
+
+        data_.last_ = sfl::dtl::move(p + 1, data_.last_, p);
+
+        sfl::dtl::destroy_at(data_.last_);
+
+        return iterator(p);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        SFL_ASSERT(cbegin() <= first && first <= last && last <= cend());
+
+        if (first == last)
+        {
+            return begin() + std::distance(cbegin(), first);
+        }
+
+        const pointer p1 = data_.first_ + std::distance(cbegin(), first);
+        const pointer p2 = data_.first_ + std::distance(cbegin(), last);
+
+        const pointer new_last = sfl::dtl::move(p2, data_.last_, p1);
+
+        sfl::dtl::destroy(new_last, data_.last_);
+
+        data_.last_ = new_last;
+
+        return iterator(p1);
+    }
+
+    size_type erase(const Key& key)
+    {
+        const auto er = equal_range(key);
+        const auto n = std::distance(er.first, er.second);
+        erase(er.first, er.second);
+        return n;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        const auto er = equal_range(x);
+        const auto n = std::distance(er.first, er.second);
+        erase(er.first, er.second);
+        return n;
+    }
+
+    void swap(static_flat_multimap& other)
+    {
+        if (this == &other)
+        {
+            return;
+        }
+
+        using std::swap;
+
+        swap(this->data_.ref_to_comp(), other.data_.ref_to_comp());
+
+        const size_type this_size  = this->size();
+        const size_type other_size = other.size();
+
+        if (this_size <= other_size)
+        {
+            std::swap_ranges
+            (
+                this->data_.first_,
+                this->data_.first_ + this_size,
+                other.data_.first_
+            );
+
+            sfl::dtl::uninitialized_move
+            (
+                other.data_.first_ + this_size,
+                other.data_.first_ + other_size,
+                this->data_.first_ + this_size
+            );
+
+            sfl::dtl::destroy
+            (
+                other.data_.first_ + this_size,
+                other.data_.first_ + other_size
+            );
+        }
+        else
+        {
+            std::swap_ranges
+            (
+                other.data_.first_,
+                other.data_.first_ + other_size,
+                this->data_.first_
+            );
+
+            sfl::dtl::uninitialized_move
+            (
+                this->data_.first_ + other_size,
+                this->data_.first_ + this_size,
+                other.data_.first_ + other_size
+            );
+
+            sfl::dtl::destroy
+            (
+                this->data_.first_ + other_size,
+                this->data_.first_ + this_size
+            );
+        }
+
+        this->data_.last_ = this->data_.first_ + other_size;
+        other.data_.last_ = other.data_.first_ + this_size;
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator lower_bound(const Key& key)
+    {
+        return std::lower_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    const_iterator lower_bound(const Key& key) const
+    {
+        return std::lower_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator lower_bound(const K& x)
+    {
+        return std::lower_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator lower_bound(const K& x) const
+    {
+        return std::lower_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    iterator upper_bound(const Key& key)
+    {
+        return std::upper_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    const_iterator upper_bound(const Key& key) const
+    {
+        return std::upper_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator upper_bound(const K& x)
+    {
+        return std::upper_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator upper_bound(const K& x) const
+    {
+        return std::upper_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const Key& key)
+    {
+        return std::equal_range(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const
+    {
+        return std::equal_range(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const K& x)
+    {
+        return std::equal_range(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const K& x) const
+    {
+        return std::equal_range(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        auto it = lower_bound(key);
+
+        if (it != end() && data_.ref_to_comp()(key, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        auto it = lower_bound(key);
+
+        if (it != end() && data_.ref_to_comp()(key, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        auto it = lower_bound(x);
+
+        if (it != end() && data_.ref_to_comp()(x, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        auto it = lower_bound(x);
+
+        if (it != end() && data_.ref_to_comp()(x, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        const auto er = equal_range(key);
+        return std::distance(er.first, er.second);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        const auto er = equal_range(x);
+        return std::distance(er.first, er.second);
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    //
+    // ---- ELEMENT ACCESS ----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_type* data() noexcept
+    {
+        return data_.first_;
+    }
+
+    SFL_NODISCARD
+    const value_type* data() const noexcept
+    {
+        return data_.first_;
+    }
+
+private:
+
+    template <typename InputIt, typename Sentinel>
+    void initialize_range(InputIt first, Sentinel last)
+    {
+        SFL_TRY
+        {
+            while (first != last)
+            {
+                insert(*first);
+                ++first;
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy(data_.first_, data_.last_);
+            SFL_RETHROW;
+        }
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void initialize_range(Range&& range)
+    {
+        initialize_range(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void initialize_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        initialize_range(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    template <typename ForwardIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_forward_iterator<ForwardIt>::value>* = nullptr>
+    void assign_range(ForwardIt first, ForwardIt last)
+    {
+        SFL_ASSERT(size_type(std::distance(first, last)) <= capacity());
+
+        const size_type n = std::distance(first, last);
+
+        const size_type size = this->size();
+
+        if (n <= size)
+        {
+            const pointer new_last = sfl::dtl::copy
+            (
+                first,
+                last,
+                data_.first_
+            );
+
+            sfl::dtl::destroy
+            (
+                new_last,
+                data_.last_
+            );
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const ForwardIt mid = std::next(first, size);
+
+            sfl::dtl::copy
+            (
+                first,
+                mid,
+                data_.first_
+            );
+
+            data_.last_ = sfl::dtl::uninitialized_copy
+            (
+                mid,
+                last,
+                data_.last_
+            );
+        }
+    }
+
+    template <typename Value>
+    iterator insert_aux(Value&& value)
+    {
+        return insert_exactly_at(lower_bound(value.first), std::forward<Value>(value));
+    }
+
+    template <typename Value>
+    iterator insert_aux(const_iterator hint, Value&& value)
+    {
+        if (is_insert_hint_good(hint, value))
+        {
+            return insert_exactly_at(hint, std::forward<Value>(value));
+        }
+
+        // Hint is not good. Use non-hinted function.
+        return insert_aux(std::forward<Value>(value));
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+
+    template <typename Value>
+    iterator insert_exactly_at(const_iterator pos, Value&& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+
+        const pointer p1 = data_.first_ + std::distance(cbegin(), pos);
+
+        if (p1 == data_.last_)
+        {
+            sfl::dtl::construct_at
+            (
+                p1,
+                std::forward<Value>(value)
+            );
+
+            ++data_.last_;
+        }
+        else
+        {
+            // This container can contain duplicates.
+            // Create temporary value before making place for new element.
+            value_type temp(std::forward<Value>(value));
+
+            const pointer p2 = data_.last_ - 1;
+
+            const pointer old_last = data_.last_;
+
+            sfl::dtl::construct_at
+            (
+                data_.last_,
+                std::move(*p2)
+            );
+
+            ++data_.last_;
+
+            sfl::dtl::move_backward
+            (
+                p1,
+                p2,
+                old_last
+            );
+
+            *p1 = std::move(temp);
+        }
+
+        return iterator(p1);
+    }
+
+    template <typename Value>
+    bool is_insert_hint_good(const_iterator hint, const Value& value)
+    {
+        return
+            // If `hint` == `value`
+            (
+                hint != end() &&
+                !data_.ref_to_comp()(*hint, value) &&
+                !data_.ref_to_comp()(value, *hint)
+            )
+            ||
+            // If `hint - 1` == `value`
+            (
+                hint != begin() &&
+                !data_.ref_to_comp()(*(hint - 1), value) &&
+                !data_.ref_to_comp()(value, *(hint - 1))
+            )
+            ||
+            // If `hint - 1` < `value` and `value` < `hint`
+            (
+                (hint == begin() || data_.ref_to_comp()(*(hint - 1), value)) &&
+                (hint == end()   || data_.ref_to_comp()(value, *hint))
+            );
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator==
+(
+    const static_flat_multimap<K, T, N, C>& x,
+    const static_flat_multimap<K, T, N, C>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator!=
+(
+    const static_flat_multimap<K, T, N, C>& x,
+    const static_flat_multimap<K, T, N, C>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator<
+(
+    const static_flat_multimap<K, T, N, C>& x,
+    const static_flat_multimap<K, T, N, C>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator>
+(
+    const static_flat_multimap<K, T, N, C>& x,
+    const static_flat_multimap<K, T, N, C>& y
+)
+{
+    return y < x;
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator<=
+(
+    const static_flat_multimap<K, T, N, C>& x,
+    const static_flat_multimap<K, T, N, C>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator>=
+(
+    const static_flat_multimap<K, T, N, C>& x,
+    const static_flat_multimap<K, T, N, C>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+void swap
+(
+    static_flat_multimap<K, T, N, C>& x,
+    static_flat_multimap<K, T, N, C>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename Predicate>
+typename static_flat_multimap<K, T, N, C>::size_type
+    erase_if(static_flat_multimap<K, T, N, C>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_STATIC_FLAT_MULTIMAP_HPP_INCLUDED

--- a/src/thirdparty/sfl/static_flat_multiset.hpp
+++ b/src/thirdparty/sfl/static_flat_multiset.hpp
@@ -1,0 +1,1112 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_STATIC_FLAT_MULTISET_HPP_INCLUDED
+#define SFL_STATIC_FLAT_MULTISET_HPP_INCLUDED
+
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/initialized_memory_algorithms.hpp>
+#include <sfl/detail/normal_iterator.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/type_traits.hpp>
+#include <sfl/detail/uninitialized_memory_algorithms.hpp>
+
+#include <algorithm>        // copy, move, lower_bound, swap, swap_ranges
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <iterator>         // distance, next, reverse_iterator
+#include <limits>           // numeric_limits
+#include <memory>           // allocator, allocator_traits, pointer_traits
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+#ifdef SFL_TEST_STATIC_FLAT_MULTISET
+void test_static_flat_multiset();
+#endif
+
+namespace sfl
+{
+
+template < typename Key,
+           std::size_t N,
+           typename Compare = std::less<Key> >
+class static_flat_multiset
+{
+    #ifdef SFL_TEST_STATIC_FLAT_MULTISET
+    friend void ::test_static_flat_multiset();
+    #endif
+
+    static_assert(N > 0, "N must be greater than zero.");
+
+public:
+
+    using key_type               = Key;
+    using value_type             = Key;
+    using size_type              = std::size_t;
+    using difference_type        = std::ptrdiff_t;
+    using key_compare            = Compare;
+    using value_compare          = Compare;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using pointer                = value_type*;
+    using const_pointer          = const value_type*;
+    using iterator               = sfl::dtl::normal_iterator<const_pointer, static_flat_multiset>; // MUST BE const_pointer
+    using const_iterator         = sfl::dtl::normal_iterator<const_pointer, static_flat_multiset>;
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+private:
+
+    class data_base
+    {
+    public:
+
+        union
+        {
+            value_type first_[N];
+        };
+
+        pointer last_;
+
+        data_base() noexcept
+            : last_(first_)
+        {}
+
+        #if defined(__clang__) && (__clang_major__ == 3) // For CentOS 7
+        ~data_base()
+        {}
+        #else
+        ~data_base() noexcept
+        {}
+        #endif
+    };
+
+    class data : public data_base, public value_compare
+    {
+    public:
+
+        data() noexcept(std::is_nothrow_default_constructible<value_compare>::value)
+            : value_compare()
+        {}
+
+        data(const value_compare& comp) noexcept(std::is_nothrow_copy_constructible<value_compare>::value)
+            : value_compare(comp)
+        {}
+
+        data(value_compare&& comp) noexcept(std::is_nothrow_move_constructible<value_compare>::value)
+            : value_compare(std::move(comp))
+        {}
+
+        value_compare& ref_to_comp() noexcept
+        {
+            return *this;
+        }
+
+        const value_compare& ref_to_comp() const noexcept
+        {
+            return *this;
+        }
+    };
+
+    data data_;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    static_flat_multiset() noexcept(std::is_nothrow_default_constructible<Compare>::value)
+        : data_()
+    {}
+
+    explicit static_flat_multiset(const Compare& comp) noexcept(std::is_nothrow_copy_constructible<Compare>::value)
+        : data_(comp)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_flat_multiset(InputIt first, InputIt last)
+        : data_()
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_flat_multiset(InputIt first, InputIt last, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(first, last);
+    }
+
+    static_flat_multiset(std::initializer_list<value_type> ilist)
+        : static_flat_multiset(ilist.begin(), ilist.end())
+    {}
+
+    static_flat_multiset(std::initializer_list<value_type> ilist, const Compare& comp)
+        : static_flat_multiset(ilist.begin(), ilist.end(), comp)
+    {}
+
+    static_flat_multiset(const static_flat_multiset& other)
+        : data_(other.data_.ref_to_comp())
+    {
+        data_.last_ = sfl::dtl::uninitialized_copy
+        (
+            pointer(other.data_.first_),
+            pointer(other.data_.last_),
+            data_.first_
+        );
+    }
+
+    static_flat_multiset(static_flat_multiset&& other)
+        : data_(std::move(other.data_.ref_to_comp()))
+    {
+        data_.last_ = sfl::dtl::uninitialized_move
+        (
+            std::make_move_iterator(pointer(other.data_.first_)),
+            std::make_move_iterator(pointer(other.data_.last_)),
+            data_.first_
+        );
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_flat_multiset(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_flat_multiset(sfl::from_range_t, Range&& range, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    static_flat_multiset(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    static_flat_multiset(sfl::from_range_t, Range&& range, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~static_flat_multiset()
+    {
+        sfl::dtl::destroy(data_.first_, data_.last_);
+    }
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    static_flat_multiset& operator=(const static_flat_multiset& other)
+    {
+        if (this != &other)
+        {
+            data_.ref_to_comp() = other.data_.ref_to_comp();
+
+            assign_range
+            (
+                pointer(other.data_.first_),
+                pointer(other.data_.last_)
+            );
+        }
+
+        return *this;
+    }
+
+    static_flat_multiset& operator=(static_flat_multiset&& other)
+    {
+        data_.ref_to_comp() = other.data_.ref_to_comp();
+
+        assign_range
+        (
+            std::make_move_iterator(pointer(other.data_.first_)),
+            std::make_move_iterator(pointer(other.data_.last_))
+        );
+
+        return *this;
+    }
+
+    static_flat_multiset& operator=(std::initializer_list<value_type> ilist)
+    {
+        assign_range(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- KEY COMPARE -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_compare key_comp() const
+    {
+        return data_.ref_to_comp();
+    }
+
+    //
+    // ---- VALUE COMPARE -----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_compare value_comp() const
+    {
+        return data_.ref_to_comp();
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    iterator nth(size_type pos) noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_iterator nth(size_type pos) const noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return const_iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    size_type index_of(const_iterator pos) const noexcept
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return std::distance(cbegin(), pos);
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return data_.first_ == data_.last_;
+    }
+
+    SFL_NODISCARD
+    bool full() const noexcept
+    {
+        return std::distance(begin(), end()) == N;
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return std::distance(begin(), end());
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type max_size() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type capacity() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    size_type available() const noexcept
+    {
+        return capacity() - size();
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear() noexcept
+    {
+        sfl::dtl::destroy(data_.first_, data_.last_);
+        data_.last_ = data_.first_;
+    }
+
+    template <typename... Args>
+    iterator emplace(Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return insert_aux(value_type(std::forward<Args>(args)...));
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value_type(std::forward<Args>(args)...));
+    }
+
+    iterator insert(const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        return insert_aux(value);
+    }
+
+    iterator insert(value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        return insert_aux(std::move(value));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, std::move(value));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    iterator erase(const_iterator pos)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos < cend());
+
+        const pointer p = data_.first_ + std::distance(cbegin(), pos);
+
+        data_.last_ = sfl::dtl::move(p + 1, data_.last_, p);
+
+        sfl::dtl::destroy_at(data_.last_);
+
+        return iterator(p);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        SFL_ASSERT(cbegin() <= first && first <= last && last <= cend());
+
+        if (first == last)
+        {
+            return begin() + std::distance(cbegin(), first);
+        }
+
+        const pointer p1 = data_.first_ + std::distance(cbegin(), first);
+        const pointer p2 = data_.first_ + std::distance(cbegin(), last);
+
+        const pointer new_last = sfl::dtl::move(p2, data_.last_, p1);
+
+        sfl::dtl::destroy(new_last, data_.last_);
+
+        data_.last_ = new_last;
+
+        return iterator(p1);
+    }
+
+    size_type erase(const Key& key)
+    {
+        const auto er = equal_range(key);
+        const auto n = std::distance(er.first, er.second);
+        erase(er.first, er.second);
+        return n;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        const auto er = equal_range(x);
+        const auto n = std::distance(er.first, er.second);
+        erase(er.first, er.second);
+        return n;
+    }
+
+    void swap(static_flat_multiset& other)
+    {
+        if (this == &other)
+        {
+            return;
+        }
+
+        using std::swap;
+
+        swap(this->data_.ref_to_comp(), other.data_.ref_to_comp());
+
+        const size_type this_size  = this->size();
+        const size_type other_size = other.size();
+
+        if (this_size <= other_size)
+        {
+            std::swap_ranges
+            (
+                this->data_.first_,
+                this->data_.first_ + this_size,
+                other.data_.first_
+            );
+
+            sfl::dtl::uninitialized_move
+            (
+                other.data_.first_ + this_size,
+                other.data_.first_ + other_size,
+                this->data_.first_ + this_size
+            );
+
+            sfl::dtl::destroy
+            (
+                other.data_.first_ + this_size,
+                other.data_.first_ + other_size
+            );
+        }
+        else
+        {
+            std::swap_ranges
+            (
+                other.data_.first_,
+                other.data_.first_ + other_size,
+                this->data_.first_
+            );
+
+            sfl::dtl::uninitialized_move
+            (
+                this->data_.first_ + other_size,
+                this->data_.first_ + this_size,
+                other.data_.first_ + other_size
+            );
+
+            sfl::dtl::destroy
+            (
+                this->data_.first_ + other_size,
+                this->data_.first_ + this_size
+            );
+        }
+
+        this->data_.last_ = this->data_.first_ + other_size;
+        other.data_.last_ = other.data_.first_ + this_size;
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator lower_bound(const Key& key)
+    {
+        return std::lower_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    const_iterator lower_bound(const Key& key) const
+    {
+        return std::lower_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator lower_bound(const K& x)
+    {
+        return std::lower_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator lower_bound(const K& x) const
+    {
+        return std::lower_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    iterator upper_bound(const Key& key)
+    {
+        return std::upper_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    const_iterator upper_bound(const Key& key) const
+    {
+        return std::upper_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator upper_bound(const K& x)
+    {
+        return std::upper_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator upper_bound(const K& x) const
+    {
+        return std::upper_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const Key& key)
+    {
+        return std::equal_range(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const
+    {
+        return std::equal_range(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const K& x)
+    {
+        return std::equal_range(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const K& x) const
+    {
+        return std::equal_range(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        auto it = lower_bound(key);
+
+        if (it != end() && data_.ref_to_comp()(key, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        auto it = lower_bound(key);
+
+        if (it != end() && data_.ref_to_comp()(key, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        auto it = lower_bound(x);
+
+        if (it != end() && data_.ref_to_comp()(x, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        auto it = lower_bound(x);
+
+        if (it != end() && data_.ref_to_comp()(x, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        const auto er = equal_range(key);
+        return std::distance(er.first, er.second);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        const auto er = equal_range(x);
+        return std::distance(er.first, er.second);
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    //
+    // ---- ELEMENT ACCESS ----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_type* data() noexcept
+    {
+        return data_.first_;
+    }
+
+    SFL_NODISCARD
+    const value_type* data() const noexcept
+    {
+        return data_.first_;
+    }
+
+private:
+
+    template <typename InputIt, typename Sentinel>
+    void initialize_range(InputIt first, Sentinel last)
+    {
+        SFL_TRY
+        {
+            while (first != last)
+            {
+                insert(*first);
+                ++first;
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy(data_.first_, data_.last_);
+            SFL_RETHROW;
+        }
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void initialize_range(Range&& range)
+    {
+        initialize_range(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void initialize_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        initialize_range(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    template <typename ForwardIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_forward_iterator<ForwardIt>::value>* = nullptr>
+    void assign_range(ForwardIt first, ForwardIt last)
+    {
+        SFL_ASSERT(size_type(std::distance(first, last)) <= capacity());
+
+        const size_type n = std::distance(first, last);
+
+        const size_type size = this->size();
+
+        if (n <= size)
+        {
+            const pointer new_last = sfl::dtl::copy
+            (
+                first,
+                last,
+                data_.first_
+            );
+
+            sfl::dtl::destroy
+            (
+                new_last,
+                data_.last_
+            );
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const ForwardIt mid = std::next(first, size);
+
+            sfl::dtl::copy
+            (
+                first,
+                mid,
+                data_.first_
+            );
+
+            data_.last_ = sfl::dtl::uninitialized_copy
+            (
+                mid,
+                last,
+                data_.last_
+            );
+        }
+    }
+
+    template <typename Value>
+    iterator insert_aux(Value&& value)
+    {
+        return insert_exactly_at(lower_bound(value), std::forward<Value>(value));
+    }
+
+    template <typename Value>
+    iterator insert_aux(const_iterator hint, Value&& value)
+    {
+        if (is_insert_hint_good(hint, value))
+        {
+            return insert_exactly_at(hint, std::forward<Value>(value));
+        }
+
+        // Hint is not good. Use non-hinted function.
+        return insert_aux(std::forward<Value>(value));
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+
+    template <typename Value>
+    iterator insert_exactly_at(const_iterator pos, Value&& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+
+        const pointer p1 = data_.first_ + std::distance(cbegin(), pos);
+
+        if (p1 == data_.last_)
+        {
+            sfl::dtl::construct_at
+            (
+                p1,
+                std::forward<Value>(value)
+            );
+
+            ++data_.last_;
+        }
+        else
+        {
+            // This container can contain duplicates.
+            // Create temporary value before making place for new element.
+            value_type temp(std::forward<Value>(value));
+
+            const pointer p2 = data_.last_ - 1;
+
+            const pointer old_last = data_.last_;
+
+            sfl::dtl::construct_at
+            (
+                data_.last_,
+                std::move(*p2)
+            );
+
+            ++data_.last_;
+
+            sfl::dtl::move_backward
+            (
+                p1,
+                p2,
+                old_last
+            );
+
+            *p1 = std::move(temp);
+        }
+
+        return iterator(p1);
+    }
+
+    template <typename Value>
+    bool is_insert_hint_good(const_iterator hint, const Value& value)
+    {
+        return
+            // If `hint` == `value`
+            (
+                hint != end() &&
+                !data_.ref_to_comp()(*hint, value) &&
+                !data_.ref_to_comp()(value, *hint)
+            )
+            ||
+            // If `hint - 1` == `value`
+            (
+                hint != begin() &&
+                !data_.ref_to_comp()(*(hint - 1), value) &&
+                !data_.ref_to_comp()(value, *(hint - 1))
+            )
+            ||
+            // If `hint - 1` < `value` and `value` < `hint`
+            (
+                (hint == begin() || data_.ref_to_comp()(*(hint - 1), value)) &&
+                (hint == end()   || data_.ref_to_comp()(value, *hint))
+            );
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator==
+(
+    const static_flat_multiset<K, N, C>& x,
+    const static_flat_multiset<K, N, C>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator!=
+(
+    const static_flat_multiset<K, N, C>& x,
+    const static_flat_multiset<K, N, C>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator<
+(
+    const static_flat_multiset<K, N, C>& x,
+    const static_flat_multiset<K, N, C>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator>
+(
+    const static_flat_multiset<K, N, C>& x,
+    const static_flat_multiset<K, N, C>& y
+)
+{
+    return y < x;
+}
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator<=
+(
+    const static_flat_multiset<K, N, C>& x,
+    const static_flat_multiset<K, N, C>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator>=
+(
+    const static_flat_multiset<K, N, C>& x,
+    const static_flat_multiset<K, N, C>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename K, std::size_t N, typename C>
+void swap
+(
+    static_flat_multiset<K, N, C>& x,
+    static_flat_multiset<K, N, C>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, std::size_t N, typename C, typename Predicate>
+typename static_flat_multiset<K, N, C>::size_type
+erase_if(static_flat_multiset<K, N, C>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_STATIC_FLAT_MULTISET_HPP_INCLUDED

--- a/src/thirdparty/sfl/static_flat_set.hpp
+++ b/src/thirdparty/sfl/static_flat_set.hpp
@@ -1,0 +1,1145 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_STATIC_FLAT_SET_HPP_INCLUDED
+#define SFL_STATIC_FLAT_SET_HPP_INCLUDED
+
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/initialized_memory_algorithms.hpp>
+#include <sfl/detail/normal_iterator.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/type_traits.hpp>
+#include <sfl/detail/uninitialized_memory_algorithms.hpp>
+
+#include <algorithm>        // copy, move, lower_bound, swap, swap_ranges
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <iterator>         // distance, next, reverse_iterator
+#include <limits>           // numeric_limits
+#include <memory>           // allocator, allocator_traits, pointer_traits
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+#ifdef SFL_TEST_STATIC_FLAT_SET
+void test_static_flat_set();
+#endif
+
+namespace sfl
+{
+
+template < typename Key,
+           std::size_t N,
+           typename Compare = std::less<Key> >
+class static_flat_set
+{
+    #ifdef SFL_TEST_STATIC_FLAT_SET
+    friend void ::test_static_flat_set();
+    #endif
+
+    static_assert(N > 0, "N must be greater than zero.");
+
+public:
+
+    using key_type               = Key;
+    using value_type             = Key;
+    using size_type              = std::size_t;
+    using difference_type        = std::ptrdiff_t;
+    using key_compare            = Compare;
+    using value_compare          = Compare;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using pointer                = value_type*;
+    using const_pointer          = const value_type*;
+    using iterator               = sfl::dtl::normal_iterator<const_pointer, static_flat_set>; // MUST BE const_pointer
+    using const_iterator         = sfl::dtl::normal_iterator<const_pointer, static_flat_set>;
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+private:
+
+    class data_base
+    {
+    public:
+
+        union
+        {
+            value_type first_[N];
+        };
+
+        pointer last_;
+
+        data_base() noexcept
+            : last_(first_)
+        {}
+
+        #if defined(__clang__) && (__clang_major__ == 3) // For CentOS 7
+        ~data_base()
+        {}
+        #else
+        ~data_base() noexcept
+        {}
+        #endif
+    };
+
+    class data : public data_base, public value_compare
+    {
+    public:
+
+        data() noexcept(std::is_nothrow_default_constructible<value_compare>::value)
+            : value_compare()
+        {}
+
+        data(const value_compare& comp) noexcept(std::is_nothrow_copy_constructible<value_compare>::value)
+            : value_compare(comp)
+        {}
+
+        data(value_compare&& comp) noexcept(std::is_nothrow_move_constructible<value_compare>::value)
+            : value_compare(std::move(comp))
+        {}
+
+        value_compare& ref_to_comp() noexcept
+        {
+            return *this;
+        }
+
+        const value_compare& ref_to_comp() const noexcept
+        {
+            return *this;
+        }
+    };
+
+    data data_;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    static_flat_set() noexcept(std::is_nothrow_default_constructible<Compare>::value)
+        : data_()
+    {}
+
+    explicit static_flat_set(const Compare& comp) noexcept(std::is_nothrow_copy_constructible<Compare>::value)
+        : data_(comp)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_flat_set(InputIt first, InputIt last)
+        : data_()
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_flat_set(InputIt first, InputIt last, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(first, last);
+    }
+
+    static_flat_set(std::initializer_list<value_type> ilist)
+        : static_flat_set(ilist.begin(), ilist.end())
+    {}
+
+    static_flat_set(std::initializer_list<value_type> ilist, const Compare& comp)
+        : static_flat_set(ilist.begin(), ilist.end(), comp)
+    {}
+
+    static_flat_set(const static_flat_set& other)
+        : data_(other.data_.ref_to_comp())
+    {
+        data_.last_ = sfl::dtl::uninitialized_copy
+        (
+            pointer(other.data_.first_),
+            pointer(other.data_.last_),
+            data_.first_
+        );
+    }
+
+    static_flat_set(static_flat_set&& other)
+        : data_(std::move(other.data_.ref_to_comp()))
+    {
+        data_.last_ = sfl::dtl::uninitialized_move
+        (
+            std::make_move_iterator(pointer(other.data_.first_)),
+            std::make_move_iterator(pointer(other.data_.last_)),
+            data_.first_
+        );
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_flat_set(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_flat_set(sfl::from_range_t, Range&& range, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    static_flat_set(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    static_flat_set(sfl::from_range_t, Range&& range, const Compare& comp)
+        : data_(comp)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~static_flat_set()
+    {
+        sfl::dtl::destroy(data_.first_, data_.last_);
+    }
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    static_flat_set& operator=(const static_flat_set& other)
+    {
+        if (this != &other)
+        {
+            data_.ref_to_comp() = other.data_.ref_to_comp();
+
+            assign_range
+            (
+                pointer(other.data_.first_),
+                pointer(other.data_.last_)
+            );
+        }
+
+        return *this;
+    }
+
+    static_flat_set& operator=(static_flat_set&& other)
+    {
+        data_.ref_to_comp() = other.data_.ref_to_comp();
+
+        assign_range
+        (
+            std::make_move_iterator(pointer(other.data_.first_)),
+            std::make_move_iterator(pointer(other.data_.last_))
+        );
+
+        return *this;
+    }
+
+    static_flat_set& operator=(std::initializer_list<value_type> ilist)
+    {
+        assign_range(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- KEY COMPARE -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_compare key_comp() const
+    {
+        return data_.ref_to_comp();
+    }
+
+    //
+    // ---- VALUE COMPARE -----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_compare value_comp() const
+    {
+        return data_.ref_to_comp();
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    SFL_NODISCARD
+    iterator nth(size_type pos) noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_iterator nth(size_type pos) const noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return const_iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    size_type index_of(const_iterator pos) const noexcept
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return std::distance(cbegin(), pos);
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return data_.first_ == data_.last_;
+    }
+
+    SFL_NODISCARD
+    bool full() const noexcept
+    {
+        return std::distance(begin(), end()) == N;
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return std::distance(begin(), end());
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type max_size() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type capacity() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    size_type available() const noexcept
+    {
+        return capacity() - size();
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear() noexcept
+    {
+        sfl::dtl::destroy(data_.first_, data_.last_);
+        data_.last_ = data_.first_;
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace(Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return insert_aux(value_type(std::forward<Args>(args)...));
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value_type(std::forward<Args>(args)...));
+    }
+
+    std::pair<iterator, bool> insert(const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        return insert_aux(value);
+    }
+
+    std::pair<iterator, bool> insert(value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        return insert_aux(std::move(value));
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    std::pair<iterator, bool> insert(K&& x)
+    {
+        SFL_ASSERT(!full());
+        return insert_aux_heterogeneous(std::forward<K>(x));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, std::move(value));
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t< sfl::dtl::has_is_transparent<Compare, K>::value &&
+                                    !std::is_convertible<K&&, const_iterator>::value &&
+                                    !std::is_convertible<K&&, iterator>::value >* = nullptr>
+    iterator insert(const_iterator hint, K&& x)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux_heterogeneous(hint, std::forward<K>(x));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    iterator erase(const_iterator pos)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos < cend());
+
+        const pointer p = data_.first_ + std::distance(cbegin(), pos);
+
+        data_.last_ = sfl::dtl::move(p + 1, data_.last_, p);
+
+        sfl::dtl::destroy_at(data_.last_);
+
+        return iterator(p);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        SFL_ASSERT(cbegin() <= first && first <= last && last <= cend());
+
+        if (first == last)
+        {
+            return begin() + std::distance(cbegin(), first);
+        }
+
+        const pointer p1 = data_.first_ + std::distance(cbegin(), first);
+        const pointer p2 = data_.first_ + std::distance(cbegin(), last);
+
+        const pointer new_last = sfl::dtl::move(p2, data_.last_, p1);
+
+        sfl::dtl::destroy(new_last, data_.last_);
+
+        data_.last_ = new_last;
+
+        return iterator(p1);
+    }
+
+    size_type erase(const Key& key)
+    {
+        auto it = find(key);
+        if (it == cend())
+        {
+            return 0;
+        }
+        erase(it);
+        return 1;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        auto it = find(x);
+        if (it == cend())
+        {
+            return 0;
+        }
+        erase(it);
+        return 1;
+    }
+
+    void swap(static_flat_set& other)
+    {
+        if (this == &other)
+        {
+            return;
+        }
+
+        using std::swap;
+
+        swap(this->data_.ref_to_comp(), other.data_.ref_to_comp());
+
+        const size_type this_size  = this->size();
+        const size_type other_size = other.size();
+
+        if (this_size <= other_size)
+        {
+            std::swap_ranges
+            (
+                this->data_.first_,
+                this->data_.first_ + this_size,
+                other.data_.first_
+            );
+
+            sfl::dtl::uninitialized_move
+            (
+                other.data_.first_ + this_size,
+                other.data_.first_ + other_size,
+                this->data_.first_ + this_size
+            );
+
+            sfl::dtl::destroy
+            (
+                other.data_.first_ + this_size,
+                other.data_.first_ + other_size
+            );
+        }
+        else
+        {
+            std::swap_ranges
+            (
+                other.data_.first_,
+                other.data_.first_ + other_size,
+                this->data_.first_
+            );
+
+            sfl::dtl::uninitialized_move
+            (
+                this->data_.first_ + other_size,
+                this->data_.first_ + this_size,
+                other.data_.first_ + other_size
+            );
+
+            sfl::dtl::destroy
+            (
+                this->data_.first_ + other_size,
+                this->data_.first_ + this_size
+            );
+        }
+
+        this->data_.last_ = this->data_.first_ + other_size;
+        other.data_.last_ = other.data_.first_ + this_size;
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator lower_bound(const Key& key)
+    {
+        return std::lower_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    const_iterator lower_bound(const Key& key) const
+    {
+        return std::lower_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator lower_bound(const K& x)
+    {
+        return std::lower_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator lower_bound(const K& x) const
+    {
+        return std::lower_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    iterator upper_bound(const Key& key)
+    {
+        return std::upper_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    const_iterator upper_bound(const Key& key) const
+    {
+        return std::upper_bound(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator upper_bound(const K& x)
+    {
+        return std::upper_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator upper_bound(const K& x) const
+    {
+        return std::upper_bound(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const Key& key)
+    {
+        return std::equal_range(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const
+    {
+        return std::equal_range(begin(), end(), key, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const K& x)
+    {
+        return std::equal_range(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const K& x) const
+    {
+        return std::equal_range(begin(), end(), x, data_.ref_to_comp());
+    }
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        auto it = lower_bound(key);
+
+        if (it != end() && data_.ref_to_comp()(key, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        auto it = lower_bound(key);
+
+        if (it != end() && data_.ref_to_comp()(key, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        auto it = lower_bound(x);
+
+        if (it != end() && data_.ref_to_comp()(x, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        auto it = lower_bound(x);
+
+        if (it != end() && data_.ref_to_comp()(x, *it))
+        {
+            it = end();
+        }
+
+        return it;
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    //
+    // ---- ELEMENT ACCESS ----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_type* data() noexcept
+    {
+        return data_.first_;
+    }
+
+    SFL_NODISCARD
+    const value_type* data() const noexcept
+    {
+        return data_.first_;
+    }
+
+private:
+
+    template <typename InputIt, typename Sentinel>
+    void initialize_range(InputIt first, Sentinel last)
+    {
+        SFL_TRY
+        {
+            while (first != last)
+            {
+                insert(*first);
+                ++first;
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy(data_.first_, data_.last_);
+            SFL_RETHROW;
+        }
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void initialize_range(Range&& range)
+    {
+        initialize_range(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void initialize_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        initialize_range(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    template <typename ForwardIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_forward_iterator<ForwardIt>::value>* = nullptr>
+    void assign_range(ForwardIt first, ForwardIt last)
+    {
+        SFL_ASSERT(size_type(std::distance(first, last)) <= capacity());
+
+        const size_type n = std::distance(first, last);
+
+        const size_type size = this->size();
+
+        if (n <= size)
+        {
+            const pointer new_last = sfl::dtl::copy
+            (
+                first,
+                last,
+                data_.first_
+            );
+
+            sfl::dtl::destroy
+            (
+                new_last,
+                data_.last_
+            );
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const ForwardIt mid = std::next(first, size);
+
+            sfl::dtl::copy
+            (
+                first,
+                mid,
+                data_.first_
+            );
+
+            data_.last_ = sfl::dtl::uninitialized_copy
+            (
+                mid,
+                last,
+                data_.last_
+            );
+        }
+    }
+
+    template <typename Value>
+    std::pair<iterator, bool> insert_aux(Value&& value)
+    {
+        auto it = lower_bound(value);
+
+        if (it == end() || data_.ref_to_comp()(value, *it))
+        {
+            return std::make_pair(insert_exactly_at(it, std::forward<Value>(value)), true);
+        }
+
+        return std::make_pair(it, false);
+    }
+
+    template <typename Value>
+    iterator insert_aux(const_iterator hint, Value&& value)
+    {
+        if (is_insert_hint_good(hint, value))
+        {
+            return insert_exactly_at(hint, std::forward<Value>(value));
+        }
+
+        // Hint is not good. Use non-hinted function.
+        return insert_aux(std::forward<Value>(value)).first;
+    }
+
+    template <typename K>
+    std::pair<iterator, bool> insert_aux_heterogeneous(K&& x)
+    {
+        auto it = lower_bound(x);
+
+        if (it == end() || data_.ref_to_comp()(x, *it))
+        {
+            return std::make_pair(insert_exactly_at(it, value_type(std::forward<K>(x))), true);
+        }
+
+        return std::make_pair(it, false);
+    }
+
+    template <typename K>
+    iterator insert_aux_heterogeneous(const_iterator hint, K&& x)
+    {
+        if (is_insert_hint_good(hint, x))
+        {
+            return insert_exactly_at(hint, value_type(std::forward<K>(x)));
+        }
+
+        // Hint is not good. Use non-hinted function.
+        return insert_aux_heterogeneous(std::forward<K>(x)).first;
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+
+    template <typename Value>
+    iterator insert_exactly_at(const_iterator pos, Value&& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+
+        const pointer p1 = data_.first_ + std::distance(cbegin(), pos);
+
+        if (p1 == data_.last_)
+        {
+            sfl::dtl::construct_at
+            (
+                p1,
+                std::forward<Value>(value)
+            );
+
+            ++data_.last_;
+        }
+        else
+        {
+            const pointer p2 = data_.last_ - 1;
+
+            const pointer old_last = data_.last_;
+
+            sfl::dtl::construct_at
+            (
+                data_.last_,
+                std::move(*p2)
+            );
+
+            ++data_.last_;
+
+            sfl::dtl::move_backward
+            (
+                p1,
+                p2,
+                old_last
+            );
+
+            *p1 = std::forward<Value>(value);
+        }
+
+        return iterator(p1);
+    }
+
+    template <typename Value>
+    bool is_insert_hint_good(const_iterator hint, const Value& value)
+    {
+        return (hint == begin() || data_.ref_to_comp()(*(hint - 1), value))
+            && (hint == end()   || data_.ref_to_comp()(value, *hint));
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator==
+(
+    const static_flat_set<K, N, C>& x,
+    const static_flat_set<K, N, C>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator!=
+(
+    const static_flat_set<K, N, C>& x,
+    const static_flat_set<K, N, C>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator<
+(
+    const static_flat_set<K, N, C>& x,
+    const static_flat_set<K, N, C>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator>
+(
+    const static_flat_set<K, N, C>& x,
+    const static_flat_set<K, N, C>& y
+)
+{
+    return y < x;
+}
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator<=
+(
+    const static_flat_set<K, N, C>& x,
+    const static_flat_set<K, N, C>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator>=
+(
+    const static_flat_set<K, N, C>& x,
+    const static_flat_set<K, N, C>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename K, std::size_t N, typename C>
+void swap
+(
+    static_flat_set<K, N, C>& x,
+    static_flat_set<K, N, C>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, std::size_t N, typename C, typename Predicate>
+typename static_flat_set<K, N, C>::size_type
+    erase_if(static_flat_set<K, N, C>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_STATIC_FLAT_SET_HPP_INCLUDED

--- a/src/thirdparty/sfl/static_map.hpp
+++ b/src/thirdparty/sfl/static_map.hpp
@@ -1,0 +1,1025 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_STATIC_MAP_HPP_INCLUDED
+#define SFL_STATIC_MAP_HPP_INCLUDED
+
+#include <sfl/detail/allocator_traits.hpp>
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/exceptions.hpp>
+#include <sfl/detail/functional.hpp>
+#include <sfl/detail/node_static_allocator.hpp>
+#include <sfl/detail/rb_tree.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/type_traits.hpp>
+
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+namespace sfl
+{
+
+template < typename Key,
+           typename T,
+           std::size_t N,
+           typename Compare = std::less<Key> >
+class static_map
+{
+    static_assert(N > 0, "N must be greater than zero.");
+
+public:
+
+    using key_type       = Key;
+    using mapped_type    = T;
+    using value_type     = std::pair<const Key, T>;
+    using key_compare    = Compare;
+
+    class value_compare : protected key_compare
+    {
+        friend class static_map;
+
+    private:
+
+        value_compare(const key_compare& c) : key_compare(c)
+        {}
+
+    public:
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_compare::operator()(x.first, y.first);
+        }
+    };
+
+private:
+
+    using tree_type = sfl::dtl::rb_tree
+    <
+        key_type,
+        value_type,
+        sfl::dtl::first,
+        key_compare,
+        sfl::dtl::node_static_allocator<value_type, N>,
+        static_map
+    >;
+
+    tree_type tree_;
+
+public:
+
+    using size_type              = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::size_type;
+    using difference_type        = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::difference_type;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using pointer                = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::pointer;
+    using const_pointer          = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::const_pointer;
+    using iterator               = typename tree_type::iterator;
+    using const_iterator         = typename tree_type::const_iterator;
+    using reverse_iterator       = typename tree_type::reverse_iterator;
+    using const_reverse_iterator = typename tree_type::const_reverse_iterator;
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    static_map() noexcept
+    (
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : tree_()
+    {}
+
+    explicit static_map(const Compare& comp) noexcept
+    (
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : tree_(comp)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_map(InputIt first, InputIt last)
+        : tree_()
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_map(InputIt first, InputIt last, const Compare& comp)
+        : tree_(comp)
+    {
+        insert(first, last);
+    }
+
+    static_map(std::initializer_list<value_type> ilist)
+        : static_map(ilist.begin(), ilist.end())
+    {}
+
+    static_map(std::initializer_list<value_type> ilist, const Compare& comp)
+        : static_map(ilist.begin(), ilist.end(), comp)
+    {}
+
+    static_map(const static_map& other)
+        : tree_(other.tree_)
+    {}
+
+    static_map(static_map&& other)
+        : tree_(std::move(other.tree_))
+    {}
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_map(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_map(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    static_map(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    static_map(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~static_map()
+    {}
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    static_map& operator=(const static_map& other)
+    {
+        tree_.operator=(other.tree_);
+        return *this;
+    }
+
+    static_map& operator=(static_map&& other)
+    {
+        tree_.operator=(std::move(other.tree_));
+        return *this;
+    }
+
+    static_map& operator=(std::initializer_list<value_type> ilist)
+    {
+        SFL_ASSERT(size_type(ilist.size()) <= capacity());
+        tree_.assign_range_unique(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- KEY COMPARE -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_compare key_comp() const
+    {
+        return key_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- VALUE COMPARE -----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_compare value_comp() const
+    {
+        return value_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return tree_.cbegin();
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return tree_.cend();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return tree_.crbegin();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return tree_.crend();
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return tree_.empty();
+    }
+
+    SFL_NODISCARD
+    bool full() const noexcept
+    {
+        return size() == capacity();
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return tree_.size();
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type max_size() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type capacity() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    size_type available() const noexcept
+    {
+        return capacity() - size();
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear()
+    {
+        tree_.clear();
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace(Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return tree_.emplace_unique(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return tree_.emplace_hint_unique(hint, std::forward<Args>(args)...);
+    }
+
+    std::pair<iterator, bool> insert(const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        return tree_.insert_unique(value);
+    }
+
+    std::pair<iterator, bool> insert(value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        return tree_.insert_unique(std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P&&>::value>* = nullptr>
+    std::pair<iterator, bool> insert(P&& value)
+    {
+        SFL_ASSERT(!full());
+        return tree_.insert_unique(std::forward<P>(value));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        return tree_.insert_hint_unique(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        return tree_.insert_hint_unique(hint, std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P>::value>* = nullptr>
+    iterator insert(const_iterator hint, P&& value)
+    {
+        SFL_ASSERT(!full());
+        return tree_.insert_hint_unique(hint, std::forward<P>(value));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    std::pair<iterator, bool> insert_or_assign(const Key& key, M&& obj)
+    {
+        SFL_ASSERT(!full());
+        return insert_or_assign_aux(key, std::forward<M>(obj));
+    }
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    std::pair<iterator, bool> insert_or_assign(Key&& key, M&& obj)
+    {
+        SFL_ASSERT(!full());
+        return insert_or_assign_aux(std::move(key), std::forward<M>(obj));
+    }
+
+    template <typename K, typename M,
+              sfl::dtl::enable_if_t< sfl::dtl::has_is_transparent<Compare, K>::value &&
+                                     std::is_assignable<mapped_type&, M&&>::value >* = nullptr>
+    std::pair<iterator, bool> insert_or_assign(K&& key, M&& obj)
+    {
+        SFL_ASSERT(!full());
+        return insert_or_assign_aux(std::forward<K>(key), std::forward<M>(obj));
+    }
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    iterator insert_or_assign(const_iterator hint, const Key& key, M&& obj)
+    {
+        SFL_ASSERT(!full());
+        return insert_or_assign_aux(hint, key, std::forward<M>(obj));
+    }
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    iterator insert_or_assign(const_iterator hint, Key&& key, M&& obj)
+    {
+        SFL_ASSERT(!full());
+        return insert_or_assign_aux(hint, std::move(key), std::forward<M>(obj));
+    }
+
+    template <typename K, typename M,
+              sfl::dtl::enable_if_t< sfl::dtl::has_is_transparent<Compare, K>::value &&
+                                     std::is_assignable<mapped_type&, M&&>::value >* = nullptr>
+    iterator insert_or_assign(const_iterator hint, K&& key, M&& obj)
+    {
+        SFL_ASSERT(!full());
+        return insert_or_assign_aux(hint, std::forward<K>(key), std::forward<M>(obj));
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(const Key& key, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return try_emplace_aux(key, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(Key&& key, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return try_emplace_aux(std::move(key), std::forward<Args>(args)...);
+    }
+
+    template <typename K, typename... Args,
+              sfl::dtl::enable_if_t<
+                #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 7)
+                // This is workaround for GCC 4 bug on CentOS 7.
+                !std::is_same<sfl::dtl::remove_cvref_t<Key>, sfl::dtl::remove_cvref_t<K>>::value &&
+                #endif
+                sfl::dtl::has_is_transparent<Compare, K>::value &&
+                !std::is_convertible<K&&, const_iterator>::value &&
+                !std::is_convertible<K&&, iterator>::value
+              >* = nullptr>
+    std::pair<iterator, bool> try_emplace(K&& key, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return try_emplace_aux(std::forward<K>(key), std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator try_emplace(const_iterator hint, const Key& key, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return try_emplace_aux(hint, key, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator try_emplace(const_iterator hint, Key&& key, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return try_emplace_aux(hint, std::move(key), std::forward<Args>(args)...);
+    }
+
+    template <typename K, typename... Args,
+              sfl::dtl::enable_if_t<
+                #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 7)
+                // This is workaround for GCC 4 bug on CentOS 7.
+                !std::is_same<sfl::dtl::remove_cvref_t<Key>, sfl::dtl::remove_cvref_t<K>>::value &&
+                #endif
+                sfl::dtl::has_is_transparent<Compare, K>::value
+              >* = nullptr>
+    iterator try_emplace(const_iterator hint, K&& key, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return try_emplace_aux(hint, std::forward<K>(key), std::forward<Args>(args)...);
+    }
+
+    iterator erase(iterator pos)
+    {
+        return tree_.erase(pos);
+    }
+
+    iterator erase(const_iterator pos)
+    {
+        return tree_.erase(pos);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        return tree_.erase(first, last);
+    }
+
+    size_type erase(const Key& key)
+    {
+        return tree_.erase(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        return tree_.erase(x);
+    }
+
+    void swap(static_map& other)
+    {
+        tree_.swap(other.tree_);
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator lower_bound(const Key& key)
+    {
+        return tree_.lower_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator lower_bound(const Key& key) const
+    {
+        return tree_.lower_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator lower_bound(const K& x)
+    {
+        return tree_.lower_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator lower_bound(const K& x) const
+    {
+        return tree_.lower_bound(x);
+    }
+
+    SFL_NODISCARD
+    iterator upper_bound(const Key& key)
+    {
+        return tree_.upper_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator upper_bound(const Key& key) const
+    {
+        return tree_.upper_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator upper_bound(const K& x)
+    {
+        return tree_.upper_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator upper_bound(const K& x) const
+    {
+        return tree_.upper_bound(x);
+    }
+
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const Key& key)
+    {
+        return tree_.equal_range(key);
+    }
+
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const
+    {
+        return tree_.equal_range(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const K& x)
+    {
+        return tree_.equal_range(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const K& x) const
+    {
+        return tree_.equal_range(x);
+    }
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        return tree_.find(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        return tree_.find(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        return tree_.find(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        return tree_.find(x);
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        return tree_.count(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        return tree_.count(x);
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return tree_.contains(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return tree_.contains(x);
+    }
+
+    //
+    // ---- ELEMENT ACCESS ----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    T& at(const Key& key)
+    {
+        auto it = find(key);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::static_map::at");
+        }
+
+        return it->second;
+    }
+
+    SFL_NODISCARD
+    const T& at(const Key& key) const
+    {
+        auto it = find(key);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::static_map::at");
+        }
+
+        return it->second;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    T& at(const K& x)
+    {
+        auto it = find(x);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::static_map::at");
+        }
+
+        return it->second;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const T& at(const K& x) const
+    {
+        auto it = find(x);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::static_map::at");
+        }
+
+        return it->second;
+    }
+
+    SFL_NODISCARD
+    T& operator[](const Key& key)
+    {
+        return try_emplace(key).first->second;
+    }
+
+    SFL_NODISCARD
+    T& operator[](Key&& key)
+    {
+        return try_emplace(std::move(key)).first->second;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    T& operator[](K&& key)
+    {
+        return try_emplace(std::forward<K>(key)).first->second;
+    }
+
+private:
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+
+    template <typename K, typename M>
+    std::pair<iterator, bool> insert_or_assign_aux(K&& key, M&& obj)
+    {
+        auto res = tree_.calculate_position_for_insert_unique(key);
+        if (res.status)
+        {
+            typename tree_type::make_node_functor make_node(tree_);
+            typename tree_type::node_pointer x = make_node
+            (
+                std::piecewise_construct,
+                std::forward_as_tuple(std::forward<K>(key)),
+                std::forward_as_tuple(std::forward<M>(obj))
+            );
+            tree_.insert(x, res.pos, res.left, tree_.data_.root(), tree_.data_.minimum());
+            ++tree_.data_.size_;
+            return std::make_pair(iterator(x), true);
+        }
+        else
+        {
+            iterator it(res.pos);
+            it->second = std::forward<M>(obj);
+            return std::make_pair(it, false);
+        }
+    }
+
+    template <typename K, typename M>
+    iterator insert_or_assign_aux(const_iterator hint, K&& key, M&& obj)
+    {
+        auto res = tree_.calculate_position_for_insert_hint_unique(hint, key);
+        if (res.status)
+        {
+            typename tree_type::make_node_functor make_node(tree_);
+            typename tree_type::node_pointer x = make_node
+            (
+                std::piecewise_construct,
+                std::forward_as_tuple(std::forward<K>(key)),
+                std::forward_as_tuple(std::forward<M>(obj))
+            );
+            tree_.insert(x, res.pos, res.left, tree_.data_.root(), tree_.data_.minimum());
+            ++tree_.data_.size_;
+            return iterator(x);
+        }
+        else
+        {
+            iterator it(res.pos);
+            it->second = std::forward<M>(obj);
+            return it;
+        }
+    }
+
+    template <typename K, typename... Args>
+    std::pair<iterator, bool> try_emplace_aux(K&& key, Args&&... args)
+    {
+        auto res = tree_.calculate_position_for_insert_unique(key);
+        if (res.status)
+        {
+            typename tree_type::make_node_functor make_node(tree_);
+            typename tree_type::node_pointer x = make_node
+            (
+                std::piecewise_construct,
+                std::forward_as_tuple(std::forward<K>(key)),
+                std::forward_as_tuple(std::forward<Args>(args)...)
+            );
+            tree_.insert(x, res.pos, res.left, tree_.data_.root(), tree_.data_.minimum());
+            ++tree_.data_.size_;
+            return std::make_pair(iterator(x), true);
+        }
+        else
+        {
+            return std::make_pair(iterator(res.pos), false);
+        }
+    }
+
+    template <typename K, typename... Args>
+    iterator try_emplace_aux(const_iterator hint, K&& key, Args&&... args)
+    {
+        auto res = tree_.calculate_position_for_insert_hint_unique(hint, key);
+        if (res.status)
+        {
+            typename tree_type::make_node_functor make_node(tree_);
+            typename tree_type::node_pointer x = make_node
+            (
+                std::piecewise_construct,
+                std::forward_as_tuple(std::forward<K>(key)),
+                std::forward_as_tuple(std::forward<Args>(args)...)
+            );
+            tree_.insert(x, res.pos, res.left, tree_.data_.root(), tree_.data_.minimum());
+            ++tree_.data_.size_;
+            return iterator(x);
+        }
+        else
+        {
+            return iterator(res.pos);
+        }
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator==
+(
+    const static_map<K, T, N, C>& x,
+    const static_map<K, T, N, C>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator!=
+(
+    const static_map<K, T, N, C>& x,
+    const static_map<K, T, N, C>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator<
+(
+    const static_map<K, T, N, C>& x,
+    const static_map<K, T, N, C>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator>
+(
+    const static_map<K, T, N, C>& x,
+    const static_map<K, T, N, C>& y
+)
+{
+    return y < x;
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator<=
+(
+    const static_map<K, T, N, C>& x,
+    const static_map<K, T, N, C>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator>=
+(
+    const static_map<K, T, N, C>& x,
+    const static_map<K, T, N, C>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+void swap
+(
+    static_map<K, T, N, C>& x,
+    static_map<K, T, N, C>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename Predicate>
+typename static_map<K, T, N, C>::size_type
+    erase_if(static_map<K, T, N, C>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_STATIC_MAP_HPP_INCLUDED

--- a/src/thirdparty/sfl/static_multimap.hpp
+++ b/src/thirdparty/sfl/static_multimap.hpp
@@ -1,0 +1,740 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_STATIC_MULTIMAP_HPP_INCLUDED
+#define SFL_STATIC_MULTIMAP_HPP_INCLUDED
+
+#include <sfl/detail/allocator_traits.hpp>
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/functional.hpp>
+#include <sfl/detail/node_static_allocator.hpp>
+#include <sfl/detail/rb_tree.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/type_traits.hpp>
+
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+namespace sfl
+{
+
+template < typename Key,
+           typename T,
+           std::size_t N,
+           typename Compare = std::less<Key> >
+class static_multimap
+{
+    static_assert(N > 0, "N must be greater than zero.");
+
+public:
+
+    using key_type       = Key;
+    using mapped_type    = T;
+    using value_type     = std::pair<const Key, T>;
+    using key_compare    = Compare;
+
+    class value_compare : protected key_compare
+    {
+        friend class static_multimap;
+
+    private:
+
+        value_compare(const key_compare& c) : key_compare(c)
+        {}
+
+    public:
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_compare::operator()(x.first, y.first);
+        }
+    };
+
+private:
+
+    using tree_type = sfl::dtl::rb_tree
+    <
+        key_type,
+        value_type,
+        sfl::dtl::first,
+        key_compare,
+        sfl::dtl::node_static_allocator<value_type, N>,
+        static_multimap
+    >;
+
+    tree_type tree_;
+
+public:
+
+    using size_type              = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::size_type;
+    using difference_type        = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::difference_type;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using pointer                = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::pointer;
+    using const_pointer          = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::const_pointer;
+    using iterator               = typename tree_type::iterator;
+    using const_iterator         = typename tree_type::const_iterator;
+    using reverse_iterator       = typename tree_type::reverse_iterator;
+    using const_reverse_iterator = typename tree_type::const_reverse_iterator;
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    static_multimap() noexcept
+    (
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : tree_()
+    {}
+
+    explicit static_multimap(const Compare& comp) noexcept
+    (
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : tree_(comp)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_multimap(InputIt first, InputIt last)
+        : tree_()
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_multimap(InputIt first, InputIt last, const Compare& comp)
+        : tree_(comp)
+    {
+        insert(first, last);
+    }
+
+    static_multimap(std::initializer_list<value_type> ilist)
+        : static_multimap(ilist.begin(), ilist.end())
+    {}
+
+    static_multimap(std::initializer_list<value_type> ilist, const Compare& comp)
+        : static_multimap(ilist.begin(), ilist.end(), comp)
+    {}
+
+    static_multimap(const static_multimap& other)
+        : tree_(other.tree_)
+    {}
+
+    static_multimap(static_multimap&& other)
+        : tree_(std::move(other.tree_))
+    {}
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_multimap(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_multimap(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    static_multimap(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    static_multimap(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~static_multimap()
+    {}
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    static_multimap& operator=(const static_multimap& other)
+    {
+        tree_.operator=(other.tree_);
+        return *this;
+    }
+
+    static_multimap& operator=(static_multimap&& other)
+    {
+        tree_.operator=(std::move(other.tree_));
+        return *this;
+    }
+
+    static_multimap& operator=(std::initializer_list<value_type> ilist)
+    {
+        SFL_ASSERT(size_type(ilist.size()) <= capacity());
+        tree_.assign_range_equal(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- KEY COMPARE -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_compare key_comp() const
+    {
+        return key_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- VALUE COMPARE -----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_compare value_comp() const
+    {
+        return value_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return tree_.cbegin();
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return tree_.cend();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return tree_.crbegin();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return tree_.crend();
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return tree_.empty();
+    }
+
+    SFL_NODISCARD
+    bool full() const noexcept
+    {
+        return size() == capacity();
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return tree_.size();
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type max_size() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type capacity() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    size_type available() const noexcept
+    {
+        return capacity() - size();
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear()
+    {
+        tree_.clear();
+    }
+
+    template <typename... Args>
+    iterator emplace(Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return tree_.emplace_equal(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return tree_.emplace_hint_equal(hint, std::forward<Args>(args)...);
+    }
+
+    iterator insert(const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        return tree_.insert_equal(value);
+    }
+
+    iterator insert(value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        return tree_.insert_equal(std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P&&>::value>* = nullptr>
+    iterator insert(P&& value)
+    {
+        SFL_ASSERT(!full());
+        return tree_.insert_equal(std::forward<P>(value));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        return tree_.insert_hint_equal(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        return tree_.insert_hint_equal(hint, std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P>::value>* = nullptr>
+    iterator insert(const_iterator hint, P&& value)
+    {
+        SFL_ASSERT(!full());
+        return tree_.insert_hint_equal(hint, std::forward<P>(value));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    iterator erase(iterator pos)
+    {
+        return tree_.erase(pos);
+    }
+
+    iterator erase(const_iterator pos)
+    {
+        return tree_.erase(pos);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        return tree_.erase(first, last);
+    }
+
+    size_type erase(const Key& key)
+    {
+        return tree_.erase(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        return tree_.erase(x);
+    }
+
+    void swap(static_multimap& other)
+    {
+        tree_.swap(other.tree_);
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator lower_bound(const Key& key)
+    {
+        return tree_.lower_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator lower_bound(const Key& key) const
+    {
+        return tree_.lower_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator lower_bound(const K& x)
+    {
+        return tree_.lower_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator lower_bound(const K& x) const
+    {
+        return tree_.lower_bound(x);
+    }
+
+    SFL_NODISCARD
+    iterator upper_bound(const Key& key)
+    {
+        return tree_.upper_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator upper_bound(const Key& key) const
+    {
+        return tree_.upper_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator upper_bound(const K& x)
+    {
+        return tree_.upper_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator upper_bound(const K& x) const
+    {
+        return tree_.upper_bound(x);
+    }
+
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const Key& key)
+    {
+        return tree_.equal_range(key);
+    }
+
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const
+    {
+        return tree_.equal_range(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const K& x)
+    {
+        return tree_.equal_range(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const K& x) const
+    {
+        return tree_.equal_range(x);
+    }
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        return tree_.find(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        return tree_.find(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        return tree_.find(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        return tree_.find(x);
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        return tree_.count(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        return tree_.count(x);
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return tree_.contains(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return tree_.contains(x);
+    }
+
+private:
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator==
+(
+    const static_multimap<K, T, N, C>& x,
+    const static_multimap<K, T, N, C>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator!=
+(
+    const static_multimap<K, T, N, C>& x,
+    const static_multimap<K, T, N, C>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator<
+(
+    const static_multimap<K, T, N, C>& x,
+    const static_multimap<K, T, N, C>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator>
+(
+    const static_multimap<K, T, N, C>& x,
+    const static_multimap<K, T, N, C>& y
+)
+{
+    return y < x;
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator<=
+(
+    const static_multimap<K, T, N, C>& x,
+    const static_multimap<K, T, N, C>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator>=
+(
+    const static_multimap<K, T, N, C>& x,
+    const static_multimap<K, T, N, C>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename K, typename T, std::size_t N, typename C>
+void swap
+(
+    static_multimap<K, T, N, C>& x,
+    static_multimap<K, T, N, C>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, typename T, std::size_t N, typename C, typename Predicate>
+typename static_multimap<K, T, N, C>::size_type
+    erase_if(static_multimap<K, T, N, C>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_STATIC_MULTIMAP_HPP_INCLUDED

--- a/src/thirdparty/sfl/static_multiset.hpp
+++ b/src/thirdparty/sfl/static_multiset.hpp
@@ -1,0 +1,701 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_STATIC_MULTISET_HPP_INCLUDED
+#define SFL_STATIC_MULTISET_HPP_INCLUDED
+
+#include <sfl/detail/allocator_traits.hpp>
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/functional.hpp>
+#include <sfl/detail/node_static_allocator.hpp>
+#include <sfl/detail/rb_tree.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/type_traits.hpp>
+
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+namespace sfl
+{
+
+template < typename Key,
+           std::size_t N,
+           typename Compare = std::less<Key> >
+class static_multiset
+{
+    static_assert(N > 0, "N must be greater than zero.");
+
+public:
+
+    using key_type      = Key;
+    using value_type    = Key;
+    using key_compare   = Compare;
+    using value_compare = Compare;
+
+private:
+
+    using tree_type = sfl::dtl::rb_tree
+    <
+        key_type,
+        value_type,
+        sfl::dtl::identity,
+        key_compare,
+        sfl::dtl::node_static_allocator<value_type, N>,
+        static_multiset
+    >;
+
+    tree_type tree_;
+
+public:
+
+    using size_type              = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::size_type;
+    using difference_type        = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::difference_type;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using pointer                = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::pointer;
+    using const_pointer          = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::const_pointer;
+    using iterator               = typename tree_type::const_iterator; // MUST BE const
+    using const_iterator         = typename tree_type::const_iterator;
+    using reverse_iterator       = typename tree_type::const_reverse_iterator; // MUST BE const
+    using const_reverse_iterator = typename tree_type::const_reverse_iterator;
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    static_multiset() noexcept
+    (
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : tree_()
+    {}
+
+    explicit static_multiset(const Compare& comp) noexcept
+    (
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : tree_(comp)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_multiset(InputIt first, InputIt last)
+        : tree_()
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_multiset(InputIt first, InputIt last, const Compare& comp)
+        : tree_(comp)
+    {
+        insert(first, last);
+    }
+
+    static_multiset(std::initializer_list<value_type> ilist)
+        : static_multiset(ilist.begin(), ilist.end())
+    {}
+
+    static_multiset(std::initializer_list<value_type> ilist, const Compare& comp)
+        : static_multiset(ilist.begin(), ilist.end(), comp)
+    {}
+
+    static_multiset(const static_multiset& other)
+        : tree_(other.tree_)
+    {}
+
+    static_multiset(static_multiset&& other)
+        : tree_(std::move(other.tree_))
+    {}
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_multiset(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_multiset(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    static_multiset(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    static_multiset(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~static_multiset()
+    {}
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    static_multiset& operator=(const static_multiset& other)
+    {
+        tree_.operator=(other.tree_);
+        return *this;
+    }
+
+    static_multiset& operator=(static_multiset&& other)
+    {
+        tree_.operator=(std::move(other.tree_));
+        return *this;
+    }
+
+    static_multiset& operator=(std::initializer_list<value_type> ilist)
+    {
+        SFL_ASSERT(size_type(ilist.size()) <= capacity());
+        tree_.assign_range_equal(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- KEY COMPARE -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_compare key_comp() const
+    {
+        return key_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- VALUE COMPARE -----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_compare value_comp() const
+    {
+        return value_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return tree_.cbegin();
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return tree_.cend();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return tree_.crbegin();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return tree_.crend();
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return tree_.empty();
+    }
+
+    SFL_NODISCARD
+    bool full() const noexcept
+    {
+        return size() == capacity();
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return tree_.size();
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type max_size() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type capacity() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    size_type available() const noexcept
+    {
+        return capacity() - size();
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear()
+    {
+        tree_.clear();
+    }
+
+    template <typename... Args>
+    iterator emplace(Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return tree_.emplace_equal(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return tree_.emplace_hint_equal(hint, std::forward<Args>(args)...);
+    }
+
+    iterator insert(const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        return tree_.insert_equal(value);
+    }
+
+    iterator insert(value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        return tree_.insert_equal(std::move(value));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        return tree_.insert_hint_equal(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        return tree_.insert_hint_equal(hint, std::move(value));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    iterator erase(const_iterator pos)
+    {
+        return tree_.erase(pos);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        return tree_.erase(first, last);
+    }
+
+    size_type erase(const Key& key)
+    {
+        return tree_.erase(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        return tree_.erase(x);
+    }
+
+    void swap(static_multiset& other)
+    {
+        tree_.swap(other.tree_);
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator lower_bound(const Key& key)
+    {
+        return tree_.lower_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator lower_bound(const Key& key) const
+    {
+        return tree_.lower_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator lower_bound(const K& x)
+    {
+        return tree_.lower_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator lower_bound(const K& x) const
+    {
+        return tree_.lower_bound(x);
+    }
+
+    SFL_NODISCARD
+    iterator upper_bound(const Key& key)
+    {
+        return tree_.upper_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator upper_bound(const Key& key) const
+    {
+        return tree_.upper_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator upper_bound(const K& x)
+    {
+        return tree_.upper_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator upper_bound(const K& x) const
+    {
+        return tree_.upper_bound(x);
+    }
+
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const Key& key)
+    {
+        return tree_.equal_range(key);
+    }
+
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const
+    {
+        return tree_.equal_range(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const K& x)
+    {
+        return tree_.equal_range(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const K& x) const
+    {
+        return tree_.equal_range(x);
+    }
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        return tree_.find(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        return tree_.find(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        return tree_.find(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        return tree_.find(x);
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        return tree_.count(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        return tree_.count(x);
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return tree_.contains(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return tree_.contains(x);
+    }
+
+private:
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator==
+(
+    const static_multiset<K, N, C>& x,
+    const static_multiset<K, N, C>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator!=
+(
+    const static_multiset<K, N, C>& x,
+    const static_multiset<K, N, C>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator<
+(
+    const static_multiset<K, N, C>& x,
+    const static_multiset<K, N, C>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator>
+(
+    const static_multiset<K, N, C>& x,
+    const static_multiset<K, N, C>& y
+)
+{
+    return y < x;
+}
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator<=
+(
+    const static_multiset<K, N, C>& x,
+    const static_multiset<K, N, C>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator>=
+(
+    const static_multiset<K, N, C>& x,
+    const static_multiset<K, N, C>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename K, std::size_t N, typename C>
+void swap
+(
+    static_multiset<K, N, C>& x,
+    static_multiset<K, N, C>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, std::size_t N, typename C, typename Predicate>
+typename static_multiset<K, N, C>::size_type
+    erase_if(static_multiset<K, N, C>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_STATIC_MULTISET_HPP_INCLUDED

--- a/src/thirdparty/sfl/static_set.hpp
+++ b/src/thirdparty/sfl/static_set.hpp
@@ -1,0 +1,701 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_STATIC_SET_HPP_INCLUDED
+#define SFL_STATIC_SET_HPP_INCLUDED
+
+#include <sfl/detail/allocator_traits.hpp>
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/functional.hpp>
+#include <sfl/detail/node_static_allocator.hpp>
+#include <sfl/detail/rb_tree.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/type_traits.hpp>
+
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+namespace sfl
+{
+
+template < typename Key,
+           std::size_t N,
+           typename Compare = std::less<Key> >
+class static_set
+{
+    static_assert(N > 0, "N must be greater than zero.");
+
+public:
+
+    using key_type      = Key;
+    using value_type    = Key;
+    using key_compare   = Compare;
+    using value_compare = Compare;
+
+private:
+
+    using tree_type = sfl::dtl::rb_tree
+    <
+        key_type,
+        value_type,
+        sfl::dtl::identity,
+        key_compare,
+        sfl::dtl::node_static_allocator<value_type, N>,
+        static_set
+    >;
+
+    tree_type tree_;
+
+public:
+
+    using size_type              = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::size_type;
+    using difference_type        = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::difference_type;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using pointer                = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::pointer;
+    using const_pointer          = typename sfl::dtl::allocator_traits<typename tree_type::allocator_type>::const_pointer;
+    using iterator               = typename tree_type::const_iterator; // MUST BE const
+    using const_iterator         = typename tree_type::const_iterator;
+    using reverse_iterator       = typename tree_type::const_reverse_iterator; // MUST BE const
+    using const_reverse_iterator = typename tree_type::const_reverse_iterator;
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    static_set() noexcept
+    (
+        std::is_nothrow_default_constructible<Compare>::value
+    )
+        : tree_()
+    {}
+
+    explicit static_set(const Compare& comp) noexcept
+    (
+        std::is_nothrow_copy_constructible<Compare>::value
+    )
+        : tree_(comp)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_set(InputIt first, InputIt last)
+        : tree_()
+    {
+        insert(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_set(InputIt first, InputIt last, const Compare& comp)
+        : tree_(comp)
+    {
+        insert(first, last);
+    }
+
+    static_set(std::initializer_list<value_type> ilist)
+        : static_set(ilist.begin(), ilist.end())
+    {}
+
+    static_set(std::initializer_list<value_type> ilist, const Compare& comp)
+        : static_set(ilist.begin(), ilist.end(), comp)
+    {}
+
+    static_set(const static_set& other)
+        : tree_(other.tree_)
+    {}
+
+    static_set(static_set&& other)
+        : tree_(std::move(other.tree_))
+    {}
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_set(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_set(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    static_set(sfl::from_range_t, Range&& range)
+        : tree_()
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    static_set(sfl::from_range_t, Range&& range, const Compare& comp)
+        : tree_(comp)
+    {
+        insert_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~static_set()
+    {}
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    static_set& operator=(const static_set& other)
+    {
+        tree_.operator=(other.tree_);
+        return *this;
+    }
+
+    static_set& operator=(static_set&& other)
+    {
+        tree_.operator=(std::move(other.tree_));
+        return *this;
+    }
+
+    static_set& operator=(std::initializer_list<value_type> ilist)
+    {
+        SFL_ASSERT(size_type(ilist.size()) <= capacity());
+        tree_.assign_range_unique(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- KEY COMPARE -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_compare key_comp() const
+    {
+        return key_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- VALUE COMPARE -----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_compare value_comp() const
+    {
+        return value_compare(tree_.ref_to_comp());
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return tree_.begin();
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return tree_.cbegin();
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return tree_.end();
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return tree_.cend();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rbegin() noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return tree_.rbegin();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return tree_.crbegin();
+    }
+
+    SFL_NODISCARD
+    reverse_iterator rend() noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator rend() const noexcept
+    {
+        return tree_.rend();
+    }
+
+    SFL_NODISCARD
+    const_reverse_iterator crend() const noexcept
+    {
+        return tree_.crend();
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return tree_.empty();
+    }
+
+    SFL_NODISCARD
+    bool full() const noexcept
+    {
+        return size() == capacity();
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return tree_.size();
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type max_size() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type capacity() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    size_type available() const noexcept
+    {
+        return capacity() - size();
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear()
+    {
+        tree_.clear();
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace(Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return tree_.emplace_unique(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return tree_.emplace_hint_unique(hint, std::forward<Args>(args)...);
+    }
+
+    std::pair<iterator, bool> insert(const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        return tree_.insert_unique(value);
+    }
+
+    std::pair<iterator, bool> insert(value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        return tree_.insert_unique(std::move(value));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        return tree_.insert_hint_unique(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        return tree_.insert_hint_unique(hint, std::move(value));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    iterator erase(const_iterator pos)
+    {
+        return tree_.erase(pos);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        return tree_.erase(first, last);
+    }
+
+    size_type erase(const Key& key)
+    {
+        return tree_.erase(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        return tree_.erase(x);
+    }
+
+    void swap(static_set& other)
+    {
+        tree_.swap(other.tree_);
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator lower_bound(const Key& key)
+    {
+        return tree_.lower_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator lower_bound(const Key& key) const
+    {
+        return tree_.lower_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator lower_bound(const K& x)
+    {
+        return tree_.lower_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator lower_bound(const K& x) const
+    {
+        return tree_.lower_bound(x);
+    }
+
+    SFL_NODISCARD
+    iterator upper_bound(const Key& key)
+    {
+        return tree_.upper_bound(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator upper_bound(const Key& key) const
+    {
+        return tree_.upper_bound(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator upper_bound(const K& x)
+    {
+        return tree_.upper_bound(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator upper_bound(const K& x) const
+    {
+        return tree_.upper_bound(x);
+    }
+
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const Key& key)
+    {
+        return tree_.equal_range(key);
+    }
+
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const
+    {
+        return tree_.equal_range(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<iterator, iterator> equal_range(const K& x)
+    {
+        return tree_.equal_range(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    std::pair<const_iterator, const_iterator> equal_range(const K& x) const
+    {
+        return tree_.equal_range(x);
+    }
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        return tree_.find(key);
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        return tree_.find(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        return tree_.find(x);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        return tree_.find(x);
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        return tree_.count(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        return tree_.count(x);
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return tree_.contains(key);
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<Compare, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return tree_.contains(x);
+    }
+
+private:
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator==
+(
+    const static_set<K, N, C>& x,
+    const static_set<K, N, C>& y
+)
+{
+    return x.size() == y.size() && std::equal(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator!=
+(
+    const static_set<K, N, C>& x,
+    const static_set<K, N, C>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator<
+(
+    const static_set<K, N, C>& x,
+    const static_set<K, N, C>& y
+)
+{
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator>
+(
+    const static_set<K, N, C>& x,
+    const static_set<K, N, C>& y
+)
+{
+    return y < x;
+}
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator<=
+(
+    const static_set<K, N, C>& x,
+    const static_set<K, N, C>& y
+)
+{
+    return !(y < x);
+}
+
+template <typename K, std::size_t N, typename C>
+SFL_NODISCARD
+bool operator>=
+(
+    const static_set<K, N, C>& x,
+    const static_set<K, N, C>& y
+)
+{
+    return !(x < y);
+}
+
+template <typename K, std::size_t N, typename C>
+void swap
+(
+    static_set<K, N, C>& x,
+    static_set<K, N, C>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, std::size_t N, typename C, typename Predicate>
+typename static_set<K, N, C>::size_type
+    erase_if(static_set<K, N, C>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_STATIC_SET_HPP_INCLUDED

--- a/src/thirdparty/sfl/static_unordered_flat_map.hpp
+++ b/src/thirdparty/sfl/static_unordered_flat_map.hpp
@@ -1,0 +1,1291 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_STATIC_UNORDERED_FLAT_MAP_HPP_INCLUDED
+#define SFL_STATIC_UNORDERED_FLAT_MAP_HPP_INCLUDED
+
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/exceptions.hpp>
+#include <sfl/detail/ignore_unused.hpp>
+#include <sfl/detail/initialized_memory_algorithms.hpp>
+#include <sfl/detail/normal_iterator.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/type_traits.hpp>
+#include <sfl/detail/uninitialized_memory_algorithms.hpp>
+
+#include <algorithm>        // copy, move, lower_bound, swap, swap_ranges
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <iterator>         // distance, next, reverse_iterator
+#include <limits>           // numeric_limits
+#include <memory>           // allocator, allocator_traits, pointer_traits
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+#ifdef SFL_TEST_STATIC_UNORDERED_FLAT_MAP
+void test_static_unordered_flat_map();
+#endif
+
+namespace sfl
+{
+
+template < typename Key,
+           typename T,
+           std::size_t N,
+           typename KeyEqual = std::equal_to<Key> >
+class static_unordered_flat_map
+{
+    #ifdef SFL_TEST_STATIC_UNORDERED_FLAT_MAP
+    friend void ::test_static_unordered_flat_map();
+    #endif
+
+    static_assert(N > 0, "N must be greater than zero.");
+
+public:
+
+    using key_type         = Key;
+    using mapped_type      = T;
+    using value_type       = std::pair<Key, T>;
+    using size_type        = std::size_t;
+    using difference_type  = std::ptrdiff_t;
+    using key_equal        = KeyEqual;
+    using reference        = value_type&;
+    using const_reference  = const value_type&;
+    using pointer          = value_type*;
+    using const_pointer    = const value_type*;
+    using iterator         = sfl::dtl::normal_iterator<pointer, static_unordered_flat_map>;
+    using const_iterator   = sfl::dtl::normal_iterator<const_pointer, static_unordered_flat_map>;
+
+    class value_equal : protected key_equal
+    {
+        friend class static_unordered_flat_map;
+
+    private:
+
+        value_equal(const key_equal& e)
+            : key_equal(e)
+        {}
+
+    public:
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_equal::operator()(x.first, y.first);
+        }
+    };
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+private:
+
+    // Like `value_equal` but with additional operators.
+    // For internal use only.
+    class ultra_equal : public key_equal
+    {
+    public:
+
+        ultra_equal() noexcept(std::is_nothrow_default_constructible<key_equal>::value)
+        {}
+
+        ultra_equal(const key_equal& e) noexcept(std::is_nothrow_copy_constructible<key_equal>::value)
+            : key_equal(e)
+        {}
+
+        ultra_equal(key_equal&& e) noexcept(std::is_nothrow_move_constructible<key_equal>::value)
+            : key_equal(std::move(e))
+        {}
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_equal::operator()(x.first, y.first);
+        }
+
+        template <typename K>
+        bool operator()(const value_type& x, const K& y) const
+        {
+            return key_equal::operator()(x.first, y);
+        }
+
+        template <typename K>
+        bool operator()(const K& x, const value_type& y) const
+        {
+            return key_equal::operator()(x, y.first);
+        }
+    };
+
+    class data_base
+    {
+    public:
+
+        union
+        {
+            value_type first_[N];
+        };
+
+        pointer last_;
+
+        data_base() noexcept
+            : last_(first_)
+        {}
+
+        #if defined(__clang__) && (__clang_major__ == 3) // For CentOS 7
+        ~data_base()
+        {}
+        #else
+        ~data_base() noexcept
+        {}
+        #endif
+    };
+
+    class data : public data_base, public ultra_equal
+    {
+    public:
+
+        data() noexcept(std::is_nothrow_default_constructible<ultra_equal>::value)
+            : ultra_equal()
+        {}
+
+        data(const ultra_equal& equal) noexcept(std::is_nothrow_copy_constructible<ultra_equal>::value)
+            : ultra_equal(equal)
+        {}
+
+        data(ultra_equal&& equal) noexcept(std::is_nothrow_move_constructible<ultra_equal>::value)
+            : ultra_equal(std::move(equal))
+        {}
+
+        ultra_equal& ref_to_equal() noexcept
+        {
+            return *this;
+        }
+
+        const ultra_equal& ref_to_equal() const noexcept
+        {
+            return *this;
+        }
+    };
+
+    data data_;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    static_unordered_flat_map() noexcept(std::is_nothrow_default_constructible<KeyEqual>::value)
+        : data_()
+    {}
+
+    explicit static_unordered_flat_map(const KeyEqual& equal) noexcept(std::is_nothrow_copy_constructible<KeyEqual>::value)
+        : data_(equal)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_unordered_flat_map(InputIt first, InputIt last)
+        : data_()
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_unordered_flat_map(InputIt first, InputIt last, const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(first, last);
+    }
+
+    static_unordered_flat_map(std::initializer_list<value_type> ilist)
+        : static_unordered_flat_map(ilist.begin(), ilist.end())
+    {}
+
+    static_unordered_flat_map(std::initializer_list<value_type> ilist, const KeyEqual& equal)
+        : static_unordered_flat_map(ilist.begin(), ilist.end(), equal)
+    {}
+
+    static_unordered_flat_map(const static_unordered_flat_map& other)
+        : data_(other.data_.ref_to_equal())
+    {
+        data_.last_ = sfl::dtl::uninitialized_copy
+        (
+            pointer(other.data_.first_),
+            pointer(other.data_.last_),
+            data_.first_
+        );
+    }
+
+    static_unordered_flat_map(static_unordered_flat_map&& other)
+        : data_(std::move(other.data_.ref_to_equal()))
+    {
+        data_.last_ = sfl::dtl::uninitialized_move
+        (
+            std::make_move_iterator(pointer(other.data_.first_)),
+            std::make_move_iterator(pointer(other.data_.last_)),
+            data_.first_
+        );
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_unordered_flat_map(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_unordered_flat_map(sfl::from_range_t, Range&& range, const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    static_unordered_flat_map(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    static_unordered_flat_map(sfl::from_range_t, Range&& range, const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~static_unordered_flat_map()
+    {
+        sfl::dtl::destroy(data_.first_, data_.last_);
+    }
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    static_unordered_flat_map& operator=(const static_unordered_flat_map& other)
+    {
+        if (this != &other)
+        {
+            data_.ref_to_equal() = other.data_.ref_to_equal();
+
+            assign_range
+            (
+                pointer(other.data_.first_),
+                pointer(other.data_.last_)
+            );
+        }
+
+        return *this;
+    }
+
+    static_unordered_flat_map& operator=(static_unordered_flat_map&& other)
+    {
+        data_.ref_to_equal() = other.data_.ref_to_equal();
+
+        assign_range
+        (
+            std::make_move_iterator(pointer(other.data_.first_)),
+            std::make_move_iterator(pointer(other.data_.last_))
+        );
+
+        return *this;
+    }
+
+    static_unordered_flat_map& operator=(std::initializer_list<value_type> ilist)
+    {
+        assign_range(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- KEY EQUAL ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_equal key_eq() const
+    {
+        return data_.ref_to_equal();
+    }
+
+    //
+    // ---- VALUE EQUAL -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_equal value_eq() const
+    {
+        return value_equal(data_.ref_to_equal());
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    iterator nth(size_type pos) noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_iterator nth(size_type pos) const noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return const_iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    size_type index_of(const_iterator pos) const noexcept
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return std::distance(cbegin(), pos);
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return data_.first_ == data_.last_;
+    }
+
+    SFL_NODISCARD
+    bool full() const noexcept
+    {
+        return std::distance(begin(), end()) == N;
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return std::distance(begin(), end());
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type max_size() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type capacity() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    size_type available() const noexcept
+    {
+        return capacity() - size();
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear() noexcept
+    {
+        sfl::dtl::destroy(data_.first_, data_.last_);
+        data_.last_ = data_.first_;
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace(Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return emplace_aux(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return emplace_hint_aux(hint, std::forward<Args>(args)...);
+    }
+
+    std::pair<iterator, bool> insert(const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        return insert_aux(value);
+    }
+
+    std::pair<iterator, bool> insert(value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        return insert_aux(std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P&&>::value>* = nullptr>
+    std::pair<iterator, bool> insert(P&& value)
+    {
+        SFL_ASSERT(!full());
+        return insert_aux(value_type(std::forward<P>(value)));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P&&>::value>* = nullptr>
+    iterator insert(const_iterator hint, P&& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value_type(std::forward<P>(value)));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    std::pair<iterator, bool> insert_or_assign(const Key& key, M&& obj)
+    {
+        SFL_ASSERT(!full());
+        return insert_or_assign_aux(key, std::forward<M>(obj));
+    }
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    std::pair<iterator, bool> insert_or_assign(Key&& key, M&& obj)
+    {
+        SFL_ASSERT(!full());
+        return insert_or_assign_aux(std::move(key), std::forward<M>(obj));
+    }
+
+    template <typename K, typename M,
+              sfl::dtl::enable_if_t< sfl::dtl::has_is_transparent<KeyEqual, K>::value &&
+                                     std::is_assignable<mapped_type&, M&&>::value >* = nullptr>
+    std::pair<iterator, bool> insert_or_assign(K&& key, M&& obj)
+    {
+        SFL_ASSERT(!full());
+        return insert_or_assign_aux(std::forward<K>(key), std::forward<M>(obj));
+    }
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    iterator insert_or_assign(const_iterator hint, const Key& key, M&& obj)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_or_assign_aux(hint, key, std::forward<M>(obj));
+    }
+
+    template <typename M,
+              sfl::dtl::enable_if_t<std::is_assignable<mapped_type&, M&&>::value>* = nullptr>
+    iterator insert_or_assign(const_iterator hint, Key&& key, M&& obj)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_or_assign_aux(hint, std::move(key), std::forward<M>(obj));
+    }
+
+    template <typename K, typename M,
+              sfl::dtl::enable_if_t< sfl::dtl::has_is_transparent<KeyEqual, K>::value &&
+                                     std::is_assignable<mapped_type&, M&&>::value >* = nullptr>
+    iterator insert_or_assign(const_iterator hint, K&& key, M&& obj)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_or_assign_aux(hint, std::forward<K>(key), std::forward<M>(obj));
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(const Key& key, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return try_emplace_aux(key, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(Key&& key, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return try_emplace_aux(std::move(key), std::forward<Args>(args)...);
+    }
+
+    template <typename K, typename... Args,
+              sfl::dtl::enable_if_t<
+                #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 7)
+                // This is workaround for GCC 4 bug on CentOS 7.
+                !std::is_same<sfl::dtl::remove_cvref_t<Key>, sfl::dtl::remove_cvref_t<K>>::value &&
+                #endif
+                sfl::dtl::has_is_transparent<KeyEqual, K>::value &&
+                !std::is_convertible<K&&, const_iterator>::value &&
+                !std::is_convertible<K&&, iterator>::value
+              >* = nullptr>
+    std::pair<iterator, bool> try_emplace(K&& key, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return try_emplace_aux(std::forward<K>(key), std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator try_emplace(const_iterator hint, const Key& key, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return try_emplace_aux(hint, key, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator try_emplace(const_iterator hint, Key&& key, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return try_emplace_aux(hint, std::move(key), std::forward<Args>(args)...);
+    }
+
+    template <typename K, typename... Args,
+              sfl::dtl::enable_if_t<
+                #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 7)
+                // This is workaround for GCC 4 bug on CentOS 7.
+                !std::is_same<sfl::dtl::remove_cvref_t<Key>, sfl::dtl::remove_cvref_t<K>>::value &&
+                #endif
+                sfl::dtl::has_is_transparent<KeyEqual, K>::value
+              >* = nullptr>
+    iterator try_emplace(const_iterator hint, K&& key, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return try_emplace_aux(hint, std::forward<K>(key), std::forward<Args>(args)...);
+    }
+
+    iterator erase(iterator pos)
+    {
+        return erase(const_iterator(pos));
+    }
+
+    iterator erase(const_iterator pos)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos < cend());
+
+        const difference_type offset = std::distance(cbegin(), pos);
+
+        const pointer p = data_.first_ + offset;
+
+        if (p < data_.last_ - 1)
+        {
+            *p = std::move(*(data_.last_ - 1));
+        }
+
+        --data_.last_;
+
+        sfl::dtl::destroy_at(data_.last_);
+
+        return iterator(p);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        SFL_ASSERT(cbegin() <= first && first <= last && last <= cend());
+
+        if (first == last)
+        {
+            return begin() + std::distance(cbegin(), first);
+        }
+
+        const difference_type count1 = std::distance(first, last);
+        const difference_type count2 = std::distance(last, cend());
+
+        const difference_type offset = std::distance(cbegin(), first);
+
+        const pointer p1 = data_.first_ + offset;
+
+        if (count1 >= count2)
+        {
+            const pointer p2 = p1 + count1;
+
+            const pointer new_last = sfl::dtl::move(p2, data_.last_, p1);
+
+            sfl::dtl::destroy(new_last, data_.last_);
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const pointer p2 = p1 + count2;
+
+            sfl::dtl::move(p2, data_.last_, p1);
+
+            const pointer new_last = p2;
+
+            sfl::dtl::destroy(new_last, data_.last_);
+
+            data_.last_ = new_last;
+        }
+
+        return iterator(p1);
+    }
+
+    size_type erase(const Key& key)
+    {
+        auto it = find(key);
+
+        if (it == cend())
+        {
+            return 0;
+        }
+
+        erase(it);
+        return 1;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        auto it = find(x);
+
+        if (it == cend())
+        {
+            return 0;
+        }
+
+        erase(it);
+        return 1;
+    }
+
+    void swap(static_unordered_flat_map& other)
+    {
+        if (this == &other)
+        {
+            return;
+        }
+
+        using std::swap;
+
+        swap(this->data_.ref_to_equal(), other.data_.ref_to_equal());
+
+        const size_type this_size  = this->size();
+        const size_type other_size = other.size();
+
+        if (this_size <= other_size)
+        {
+            std::swap_ranges
+            (
+                this->data_.first_,
+                this->data_.first_ + this_size,
+                other.data_.first_
+            );
+
+            sfl::dtl::uninitialized_move
+            (
+                other.data_.first_ + this_size,
+                other.data_.first_ + other_size,
+                this->data_.first_ + this_size
+            );
+
+            sfl::dtl::destroy
+            (
+                other.data_.first_ + this_size,
+                other.data_.first_ + other_size
+            );
+        }
+        else
+        {
+            std::swap_ranges
+            (
+                other.data_.first_,
+                other.data_.first_ + other_size,
+                this->data_.first_
+            );
+
+            sfl::dtl::uninitialized_move
+            (
+                this->data_.first_ + other_size,
+                this->data_.first_ + this_size,
+                other.data_.first_ + other_size
+            );
+
+            sfl::dtl::destroy
+            (
+                this->data_.first_ + other_size,
+                this->data_.first_ + this_size
+            );
+        }
+
+        this->data_.last_ = this->data_.first_ + other_size;
+        other.data_.last_ = other.data_.first_ + this_size;
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    //
+    // ---- ELEMENT ACCESS ----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    T& at(const Key& key)
+    {
+        auto it = find(key);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::static_unordered_flat_map::at");
+        }
+
+        return it->second;
+    }
+
+    SFL_NODISCARD
+    const T& at(const Key& key) const
+    {
+        auto it = find(key);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::static_unordered_flat_map::at");
+        }
+
+        return it->second;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    T& at(const K& x)
+    {
+        auto it = find(x);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::static_unordered_flat_map::at");
+        }
+
+        return it->second;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const T& at(const K& x) const
+    {
+        auto it = find(x);
+
+        if (it == end())
+        {
+            sfl::dtl::throw_out_of_range("sfl::static_unordered_flat_map::at");
+        }
+
+        return it->second;
+    }
+
+    SFL_NODISCARD
+    T& operator[](const Key& key)
+    {
+        return try_emplace(key).first->second;
+    }
+
+    SFL_NODISCARD
+    T& operator[](Key&& key)
+    {
+        return try_emplace(std::move(key)).first->second;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    T& operator[](K&& key)
+    {
+        return try_emplace(std::forward<K>(key)).first->second;
+    }
+
+    SFL_NODISCARD
+    value_type* data() noexcept
+    {
+        return data_.first_;
+    }
+
+    SFL_NODISCARD
+    const value_type* data() const noexcept
+    {
+        return data_.first_;
+    }
+
+private:
+
+    template <typename InputIt, typename Sentinel>
+    void initialize_range(InputIt first, Sentinel last)
+    {
+        SFL_TRY
+        {
+            while (first != last)
+            {
+                insert(*first);
+                ++first;
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy(data_.first_, data_.last_);
+            SFL_RETHROW;
+        }
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void initialize_range(Range&& range)
+    {
+        initialize_range(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void initialize_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        initialize_range(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    template <typename ForwardIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_forward_iterator<ForwardIt>::value>* = nullptr>
+    void assign_range(ForwardIt first, ForwardIt last)
+    {
+        SFL_ASSERT(size_type(std::distance(first, last)) <= capacity());
+
+        const size_type n = std::distance(first, last);
+
+        const size_type size = this->size();
+
+        if (n <= size)
+        {
+            const pointer new_last = sfl::dtl::copy
+            (
+                first,
+                last,
+                data_.first_
+            );
+
+            sfl::dtl::destroy
+            (
+                new_last,
+                data_.last_
+            );
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const ForwardIt mid = std::next(first, size);
+
+            sfl::dtl::copy
+            (
+                first,
+                mid,
+                data_.first_
+            );
+
+            data_.last_ = sfl::dtl::uninitialized_copy
+            (
+                mid,
+                last,
+                data_.last_
+            );
+        }
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace_aux(Args&&... args)
+    {
+        const auto it1 = emplace_back(std::forward<Args>(args)...);
+        const auto it2 = find(it1->first);
+
+        const bool is_unique = it1 == it2;
+
+        if (!is_unique)
+        {
+            pop_back();
+        }
+
+        return std::make_pair(it2, is_unique);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint_aux(const_iterator hint, Args&&... args)
+    {
+        sfl::dtl::ignore_unused(hint);
+        return emplace_aux(std::forward<Args>(args)...).first;
+    }
+
+    template <typename Value>
+    std::pair<iterator, bool> insert_aux(Value&& value)
+    {
+        const auto it = find(value.first);
+
+        if (it == end())
+        {
+            return std::make_pair(emplace_back(std::forward<Value>(value)), true);
+        }
+
+        return std::make_pair(it, false);
+    }
+
+    template <typename Value>
+    iterator insert_aux(const_iterator hint, Value&& value)
+    {
+        sfl::dtl::ignore_unused(hint);
+        return insert_aux(std::forward<Value>(value)).first;
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+
+    template <typename K, typename M>
+    std::pair<iterator, bool> insert_or_assign_aux(K&& key, M&& obj)
+    {
+        const auto it = find(key);
+
+        if (it == end())
+        {
+            return std::make_pair
+            (
+                emplace_back
+                (
+                    std::piecewise_construct,
+                    std::forward_as_tuple(std::forward<K>(key)),
+                    std::forward_as_tuple(std::forward<M>(obj))
+                ),
+                true
+            );
+        }
+
+        it->second = std::forward<M>(obj);
+        return std::make_pair(it, false);
+    }
+
+    template <typename K, typename M>
+    iterator insert_or_assign_aux(const_iterator hint, K&& key, M&& obj)
+    {
+        sfl::dtl::ignore_unused(hint);
+        return insert_or_assign_aux(std::forward<K>(key), std::forward<M>(obj)).first;
+    }
+
+    template <typename K, typename... Args>
+    std::pair<iterator, bool> try_emplace_aux(K&& key, Args&&... args)
+    {
+        const auto it = find(key);
+
+        if (it == end())
+        {
+            return std::make_pair
+            (
+                emplace_back
+                (
+                    std::piecewise_construct,
+                    std::forward_as_tuple(std::forward<K>(key)),
+                    std::forward_as_tuple(std::forward<Args>(args)...)
+                ),
+                true
+            );
+        }
+
+        return std::make_pair(it, false);
+    }
+
+    template <typename K, typename... Args>
+    iterator try_emplace_aux(const_iterator hint, K&& key, Args&&... args)
+    {
+        sfl::dtl::ignore_unused(hint);
+        return try_emplace_aux(std::forward<K>(key), std::forward<Args>(args)...).first;
+    }
+
+    template <typename... Args>
+    iterator emplace_back(Args&&... args)
+    {
+        SFL_ASSERT(!full());
+
+        const pointer old_last = data_.last_;
+
+        sfl::dtl::construct_at
+        (
+            data_.last_,
+            std::forward<Args>(args)...
+        );
+
+        ++data_.last_;
+
+        return iterator(old_last);
+    }
+
+    void pop_back()
+    {
+        SFL_ASSERT(!empty());
+
+        --data_.last_;
+
+        sfl::dtl::destroy_at(data_.last_);
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, typename T, std::size_t N, typename E>
+SFL_NODISCARD
+bool operator==
+(
+    const static_unordered_flat_map<K, T, N, E>& x,
+    const static_unordered_flat_map<K, T, N, E>& y
+)
+{
+    return x.size() == y.size() && std::is_permutation(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, typename T, std::size_t N, typename E>
+SFL_NODISCARD
+bool operator!=
+(
+    const static_unordered_flat_map<K, T, N, E>& x,
+    const static_unordered_flat_map<K, T, N, E>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, typename T, std::size_t N, typename E>
+void swap
+(
+    static_unordered_flat_map<K, T, N, E>& x,
+    static_unordered_flat_map<K, T, N, E>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, typename T, std::size_t N, typename E, typename Predicate>
+typename static_unordered_flat_map<K, T, N, E>::size_type
+    erase_if(static_unordered_flat_map<K, T, N, E>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_STATIC_UNORDERED_FLAT_MAP_HPP_INCLUDED

--- a/src/thirdparty/sfl/static_unordered_flat_multimap.hpp
+++ b/src/thirdparty/sfl/static_unordered_flat_multimap.hpp
@@ -1,0 +1,1027 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_STATIC_UNORDERED_FLAT_MULTIMAP_HPP_INCLUDED
+#define SFL_STATIC_UNORDERED_FLAT_MULTIMAP_HPP_INCLUDED
+
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/ignore_unused.hpp>
+#include <sfl/detail/initialized_memory_algorithms.hpp>
+#include <sfl/detail/normal_iterator.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/type_traits.hpp>
+#include <sfl/detail/uninitialized_memory_algorithms.hpp>
+
+#include <algorithm>        // copy, move, lower_bound, swap, swap_ranges
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <iterator>         // distance, next, reverse_iterator
+#include <limits>           // numeric_limits
+#include <memory>           // allocator, allocator_traits, pointer_traits
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+#ifdef SFL_TEST_STATIC_UNORDERED_FLAT_MULTIMAP
+void test_static_unordered_flat_multimap();
+#endif
+
+namespace sfl
+{
+
+template < typename Key,
+           typename T,
+           std::size_t N,
+           typename KeyEqual = std::equal_to<Key> >
+class static_unordered_flat_multimap
+{
+    #ifdef SFL_TEST_STATIC_UNORDERED_FLAT_MULTIMAP
+    friend void ::test_static_unordered_flat_multimap();
+    #endif
+
+    static_assert(N > 0, "N must be greater than zero.");
+
+public:
+
+    using key_type         = Key;
+    using mapped_type      = T;
+    using value_type       = std::pair<Key, T>;
+    using size_type        = std::size_t;
+    using difference_type  = std::ptrdiff_t;
+    using key_equal        = KeyEqual;
+    using reference        = value_type&;
+    using const_reference  = const value_type&;
+    using pointer          = value_type*;
+    using const_pointer    = const value_type*;
+    using iterator         = sfl::dtl::normal_iterator<pointer, static_unordered_flat_multimap>;
+    using const_iterator   = sfl::dtl::normal_iterator<const_pointer, static_unordered_flat_multimap>;
+
+    class value_equal : protected key_equal
+    {
+        friend class static_unordered_flat_multimap;
+
+    private:
+
+        value_equal(const key_equal& e)
+            : key_equal(e)
+        {}
+
+    public:
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_equal::operator()(x.first, y.first);
+        }
+    };
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+private:
+
+    // Like `value_equal` but with additional operators.
+    // For internal use only.
+    class ultra_equal : public key_equal
+    {
+    public:
+
+        ultra_equal() noexcept(std::is_nothrow_default_constructible<key_equal>::value)
+        {}
+
+        ultra_equal(const key_equal& e) noexcept(std::is_nothrow_copy_constructible<key_equal>::value)
+            : key_equal(e)
+        {}
+
+        ultra_equal(key_equal&& e) noexcept(std::is_nothrow_move_constructible<key_equal>::value)
+            : key_equal(std::move(e))
+        {}
+
+        bool operator()(const value_type& x, const value_type& y) const
+        {
+            return key_equal::operator()(x.first, y.first);
+        }
+
+        template <typename K>
+        bool operator()(const value_type& x, const K& y) const
+        {
+            return key_equal::operator()(x.first, y);
+        }
+
+        template <typename K>
+        bool operator()(const K& x, const value_type& y) const
+        {
+            return key_equal::operator()(x, y.first);
+        }
+    };
+
+    class data_base
+    {
+    public:
+
+        union
+        {
+            value_type first_[N];
+        };
+
+        pointer last_;
+
+        data_base() noexcept
+            : last_(first_)
+        {}
+
+        #if defined(__clang__) && (__clang_major__ == 3) // For CentOS 7
+        ~data_base()
+        {}
+        #else
+        ~data_base() noexcept
+        {}
+        #endif
+    };
+
+    class data : public data_base, public ultra_equal
+    {
+    public:
+
+        data() noexcept(std::is_nothrow_default_constructible<ultra_equal>::value)
+            : ultra_equal()
+        {}
+
+        data(const ultra_equal& equal) noexcept(std::is_nothrow_copy_constructible<ultra_equal>::value)
+            : ultra_equal(equal)
+        {}
+
+        data(ultra_equal&& equal) noexcept(std::is_nothrow_move_constructible<ultra_equal>::value)
+            : ultra_equal(std::move(equal))
+        {}
+
+        ultra_equal& ref_to_equal() noexcept
+        {
+            return *this;
+        }
+
+        const ultra_equal& ref_to_equal() const noexcept
+        {
+            return *this;
+        }
+    };
+
+    data data_;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    static_unordered_flat_multimap() noexcept(std::is_nothrow_default_constructible<KeyEqual>::value)
+        : data_()
+    {}
+
+    explicit static_unordered_flat_multimap(const KeyEqual& equal) noexcept(std::is_nothrow_copy_constructible<KeyEqual>::value)
+        : data_(equal)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_unordered_flat_multimap(InputIt first, InputIt last)
+        : data_()
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_unordered_flat_multimap(InputIt first, InputIt last, const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(first, last);
+    }
+
+    static_unordered_flat_multimap(std::initializer_list<value_type> ilist)
+        : static_unordered_flat_multimap(ilist.begin(), ilist.end())
+    {}
+
+    static_unordered_flat_multimap(std::initializer_list<value_type> ilist, const KeyEqual& equal)
+        : static_unordered_flat_multimap(ilist.begin(), ilist.end(), equal)
+    {}
+
+    static_unordered_flat_multimap(const static_unordered_flat_multimap& other)
+        : data_(other.data_.ref_to_equal())
+    {
+        data_.last_ = sfl::dtl::uninitialized_copy
+        (
+            pointer(other.data_.first_),
+            pointer(other.data_.last_),
+            data_.first_
+        );
+    }
+
+    static_unordered_flat_multimap(static_unordered_flat_multimap&& other)
+        : data_(std::move(other.data_.ref_to_equal()))
+    {
+        data_.last_ = sfl::dtl::uninitialized_move
+        (
+            std::make_move_iterator(pointer(other.data_.first_)),
+            std::make_move_iterator(pointer(other.data_.last_)),
+            data_.first_
+        );
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_unordered_flat_multimap(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_unordered_flat_multimap(sfl::from_range_t, Range&& range, const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    static_unordered_flat_multimap(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    static_unordered_flat_multimap(sfl::from_range_t, Range&& range, const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~static_unordered_flat_multimap()
+    {
+        sfl::dtl::destroy(data_.first_, data_.last_);
+    }
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    static_unordered_flat_multimap& operator=(const static_unordered_flat_multimap& other)
+    {
+        if (this != &other)
+        {
+            data_.ref_to_equal() = other.data_.ref_to_equal();
+
+            assign_range
+            (
+                pointer(other.data_.first_),
+                pointer(other.data_.last_)
+            );
+        }
+
+        return *this;
+    }
+
+    static_unordered_flat_multimap& operator=(static_unordered_flat_multimap&& other)
+    {
+        data_.ref_to_equal() = other.data_.ref_to_equal();
+
+        assign_range
+        (
+            std::make_move_iterator(pointer(other.data_.first_)),
+            std::make_move_iterator(pointer(other.data_.last_))
+        );
+
+        return *this;
+    }
+
+    static_unordered_flat_multimap& operator=(std::initializer_list<value_type> ilist)
+    {
+        assign_range(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- KEY EQUAL ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_equal key_eq() const
+    {
+        return data_.ref_to_equal();
+    }
+
+    //
+    // ---- VALUE EQUAL -------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_equal value_eq() const
+    {
+        return value_equal(data_.ref_to_equal());
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    iterator nth(size_type pos) noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_iterator nth(size_type pos) const noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return const_iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    size_type index_of(const_iterator pos) const noexcept
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return std::distance(cbegin(), pos);
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return data_.first_ == data_.last_;
+    }
+
+    SFL_NODISCARD
+    bool full() const noexcept
+    {
+        return std::distance(begin(), end()) == N;
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return std::distance(begin(), end());
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type max_size() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type capacity() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    size_type available() const noexcept
+    {
+        return capacity() - size();
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear() noexcept
+    {
+        sfl::dtl::destroy(data_.first_, data_.last_);
+        data_.last_ = data_.first_;
+    }
+
+    template <typename... Args>
+    iterator emplace(Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return emplace_back(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        sfl::dtl::ignore_unused(hint);
+        return emplace_back(std::forward<Args>(args)...);
+    }
+
+    iterator insert(const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        return emplace_back(value);
+    }
+
+    iterator insert(value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        return emplace_back(std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P&&>::value>* = nullptr>
+    iterator insert(P&& value)
+    {
+        SFL_ASSERT(!full());
+        return emplace_back(std::forward<P>(value));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        sfl::dtl::ignore_unused(hint);
+        return emplace_back(value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        sfl::dtl::ignore_unused(hint);
+        return emplace_back(std::move(value));
+    }
+
+    template <typename P,
+              sfl::dtl::enable_if_t<std::is_constructible<value_type, P&&>::value>* = nullptr>
+    iterator insert(const_iterator hint, P&& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        sfl::dtl::ignore_unused(hint);
+        return emplace_back(std::forward<P>(value));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    iterator erase(iterator pos)
+    {
+        return erase(const_iterator(pos));
+    }
+
+    iterator erase(const_iterator pos)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos < cend());
+
+        const difference_type offset = std::distance(cbegin(), pos);
+
+        const pointer p = data_.first_ + offset;
+
+        if (p < data_.last_ - 1)
+        {
+            *p = std::move(*(data_.last_ - 1));
+        }
+
+        --data_.last_;
+
+        sfl::dtl::destroy_at(data_.last_);
+
+        return iterator(p);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        SFL_ASSERT(cbegin() <= first && first <= last && last <= cend());
+
+        if (first == last)
+        {
+            return begin() + std::distance(cbegin(), first);
+        }
+
+        const difference_type count1 = std::distance(first, last);
+        const difference_type count2 = std::distance(last, cend());
+
+        const difference_type offset = std::distance(cbegin(), first);
+
+        const pointer p1 = data_.first_ + offset;
+
+        if (count1 >= count2)
+        {
+            const pointer p2 = p1 + count1;
+
+            const pointer new_last = sfl::dtl::move(p2, data_.last_, p1);
+
+            sfl::dtl::destroy(new_last, data_.last_);
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const pointer p2 = p1 + count2;
+
+            sfl::dtl::move(p2, data_.last_, p1);
+
+            const pointer new_last = p2;
+
+            sfl::dtl::destroy(new_last, data_.last_);
+
+            data_.last_ = new_last;
+        }
+
+        return iterator(p1);
+    }
+
+    size_type erase(const Key& key)
+    {
+        size_type n = 0;
+
+        for (auto it = begin(); it != end();)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                it = erase(it);
+                ++n;
+            }
+            else
+            {
+                ++it;
+            }
+        }
+
+        return n;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        size_type n = 0;
+
+        for (auto it = begin(); it != end();)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                it = erase(it);
+                ++n;
+            }
+            else
+            {
+                ++it;
+            }
+        }
+
+        return n;
+    }
+
+    void swap(static_unordered_flat_multimap& other)
+    {
+        if (this == &other)
+        {
+            return;
+        }
+
+        using std::swap;
+
+        swap(this->data_.ref_to_equal(), other.data_.ref_to_equal());
+
+        const size_type this_size  = this->size();
+        const size_type other_size = other.size();
+
+        if (this_size <= other_size)
+        {
+            std::swap_ranges
+            (
+                this->data_.first_,
+                this->data_.first_ + this_size,
+                other.data_.first_
+            );
+
+            sfl::dtl::uninitialized_move
+            (
+                other.data_.first_ + this_size,
+                other.data_.first_ + other_size,
+                this->data_.first_ + this_size
+            );
+
+            sfl::dtl::destroy
+            (
+                other.data_.first_ + this_size,
+                other.data_.first_ + other_size
+            );
+        }
+        else
+        {
+            std::swap_ranges
+            (
+                other.data_.first_,
+                other.data_.first_ + other_size,
+                this->data_.first_
+            );
+
+            sfl::dtl::uninitialized_move
+            (
+                this->data_.first_ + other_size,
+                this->data_.first_ + this_size,
+                other.data_.first_ + other_size
+            );
+
+            sfl::dtl::destroy
+            (
+                this->data_.first_ + other_size,
+                this->data_.first_ + this_size
+            );
+        }
+
+        this->data_.last_ = this->data_.first_ + other_size;
+        other.data_.last_ = other.data_.first_ + this_size;
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        size_type n = 0;
+
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                ++n;
+            }
+        }
+
+        return n;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        size_type n = 0;
+
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                ++n;
+            }
+        }
+
+        return n;
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    //
+    // ---- ELEMENT ACCESS ----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_type* data() noexcept
+    {
+        return data_.first_;
+    }
+
+    SFL_NODISCARD
+    const value_type* data() const noexcept
+    {
+        return data_.first_;
+    }
+
+private:
+
+    template <typename InputIt, typename Sentinel>
+    void initialize_range(InputIt first, Sentinel last)
+    {
+        SFL_TRY
+        {
+            while (first != last)
+            {
+                insert(*first);
+                ++first;
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy(data_.first_, data_.last_);
+            SFL_RETHROW;
+        }
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void initialize_range(Range&& range)
+    {
+        initialize_range(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void initialize_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        initialize_range(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    template <typename ForwardIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_forward_iterator<ForwardIt>::value>* = nullptr>
+    void assign_range(ForwardIt first, ForwardIt last)
+    {
+        SFL_ASSERT(size_type(std::distance(first, last)) <= capacity());
+
+        const size_type n = std::distance(first, last);
+
+        const size_type size = this->size();
+
+        if (n <= size)
+        {
+            const pointer new_last = sfl::dtl::copy
+            (
+                first,
+                last,
+                data_.first_
+            );
+
+            sfl::dtl::destroy
+            (
+                new_last,
+                data_.last_
+            );
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const ForwardIt mid = std::next(first, size);
+
+            sfl::dtl::copy
+            (
+                first,
+                mid,
+                data_.first_
+            );
+
+            data_.last_ = sfl::dtl::uninitialized_copy
+            (
+                mid,
+                last,
+                data_.last_
+            );
+        }
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+
+    template <typename... Args>
+    iterator emplace_back(Args&&... args)
+    {
+        SFL_ASSERT(!full());
+
+        const pointer old_last = data_.last_;
+
+        sfl::dtl::construct_at
+        (
+            data_.last_,
+            std::forward<Args>(args)...
+        );
+
+        ++data_.last_;
+
+        return iterator(old_last);
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, typename T, std::size_t N, typename E>
+SFL_NODISCARD
+bool operator==
+(
+    const static_unordered_flat_multimap<K, T, N, E>& x,
+    const static_unordered_flat_multimap<K, T, N, E>& y
+)
+{
+    return x.size() == y.size() && std::is_permutation(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, typename T, std::size_t N, typename E>
+SFL_NODISCARD
+bool operator!=
+(
+    const static_unordered_flat_multimap<K, T, N, E>& x,
+    const static_unordered_flat_multimap<K, T, N, E>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, typename T, std::size_t N, typename E>
+void swap
+(
+    static_unordered_flat_multimap<K, T, N, E>& x,
+    static_unordered_flat_multimap<K, T, N, E>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, typename T, std::size_t N, typename E, typename Predicate>
+typename static_unordered_flat_multimap<K, T, N, E>::size_type
+    erase_if(static_unordered_flat_multimap<K, T, N, E>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_STATIC_UNORDERED_FLAT_MULTIMAP_HPP_INCLUDED

--- a/src/thirdparty/sfl/static_unordered_flat_multiset.hpp
+++ b/src/thirdparty/sfl/static_unordered_flat_multiset.hpp
@@ -1,0 +1,939 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_STATIC_UNORDERED_FLAT_MULTISET_HPP_INCLUDED
+#define SFL_STATIC_UNORDERED_FLAT_MULTISET_HPP_INCLUDED
+
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/ignore_unused.hpp>
+#include <sfl/detail/initialized_memory_algorithms.hpp>
+#include <sfl/detail/normal_iterator.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/type_traits.hpp>
+#include <sfl/detail/uninitialized_memory_algorithms.hpp>
+
+#include <algorithm>        // copy, move, lower_bound, swap, swap_ranges
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <iterator>         // distance, next, reverse_iterator
+#include <limits>           // numeric_limits
+#include <memory>           // allocator, allocator_traits, pointer_traits
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+#ifdef SFL_TEST_STATIC_UNORDERED_FLAT_MULTISET
+void test_static_unordered_flat_multiset();
+#endif
+
+namespace sfl
+{
+
+template < typename Key,
+           std::size_t N,
+           typename KeyEqual = std::equal_to<Key> >
+class static_unordered_flat_multiset
+{
+    #ifdef SFL_TEST_STATIC_UNORDERED_FLAT_MULTISET
+    friend void ::test_static_unordered_flat_multiset();
+    #endif
+
+    static_assert(N > 0, "N must be greater than zero.");
+
+public:
+
+    using key_type         = Key;
+    using value_type       = Key;
+    using size_type        = std::size_t;
+    using difference_type  = std::ptrdiff_t;
+    using key_equal        = KeyEqual;
+    using reference        = value_type&;
+    using const_reference  = const value_type&;
+    using pointer          = value_type*;
+    using const_pointer    = const value_type*;
+    using iterator         = sfl::dtl::normal_iterator<const_pointer, static_unordered_flat_multiset>; // MUST BE const_pointer
+    using const_iterator   = sfl::dtl::normal_iterator<const_pointer, static_unordered_flat_multiset>;
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+private:
+
+    class data_base
+    {
+    public:
+
+        union
+        {
+            value_type first_[N];
+        };
+
+        pointer last_;
+
+        data_base() noexcept
+            : last_(first_)
+        {}
+
+        #if defined(__clang__) && (__clang_major__ == 3) // For CentOS 7
+        ~data_base()
+        {}
+        #else
+        ~data_base() noexcept
+        {}
+        #endif
+    };
+
+    class data : public data_base, public key_equal
+    {
+    public:
+
+        data() noexcept(std::is_nothrow_default_constructible<key_equal>::value)
+            : key_equal()
+        {}
+
+        data(const key_equal& equal) noexcept(std::is_nothrow_copy_constructible<key_equal>::value)
+            : key_equal(equal)
+        {}
+
+        data(key_equal&& equal) noexcept(std::is_nothrow_move_constructible<key_equal>::value)
+            : key_equal(std::move(equal))
+        {}
+
+        key_equal& ref_to_equal() noexcept
+        {
+            return *this;
+        }
+
+        const key_equal& ref_to_equal() const noexcept
+        {
+            return *this;
+        }
+    };
+
+    data data_;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    static_unordered_flat_multiset() noexcept(std::is_nothrow_default_constructible<KeyEqual>::value)
+        : data_()
+    {}
+
+    explicit static_unordered_flat_multiset(const KeyEqual& equal) noexcept(std::is_nothrow_copy_constructible<KeyEqual>::value)
+        : data_(equal)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_unordered_flat_multiset(InputIt first, InputIt last)
+        : data_()
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_unordered_flat_multiset(InputIt first, InputIt last, const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(first, last);
+    }
+
+    static_unordered_flat_multiset(std::initializer_list<value_type> ilist)
+        : static_unordered_flat_multiset(ilist.begin(), ilist.end())
+    {}
+
+    static_unordered_flat_multiset(std::initializer_list<value_type> ilist, const KeyEqual& equal)
+        : static_unordered_flat_multiset(ilist.begin(), ilist.end(), equal)
+    {}
+
+    static_unordered_flat_multiset(const static_unordered_flat_multiset& other)
+        : data_(other.data_.ref_to_equal())
+    {
+        data_.last_ = sfl::dtl::uninitialized_copy
+        (
+            pointer(other.data_.first_),
+            pointer(other.data_.last_),
+            data_.first_
+        );
+    }
+
+    static_unordered_flat_multiset(static_unordered_flat_multiset&& other)
+        : data_(std::move(other.data_.ref_to_equal()))
+    {
+        data_.last_ = sfl::dtl::uninitialized_move
+        (
+            std::make_move_iterator(pointer(other.data_.first_)),
+            std::make_move_iterator(pointer(other.data_.last_)),
+            data_.first_
+        );
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_unordered_flat_multiset(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_unordered_flat_multiset(sfl::from_range_t, Range&& range, const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    static_unordered_flat_multiset(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    static_unordered_flat_multiset(sfl::from_range_t, Range&& range, const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~static_unordered_flat_multiset()
+    {
+        sfl::dtl::destroy(data_.first_, data_.last_);
+    }
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    static_unordered_flat_multiset& operator=(const static_unordered_flat_multiset& other)
+    {
+        if (this != &other)
+        {
+            data_.ref_to_equal() = other.data_.ref_to_equal();
+
+            assign_range
+            (
+                pointer(other.data_.first_),
+                pointer(other.data_.last_)
+            );
+        }
+
+        return *this;
+    }
+
+    static_unordered_flat_multiset& operator=(static_unordered_flat_multiset&& other)
+    {
+        data_.ref_to_equal() = other.data_.ref_to_equal();
+
+        assign_range
+        (
+            std::make_move_iterator(pointer(other.data_.first_)),
+            std::make_move_iterator(pointer(other.data_.last_))
+        );
+
+        return *this;
+    }
+
+    static_unordered_flat_multiset& operator=(std::initializer_list<value_type> ilist)
+    {
+        assign_range(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- KEY EQUAL ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_equal key_eq() const
+    {
+        return data_.ref_to_equal();
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    iterator nth(size_type pos) noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_iterator nth(size_type pos) const noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return const_iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    size_type index_of(const_iterator pos) const noexcept
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return std::distance(cbegin(), pos);
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return data_.first_ == data_.last_;
+    }
+
+    SFL_NODISCARD
+    bool full() const noexcept
+    {
+        return std::distance(begin(), end()) == N;
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return std::distance(begin(), end());
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type max_size() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type capacity() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    size_type available() const noexcept
+    {
+        return capacity() - size();
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear() noexcept
+    {
+        sfl::dtl::destroy(data_.first_, data_.last_);
+        data_.last_ = data_.first_;
+    }
+
+    template <typename... Args>
+    iterator emplace(Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return emplace_back(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        sfl::dtl::ignore_unused(hint);
+        return emplace_back(std::forward<Args>(args)...);
+    }
+
+    iterator insert(const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        return emplace_back(value);
+    }
+
+    iterator insert(value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        return emplace_back(std::move(value));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        sfl::dtl::ignore_unused(hint);
+        return emplace_back(value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        sfl::dtl::ignore_unused(hint);
+        return emplace_back(std::move(value));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    iterator erase(const_iterator pos)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos < cend());
+
+        const difference_type offset = std::distance(cbegin(), pos);
+
+        const pointer p = data_.first_ + offset;
+
+        if (p < data_.last_ - 1)
+        {
+            *p = std::move(*(data_.last_ - 1));
+        }
+
+        --data_.last_;
+
+        sfl::dtl::destroy_at(data_.last_);
+
+        return iterator(p);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        SFL_ASSERT(cbegin() <= first && first <= last && last <= cend());
+
+        if (first == last)
+        {
+            return begin() + std::distance(cbegin(), first);
+        }
+
+        const difference_type count1 = std::distance(first, last);
+        const difference_type count2 = std::distance(last, cend());
+
+        const difference_type offset = std::distance(cbegin(), first);
+
+        const pointer p1 = data_.first_ + offset;
+
+        if (count1 >= count2)
+        {
+            const pointer p2 = p1 + count1;
+
+            const pointer new_last = sfl::dtl::move(p2, data_.last_, p1);
+
+            sfl::dtl::destroy(new_last, data_.last_);
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const pointer p2 = p1 + count2;
+
+            sfl::dtl::move(p2, data_.last_, p1);
+
+            const pointer new_last = p2;
+
+            sfl::dtl::destroy(new_last, data_.last_);
+
+            data_.last_ = new_last;
+        }
+
+        return iterator(p1);
+    }
+
+    size_type erase(const Key& key)
+    {
+        size_type n = 0;
+
+        for (auto it = begin(); it != end();)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                it = erase(it);
+                ++n;
+            }
+            else
+            {
+                ++it;
+            }
+        }
+
+        return n;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        size_type n = 0;
+
+        for (auto it = begin(); it != end();)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                it = erase(it);
+                ++n;
+            }
+            else
+            {
+                ++it;
+            }
+        }
+
+        return n;
+    }
+
+    void swap(static_unordered_flat_multiset& other)
+    {
+        if (this == &other)
+        {
+            return;
+        }
+
+        using std::swap;
+
+        swap(this->data_.ref_to_equal(), other.data_.ref_to_equal());
+
+        const size_type this_size  = this->size();
+        const size_type other_size = other.size();
+
+        if (this_size <= other_size)
+        {
+            std::swap_ranges
+            (
+                this->data_.first_,
+                this->data_.first_ + this_size,
+                other.data_.first_
+            );
+
+            sfl::dtl::uninitialized_move
+            (
+                other.data_.first_ + this_size,
+                other.data_.first_ + other_size,
+                this->data_.first_ + this_size
+            );
+
+            sfl::dtl::destroy
+            (
+                other.data_.first_ + this_size,
+                other.data_.first_ + other_size
+            );
+        }
+        else
+        {
+            std::swap_ranges
+            (
+                other.data_.first_,
+                other.data_.first_ + other_size,
+                this->data_.first_
+            );
+
+            sfl::dtl::uninitialized_move
+            (
+                this->data_.first_ + other_size,
+                this->data_.first_ + this_size,
+                other.data_.first_ + other_size
+            );
+
+            sfl::dtl::destroy
+            (
+                this->data_.first_ + other_size,
+                this->data_.first_ + this_size
+            );
+        }
+
+        this->data_.last_ = this->data_.first_ + other_size;
+        other.data_.last_ = other.data_.first_ + this_size;
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        size_type n = 0;
+
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                ++n;
+            }
+        }
+
+        return n;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        size_type n = 0;
+
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                ++n;
+            }
+        }
+
+        return n;
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    //
+    // ---- ELEMENT ACCESS ----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_type* data() noexcept
+    {
+        return data_.first_;
+    }
+
+    SFL_NODISCARD
+    const value_type* data() const noexcept
+    {
+        return data_.first_;
+    }
+
+private:
+
+    template <typename InputIt, typename Sentinel>
+    void initialize_range(InputIt first, Sentinel last)
+    {
+        SFL_TRY
+        {
+            while (first != last)
+            {
+                insert(*first);
+                ++first;
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy(data_.first_, data_.last_);
+            SFL_RETHROW;
+        }
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void initialize_range(Range&& range)
+    {
+        initialize_range(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void initialize_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        initialize_range(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    template <typename ForwardIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_forward_iterator<ForwardIt>::value>* = nullptr>
+    void assign_range(ForwardIt first, ForwardIt last)
+    {
+        SFL_ASSERT(size_type(std::distance(first, last)) <= capacity());
+
+        const size_type n = std::distance(first, last);
+
+        const size_type size = this->size();
+
+        if (n <= size)
+        {
+            const pointer new_last = sfl::dtl::copy
+            (
+                first,
+                last,
+                data_.first_
+            );
+
+            sfl::dtl::destroy
+            (
+                new_last,
+                data_.last_
+            );
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const ForwardIt mid = std::next(first, size);
+
+            sfl::dtl::copy
+            (
+                first,
+                mid,
+                data_.first_
+            );
+
+            data_.last_ = sfl::dtl::uninitialized_copy
+            (
+                mid,
+                last,
+                data_.last_
+            );
+        }
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+
+    template <typename... Args>
+    iterator emplace_back(Args&&... args)
+    {
+        SFL_ASSERT(!full());
+
+        const pointer old_last = data_.last_;
+
+        sfl::dtl::construct_at
+        (
+            data_.last_,
+            std::forward<Args>(args)...
+        );
+
+        ++data_.last_;
+
+        return iterator(old_last);
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, std::size_t N, typename E>
+SFL_NODISCARD
+bool operator==
+(
+    const static_unordered_flat_multiset<K, N, E>& x,
+    const static_unordered_flat_multiset<K, N, E>& y
+)
+{
+    return x.size() == y.size() && std::is_permutation(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, std::size_t N, typename E>
+SFL_NODISCARD
+bool operator!=
+(
+    const static_unordered_flat_multiset<K, N, E>& x,
+    const static_unordered_flat_multiset<K, N, E>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, std::size_t N, typename E>
+void swap
+(
+    static_unordered_flat_multiset<K, N, E>& x,
+    static_unordered_flat_multiset<K, N, E>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, std::size_t N, typename E, typename Predicate>
+typename static_unordered_flat_multiset<K, N, E>::size_type
+    erase_if(static_unordered_flat_multiset<K, N, E>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_STATIC_UNORDERED_FLAT_MULTISET_HPP_INCLUDED

--- a/src/thirdparty/sfl/static_unordered_flat_set.hpp
+++ b/src/thirdparty/sfl/static_unordered_flat_set.hpp
@@ -1,0 +1,993 @@
+//
+// Copyright (c) 2022 Slaven Falandys
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef SFL_STATIC_UNORDERED_FLAT_SET_HPP_INCLUDED
+#define SFL_STATIC_UNORDERED_FLAT_SET_HPP_INCLUDED
+
+#include <sfl/detail/container_compatible_range.hpp>
+#include <sfl/detail/cpp.hpp>
+#include <sfl/detail/ignore_unused.hpp>
+#include <sfl/detail/initialized_memory_algorithms.hpp>
+#include <sfl/detail/normal_iterator.hpp>
+#include <sfl/detail/tags.hpp>
+#include <sfl/detail/type_traits.hpp>
+#include <sfl/detail/uninitialized_memory_algorithms.hpp>
+
+#include <algorithm>        // copy, move, lower_bound, swap, swap_ranges
+#include <cstddef>          // size_t
+#include <functional>       // equal_to, less
+#include <initializer_list> // initializer_list
+#include <iterator>         // distance, next, reverse_iterator
+#include <limits>           // numeric_limits
+#include <memory>           // allocator, allocator_traits, pointer_traits
+#include <type_traits>      // is_same, is_nothrow_xxxxx
+#include <utility>          // forward, move, pair
+
+#ifdef SFL_TEST_STATIC_UNORDERED_FLAT_SET
+void test_static_unordered_flat_set();
+#endif
+
+namespace sfl
+{
+
+template < typename Key,
+           std::size_t N,
+           typename KeyEqual = std::equal_to<Key> >
+class static_unordered_flat_set
+{
+    #ifdef SFL_TEST_STATIC_UNORDERED_FLAT_SET
+    friend void ::test_static_unordered_flat_set();
+    #endif
+
+    static_assert(N > 0, "N must be greater than zero.");
+
+public:
+
+    using key_type         = Key;
+    using value_type       = Key;
+    using size_type        = std::size_t;
+    using difference_type  = std::ptrdiff_t;
+    using key_equal        = KeyEqual;
+    using reference        = value_type&;
+    using const_reference  = const value_type&;
+    using pointer          = value_type*;
+    using const_pointer    = const value_type*;
+    using iterator         = sfl::dtl::normal_iterator<const_pointer, static_unordered_flat_set>; // MUST BE const_pointer
+    using const_iterator   = sfl::dtl::normal_iterator<const_pointer, static_unordered_flat_set>;
+
+public:
+
+    static constexpr size_type static_capacity = N;
+
+private:
+
+    class data_base
+    {
+    public:
+
+        union
+        {
+            value_type first_[N];
+        };
+
+        pointer last_;
+
+        data_base() noexcept
+            : last_(first_)
+        {}
+
+        #if defined(__clang__) && (__clang_major__ == 3) // For CentOS 7
+        ~data_base()
+        {}
+        #else
+        ~data_base() noexcept
+        {}
+        #endif
+    };
+
+    class data : public data_base, public key_equal
+    {
+    public:
+
+        data() noexcept(std::is_nothrow_default_constructible<key_equal>::value)
+            : key_equal()
+        {}
+
+        data(const key_equal& equal) noexcept(std::is_nothrow_copy_constructible<key_equal>::value)
+            : key_equal(equal)
+        {}
+
+        data(key_equal&& equal) noexcept(std::is_nothrow_move_constructible<key_equal>::value)
+            : key_equal(std::move(equal))
+        {}
+
+        key_equal& ref_to_equal() noexcept
+        {
+            return *this;
+        }
+
+        const key_equal& ref_to_equal() const noexcept
+        {
+            return *this;
+        }
+    };
+
+    data data_;
+
+public:
+
+    //
+    // ---- CONSTRUCTION AND DESTRUCTION --------------------------------------
+    //
+
+    static_unordered_flat_set() noexcept(std::is_nothrow_default_constructible<KeyEqual>::value)
+        : data_()
+    {}
+
+    explicit static_unordered_flat_set(const KeyEqual& equal) noexcept(std::is_nothrow_copy_constructible<KeyEqual>::value)
+        : data_(equal)
+    {}
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_unordered_flat_set(InputIt first, InputIt last)
+        : data_()
+    {
+        initialize_range(first, last);
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    static_unordered_flat_set(InputIt first, InputIt last, const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(first, last);
+    }
+
+    static_unordered_flat_set(std::initializer_list<value_type> ilist)
+        : static_unordered_flat_set(ilist.begin(), ilist.end())
+    {}
+
+    static_unordered_flat_set(std::initializer_list<value_type> ilist, const KeyEqual& equal)
+        : static_unordered_flat_set(ilist.begin(), ilist.end(), equal)
+    {}
+
+    static_unordered_flat_set(const static_unordered_flat_set& other)
+        : data_(other.data_.ref_to_equal())
+    {
+        data_.last_ = sfl::dtl::uninitialized_copy
+        (
+            pointer(other.data_.first_),
+            pointer(other.data_.last_),
+            data_.first_
+        );
+    }
+
+    static_unordered_flat_set(static_unordered_flat_set&& other)
+        : data_(std::move(other.data_.ref_to_equal()))
+    {
+        data_.last_ = sfl::dtl::uninitialized_move
+        (
+            std::make_move_iterator(pointer(other.data_.first_)),
+            std::make_move_iterator(pointer(other.data_.last_)),
+            data_.first_
+        );
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_unordered_flat_set(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    static_unordered_flat_set(sfl::from_range_t, Range&& range, const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    static_unordered_flat_set(sfl::from_range_t, Range&& range)
+        : data_()
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+    template <typename Range>
+    static_unordered_flat_set(sfl::from_range_t, Range&& range, const KeyEqual& equal)
+        : data_(equal)
+    {
+        initialize_range(std::forward<Range>(range));
+    }
+
+#endif // before C++20
+
+    ~static_unordered_flat_set()
+    {
+        sfl::dtl::destroy(data_.first_, data_.last_);
+    }
+
+    //
+    // ---- ASSIGNMENT --------------------------------------------------------
+    //
+
+    static_unordered_flat_set& operator=(const static_unordered_flat_set& other)
+    {
+        if (this != &other)
+        {
+            data_.ref_to_equal() = other.data_.ref_to_equal();
+
+            assign_range
+            (
+                pointer(other.data_.first_),
+                pointer(other.data_.last_)
+            );
+        }
+
+        return *this;
+    }
+
+    static_unordered_flat_set& operator=(static_unordered_flat_set&& other)
+    {
+        data_.ref_to_equal() = other.data_.ref_to_equal();
+
+        assign_range
+        (
+            std::make_move_iterator(pointer(other.data_.first_)),
+            std::make_move_iterator(pointer(other.data_.last_))
+        );
+
+        return *this;
+    }
+
+    static_unordered_flat_set& operator=(std::initializer_list<value_type> ilist)
+    {
+        assign_range(ilist.begin(), ilist.end());
+        return *this;
+    }
+
+    //
+    // ---- KEY EQUAL ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    key_equal key_eq() const
+    {
+        return data_.ref_to_equal();
+    }
+
+    //
+    // ---- ITERATORS ---------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator begin() noexcept
+    {
+        return iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator begin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(data_.first_);
+    }
+
+    SFL_NODISCARD
+    iterator end() noexcept
+    {
+        return iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator end() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    const_iterator cend() const noexcept
+    {
+        return const_iterator(data_.last_);
+    }
+
+    SFL_NODISCARD
+    iterator nth(size_type pos) noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    const_iterator nth(size_type pos) const noexcept
+    {
+        SFL_ASSERT(pos <= size());
+        return const_iterator(data_.first_ + pos);
+    }
+
+    SFL_NODISCARD
+    size_type index_of(const_iterator pos) const noexcept
+    {
+        SFL_ASSERT(cbegin() <= pos && pos <= cend());
+        return std::distance(cbegin(), pos);
+    }
+
+    //
+    // ---- SIZE AND CAPACITY -------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    bool empty() const noexcept
+    {
+        return data_.first_ == data_.last_;
+    }
+
+    SFL_NODISCARD
+    bool full() const noexcept
+    {
+        return std::distance(begin(), end()) == N;
+    }
+
+    SFL_NODISCARD
+    size_type size() const noexcept
+    {
+        return std::distance(begin(), end());
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type max_size() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    static constexpr size_type capacity() noexcept
+    {
+        return N;
+    }
+
+    SFL_NODISCARD
+    size_type available() const noexcept
+    {
+        return capacity() - size();
+    }
+
+    //
+    // ---- MODIFIERS ---------------------------------------------------------
+    //
+
+    void clear() noexcept
+    {
+        sfl::dtl::destroy(data_.first_, data_.last_);
+        data_.last_ = data_.first_;
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace(Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        return emplace_aux(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return emplace_hint_aux(hint, std::forward<Args>(args)...);
+    }
+
+    std::pair<iterator, bool> insert(const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        return insert_aux(value);
+    }
+
+    std::pair<iterator, bool> insert(value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        return insert_aux(std::move(value));
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    std::pair<iterator, bool> insert(K&& x)
+    {
+        SFL_ASSERT(!full());
+        return insert_aux_heterogeneous(std::forward<K>(x));
+    }
+
+    iterator insert(const_iterator hint, const value_type& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, value);
+    }
+
+    iterator insert(const_iterator hint, value_type&& value)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux(hint, std::move(value));
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t< sfl::dtl::has_is_transparent<KeyEqual, K>::value &&
+                                    !std::is_convertible<K&&, const_iterator>::value &&
+                                    !std::is_convertible<K&&, iterator>::value >* = nullptr>
+    iterator insert(const_iterator hint, K&& x)
+    {
+        SFL_ASSERT(!full());
+        SFL_ASSERT(cbegin() <= hint && hint <= cend());
+        return insert_aux_heterogeneous(hint, std::forward<K>(x));
+    }
+
+    template <typename InputIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_input_iterator<InputIt>::value>* = nullptr>
+    void insert(InputIt first, InputIt last)
+    {
+        insert_range_aux(first, last);
+    }
+
+    void insert(std::initializer_list<value_type> ilist)
+    {
+        insert_range_aux(ilist.begin(), ilist.end());
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void insert_range(Range&& range)
+    {
+        insert_range_aux(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void insert_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        insert_range_aux(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    iterator erase(const_iterator pos)
+    {
+        SFL_ASSERT(cbegin() <= pos && pos < cend());
+
+        const difference_type offset = std::distance(cbegin(), pos);
+
+        const pointer p = data_.first_ + offset;
+
+        if (p < data_.last_ - 1)
+        {
+            *p = std::move(*(data_.last_ - 1));
+        }
+
+        --data_.last_;
+
+        sfl::dtl::destroy_at(data_.last_);
+
+        return iterator(p);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        SFL_ASSERT(cbegin() <= first && first <= last && last <= cend());
+
+        if (first == last)
+        {
+            return begin() + std::distance(cbegin(), first);
+        }
+
+        const difference_type count1 = std::distance(first, last);
+        const difference_type count2 = std::distance(last, cend());
+
+        const difference_type offset = std::distance(cbegin(), first);
+
+        const pointer p1 = data_.first_ + offset;
+
+        if (count1 >= count2)
+        {
+            const pointer p2 = p1 + count1;
+
+            const pointer new_last = sfl::dtl::move(p2, data_.last_, p1);
+
+            sfl::dtl::destroy(new_last, data_.last_);
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const pointer p2 = p1 + count2;
+
+            sfl::dtl::move(p2, data_.last_, p1);
+
+            const pointer new_last = p2;
+
+            sfl::dtl::destroy(new_last, data_.last_);
+
+            data_.last_ = new_last;
+        }
+
+        return iterator(p1);
+    }
+
+    size_type erase(const Key& key)
+    {
+        auto it = find(key);
+
+        if (it == cend())
+        {
+            return 0;
+        }
+
+        erase(it);
+        return 1;
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    size_type erase(K&& x)
+    {
+        auto it = find(x);
+
+        if (it == cend())
+        {
+            return 0;
+        }
+
+        erase(it);
+        return 1;
+    }
+
+    void swap(static_unordered_flat_set& other)
+    {
+        if (this == &other)
+        {
+            return;
+        }
+
+        using std::swap;
+
+        swap(this->data_.ref_to_equal(), other.data_.ref_to_equal());
+
+        const size_type this_size  = this->size();
+        const size_type other_size = other.size();
+
+        if (this_size <= other_size)
+        {
+            std::swap_ranges
+            (
+                this->data_.first_,
+                this->data_.first_ + this_size,
+                other.data_.first_
+            );
+
+            sfl::dtl::uninitialized_move
+            (
+                other.data_.first_ + this_size,
+                other.data_.first_ + other_size,
+                this->data_.first_ + this_size
+            );
+
+            sfl::dtl::destroy
+            (
+                other.data_.first_ + this_size,
+                other.data_.first_ + other_size
+            );
+        }
+        else
+        {
+            std::swap_ranges
+            (
+                other.data_.first_,
+                other.data_.first_ + other_size,
+                this->data_.first_
+            );
+
+            sfl::dtl::uninitialized_move
+            (
+                this->data_.first_ + other_size,
+                this->data_.first_ + this_size,
+                other.data_.first_ + other_size
+            );
+
+            sfl::dtl::destroy
+            (
+                this->data_.first_ + other_size,
+                this->data_.first_ + this_size
+            );
+        }
+
+        this->data_.last_ = this->data_.first_ + other_size;
+        other.data_.last_ = other.data_.first_ + this_size;
+    }
+
+    //
+    // ---- LOOKUP ------------------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    iterator find(const Key& key)
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    SFL_NODISCARD
+    const_iterator find(const Key& key) const
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, key))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    iterator find(const K& x)
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    const_iterator find(const K& x) const
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (data_.ref_to_equal()(*it, x))
+            {
+                return it;
+            }
+        }
+
+        return end();
+    }
+
+    SFL_NODISCARD
+    size_type count(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    size_type count(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    SFL_NODISCARD
+    bool contains(const Key& key) const
+    {
+        return find(key) != end();
+    }
+
+    template <typename K,
+              sfl::dtl::enable_if_t<sfl::dtl::has_is_transparent<KeyEqual, K>::value>* = nullptr>
+    SFL_NODISCARD
+    bool contains(const K& x) const
+    {
+        return find(x) != end();
+    }
+
+    //
+    // ---- ELEMENT ACCESS ----------------------------------------------------
+    //
+
+    SFL_NODISCARD
+    value_type* data() noexcept
+    {
+        return data_.first_;
+    }
+
+    SFL_NODISCARD
+    const value_type* data() const noexcept
+    {
+        return data_.first_;
+    }
+
+private:
+
+    template <typename InputIt, typename Sentinel>
+    void initialize_range(InputIt first, Sentinel last)
+    {
+        SFL_TRY
+        {
+            while (first != last)
+            {
+                insert(*first);
+                ++first;
+            }
+        }
+        SFL_CATCH (...)
+        {
+            sfl::dtl::destroy(data_.first_, data_.last_);
+            SFL_RETHROW;
+        }
+    }
+
+#if SFL_CPP_VERSION >= SFL_CPP_20
+
+    template <sfl::dtl::container_compatible_range<value_type> Range>
+    void initialize_range(Range&& range)
+    {
+        initialize_range(std::ranges::begin(range), std::ranges::end(range));
+    }
+
+#else // before C++20
+
+    template <typename Range>
+    void initialize_range(Range&& range)
+    {
+        using std::begin;
+        using std::end;
+        initialize_range(begin(range), end(range));
+    }
+
+#endif // before C++20
+
+    template <typename ForwardIt,
+              sfl::dtl::enable_if_t<sfl::dtl::is_forward_iterator<ForwardIt>::value>* = nullptr>
+    void assign_range(ForwardIt first, ForwardIt last)
+    {
+        SFL_ASSERT(size_type(std::distance(first, last)) <= capacity());
+
+        const size_type n = std::distance(first, last);
+
+        const size_type size = this->size();
+
+        if (n <= size)
+        {
+            const pointer new_last = sfl::dtl::copy
+            (
+                first,
+                last,
+                data_.first_
+            );
+
+            sfl::dtl::destroy
+            (
+                new_last,
+                data_.last_
+            );
+
+            data_.last_ = new_last;
+        }
+        else
+        {
+            const ForwardIt mid = std::next(first, size);
+
+            sfl::dtl::copy
+            (
+                first,
+                mid,
+                data_.first_
+            );
+
+            data_.last_ = sfl::dtl::uninitialized_copy
+            (
+                mid,
+                last,
+                data_.last_
+            );
+        }
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace_aux(Args&&... args)
+    {
+        const auto it1 = emplace_back(std::forward<Args>(args)...);
+        const auto it2 = find(*it1);
+
+        const bool is_unique = it1 == it2;
+
+        if (!is_unique)
+        {
+            pop_back();
+        }
+
+        return std::make_pair(it2, is_unique);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint_aux(const_iterator hint, Args&&... args)
+    {
+        sfl::dtl::ignore_unused(hint);
+        return emplace_aux(std::forward<Args>(args)...).first;
+    }
+
+    template <typename Value>
+    std::pair<iterator, bool> insert_aux(Value&& value)
+    {
+        const auto it = find(value);
+
+        if (it == end())
+        {
+            return std::make_pair(emplace_back(std::forward<Value>(value)), true);
+        }
+
+        return std::make_pair(it, false);
+    }
+
+    template <typename Value>
+    iterator insert_aux(const_iterator hint, Value&& value)
+    {
+        sfl::dtl::ignore_unused(hint);
+        return insert_aux(std::forward<Value>(value)).first;
+    }
+
+    template <typename K>
+    std::pair<iterator, bool> insert_aux_heterogeneous(K&& x)
+    {
+        const auto it = find(x);
+
+        if (it == end())
+        {
+            return std::make_pair(emplace_back(value_type(std::forward<K>(x))), true);
+        }
+
+        return std::make_pair(it, false);
+    }
+
+    template <typename K>
+    iterator insert_aux_heterogeneous(const_iterator hint, K&& x)
+    {
+        sfl::dtl::ignore_unused(hint);
+        return insert_aux_heterogeneous(std::forward<K>(x)).first;
+    }
+
+    template <typename InputIt, typename Sentinel>
+    void insert_range_aux(InputIt first, Sentinel last)
+    {
+        while (first != last)
+        {
+            insert(*first);
+            ++first;
+        }
+    }
+
+    template <typename... Args>
+    iterator emplace_back(Args&&... args)
+    {
+        SFL_ASSERT(!full());
+
+        const pointer old_last = data_.last_;
+
+        sfl::dtl::construct_at
+        (
+            data_.last_,
+            std::forward<Args>(args)...
+        );
+
+        ++data_.last_;
+
+        return iterator(old_last);
+    }
+
+    void pop_back()
+    {
+        SFL_ASSERT(!empty());
+
+        --data_.last_;
+
+        sfl::dtl::destroy_at(data_.last_);
+    }
+};
+
+//
+// ---- NON-MEMBER FUNCTIONS --------------------------------------------------
+//
+
+template <typename K, std::size_t N, typename E>
+SFL_NODISCARD
+bool operator==
+(
+    const static_unordered_flat_set<K, N, E>& x,
+    const static_unordered_flat_set<K, N, E>& y
+)
+{
+    return x.size() == y.size() && std::is_permutation(x.begin(), x.end(), y.begin());
+}
+
+template <typename K, std::size_t N, typename E>
+SFL_NODISCARD
+bool operator!=
+(
+    const static_unordered_flat_set<K, N, E>& x,
+    const static_unordered_flat_set<K, N, E>& y
+)
+{
+    return !(x == y);
+}
+
+template <typename K, std::size_t N, typename E>
+void swap
+(
+    static_unordered_flat_set<K, N, E>& x,
+    static_unordered_flat_set<K, N, E>& y
+)
+{
+    x.swap(y);
+}
+
+template <typename K, std::size_t N, typename E, typename Predicate>
+typename static_unordered_flat_set<K, N, E>::size_type
+    erase_if(static_unordered_flat_set<K, N, E>& c, Predicate pred)
+{
+    auto old_size = c.size();
+
+    for (auto it = c.begin(); it != c.end(); )
+    {
+        if (pred(*it))
+        {
+            it = c.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return old_size - c.size();
+}
+
+} // namespace sfl
+
+#endif // SFL_STATIC_UNORDERED_FLAT_SET_HPP_INCLUDED


### PR DESCRIPTION
Ignore the first commit, that's just bringing in the latest from sfl. As for the numbers I picked, I went with collecting the average for some parks to avoid heap most of the time.

develop:
![openrct2_2025-03-22_17-19-57a114d5e7f6af3295c](https://github.com/user-attachments/assets/e756588a-c7e8-4234-9ad6-eb1add020fe9)
![openrct2_2025-03-22_17-31-23c6d5f0868f580fc1a](https://github.com/user-attachments/assets/b2c26f9d-2f17-4cb0-9f7f-1e86f00c2406)

PR:
![openrct2_2025-03-22_17-22-16c0e060d6a862faae4](https://github.com/user-attachments/assets/210a51b0-f5f2-444b-aede-edb9df1c7467)
![openrct2_2025-03-22_17-30-41ef21407b9286c7a6a](https://github.com/user-attachments/assets/3dbfc239-4a51-4da3-8de6-52aa6a2515fb)

In some cases it can yield additional 20+ FPS. This will mostly affect parks where a lot of transparent things or water is used.