### PR TITLE
Rework map iteration for the two smoothing algorithms in use

### DIFF
--- a/src/openrct2/world/map_generator/MapHelpers.h
+++ b/src/openrct2/world/map_generator/MapHelpers.h
@@ -11,6 +11,8 @@
 
 #include "../Location.hpp"
 
+#include <functional>
+
 namespace OpenRCT2::World::MapGenerator
 {
     enum
@@ -21,6 +23,10 @@ namespace OpenRCT2::World::MapGenerator
         SLOPE_E_THRESHOLD_FLAGS = (1 << 3)
     };
 
-    int32_t MapSmooth(int32_t l, int32_t t, int32_t r, int32_t b);
-    int32_t TileSmooth(const TileCoordsXY& tileCoords);
+    using SmoothFunction = std::function<int32_t(const TileCoordsXY)>;
+
+    int32_t smoothTileStrong(TileCoordsXY tileCoord);
+    int32_t smoothTileWeak(TileCoordsXY tileCoord);
+
+    void smoothMap(TileCoordsXY mapSize, SmoothFunction smoothFunc);
 } // namespace OpenRCT2::World::MapGenerator

--- a/src/openrct2/world/map_generator/PngTerrainGenerator.cpp
+++ b/src/openrct2/world/map_generator/PngTerrainGenerator.cpp
@@ -235,22 +235,8 @@ namespace OpenRCT2::World::MapGenerator
         // Smooth tile edges
         if (settings->smoothTileEdges)
         {
-            // Keep smoothing the entire map until no tiles are changed anymore
-            while (true)
-            {
-                uint32_t numTilesChanged = 0;
-                for (auto y = 0; y < dest.height; y++)
-                {
-                    for (auto x = 0; x < dest.width; x++)
-                    {
-                        auto tileCoords = HeightmapCoordToTileCoordsXY(x, y);
-                        numTilesChanged += TileSmooth(tileCoords);
-                    }
-                }
-
-                if (numTilesChanged == 0)
-                    break;
-            }
+            // Set the tile slopes so that there are no cliffs
+            smoothMap(settings->mapSize, smoothTileWeak);
         }
     }
 } // namespace OpenRCT2::World::MapGenerator

--- a/src/openrct2/world/map_generator/SimplexNoise.cpp
+++ b/src/openrct2/world/map_generator/SimplexNoise.cpp
@@ -217,9 +217,7 @@ namespace OpenRCT2::World::MapGenerator
         if (settings->smoothTileEdges)
         {
             // Set the tile slopes so that there are no cliffs
-            while (MapSmooth(1, 1, mapSize.x - 1, mapSize.y - 1))
-            {
-            }
+            smoothMap(settings->mapSize, smoothTileStrong);
         }
 
         // Add the water


### PR DESCRIPTION
The map generator currently contains two map smoothing algorithms: one that originates in the simplex generator, and one that originates in the PNG heightmap generator (#5282). This PR harmonises the interface to both to use the same map iteration process, while also renaming the former to 'strong' and the latter to 'weak'.

Ideally, I would like us to move to just one smoothing algorithm. However, both smoothing algorithms have their pros and cons.

Personally, I find the 'weak' one easier to read. However, it's much less aggressive about simplifying corner edges. This has some advantages, like rivers (#23999) being much more pronounced. It also clearly retains more of the features from a PNG heightmap. However, generally maps will look less smooth when using the 'weak' smoothing algorithm. Currently, that means it does not make for a good default.

Perhaps we should expose these as a choice to the user? Either way, this PR settles on just harmonising the function interface.

Note for reviewers: best turn white-space diffs off for this one.