### PR TITLE
Build G2.dat when building the Windows exe under VS

### DIFF
--- a/openrct2.proj
+++ b/openrct2.proj
@@ -27,7 +27,6 @@
     <TargetDir>$(RootDir)bin\</TargetDir>
 
     <OutputExe>$(TargetDir)openrct2.exe</OutputExe>
-    <g2Output>$(TargetDir)data\g2.dat</g2Output>
 
     <!-- Set openrct2.sln properties -->
     <SlnProperties>$(SlnProperties);Platform=$(Platform)</SlnProperties>
@@ -55,9 +54,6 @@
     <ReplaysSha1>637E73F20C03DCD52ACA36FAEE15DADB31797FE0</ReplaysSha1>
   </PropertyGroup>
 
-  <ItemGroup>
-    <g2Inputs Include="$(RootDir)resources\g2\*" />
-  </ItemGroup>
 
   <Target Name="DownloadLibs">
     <!-- libs -->
@@ -107,14 +103,8 @@
     <MSBuild Projects="openrct2.sln" Targets="Rebuild" Properties="$(SlnProperties)" />
   </Target>
 
-  <!-- Target to build g2.dat containing OpenRCT2 sprites -->
-  <!-- Only Arm64 machines will build g2.dat for Arm64 -->
-  <!-- Note: Arm64 machines can build for x86, x64 and Arm64 -->
-  <Target Name="g2" AfterTargets="Build" Inputs="@(g2Inputs)" Outputs="$(g2Output)"
-          Condition="'$(TestConfig)'!='true' and ('$(Platform)'!='ARM64' or '$(PROCESSOR_ARCHITECTURE)'=='ARM64')">
-    <Message Text="Building g2.dat..." Importance="high" />
-    <Exec Command="&quot;$(OutputExe)&quot; sprite build &quot;$(g2Output)&quot; &quot;$(RootDir)resources\g2\sprites.json&quot;"
-          StandardOutputImportance="normal" />
+  <Target Name="g2">
+    <MSBuild Projects="src\openrct2-win\openrct2-win.vcxproj" Targets="g2" />
   </Target>
 
   <!-- Target to download the title sequences -->

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -104,7 +104,7 @@
   </Target>
 
   <Target Name="g2">
-    <MSBuild Projects="src\openrct2-win\openrct2-win.vcxproj" Targets="g2" />
+    <MSBuild Projects="src\openrct2-cli\openrct2-cli.vcxproj" Targets="g2" />
   </Target>
 
   <!-- Target to download the title sequences -->

--- a/src/openrct2-cli/openrct2-cli.vcxproj
+++ b/src/openrct2-cli/openrct2-cli.vcxproj
@@ -75,5 +75,25 @@
   <ItemGroup>
     <ClCompile Include="Cli.cpp" />
   </ItemGroup>
+  
+  <ItemGroup Label="G2 Build Items">
+    <g2Inputs Include="$(SolutionDir)resources\g2\*" />
+  </ItemGroup>
+  <PropertyGroup Label="G2 Build Properties">
+    <g2Output>$(SolutionDir)data\g2.dat</g2Output>
+  </PropertyGroup>
+  <!-- Target to build g2.dat containing OpenRCT2 sprites -->
+  <!-- Only Arm64 machines will build g2.dat for Arm64 -->
+  <!-- Note: Arm64 machines can build for x86, x64 and Arm64 -->
+  <Target Name="g2" AfterTargets="Build" Inputs="@(g2Inputs)" Outputs="$(g2Output)"
+          Condition="'$(TestConfig)'!='true' and ('$(Platform)'!='ARM64' or '$(PROCESSOR_ARCHITECTURE)'=='ARM64')">
+    <Message Text="Building g2.dat..." Importance="high" />
+    <Exec Command="&quot;$(OutDir)$(TargetName)$(TargetExt)&quot; sprite build &quot;$(g2Output)&quot; &quot;$(SolutionDir)resources\g2\sprites.json&quot;"
+          StandardOutputImportance="normal" />
+  </Target>
+  <Target Name="clean-g2" AfterTargets="Clean">
+    <Delete Files="$(g2Output)" />
+  </Target>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/src/openrct2-win/openrct2-win.vcxproj
+++ b/src/openrct2-win/openrct2-win.vcxproj
@@ -78,25 +78,5 @@
   <ItemGroup>
     <Manifest Include="openrct2-win.manifest" />
   </ItemGroup>
