### PR TITLE
Add api call to make vehicles appear as crashed vehicles, without actually crashing the ride

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,7 +1,8 @@
 0.4.23 (in development)
 ------------------------------------------------------------------------
+- Feature: [#24313] [Plugin] Add API for setting a ride vehicle’s sprite to a smoke plume. 
 - Improved: [#24368] Clicking the in-game update notication now leads to a more user-friendly download page.
-- Change: [#24342] g2.dat is now split into g2.dat and fonts.dat. 
+- Change: [#24342] g2.dat is now split into g2.dat and fonts.dat.
 - Change: [#24362] The Windows installer now prevents installing to the same folder as RollerCoaster Tycoon 2 or Classic.
 - Fix: [#24346] Possible crash during line drawing in OpenGL mode.
 - Fix: [#24353] ‘Show dirty visuals’ is off by one pixel and does not work correctly with higher framerates.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -2923,6 +2923,11 @@ declare global {
         isReversed: boolean;
 
         /**
+         * Whether to draw the car sprite as a smoke plume.
+         */
+        isCrashed: boolean;
+
+        /**
          * The colour of the car.
          */
         colours: VehicleColour;

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -46,7 +46,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t kPluginApiVersion = 107;
+    static constexpr int32_t kPluginApiVersion = 108;
 
     // Versions marking breaking changes.
     static constexpr int32_t kApiVersionPeepDeprecation = 33;

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
@@ -77,6 +77,8 @@ namespace OpenRCT2::Scripting
         dukglue_register_property(
             ctx, &ScVehicle::flag_get<VehicleFlags::CarIsReversed>, &ScVehicle::flag_set<VehicleFlags::CarIsReversed>,
             "isReversed");
+        dukglue_register_property(
+            ctx, &ScVehicle::flag_get<VehicleFlags::Crashed>, &ScVehicle::flag_set<VehicleFlags::Crashed>, "isCrashed");
         dukglue_register_property(ctx, &ScVehicle::colours_get, &ScVehicle::colours_set, "colours");
         dukglue_register_property(ctx, &ScVehicle::trackLocation_get, nullptr, "trackLocation");
         dukglue_register_property(ctx, &ScVehicle::trackProgress_get, nullptr, "trackProgress");


### PR DESCRIPTION
I added a flag which can be set and unset to toggle a vehicle's appearance between the type of vehicle it is, and a crashed vehicle smoke plume.
The smoke plume is not animated automatically, but using a vehicle that normally updates its sprite, such as a Single Deck Observation Cabin, also makes the smoke be animated. 