### PR TITLE
Generalise white close button strings to all translucent title bars

### DIFF
--- a/src/openrct2-ui/interface/Widget.h
+++ b/src/openrct2-ui/interface/Widget.h
@@ -16,7 +16,7 @@
 #include <openrct2/interface/Widget.h>
 
 // clang-format off
-#define WINDOW_SHIM_RAW(TITLE, WIDTH, HEIGHT, CLOSE_STR) \
+#define WINDOW_SHIM(TITLE, WIDTH, HEIGHT) \
     { WindowWidgetType::Frame,    0,  0,  WIDTH - 1, 0, HEIGHT - 1, 0xFFFFFFFF,  kStringIdNone        }, \
     { WindowWidgetType::Caption,  0,  1,  WIDTH - 2, 1, 14,         TITLE,       STR_WINDOW_TITLE_TIP }, \
     { .type    = WindowWidgetType::CloseBox, \
@@ -25,11 +25,8 @@
       .right   = WIDTH - 3,                  \
       .top     = 2,                          \
       .bottom  = 13,                         \
-      .string  = CLOSE_STR,                  \
+      .string  = kCloseBoxStringBlackNormal, \
       .tooltip = STR_CLOSE_WINDOW_TIP }
-
-#define WINDOW_SHIM(TITLE, WIDTH, HEIGHT) WINDOW_SHIM_RAW(TITLE, WIDTH, HEIGHT, kCloseBoxStringBlackNormal)
-#define WINDOW_SHIM_WHITE(TITLE, WIDTH, HEIGHT) WINDOW_SHIM_RAW(TITLE, WIDTH, HEIGHT, kCloseBoxStringWhiteNormal)
 // clang-format on
 
 namespace OpenRCT2::Ui

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -486,11 +486,12 @@ namespace OpenRCT2::Ui::Windows
 
         void OnPrepareDraw() override
         {
-            bool useWhite = colours[0].hasFlag(ColourFlag::translucent);
+            auto& closeButton = widgets[WIDX_CLOSE];
+            bool translucent = colours[closeButton.colour].hasFlag(ColourFlag::translucent);
             if (Config::Get().interface.EnlargedUi)
-                widgets[WIDX_CLOSE].string = !useWhite ? kCloseBoxStringBlackLarge : kCloseBoxStringWhiteLarge;
+                closeButton.string = !translucent ? kCloseBoxStringBlackLarge : kCloseBoxStringWhiteLarge;
             else
-                widgets[WIDX_CLOSE].string = !useWhite ? kCloseBoxStringBlackNormal : kCloseBoxStringWhiteNormal;
+                closeButton.string = !translucent ? kCloseBoxStringBlackNormal : kCloseBoxStringWhiteNormal;
 
             // Having the content panel visible for transparent windows makes the borders darker than they should be
             // For now just hide it if there are no tabs and the window is not resizable

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -35,7 +35,7 @@ namespace OpenRCT2::Ui::Windows
     // clang-format off
     static constexpr Widget window_ride_demolish_widgets[] =
     {
-        WINDOW_SHIM_WHITE(STR_DEMOLISH_RIDE, WW, WH),
+        WINDOW_SHIM(STR_DEMOLISH_RIDE, WW, WH),
         MakeWidget({     10, WH - 22}, {85, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_DEMOLISH          ),
         MakeWidget({WW - 95, WH - 22}, {85, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_SAVE_PROMPT_CANCEL),
     };

--- a/src/openrct2-ui/windows/OverwritePrompt.cpp
+++ b/src/openrct2-ui/windows/OverwritePrompt.cpp
@@ -33,7 +33,7 @@ namespace OpenRCT2::Ui::Windows
 
     // clang-format off
     static constexpr Widget window_overwrite_prompt_widgets[] = {
-        WINDOW_SHIM_WHITE(STR_FILEBROWSER_OVERWRITE_TITLE, OVERWRITE_WW, OVERWRITE_WH),
+        WINDOW_SHIM(STR_FILEBROWSER_OVERWRITE_TITLE, OVERWRITE_WW, OVERWRITE_WH),
         MakeWidget({                10, OVERWRITE_WH - 20 }, { 84, 11 }, WindowWidgetType::Button, WindowColour::Primary, STR_FILEBROWSER_OVERWRITE_TITLE),
         MakeWidget({ OVERWRITE_WW - 95, OVERWRITE_WH - 20 }, { 85, 11 }, WindowWidgetType::Button, WindowColour::Primary, STR_SAVE_PROMPT_CANCEL),
     };

--- a/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
@@ -34,7 +34,7 @@ namespace OpenRCT2::Ui::Windows
     // clang-format off
     static constexpr Widget window_ride_refurbish_widgets[] =
     {
-        WINDOW_SHIM_WHITE(STR_REFURBISH_RIDE, WW, WH),
+        WINDOW_SHIM(STR_REFURBISH_RIDE, WW, WH),
         MakeWidget({ 10, WH - 22 }, { 85, 14 }, WindowWidgetType::Button, WindowColour::Primary, STR_REFURBISH),
         MakeWidget({ WW - 95, WH - 22 }, { 85, 14 }, WindowWidgetType::Button, WindowColour::Primary, STR_SAVE_PROMPT_CANCEL),
     };

--- a/src/openrct2-ui/windows/SavePrompt.cpp
+++ b/src/openrct2-ui/windows/SavePrompt.cpp
@@ -41,7 +41,7 @@ namespace OpenRCT2::Ui::Windows
 
     // clang-format off
     static constexpr Widget _savePromptWidgets[] = {
-        WINDOW_SHIM_WHITE(kStringIdNone, WW_SAVE, WH_SAVE),
+        WINDOW_SHIM(kStringIdNone, WW_SAVE, WH_SAVE),
         MakeWidget({  2, 19}, {256, 12}, WindowWidgetType::LabelCentred, WindowColour::Primary, kStringIdEmpty                ), // question/label
         MakeWidget({  8, 35}, { 78, 14}, WindowWidgetType::Button,        WindowColour::Primary, STR_SAVE_PROMPT_SAVE     ), // save
         MakeWidget({ 91, 35}, { 78, 14}, WindowWidgetType::Button,        WindowColour::Primary, STR_SAVE_PROMPT_DONT_SAVE), // don't save
@@ -60,7 +60,7 @@ namespace OpenRCT2::Ui::Windows
 
     // clang-format off
     static constexpr Widget _quitPromptWidgets[] = {
-        WINDOW_SHIM_WHITE(STR_QUIT_GAME_PROMPT_TITLE, WW_QUIT, WH_QUIT),
+        WINDOW_SHIM(STR_QUIT_GAME_PROMPT_TITLE, WW_QUIT, WH_QUIT),
         MakeWidget({ 8, 19}, {78, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_OK    ), // ok
         MakeWidget({91, 19}, {78, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_CANCEL), // cancel
     };

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -574,7 +574,7 @@ namespace OpenRCT2::Ui::Windows
     };
 
     static constexpr Widget WindowResetShortcutKeysPromptWidgets[] = {
-        WINDOW_SHIM_WHITE(STR_SHORTCUT_ACTION_RESET, RESET_PROMPT_WW, RESET_PROMPT_WH),
+        WINDOW_SHIM(STR_SHORTCUT_ACTION_RESET, RESET_PROMPT_WW, RESET_PROMPT_WH),
         MakeWidget(
             { 2, 30 }, { RESET_PROMPT_WW - 4, 12 }, WindowWidgetType::LabelCentred, WindowColour::Primary,
             STR_RESET_SHORTCUT_KEYS_PROMPT),

--- a/src/openrct2-ui/windows/StaffFirePrompt.cpp
+++ b/src/openrct2-ui/windows/StaffFirePrompt.cpp
@@ -36,7 +36,7 @@ namespace OpenRCT2::Ui::Windows
     // clang-format off
     // 0x9AFB4C
     static constexpr Widget _staffFireWidgets[] = {
-        WINDOW_SHIM_WHITE(WINDOW_TITLE, WW, WH),
+        WINDOW_SHIM(WINDOW_TITLE, WW, WH),
         MakeWidget({     10, WH - 20}, {85, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_YES               ),
         MakeWidget({WW - 95, WH - 20}, {85, 14}, WindowWidgetType::Button, WindowColour::Primary, STR_SAVE_PROMPT_CANCEL),
     };

--- a/src/openrct2/interface/WindowBase.cpp
+++ b/src/openrct2/interface/WindowBase.cpp
@@ -41,7 +41,7 @@ namespace OpenRCT2
         return CursorID::Arrow;
     }
 
-    static inline void repositionCloseButton(Widget& closeButton, int32_t windowWidth)
+    static inline void repositionCloseButton(Widget& closeButton, int32_t windowWidth, bool translucent)
     {
         auto closeButtonSize = Config::Get().interface.EnlargedUi ? kCloseButtonSizeTouch : kCloseButtonSize;
         if (Config::Get().interface.WindowButtonsOnTheLeft)
@@ -56,11 +56,10 @@ namespace OpenRCT2
         }
 
         // Set appropriate close button
-        bool useWhite = closeButton.string == kCloseBoxStringWhiteLarge || closeButton.string == kCloseBoxStringWhiteNormal;
         if (closeButtonSize == kCloseButtonSizeTouch)
-            closeButton.string = !useWhite ? kCloseBoxStringBlackLarge : kCloseBoxStringWhiteLarge;
+            closeButton.string = !translucent ? kCloseBoxStringBlackLarge : kCloseBoxStringWhiteLarge;
         else
-            closeButton.string = !useWhite ? kCloseBoxStringBlackNormal : kCloseBoxStringWhiteNormal;
+            closeButton.string = !translucent ? kCloseBoxStringBlackNormal : kCloseBoxStringWhiteNormal;
     }
 
     void WindowBase::ResizeFrame()
@@ -85,7 +84,10 @@ namespace OpenRCT2
         // Close button
         auto& closeButton = widgets[2];
         if (closeButton.type == WindowWidgetType::CloseBox || closeButton.type == WindowWidgetType::Empty)
-            repositionCloseButton(closeButton, width);
+        {
+            bool translucent = colours[closeButton.colour].hasFlag(ColourFlag::translucent);
+            repositionCloseButton(closeButton, width, translucent);
+        }
 
         // Page/resize widget
         if (widgets.size() >= 4)


### PR DESCRIPTION
Windows that were customised into translucent background colours would still use the normal/black ‘×’ string. This PR generalises this, such that the white ‘×’ string is now used for these windows as well.

As an added bonus, this removes the need for the `WINDOW_SHIM_WHITE` macro. (Please disregard `clang-tidy`'s complaints about macros this time — we're removing two, not adding one.)

Should fix #24266.