### PR TITLE
Add Joshua Jacobs to development team

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -13,6 +13,7 @@ Includes all git commit authors. Aliases are GitHub usernames or community nickn
 * Michael Bernardi (mrmbernardi) - Programming
 * Michael Steenbeek (Gymnasiast) - Lead Localisation - Programming
 * Aaron van Geffen (AaronVanGeffen) - Programming
+* Joshua Jacobs (leicestersquare) - Graphic Artist
 
 ## Support team
 * Kenton Boadway (Krutonium) - Lead OpenScenarios


### PR DESCRIPTION
Joshua has been part of the development team for about a year now, but it seems we forgot to add him to the contributors file. This PR amends that oversight. Sorry, Joshua!