### PR TITLE
Query SDL for actual drawable size #21772

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -826,9 +826,12 @@ private:
 
     void OnResize(int32_t width, int32_t height)
     {
-        // Scale the native window size to the game's canvas size
-        _width = static_cast<int32_t>(width / Config::Get().general.WindowScale);
-        _height = static_cast<int32_t>(height / Config::Get().general.WindowScale);
+        
+        int drawableWidth, drawableHeight;
+        SDL_GL_GetDrawableSize(_window, &drawableWidth, &drawableHeight);
+    
+        _width = drawableWidth;
+        _height = drawableHeight;
 
         DrawingEngineResize();
 


### PR DESCRIPTION
Avoids scaling the size twice when SDL is already scaling the size behind the scenes, creating the 1/4 window. Querys SDL_GL_GetDrawableSize before calling DrawingEngineResize to avoid an unnecessary scaling.