-  
-  <ItemGroup Label="G2 Build Items">
-    <g2Inputs Include="$(SolutionDir)resources\g2\*" />
-  </ItemGroup>
-  <PropertyGroup Label="G2 Build Properties">
-    <g2Output>$(SolutionDir)data\g2.dat</g2Output>
-  </PropertyGroup>
-  <!-- Target to build g2.dat containing OpenRCT2 sprites -->
-  <!-- Only Arm64 machines will build g2.dat for Arm64 -->
-  <!-- Note: Arm64 machines can build for x86, x64 and Arm64 -->
-  <Target Name="g2" AfterTargets="Build" Inputs="@(g2Inputs)" Outputs="$(g2Output)"
-          Condition="'$(TestConfig)'!='true' and ('$(Platform)'!='ARM64' or '$(PROCESSOR_ARCHITECTURE)'=='ARM64')">
-    <Message Text="Building g2.dat..." Importance="high" />
-    <Exec Command="&quot;$(OutDir)$(TargetName)$(TargetExt)&quot; sprite build &quot;$(g2Output)&quot; &quot;$(SolutionDir)resources\g2\sprites.json&quot;"
-          StandardOutputImportance="normal" />
-  </Target>
-  <Target Name="clean-g2" AfterTargets="Clean">
-    <Delete Files="$(g2Output)" />
-  </Target>
-
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/src/openrct2-win/openrct2-win.vcxproj
+++ b/src/openrct2-win/openrct2-win.vcxproj
@@ -78,5 +78,25 @@
   <ItemGroup>
     <Manifest Include="openrct2-win.manifest" />
   </ItemGroup>
+  
+  <ItemGroup Label="G2 Build Items">
+    <g2Inputs Include="$(SolutionDir)resources\g2\*" />
+  </ItemGroup>
+  <PropertyGroup Label="G2 Build Properties">
+    <g2Output>$(SolutionDir)data\g2.dat</g2Output>
+  </PropertyGroup>
+  <!-- Target to build g2.dat containing OpenRCT2 sprites -->
+  <!-- Only Arm64 machines will build g2.dat for Arm64 -->
+  <!-- Note: Arm64 machines can build for x86, x64 and Arm64 -->
+  <Target Name="g2" AfterTargets="Build" Inputs="@(g2Inputs)" Outputs="$(g2Output)"
+          Condition="'$(TestConfig)'!='true' and ('$(Platform)'!='ARM64' or '$(PROCESSOR_ARCHITECTURE)'=='ARM64')">
+    <Message Text="Building g2.dat..." Importance="high" />
+    <Exec Command="&quot;$(OutDir)$(TargetName)$(TargetExt)&quot; sprite build &quot;$(g2Output)&quot; &quot;$(SolutionDir)resources\g2\sprites.json&quot;"
+          StandardOutputImportance="normal" />
+  </Target>
+  <Target Name="clean-g2" AfterTargets="Clean">
+    <Delete Files="$(g2Output)" />
+  </Target>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>


### PR DESCRIPTION
By moving the target into the .vcxproj and adjusting some values we will run the g2 step as part of every build of the vcxproj. This moves the building of the g2.dat to before the tests. In the VS IDE where this never ran it will now run when the exe is built/rebuilt. The g2 step will not always run in the VS IDE because the IDE's up-to-date check will not consider the input or output as part of the build. Fixing that requires further work either by using tlog files or breaking this all out to a new proj file in the sln.

Part of #24153.