### PR TITLE
Fix CMake on docker / use aliases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,22 +391,6 @@ if(NOT DISABLE_GUI)
     include("${ROOT_DIR}/src/openrct2-ui/CMakeLists.txt" NO_POLICY_SCOPE)
 endif()
 
-# Defines
-target_compile_definitions(libopenrct2 PUBLIC
-    $<$<BOOL:${USE_MMAP}>:USE_MMAP>
-    $<$<BOOL:${DISABLE_NETWORK}>:DISABLE_NETWORK>
-    $<$<BOOL:${DISABLE_HTTP}>:DISABLE_HTTP>
-    $<$<BOOL:${DISABLE_TTF}>:DISABLE_TTF>
-    $<$<BOOL:${DISABLE_VERSION_CHECKER}>:DISABLE_VERSION_CHECKER>
-    $<$<BOOL:${ENABLE_SCRIPTING}>:ENABLE_SCRIPTING>
-)
-
-target_compile_options(libopenrct2 PUBLIC $<$<BOOL:${ENABLE_ASAN}>:-fsanitize=address>)
-target_link_options(libopenrct2 PUBLIC $<$<BOOL:${ENABLE_ASAN}>:-fsanitize=address>)
-
-target_compile_options(libopenrct2 PUBLIC $<$<BOOL:${ENABLE_UBSAN}>:-fsanitize=undefined>)
-target_link_options(libopenrct2 PUBLIC  $<$<BOOL:${ENABLE_UBSAN}>:-fsanitize=undefined>)
-
 # g2
 if (NOT (MACOS_BUNDLE AND (NOT CMAKE_OSX_ARCHITECTURES MATCHES "${SYSTEM_MACOS_ARCH}")))
     add_custom_command(
@@ -414,7 +398,7 @@ if (NOT (MACOS_BUNDLE AND (NOT CMAKE_OSX_ARCHITECTURES MATCHES "${SYSTEM_MACOS_A
         COMMAND ./openrct2-cli sprite build ${CMAKE_BINARY_DIR}/g2.dat ${ROOT_DIR}/resources/g2/sprites.json
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
-    add_custom_target(g2 DEPENDS openrct2 g2.dat)
+    add_custom_target(g2 DEPENDS OpenRCT2::openrct2-cli g2.dat)
 else ()
     message("Skipping g2.dat generation in macOS cross-compile")
 endif ()

--- a/src/openrct2-cli/CMakeLists.txt
+++ b/src/openrct2-cli/CMakeLists.txt
@@ -7,6 +7,8 @@ file(GLOB_RECURSE OPENRCT2_CLI_SOURCES
     "${CMAKE_CURRENT_LIST_DIR}/*.hpp")
 
 add_executable(openrct2-cli ${OPENRCT2_CLI_SOURCES})
+add_executable(OpenRCT2::openrct2-cli ALIAS openrct2-cli)
+
 target_include_directories(openrct2-cli PRIVATE "${CMAKE_CURRENT_LIST_DIR}/..")
 ipo_set_target_properties(openrct2-cli)
 if (EMSCRIPTEN)

--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -59,6 +59,8 @@ endif ()
 
 # Outputs
 add_executable(openrct2 ${OPENRCT2_UI_SOURCES} ${OPENRCT2_UI_MM_SOURCES})
+add_executable(OpenRCT2::openrct2 ALIAS openrct2)
+
 SET_CHECK_CXX_FLAGS(openrct2)
 ipo_set_target_properties(openrct2)
 

--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -20,6 +20,8 @@ if (ENABLE_SCRIPTING)
 endif ()
 
 add_library(libopenrct2 ${OPENRCT2_CORE_SOURCES} ${OPENRCT2_CORE_MM_SOURCES} ${OPENRCT2_DUKTAPE_SOURCES})
+add_library(OpenRCT2::libopenrct2 ALIAS libopenrct2)
+
 if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "13")
 	message(WARNING "Buggy GCC 12 detected! Disabling some warnings")
 	set_source_files_properties("${CMAKE_CURRENT_LIST_DIR}/localisation/FormatCodes.cpp" PROPERTIES COMPILE_FLAGS "-Wno-restrict")
@@ -280,6 +282,22 @@ endif ()
 if (UNIX)
     add_definitions(-D_FILE_OFFSET_BITS=64)
 endif ()
+
+# Defines
+target_compile_definitions(libopenrct2 PUBLIC
+    $<$<BOOL:${USE_MMAP}>:USE_MMAP>
+    $<$<BOOL:${DISABLE_NETWORK}>:DISABLE_NETWORK>
+    $<$<BOOL:${DISABLE_HTTP}>:DISABLE_HTTP>
+    $<$<BOOL:${DISABLE_TTF}>:DISABLE_TTF>
+    $<$<BOOL:${DISABLE_VERSION_CHECKER}>:DISABLE_VERSION_CHECKER>
+    $<$<BOOL:${ENABLE_SCRIPTING}>:ENABLE_SCRIPTING>
+)
+
+target_compile_options(libopenrct2 PUBLIC $<$<BOOL:${ENABLE_ASAN}>:-fsanitize=address>)
+target_link_options(libopenrct2 PUBLIC $<$<BOOL:${ENABLE_ASAN}>:-fsanitize=address>)
+
+target_compile_options(libopenrct2 PUBLIC $<$<BOOL:${ENABLE_UBSAN}>:-fsanitize=undefined>)
+target_link_options(libopenrct2 PUBLIC  $<$<BOOL:${ENABLE_UBSAN}>:-fsanitize=undefined>)
 
 if (CMAKE_LIBRARY_ARCHITECTURE MATCHES "arm-linux-gnueabihf")
     message(STATUS "Linking to armhf libs; adding libatomic")

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -37,6 +37,8 @@ set(test_files
    "${CMAKE_CURRENT_SOURCE_DIR}/TileElementsView.cpp")
 
 add_executable(OpenRCT2Tests ${test_files})
+add_executable(OpenRCT2::OpenRCT2Tests ALIAS OpenRCT2Tests)
+
 target_link_libraries(OpenRCT2Tests GTest::gtest GTest::gtest_main libopenrct2)
 target_include_directories(OpenRCT2Tests PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
 set_target_properties(OpenRCT2Tests PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
The old cmake had a mistake in its dependency chain for building g2.dat it depended on ${PROJECT_NAME} that was being dynamically changed depending on whether you were building with GUI or not. This was not at all obvious and it was also not what you would have expected. When i updated our cmake to not use ${PROJECT_NAME} i replaced the dynamicly changing name to just `openrct2` as that is what it was for most builds (ones that include GUI). This broke on docker which doesn't use GUI and therefore doesn't build `openrct2`.

I've changed it so that g2 depends on openrct2-cli which is what you would expect (since it uses the openrct2-cli binary). I've also changed to using aliases with a namespace in cmake this ensures that you can't make this mistake (it would be a cmake configuration time error).