### PR TITLE
Let checkbox widgets respect widget width for their labels

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Fix: [#21919] Non-recolourable cars still show colour picker.
 - Fix: [#23108] Missing pieces on Hypercoaster and Hyper-Twister, even with the ‘all drawable track pieces’ cheat enabled.
 - Fix: [#24013] Failure to load a scenario preview image (minimap) could lead to an uncaught exception error message.
+- Fix: [#24121] Checkbox labels run beyond the edge of the window if they’re too long to fit.
 - Fix: [#24142] [Plugin] Track origin is miscalculated on downward slopes.
 - Fix: [#24220] Narrow station platforms have missing sides on certain rotations.
 

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -653,8 +653,16 @@ namespace OpenRCT2::Ui
         if (widget.text == kStringIdNone)
             return;
 
-        auto [stringId, formatArgs] = WidgetGetStringidAndArgs(widget);
-        GfxDrawStringLeftCentred(dpi, stringId, formatArgs, colour, { midLeft + ScreenCoordsXY{ 14, 0 } });
+        auto stringId = widget.text;
+        auto ft = Formatter::Common();
+        if (widget.flags & WIDGET_FLAGS::TEXT_IS_STRING)
+        {
+            stringId = STR_STRING;
+            ft.Add<utf8*>(widget.string);
+        }
+
+        DrawTextEllipsised(
+            dpi, w.windowPos + ScreenCoordsXY{ widget.left + 14, widget.textTop() }, widget.width() - 14, stringId, ft, colour);
     }
 
     /**

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -447,26 +447,6 @@ namespace OpenRCT2::Ui
         WidgetText(dpi, w, widgetIndex);
     }
 
-    static std::pair<StringId, void*> WidgetGetStringidAndArgs(const Widget& widget)
-    {
-        auto stringId = widget.text;
-        void* formatArgs = gCommonFormatArgs;
-        if (widget.flags & WIDGET_FLAGS::TEXT_IS_STRING)
-        {
-            if (widget.string == nullptr || widget.string[0] == '\0')
-            {
-                stringId = kStringIdNone;
-                formatArgs = nullptr;
-            }
-            else
-            {
-                stringId = STR_STRING;
-                formatArgs = const_cast<void*>(reinterpret_cast<const void*>(&widget.string));
-            }
-        }
-        return std::make_pair(stringId, formatArgs);
-    }
-
     /**
      *
      *  rct2: 0x006EB535
@@ -482,7 +462,21 @@ namespace OpenRCT2::Ui
         auto textRight = l;
 
         // Text
-        auto [stringId, formatArgs] = WidgetGetStringidAndArgs(widget);
+        auto stringId = widget.text;
+        auto rawFt = Formatter::Common();
+        if (widget.flags & WIDGET_FLAGS::TEXT_IS_STRING)
+        {
+            if (widget.string != nullptr && widget.string[0] != '\0')
+            {
+                stringId = STR_STRING;
+                rawFt.Add<utf8*>(widget.string);
+            }
+            else
+            {
+                stringId = kStringIdNone;
+            }
+        }
+
         if (stringId != kStringIdNone)
         {
             auto colour = w.colours[widget.colour].withFlag(ColourFlag::translucent, false);
@@ -490,7 +484,8 @@ namespace OpenRCT2::Ui
                 colour.setFlag(ColourFlag::inset, true);
 
             utf8 buffer[512] = { 0 };
-            OpenRCT2::FormatStringLegacy(buffer, sizeof(buffer), stringId, formatArgs);
+            OpenRCT2::FormatStringLegacy(buffer, sizeof(buffer), stringId, rawFt.Data());
+
             auto ft = Formatter();
             ft.Add<utf8*>(buffer);
             DrawTextBasic(dpi, { l, t }, STR_STRING, ft, { colour });


### PR DESCRIPTION
This change lets checkbox widgets respect widget width when drawing their labels. This prevents text from flickering when part of the window is invalidated.

Note that this change may reveal some widgets have been defined too short for their actual contents. I don't expect this to be a widespread problem, though.

Closes #24121.