### PR TITLE
Load scripts in the scenario editor and track designer

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.22 (in development)
 ------------------------------------------------------------------------
 - Change: [#23803] Lightning strikes and thunder happen at the same frequency independently of the game speed.
+- Change: [#24069] [Plugin] Plugins are now available in the scenario editor and track designer.
 - Change: [#24135] Compress Emscripten js/wasm files.
 - Fix: [#21919] Non-recolourable cars still show colour picker.
 - Fix: [#23108] Missing pieces on Hypercoaster and Hyper-Twister, even with the ‘all drawable track pieces’ cheat enabled.

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -269,7 +269,18 @@ namespace OpenRCT2::Ui::Windows
             intent.PutEnumExtra<LoadSaveAction>(INTENT_EXTRA_LOADSAVE_ACTION, LoadSaveAction::save);
             intent.PutEnumExtra<LoadSaveType>(INTENT_EXTRA_LOADSAVE_TYPE, LoadSaveType::scenario);
             intent.PutExtra(INTENT_EXTRA_PATH, gameState.scenarioName);
+            intent.PutExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<CloseCallback>(SaveScenarioCallback));
             ContextOpenIntent(&intent);
+        }
+
+        static void SaveScenarioCallback(ModalResult result, const utf8* path)
+        {
+            if (result != ModalResult::ok)
+            {
+                return;
+            }
+
+            GameUnloadScripts();
         }
 
         void HidePreviousStepButton()

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -116,6 +116,9 @@ namespace OpenRCT2::Editor
         LoadPalette();
         gScreenAge = 0;
         gameState.scenarioName = LanguageGetString(STR_MY_NEW_SCENARIO);
+
+        GameLoadScripts();
+        GameNotifyMapChanged();
     }
 
     /**
@@ -154,6 +157,9 @@ namespace OpenRCT2::Editor
         OpenEditorWindows();
         FinaliseMainView();
         gScreenAge = 0;
+
+        GameLoadScripts();
+        GameNotifyMapChanged();
     }
 
     /**
@@ -179,6 +185,9 @@ namespace OpenRCT2::Editor
         WindowBase* mainWindow = OpenEditorWindows();
         mainWindow->SetLocation(TileCoordsXYZ{ 75, 75, 14 }.ToCoordsXYZ());
         LoadPalette();
+
+        GameLoadScripts();
+        GameNotifyMapChanged();
     }
 
     /**
@@ -204,6 +213,9 @@ namespace OpenRCT2::Editor
         WindowBase* mainWindow = OpenEditorWindows();
         mainWindow->SetLocation(TileCoordsXYZ{ 75, 75, 14 }.ToCoordsXYZ());
         LoadPalette();
+
+        GameLoadScripts();
+        GameNotifyMapChanged();
     }
 
     /**
@@ -238,6 +250,9 @@ namespace OpenRCT2::Editor
         ViewportInitAll();
         OpenEditorWindows();
         FinaliseMainView();
+
+        GameLoadScripts();
+        GameNotifyMapChanged();
     }
 
     bool LoadLandscape(const utf8* path)


### PR DESCRIPTION
This PR makes plugins available in the scenario editor and track designer. It seems overdue to enable them — plugins like the scenery manager and world painter make great additions to the scenario editor, too.