### PR TITLE
Support RCT Classic+, look in /Applications for installs

### DIFF
--- a/src/openrct2/PlatformEnvironment.cpp
+++ b/src/openrct2/PlatformEnvironment.cpp
@@ -122,6 +122,9 @@ public:
                     case RCT2Variant::rctClassicMac:
                         directoryName = OpenRCT2::Platform::kRCTClassicMacOSDataFolder;
                         break;
+                    case RCT2Variant::rctClassicPlusMac:
+                        directoryName = OpenRCT2::Platform::kRCTClassicPlusMacOSDataFolder;
+                        break;
                 }
                 break;
             case DirBase::openrct2:

--- a/src/openrct2/platform/Platform.Common.cpp
+++ b/src/openrct2/platform/Platform.Common.cpp
@@ -105,6 +105,10 @@ namespace OpenRCT2::Platform
         if (File::Exists(combinedPath))
             return std::make_optional<RCT2Variant>(RCT2Variant::rctClassicMac);
 
+        combinedPath = Path::ResolveCasing(Path::Combine(path, OpenRCT2::Platform::kRCTClassicPlusMacOSDataFolder, u8"g1.dat"));
+        if (File::Exists(combinedPath))
+            return std::make_optional<RCT2Variant>(RCT2Variant::rctClassicPlusMac);
+
         return std::nullopt;
     }
 

--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -51,6 +51,7 @@ enum class RCT2Variant : uint8_t
     rct2Original,
     rctClassicWindows,
     rctClassicMac,
+    rctClassicPlusMac,
 };
 
 struct RealWorldDate;
@@ -63,6 +64,8 @@ namespace OpenRCT2::Platform
     // clang-format off
     constexpr u8string_view kRCTClassicMacOSDataFolder =
         u8"RCT Classic.app" PATH_SEPARATOR "Contents" PATH_SEPARATOR "Resources";
+    constexpr u8string_view kRCTClassicPlusMacOSDataFolder =
+        u8"RCT Classic+.app" PATH_SEPARATOR "Contents" PATH_SEPARATOR "Resources";
     // clang-format on
 
     std::string GetEnvironmentVariable(std::string_view name);

--- a/src/openrct2/platform/Platform.macOS.mm
+++ b/src/openrct2/platform/Platform.macOS.mm
@@ -289,7 +289,7 @@ namespace OpenRCT2::Platform
 
     std::vector<std::string_view> GetSearchablePathsRCT2()
     {
-        return {};
+        return { "/Applications" };
     }
 } // namespace OpenRCT2::Platform
 


### PR DESCRIPTION
This should hopefully make sure that RCT Classic and RCT Classic+ for macOS are automatically detected as a source for the RCT2 files on macOS, providing an easy way for macOS users to run OpenRCT2.

@BeeksElectric35 this should hopefully make the game work for you. Could you try downloading a build from the CI of this pull request to see if it works?

Direct link to the build (requires you to be logged into Github): https://github.com/OpenRCT2/OpenRCT2/actions/runs/14523336787/artifacts/2966330262