### PR TITLE
zh-TW: Add zh-TW text to Appdata file

### DIFF
--- a/distribution/linux/openrct2.appdata.xml
+++ b/distribution/linux/openrct2.appdata.xml
@@ -28,6 +28,7 @@
   <developer_name xml:lang="nl">Het OpenRCT2-team</developer_name>
   <developer_name xml:lang="pl">Zespół OpenRCT2</developer_name>
   <developer_name xml:lang="pt">Equipe do OpenRCT2</developer_name>
+  <developer_name xml:lang="zh-TW">OpenRCT2團隊</developer_name>
   <launchable type="desktop-id">openrct2.desktop</launchable>
   <description>
     <p>
@@ -141,6 +142,13 @@
       “caixa de areia” deixa o jogador construir um parque mais flexível, opcionalmente sem
       restrições ou finanças.
     </p>
+    <p xml:lang="zh-TW">
+      OpenRCT2為一個免費及開放原始碼的模擬樂園2(RCT2)重製版本.
+      遊戲方式圍繞著建造及經營內含遊樂設施, 店鋪及其他設施的主題樂園
+      玩家需要於牟利及維持良好的樂園評價的同時讓遊客高興. OpenRCT2允許
+      劇情及沙盒遊戲方式. 劇情模式需要玩家在指定的時間限制內完成指定目標,
+      而沙盒模式容許玩家建造一個可選無目標或金錢限制, 較無束縛的樂園.
+    </p>
 
     <p>
       OpenRCT2 features many changes compared to the original RollerCoaster Tycoon 2 game. A few of them are listed here.
@@ -178,6 +186,9 @@
     <p xml:lang="pt">
       O OpenRCT2 conta com muitas mudanças quando comparado ao jogo RollerCoaster Tycoon 2 original. Aqui são listadas algumas delas.
     </p>
+    <p xml:lang="zh-TW">
+      OpenRCT2 對比原本的模擬樂園2(RCT2)有著很多改變. 一些改變的例子如下.
+    </p>
 
     <ul>
       <li>User Interface theming.</li>
@@ -192,6 +203,7 @@
       <li xml:lang="nl">Thema’s voor de grafische interface.</li>
       <li xml:lang="pl">Edycja motywów interfejsu użytkownika</li>
       <li xml:lang="pt">Customização por temas da interface de usuário.</li>
+      <li xml:lang="zh-TW">自訂操作介面主題.</li>
 
       <li>Fast-forwarding gameplay.</li>
       <li xml:lang="ca">Diferents velocitats de joc</li>
@@ -205,6 +217,7 @@
       <li xml:lang="nl">Tijd sneller laten verlopen.</li>
       <li xml:lang="pl">Przyspieszanie rozgrywki</li>
       <li xml:lang="pt">Dinâmica de jogo acelerável.</li>
+      <li xml:lang="zh-TW">快轉遊戲運作.</li>
 
       <li>Multiplayer support.</li>
       <li xml:lang="ca">Suport multijugador</li>
@@ -218,6 +231,7 @@
       <li xml:lang="nl">Ondersteuning voor multiplayer.</li>
       <li xml:lang="pl">Tryb wieloosobowy</li>
       <li xml:lang="pt">Suporte multijogador.</li>
+      <li xml:lang="zh-TW">多人遊戲功能.</li>
 
       <li>Multilingual. Improved translations.</li>
       <li xml:lang="ca">Traduccions a diversos idiomes i correccions de les traduccions originals</li>
@@ -231,6 +245,7 @@
       <li xml:lang="nl">In meerdere talen vertaald. Verbeterde vertalingen.</li>
       <li xml:lang="pl">Wielojęzyczność i ulepszone tłumaczenia</li>
       <li xml:lang="pt">Multilíngue. Traduções aperfeiçoadas.</li>
+      <li xml:lang="zh-TW">多語言. 翻譯改進.</li>
 
       <li>OpenGL hardware rendering.</li>
       <li xml:lang="ca">Renderització OpenGL per maquinari</li>
