### PR TITLE
Optimize AddToEntityList for end of list edgecase

### DIFF
--- a/src/openrct2/core/Algorithm.hpp
+++ b/src/openrct2/core/Algorithm.hpp
@@ -12,6 +12,9 @@
 #include <algorithm>
 #include <functional>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnull-dereference"
+
 namespace OpenRCT2::Core::Algorithm
 {
 
@@ -37,3 +40,5 @@ namespace OpenRCT2::Core::Algorithm
     }
 
 } // namespace OpenRCT2::Core::Algorithm
+
+#pragma GCC diagnostic pop

--- a/src/openrct2/core/Algorithm.hpp
+++ b/src/openrct2/core/Algorithm.hpp
@@ -12,9 +12,28 @@
 #include <algorithm>
 #include <functional>
 
-template<class ForwardIt, class T, class Compare = std::less<>>
-ForwardIt BinaryFind(ForwardIt first, ForwardIt last, const T& value, Compare comp = {})
+namespace OpenRCT2::Core::Algorithm
 {
-    first = std::lower_bound(first, last, value, comp);
-    return first != last && !comp(value, *first) ? first : last;
-}
+
+    template<class ForwardIt, class T, class Compare = std::less<>>
+    ForwardIt binaryFind(ForwardIt first, ForwardIt last, const T& value, Compare comp = {})
+    {
+        first = std::lower_bound(first, last, value, comp);
+        return first != last && !comp(value, *first) ? first : last;
+    }
+
+    template<typename Container, typename T, class Compare = std::less<>>
+    auto sortedInsert(Container& cont, const T& value, Compare comp = {})
+    {
+        if (cont.empty() || value < cont.front())
+        {
+            return cont.insert(cont.begin(), value);
+        }
+        if (value > cont.back())
+        {
+            return cont.insert(cont.end(), value);
+        }
+        return cont.insert(std::lower_bound(cont.begin(), cont.end(), value, comp), value);
+    }
+
+} // namespace OpenRCT2::Core::Algorithm

--- a/src/openrct2/core/Algorithm.hpp
+++ b/src/openrct2/core/Algorithm.hpp
@@ -16,14 +16,14 @@ namespace OpenRCT2::Core::Algorithm
 {
 
     template<class ForwardIt, class T, class Compare = std::less<>>
-    ForwardIt binaryFind(ForwardIt first, ForwardIt last, const T& value, Compare comp = {})
+    ForwardIt binaryFind(ForwardIt first, ForwardIt last, T&& value, const Compare comp = {})
     {
-        first = std::lower_bound(first, last, value, comp);
+        first = std::lower_bound(first, last, std::forward<T>(value), comp);
         return first != last && !comp(value, *first) ? first : last;
     }
 
     template<typename Container, typename T, class Compare = std::less<>>
-    auto sortedInsert(Container& cont, const T& value, Compare comp = {})
+    auto sortedInsert(Container& cont, T&& value, const Compare comp = {})
     {
         if (cont.empty() || value < cont.front())
         {
@@ -33,7 +33,7 @@ namespace OpenRCT2::Core::Algorithm
         {
             return cont.insert(cont.end(), value);
         }
-        return cont.insert(std::lower_bound(cont.begin(), cont.end(), value, comp), value);
+        return cont.insert(std::lower_bound(cont.begin(), cont.end(), std::forward<T>(value), comp), std::forward<T>(value));
     }
 
 } // namespace OpenRCT2::Core::Algorithm

--- a/src/openrct2/entity/EntityRegistry.cpp
+++ b/src/openrct2/entity/EntityRegistry.cpp
@@ -275,7 +275,14 @@ static void AddToEntityList(EntityBase* entity)
 {
     auto& list = gEntityLists[EnumValue(entity->Type)];
     // Entity list must be in sprite_index order to prevent desync issues
-    list.insert(std::lower_bound(std::begin(list), std::end(list), entity->Id), entity->Id);
+    if (!list.empty() && list.back() < entity->Id)
+    {
+        list.push_back(entity->Id);
+    }
+    else
+    {
+        list.insert(std::lower_bound(std::begin(list), std::end(list), entity->Id), entity->Id);
+    }
 }
 
 static void AddToFreeList(EntityId index)

--- a/src/openrct2/entity/PatrolArea.cpp
+++ b/src/openrct2/entity/PatrolArea.cpp
@@ -15,6 +15,9 @@
 
 #include <cassert>
 
+using namespace OpenRCT2;
+using namespace OpenRCT2::Core;
+
 static PatrolArea _consolidatedPatrolArea[EnumValue(StaffType::Count)];
 static std::variant<StaffType, EntityId> _patrolAreaToRender;
 
@@ -59,7 +62,7 @@ bool PatrolArea::Get(const TileCoordsXY& pos) const
     if (area == nullptr)
         return false;
 
-    auto it = BinaryFind(area->SortedTiles.begin(), area->SortedTiles.end(), pos, CompareTileCoordsXY);
+    auto it = Algorithm::binaryFind(area->SortedTiles.begin(), area->SortedTiles.end(), pos, CompareTileCoordsXY);
     auto found = it != area->SortedTiles.end();
     return found;
 }


### PR DESCRIPTION
When loading the game, the new Id will be greater than any ids in the list so we save a considerable amount of time by skipping searching where to add it.

On a large map I was testing with this saves 7 seconds on my machine