### PR TITLE
Fix 'window buttons on the left' toggle

### DIFF
--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1612,6 +1612,7 @@ namespace OpenRCT2::Ui::Windows
                     Config::Save();
                     Invalidate();
                     windowMgr->InvalidateAll();
+                    WindowVisitEach([](WindowBase* w) { w->ResizeFrame(); });
                     break;
                 case WIDX_ENLARGED_UI:
                     Config::Get().interface.EnlargedUi ^= 1;


### PR DESCRIPTION
The 'window buttons on the left' toggle was working, but not updating existing windows. This fixes the issue.

Regression from #23590