### PR TITLE
Touch friendly Interface. by TouchEnhancements Options. 

### DIFF
--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -27,6 +27,7 @@
 #include <openrct2/actions/FootpathPlaceAction.h>
 #include <openrct2/actions/FootpathRemoveAction.h>
 #include <openrct2/audio/Audio.h>
+#include <openrct2/config/Config.h>
 #include <openrct2/core/FlagHolder.hpp>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/object/FootpathObject.h>
@@ -437,9 +438,12 @@ namespace OpenRCT2::Ui::Windows
 
         void OnToolDrag(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords) override
         {
-            if (widgetIndex == WIDX_CONSTRUCT_ON_LAND)
+            if (!Config::Get().interface.TouchEnhancements)
             {
-                WindowFootpathPlacePathAtPoint(screenCoords);
+                if (widgetIndex == WIDX_CONSTRUCT_ON_LAND)
+                {
+                    WindowFootpathPlacePathAtPoint(screenCoords);
+                }
             }
         }
 

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -462,10 +462,26 @@ namespace OpenRCT2::Ui::Windows
 
         void OnScrollMouseDown(int32_t scrollIndex, const ScreenCoordsXY& screenCoords) override
         {
+            static RideSelection PreSelected;
+
             RideSelection item = ScrollGetRideListItemAt(screenCoords);
             if (item.Type == kRideTypeNull && item.EntryIndex == kObjectEntryIndexNull)
             {
                 return;
+            }
+
+            if (Config::Get().interface.TouchEnhancements)
+            {
+                if (PreSelected != item)
+                {
+                    PreSelected = item;
+                    return;
+                }
+                else
+                {
+                    PreSelected.Type = kRideTypeNull;
+                    PreSelected.EntryIndex = kObjectEntryIndexNull;
+                }
             }
 
             _newRideVars.SelectedRide = item;


### PR DESCRIPTION
This is issue for #6146
and improve from #24096

1. Viewport Move by MouseLeft Button. So, Mouse's "state = ViewportLeft" Can Move Viewport.
     This is bertter patrol Setting or Scenery By touch control.
2. Scroll by MouseLeft button. Too. But, If Mouse Left Button Down on Scroll Widget, Mouse's "state = ScrollRight". This is different to Viewport.
3. Select on Scrollwidget, need two touch. first touch is select content. Second is decide that.
4. Scenery or Ride Construct, It is need two touch, too.
5. using land or water tool, first touch on viewport, this is Select section. and touch drag from same where, viewport is fixed. Because, Land or Water ToolDrag is Conflict from Viewport Move. So, I make moveViewport flag.
6. Banner can click by LeftButton. (Interactive Left)
6. At Ride Construct window is opened, Select Track by Left Click This is construction's Convenience for Touch Interface.

These are only enabled at  TouchEnhancements is checked. If is not same as original.

https://youtu.be/V5-HtimyzMo