### PR TITLE
Prevent station ends, flat rides and shops invalidating unnecessarily

### DIFF
--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -332,10 +332,12 @@ static void RideInvalidateStationStart(Ride& ride, StationIndex stationIndex, bo
     if (tileElement == nullptr)
         return;
 
-    tileElement->AsTrack()->SetHasGreenLight(greenLight);
-
-    // Invalidate map tile
-    MapInvalidateTileZoom1({ startPos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() });
+    TrackElement* const trackElement = tileElement->AsTrack();
+    if (trackElement->HasGreenLight() != greenLight)
+    {
+        trackElement->SetHasGreenLight(greenLight);
+        MapInvalidateTileZoom1({ startPos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() });
+    }
 }
 
 TileElement* RideGetStationStartTrackElement(const Ride& ride, StationIndex stationIndex)


### PR DESCRIPTION
This prevents station ends, parts of flat rides and shops redrawing every frame unnecessarily. Previously it would invalidate whether the green light had changed or not, so this just skips it if it didn't change.

I think that shops (and flat rides?) probably shouldn't be calling this function anyway, but as this need to be done regardless, I decided to just leave it for now.