### PR TITLE
Clear plugin storage when converting save game for scenario

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Fix: [#21919] Non-recolourable cars still show colour picker.
 - Fix: [#23108] Missing pieces on Hypercoaster and Hyper-Twister, even with the ‘all drawable track pieces’ cheat enabled.
 - Fix: [#24013] Failure to load a scenario preview image (minimap) could lead to an uncaught exception error message.
+- Fix: [#24045] [Plugin] Data storage is not cleared when converting save game to scenario.
 - Fix: [#24121] Checkbox labels run beyond the edge of the window if they’re too long to fit.
 - Fix: [#24142] [Plugin] Track origin is miscalculated on downward slopes.
 - Fix: [#24220] Narrow station platforms have missing sides on certain rotations.

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -22,6 +22,7 @@
 #include <openrct2/audio/Audio.h>
 #include <openrct2/entity/EntityList.h>
 #include <openrct2/management/Research.h>
+#include <openrct2/scripting/ScriptEngine.h>
 #include <openrct2/ui/WindowManager.h>
 #include <openrct2/windows/Intent.h>
 #include <openrct2/world/Park.h>
@@ -262,6 +263,12 @@ namespace OpenRCT2::Ui::Windows
                 GfxInvalidateScreen();
                 return;
             }
+
+#ifdef ENABLE_SCRIPTING
+            // Clear the plugin storage before saving
+            auto& scriptEngine = GetContext()->GetScriptEngine();
+            scriptEngine.ClearParkStorage();
+#endif
 
             auto* windowMgr = Ui::GetWindowManager();
             windowMgr->CloseAll();

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -38,6 +38,7 @@
 #include "object/ObjectRepository.h"
 #include "peep/PeepAnimations.h"
 #include "rct1/RCT1.h"
+#include "scripting/ScriptEngine.h"
 #include "ui/WindowManager.h"
 #include "windows/Intent.h"
 #include "world/Climate.h"
@@ -160,6 +161,12 @@ namespace OpenRCT2::Editor
 
         GameLoadScripts();
         GameNotifyMapChanged();
+
+#ifdef ENABLE_SCRIPTING
+        // Clear the plugin storage before saving
+        auto& scriptEngine = GetContext()->GetScriptEngine();
+        scriptEngine.ClearParkStorage();
+#endif
     }
 
     /**
@@ -279,7 +286,6 @@ namespace OpenRCT2::Editor
 
         RideInitAll();
 
-        //
         for (auto* guest : EntityList<Guest>())
         {
             guest->SetName({});


### PR DESCRIPTION
Closes #24045. Depends on #24090.

@Crazycolbster Could you test this?