### PR TITLE
Update macOS Steam path (for download_depot)

### DIFF
--- a/src/openrct2/platform/Platform.macOS.mm
+++ b/src/openrct2/platform/Platform.macOS.mm
@@ -244,7 +244,7 @@ namespace OpenRCT2::Platform
         }
 
         auto steamPath = Path::Combine(
-            homeDir, "Library/Application Support/Steam/Steam.AppBundle/Steam/Contents/MacOS/steamapps");
+            homeDir, "Library/Application Support/Steam/Steam.AppBundle/Steam/Contents/MacOS/steamapps/content");
         if (Path::DirectoryExists(steamPath))
         {
             return steamPath;


### PR DESCRIPTION
To test (assumes you have the RCT2 files already downloaded via download_depot):

1. Rename `config.ini`
2. Start the current develop/release version, verify it doesn’t automatically find the RCT2 install and will ask the user to locate them
3. Install the version from this PR
4. Start OpenRCT2 again, verify it **does** automatically find the RCT2 and RCT1 installs (and won’t ask to user to locate them)

After testing, you can put the original `config.ini` back if desired.