### PR TITLE
Fix #24151: Use high precision and clamp textured coordinates

### DIFF
--- a/data/shaders/applytransparency.frag
+++ b/data/shaders/applytransparency.frag
@@ -34,11 +34,13 @@ void main()
         }
         else
         {
-            oColour = texture(uBlendPaletteTex, vec2(opaque, blendColour) / 256.f).r;
+            vec2 blendUV = clamp(vec2(float(opaque), float(blendColour)) / 256.0, 0.0, 1.0);
+            oColour = texture(uBlendPaletteTex, blendUV).r;
         }
     }
     else
     {
-        oColour = texture(uPaletteTex, vec2(opaque, transparent) / 256.f).r;
+        vec2 paletteUV = clamp(vec2(float(opaque), float(transparent)) / 256.0, 0.0, 1.0);
+        oColour = texture(uPaletteTex, paletteUV).r;
     }
 }

--- a/data/shaders/drawline.vert
+++ b/data/shaders/drawline.vert
@@ -17,12 +17,16 @@ flat out uint fColour;
 
 void main()
 {
-    vec2 pos = vVertMat * vec4(vBounds);
+    // Explicitly cast ivec4 to vec4 for position computation
+    vec2 pos = vVertMat * vec4(float(vBounds.x), float(vBounds.y), float(vBounds.z), float(vBounds.w));
 
-    // Transform screen coordinates to viewport coordinates
-    pos = (pos * (2.0 / vec2(uScreenSize))) - 1.0;
+    // Explicitly cast ivec2 to vec2 for screen size
+    vec2 screenSizeFloat = vec2(float(uScreenSize.x), float(uScreenSize.y));
+    pos = (pos * (2.0 / screenSizeFloat)) - 1.0;
     pos.y *= -1.0;
+
     float depth = 1.0 - (float(vDepth) + 1.0) * DEPTH_INCREMENT;
+    depth = clamp(depth, 0.0, 1.0);
 
     fColour = vColour;
 

--- a/data/shaders/drawrect.frag
+++ b/data/shaders/drawrect.frag
@@ -41,13 +41,13 @@ void main()
         }
     }
 
-    vec2 position = (gl_FragCoord.xy - fPosition) * fZoom;
+    highp vec2 position = (gl_FragCoord.xy - fPosition) * fZoom;
 
     uint texel;
     if ((fFlags & FLAG_NO_TEXTURE) == 0)
     {
-        float colourU = (fTexColour.x + position.x) / fTexColour.z;
-        float colourV = (fTexColour.y + position.y) / fTexColour.w;
+        highp float colourU = (fTexColour.x + position.x) / fTexColour.z;
+        highp float colourV = (fTexColour.y + position.y) / fTexColour.w;
         texel = texture(uTexture, vec3(colourU, colourV, fTexColourAtlas)).r;
         if (texel == 0u)
         {
@@ -111,8 +111,8 @@ void main()
 
     if ((fFlags & FLAG_MASK) != 0)
     {
-        float maskU = (fTexMask.x + position.x) / fTexMask.z;
-        float maskV = (fTexMask.y + position.y) / fTexMask.w;
+        highp float maskU = (fTexMask.x + position.x) / fTexMask.z;
+        highp float maskV = (fTexMask.y + position.y) / fTexMask.w;
         uint mask = texture(uTexture, vec3(maskU, maskV, fTexMaskAtlas)).r;
         if (mask == 0u)
         {

--- a/data/shaders/drawrect.vert
+++ b/data/shaders/drawrect.vert
@@ -36,26 +36,32 @@ flat out int   fTexMaskAtlas;
 void main()
 {
     // Clamp position by vClip, correcting interpolated values for the clipping
+    vec2 boundsDiff = vec2(float(vBounds.z - vBounds.x), float(vBounds.w - vBounds.y));
+    // Avoid division by zero with a small epsilon
+    boundsDiff = max(boundsDiff, vec2(0.0001));
     vec2 m = clamp(
-        ((vVertMat * vec4(vClip)) - (vVertMat * vec4(vBounds))) / vec2(vBounds.zw - vBounds.xy) + vVertVec, 0.0, 1.0);
-    vec2 pos = mix(vec2(vBounds.xy), vec2(vBounds.zw), m);
+        ((vVertMat * vec4(float(vClip.x), float(vClip.y), float(vClip.z), float(vClip.w))) -
+         (vVertMat * vec4(float(vBounds.x), float(vBounds.y), float(vBounds.z), float(vBounds.w)))) /
+                boundsDiff + vVertVec,
+        0.0, 1.0);
+    vec2 pos = mix(vec2(float(vBounds.x), float(vBounds.y)), vec2(float(vBounds.z), float(vBounds.w)), m);
+
     fTexColour = vTexColourCoords;
     fTexMask = vTexMaskCoords;
-
-    fPosition = vBounds.xy;
+    fPosition = vec2(float(vBounds.x), float(vBounds.y));
     fZoom = vZoom;
     fTexColourAtlas = vTexColourAtlas;
     fTexMaskAtlas = vTexMaskAtlas;
 
     // Transform screen coordinates to texture coordinates
     float depth = 1.0 - (float(vDepth) + 1.0) * DEPTH_INCREMENT;
-    pos = pos / vec2(uScreenSize);
+    pos = pos / vec2(float(uScreenSize.x), float(uScreenSize.y));
     pos.y = pos.y * -1.0 + 1.0;
     fPeelPos = vec3(pos, depth * 0.5 + 0.5);
 
     fFlags = vFlags;
     fColour = vColour;
-    fPalettes = vec3(vPalettes);
+    fPalettes = vec3(float(vPalettes.x), float(vPalettes.y), float(vPalettes.z));
 
     // Transform texture coordinates to viewport coordinates
     pos = pos * 2.0 - 1.0;


### PR DESCRIPTION
- Use highp for higher precision.
- Make integer to float casts explicit.
- Clamp the coordinates to ensure we don't get garbage from the samplers.

The user confirmed that this solves the issue.

Close #24151