### PR TITLE
Remove unused includes

### DIFF
--- a/src/openrct2/actions/GameAction.h
+++ b/src/openrct2/actions/GameAction.h
@@ -12,13 +12,10 @@
 #include "../Game.h"
 #include "../core/DataSerialiser.h"
 #include "../core/Identifier.hpp"
-#include "../localisation/StringIds.h"
 #include "GameActionResult.h"
 
-#include <array>
 #include <functional>
 #include <memory>
-#include <utility>
 
 namespace OpenRCT2::GameActions
 {

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -21,7 +21,6 @@
 #include <functional>
 #include <list>
 #include <memory>
-#include <variant>
 
 struct DrawPixelInfo;
 struct TrackDesignFileRef;

--- a/src/openrct2/interface/WindowBase.h
+++ b/src/openrct2/interface/WindowBase.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <span>
 #include <vector>
+#include <variant>
 
 enum class TileInspectorPage : int16_t;
 

--- a/src/openrct2/interface/WindowBase.h
+++ b/src/openrct2/interface/WindowBase.h
@@ -17,8 +17,8 @@
 #include <list>
 #include <memory>
 #include <span>
-#include <vector>
 #include <variant>
+#include <vector>
 
 enum class TileInspectorPage : int16_t;
 


### PR DESCRIPTION
Processing GameAction.h takes the most amount of time (in the Windows build) when rebuilding libopenrct2. Reducing the includes should speed the build up by a tiny bit. Window.h used the most processing time for libopenrct2-ui.