### PR TITLE
expose show/hideGridlines to scripting

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -4627,6 +4627,9 @@ declare global {
         registerToolboxMenuItem(text: string, callback: () => void): void;
 
         registerShortcut(desc: ShortcutDesc): void;
+
+        showGridlines(): void;
+        hideGridlines(): void;
     }
 
     /**

--- a/src/openrct2-ui/scripting/ScUi.hpp
+++ b/src/openrct2-ui/scripting/ScUi.hpp
@@ -371,6 +371,16 @@ namespace OpenRCT2::Scripting
             }
         }
 
+        void showGridlines()
+        {
+            ShowGridlines();
+        }
+
+        void hideGridlines()
+        {
+            HideGridlines();
+        }
+
     public:
         static void Register(duk_context* ctx)
         {
@@ -393,6 +403,8 @@ namespace OpenRCT2::Scripting
             dukglue_register_method(ctx, &ScUi::registerMenuItem, "registerMenuItem");
             dukglue_register_method(ctx, &ScUi::registerToolboxMenuItem, "registerToolboxMenuItem");
             dukglue_register_method(ctx, &ScUi::registerShortcut, "registerShortcut");
+            dukglue_register_method(ctx, &ScUi::showGridlines, "showGridlines");
+            dukglue_register_method(ctx, &ScUi::hideGridlines, "hideGridlines");
         }
 
     private:


### PR DESCRIPTION
right now the only way for plugins to turn on gridlines is to edit the main viewport flags at `VIEWPORT_FLAG_GRIDLINES`.

This works, but doesn't play nice with other tools. If a plugin tool turns gridlines bit on start and turns the bit off on stop, when you fire another game tool (say land tool), land tool will start, add their own gridlines, then call the plugin onFinish, which will turn the grid back off.

Other game tools don't face this issue because they all use `ShowGridlines`/`HideGridlines` (Viewport.cpp) which uses some reference counting scheme to make sure new tools don't get their grid stolen
```
    /**
     *
     *  rct2: 0x006646B4
     */
    void HideGridlines()
    {
        if (gShowGridLinesRefCount > 0)
            gShowGridLinesRefCount--;

        if (gShowGridLinesRefCount == 0)
        {
            WindowBase* mainWindow = WindowGetMain();
            if (mainWindow != nullptr)
            {
                if (!Config::Get().general.AlwaysShowGridlines)
                {
                    mainWindow->viewport->flags &= ~VIEWPORT_FLAG_GRIDLINES;
                    mainWindow->Invalidate();
                }
            }
        }
    }
```

okay, so let's expose that to scripting! now calling `showGridlines`/`hideGridlines` instead of setting/unsetting the `VIEWPORT_FLAG_GRIDLINES` bit will play nicer with other game tools and won't steal their grid.