### PR TITLE
Rename WindowResize to WindowResizeByDelta

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -522,7 +522,7 @@ namespace OpenRCT2
             int32_t targetWidth = _originalWindowWidth + differentialCoords.x - w.width;
             int32_t targetHeight = _originalWindowHeight + differentialCoords.y - w.height;
 
-            WindowResize(w, targetWidth, targetHeight);
+            WindowResizeByDelta(w, targetWidth, targetHeight);
         }
     }
 

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -678,7 +678,7 @@ namespace OpenRCT2::Ui::Windows
         return _currentTextBox;
     }
 
-    void WindowResize(WindowBase& w, int16_t dw, int16_t dh)
+    void WindowResizeByDelta(WindowBase& w, int16_t dw, int16_t dh)
     {
         if (dw == 0 && dh == 0)
             return;

--- a/src/openrct2-ui/interface/Window.h
+++ b/src/openrct2-ui/interface/Window.h
@@ -71,7 +71,7 @@ namespace OpenRCT2::Ui::Windows
     bool TextBoxCaretIsFlashed();
     const WidgetIdentifier& GetCurrentTextBox();
 
-    void WindowResize(WindowBase& w, int16_t dw, int16_t dh);
+    void WindowResizeByDelta(WindowBase& w, int16_t dw, int16_t dh);
     void WindowInitScrollWidgets(WindowBase& w);
     void WindowUpdateScrollWidgets(WindowBase& w);
 

--- a/src/openrct2-ui/scripting/ScWindow.hpp
+++ b/src/openrct2-ui/scripting/ScWindow.hpp
@@ -99,7 +99,7 @@ namespace OpenRCT2::Scripting
             {
                 if (WindowCanResize(*w))
                 {
-                    WindowResize(*w, value - w->width, 0);
+                    WindowResizeByDelta(*w, value - w->width, 0);
                 }
                 else
                 {
@@ -123,7 +123,7 @@ namespace OpenRCT2::Scripting
             {
                 if (WindowCanResize(*w))
                 {
-                    WindowResize(*w, 0, value - w->height);
+                    WindowResizeByDelta(*w, 0, value - w->height);
                 }
                 else
                 {


### PR DESCRIPTION
This renames the internal function `WindowResize` to `WindowResizeByDelta` to make clear that its parameters are _mouse_ resize deltas rather than new window dimensions.

(Yes, this bit me in #23590.)