### PR TITLE
Expose transparent buttons to scripting

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -4879,7 +4879,9 @@ declare global {
         "search" | "selection_edge_ne" | "selection_edge_nw" | "selection_edge_se" | "selection_edge_sw" | "server_password" |
         "shops_and_stalls" | "sideways_tab" | "sideways_tab_active" | "simulate" | "small_scenery" | "sort" | "stats" | "testing" |
         "terrain_edges" | "title_play" | "title_restart" | "title_skip" | "title_stop" | "unmute" | "unmute_pressed" | "view" |
-        "water" | "zoom_in" | "zoom_in_background" | "zoom_out" | "zoom_out_background";
+        "water" | "zoom_in" | "zoom_in_background" | "zoom_out" | "zoom_out_background" | "land_tool_size_0" | "land_tool_size_1" |
+        "land_tool_size_2" | "land_tool_size_3" | "land_tool_size_4" | "land_tool_size_5" | "land_tool_size_6" | "land_tool_size_7" |
+        "land_tool_decrease" | "land_tool_increase";
 
     interface WidgetBase {
         readonly window: Window;
@@ -4901,6 +4903,7 @@ declare global {
          * By default, text buttons have borders and image buttons do not but it can be overridden.
          */
         border: boolean;
+        readonly transparent: boolean;
         image: number | IconName;
         isPressed: boolean;
         text: string;
@@ -5048,6 +5051,13 @@ declare global {
          */
         border?: boolean;
         image?: number | IconName;
+        /**
+         * Whether the button is transparent.
+         * By default, a rect is drawn around the button sprite. With transparent set to true,
+         * the rect will not be drawn. Instead, the button sprite will be drawn directly, and
+         * the button sprite id + 1 will be used for the pressed state.
+         */
+        transparent?: boolean;
         isPressed?: boolean;
         text?: string;
         onClick?: () => void;

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -75,6 +75,7 @@ namespace OpenRCT2::Ui::Windows
         bool IsDisabled{};
         bool IsVisible{};
         bool IsPressed{};
+        bool Transparent{};
         bool HasBorder{};
         bool ShowColumnHeaders{};
         bool IsStriped{};
@@ -114,6 +115,7 @@ namespace OpenRCT2::Ui::Windows
                     result.HasBorder = true;
                 }
                 result.IsPressed = AsOrDefault(desc["isPressed"], false);
+                result.Transparent = AsOrDefault(desc["transparent"], false);
                 result.OnClick = desc["onClick"];
             }
             else if (result.Type == "checkbox")
@@ -976,7 +978,9 @@ namespace OpenRCT2::Ui::Windows
             {
                 if (desc.Image.HasValue())
                 {
-                    widget.type = desc.HasBorder ? WindowWidgetType::ImgBtn : WindowWidgetType::FlatBtn;
+                    widget.type = desc.Transparent ? WindowWidgetType::TrnBtn
+                        : desc.HasBorder           ? WindowWidgetType::ImgBtn
+                                                   : WindowWidgetType::FlatBtn;
                     widget.image = desc.Image;
                 }
                 else

--- a/src/openrct2-ui/scripting/ScWidget.hpp
+++ b/src/openrct2-ui/scripting/ScWidget.hpp
@@ -459,6 +459,7 @@ namespace OpenRCT2::Scripting
             dukglue_register_property(ctx, &ScButtonWidget::border_get, &ScButtonWidget::border_set, "border");
             dukglue_register_property(ctx, &ScButtonWidget::isPressed_get, &ScButtonWidget::isPressed_set, "isPressed");
             dukglue_register_property(ctx, &ScButtonWidget::image_get, &ScButtonWidget::image_set, "image");
+            dukglue_register_property(ctx, &ScButtonWidget::transparent_get, nullptr, "transparent");
             // Explicit template due to text being a base method
             dukglue_register_property<ScButtonWidget, std::string, std::string>(
                 ctx, &ScButtonWidget::text_get, &ScButtonWidget::text_set, "text");
@@ -528,6 +529,12 @@ namespace OpenRCT2::Scripting
                 widget->image = ImageId(ImageFromDuk(value));
                 Invalidate();
             }
+        }
+
+        bool transparent_get() const
+        {
+            auto widget = GetWidget();
+            return widget != nullptr && widget->type == WindowWidgetType::TrnBtn;
         }
     };
 

