### PR TITLE
Force object selection window to close when changing scenes

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Feature: [#23876] New park save files now contain a preview image, shown in the load/save window.
 - Change: [#23932] The land rights window now checks “Land Owned” by default.
 - Change: [#23936] The ‘guests prefer less/more intense rides’ settings have been turned into a dropdown.
+- Change: [#24059] The ‘select other ride’ button is now available in the track manager.
 - Change: [#24067] [Plugin] Registered menu items are now listed alphabetically.
 - Change: [#24070] Footpath selection menus now show object names on hover using a tooltip.
 - Change: [#24101] Frozen peeps are no longer removed when using the 'remove all guests' cheat.

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -586,6 +586,10 @@ public:
     {
         switch (windowClass)
         {
+            case WindowClass::EditorObjectSelection:
+                EditorObjectSelectionClose();
+                break;
+
             case WindowClass::NetworkStatus:
                 WindowNetworkStatusClose();
                 break;

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -261,6 +261,7 @@ namespace OpenRCT2::Ui::Windows
         u8string _filter;
         uint32_t _filterFlags = FILTER_RIDES_ALL;
         uint8_t _selectedSubTab = 0;
+        bool _overrideChecks = false;
 
     public:
         /**
@@ -292,10 +293,15 @@ namespace OpenRCT2::Ui::Windows
             VisibleListRefresh();
         }
 
+        void SetOverrideChecks(bool newState)
+        {
+            _overrideChecks = newState;
+        }
+
         bool CanClose() override
         {
             // Prevent window closure when selection is invalid
-            return EditorObjectSelectionWindowCheck();
+            return _overrideChecks || EditorObjectSelectionWindowCheck();
         }
 
         /**
@@ -1623,6 +1629,20 @@ namespace OpenRCT2::Ui::Windows
         auto* windowMgr = GetWindowManager();
         return windowMgr->FocusOrCreate<EditorObjectSelectionWindow>(
             WindowClass::EditorObjectSelection, 755, 400, WF_10 | WF_RESIZABLE | WF_CENTRE_SCREEN);
+    }
+
+    // Used for forced closure
+    void EditorObjectSelectionClose()
+    {
+        auto* windowMgr = GetWindowManager();
+        auto window = windowMgr->FindByClass(WindowClass::EditorObjectSelection);
+        if (window == nullptr)
+        {
+            return;
+        }
+        auto objSelWindow = static_cast<EditorObjectSelectionWindow*>(window);
+        objSelWindow->SetOverrideChecks(true);
+        objSelWindow->Close();
     }
 
     static bool VisibleListSortRideName(const ObjectListItem& a, const ObjectListItem& b)

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -306,7 +306,7 @@ namespace OpenRCT2::Ui::Windows
         {
             UnloadUnselectedObjects();
             EditorLoadSelectedObjects();
-            EditorObjectFlagsFree();
+            EditorObjectFlagsClear();
 
             if (_loadedObject != nullptr)
                 _loadedObject->Unload();
@@ -327,7 +327,7 @@ namespace OpenRCT2::Ui::Windows
             auto intent = Intent(INTENT_ACTION_REFRESH_NEW_RIDES);
             ContextBroadcastIntent(&intent);
 
-            VisibleListDispose();
+            VisibleListClear();
 
             intent = Intent(INTENT_ACTION_REFRESH_SCENERY);
             ContextBroadcastIntent(&intent);
@@ -1173,7 +1173,7 @@ namespace OpenRCT2::Ui::Windows
         {
             int32_t numObjects = static_cast<int32_t>(ObjectRepositoryGetItemsCount());
 
-            VisibleListDispose();
+            VisibleListClear();
             selected_list_item = -1;
 
             const ObjectRepositoryItem* items = ObjectRepositoryGetItems();
@@ -1200,7 +1200,7 @@ namespace OpenRCT2::Ui::Windows
 
             if (_listItems.empty())
             {
-                VisibleListDispose();
+                VisibleListClear();
             }
             else
             {
@@ -1229,7 +1229,7 @@ namespace OpenRCT2::Ui::Windows
             Invalidate();
         }
 
-        void VisibleListDispose()
+        void VisibleListClear()
         {
             _listItems.clear();
             _listItems.shrink_to_fit();

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -636,9 +636,10 @@ namespace OpenRCT2::Ui::Windows
                 auto& objManager = GetContext()->GetObjectManager();
                 objManager.LoadObject(_loadedObject.get()->GetIdentifier());
 
+                windowMgr->ForceClose(WindowClass::EditorObjectSelection);
+
                 // This function calls window_track_list_open
                 ManageTracks();
-                Close();
                 return;
             }
 

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -422,7 +422,7 @@ namespace OpenRCT2::Ui::Windows
         }
 
         auto* windowMgr = Ui::GetWindowManager();
-        windowMgr->CloseByClass(WindowClass::EditorObjectSelection);
+        windowMgr->ForceClose(WindowClass::EditorObjectSelection);
         windowMgr->CloseConstructionWindows();
 
         gTrackDesignSceneryToggle = false;

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -221,15 +221,6 @@ namespace OpenRCT2::Ui::Windows
 
             LoadDesignsList(_window_track_list_item);
 
-            if (gLegacyScene == LegacyScene::trackDesignsManager)
-            {
-                widgets[WIDX_BACK].type = WindowWidgetType::Empty;
-            }
-            else
-            {
-                widgets[WIDX_BACK].type = WindowWidgetType::TableHeader;
-            }
-
             WindowInitScrollWidgets(*this);
             _selectedItemIsBeingUpdated = false;
             _reloadTrackDesigns = false;
@@ -246,6 +237,14 @@ namespace OpenRCT2::Ui::Windows
 
             _loadedTrackDesign = nullptr;
             _loadedTrackDesignIndex = TRACK_DESIGN_INDEX_UNLOADED;
+        }
+
+        void ReopenTrackManager()
+        {
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->CloseByNumber(WindowClass::ManageTrackDesign, number);
+            windowMgr->CloseByNumber(WindowClass::TrackDeletePrompt, number);
+            Editor::LoadTrackManager();
         }
 
         void OnClose() override
@@ -265,10 +264,7 @@ namespace OpenRCT2::Ui::Windows
             // try to load the track manager again, and an infinite loop will result.
             if ((gLegacyScene == LegacyScene::trackDesignsManager) && gScreenAge != 0)
             {
-                auto* windowMgr = Ui::GetWindowManager();
-                windowMgr->CloseByNumber(WindowClass::ManageTrackDesign, number);
-                windowMgr->CloseByNumber(WindowClass::TrackDeletePrompt, number);
-                Editor::LoadTrackManager();
+                ReopenTrackManager();
             }
         }
 
@@ -294,6 +290,10 @@ namespace OpenRCT2::Ui::Windows
                     if (!(gLegacyScene == LegacyScene::trackDesignsManager))
                     {
                         ContextOpenWindow(WindowClass::ConstructRide);
+                    }
+                    else
+                    {
+                        ReopenTrackManager();
                     }
                     break;
                 case WIDX_FILTER_STRING:

--- a/src/openrct2-ui/windows/Windows.h
+++ b/src/openrct2-ui/windows/Windows.h
@@ -81,6 +81,7 @@ namespace OpenRCT2::Ui::Windows
     // EditorObjectSelection
     WindowBase* EditorObjectSelectionOpen();
     bool EditorObjectSelectionWindowCheck();
+    void EditorObjectSelectionClose();
 
     // EditorParkEntrance
     WindowBase* EditorParkEntranceOpen();

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -355,7 +355,7 @@ void Sub6AB211()
  *
  *  rct2: 0x006AB316
  */
-void EditorObjectFlagsFree()
+void EditorObjectFlagsClear()
 {
     _objectSelectionFlags.clear();
     _objectSelectionFlags.shrink_to_fit();
@@ -771,7 +771,7 @@ int32_t EditorRemoveUnusedObjects()
         }
     }
     UnloadUnselectedObjects();
-    EditorObjectFlagsFree();
+    EditorObjectFlagsClear();
 
     auto intent = Intent(INTENT_ACTION_REFRESH_SCENERY);
     ContextBroadcastIntent(&intent);

--- a/src/openrct2/EditorObjectSelectionSession.h
+++ b/src/openrct2/EditorObjectSelectionSession.h
@@ -33,7 +33,7 @@ extern uint32_t _numSelectedObjectsForType[EnumValue(ObjectType::count)];
 bool EditorCheckObjectGroupAtLeastOneSelected(ObjectType checkObjectType);
 bool EditorCheckObjectGroupAtLeastOneOfPeepTypeSelected(uint8_t peepType);
 bool EditorCheckObjectGroupAtLeastOneSurfaceSelected(bool queue);
-void EditorObjectFlagsFree();
+void EditorObjectFlagsClear();
 void UnloadUnselectedObjects();
 void Sub6AB211();
 void ResetSelectedObjectCountAndSize();

--- a/src/openrct2/scenes/game/GameScene.cpp
+++ b/src/openrct2/scenes/game/GameScene.cpp
@@ -35,4 +35,9 @@ void GameScene::Tick()
 void GameScene::Stop()
 {
     Audio::StopAll();
+
+    // Force closure of any object selection windows, regardless of valid state.
+    // NB: this is relevant for both in-game scenes and editors, as the window
+    // may be opened in-game using cheats.
+    ContextForceCloseWindowByClass(WindowClass::EditorObjectSelection);
 }


### PR DESCRIPTION
This PR adds a mechanism to force the object selection window to close when changing scenes, similar to what we already use for the network status and progress windows. This fixes #24044. (No changelog entry necessary, as this concerns a recent regression.)

While investigating the issue, I also renamed `EditorObjectFlagsClear` (was `EditorObjectFlagsFree`), and `VisibleListClear` (was `VisibleListDispose`) to more accurately reflect their functions. No pointers are actually being freed.