@@ -244,6 +259,7 @@
       <li xml:lang="nl">Hardwarerendering via OpenGL.</li>
       <li xml:lang="pl">Obsługa renderowania OpenGL</li>
       <li xml:lang="pt">Renderização por hardware OpenGL.</li>
+      <li xml:lang="zh-TW">OpenGL硬體渲染.</li>
 
       <li>Various fixes and improvements for bugs in the original game.</li>
       <li xml:lang="ca">Correccions i millores dels errors del joc original</li>
@@ -257,6 +273,7 @@
       <li xml:lang="nl">Veel fixes en verbeteringen voor bugs die in het originele spel zaten.</li>
       <li xml:lang="pl">Poprawki błędów i usprawnienia względem oryginalnej gry</li>
       <li xml:lang="pt">Várias correções e melhorias para problemas no jogo original.</li>
+      <li xml:lang="zh-TW">眾多對原遊戲的修復及改進.</li>
 
       <li>Native support for Linux and macOS.</li>
       <li xml:lang="ca">Suport natiu per a Linux i macOS</li>
@@ -270,6 +287,7 @@
       <li xml:lang="nl">Ondersteunt Linux en macOS direct.</li>
       <li xml:lang="pl">Natywna obsługa systemów Linux i macOS</li>
       <li xml:lang="pt">Suporte nativo para Linux e macOS.</li>
+      <li xml:lang="zh-TW">對Linux and macOS的原生支援.</li>
 
       <li>Added hacks and cheats.</li>
       <li xml:lang="ca">Es poden fer trucs i trampes</li>
@@ -283,6 +301,7 @@
       <li xml:lang="nl">Ingebouwde ondersteuning voor hacks en cheats.</li>
       <li xml:lang="pl">Kody i hacki</li>
       <li xml:lang="pt">Trapaças e hacks adicionados.</li>
+      <li xml:lang="zh-TW">新增及密技.</li>
 
       <li>Auto-saving and giant screenshots.</li>
       <li xml:lang="ca">Desades automàtiques i captures de pantalla gegants</li>
@@ -296,6 +315,7 @@
       <li xml:lang="nl">Automatische backups. Screenshots van het hele park.</li>
       <li xml:lang="pl">Autozapis i możliwość robienia ogromnych zrzutów ekranu</li>
       <li xml:lang="pt">Salvamento automático e capturas de tela gigantes.</li>
+      <li xml:lang="zh-TW">自動儲存及巨型截圖.</li>
     </ul>
 
     <p>
@@ -334,6 +354,9 @@
     <p xml:lang="pt">
       Arquivos dos jogos originais RollerCoaster Tycoon 2 ou RollerCoaster Tycoon Classic são necessários para jogar OpenRCT2.
     </p>
+    <p xml:lang="zh-TW">
+      OpenRCT2需要原本的模擬樂園2(RCT2)或RollerCoaster Tycoon Classic的遊戲檔案才能運行.
+    </p>
   </description>
   <screenshots>
     <screenshot type="default">
@@ -350,6 +373,7 @@
       <caption xml:lang="nl">Pretpark met een omgekeerde achtbaan, een wildwaterbaan en zelfgemaakt decor.</caption>
       <caption xml:lang="pl">Park rozrywki z odwróconą kolejką górską, spływem rwącą rzeką i niestandardową scenerią</caption>
       <caption xml:lang="pt">Parque de diversões que conta com uma montanha-russa invertida, corredeira de rio e cenários customizados</caption>
+      <caption xml:lang="zh-TW">一個附有懸吊式雲霄飛車. 一個激流船及自定義景物的主題樂園</caption>
     </screenshot>
   </screenshots>
   <url type="homepage">https://openrct2.io/</url>


### PR DESCRIPTION
OpenRCT2/Localisation#2973

Added zh-TW translations to the file. Language code `zh-tw` cross-checked with https://github.com/KDE/kmenuedit/blob/master/org.kde.kmenuedit.appdata.xml.