### PR TITLE
Improve scenery window (minimum) height

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Change: [#24235] Small changes to RCT1 theme.
 - Change: [#24236] Controls and Interface options now both have their own tabs in the Options window.
 - Change: [#24308] “Software” and “Software (hardware display)” renderers have been merged into a single “Software” renderer.
+- Change: [#24317] The scenery window now shows at least one row of scenery objects, even if there are multiple rows of tabs.
 - Fix: [#19782] Game stops counting inversions and golf holes after 31 (original bug).
 - Fix: [#21207] Track List window gets positioned incorrectly.
 - Fix: [#21919] Non-recolourable cars still show colour picker (original bug).

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -641,7 +641,7 @@ namespace OpenRCT2::Ui::Windows
         {
             // Minimum window height: title, one scenery button, status bar, padding
             _actualMinHeight = getTitleBarTargetHeight() + SCENERY_BUTTON_HEIGHT + kDescriptionHeight + 2 * kTabMargin;
-            _actualMinHeight += (1 + (_tabEntries.size() / GetMaxTabCountInARow())) * TabHeight;
+            _actualMinHeight += static_cast<int32_t>(1 + (_tabEntries.size() / GetMaxTabCountInARow())) * TabHeight;
             _actualMinHeight += widgets[WIDX_FILTER_TEXT_BOX].height() + 2 * kInputMargin;
 
             // Set the window title

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -71,6 +71,8 @@ namespace OpenRCT2::Ui::Windows
     constexpr int32_t WINDOW_SCENERY_MIN_HEIGHT = 195 - kTitleHeightNormal;
     constexpr int32_t SCENERY_BUTTON_WIDTH = 66;
     constexpr int32_t SCENERY_BUTTON_HEIGHT = 80;
+    constexpr int32_t kDescriptionHeight = 24;
+    constexpr int32_t kInputMargin = 2;
     constexpr int32_t kMaxWindowHeight = 473;
     constexpr int32_t kTabMargin = 3;
     constexpr int32_t TabWidth = 31;
@@ -113,7 +115,7 @@ namespace OpenRCT2::Ui::Windows
         MakeWidget     ({  2,  62}, {607, 80}, WindowWidgetType::Scroll,    WindowColour::Secondary, SCROLL_VERTICAL                                 ), // 1000000   0x009DE418
         MakeWidget     ({609,  59}, { 24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_ROTATE_ARROW),    STR_ROTATE_OBJECTS_90      ), // 2000000   0x009DE428
         MakeWidget     ({609,  83}, { 24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_PAINTBRUSH),      STR_SCENERY_PAINTBRUSH_TIP ), // 4000000   0x009DE438
-        MakeWidget     ({615,  108}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_COLOUR          ), // 8000000   0x009DE448
+        MakeWidget     ({615, 108}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_COLOUR          ), // 8000000   0x009DE448
         MakeWidget     ({615, 120}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_SECONDARY_COLOUR), // 10000000  0x009DE458
         MakeWidget     ({615, 132}, { 12, 12}, WindowWidgetType::ColourBtn, WindowColour::Secondary, 0xFFFFFFFF,          STR_SELECT_TERTIARY_COLOUR  ), // 20000000  0x009DE468
         MakeWidget     ({609, 145}, { 24, 24}, WindowWidgetType::FlatBtn,   WindowColour::Secondary, ImageId(SPR_G2_EYEDROPPER),   STR_SCENERY_EYEDROPPER_TIP ), // 40000000  0x009DE478
@@ -478,7 +480,7 @@ namespace OpenRCT2::Ui::Windows
                         else
                         {
                             const auto& listWidget = widgets[WIDX_SCENERY_LIST];
-                            const auto nonListHeight = height - listWidget.height() + 12;
+                            const auto nonListHeight = height - listWidget.height() + 2;
 
                             const auto numRows = static_cast<int32_t>(CountRows());
                             const auto maxContentHeight = numRows * SCENERY_BUTTON_HEIGHT;
@@ -637,7 +639,10 @@ namespace OpenRCT2::Ui::Windows
 
         void OnPrepareDraw() override
         {
-            _actualMinHeight = WINDOW_SCENERY_MIN_HEIGHT + getTitleBarTargetHeight();
+            // Minimum window height: title, one scenery button, status bar, padding
+            _actualMinHeight = getTitleBarTargetHeight() + SCENERY_BUTTON_HEIGHT + kDescriptionHeight + 2 * kTabMargin;
+            _actualMinHeight += (1 + (_tabEntries.size() / GetMaxTabCountInARow())) * TabHeight;
+            _actualMinHeight += widgets[WIDX_FILTER_TEXT_BOX].height() + 2 * kInputMargin;
 
             // Set the window title
             StringId titleStringId = STR_MISCELLANEOUS;
@@ -806,7 +811,7 @@ namespace OpenRCT2::Ui::Windows
 
             ResizeFrame();
             widgets[WIDX_SCENERY_LIST].right = windowWidth - 26;
-            widgets[WIDX_SCENERY_LIST].bottom = height - 24;
+            widgets[WIDX_SCENERY_LIST].bottom = height - kDescriptionHeight;
 
             widgets[WIDX_SCENERY_ROTATE_OBJECTS_BUTTON].left = windowWidth - 25;
             widgets[WIDX_SCENERY_REPAINT_SCENERY_BUTTON].left = windowWidth - 25;

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -71,6 +71,7 @@ namespace OpenRCT2::Ui::Windows
     constexpr int32_t WINDOW_SCENERY_MIN_HEIGHT = 195 - kTitleHeightNormal;
     constexpr int32_t SCENERY_BUTTON_WIDTH = 66;
     constexpr int32_t SCENERY_BUTTON_HEIGHT = 80;
+    constexpr int32_t kMaxWindowHeight = 473;
     constexpr int32_t kTabMargin = 3;
     constexpr int32_t TabWidth = 31;
     constexpr int32_t TabHeight = 28;
@@ -481,8 +482,8 @@ namespace OpenRCT2::Ui::Windows
 
                             const auto numRows = static_cast<int32_t>(CountRows());
                             const auto maxContentHeight = numRows * SCENERY_BUTTON_HEIGHT;
-                            const auto maxWindowHeight = maxContentHeight + nonListHeight;
-                            const auto windowHeight = std::clamp(maxWindowHeight, _actualMinHeight, 473);
+                            const auto expandedWindowHeight = maxContentHeight + nonListHeight;
+                            const auto windowHeight = std::clamp(expandedWindowHeight, _actualMinHeight, kMaxWindowHeight);
 
                             min_height = windowHeight;
                             max_height = windowHeight;

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -828,6 +828,10 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].right = windowWidth - 8;
             widgets[WIDX_SCENERY_SECONDARY_COLOUR_BUTTON].right = windowWidth - 8;
             widgets[WIDX_SCENERY_TERTIARY_COLOUR_BUTTON].right = windowWidth - 8;
+
+            const bool canFit = widgets[WIDX_SCENERY_BUILD_CLUSTER_BUTTON].top < height;
+            widgets[WIDX_SCENERY_EYEDROPPER_BUTTON].type = canFit ? WindowWidgetType::FlatBtn : WindowWidgetType::Empty;
+            widgets[WIDX_SCENERY_BUILD_CLUSTER_BUTTON].type = canFit ? WindowWidgetType::FlatBtn : WindowWidgetType::Empty;
         }
 
         void OnDraw(DrawPixelInfo& dpi) override


### PR DESCRIPTION
Having more than one tab strip currently eats away at the height left for scenery items. This PR changes the minimum height for the scenery window to fit all the tabs as well as at one full row of scenery items.

Furthermore, regardless of the above, the eyedropper and cluster buttons are rendered outside the window in 'collapsed' mode. These two widgets are now hidden when the window is too small.

**Question**:
We could also increase the minimum height to include more than one row of items (even say 1.5), such that we can accommodate the lower buttons as well. Let me know if that's preferable.

### Before (develop)
![Imagination Megapark 2025-05-02 12-25-13](https://github.com/user-attachments/assets/965df5f1-d61e-4975-b687-267a5778ee21)
![Imagination Megapark 2025-05-02 12-25-16](https://github.com/user-attachments/assets/716d09e0-7704-4972-a867-e55d3f513955)

### After (PR)
![Imagination Megapark 2025-05-02 12-26-06](https://github.com/user-attachments/assets/92f154c7-a76c-402a-8d50-4aa4eabd5b60)
![Imagination Megapark 2025-05-02 12-26-10](https://github.com/user-attachments/assets/07edbd8b-285a-4271-924d-c79802bd7a03)

