### PR TITLE
Fix link to NixOS package in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ Alternatively to using the launcher, for most Linux distributions, we recommend 
 Some Linux distributions offer native packages:
 * Arch Linux: [openrct2](https://archlinux.org/packages/extra/x86_64/openrct2/) latest release (`extra` repository) and, alternatively, [openrct2-git](https://aur.archlinux.org/packages/openrct2-git) (AUR)
 * Gentoo (main portage tree): [games-simulation/openrct2](https://packages.gentoo.org/packages/games-simulation/openrct2)
-* NixOS (`nixos-unstable` channel): [openrct2](https://github.com/NixOS/nixpkgs/blob/master/pkgs/games/openrct2/default.nix)
+* NixOS: [openrct2](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/op/openrct2/package.nix)
 * openSUSE OBS: [games/openrct2](https://software.opensuse.org/download.html?project=games&package=openrct2)
 * Ubuntu PPA (nightly builds): [`develop` branch](https://launchpad.net/~openrct2/+archive/ubuntu/nightly)
 


### PR DESCRIPTION
Since NixOS/nixpkgs@571c71e6f73af34a229414f51585738894211408 and NixOS/nixpkgs@4f0dadbf38ee4cf4cc38cbc232b7708fddf965bc the location of `openrct2`'s package in nixpkgs was changed. This PR reflects this change.

Also the package is in NixOS' stable and unstable channel, the reference to the unstable channel is not needed anymore. Maybe a note about newer releases being in the unstable channel could be added, though.