### PR TITLE
Fix crash from failing to open file for preview

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Change: [#23803] Lightning strikes and thunder happen at the same frequency independently of the game speed.
 - Fix: [#21919] Non-recolourable cars still show colour picker.
 - Fix: [#23108] Missing pieces on Hypercoaster and Hyper-Twister, even with the ‘all drawable track pieces’ cheat enabled.
+- Fix: [#24013] Failure to load a scenario preview image (minimap) could lead to an uncaught exception error message.
 
 0.4.21 (2025-04-05)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -180,17 +180,17 @@ namespace OpenRCT2::Ui::Windows
                 return;
 
             auto& path = _highlightedScenario->Path;
-            auto fs = FileStream(path, FileMode::open);
-
-            ClassifiedFileInfo info;
-            if (!TryClassifyFile(&fs, &info) || info.Type != FileType::park)
-            {
-                // TODO: try loading a preview from a 'scenario meta' object file
-                return;
-            }
-
             try
             {
+                auto fs = FileStream(path, FileMode::open);
+
+                ClassifiedFileInfo info;
+                if (!TryClassifyFile(&fs, &info) || info.Type != FileType::park)
+                {
+                    // TODO: try loading a preview from a 'scenario meta' object file
+                    return;
+                }
+
                 auto& objectRepository = GetContext()->GetObjectRepository();
                 auto parkImporter = ParkImporter::CreateParkFile(objectRepository);
                 parkImporter->LoadFromStream(&fs, false, true, path.c_str());
@@ -198,7 +198,7 @@ namespace OpenRCT2::Ui::Windows
             }
             catch (const std::exception& e)
             {
-                LOG_ERROR("Could not get preview:", e.what());
+                LOG_ERROR("Could not get preview for \"%s\" due to %s", path.c_str(), e.what());
                 _preview = {};
                 return;
             }


### PR DESCRIPTION
If the file open fails in FileStream it will throw an IOException. We now capture that exception in the existing catch. This probably fixes #24161 and #24170.