### PR TITLE
Prevent unnecessary tweening invalidations

### DIFF
--- a/src/openrct2/entity/EntityTweener.cpp
+++ b/src/openrct2/entity/EntityTweener.cpp
@@ -108,7 +108,7 @@ void EntityTweener::Restore()
     for (size_t i = 0; i < Entities.size(); ++i)
     {
         auto* ent = Entities[i];
-        if (ent == nullptr)
+        if (ent == nullptr || PrePos[i] == PostPos[i])
             continue;
 
         ent->MoveTo(PostPos[i]);


### PR DESCRIPTION
This prevents the entity tweener from invalidating every entity on every frame, causing it to redraw, even when they haven't moved. This skips the call to restore the entities position at the end of the frame, which will invalidate it, if it is already at that position.

This affects the software modes with uncap fps. It helps the most when the game is paused but also helps when any entity is not moving.