### PR TITLE
Fix #24077: Track Designer crashes when clicking the park fence

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -30,6 +30,7 @@
 - Fix: [#23983] Ordering files by size does not work and occasionally crashes the game.
 - Fix: [#24009] [Plugin] The object manager API does not identify recently introduced object types.
 - Fix: [#24028] Giga and LSM Launched Coaster booster sprites have pixels that draw over transparent pixels.
+- Fix: [#24077] Track Designer crashes when clicking the park fence.
 
 0.4.20 (2025-02-25)
 ------------------------------------------------------------------------

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -78,7 +78,7 @@ namespace OpenRCT2::Editor
 
         // Reset loaded objects to just defaults
         // Load minimum required objects (like surface and edge)
-        for (const auto& entry : MinimumRequiredObjects)
+        for (const auto& entry : kMinimumRequiredObjects)
         {
             objectManager.LoadObject(entry);
         }

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -54,8 +54,8 @@ static int32_t _numAvailableObjectsForType[EnumValue(ObjectType::count)];
 static void SetupInUseSelectionFlags();
 static void SetupTrackDesignerObjects();
 static void SetupTrackManagerObjects();
-static void WindowEditorObjectSelectionSelectDefaultObjects();
-static void SelectDesignerObjects();
+static void selectScenarioEditorObjects();
+static void selectTrackDesignerObjects();
 static void ReplaceSelectedWaterPalette(const ObjectRepositoryItem* item);
 
 /**
@@ -105,7 +105,7 @@ static void SetupTrackDesignerObjects()
 {
     int32_t numObjects = static_cast<int32_t>(ObjectRepositoryGetItemsCount());
     const ObjectRepositoryItem* items = ObjectRepositoryGetItems();
-    SelectDesignerObjects();
+    selectTrackDesignerObjects();
     for (int32_t i = 0; i < numObjects; i++)
     {
         uint8_t* selectionFlags = &_objectSelectionFlags[i];
@@ -344,7 +344,7 @@ void Sub6AB211()
         // To prevent it breaking in scenario mode.
         if (gLegacyScene == LegacyScene::scenarioEditor)
         {
-            WindowEditorObjectSelectionSelectDefaultObjects();
+            selectScenarioEditorObjects();
         }
     }
 
@@ -431,11 +431,19 @@ void UnloadUnselectedObjects()
  *
  *  rct2: 0x006AA805
  */
-static void WindowEditorObjectSelectionSelectDefaultObjects()
+static void selectScenarioEditorObjects()
 {
     if (_numSelectedObjectsForType[0] == 0)
     {
-        for (auto defaultSelectedObject : DefaultSelectedObjects)
+        for (auto designerSelectedObject : kCommonScenarioAndTrackDesignerObjects)
+        {
+            WindowEditorObjectSelectionSelectObject(
+                0,
+                INPUT_FLAG_EDITOR_OBJECT_SELECT | INPUT_FLAG_EDITOR_OBJECT_1
+                    | INPUT_FLAG_EDITOR_OBJECT_SELECT_OBJECTS_IN_SCENERY_GROUP,
+                ObjectEntryDescriptor(designerSelectedObject));
+        }
+        for (auto defaultSelectedObject : kDefaultScenarioObjects)
         {
             WindowEditorObjectSelectionSelectObject(
                 0,
@@ -446,11 +454,11 @@ static void WindowEditorObjectSelectionSelectDefaultObjects()
     }
 }
 
-static void SelectDesignerObjects()
+static void selectTrackDesignerObjects()
 {
     if (_numSelectedObjectsForType[0] == 0)
     {
-        for (auto designerSelectedObject : DesignerSelectedObjects)
+        for (auto designerSelectedObject : kCommonScenarioAndTrackDesignerObjects)
         {
             WindowEditorObjectSelectionSelectObject(
                 0,

--- a/src/openrct2/object/DefaultObjects.cpp
+++ b/src/openrct2/object/DefaultObjects.cpp
@@ -121,7 +121,6 @@ constexpr std::array<std::string_view, 82> kCommonScenarioAndTrackDesignerObject
 };
 
 constexpr std::array<std::string_view, 37> kDefaultScenarioObjects = {
-
     "rct2.ride.twist1", // Ride: Twist
     "rct2.ride.ptct1",  // Ride: Wooden Roller Coaster (Wooden Roller Coaster Trains)
     "rct2.ride.zldb",   // Ride: Junior Roller Coaster (Ladybird Trains)

--- a/src/openrct2/object/DefaultObjects.cpp
+++ b/src/openrct2/object/DefaultObjects.cpp
@@ -11,10 +11,14 @@
 
 #include "Object.h"
 
-// clang-format off
-const std::string_view MinimumRequiredObjects[] = { "rct2.terrain_surface.grass", "rct2.terrain_edge.rock" };
+constexpr std::array<std::string_view, 3> kMinimumRequiredObjects = {
+    "rct2.terrain_surface.grass",
+    "rct2.terrain_edge.rock",
 
-const std::string_view DefaultSelectedObjects[] = {
+    "rct2.station.plain",
+};
+
+constexpr std::array<std::string_view, 82> kCommonScenarioAndTrackDesignerObjects = {
     // An initial default selection
     "rct2.scenery_group.scgtrees", // Scenery: Trees
     "rct2.scenery_group.scgshrub", // Scenery: Shrubs and Ornaments
@@ -22,54 +26,12 @@ const std::string_view DefaultSelectedObjects[] = {
     "rct2.scenery_group.scgfence", // Scenery: Fences and Walls
     "rct2.scenery_group.scgwalls", // Scenery: Walls and Roofs
     "rct2.scenery_group.scgpathx", // Scenery: Signs and Items for Footpaths
-    "rct2.ride.twist1",   // Ride: Twist
-    "rct2.ride.ptct1",    // Ride: Wooden Roller Coaster (Wooden Roller Coaster Trains)
-    "rct2.ride.zldb",     // Ride: Junior Roller Coaster (Ladybird Trains)
-    "rct2.ride.lfb1",     // Ride: Log Flume
-    "rct2.ride.vcr",      // Ride: Vintage Cars
-    "rct2.ride.mgr1",     // Ride: Merry-Go-Round
-    "rct2.ride.tlt1",     // Ride: Toilet
-    "rct2.ride.atm1",     // Ride: Cash Machine
-    "rct2.ride.faid1",    // Ride: First Aid Room
-    "rct2.ride.infok",    // Ride: Information Kiosk
-    "rct2.ride.drnks",    // Ride: Drinks Stall
-    "rct2.ride.cndyf",    // Ride: Candyfloss Stall
-    "rct2.ride.burgb",    // Ride: Burger Bar
-    "rct2.ride.balln",    // Ride: Balloon Stall
-    "rct2.ride.arrt1",    // Ride: Corkscrew Roller Coaster
-    "rct2.ride.rboat",    // Ride: Rowing Boats
-    "rct2.park_entrance.pkent1",   // Park Entrance: Traditional Park Entrance
-    "rct2.water.wtrcyan",  // Water: Natural Water
 
-    // The following are for all random map generation features to work out the box
-    "rct2.scenery_group.scgjungl", // Jungle Theming
-    "rct2.scenery_group.scgsnow",  // Snow and Ice Theming
-    "rct2.scenery_group.scgwater", // Water Feature Theming
+    "rct2.park_entrance.pkent1", // Park Entrance: Traditional Park Entrance
 
-    // Surfaces
-    "rct2.terrain_surface.grass",
-    "rct2.terrain_surface.sand",
-    "rct2.terrain_surface.dirt",
-    "rct2.terrain_surface.rock",
-    "rct2.terrain_surface.martian",
-    "rct2.terrain_surface.chequerboard",
-    "rct2.terrain_surface.grass_clumps",
-    "rct2.terrain_surface.ice",
-    "rct2.terrain_surface.grid_red",
-    "rct2.terrain_surface.grid_yellow",
-    "rct2.terrain_surface.grid_purple",
-    "rct2.terrain_surface.grid_green",
-    "rct2.terrain_surface.sand_red",
-    "rct2.terrain_surface.sand_brown",
-
-    // Edges
-    "rct2.terrain_edge.rock",
-    "rct2.terrain_edge.wood_red",
-    "rct2.terrain_edge.wood_black",
-    "rct2.terrain_edge.ice",
+    "rct2.water.wtrcyan", // Water: Natural Water
 
     // Stations
-    "rct2.station.plain",
     "rct2.station.wooden",
     "rct2.station.canvas_tent",
     "rct2.station.castle_grey",
@@ -158,53 +120,47 @@ const std::string_view DefaultSelectedObjects[] = {
     "rct2.climate.warm",
 };
 
-const std::string_view DesignerSelectedObjects[] = {
-    // An initial default selection + all standard footpaths + all standard stations
-    "rct2.scenery_group.scgtrees", // Scenery: Trees
-    "rct2.scenery_group.scgshrub", // Scenery: Shrubs and Ornaments
-    "rct2.scenery_group.scggardn", // Scenery: Gardens
-    "rct2.scenery_group.scgfence", // Scenery: Fences and Walls
-    "rct2.scenery_group.scgwalls", // Scenery: Walls and Roofs
-    "rct2.scenery_group.scgpathx", // Scenery: Signs and Items for Footpaths
-    "rct2.water.wtrcyan",          // Water: Natural Water
-    "rct2.park_entrance.pkent1",   // Park Entrance: Traditional Park Entrance
-    "rct2.terrain_surface.grass",
-    "rct2.terrain_edge.rock",
+constexpr std::array<std::string_view, 37> kDefaultScenarioObjects = {
 
-    // Footpath surfaces
-    "rct2.footpath_surface.tarmac",
-    "rct2.footpath_surface.tarmac_brown",
-    "rct2.footpath_surface.tarmac_red",
-    "rct2.footpath_surface.tarmac_green",
-    "rct2.footpath_surface.dirt",
-    "rct2.footpath_surface.crazy_paving",
-    "rct2.footpath_surface.ash",
-    "rct2.footpath_surface.queue_blue",
-    "rct2.footpath_surface.queue_green",
-    "rct2.footpath_surface.queue_red",
-    "rct2.footpath_surface.queue_yellow",
+    "rct2.ride.twist1", // Ride: Twist
+    "rct2.ride.ptct1",  // Ride: Wooden Roller Coaster (Wooden Roller Coaster Trains)
+    "rct2.ride.zldb",   // Ride: Junior Roller Coaster (Ladybird Trains)
+    "rct2.ride.lfb1",   // Ride: Log Flume
+    "rct2.ride.vcr",    // Ride: Vintage Cars
+    "rct2.ride.mgr1",   // Ride: Merry-Go-Round
+    "rct2.ride.tlt1",   // Ride: Toilet
+    "rct2.ride.atm1",   // Ride: Cash Machine
+    "rct2.ride.faid1",  // Ride: First Aid Room
+    "rct2.ride.infok",  // Ride: Information Kiosk
+    "rct2.ride.drnks",  // Ride: Drinks Stall
+    "rct2.ride.cndyf",  // Ride: Candyfloss Stall
+    "rct2.ride.burgb",  // Ride: Burger Bar
+    "rct2.ride.balln",  // Ride: Balloon Stall
+    "rct2.ride.arrt1",  // Ride: Corkscrew Roller Coaster
+    "rct2.ride.rboat",  // Ride: Rowing Boats
 
-    // Footpath railings
-    "rct2.footpath_railings.bamboo_black",
-    "rct2.footpath_railings.bamboo_brown",
-    "rct2.footpath_railings.concrete",
-    "rct2.footpath_railings.concrete_green",
-    "rct2.footpath_railings.space",
-    "rct2.footpath_railings.wood",
+    // The following are for all random map generation features to work out the box
+    "rct2.scenery_group.scgjungl", // Jungle Theming
+    "rct2.scenery_group.scgsnow",  // Snow and Ice Theming
+    "rct2.scenery_group.scgwater", // Water Feature Theming
 
-    // Stations
-    "rct2.station.plain",
-    "rct2.station.wooden",
-    "rct2.station.canvas_tent",
-    "rct2.station.castle_grey",
-    "rct2.station.castle_brown",
-    "rct2.station.jungle",
-    "rct2.station.log",
-    "rct2.station.classical",
-    "rct2.station.abstract",
-    "rct2.station.snow",
-    "rct2.station.pagoda",
-    "rct2.station.space",
+    // Surfaces
+    "rct2.terrain_surface.sand",
+    "rct2.terrain_surface.dirt",
+    "rct2.terrain_surface.rock",
+    "rct2.terrain_surface.martian",
+    "rct2.terrain_surface.chequerboard",
+    "rct2.terrain_surface.grass_clumps",
+    "rct2.terrain_surface.ice",
+    "rct2.terrain_surface.grid_red",
+    "rct2.terrain_surface.grid_yellow",
+    "rct2.terrain_surface.grid_purple",
+    "rct2.terrain_surface.grid_green",
+    "rct2.terrain_surface.sand_red",
+    "rct2.terrain_surface.sand_brown",
+
+    // Edges
+    "rct2.terrain_edge.wood_red",
+    "rct2.terrain_edge.wood_black",
+    "rct2.terrain_edge.ice",
 };
-
-// clang-format on

--- a/src/openrct2/object/DefaultObjects.h
+++ b/src/openrct2/object/DefaultObjects.h
@@ -11,6 +11,19 @@
 
 #include "Object.h"
 
-extern const std::string_view MinimumRequiredObjects[2];
-extern const std::string_view DefaultSelectedObjects[120];
-extern const std::string_view DesignerSelectedObjects[39];
+#include <array>
+
+/**
+ * Used by all editor modes: Scenario Editor, Track Designer and Track Designs Manager.
+ */
+extern const std::array<std::string_view, 3> kMinimumRequiredObjects;
+
+/**
+ * Used by the Scenario Editor and Track Designer.
+ */
+extern const std::array<std::string_view, 82> kCommonScenarioAndTrackDesignerObjects;
+
+/**
+ * Used only by the Scenario Editor.
+ */
+extern const std::array<std::string_view, 37> kDefaultScenarioObjects;


### PR DESCRIPTION
This fixes the issue by having the Track Designer and Scenario Editor share a list of objects (with the Scenario Editor adding a few of its own on top).

When testing, also noticed another bug in the Track Designs Manager, but that’s something for another PR.