### PR TITLE
Fix narrow station base drawing with incorrect rotation

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#23108] Missing pieces on Hypercoaster and Hyper-Twister, even with the ‘all drawable track pieces’ cheat enabled.
 - Fix: [#24013] Failure to load a scenario preview image (minimap) could lead to an uncaught exception error message.
 - Fix: [#24142] [Plugin] Track origin is miscalculated on downward slopes.
+- Fix: [#24220] Narrow station platforms have missing sides on certain rotations.
 
 0.4.21 (2025-04-05)
 ------------------------------------------------------------------------

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -741,7 +741,7 @@ bool TrackPaintUtilDrawNarrowStationPlatform(
     if (direction & 1)
     {
         PaintAddImageAsParent(
-            session, colour.WithIndex(kStationBaseTypeSpriteIndexes[EnumValue(baseType)][0]), { 0, 0, height + baseOffsetZ },
+            session, colour.WithIndex(kStationBaseTypeSpriteIndexes[EnumValue(baseType)][1]), { 0, 0, height + baseOffsetZ },
             { { 0, 2, height }, { 32, 28, 1 } });
 
         bool hasFence = TrackPaintUtilHasFence(EDGE_NE, position, trackElement, ride, session.CurrentRotation);


### PR DESCRIPTION
This fixes the narrow station base incorrect rotation in 2 of the view rotations. I missed this when moving the base in to the shared functions recently.

![narrowstationbaserotationbug](https://github.com/user-attachments/assets/02764472-f253-4dc3-82d3-37383d6443d1)
![narrowstationbaserotationfix](https://github.com/user-attachments/assets/4844ad39-6fa0-466d-9126-07ab2cb5942c)
