### PR TITLE
Android CI: enable native build (cmake) output

### DIFF
--- a/src/openrct2-android/gradle.properties
+++ b/src/openrct2-android/gradle.properties
@@ -20,3 +20,7 @@ android.enableJetifier=false
 android.useAndroidX=true
 org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Xmx4096m
+
+# Enable verbose output to see cmake and ninja logs during build for native output:
+# https://developer.android.com/studio/releases/gradle-plugin#native-build-output
+android.native.buildOutput=verbose


### PR DESCRIPTION
This Android CI currently only shows what Gradle is being executed. This PR changes the `android.native.buildOutput` setting, allowing us to see what cmake/ninja is working on.