### PR TITLE
Improve emscripten performance

### DIFF
--- a/scripts/build-emscripten
+++ b/scripts/build-emscripten
@@ -25,7 +25,7 @@ emcmake cmake ../ \
 	-DICU_DT_LIBRARY_RELEASE="$ICU_ROOT/stubdata/libicudata.so" \
 	-DLIBZIP_LIBRARIES="$LIBZIP_ROOT/build/lib/libzip.a" \
 	-DEMSCRIPTEN_FLAGS="-s USE_SDL=2 -s USE_BZIP2=1 -s USE_LIBPNG=1 -pthread -O3" \
-	-DEMSCRIPTEN_LDFLAGS="-Wno-pthreads-mem-growth -s ASYNCIFY -s FULL_ES3 -s SAFE_HEAP=0 -s ALLOW_MEMORY_GROWTH=1 -s MAXIMUM_MEMORY=4GB -s INITIAL_MEMORY=2GB -s MAX_WEBGL_VERSION=2 -s PTHREAD_POOL_SIZE=120 -pthread -sEXPORTED_RUNTIME_METHODS=ccall,FS,callMain,UTF8ToString,stringToNewUTF8 -lidbfs.js --use-preload-plugins -s MODULARIZE=1 -s 'EXPORT_NAME=\"OPENRCT2_WEB\"'"
+	-DEMSCRIPTEN_LDFLAGS="-Wno-pthreads-mem-growth -s SAFE_HEAP=0 -s ALLOW_MEMORY_GROWTH=1 -s MAXIMUM_MEMORY=4GB -s INITIAL_MEMORY=2GB -s MIN_WEBGL_VERSION=2 -s MAX_WEBGL_VERSION=2 -s PTHREAD_POOL_SIZE=120 -pthread -s EXPORTED_RUNTIME_METHODS=ccall,FS,callMain,UTF8ToString,stringToNewUTF8 -lidbfs.js --use-preload-plugins -s MODULARIZE=1 -s 'EXPORT_NAME=\"OPENRCT2_WEB\"'"
 
 emmake ninja
 


### PR DESCRIPTION
This PR does the following:

- Disables Emscripten's `ASYNCIFY`. We don't currently use this, if HTTP support is ever implemented it will need to be pulled back in
- Disables `FULL_ES3`. There is no need since there is no GLES3 renderer. SDL will pull in what is needed otherwise
- Sets `MIN_WEBGL_VERSION` to `2`. This may drop support for a very small subset of older devices that don't support newer opengl drivers. (I do not have one to test)

Overall performance improvement is about 20-30% more fps in my (not super extensive) testing

This also significantly reduces the wasm binary size, from around `21.0 MB` to `13.4 MB`