### PR TITLE
Prevent animation invalidation when paused

### DIFF
--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -169,10 +169,6 @@ namespace OpenRCT2
                 // Keep updating the money effect even when paused.
                 UpdateMoneyEffect();
 
-                // Update the animation list. Note this does not
-                // increment the map animation.
-                MapAnimationInvalidateAll();
-
                 // Post-tick network update
                 NetworkProcessPending();
 


### PR DESCRIPTION
This prevents animations being invalidated when paused, causing them to redraw every frame unnecessarily. This affects software rendering modes whilst paused.

The comment here seems to be out of date, as far as I can tell calling this function only leads to invalidations. This will prevent the clock scenery from updating in real time when paused. I'm not sure how important that is to anybody. You could argue that paused should mean that nothing changes.