### PR TITLE
Purge leftover references to SetClimate game command

### DIFF
--- a/src/openrct2/Game.h
+++ b/src/openrct2/Game.h
@@ -95,7 +95,6 @@ enum class GameCommand : int32_t
     ModifyTile,
     EditScenarioOptions,
     PlacePeepSpawn,
-    SetClimate,
     SetColourScheme,
     SetStaffCostume,
     PlaceFootpathAddition,

--- a/src/openrct2/network/NetworkAction.cpp
+++ b/src/openrct2/network/NetworkAction.cpp
@@ -262,7 +262,6 @@ const std::array<NetworkAction, static_cast<size_t>(NetworkPermission::Count)> N
         "PERMISSION_EDIT_SCENARIO_OPTIONS",
         {
             GameCommand::EditScenarioOptions,
-            GameCommand::SetClimate,
         },
     },
 };

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -49,7 +49,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kNetworkStreamVersion = 0;
+constexpr uint8_t kNetworkStreamVersion = 1;
 
 const std::string kNetworkStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kNetworkStreamVersion);
 

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -1358,7 +1358,6 @@ const static EnumMap<GameCommand> ActionNameToType = {
     { "bannersetname", GameCommand::SetBannerName },
     { "bannersetstyle", GameCommand::SetBannerStyle },
     { "clearscenery", GameCommand::ClearScenery },
-    { "climateset", GameCommand::SetClimate },
     { "footpathplace", GameCommand::PlacePath },
     { "footpathlayoutplace", GameCommand::PlacePathLayout },
     { "footpathremove", GameCommand::RemovePath },


### PR DESCRIPTION
These came up in #24073. ~~Likely explains why I didn't have to re-record replays when I removed the SetClimate action in #23774.~~ Let's see what CI does... 😅