--- a/src/openrct2/scripting/IconNames.hpp
+++ b/src/openrct2/scripting/IconNames.hpp
@@ -71,6 +71,16 @@ namespace OpenRCT2::Scripting
         { "rides_water", SPR_TAB_RIDES_WATER_0 },
         { "rides_thrill", SPR_TAB_RIDES_THRILL_0 },
         { "pause", SPR_TOOLBAR_PAUSE },
+        { "land_tool_decrease", SPR_LAND_TOOL_DECREASE },
+        { "land_tool_increase", SPR_LAND_TOOL_INCREASE },
+        { "land_tool_size_0", SPR_LAND_TOOL_SIZE_0 },
+        { "land_tool_size_1", SPR_LAND_TOOL_SIZE_1 },
+        { "land_tool_size_2", SPR_LAND_TOOL_SIZE_2 },
+        { "land_tool_size_3", SPR_LAND_TOOL_SIZE_3 },
+        { "land_tool_size_4", SPR_LAND_TOOL_SIZE_4 },
+        { "land_tool_size_5", SPR_LAND_TOOL_SIZE_5 },
+        { "land_tool_size_6", SPR_LAND_TOOL_SIZE_6 },
+        { "land_tool_size_7", SPR_LAND_TOOL_SIZE_7 },
 
         // G2 Icons
         { "empty", SPR_G2_EMPTY },


### PR DESCRIPTION
Until now, scripts could only create buttons of type `WindowWidgetType::ImgBtn` and `WindowWidgetType::FlatBtn`

I wanted to replicate the type of UI you can see in the land editing/clear scenery windows you see for the land brush size.
![image](https://github.com/user-attachments/assets/2d2495f4-2aef-4d7d-add1-865ec2110aeb)

so, digging into the code, I see `ClearScenery.cpp` initializes the +/- buttons as `TrnBtn`
```c++
MakeWidget(
            { 27, 17 }, { 44, 32 }, WindowWidgetType::ImgBtn, WindowColour::Primary, SPR_LAND_TOOL_SIZE_0,
            kStringIdNone), // preview box
        MakeRemapWidget(
            { 28, 18 }, { 16, 16 }, WindowWidgetType::TrnBtn, WindowColour::Secondary, SPR_LAND_TOOL_DECREASE,
            STR_ADJUST_SMALLER_LAND_TIP), // decrement size
        MakeRemapWidget(
            { 54, 32 }, { 16, 16 }, WindowWidgetType::TrnBtn, WindowColour::Secondary, SPR_LAND_TOOL_INCREASE,
            STR_ADJUST_LARGER_LAND_TIP), // increment size
```

Playing around with the consts and recompiling here got me to conclude a `CustomWindow.cpp` flow that instantiates a button to be `WindowWidgetType::TrnBtn` is needed.

Forking [OpenRCT2-FlexUI](https://github.com/Basssiiie/OpenRCT2-FlexUI) (PR soon) and filling a bit of code allowed me to replicate the land editing UI in a plugin script:
```
import { Colour, button, transparentButton, window, absolute } from "openrct2-flexui";

export const myWindow = window({
	title: "Hello from plugin",
	width: 120,
	height: 80,
	colours: [Colour.DarkBrown, Colour.DarkBrown],
	content: [
		absolute({
			content: [
				button({
					x: 0,
					y: 0,
					width: 44,
					height: 32,
					image: "land_tool_size_2",
					border: true,
					isPressed: true,
					onClick: () => {
						console.log("clicked");
					}
				}),
				transparentButton({
					x: 1,
					y: 1,
					width: 16,
					height: 16,
					image: "land_tool_decrease",
					onClick: () => {
						console.log("clicked");
					}
				}),
				transparentButton({
					x: 27,
					y: 15,
					width: 16,
					height: 16,
					image: "land_tool_increase",
					onClick: () => {
						console.log("clicked");
					}
				}),
			]
		})
	],
});
```

got me to
![image](https://github.com/user-attachments/assets/f02ff4fe-e2f9-4c3f-83b5-73c2a92b8698)
