### PR TITLE
Fix #21919: Non-recolourable cars still show colour picker 

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.22 (in development)
 ------------------------------------------------------------------------
 - Change: [#23803] Lightning strikes and thunder happen at the same frequency independently of the game speed.
+- Fix: [#21919] Non-recolourable cars still show colour picker.
 - Fix: [#23108] Missing pieces on Hypercoaster and Hyper-Twister, even with the ‘all drawable track pieces’ cheat enabled.
 
 0.4.21 (2025-04-05)

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4253,20 +4253,21 @@ namespace OpenRCT2::Ui::Windows
                     if (rideEntry == nullptr)
                         return;
 
+                    bool allowChangingBodyColour = false;
                     bool allowChangingTrimColour = false;
                     bool allowChangingTertiaryColour = false;
                     for (int32_t i = 0; i < ride->numCarsPerTrain; i++)
                     {
                         uint8_t vehicleTypeIndex = RideEntryGetVehicleAtPosition(ride->subtype, ride->numCarsPerTrain, i);
 
+                        if (rideEntry->Cars[vehicleTypeIndex].flags & CAR_ENTRY_FLAG_ENABLE_BODY_COLOUR)
+                            allowChangingBodyColour = true;
+
                         if (rideEntry->Cars[vehicleTypeIndex].flags & CAR_ENTRY_FLAG_ENABLE_TRIM_COLOUR)
-                        {
                             allowChangingTrimColour = true;
-                        }
+
                         if (rideEntry->Cars[vehicleTypeIndex].flags & CAR_ENTRY_FLAG_ENABLE_TERTIARY_COLOUR)
-                        {
                             allowChangingTertiaryColour = true;
-                        }
                     }
 
                     int32_t numItems = ride->numTrains;
@@ -4275,23 +4276,28 @@ namespace OpenRCT2::Ui::Windows
 
                     for (auto i = 0; i < numItems; i++)
                     {
-                        colour_t colour = UtilRand() % kColourNumNormal;
-                        auto vehicleSetBodyColourAction = RideSetAppearanceAction(
-                            rideId, RideSetAppearanceType::VehicleColourBody, colour, i);
-                        GameActions::Execute(&vehicleSetBodyColourAction);
+                        if (allowChangingBodyColour)
+                        {
+                            colour_t colour = UtilRand() % kColourNumNormal;
+                            auto vehicleSetBodyColourAction = RideSetAppearanceAction(
+                                rideId, RideSetAppearanceType::VehicleColourBody, colour, i);
+                            GameActions::Execute(&vehicleSetBodyColourAction);
+                        }
+
                         if (allowChangingTrimColour)
                         {
-                            colour = UtilRand() % kColourNumNormal;
+                            colour_t colour = UtilRand() % kColourNumNormal;
                             auto vehicleSetTrimColourAction = RideSetAppearanceAction(
                                 rideId, RideSetAppearanceType::VehicleColourTrim, colour, i);
                             GameActions::Execute(&vehicleSetTrimColourAction);
-                            if (allowChangingTertiaryColour)
-                            {
-                                colour = UtilRand() % kColourNumNormal;
-                                auto vehicleSetTertiaryColourAction = RideSetAppearanceAction(
-                                    rideId, RideSetAppearanceType::VehicleColourTertiary, colour, i);
-                                GameActions::Execute(&vehicleSetTertiaryColourAction);
-                            }
+                        }
+
+                        if (allowChangingTertiaryColour)
+                        {
+                            colour_t colour = UtilRand() % kColourNumNormal;
+                            auto vehicleSetTertiaryColourAction = RideSetAppearanceAction(
+                                rideId, RideSetAppearanceType::VehicleColourTertiary, colour, i);
+                            GameActions::Execute(&vehicleSetTertiaryColourAction);
                         }
                     }
                     break;
@@ -4722,6 +4728,7 @@ namespace OpenRCT2::Ui::Windows
                 widgets[WIDX_VEHICLE_BODY_COLOUR].type = WindowWidgetType::ColourBtn;
                 widgets[WIDX_VEHICLE_BODY_COLOUR].image = GetColourButtonImage(vehicleColour.Body);
 
+                bool allowChangingBodyColour = false;
                 bool allowChangingTrimColour = false;
                 bool allowChangingTertiaryColour = false;
 
@@ -4729,35 +4736,34 @@ namespace OpenRCT2::Ui::Windows
                 {
                     uint8_t vehicleTypeIndex = RideEntryGetVehicleAtPosition(ride->subtype, ride->numCarsPerTrain, i);
 
+                    if (rideEntry->Cars[vehicleTypeIndex].flags & CAR_ENTRY_FLAG_ENABLE_BODY_COLOUR)
+                        allowChangingBodyColour = true;
+
                     if (rideEntry->Cars[vehicleTypeIndex].flags & CAR_ENTRY_FLAG_ENABLE_TRIM_COLOUR)
-                    {
                         allowChangingTrimColour = true;
-                    }
+
                     if (rideEntry->Cars[vehicleTypeIndex].flags & CAR_ENTRY_FLAG_ENABLE_TERTIARY_COLOUR)
-                    {
                         allowChangingTertiaryColour = true;
-                    }
                 }
 
-                // Additional colours
+                widgets[WIDX_VEHICLE_BODY_COLOUR].type = WindowWidgetType::Empty;
+                widgets[WIDX_VEHICLE_TRIM_COLOUR].type = WindowWidgetType::Empty;
+                widgets[WIDX_VEHICLE_TERTIARY_COLOUR].type = WindowWidgetType::Empty;
+
+                if (allowChangingBodyColour)
+                {
+                    widgets[WIDX_VEHICLE_BODY_COLOUR].type = WindowWidgetType::ColourBtn;
+                    widgets[WIDX_VEHICLE_BODY_COLOUR].image = GetColourButtonImage(vehicleColour.Body);
+                }
                 if (allowChangingTrimColour)
                 {
                     widgets[WIDX_VEHICLE_TRIM_COLOUR].type = WindowWidgetType::ColourBtn;
                     widgets[WIDX_VEHICLE_TRIM_COLOUR].image = GetColourButtonImage(vehicleColour.Trim);
-                    if (allowChangingTertiaryColour)
-                    {
-                        widgets[WIDX_VEHICLE_TERTIARY_COLOUR].type = WindowWidgetType::ColourBtn;
-                        widgets[WIDX_VEHICLE_TERTIARY_COLOUR].image = GetColourButtonImage(vehicleColour.Tertiary);
-                    }
-                    else
-                    {
-                        widgets[WIDX_VEHICLE_TERTIARY_COLOUR].type = WindowWidgetType::Empty;
-                    }
                 }
-                else
+                if (allowChangingTertiaryColour)
                 {
-                    widgets[WIDX_VEHICLE_TRIM_COLOUR].type = WindowWidgetType::Empty;
-                    widgets[WIDX_VEHICLE_TERTIARY_COLOUR].type = WindowWidgetType::Empty;
+                    widgets[WIDX_VEHICLE_TERTIARY_COLOUR].type = WindowWidgetType::ColourBtn;
+                    widgets[WIDX_VEHICLE_TERTIARY_COLOUR].image = GetColourButtonImage(vehicleColour.Tertiary);
                 }
 
                 // Vehicle colour scheme type

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -408,6 +408,8 @@ void RideObject::ReadLegacyCar([[maybe_unused]] IReadObjectContext* context, ISt
     car->sprite_height_positive = stream->ReadValue<uint8_t>();
     auto legacyAnimation = stream->ReadValue<uint8_t>();
     car->flags = stream->ReadValue<uint32_t>();
+    // Implied in vanilla, but can be turned off in OpenRCT2.
+    car->flags |= CAR_ENTRY_FLAG_ENABLE_BODY_COLOUR;
     car->base_num_frames = stream->ReadValue<uint16_t>();
     stream->Seek(15 * 4, STREAM_SEEK_CURRENT);
     car->no_seating_rows = stream->ReadValue<uint8_t>();
@@ -833,6 +835,8 @@ CarEntry RideObject::ReadJsonCar([[maybe_unused]] IReadObjectContext* context, j
             // Obsolete flag, only used on Boat Hire. Remaining usages have not yet been updated as of 2022-07-11.
             { "VEHICLE_ENTRY_FLAG_11", CAR_ENTRY_FLAG_USE_16_ROTATION_FRAMES },
         });
+    if (Json::GetBoolean(jCar["hasBaseColour"], true))
+        car.flags |= CAR_ENTRY_FLAG_ENABLE_BODY_COLOUR;
 
     // legacy sprite groups
     auto jFrames = jCar["frames"];

--- a/src/openrct2/ride/CarEntry.h
+++ b/src/openrct2/ride/CarEntry.h
@@ -36,7 +36,7 @@ enum class CarEntryAnimation : uint8_t
     Count,
 };
 
-enum : uint32_t
+enum : uint64_t
 {
     CAR_ENTRY_FLAG_POWERED_RIDE_UNRESTRICTED_GRAVITY = 1
         << 0, // Set on powered vehicles that do not slow down when going down a hill.
@@ -84,6 +84,7 @@ enum : uint32_t
     CAR_ENTRY_FLAG_WATER_RIDE = 1 << 29, // Set on rides where water would provide continuous propulsion.
     CAR_ENTRY_FLAG_GO_KART = 1 << 30,
     CAR_ENTRY_FLAG_DODGEM_CAR_PLACEMENT = 1u << 31,
+    CAR_ENTRY_FLAG_ENABLE_BODY_COLOUR = 1uLL << 32,
 };
 
 enum : uint32_t
@@ -202,7 +203,7 @@ struct CarEntry
     uint8_t sprite_height_negative;
     uint8_t sprite_height_positive;
     CarEntryAnimation animation;
-    uint32_t flags;
+    uint64_t flags;
     uint16_t base_num_frames; // The number of sprites of animation or swinging per rotation frame
     uint32_t base_image_id;
     VehicleSpriteGroup SpriteGroups[EnumValue(SpriteGroupType::Count)];


### PR DESCRIPTION
Dependent on the v1.6.1 objects release, which will be pulled in in another PR.