### PR TITLE
Fix park window frame after switching to viewport tab

### DIFF
--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -1201,8 +1201,9 @@ namespace OpenRCT2::Ui::Windows
             }
 
             OnResize();
-            OnPrepareDraw();
             OnUpdate();
+            ResizeFrame();
+
             if (listen && viewport != nullptr)
                 viewport->flags |= VIEWPORT_FLAG_SOUND_ON;
         }


### PR DESCRIPTION
The tabs in the Park window apply different size restrictions. This may lead to the window being resized automatically when switching tabs, triggering a `ResizeFrame` call.

As reported in #24292, sometimes the `ResizeFrame` function is not invoked. I think this happens when switching from one of the chart tabs. Like the chart tabs, the viewport tab has flexible dimensions, and so the window does not have to be resized. However, it still needs to resize the window frame correctly! We fix this by explicitly invoking `ResizeFrame` in the `SetPage` function.

I've removed the explicit call to `OnPrepareDraw` as well. I assume it was taking care of the call to `ResizeFrame` before we removed them in #23590.