### PR TITLE
Fix #23484: Castle station styles are erroneously remappable

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Fix: [#18169] CJK, Arabic and Vietnamese display all text as ‘???’ on Android.
 - Fix: [#18309] Flying and Multi Dimension trains glitch when changing between inverted and uninverted track when uncap fps is on.
 - Fix: [#19506] Queue paths can be placed on level crossings by replacing an existing regular path.
+- Fix: [#23484] Stray coloured pixels on castle-themed stations and Roman-themed entrances/exits (original bug).
 - Fix: [#23486] Object selection minimum requirements can be bypassed with close window hotkey.
 - Fix: [#23743] Parks with guest goals over 32767 do not appear in the scenario list.
 - Fix: [#23844] Sound effects keep playing when loading another save.

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -141,8 +141,7 @@ static void PaintRideEntranceExit(PaintSession& session, uint8_t direction, int3
 
     auto hasGlass = (stationObj->Flags & StationObjectFlags::isTransparent) != 0;
     auto colourPrimary = ride->trackColours[0].main;
-    auto colourSecondary = ride->trackColours[0].additional;
-    auto imageTemplate = ImageId(0, colourPrimary, colourSecondary);
+    auto imageTemplate = ImageId(0);
     ImageId glassImageTemplate;
     if (hasGlass)
     {
@@ -157,6 +156,18 @@ static void PaintRideEntranceExit(PaintSession& session, uint8_t direction, int3
     else if (session.SelectedElement == reinterpret_cast<const TileElement*>(&entranceEl))
     {
         imageTemplate = ImageId().WithRemap(FilterPaletteID::PaletteGhost);
+    }
+    else
+    {
+        if (stationObj->Flags & StationObjectFlags::hasPrimaryColour)
+        {
+            imageTemplate = imageTemplate.WithPrimary(colourPrimary);
+        }
+        if (stationObj->Flags & StationObjectFlags::hasSecondaryColour)
+        {
+            auto colourSecondary = ride->trackColours[0].additional;
+            imageTemplate = imageTemplate.WithSecondary(colourSecondary);
+        }
     }
 
     // Format modified to stop repeated code

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -708,14 +708,22 @@ bool TrackPaintUtilDrawStationCovers2(
         imageOffset += SPR_STATION_COVER_OFFSET_TALL;
     }
 
-    auto imageTemplate = session.TrackColours;
-    auto imageId = imageTemplate.WithIndex(baseImageIndex + imageOffset);
+    auto imageId = session.TrackColours.WithIndex(baseImageIndex + imageOffset);
+    if (!session.TrackColours.IsRemap())
+    {
+        imageId = ImageId(baseImageIndex + imageOffset);
+        if (stationObject->Flags & StationObjectFlags::hasPrimaryColour)
+            imageId = imageId.WithPrimary(session.TrackColours.GetPrimary());
+        if (stationObject->Flags & StationObjectFlags::hasSecondaryColour)
+            imageId = imageId.WithSecondary(session.TrackColours.GetSecondary());
+    }
+
     PaintAddImageAsParent(session, imageId, offset, boundBox);
 
     // Glass
     if (colour == TrackStationColour && (stationObject->Flags & StationObjectFlags::isTransparent))
     {
-        imageId = ImageId(baseImageIndex + imageOffset + 12).WithTransparency(imageTemplate.GetPrimary());
+        imageId = ImageId(baseImageIndex + imageOffset + 12).WithTransparency(session.TrackColours.GetPrimary());
         PaintAddImageAsChild(session, imageId, offset, boundBox);
     }
     return true;


### PR DESCRIPTION
The drawing code always applied two or three remaps to the images. Changed it to actually read the correct number from the object.