### PR TITLE
Close #21767: Cannot select macOS version of RCTC as source

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.22 (in development)
 ------------------------------------------------------------------------
+- Improved: [#21767] RCT Classic for macOS can now be used as the source game.
 - Change: [#23803] Lightning strikes and thunder happen at the same frequency independently of the game speed.
 - Change: [#24135] Compress Emscripten js/wasm files.
 - Fix: [#21919] Non-recolourable cars still show colour picker.

--- a/src/openrct2/PlatformEnvironment.cpp
+++ b/src/openrct2/PlatformEnvironment.cpp
@@ -84,7 +84,7 @@ class PlatformEnvironment final : public IPlatformEnvironment
 {
 private:
     u8string _basePath[kDirBaseCount];
-    RCT2Variant _rct2Variant = RCT2Variant::rct2;
+    RCT2Variant _rct2Variant = RCT2Variant::rct2Original;
 
 public:
     explicit PlatformEnvironment(DirBaseValues basePaths)
@@ -113,7 +113,7 @@ public:
             case DirBase::rct2:
                 switch (_rct2Variant)
                 {
-                    case RCT2Variant::rct2:
+                    case RCT2Variant::rct2Original:
                         directoryName = kDirectoryNamesRCT2[EnumValue(did)];
                         break;
                     case RCT2Variant::rctClassicWindows:
@@ -147,7 +147,7 @@ public:
         auto dataPath = GetDirectoryPath(base, did);
 
         std::string alternativeFilename;
-        if (_rct2Variant != RCT2Variant::rct2 && base == DirBase::rct2 && did == DirId::data)
+        if (_rct2Variant != RCT2Variant::rct2Original && base == DirBase::rct2 && did == DirId::data)
         {
             // Special case, handle RCT Classic css ogg files
             if (String::startsWith(fileName, "css", true) && String::endsWith(fileName, ".dat", true))
@@ -188,7 +188,7 @@ public:
 
     bool IsUsingClassic() const override
     {
-        return _rct2Variant != RCT2Variant::rct2;
+        return _rct2Variant != RCT2Variant::rct2Original;
     }
 
 private:

--- a/src/openrct2/PlatformEnvironment.cpp
+++ b/src/openrct2/PlatformEnvironment.cpp
@@ -84,7 +84,7 @@ class PlatformEnvironment final : public IPlatformEnvironment
 {
 private:
     u8string _basePath[kDirBaseCount];
-    bool _usingRCTClassic{};
+    RCT2Variant _rct2Variant = RCT2Variant::rct2;
 
 public:
     explicit PlatformEnvironment(DirBaseValues basePaths)
@@ -111,7 +111,18 @@ public:
                 directoryName = kDirectoryNamesRCT2[EnumValue(did)];
                 break;
             case DirBase::rct2:
-                directoryName = _usingRCTClassic ? "Assets" : kDirectoryNamesRCT2[EnumValue(did)];
+                switch (_rct2Variant)
+                {
+                    case RCT2Variant::rct2:
+                        directoryName = kDirectoryNamesRCT2[EnumValue(did)];
+                        break;
+                    case RCT2Variant::rctClassicWindows:
+                        directoryName = OpenRCT2::Platform::kRCTClassicWindowsDataFolder;
+                        break;
+                    case RCT2Variant::rctClassicMac:
+                        directoryName = OpenRCT2::Platform::kRCTClassicMacOSDataFolder;
+                        break;
+                }
                 break;
             case DirBase::openrct2:
             case DirBase::user:
@@ -136,7 +147,7 @@ public:
         auto dataPath = GetDirectoryPath(base, did);
 
         std::string alternativeFilename;
-        if (_usingRCTClassic && base == DirBase::rct2 && did == DirId::data)
+        if (_rct2Variant != RCT2Variant::rct2 && base == DirBase::rct2 && did == DirId::data)
         {
             // Special case, handle RCT Classic css ogg files
             if (String::startsWith(fileName, "css", true) && String::endsWith(fileName, ".dat", true))
@@ -168,13 +179,16 @@ public:
 
         if (base == DirBase::rct2)
         {
-            _usingRCTClassic = Platform::IsRCTClassicPath(path);
+            // This value being empty can be valid on headless.
+            auto variant = Platform::classifyGamePath(path);
+            if (variant.has_value())
+                _rct2Variant = variant.value();
         }
     }
 
     bool IsUsingClassic() const override
     {
-        return _usingRCTClassic;
+        return _rct2Variant != RCT2Variant::rct2;
     }
 
 private:

--- a/src/openrct2/platform/Platform.Common.cpp
+++ b/src/openrct2/platform/Platform.Common.cpp
@@ -95,7 +95,7 @@ namespace OpenRCT2::Platform
     {
         auto combinedPath = Path::ResolveCasing(Path::Combine(path, u8"Data", u8"g1.dat"));
         if (File::Exists(combinedPath))
-            return std::make_optional<RCT2Variant>(RCT2Variant::rct2);
+            return std::make_optional<RCT2Variant>(RCT2Variant::rct2Original);
 
         combinedPath = Path::ResolveCasing(Path::Combine(path, OpenRCT2::Platform::kRCTClassicWindowsDataFolder, u8"g1.dat"));
         if (File::Exists(combinedPath))

--- a/src/openrct2/platform/Platform.Common.cpp
+++ b/src/openrct2/platform/Platform.Common.cpp
@@ -91,21 +91,26 @@ namespace OpenRCT2::Platform
         return outTime;
     }
 
-    bool IsRCT2Path(std::string_view path)
+    std::optional<RCT2Variant> classifyGamePath(std::string_view path)
     {
         auto combinedPath = Path::ResolveCasing(Path::Combine(path, u8"Data", u8"g1.dat"));
-        return File::Exists(combinedPath);
-    }
+        if (File::Exists(combinedPath))
+            return std::make_optional<RCT2Variant>(RCT2Variant::rct2);
 
-    bool IsRCTClassicPath(std::string_view path)
-    {
-        auto combinedPath = Path::ResolveCasing(Path::Combine(path, u8"Assets", u8"g1.dat"));
-        return File::Exists(combinedPath);
+        combinedPath = Path::ResolveCasing(Path::Combine(path, OpenRCT2::Platform::kRCTClassicWindowsDataFolder, u8"g1.dat"));
+        if (File::Exists(combinedPath))
+            return std::make_optional<RCT2Variant>(RCT2Variant::rctClassicWindows);
+
+        combinedPath = Path::ResolveCasing(Path::Combine(path, OpenRCT2::Platform::kRCTClassicMacOSDataFolder, u8"g1.dat"));
+        if (File::Exists(combinedPath))
+            return std::make_optional<RCT2Variant>(RCT2Variant::rctClassicMac);
+
+        return std::nullopt;
     }
 
     bool OriginalGameDataExists(std::string_view path)
     {
-        return IsRCT2Path(path) || IsRCTClassicPath(path);
+        return classifyGamePath(path) != std::nullopt;
     }
 
     std::string SanitiseFilename(std::string_view originalName)

--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -48,7 +48,7 @@ enum class SpecialFolder
 
 enum class RCT2Variant : uint8_t
 {
-    rct2,
+    rct2Original,
     rctClassicWindows,
     rctClassicMac,
 };

--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -15,6 +15,7 @@
 
 #include <bit>
 #include <ctime>
+#include <optional>
 #include <vector>
 
 #ifdef _WIN32
@@ -45,12 +46,25 @@ enum class SpecialFolder
     rct2Discord,
 };
 
+enum class RCT2Variant
+{
+    rct2,
+    rctClassicWindows,
+    rctClassicMac,
+};
+
 struct RealWorldDate;
 struct RealWorldTime;
 struct TTFFontDescriptor;
 
 namespace OpenRCT2::Platform
 {
+    constexpr u8string_view kRCTClassicWindowsDataFolder = u8"Assets";
+    // clang-format off
+    constexpr u8string_view kRCTClassicMacOSDataFolder =
+        u8"RCT Classic.app" PATH_SEPARATOR "Contents" PATH_SEPARATOR "Resources";
+    // clang-format on
+
     std::string GetEnvironmentVariable(std::string_view name);
     std::string GetFolderPath(SpecialFolder folder);
     std::string GetInstallPath();
@@ -79,8 +93,7 @@ namespace OpenRCT2::Platform
     bool ProcessIsElevated();
     float GetDefaultScale();
 
-    bool IsRCT2Path(std::string_view path);
-    bool IsRCTClassicPath(std::string_view path);
+    std::optional<RCT2Variant> classifyGamePath(std::string_view path);
     bool OriginalGameDataExists(std::string_view path);
 
     std::string GetUsername();

--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -46,7 +46,7 @@ enum class SpecialFolder
     rct2Discord,
 };
 
-enum class RCT2Variant
+enum class RCT2Variant : uint8_t
 {
     rct2,
     rctClassicWindows,


### PR DESCRIPTION
You simply provide it with the folder where RCT Classic.app resides, e.g.:

- `/Applications`
- `/Users/<user>/Library/Application Support/Steam/steamapps/common/RollerCoaster Tycoon Classic`

(We should also add the possibility to autodetect RCT Classic installs on Steam, but I think that is better left for another PR.)