### PR TITLE
Exempt frozen peeps from being removed

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Change: [#23936] The ‘guests prefer less/more intense rides’ settings have been turned into a dropdown.
 - Change: [#24067] [Plugin] Registered menu items are now listed alphabetically.
 - Change: [#24070] Footpath selection menus now show object names on hover using a tooltip.
+- Change: [#24101] Frozen peeps are no longer removed when using the 'remove all guests' cheat.
 - Fix: [#4225] Ride Construction window offers non-existent banked sloped to level curve (original bug).
 - Fix: [#5281] Missing supports on miniature railways built backwards.
 - Fix: [#10379] Banners outside the park can be renamed and modified (original bug).

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -761,6 +761,11 @@ void CheatSetAction::RemoveAllGuests() const
     // will be fetched on a deleted guest.
     for (auto guest : EntityList<Guest>())
     {
+        // Frozen peeps are usually placed and tweaked for artistic purposes,
+        // so exempt them from being removed.
+        if (guest->PeepFlags & PEEP_FLAGS_POSITION_FROZEN)
+            continue;
+
         guest->Remove();
     }
 

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -49,7 +49,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kNetworkStreamVersion = 1;
+constexpr uint8_t kNetworkStreamVersion = 2;
 
 const std::string kNetworkStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kNetworkStreamVersion);
 


### PR DESCRIPTION
Plugins like @Manticore-007's Peep Editor can 'freeze' guests in place for artistic purposes. This PR exempts such guests from removal through the 'remove all guests' cheat.