### PR TITLE
Fix #22961: Clicking on the construction preview places duplicate flat rides and stalls

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -18,6 +18,7 @@
 - Fix: [#18309] Flying and Multi Dimension trains glitch when changing between inverted and uninverted track when uncap fps is on.
 - Fix: [#19506] Queue paths can be placed on level crossings by replacing an existing regular path.
 - Fix: [#21908] Ride mode warnings when hovering track designs.
+- Fix: [#22961] Clicking on the construction preview places duplicate flat rides and stalls.
 - Fix: [#23443] New GOG version of RCT2 is not extracted correctly.
 - Fix: [#23484] Stray coloured pixels on castle-themed stations and Roman-themed entrances/exits (original bug).
 - Fix: [#23486] Object selection minimum requirements can be bypassed with close window hotkey.

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -345,6 +345,11 @@ namespace OpenRCT2::Ui::Windows
 
             uint64_t disabledWidgets = 0;
 
+            if (_rideConstructionState == RideConstructionState::Place)
+            {
+                disabledWidgets |= (1uLL << WIDX_CONSTRUCT);
+            }
+
             if (_currentlySelectedTrack.isTrackType)
             {
                 disabledWidgets |= (1uLL << WIDX_SLOPE_GROUPBOX) | (1uLL << WIDX_BANKING_GROUPBOX)


### PR DESCRIPTION
Fixes #22961

Disabling the construct preview button for flat rides and stalls was accidentally removed in da89a4e41399def616594d00928d1363e1346420.

https://github.com/OpenRCT2/OpenRCT2/commit/da89a4e41399def616594d00928d1363e1346420#diff-ab29fc4bd54886f0537c8272e7b4bbc76a8385184b66405de54831092b66e034L422-L425