### PR TITLE
[Plugin] Fix missing invalidation on various plugin api setters for entities

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -22,6 +22,7 @@
 - Fix: [#24121] Checkbox labels run beyond the edge of the window if they’re too long to fit.
 - Fix: [#24142] [Plugin] Track origin is miscalculated on downward slopes.
 - Fix: [#24220] Narrow station platforms have missing sides on certain rotations.
+- Fix: [#24310] [Plugin] Missing invalidation on various plugin api setters for entities.
 
 0.4.21 (2025-04-05)
 ------------------------------------------------------------------------

--- a/src/openrct2/scripting/bindings/entity/ScBalloon.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScBalloon.cpp
@@ -47,6 +47,7 @@ namespace OpenRCT2::Scripting
         if (balloon != nullptr)
         {
             balloon->colour = value;
+            balloon->Invalidate();
         }
     }
 

--- a/src/openrct2/scripting/bindings/entity/ScLitter.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScLitter.cpp
@@ -70,6 +70,7 @@ namespace OpenRCT2::Scripting
             return;
         auto* litter = GetLitter();
         litter->SubType = it->second;
+        litter->Invalidate();
     }
 
     uint32_t ScLitter::creationTick_get() const

--- a/src/openrct2/scripting/bindings/entity/ScParticle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScParticle.cpp
@@ -58,6 +58,7 @@ namespace OpenRCT2::Scripting
         {
             entity->frame = std::clamp<uint16_t>(value, 0, kCrashedVehicleParticleNumberSprites - 1)
                 * kCrashedVehicleParticleFrameToSprite;
+            entity->Invalidate();
         }
     }
     uint8_t ScCrashedVehicleParticle::frame_get() const
@@ -76,6 +77,7 @@ namespace OpenRCT2::Scripting
         if (entity != nullptr)
         {
             entity->crashed_sprite_base = CrashParticleTypeMap[value];
+            entity->Invalidate();
         }
     }
     std::string ScCrashedVehicleParticle::crashedSpriteBase_get() const
@@ -194,6 +196,7 @@ namespace OpenRCT2::Scripting
             {
                 entity->crashed_sprite_base = CrashParticleTypeMap[value["crashParticleType"].as_string()];
             }
+            entity->Invalidate();
         }
     }
 
@@ -218,6 +221,7 @@ namespace OpenRCT2::Scripting
             auto colours = FromDuk<VehicleColour>(value);
             entity->colour[0] = colours.Body;
             entity->colour[1] = colours.Trim;
+            entity->Invalidate();
         }
     }
 }; // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/entity/ScPeep.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScPeep.hpp
@@ -155,6 +155,7 @@ namespace OpenRCT2::Scripting
             {
                 peep->PeepDirection = value;
                 peep->Orientation = value << 3;
+                peep->Invalidate();
             }
         }
 
@@ -171,6 +172,7 @@ namespace OpenRCT2::Scripting
             {
                 value = std::clamp(value, kPeepMinEnergy, kPeepMaxEnergy);
                 peep->Energy = value;
+                peep->Invalidate();
             }
         }
 

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -102,6 +102,7 @@ namespace OpenRCT2::Scripting
             // Reset state to walking to prevent invalid actions from carrying over
             peep->Action = PeepActionType::Walking;
             peep->AnimationType = peep->NextAnimationType = PeepAnimationType::Walking;
+            peep->Invalidate();
         }
     }
 
@@ -119,6 +120,7 @@ namespace OpenRCT2::Scripting
         {
             peep->TshirtColour = value;
             peep->TrousersColour = value;
+            peep->Invalidate();
         }
     }
 
@@ -210,6 +212,7 @@ namespace OpenRCT2::Scripting
 
         peep->AnimationObjectIndex = costume->objectId;
         peep->AnimationGroup = costume->group;
+        peep->Invalidate();
     }
 
     std::shared_ptr<ScPatrolArea> ScStaff::patrolArea_get() const

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
@@ -111,6 +111,7 @@ namespace OpenRCT2::Scripting
         if (vehicle != nullptr)
         {
             vehicle->ride_subtype = value;
+            vehicle->Invalidate();
         }
     }
 
@@ -126,6 +127,7 @@ namespace OpenRCT2::Scripting
         if (vehicle != nullptr)
         {
             vehicle->vehicle_type = value;
+            vehicle->Invalidate();
         }
     }
 
@@ -141,6 +143,7 @@ namespace OpenRCT2::Scripting
         if (vehicle != nullptr)
         {
             vehicle->Pitch = value;
+            vehicle->Invalidate();
         }
     }
 
@@ -337,6 +340,7 @@ namespace OpenRCT2::Scripting
         if (vehicle != nullptr)
         {
             vehicle->bank_rotation = value;
+            vehicle->Invalidate();
         }
     }
 
@@ -362,6 +366,7 @@ namespace OpenRCT2::Scripting
             {
                 vehicle->ClearFlag(flag);
             }
+            vehicle->Invalidate();
         }
     }
 
@@ -382,6 +387,7 @@ namespace OpenRCT2::Scripting
         if (vehicle != nullptr)
         {
             vehicle->colours = FromDuk<VehicleColour>(value);
+            vehicle->Invalidate();
         }
     }
 
@@ -485,6 +491,7 @@ namespace OpenRCT2::Scripting
         if (vehicle != nullptr)
         {
             vehicle->spin_sprite = value;
+            vehicle->Invalidate();
         }
     }
 


### PR DESCRIPTION
Hello,

The awesome additions of the OpenGL invalidation in #20073 shined some light on various plugin api setters that were not properly invalidating the affected entity. The issues were likely already present in software rendering for much longer, but I wasn't aware of that until recently. 

This PR aims to fix that by calling `Invalidate()` in the various setters that could affect what is shown on the screen, and did not yet invalidate the screen for it.

To test it, you can for example open the RideVehicleEditor, and try to change a vehicle's colour, type, or variant. On develop, it will update on the window's viewport, but not always on the main viewport. This is easiest noticeable if you spawn lots of trains, enable the "Synchronise" button, en select "All vehicles on all trains" from the target dropdown.

Thank you for your time. 🙂