### PR TITLE
Prevent unpacking objects when loading a save file preview

### DIFF
--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -316,7 +316,7 @@ namespace OpenRCT2::Title
                     ReportProgress(0);
                     auto parkImporter = ParkImporter::Create(path);
 
-                    auto result = parkImporter->Load(path);
+                    auto result = parkImporter->Load(path, false);
                     ReportProgress(10);
 
                     auto& objectManager = GetContext()->GetObjectManager();

--- a/src/openrct2/ParkImporter.h
+++ b/src/openrct2/ParkImporter.h
@@ -50,7 +50,7 @@ struct IParkImporter
 public:
     virtual ~IParkImporter() = default;
 
-    virtual ParkLoadResult Load(const u8string& path) = 0;
+    virtual ParkLoadResult Load(const u8string& path, bool skipObjectCheck = false) = 0;
     virtual ParkLoadResult LoadSavedGame(const u8string& path, bool skipObjectCheck = false) = 0;
     virtual ParkLoadResult LoadScenario(const u8string& path, bool skipObjectCheck = false) = 0;
     virtual ParkLoadResult LoadFromStream(

--- a/src/openrct2/ParkImporter.h
+++ b/src/openrct2/ParkImporter.h
@@ -50,7 +50,7 @@ struct IParkImporter
 public:
     virtual ~IParkImporter() = default;
 
-    virtual ParkLoadResult Load(const u8string& path, bool skipObjectCheck = false) = 0;
+    virtual ParkLoadResult Load(const u8string& path, bool skipObjectCheck) = 0;
     virtual ParkLoadResult LoadSavedGame(const u8string& path, bool skipObjectCheck = false) = 0;
     virtual ParkLoadResult LoadScenario(const u8string& path, bool skipObjectCheck = false) = 0;
     virtual ParkLoadResult LoadFromStream(

--- a/src/openrct2/command_line/ConvertCommand.cpp
+++ b/src/openrct2/command_line/ConvertCommand.cpp
@@ -97,7 +97,7 @@ exitcode_t CommandLine::HandleCommandConvert(CommandLineArgEnumerator* enumerato
     try
     {
         auto importer = ParkImporter::Create(sourcePath);
-        auto loadResult = importer->Load(sourcePath.c_str());
+        auto loadResult = importer->Load(sourcePath.c_str(), false);
 
         objManager.LoadObjects(loadResult.RequiredObjects);
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -145,16 +145,16 @@ namespace OpenRCT2::RCT1
         IScenarioRepository* _scenarioRepository = GetScenarioRepository();
 
     public:
-        ParkLoadResult Load(const u8string& path) override
+        ParkLoadResult Load(const u8string& path, const bool skipObjectCheck) override
         {
             const auto extension = Path::GetExtension(path);
             if (String::iequals(extension, ".sc4"))
             {
-                return LoadScenario(path);
+                return LoadScenario(path, skipObjectCheck);
             }
             if (String::iequals(extension, ".sv4"))
             {
-                return LoadSavedGame(path);
+                return LoadSavedGame(path, skipObjectCheck);
             }
 
             throw std::runtime_error("Invalid RCT1 park extension.");


### PR DESCRIPTION
This prevents objects from being unpacked when loading a save file to view a preview of it.

I've reused the skipObjectCheck parameter because it currently does nothing, and the preview loader is the only one that sets it to true, so it's a smaller change to make. Maybe this is what it was supposed to be doing anyway?