### PR TITLE
Fix #24289: Prebuilt track designs using an invalid drawing state

### DIFF
--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -2131,6 +2131,8 @@ void TrackDesignDrawPreview(TrackDesign& td, uint8_t* pixels)
     auto drawingEngine = std::make_unique<X8DrawingEngine>(GetContext()->GetUiContext());
     dpi.DrawingEngine = drawingEngine.get();
 
+    drawingEngine->BeginDraw();
+
     const ScreenCoordsXY offset = { size_x / 2, size_y / 2 };
     for (uint8_t i = 0; i < 4; i++)
     {
@@ -2140,6 +2142,8 @@ void TrackDesignDrawPreview(TrackDesign& td, uint8_t* pixels)
 
         dpi.bits += kTrackPreviewImageSize;
     }
+
+    drawingEngine->EndDraw();
 
     ride->remove();
     UnstashMap();


### PR DESCRIPTION
I don't know how I missed that one, I specifically looked for anything that creates the X8DrawingEngine.

Close #24289