### PR TITLE
Rename DrawPixelInfo to RenderTarget

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -152,7 +152,7 @@ public:
         WindowDispatchUpdateAll();
     }
 
-    void Draw(DrawPixelInfo& dpi) override
+    void Draw(RenderTarget& dpi) override
     {
         auto bgColour = ThemeGetColour(WindowClass::Chat, 0);
         ChatDraw(dpi, bgColour);
@@ -302,7 +302,7 @@ public:
         return std::make_shared<DrawingEngineFactory>();
     }
 
-    void DrawWeatherAnimation(IWeatherDrawer* weatherDrawer, DrawPixelInfo& dpi, DrawWeatherFunc drawFunc) override
+    void DrawWeatherAnimation(IWeatherDrawer* weatherDrawer, RenderTarget& dpi, DrawWeatherFunc drawFunc) override
     {
         int32_t left = dpi.x;
         int32_t right = left + dpi.width;
@@ -940,7 +940,7 @@ private:
     }
 
     static void DrawWeatherWindow(
-        DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, WindowBase* original_w, int16_t left, int16_t right, int16_t top,
+        RenderTarget& dpi, IWeatherDrawer* weatherDrawer, WindowBase* original_w, int16_t left, int16_t right, int16_t top,
         int16_t bottom, DrawWeatherFunc drawFunc)
     {
         WindowBase* w{};

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -152,11 +152,11 @@ public:
         WindowDispatchUpdateAll();
     }
 
-    void Draw(RenderTarget& dpi) override
+    void Draw(RenderTarget& rt) override
     {
         auto bgColour = ThemeGetColour(WindowClass::Chat, 0);
-        ChatDraw(dpi, bgColour);
-        _inGameConsole.Draw(dpi);
+        ChatDraw(rt, bgColour);
+        _inGameConsole.Draw(rt);
     }
 
     // Window
@@ -302,16 +302,16 @@ public:
         return std::make_shared<DrawingEngineFactory>();
     }
 
-    void DrawWeatherAnimation(IWeatherDrawer* weatherDrawer, RenderTarget& dpi, DrawWeatherFunc drawFunc) override
+    void DrawWeatherAnimation(IWeatherDrawer* weatherDrawer, RenderTarget& rt, DrawWeatherFunc drawFunc) override
     {
-        int32_t left = dpi.x;
-        int32_t right = left + dpi.width;
-        int32_t top = dpi.y;
-        int32_t bottom = top + dpi.height;
+        int32_t left = rt.x;
+        int32_t right = left + rt.width;
+        int32_t top = rt.y;
+        int32_t bottom = top + rt.height;
 
         for (auto& w : g_window_list)
         {
-            DrawWeatherWindow(dpi, weatherDrawer, w.get(), left, right, top, bottom, drawFunc);
+            DrawWeatherWindow(rt, weatherDrawer, w.get(), left, right, top, bottom, drawFunc);
         }
     }
 
@@ -940,7 +940,7 @@ private:
     }
 
     static void DrawWeatherWindow(
-        RenderTarget& dpi, IWeatherDrawer* weatherDrawer, WindowBase* original_w, int16_t left, int16_t right, int16_t top,
+        RenderTarget& rt, IWeatherDrawer* weatherDrawer, WindowBase* original_w, int16_t left, int16_t right, int16_t top,
         int16_t bottom, DrawWeatherFunc drawFunc)
     {
         WindowBase* w{};
@@ -961,7 +961,7 @@ private:
                     {
                         auto width = right - left;
                         auto height = bottom - top;
-                        drawFunc(dpi, weatherDrawer, left, top, width, height);
+                        drawFunc(rt, weatherDrawer, left, top, width, height);
                     }
                 }
                 return;
@@ -989,39 +989,39 @@ private:
                 break;
             }
 
-            DrawWeatherWindow(dpi, weatherDrawer, original_w, left, w->windowPos.x, top, bottom, drawFunc);
+            DrawWeatherWindow(rt, weatherDrawer, original_w, left, w->windowPos.x, top, bottom, drawFunc);
 
             left = w->windowPos.x;
-            DrawWeatherWindow(dpi, weatherDrawer, original_w, left, right, top, bottom, drawFunc);
+            DrawWeatherWindow(rt, weatherDrawer, original_w, left, right, top, bottom, drawFunc);
             return;
         }
 
         int16_t w_right = RCT_WINDOW_RIGHT(w);
         if (right > w_right)
         {
-            DrawWeatherWindow(dpi, weatherDrawer, original_w, left, w_right, top, bottom, drawFunc);
+            DrawWeatherWindow(rt, weatherDrawer, original_w, left, w_right, top, bottom, drawFunc);
 
             left = w_right;
-            DrawWeatherWindow(dpi, weatherDrawer, original_w, left, right, top, bottom, drawFunc);
+            DrawWeatherWindow(rt, weatherDrawer, original_w, left, right, top, bottom, drawFunc);
             return;
         }
 
         if (top < w->windowPos.y)
         {
-            DrawWeatherWindow(dpi, weatherDrawer, original_w, left, right, top, w->windowPos.y, drawFunc);
+            DrawWeatherWindow(rt, weatherDrawer, original_w, left, right, top, w->windowPos.y, drawFunc);
 
             top = w->windowPos.y;
-            DrawWeatherWindow(dpi, weatherDrawer, original_w, left, right, top, bottom, drawFunc);
+            DrawWeatherWindow(rt, weatherDrawer, original_w, left, right, top, bottom, drawFunc);
             return;
         }
 
         int16_t w_bottom = RCT_WINDOW_BOTTOM(w);
         if (bottom > w_bottom)
         {
-            DrawWeatherWindow(dpi, weatherDrawer, original_w, left, right, top, w_bottom, drawFunc);
+            DrawWeatherWindow(rt, weatherDrawer, original_w, left, right, top, w_bottom, drawFunc);
 
             top = w_bottom;
-            DrawWeatherWindow(dpi, weatherDrawer, original_w, left, right, top, bottom, drawFunc);
+            DrawWeatherWindow(rt, weatherDrawer, original_w, left, right, top, bottom, drawFunc);
             return;
         }
     }

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -86,7 +86,7 @@ private:
 
     static uint8_t ComputeOutCode(ScreenCoordsXY, ScreenCoordsXY, ScreenCoordsXY);
     static bool CohenSutherlandLineClip(ScreenLine&, const RenderTarget&);
-    [[nodiscard]] ScreenRect CalculateClipping(const RenderTarget& dpi) const;
+    [[nodiscard]] ScreenRect CalculateClipping(const RenderTarget& rt) const;
 
 public:
     explicit OpenGLDrawingContext(OpenGLDrawingEngine& engine);
@@ -113,18 +113,18 @@ public:
     void StartNewDraw();
     void FinishDraw();
 
-    void Clear(RenderTarget& dpi, uint8_t paletteIndex) override;
-    void FillRect(RenderTarget& dpi, uint32_t colour, int32_t x, int32_t y, int32_t w, int32_t h) override;
+    void Clear(RenderTarget& rt, uint8_t paletteIndex) override;
+    void FillRect(RenderTarget& rt, uint32_t colour, int32_t x, int32_t y, int32_t w, int32_t h) override;
     void FilterRect(
-        RenderTarget& dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) override;
-    void DrawLine(RenderTarget& dpi, uint32_t colour, const ScreenLine& line) override;
-    void DrawSprite(RenderTarget& dpi, const ImageId imageId, int32_t x, int32_t y) override;
+        RenderTarget& rt, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) override;
+    void DrawLine(RenderTarget& rt, uint32_t colour, const ScreenLine& line) override;
+    void DrawSprite(RenderTarget& rt, const ImageId imageId, int32_t x, int32_t y) override;
     void DrawSpriteRawMasked(
-        RenderTarget& dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) override;
-    void DrawSpriteSolid(RenderTarget& dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) override;
-    void DrawGlyph(RenderTarget& dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette) override;
+        RenderTarget& rt, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) override;
+    void DrawSpriteSolid(RenderTarget& rt, const ImageId image, int32_t x, int32_t y, uint8_t colour) override;
+    void DrawGlyph(RenderTarget& rt, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette) override;
     void DrawTTFBitmap(
-        RenderTarget& dpi, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y, uint8_t hintingThreshold) override;
+        RenderTarget& rt, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y, uint8_t hintingThreshold) override;
 
     void FlushCommandBuffers();
 
@@ -150,7 +150,7 @@ public:
     }
 
     virtual void Draw(
-        RenderTarget& dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
+        RenderTarget& rt, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
         const uint8_t* weatherpattern) override
     {
         const uint8_t* pattern = weatherpattern;
@@ -160,7 +160,7 @@ public:
         uint8_t patternStartXOffset = xStart % patternXSpace;
         uint8_t patternStartYOffset = yStart % patternYSpace;
 
-        uint32_t pixelOffset = dpi.LineStride() * y + x;
+        uint32_t pixelOffset = rt.LineStride() * y + x;
         uint8_t patternYPos = patternStartYOffset % patternYSpace;
 
         for (; height != 0; height--)
@@ -176,14 +176,14 @@ public:
                 auto patternPixel = pattern[patternYPos * 2 + 1];
                 for (; xPixelOffset < finalPixelOffset; xPixelOffset += patternXSpace)
                 {
-                    int32_t pixelX = xPixelOffset % dpi.width;
-                    int32_t pixelY = (xPixelOffset / dpi.width) % dpi.height;
+                    int32_t pixelX = xPixelOffset % rt.width;
+                    int32_t pixelY = (xPixelOffset / rt.width) % rt.height;
 
-                    _drawingContext->DrawLine(dpi, patternPixel, { { pixelX, pixelY }, { pixelX + 1, pixelY + 1 } });
+                    _drawingContext->DrawLine(rt, patternPixel, { { pixelX, pixelY }, { pixelX + 1, pixelY + 1 } });
                 }
             }
 
-            pixelOffset += dpi.LineStride();
+            pixelOffset += rt.LineStride();
             patternYPos++;
             patternYPos %= patternYSpace;
         }
@@ -203,7 +203,7 @@ private:
     size_t _bitsSize = 0;
     std::unique_ptr<uint8_t[]> _bits;
 
-    RenderTarget _bitsDPI = {};
+    RenderTarget _mainRT = {};
 
     std::unique_ptr<OpenGLDrawingContext> _drawingContext;
 
@@ -224,7 +224,7 @@ public:
         , _weatherDrawer(_drawingContext.get())
     {
         _window = static_cast<SDL_Window*>(_uiContext->GetWindow());
-        _bitsDPI.DrawingEngine = this;
+        _mainRT.DrawingEngine = this;
         LightFx::SetAvailable(false);
     }
 
@@ -268,7 +268,7 @@ public:
         _drawingContext->Resize(width, height);
 
         _drawingContext->StartNewDraw();
-        _drawingContext->Clear(_bitsDPI, PaletteIndex::pi10);
+        _drawingContext->Clear(_mainRT, PaletteIndex::pi10);
         _drawingContext->FlushCommandBuffers();
         _drawingContext->FinishDraw();
     }
@@ -367,7 +367,7 @@ public:
             WindowUpdateAllViewports();
             // OpenGL doesn't support restoring pixels, always redraw.
             // TODO: Render the weather to a texture and use that instead.
-            WindowDrawAll(_bitsDPI, 0, 0, static_cast<int32_t>(_width), static_cast<int32_t>(_height));
+            WindowDrawAll(_mainRT, 0, 0, static_cast<int32_t>(_width), static_cast<int32_t>(_height));
         }
         else
         {
@@ -390,20 +390,20 @@ public:
     void DrawDirtyBlocks(int32_t left, int32_t top, int32_t right, int32_t bottom)
     {
         // Draw region
-        WindowDrawAll(_bitsDPI, left, top, right, bottom);
+        WindowDrawAll(_mainRT, left, top, right, bottom);
     }
 
     void PaintWeather() override
     {
-        DrawWeather(_bitsDPI, &_weatherDrawer);
+        DrawWeather(_mainRT, &_weatherDrawer);
     }
 
     std::string Screenshot() override
     {
         const OpenGLFramebuffer& framebuffer = _drawingContext->GetFinalFramebuffer();
         framebuffer.Bind();
-        framebuffer.GetPixels(_bitsDPI);
-        std::string result = ScreenshotDumpPNG(_bitsDPI);
+        framebuffer.GetPixels(_mainRT);
+        std::string result = ScreenshotDumpPNG(_mainRT);
         return result;
     }
 
@@ -416,7 +416,7 @@ public:
 
         OpenGLFramebuffer& framebuffer = _drawingContext->GetFinalFramebuffer();
         framebuffer.Bind();
-        framebuffer.GetPixels(_bitsDPI);
+        framebuffer.GetPixels(_mainRT);
 
         // Originally 0x00683359
         // Adjust for move off screen
@@ -432,9 +432,9 @@ public:
         width += lmargin + rmargin;
         height += tmargin + bmargin;
 
-        int32_t stride = _bitsDPI.LineStride();
-        uint8_t* to = _bitsDPI.bits + y * stride + x;
-        uint8_t* from = _bitsDPI.bits + (y - dy) * stride + x - dx;
+        int32_t stride = _mainRT.LineStride();
+        uint8_t* to = _mainRT.bits + y * stride + x;
+        uint8_t* from = _mainRT.bits + (y - dy) * stride + x - dx;
 
         if (dy > 0)
         {
@@ -452,7 +452,7 @@ public:
             from += stride;
         }
 
-        framebuffer.SetPixels(_bitsDPI);
+        framebuffer.SetPixels(_mainRT);
     }
 
     IDrawingContext* GetDrawingContext() override
@@ -467,7 +467,7 @@ public:
 
     RenderTarget* GetDrawingPixelInfo() override
     {
-        return &_bitsDPI;
+        return &_mainRT;
     }
 
     DrawingEngineFlags GetFlags() override
@@ -482,7 +482,7 @@ public:
 
     RenderTarget* GetDPI()
     {
-        return &_bitsDPI;
+        return &_mainRT;
     }
 
 private:
@@ -540,13 +540,13 @@ private:
         _height = height;
         _pitch = pitch;
 
-        RenderTarget* dpi = &_bitsDPI;
-        dpi->bits = _bits.get();
-        dpi->x = 0;
-        dpi->y = 0;
-        dpi->width = width;
-        dpi->height = height;
-        dpi->pitch = _pitch - width;
+        RenderTarget* rt = &_mainRT;
+        rt->bits = _bits.get();
+        rt->x = 0;
+        rt->y = 0;
+        rt->width = width;
+        rt->height = height;
+        rt->pitch = _pitch - width;
     }
 
     void ConfigureCanvas()
@@ -629,24 +629,23 @@ void OpenGLDrawingContext::FinishDraw()
     _inDraw = false;
 }
 
-void OpenGLDrawingContext::Clear(RenderTarget& dpi, uint8_t paletteIndex)
+void OpenGLDrawingContext::Clear(RenderTarget& rt, uint8_t paletteIndex)
 {
     Guard::Assert(_inDraw == true);
 
-    FillRect(dpi, paletteIndex, dpi.x, dpi.y, dpi.x + dpi.width, dpi.y + dpi.height);
+    FillRect(rt, paletteIndex, rt.x, rt.y, rt.x + rt.width, rt.y + rt.height);
 }
 
-void OpenGLDrawingContext::FillRect(
-    RenderTarget& dpi, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom)
+void OpenGLDrawingContext::FillRect(RenderTarget& rt, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
     Guard::Assert(_inDraw == true);
 
-    const ScreenRect clip = CalculateClipping(dpi);
+    const ScreenRect clip = CalculateClipping(rt);
 
-    left += clip.GetLeft() - dpi.x;
-    top += clip.GetTop() - dpi.y;
-    right += clip.GetLeft() - dpi.x;
-    bottom += clip.GetTop() - dpi.y;
+    left += clip.GetLeft() - rt.x;
+    top += clip.GetTop() - rt.y;
+    right += clip.GetLeft() - rt.x;
+    bottom += clip.GetTop() - rt.y;
 
     DrawRectCommand& command = _commandBuffers.rects.allocate();
 
@@ -675,16 +674,16 @@ void OpenGLDrawingContext::FillRect(
 }
 
 void OpenGLDrawingContext::FilterRect(
-    RenderTarget& dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom)
+    RenderTarget& rt, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
     Guard::Assert(_inDraw == true);
 
-    const ScreenRect clip = CalculateClipping(dpi);
+    const ScreenRect clip = CalculateClipping(rt);
 
-    left += clip.GetLeft() - dpi.x;
-    top += clip.GetTop() - dpi.y;
-    right += clip.GetLeft() - dpi.x;
-    bottom += clip.GetTop() - dpi.y;
+    left += clip.GetLeft() - rt.x;
+    top += clip.GetTop() - rt.y;
+    right += clip.GetLeft() - rt.x;
+    bottom += clip.GetTop() - rt.y;
 
     DrawRectCommand& command = _commandBuffers.transparent.allocate();
 
@@ -719,12 +718,12 @@ uint8_t OpenGLDrawingContext::ComputeOutCode(
     return code;
 }
 
-// Trims the line to be within the bounds of the dpi.
+// Trims the line to be within the bounds of the render target.
 // based on: https://en.wikipedia.org/wiki/Cohen%E2%80%93Sutherland_algorithm
-bool OpenGLDrawingContext::CohenSutherlandLineClip(ScreenLine& line, const RenderTarget& dpi)
+bool OpenGLDrawingContext::CohenSutherlandLineClip(ScreenLine& line, const RenderTarget& rt)
 {
-    ScreenCoordsXY topLeft = { dpi.x, dpi.y };
-    ScreenCoordsXY bottomRight = { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 };
+    ScreenCoordsXY topLeft = { rt.x, rt.y };
+    ScreenCoordsXY bottomRight = { rt.x + rt.width - 1, rt.y + rt.height - 1 };
     uint8_t outcode1 = ComputeOutCode(line.Point1, topLeft, bottomRight);
     uint8_t outcode2 = ComputeOutCode(line.Point2, topLeft, bottomRight);
 
@@ -732,12 +731,12 @@ bool OpenGLDrawingContext::CohenSutherlandLineClip(ScreenLine& line, const Rende
     {
         if (outcode1 == kCSInside && outcode2 == kCSInside)
         {
-            // both points inside dpi
+            // both points inside render target
             return true;
         }
         if (outcode1 & outcode2)
         {
-            // both points share an outside zone so both must be outside dpi
+            // both points share an outside zone so both must be outside render target
             return false;
         }
 
@@ -785,23 +784,23 @@ bool OpenGLDrawingContext::CohenSutherlandLineClip(ScreenLine& line, const Rende
     }
 }
 
-void OpenGLDrawingContext::DrawLine(RenderTarget& dpi, uint32_t colour, const ScreenLine& line)
+void OpenGLDrawingContext::DrawLine(RenderTarget& rt, uint32_t colour, const ScreenLine& line)
 {
     Guard::Assert(_inDraw == true);
 
-    const ZoomLevel zoom = dpi.zoom_level;
+    const ZoomLevel zoom = rt.zoom_level;
     ScreenLine trimmedLine = { { zoom.ApplyInversedTo(line.GetX1()), zoom.ApplyInversedTo(line.GetY1()) },
                                { zoom.ApplyInversedTo(line.GetX2()), zoom.ApplyInversedTo(line.GetY2()) } };
-    if (!CohenSutherlandLineClip(trimmedLine, dpi))
+    if (!CohenSutherlandLineClip(trimmedLine, rt))
         return;
 
     DrawLineCommand& command = _commandBuffers.lines.allocate();
 
-    const ScreenRect clip = CalculateClipping(dpi);
-    const int32_t x1 = trimmedLine.GetX1() - dpi.x + clip.GetLeft();
-    const int32_t y1 = trimmedLine.GetY1() - dpi.y + clip.GetTop();
-    const int32_t x2 = trimmedLine.GetX2() - dpi.x + clip.GetLeft();
-    const int32_t y2 = trimmedLine.GetY2() - dpi.y + clip.GetTop();
+    const ScreenRect clip = CalculateClipping(rt);
+    const int32_t x1 = trimmedLine.GetX1() - rt.x + clip.GetLeft();
+    const int32_t y1 = trimmedLine.GetY1() - rt.y + clip.GetTop();
+    const int32_t x2 = trimmedLine.GetX2() - rt.x + clip.GetLeft();
+    const int32_t y2 = trimmedLine.GetY2() - rt.y + clip.GetTop();
 
     command.bounds = { x1, y1, x2, y2 };
     command.colour = colour & 0xFF;
@@ -814,7 +813,7 @@ static auto EuclideanRemainder(const auto a, const auto b)
     return r >= 0 ? r : r + b;
 };
 
-void OpenGLDrawingContext::DrawSprite(RenderTarget& dpi, const ImageId imageId, const int32_t x, const int32_t y)
+void OpenGLDrawingContext::DrawSprite(RenderTarget& rt, const ImageId imageId, const int32_t x, const int32_t y)
 {
     Guard::Assert(_inDraw == true);
 
@@ -824,19 +823,19 @@ void OpenGLDrawingContext::DrawSprite(RenderTarget& dpi, const ImageId imageId, 
         return;
     }
 
-    if (dpi.zoom_level > ZoomLevel{ 0 })
+    if (rt.zoom_level > ZoomLevel{ 0 })
     {
         if (g1Element->flags & G1_FLAG_HAS_ZOOM_SPRITE)
         {
-            RenderTarget zoomedDPI;
-            zoomedDPI.bits = dpi.bits;
-            zoomedDPI.x = dpi.x;
-            zoomedDPI.y = dpi.y;
-            zoomedDPI.height = dpi.height;
-            zoomedDPI.width = dpi.width;
-            zoomedDPI.pitch = dpi.pitch;
-            zoomedDPI.zoom_level = dpi.zoom_level - 1;
-            DrawSprite(zoomedDPI, imageId.WithIndex(imageId.GetIndex() - g1Element->zoomed_offset), x >> 1, y >> 1);
+            RenderTarget zoomedRT;
+            zoomedRT.bits = rt.bits;
+            zoomedRT.x = rt.x;
+            zoomedRT.y = rt.y;
+            zoomedRT.height = rt.height;
+            zoomedRT.width = rt.width;
+            zoomedRT.pitch = rt.pitch;
+            zoomedRT.zoom_level = rt.zoom_level - 1;
+            DrawSprite(zoomedRT, imageId.WithIndex(imageId.GetIndex() - g1Element->zoomed_offset), x >> 1, y >> 1);
             return;
         }
         if (g1Element->flags & G1_FLAG_NO_ZOOM_DRAW)
@@ -854,9 +853,9 @@ void OpenGLDrawingContext::DrawSprite(RenderTarget& dpi, const ImageId imageId, 
     int32_t yModifier = 0;
     int32_t widthModifier = 0;
 
-    if (dpi.zoom_level > ZoomLevel{ 0 })
+    if (rt.zoom_level > ZoomLevel{ 0 })
     {
-        const int32_t interval = dpi.zoom_level.ApplyTo(1);
+        const int32_t interval = rt.zoom_level.ApplyTo(1);
 
         xModifier = EuclideanRemainder(left, interval);
         xModifier = xModifier ? interval - xModifier : 0;
@@ -868,19 +867,19 @@ void OpenGLDrawingContext::DrawSprite(RenderTarget& dpi, const ImageId imageId, 
         texture.coords.y += (interval - 1) - yModifier;
     }
 
-    left = dpi.zoom_level.ApplyInversedTo(left + xModifier);
-    top = dpi.zoom_level.ApplyInversedTo(top);
-    int32_t right = left + dpi.zoom_level.ApplyInversedTo(g1Element->width + widthModifier);
-    int32_t bottom = top + dpi.zoom_level.ApplyInversedTo(g1Element->height + yModifier);
+    left = rt.zoom_level.ApplyInversedTo(left + xModifier);
+    top = rt.zoom_level.ApplyInversedTo(top);
+    int32_t right = left + rt.zoom_level.ApplyInversedTo(g1Element->width + widthModifier);
+    int32_t bottom = top + rt.zoom_level.ApplyInversedTo(g1Element->height + yModifier);
 
-    const ScreenRect clip = CalculateClipping(dpi);
-    left += clip.GetLeft() - dpi.x;
-    top += clip.GetTop() - dpi.y;
-    right += clip.GetLeft() - dpi.x;
-    bottom += clip.GetTop() - dpi.y;
+    const ScreenRect clip = CalculateClipping(rt);
+    left += clip.GetLeft() - rt.x;
+    top += clip.GetTop() - rt.y;
+    right += clip.GetLeft() - rt.x;
+    bottom += clip.GetTop() - rt.y;
 
-    const float zoom = dpi.zoom_level >= ZoomLevel{ 0 } ? static_cast<float>(dpi.zoom_level.ApplyTo(1))
-                                                        : 1.0f / static_cast<float>(dpi.zoom_level.ApplyInversedTo(1));
+    const float zoom = rt.zoom_level >= ZoomLevel{ 0 } ? static_cast<float>(rt.zoom_level.ApplyTo(1))
+                                                       : 1.0f / static_cast<float>(rt.zoom_level.ApplyInversedTo(1));
 
     int paletteCount;
     ivec3 palettes{};
@@ -949,7 +948,7 @@ void OpenGLDrawingContext::DrawSprite(RenderTarget& dpi, const ImageId imageId, 
 }
 
 void OpenGLDrawingContext::DrawSpriteRawMasked(
-    RenderTarget& dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage)
+    RenderTarget& rt, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage)
 {
     Guard::Assert(_inDraw == true);
 
@@ -982,19 +981,19 @@ void OpenGLDrawingContext::DrawSpriteRawMasked(
         std::swap(top, bottom);
     }
 
-    left = dpi.zoom_level.ApplyInversedTo(left);
-    top = dpi.zoom_level.ApplyInversedTo(top);
-    right = dpi.zoom_level.ApplyInversedTo(right);
-    bottom = dpi.zoom_level.ApplyInversedTo(bottom);
+    left = rt.zoom_level.ApplyInversedTo(left);
+    top = rt.zoom_level.ApplyInversedTo(top);
+    right = rt.zoom_level.ApplyInversedTo(right);
+    bottom = rt.zoom_level.ApplyInversedTo(bottom);
 
-    const ScreenRect clip = CalculateClipping(dpi);
-    left += clip.GetLeft() - dpi.x;
-    top += clip.GetTop() - dpi.y;
-    right += clip.GetLeft() - dpi.x;
-    bottom += clip.GetTop() - dpi.y;
+    const ScreenRect clip = CalculateClipping(rt);
+    left += clip.GetLeft() - rt.x;
+    top += clip.GetTop() - rt.y;
+    right += clip.GetLeft() - rt.x;
+    bottom += clip.GetTop() - rt.y;
 
-    const float zoom = dpi.zoom_level >= ZoomLevel{ 0 } ? static_cast<float>(dpi.zoom_level.ApplyTo(1))
-                                                        : 1.0f / static_cast<float>(dpi.zoom_level.ApplyInversedTo(1));
+    const float zoom = rt.zoom_level >= ZoomLevel{ 0 } ? static_cast<float>(rt.zoom_level.ApplyTo(1))
+                                                       : 1.0f / static_cast<float>(rt.zoom_level.ApplyInversedTo(1));
 
     DrawRectCommand& command = _commandBuffers.rects.allocate();
 
@@ -1011,7 +1010,7 @@ void OpenGLDrawingContext::DrawSpriteRawMasked(
     command.zoom = zoom;
 }
 
-void OpenGLDrawingContext::DrawSpriteSolid(RenderTarget& dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour)
+void OpenGLDrawingContext::DrawSpriteSolid(RenderTarget& rt, const ImageId image, int32_t x, int32_t y, uint8_t colour)
 {
     Guard::Assert(_inDraw == true);
 
@@ -1042,11 +1041,11 @@ void OpenGLDrawingContext::DrawSpriteSolid(RenderTarget& dpi, const ImageId imag
         std::swap(top, bottom);
     }
 
-    const ScreenRect clip = CalculateClipping(dpi);
-    left += clip.GetLeft() - dpi.x;
-    top += clip.GetTop() - dpi.y;
-    right += clip.GetLeft() - dpi.x;
-    bottom += clip.GetTop() - dpi.y;
+    const ScreenRect clip = CalculateClipping(rt);
+    left += clip.GetLeft() - rt.x;
+    top += clip.GetTop() - rt.y;
+    right += clip.GetLeft() - rt.x;
+    bottom += clip.GetTop() - rt.y;
 
     DrawRectCommand& command = _commandBuffers.rects.allocate();
 
@@ -1063,7 +1062,7 @@ void OpenGLDrawingContext::DrawSpriteSolid(RenderTarget& dpi, const ImageId imag
     command.zoom = 1.0f;
 }
 
-void OpenGLDrawingContext::DrawGlyph(RenderTarget& dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette)
+void OpenGLDrawingContext::DrawGlyph(RenderTarget& rt, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette)
 {
     Guard::Assert(_inDraw == true);
 
@@ -1089,19 +1088,19 @@ void OpenGLDrawingContext::DrawGlyph(RenderTarget& dpi, const ImageId image, int
         std::swap(top, bottom);
     }
 
-    left = dpi.zoom_level.ApplyInversedTo(left);
-    top = dpi.zoom_level.ApplyInversedTo(top);
-    right = dpi.zoom_level.ApplyInversedTo(right);
-    bottom = dpi.zoom_level.ApplyInversedTo(bottom);
+    left = rt.zoom_level.ApplyInversedTo(left);
+    top = rt.zoom_level.ApplyInversedTo(top);
+    right = rt.zoom_level.ApplyInversedTo(right);
+    bottom = rt.zoom_level.ApplyInversedTo(bottom);
 
-    const ScreenRect clip = CalculateClipping(dpi);
-    left += clip.GetLeft() - dpi.x;
-    top += clip.GetTop() - dpi.y;
-    right += clip.GetLeft() - dpi.x;
-    bottom += clip.GetTop() - dpi.y;
+    const ScreenRect clip = CalculateClipping(rt);
+    left += clip.GetLeft() - rt.x;
+    top += clip.GetTop() - rt.y;
+    right += clip.GetLeft() - rt.x;
+    bottom += clip.GetTop() - rt.y;
 
-    const float zoom = dpi.zoom_level >= ZoomLevel{ 0 } ? static_cast<float>(dpi.zoom_level.ApplyTo(1))
-                                                        : 1.0f / static_cast<float>(dpi.zoom_level.ApplyInversedTo(1));
+    const float zoom = rt.zoom_level >= ZoomLevel{ 0 } ? static_cast<float>(rt.zoom_level.ApplyTo(1))
+                                                       : 1.0f / static_cast<float>(rt.zoom_level.ApplyInversedTo(1));
 
     DrawRectCommand& command = _commandBuffers.rects.allocate();
 
@@ -1119,7 +1118,7 @@ void OpenGLDrawingContext::DrawGlyph(RenderTarget& dpi, const ImageId image, int
 }
 
 void OpenGLDrawingContext::DrawTTFBitmap(
-    RenderTarget& dpi, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y, uint8_t hintingThreshold)
+    RenderTarget& rt, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y, uint8_t hintingThreshold)
 {
     Guard::Assert(_inDraw == true);
 
@@ -1153,11 +1152,11 @@ void OpenGLDrawingContext::DrawTTFBitmap(
         std::swap(top, bottom);
     }
 
-    const ScreenRect clip = CalculateClipping(dpi);
-    left += clip.GetLeft() - dpi.x;
-    top += clip.GetTop() - dpi.y;
-    right += clip.GetLeft() - dpi.x;
-    bottom += clip.GetTop() - dpi.y;
+    const ScreenRect clip = CalculateClipping(rt);
+    left += clip.GetLeft() - rt.x;
+    top += clip.GetTop() - rt.y;
+    right += clip.GetLeft() - rt.x;
+    bottom += clip.GetTop() - rt.y;
 
     if (info->flags & TEXT_DRAW_FLAG_OUTLINE)
     {
@@ -1293,22 +1292,22 @@ void OpenGLDrawingContext::HandleTransparency()
     _commandBuffers.transparent.clear();
 }
 
-ScreenRect OpenGLDrawingContext::CalculateClipping(const RenderTarget& dpi) const
+ScreenRect OpenGLDrawingContext::CalculateClipping(const RenderTarget& rt) const
 {
     // mber: Calculating the screen coordinates by dividing the difference between pointers like this is a dirty hack.
     //       It's also quite slow. In future the drawing code needs to be refactored to avoid this somehow.
-    const RenderTarget* screenDPI = _engine.GetDPI();
-    const int32_t bytesPerRow = screenDPI->LineStride();
-    const int32_t bitsOffset = static_cast<int32_t>(dpi.bits - screenDPI->bits);
+    const RenderTarget* mainRT = _engine.GetDPI();
+    const int32_t bytesPerRow = mainRT->LineStride();
+    const int32_t bitsOffset = static_cast<int32_t>(rt.bits - mainRT->bits);
     #ifndef NDEBUG
-    const ptrdiff_t bitsSize = static_cast<ptrdiff_t>(screenDPI->height) * static_cast<ptrdiff_t>(bytesPerRow);
+    const ptrdiff_t bitsSize = static_cast<ptrdiff_t>(mainRT->height) * static_cast<ptrdiff_t>(bytesPerRow);
     assert(static_cast<ptrdiff_t>(bitsOffset) < bitsSize && static_cast<ptrdiff_t>(bitsOffset) >= 0);
     #endif
 
     const int32_t left = bitsOffset % bytesPerRow;
     const int32_t top = bitsOffset / bytesPerRow;
-    const int32_t right = left + dpi.width;
-    const int32_t bottom = top + dpi.height;
+    const int32_t right = left + rt.width;
+    const int32_t bottom = top + rt.height;
 
     return { { left, top }, { right, bottom } };
 }

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.cpp
@@ -89,7 +89,7 @@ void OpenGLFramebuffer::BindRead() const
     glBindFramebuffer(GL_READ_FRAMEBUFFER, _id);
 }
 
-void OpenGLFramebuffer::GetPixels(DrawPixelInfo& dpi) const
+void OpenGLFramebuffer::GetPixels(RenderTarget& dpi) const
 {
     assert(dpi.width == _width && dpi.height == _height);
 
@@ -150,7 +150,7 @@ GLuint OpenGLFramebuffer::CreateDepthTexture(int32_t width, int32_t height)
     return depth;
 }
 
-void OpenGLFramebuffer::SetPixels(const DrawPixelInfo& dpi)
+void OpenGLFramebuffer::SetPixels(const RenderTarget& dpi)
 {
     assert(dpi.width == _width && dpi.height == _height);
 

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.cpp
@@ -89,9 +89,9 @@ void OpenGLFramebuffer::BindRead() const
     glBindFramebuffer(GL_READ_FRAMEBUFFER, _id);
 }
 
-void OpenGLFramebuffer::GetPixels(RenderTarget& dpi) const
+void OpenGLFramebuffer::GetPixels(RenderTarget& rt) const
 {
-    assert(dpi.width == _width && dpi.height == _height);
+    assert(rt.width == _width && rt.height == _height);
 
     auto pixels = std::make_unique<uint8_t[]>(_width * _height);
     glBindTexture(GL_TEXTURE_2D, _texture);
@@ -100,12 +100,12 @@ void OpenGLFramebuffer::GetPixels(RenderTarget& dpi) const
 
     // Flip pixels vertically on copy
     uint8_t* src = pixels.get() + ((_height - 1) * _width);
-    uint8_t* dst = dpi.bits;
+    uint8_t* dst = rt.bits;
     for (int32_t y = 0; y < _height; y++)
     {
         std::copy_n(src, _width, dst);
         src -= _width;
-        dst += dpi.LineStride();
+        dst += rt.LineStride();
     }
 }
 
@@ -150,18 +150,18 @@ GLuint OpenGLFramebuffer::CreateDepthTexture(int32_t width, int32_t height)
     return depth;
 }
 
-void OpenGLFramebuffer::SetPixels(const RenderTarget& dpi)
+void OpenGLFramebuffer::SetPixels(const RenderTarget& rt)
 {
-    assert(dpi.width == _width && dpi.height == _height);
+    assert(rt.width == _width && rt.height == _height);
 
     auto pixels = std::make_unique<uint8_t[]>(_width * _height);
     // Flip pixels vertically on copy
     uint8_t* dst = pixels.get() + ((_height - 1) * _width);
-    uint8_t* src = dpi.bits;
+    uint8_t* src = rt.bits;
     for (int32_t y = 0; y < _height; y++)
     {
         std::copy_n(src, _width, dst);
-        src += dpi.width + dpi.pitch;
+        src += rt.width + rt.pitch;
         dst -= _width;
     }
 

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.h
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.h
@@ -54,12 +54,12 @@ namespace OpenRCT2::Ui
         void Bind() const;
         void BindDraw() const;
         void BindRead() const;
-        void GetPixels(RenderTarget& dpi) const;
+        void GetPixels(RenderTarget& rt) const;
 
         void SwapColourBuffer(OpenGLFramebuffer& other);
         GLuint SwapDepthTexture(GLuint depth);
         void Copy(OpenGLFramebuffer& src, GLenum filter);
-        void SetPixels(const RenderTarget& dpi);
+        void SetPixels(const RenderTarget& rt);
 
         static GLuint CreateDepthTexture(int32_t width, int32_t height);
     };

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.h
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.h
@@ -54,12 +54,12 @@ namespace OpenRCT2::Ui
         void Bind() const;
         void BindDraw() const;
         void BindRead() const;
-        void GetPixels(DrawPixelInfo& dpi) const;
+        void GetPixels(RenderTarget& dpi) const;
 
         void SwapColourBuffer(OpenGLFramebuffer& other);
         GLuint SwapDepthTexture(GLuint depth);
         void Copy(OpenGLFramebuffer& src, GLenum filter);
-        void SetPixels(const DrawPixelInfo& dpi);
+        void SetPixels(const RenderTarget& dpi);
 
         static GLuint CreateDepthTexture(int32_t width, int32_t height);
     };

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
@@ -295,8 +295,8 @@ AtlasTextureInfo TextureCache::LoadImageTexture(const ImageId imageId)
 
     glBindTexture(GL_TEXTURE_2D_ARRAY, _atlasesTexture);
     glTexSubImage3D(
-        GL_TEXTURE_2D_ARRAY, 0, cacheInfo.bounds.x, cacheInfo.bounds.y, cacheInfo.index, rt.width, rt.height, 1,
-        GL_RED_INTEGER, GL_UNSIGNED_BYTE, rt.bits);
+        GL_TEXTURE_2D_ARRAY, 0, cacheInfo.bounds.x, cacheInfo.bounds.y, cacheInfo.index, rt.width, rt.height, 1, GL_RED_INTEGER,
+        GL_UNSIGNED_BYTE, rt.bits);
 
     DeleteDPI(rt);
 
@@ -312,8 +312,8 @@ AtlasTextureInfo TextureCache::LoadGlyphTexture(const ImageId imageId, const Pal
 
     glBindTexture(GL_TEXTURE_2D_ARRAY, _atlasesTexture);
     glTexSubImage3D(
-        GL_TEXTURE_2D_ARRAY, 0, cacheInfo.bounds.x, cacheInfo.bounds.y, cacheInfo.index, rt.width, rt.height, 1,
-        GL_RED_INTEGER, GL_UNSIGNED_BYTE, rt.bits);
+        GL_TEXTURE_2D_ARRAY, 0, cacheInfo.bounds.x, cacheInfo.bounds.y, cacheInfo.index, rt.width, rt.height, 1, GL_RED_INTEGER,
+        GL_UNSIGNED_BYTE, rt.bits);
 
     DeleteDPI(rt);
 

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
@@ -221,7 +221,7 @@ void TextureCache::GeneratePaletteTexture()
     static_assert(kPaletteTotalOffsets + 5 < 256, "Height of palette too large!");
     constexpr int32_t height = 256;
     constexpr int32_t width = height;
-    DrawPixelInfo dpi = CreateDPI(width, height);
+    RenderTarget dpi = CreateDPI(width, height);
 
     // Init no-op palette
     for (int i = 0; i < width; ++i)
@@ -288,7 +288,7 @@ void TextureCache::EnlargeAtlasesTexture(GLuint newEntries)
 
 AtlasTextureInfo TextureCache::LoadImageTexture(const ImageId imageId)
 {
-    DrawPixelInfo dpi = GetImageAsDPI(ImageId(imageId.GetIndex()));
+    RenderTarget dpi = GetImageAsDPI(ImageId(imageId.GetIndex()));
 
     auto cacheInfo = AllocateImage(dpi.width, dpi.height);
     cacheInfo.image = imageId.GetIndex();
@@ -305,7 +305,7 @@ AtlasTextureInfo TextureCache::LoadImageTexture(const ImageId imageId)
 
 AtlasTextureInfo TextureCache::LoadGlyphTexture(const ImageId imageId, const PaletteMap& paletteMap)
 {
-    DrawPixelInfo dpi = GetGlyphAsDPI(imageId, paletteMap);
+    RenderTarget dpi = GetGlyphAsDPI(imageId, paletteMap);
 
     auto cacheInfo = AllocateImage(dpi.width, dpi.height);
     cacheInfo.image = imageId.GetIndex();
@@ -367,24 +367,24 @@ AtlasTextureInfo TextureCache::AllocateImage(int32_t imageWidth, int32_t imageHe
     return _atlases.back().Allocate(imageWidth, imageHeight);
 }
 
-DrawPixelInfo TextureCache::GetImageAsDPI(const ImageId imageId)
+RenderTarget TextureCache::GetImageAsDPI(const ImageId imageId)
 {
     auto g1Element = GfxGetG1Element(imageId);
     int32_t width = g1Element->width;
     int32_t height = g1Element->height;
 
-    DrawPixelInfo dpi = CreateDPI(width, height);
+    RenderTarget dpi = CreateDPI(width, height);
     GfxDrawSpriteSoftware(dpi, imageId, { -g1Element->x_offset, -g1Element->y_offset });
     return dpi;
 }
 
-DrawPixelInfo TextureCache::GetGlyphAsDPI(const ImageId imageId, const PaletteMap& palette)
+RenderTarget TextureCache::GetGlyphAsDPI(const ImageId imageId, const PaletteMap& palette)
 {
     auto g1Element = GfxGetG1Element(imageId);
     int32_t width = g1Element->width;
     int32_t height = g1Element->height;
 
-    DrawPixelInfo dpi = CreateDPI(width, height);
+    RenderTarget dpi = CreateDPI(width, height);
 
     const auto glyphCoords = ScreenCoordsXY{ -g1Element->x_offset, -g1Element->y_offset };
     GfxDrawSpritePaletteSetSoftware(dpi, imageId, glyphCoords, palette);
@@ -399,13 +399,13 @@ void TextureCache::FreeTextures()
     std::fill(_indexMap.begin(), _indexMap.end(), kUnusedIndex);
 }
 
-DrawPixelInfo TextureCache::CreateDPI(int32_t width, int32_t height)
+RenderTarget TextureCache::CreateDPI(int32_t width, int32_t height)
 {
     size_t numPixels = width * height;
     auto pixels8 = new uint8_t[numPixels];
     std::fill_n(pixels8, numPixels, 0);
 
-    DrawPixelInfo dpi;
+    RenderTarget dpi;
     dpi.bits = pixels8;
     dpi.pitch = 0;
     dpi.x = 0;
@@ -416,7 +416,7 @@ DrawPixelInfo TextureCache::CreateDPI(int32_t width, int32_t height)
     return dpi;
 }
 
-void TextureCache::DeleteDPI(DrawPixelInfo dpi)
+void TextureCache::DeleteDPI(RenderTarget dpi)
 {
     delete[] dpi.bits;
 }

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
@@ -21,7 +21,7 @@
 #include <unordered_map>
 #include <vector>
 
-struct DrawPixelInfo;
+struct RenderTarget;
 struct PaletteMap;
 enum class FilterPaletteID : int32_t;
 
@@ -226,11 +226,11 @@ namespace OpenRCT2::Ui
         AtlasTextureInfo LoadGlyphTexture(const ImageId image, const PaletteMap& paletteMap);
         AtlasTextureInfo AllocateImage(int32_t imageWidth, int32_t imageHeight);
         AtlasTextureInfo LoadBitmapTexture(ImageIndex image, const void* pixels, size_t width, size_t height);
-        static DrawPixelInfo GetImageAsDPI(const ImageId imageId);
-        static DrawPixelInfo GetGlyphAsDPI(const ImageId imageId, const PaletteMap& paletteMap);
+        static RenderTarget GetImageAsDPI(const ImageId imageId);
+        static RenderTarget GetGlyphAsDPI(const ImageId imageId, const PaletteMap& paletteMap);
         void FreeTextures();
 
-        static DrawPixelInfo CreateDPI(int32_t width, int32_t height);
-        static void DeleteDPI(DrawPixelInfo dpi);
+        static RenderTarget CreateDPI(int32_t width, int32_t height);
+        static void DeleteDPI(RenderTarget dpi);
     };
 } // namespace OpenRCT2::Ui

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
@@ -231,6 +231,6 @@ namespace OpenRCT2::Ui
         void FreeTextures();
 
         static RenderTarget CreateDPI(int32_t width, int32_t height);
-        static void DeleteDPI(RenderTarget dpi);
+        static void DeleteDPI(RenderTarget rt);
     };
 } // namespace OpenRCT2::Ui

--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -22,7 +22,7 @@ namespace OpenRCT2::Graph
 
     template<typename T>
     static void DrawYLabels(
-        DrawPixelInfo& dpi, const ScreenRect& internalBounds, const T min, const T max, const int32_t numYLabels,
+        RenderTarget& dpi, const ScreenRect& internalBounds, const T min, const T max, const int32_t numYLabels,
         const int32_t yLabelStepPx, const ColourWithFlags lineCol, const FmtString& fmt)
     {
         T curLabel = max;
@@ -50,7 +50,7 @@ namespace OpenRCT2::Graph
     }
 
     template<typename T, T TkNoValue>
-    static void DrawMonths(DrawPixelInfo& dpi, const T* series, int32_t count, const ScreenRect& bounds, const int32_t xStep)
+    static void DrawMonths(RenderTarget& dpi, const T* series, int32_t count, const ScreenRect& bounds, const int32_t xStep)
     {
         auto& date = GetDate();
         int32_t currentMonth = date.GetMonth();
@@ -79,7 +79,7 @@ namespace OpenRCT2::Graph
 
     template<typename T>
     static void DrawHoveredValue(
-        DrawPixelInfo& dpi, const T value, const int32_t hoverIdx, const ScreenRect& bounds, const int32_t xStep,
+        RenderTarget& dpi, const T value, const int32_t hoverIdx, const ScreenRect& bounds, const int32_t xStep,
         const T minValue, const T maxValue, const_utf8string text, ColourWithFlags textCol)
     {
         const T screenRange = bounds.GetHeight();
@@ -105,7 +105,7 @@ namespace OpenRCT2::Graph
 
     template<typename T, T TkNoValue, bool TbackgroundLine>
     static void DrawLine(
-        DrawPixelInfo& dpi, const T* series, const int32_t count, const ScreenRect& bounds, const int32_t xStep,
+        RenderTarget& dpi, const T* series, const int32_t count, const ScreenRect& bounds, const int32_t xStep,
         const T minValue, const T maxValue)
     {
         const T screenRange = bounds.GetHeight();
@@ -161,7 +161,7 @@ namespace OpenRCT2::Graph
 
     template<typename T, T TkNoValue>
     static void DrawGraph(
-        DrawPixelInfo& dpi, const GraphProperties<T>& p, const FmtString& labelFmt, const FmtString& tooltipFmt)
+        RenderTarget& dpi, const GraphProperties<T>& p, const FmtString& labelFmt, const FmtString& tooltipFmt)
     {
         DrawYLabels<T>(dpi, p.internalBounds, p.min, p.max, p.numYLabels, p.yLabelStepPx, p.lineCol, labelFmt);
         DrawMonths<T, TkNoValue>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx);
@@ -181,17 +181,17 @@ namespace OpenRCT2::Graph
         }
     }
 
-    void DrawFinanceGraph(DrawPixelInfo& dpi, const GraphProperties<money64>& p)
+    void DrawFinanceGraph(RenderTarget& dpi, const GraphProperties<money64>& p)
     {
         DrawGraph<money64, kMoney64Undefined>(dpi, p, "{BLACK}{CURRENCY2DP}", "{CURRENCY2DP}");
     }
 
-    void DrawRatingGraph(DrawPixelInfo& dpi, const GraphProperties<uint16_t>& p)
+    void DrawRatingGraph(RenderTarget& dpi, const GraphProperties<uint16_t>& p)
     {
         DrawGraph<uint16_t, kParkRatingHistoryUndefined>(dpi, p, "{BLACK}{COMMA32}", "{COMMA32}");
     }
 
-    void DrawGuestGraph(DrawPixelInfo& dpi, const GraphProperties<uint32_t>& p)
+    void DrawGuestGraph(RenderTarget& dpi, const GraphProperties<uint32_t>& p)
     {
         DrawGraph<uint32_t, kGuestsInParkHistoryUndefined>(dpi, p, "{BLACK}{COMMA32}", "{COMMA32}");
     }

--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -22,7 +22,7 @@ namespace OpenRCT2::Graph
 
     template<typename T>
     static void DrawYLabels(
-        RenderTarget& dpi, const ScreenRect& internalBounds, const T min, const T max, const int32_t numYLabels,
+        RenderTarget& rt, const ScreenRect& internalBounds, const T min, const T max, const int32_t numYLabels,
         const int32_t yLabelStepPx, const ColourWithFlags lineCol, const FmtString& fmt)
     {
         T curLabel = max;
@@ -34,15 +34,15 @@ namespace OpenRCT2::Graph
             char buffer[64]{};
             FormatStringToBuffer(buffer, sizeof(buffer), fmt, curLabel);
             DrawText(
-                dpi, { internalBounds.GetLeft() - kYTickMarkPadding, curScreenPos }, { FontStyle::Small, TextAlignment::RIGHT },
+                rt, { internalBounds.GetLeft() - kYTickMarkPadding, curScreenPos }, { FontStyle::Small, TextAlignment::RIGHT },
                 buffer);
             // Draw Y label tick mark
             GfxFillRect(
-                dpi, { { internalBounds.GetLeft() - 5, curScreenPos + 5 }, { internalBounds.GetLeft(), curScreenPos + 5 } },
+                rt, { { internalBounds.GetLeft() - 5, curScreenPos + 5 }, { internalBounds.GetLeft(), curScreenPos + 5 } },
                 PaletteIndex::pi10);
             // Draw horizontal gridline
             GfxFillRectInset(
-                dpi, { { internalBounds.GetLeft(), curScreenPos + 5 }, { internalBounds.GetRight(), curScreenPos + 5 } },
+                rt, { { internalBounds.GetLeft(), curScreenPos + 5 }, { internalBounds.GetRight(), curScreenPos + 5 } },
                 lineCol, INSET_RECT_FLAG_BORDER_INSET);
             curScreenPos += yLabelStepPx;
             curLabel -= yLabelStep;
@@ -50,7 +50,7 @@ namespace OpenRCT2::Graph
     }
 
     template<typename T, T TkNoValue>
-    static void DrawMonths(RenderTarget& dpi, const T* series, int32_t count, const ScreenRect& bounds, const int32_t xStep)
+    static void DrawMonths(RenderTarget& rt, const T* series, int32_t count, const ScreenRect& bounds, const int32_t xStep)
     {
         auto& date = GetDate();
         int32_t currentMonth = date.GetMonth();
@@ -65,11 +65,11 @@ namespace OpenRCT2::Graph
                 auto ft = Formatter();
                 ft.Add<StringId>(DateGameShortMonthNames[DateGetMonth((yearOver32 / 4) + MONTH_COUNT)]);
                 DrawTextBasic(
-                    dpi, screenCoords - ScreenCoordsXY{ 0, 14 }, STR_GRAPH_LABEL, ft,
+                    rt, screenCoords - ScreenCoordsXY{ 0, 14 }, STR_GRAPH_LABEL, ft,
                     { FontStyle::Small, TextAlignment::CENTRE });
                 // Draw month tick mark
                 GfxFillRect(
-                    dpi, { screenCoords - ScreenCoordsXY{ 0, 4 }, screenCoords - ScreenCoordsXY{ 0, 1 } }, PaletteIndex::pi10);
+                    rt, { screenCoords - ScreenCoordsXY{ 0, 4 }, screenCoords - ScreenCoordsXY{ 0, 1 } }, PaletteIndex::pi10);
             }
 
             yearOver32 = (yearOver32 + 1) % 32;
@@ -79,7 +79,7 @@ namespace OpenRCT2::Graph
 
     template<typename T>
     static void DrawHoveredValue(
-        RenderTarget& dpi, const T value, const int32_t hoverIdx, const ScreenRect& bounds, const int32_t xStep,
+        RenderTarget& rt, const T value, const int32_t hoverIdx, const ScreenRect& bounds, const int32_t xStep,
         const T minValue, const T maxValue, const_utf8string text, ColourWithFlags textCol)
     {
         const T screenRange = bounds.GetHeight();
@@ -89,23 +89,23 @@ namespace OpenRCT2::Graph
         ScreenCoordsXY coords = { bounds.GetRight() - hoverIdx * xStep, yPosition };
 
         GfxDrawDashedLine(
-            dpi,
+            rt,
             {
                 { coords.x, bounds.GetTop() },
                 { coords.x, bounds.GetBottom() },
             },
             kDashLength, PaletteIndex::pi10);
-        GfxDrawDashedLine(dpi, { { bounds.GetLeft(), coords.y }, coords }, kDashLength, PaletteIndex::pi10);
+        GfxDrawDashedLine(rt, { { bounds.GetLeft(), coords.y }, coords }, kDashLength, PaletteIndex::pi10);
 
-        DrawText(dpi, coords - ScreenCoordsXY{ 0, 16 }, { textCol, TextAlignment::CENTRE }, text);
+        DrawText(rt, coords - ScreenCoordsXY{ 0, 16 }, { textCol, TextAlignment::CENTRE }, text);
 
-        GfxFillRect(dpi, { { coords - ScreenCoordsXY{ 2, 2 } }, coords + ScreenCoordsXY{ 2, 2 } }, PaletteIndex::pi10);
-        GfxFillRect(dpi, { { coords - ScreenCoordsXY{ 1, 1 } }, { coords + ScreenCoordsXY{ 1, 1 } } }, PaletteIndex::pi21);
+        GfxFillRect(rt, { { coords - ScreenCoordsXY{ 2, 2 } }, coords + ScreenCoordsXY{ 2, 2 } }, PaletteIndex::pi10);
+        GfxFillRect(rt, { { coords - ScreenCoordsXY{ 1, 1 } }, { coords + ScreenCoordsXY{ 1, 1 } } }, PaletteIndex::pi21);
     }
 
     template<typename T, T TkNoValue, bool TbackgroundLine>
     static void DrawLine(
-        RenderTarget& dpi, const T* series, const int32_t count, const ScreenRect& bounds, const int32_t xStep,
+        RenderTarget& rt, const T* series, const int32_t count, const ScreenRect& bounds, const int32_t xStep,
         const T minValue, const T maxValue)
     {
         const T screenRange = bounds.GetHeight();
@@ -129,12 +129,12 @@ namespace OpenRCT2::Graph
                         auto rightBottom1 = coords + ScreenCoordsXY{ 1, 1 };
                         auto leftTop2 = lastCoords + ScreenCoordsXY{ 0, 1 };
                         auto rightBottom2 = coords + ScreenCoordsXY{ 0, 1 };
-                        GfxDrawLine(dpi, { leftTop1, rightBottom1 }, PaletteIndex::pi10);
-                        GfxDrawLine(dpi, { leftTop2, rightBottom2 }, PaletteIndex::pi10);
+                        GfxDrawLine(rt, { leftTop1, rightBottom1 }, PaletteIndex::pi10);
+                        GfxDrawLine(rt, { leftTop2, rightBottom2 }, PaletteIndex::pi10);
                     }
                     if (i == 0)
                     {
-                        GfxFillRect(dpi, { coords, coords + ScreenCoordsXY{ 2, 2 } }, PaletteIndex::pi10);
+                        GfxFillRect(rt, { coords, coords + ScreenCoordsXY{ 2, 2 } }, PaletteIndex::pi10);
                     }
                 }
                 else
@@ -143,12 +143,12 @@ namespace OpenRCT2::Graph
                     {
                         auto leftTop = lastCoords;
                         auto rightBottom = coords;
-                        GfxDrawLine(dpi, { leftTop, rightBottom }, PaletteIndex::pi21);
+                        GfxDrawLine(rt, { leftTop, rightBottom }, PaletteIndex::pi21);
                     }
                     if (i == 0)
                     {
                         GfxFillRect(
-                            dpi, { coords - ScreenCoordsXY{ 1, 1 }, coords + ScreenCoordsXY{ 1, 1 } }, PaletteIndex::pi21);
+                            rt, { coords - ScreenCoordsXY{ 1, 1 }, coords + ScreenCoordsXY{ 1, 1 } }, PaletteIndex::pi21);
                     }
                 }
 
@@ -161,12 +161,12 @@ namespace OpenRCT2::Graph
 
     template<typename T, T TkNoValue>
     static void DrawGraph(
-        RenderTarget& dpi, const GraphProperties<T>& p, const FmtString& labelFmt, const FmtString& tooltipFmt)
+        RenderTarget& rt, const GraphProperties<T>& p, const FmtString& labelFmt, const FmtString& tooltipFmt)
     {
-        DrawYLabels<T>(dpi, p.internalBounds, p.min, p.max, p.numYLabels, p.yLabelStepPx, p.lineCol, labelFmt);
-        DrawMonths<T, TkNoValue>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx);
-        DrawLine<T, TkNoValue, true>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx, p.min, p.max);
-        DrawLine<T, TkNoValue, false>(dpi, p.series, p.numPoints, p.internalBounds, p.xStepPx, p.min, p.max);
+        DrawYLabels<T>(rt, p.internalBounds, p.min, p.max, p.numYLabels, p.yLabelStepPx, p.lineCol, labelFmt);
+        DrawMonths<T, TkNoValue>(rt, p.series, p.numPoints, p.internalBounds, p.xStepPx);
+        DrawLine<T, TkNoValue, true>(rt, p.series, p.numPoints, p.internalBounds, p.xStepPx, p.min, p.max);
+        DrawLine<T, TkNoValue, false>(rt, p.series, p.numPoints, p.internalBounds, p.xStepPx, p.min, p.max);
         if (p.hoverIdx >= 0 && p.hoverIdx < p.numPoints)
         {
             const T value = p.series[p.hoverIdx];
@@ -175,7 +175,7 @@ namespace OpenRCT2::Graph
                 char buffer[64]{};
                 FormatStringToBuffer(buffer, sizeof(buffer), tooltipFmt, value);
                 DrawHoveredValue<T>(
-                    dpi, value, p.hoverIdx, p.internalBounds, p.xStepPx, p.min, p.max, buffer,
+                    rt, value, p.hoverIdx, p.internalBounds, p.xStepPx, p.min, p.max, buffer,
                     p.lineCol.withFlag(ColourFlag::withOutline, true));
             }
         }

--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -105,8 +105,8 @@ namespace OpenRCT2::Graph
 
     template<typename T, T TkNoValue, bool TbackgroundLine>
     static void DrawLine(
-        RenderTarget& rt, const T* series, const int32_t count, const ScreenRect& bounds, const int32_t xStep,
-        const T minValue, const T maxValue)
+        RenderTarget& rt, const T* series, const int32_t count, const ScreenRect& bounds, const int32_t xStep, const T minValue,
+        const T maxValue)
     {
         const T screenRange = bounds.GetHeight();
         const T valueRange = maxValue - minValue;
@@ -160,8 +160,7 @@ namespace OpenRCT2::Graph
     }
 
     template<typename T, T TkNoValue>
-    static void DrawGraph(
-        RenderTarget& rt, const GraphProperties<T>& p, const FmtString& labelFmt, const FmtString& tooltipFmt)
+    static void DrawGraph(RenderTarget& rt, const GraphProperties<T>& p, const FmtString& labelFmt, const FmtString& tooltipFmt)
     {
         DrawYLabels<T>(rt, p.internalBounds, p.min, p.max, p.numYLabels, p.yLabelStepPx, p.lineCol, labelFmt);
         DrawMonths<T, TkNoValue>(rt, p.series, p.numPoints, p.internalBounds, p.xStepPx);

--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -181,18 +181,18 @@ namespace OpenRCT2::Graph
         }
     }
 
-    void DrawFinanceGraph(RenderTarget& dpi, const GraphProperties<money64>& p)
+    void DrawFinanceGraph(RenderTarget& rt, const GraphProperties<money64>& p)
     {
-        DrawGraph<money64, kMoney64Undefined>(dpi, p, "{BLACK}{CURRENCY2DP}", "{CURRENCY2DP}");
+        DrawGraph<money64, kMoney64Undefined>(rt, p, "{BLACK}{CURRENCY2DP}", "{CURRENCY2DP}");
     }
 
-    void DrawRatingGraph(RenderTarget& dpi, const GraphProperties<uint16_t>& p)
+    void DrawRatingGraph(RenderTarget& rt, const GraphProperties<uint16_t>& p)
     {
-        DrawGraph<uint16_t, kParkRatingHistoryUndefined>(dpi, p, "{BLACK}{COMMA32}", "{COMMA32}");
+        DrawGraph<uint16_t, kParkRatingHistoryUndefined>(rt, p, "{BLACK}{COMMA32}", "{COMMA32}");
     }
 
-    void DrawGuestGraph(RenderTarget& dpi, const GraphProperties<uint32_t>& p)
+    void DrawGuestGraph(RenderTarget& rt, const GraphProperties<uint32_t>& p)
     {
-        DrawGraph<uint32_t, kGuestsInParkHistoryUndefined>(dpi, p, "{BLACK}{COMMA32}", "{COMMA32}");
+        DrawGraph<uint32_t, kGuestsInParkHistoryUndefined>(rt, p, "{BLACK}{COMMA32}", "{COMMA32}");
     }
 } // namespace OpenRCT2::Graph

--- a/src/openrct2-ui/interface/Graph.h
+++ b/src/openrct2-ui/interface/Graph.h
@@ -67,7 +67,7 @@ namespace OpenRCT2::Graph
         }
     };
 
-    void DrawFinanceGraph(RenderTarget& dpi, const GraphProperties<money64>& p);
-    void DrawRatingGraph(RenderTarget& dpi, const GraphProperties<uint16_t>& p);
-    void DrawGuestGraph(RenderTarget& dpi, const GraphProperties<uint32_t>& p);
+    void DrawFinanceGraph(RenderTarget& rt, const GraphProperties<money64>& p);
+    void DrawRatingGraph(RenderTarget& rt, const GraphProperties<uint16_t>& p);
+    void DrawGuestGraph(RenderTarget& rt, const GraphProperties<uint32_t>& p);
 } // namespace OpenRCT2::Graph

--- a/src/openrct2-ui/interface/Graph.h
+++ b/src/openrct2-ui/interface/Graph.h
@@ -67,7 +67,7 @@ namespace OpenRCT2::Graph
         }
     };
 
-    void DrawFinanceGraph(DrawPixelInfo& dpi, const GraphProperties<money64>& p);
-    void DrawRatingGraph(DrawPixelInfo& dpi, const GraphProperties<uint16_t>& p);
-    void DrawGuestGraph(DrawPixelInfo& dpi, const GraphProperties<uint32_t>& p);
+    void DrawFinanceGraph(RenderTarget& dpi, const GraphProperties<money64>& p);
+    void DrawRatingGraph(RenderTarget& dpi, const GraphProperties<uint16_t>& p);
+    void DrawGuestGraph(RenderTarget& dpi, const GraphProperties<uint32_t>& p);
 } // namespace OpenRCT2::Graph

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -289,7 +289,7 @@ void InGameConsole::Update()
     _consoleCaretTicks = (_consoleCaretTicks + 1) % 30;
 }
 
-void InGameConsole::Draw(DrawPixelInfo& dpi) const
+void InGameConsole::Draw(RenderTarget& dpi) const
 {
     if (!_isOpen)
         return;

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -289,7 +289,7 @@ void InGameConsole::Update()
     _consoleCaretTicks = (_consoleCaretTicks + 1) % 30;
 }
 
-void InGameConsole::Draw(RenderTarget& dpi) const
+void InGameConsole::Draw(RenderTarget& rt) const
 {
     if (!_isOpen)
         return;
@@ -309,18 +309,18 @@ void InGameConsole::Draw(RenderTarget& dpi) const
     Invalidate();
 
     // Give console area a translucent effect.
-    GfxFilterRect(dpi, { _consoleTopLeft, _consoleBottomRight }, FilterPaletteID::Palette51);
+    GfxFilterRect(rt, { _consoleTopLeft, _consoleBottomRight }, FilterPaletteID::Palette51);
 
     // Make input area more opaque.
     GfxFilterRect(
-        dpi, { { _consoleTopLeft.x, _consoleBottomRight.y - lineHeight - 10 }, _consoleBottomRight - ScreenCoordsXY{ 0, 1 } },
+        rt, { { _consoleTopLeft.x, _consoleBottomRight.y - lineHeight - 10 }, _consoleBottomRight - ScreenCoordsXY{ 0, 1 } },
         FilterPaletteID::Palette51);
 
     // Paint background colour.
     auto backgroundColour = ThemeGetColour(WindowClass::Console, 0);
-    GfxFillRectInset(dpi, { _consoleTopLeft, _consoleBottomRight }, backgroundColour, INSET_RECT_FLAG_FILL_NONE);
+    GfxFillRectInset(rt, { _consoleTopLeft, _consoleBottomRight }, backgroundColour, INSET_RECT_FLAG_FILL_NONE);
     GfxFillRectInset(
-        dpi, { _consoleTopLeft + ScreenCoordsXY{ 1, 1 }, _consoleBottomRight - ScreenCoordsXY{ 1, 1 } }, backgroundColour,
+        rt, { _consoleTopLeft + ScreenCoordsXY{ 1, 1 }, _consoleBottomRight - ScreenCoordsXY{ 1, 1 } }, backgroundColour,
         INSET_RECT_FLAG_BORDER_INSET);
 
     std::string lineBuffer;
@@ -336,19 +336,19 @@ void InGameConsole::Draw(RenderTarget& dpi) const
             // as opposed to a desaturated grey
             if (textColour.colour == COLOUR_BLACK)
             {
-                DrawText(dpi, screenCoords, { textColour, style }, "{BLACK}");
-                DrawText(dpi, screenCoords, { kTextColour255, style }, _consoleLines[index].first.c_str(), true);
+                DrawText(rt, screenCoords, { textColour, style }, "{BLACK}");
+                DrawText(rt, screenCoords, { kTextColour255, style }, _consoleLines[index].first.c_str(), true);
             }
             else
             {
-                DrawText(dpi, screenCoords, { textColour, style }, _consoleLines[index].first.c_str(), true);
+                DrawText(rt, screenCoords, { textColour, style }, _consoleLines[index].first.c_str(), true);
             }
         }
         else
         {
             std::string lineColour = FormatTokenToStringWithBraces(_consoleLines[index].second);
-            DrawText(dpi, screenCoords, { textColour, style }, lineColour.c_str());
-            DrawText(dpi, screenCoords, { kTextColour255, style }, _consoleLines[index].first.c_str(), true);
+            DrawText(rt, screenCoords, { textColour, style }, lineColour.c_str());
+            DrawText(rt, screenCoords, { kTextColour255, style }, _consoleLines[index].first.c_str(), true);
         }
 
         screenCoords.y += lineHeight;
@@ -359,12 +359,12 @@ void InGameConsole::Draw(RenderTarget& dpi) const
     // Draw current line
     if (textColour.colour == COLOUR_BLACK)
     {
-        DrawText(dpi, screenCoords, { textColour, style }, "{BLACK}");
-        DrawText(dpi, screenCoords, { kTextColour255, style }, _consoleCurrentLine.c_str(), true);
+        DrawText(rt, screenCoords, { textColour, style }, "{BLACK}");
+        DrawText(rt, screenCoords, { kTextColour255, style }, _consoleCurrentLine.c_str(), true);
     }
     else
     {
-        DrawText(dpi, screenCoords, { textColour, style }, _consoleCurrentLine.c_str(), true);
+        DrawText(rt, screenCoords, { textColour, style }, _consoleCurrentLine.c_str(), true);
     }
 
     // Draw caret
@@ -372,7 +372,7 @@ void InGameConsole::Draw(RenderTarget& dpi) const
     {
         auto caret = screenCoords + ScreenCoordsXY{ _caretScreenPosX, lineHeight };
         uint8_t caretColour = ColourMapA[textColour.colour].lightest;
-        GfxFillRect(dpi, { caret, caret + ScreenCoordsXY{ kConsoleCaretWidth, 1 } }, caretColour);
+        GfxFillRect(rt, { caret, caret + ScreenCoordsXY{ kConsoleCaretWidth, 1 } }, caretColour);
     }
 
     // What about border colours?
@@ -381,21 +381,21 @@ void InGameConsole::Draw(RenderTarget& dpi) const
 
     // Input area top border
     GfxFillRect(
-        dpi,
+        rt,
         { { _consoleTopLeft.x, _consoleBottomRight.y - lineHeight - 11 },
           { _consoleBottomRight.x, _consoleBottomRight.y - lineHeight - 11 } },
         borderColour1);
     GfxFillRect(
-        dpi,
+        rt,
         { { _consoleTopLeft.x, _consoleBottomRight.y - lineHeight - 10 },
           { _consoleBottomRight.x, _consoleBottomRight.y - lineHeight - 10 } },
         borderColour2);
 
     // Input area bottom border
     GfxFillRect(
-        dpi, { { _consoleTopLeft.x, _consoleBottomRight.y - 1 }, { _consoleBottomRight.x, _consoleBottomRight.y - 1 } },
+        rt, { { _consoleTopLeft.x, _consoleBottomRight.y - 1 }, { _consoleBottomRight.x, _consoleBottomRight.y - 1 } },
         borderColour1);
-    GfxFillRect(dpi, { { _consoleTopLeft.x, _consoleBottomRight.y }, _consoleBottomRight }, borderColour2);
+    GfxFillRect(rt, { { _consoleTopLeft.x, _consoleBottomRight.y }, _consoleBottomRight }, borderColour2);
 }
 
 // Calculates the amount of visible lines, based on the console size, excluding the input line.

--- a/src/openrct2-ui/interface/InGameConsole.h
+++ b/src/openrct2-ui/interface/InGameConsole.h
@@ -69,7 +69,7 @@ namespace OpenRCT2::Ui
         void Scroll(int32_t linesToScroll);
 
         void Update();
-        void Draw(RenderTarget& dpi) const;
+        void Draw(RenderTarget& rt) const;
 
     private:
         void ClearInput();

--- a/src/openrct2-ui/interface/InGameConsole.h
+++ b/src/openrct2-ui/interface/InGameConsole.h
@@ -69,7 +69,7 @@ namespace OpenRCT2::Ui
         void Scroll(int32_t linesToScroll);
 
         void Update();
-        void Draw(DrawPixelInfo& dpi) const;
+        void Draw(RenderTarget& dpi) const;
 
     private:
         void ClearInput();

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -28,34 +28,34 @@ using namespace OpenRCT2;
 
 namespace OpenRCT2::Ui
 {
-    static void WidgetFrameDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetResizeDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetButtonDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetTabDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetFlatButtonDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetTextButton(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetTextCentred(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetText(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetTextInset(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetTextBoxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetProgressBarDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetHorizontalSeparatorDraw(DrawPixelInfo& dpi, WindowBase& w, const Widget& widget);
-    static void WidgetGroupboxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetCaptionDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetCheckboxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetCloseboxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetScrollDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetFrameDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetResizeDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetButtonDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetTabDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetFlatButtonDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetTextButton(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetTextCentred(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetText(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetTextInset(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetTextBoxDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetProgressBarDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetHorizontalSeparatorDraw(RenderTarget& dpi, WindowBase& w, const Widget& widget);
+    static void WidgetGroupboxDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetCaptionDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetCheckboxDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetCloseboxDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetScrollDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
     static void WidgetHScrollbarDraw(
-        DrawPixelInfo& dpi, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour);
+        RenderTarget& dpi, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour);
     static void WidgetVScrollbarDraw(
-        DrawPixelInfo& dpi, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour);
-    static void WidgetDrawImage(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
+        RenderTarget& dpi, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour);
+    static void WidgetDrawImage(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
 
     /**
      *
      *  rct2: 0x006EB2A8
      */
-    void WidgetDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    void WidgetDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
     {
         const auto* widget = GetWidgetByIndex(w, widgetIndex);
         if (widget == nullptr)
@@ -131,7 +131,7 @@ namespace OpenRCT2::Ui
      *
      *  rct2: 0x006EB6CE
      */
-    static void WidgetFrameDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetFrameDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -161,7 +161,7 @@ namespace OpenRCT2::Ui
      *
      *  rct2: 0x006EB765
      */
-    static void WidgetResizeDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetResizeDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -188,7 +188,7 @@ namespace OpenRCT2::Ui
      *
      *  rct2: 0x006EB8E5
      */
-    static void WidgetButtonDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetButtonDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -220,7 +220,7 @@ namespace OpenRCT2::Ui
      *
      *  rct2: 0x006EB806
      */
-    static void WidgetTabDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetTabDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         auto& widget = w.widgets[widgetIndex];
@@ -269,7 +269,7 @@ namespace OpenRCT2::Ui
      *
      *  rct2: 0x006EB861
      */
-    static void WidgetFlatButtonDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetFlatButtonDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
     {
         if (!WidgetIsDisabled(w, widgetIndex) && WidgetIsHighlighted(w, widgetIndex))
         {
@@ -309,7 +309,7 @@ namespace OpenRCT2::Ui
      *
      *  rct2: 0x006EBBEB
      */
-    static void WidgetTextButton(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetTextButton(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -339,7 +339,7 @@ namespace OpenRCT2::Ui
      *
      *  rct2: 0x006EBC41
      */
-    static void WidgetTextCentred(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetTextCentred(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -384,7 +384,7 @@ namespace OpenRCT2::Ui
      *
      *  rct2: 0x006EBD52
      */
-    static void WidgetText(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetText(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -432,7 +432,7 @@ namespace OpenRCT2::Ui
      *
      *  rct2: 0x006EBD1F
      */
-    static void WidgetTextInset(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetTextInset(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -451,7 +451,7 @@ namespace OpenRCT2::Ui
      *
      *  rct2: 0x006EB535
      */
-    static void WidgetGroupboxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetGroupboxDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -526,7 +526,7 @@ namespace OpenRCT2::Ui
      *
      *  rct2: 0x006EB2F9
      */
-    static void WidgetCaptionDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetCaptionDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto* widget = &w.widgets[widgetIndex];
@@ -580,7 +580,7 @@ namespace OpenRCT2::Ui
      *
      *  rct2: 0x006EBB85
      */
-    static void WidgetCloseboxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetCloseboxDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -616,7 +616,7 @@ namespace OpenRCT2::Ui
      *
      *  rct2: 0x006EBAD9
      */
-    static void WidgetCheckboxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetCheckboxDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -664,7 +664,7 @@ namespace OpenRCT2::Ui
      *
      *  rct2: 0x006EBD96
      */
-    static void WidgetScrollDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetScrollDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         int32_t scrollIndex = WindowGetScrollDataIndex(w, widgetIndex);
@@ -716,7 +716,7 @@ namespace OpenRCT2::Ui
         bottomRight.x++;
 
         // Create a new inner scroll dpi
-        DrawPixelInfo scroll_dpi = dpi;
+        RenderTarget scroll_dpi = dpi;
 
         // Clip the scroll dpi against the outer dpi
         int32_t cl = std::max<int32_t>(dpi.x, topLeft.x);
@@ -739,7 +739,7 @@ namespace OpenRCT2::Ui
     }
 
     static void WidgetHScrollbarDraw(
-        DrawPixelInfo& dpi, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour)
+        RenderTarget& dpi, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour)
     {
         colour.setFlag(ColourFlag::translucent, false);
 
@@ -781,7 +781,7 @@ namespace OpenRCT2::Ui
     }
 
     static void WidgetVScrollbarDraw(
-        DrawPixelInfo& dpi, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour)
+        RenderTarget& dpi, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour)
     {
         colour.setFlag(ColourFlag::translucent, false);
 
@@ -820,7 +820,7 @@ namespace OpenRCT2::Ui
      *
      *  rct2: 0x006EB951
      */
-    static void WidgetDrawImage(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetDrawImage(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -1122,7 +1122,7 @@ namespace OpenRCT2::Ui
         WidgetSetPressed(w, widgetIndex, value);
     }
 
-    static void WidgetTextBoxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetTextBoxDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -1186,7 +1186,7 @@ namespace OpenRCT2::Ui
         }
     }
 
-    static void WidgetProgressBarDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetProgressBarDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
     {
         const auto& widget = w.widgets[widgetIndex];
 
@@ -1217,7 +1217,7 @@ namespace OpenRCT2::Ui
         }
     }
 
-    static void WidgetHorizontalSeparatorDraw(DrawPixelInfo& dpi, WindowBase& w, const Widget& widget)
+    static void WidgetHorizontalSeparatorDraw(RenderTarget& dpi, WindowBase& w, const Widget& widget)
     {
         ScreenCoordsXY topLeft{ w.windowPos + ScreenCoordsXY{ widget.left, widget.top } };
         ScreenCoordsXY bottomRight{ w.windowPos + ScreenCoordsXY{ widget.right, widget.bottom } };

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -28,34 +28,34 @@ using namespace OpenRCT2;
 
 namespace OpenRCT2::Ui
 {
-    static void WidgetFrameDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetResizeDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetButtonDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetTabDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetFlatButtonDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetTextButton(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetTextCentred(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetText(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetTextInset(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetTextBoxDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetProgressBarDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetHorizontalSeparatorDraw(RenderTarget& dpi, WindowBase& w, const Widget& widget);
-    static void WidgetGroupboxDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetCaptionDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetCheckboxDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetCloseboxDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetScrollDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetFrameDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetResizeDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetButtonDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetTabDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetFlatButtonDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetTextButton(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetTextCentred(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetText(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetTextInset(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetTextBoxDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetProgressBarDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetHorizontalSeparatorDraw(RenderTarget& rt, WindowBase& w, const Widget& widget);
+    static void WidgetGroupboxDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetCaptionDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetCheckboxDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetCloseboxDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
+    static void WidgetScrollDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
     static void WidgetHScrollbarDraw(
-        RenderTarget& dpi, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour);
+        RenderTarget& rt, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour);
     static void WidgetVScrollbarDraw(
-        RenderTarget& dpi, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour);
-    static void WidgetDrawImage(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
+        RenderTarget& rt, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour);
+    static void WidgetDrawImage(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
 
     /**
      *
      *  rct2: 0x006EB2A8
      */
-    void WidgetDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    void WidgetDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
     {
         const auto* widget = GetWidgetByIndex(w, widgetIndex);
         if (widget == nullptr)
@@ -67,60 +67,60 @@ namespace OpenRCT2::Ui
         switch (widget->type)
         {
             case WindowWidgetType::Frame:
-                WidgetFrameDraw(dpi, w, widgetIndex);
+                WidgetFrameDraw(rt, w, widgetIndex);
                 break;
             case WindowWidgetType::Resize:
-                WidgetResizeDraw(dpi, w, widgetIndex);
+                WidgetResizeDraw(rt, w, widgetIndex);
                 break;
             case WindowWidgetType::ImgBtn:
-                WidgetButtonDraw(dpi, w, widgetIndex);
+                WidgetButtonDraw(rt, w, widgetIndex);
                 break;
             case WindowWidgetType::ColourBtn:
             case WindowWidgetType::TrnBtn:
             case WindowWidgetType::Tab:
-                WidgetTabDraw(dpi, w, widgetIndex);
+                WidgetTabDraw(rt, w, widgetIndex);
                 break;
             case WindowWidgetType::FlatBtn:
-                WidgetFlatButtonDraw(dpi, w, widgetIndex);
+                WidgetFlatButtonDraw(rt, w, widgetIndex);
                 break;
             case WindowWidgetType::Button:
             case WindowWidgetType::TableHeader:
-                WidgetTextButton(dpi, w, widgetIndex);
+                WidgetTextButton(rt, w, widgetIndex);
                 break;
             case WindowWidgetType::LabelCentred:
-                WidgetTextCentred(dpi, w, widgetIndex);
+                WidgetTextCentred(rt, w, widgetIndex);
                 break;
             case WindowWidgetType::Label:
-                WidgetText(dpi, w, widgetIndex);
+                WidgetText(rt, w, widgetIndex);
                 break;
             case WindowWidgetType::Spinner:
             case WindowWidgetType::DropdownMenu:
             case WindowWidgetType::Viewport:
-                WidgetTextInset(dpi, w, widgetIndex);
+                WidgetTextInset(rt, w, widgetIndex);
                 break;
             case WindowWidgetType::Groupbox:
-                WidgetGroupboxDraw(dpi, w, widgetIndex);
+                WidgetGroupboxDraw(rt, w, widgetIndex);
                 break;
             case WindowWidgetType::Caption:
-                WidgetCaptionDraw(dpi, w, widgetIndex);
+                WidgetCaptionDraw(rt, w, widgetIndex);
                 break;
             case WindowWidgetType::CloseBox:
-                WidgetCloseboxDraw(dpi, w, widgetIndex);
+                WidgetCloseboxDraw(rt, w, widgetIndex);
                 break;
             case WindowWidgetType::Scroll:
-                WidgetScrollDraw(dpi, w, widgetIndex);
+                WidgetScrollDraw(rt, w, widgetIndex);
                 break;
             case WindowWidgetType::Checkbox:
-                WidgetCheckboxDraw(dpi, w, widgetIndex);
+                WidgetCheckboxDraw(rt, w, widgetIndex);
                 break;
             case WindowWidgetType::TextBox:
-                WidgetTextBoxDraw(dpi, w, widgetIndex);
+                WidgetTextBoxDraw(rt, w, widgetIndex);
                 break;
             case WindowWidgetType::ProgressBar:
-                WidgetProgressBarDraw(dpi, w, widgetIndex);
+                WidgetProgressBarDraw(rt, w, widgetIndex);
                 break;
             case WindowWidgetType::HorizontalSeparator:
-                WidgetHorizontalSeparatorDraw(dpi, w, *widget);
+                WidgetHorizontalSeparatorDraw(rt, w, *widget);
                 break;
             default:
                 break;
@@ -131,7 +131,7 @@ namespace OpenRCT2::Ui
      *
      *  rct2: 0x006EB6CE
      */
-    static void WidgetFrameDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetFrameDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -147,21 +147,21 @@ namespace OpenRCT2::Ui
         auto colour = w.colours[widget.colour];
 
         // Draw the frame
-        GfxFillRectInset(dpi, { leftTop, { r, b } }, colour, press);
+        GfxFillRectInset(rt, { leftTop, { r, b } }, colour, press);
 
         if (!w.canBeResized())
             return;
 
         // Draw the resize sprite at the bottom right corner
         leftTop = w.windowPos + ScreenCoordsXY{ widget.right - 18, widget.bottom - 18 };
-        GfxDrawSprite(dpi, ImageId(SPR_RESIZE, colour.colour), leftTop);
+        GfxDrawSprite(rt, ImageId(SPR_RESIZE, colour.colour), leftTop);
     }
 
     /**
      *
      *  rct2: 0x006EB765
      */
-    static void WidgetResizeDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetResizeDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -174,21 +174,21 @@ namespace OpenRCT2::Ui
         auto colour = w.colours[widget.colour];
 
         // Draw the panel
-        GfxFillRectInset(dpi, { leftTop, { r, b } }, colour, 0);
+        GfxFillRectInset(rt, { leftTop, { r, b } }, colour, 0);
 
         if (!w.canBeResized())
             return;
 
         // Draw the resize sprite at the bottom right corner
         leftTop = w.windowPos + ScreenCoordsXY{ widget.right - 18, widget.bottom - 18 };
-        GfxDrawSprite(dpi, ImageId(SPR_RESIZE, colour.colour), leftTop);
+        GfxDrawSprite(rt, ImageId(SPR_RESIZE, colour.colour), leftTop);
     }
 
     /**
      *
      *  rct2: 0x006EB8E5
      */
-    static void WidgetButtonDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetButtonDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -206,21 +206,21 @@ namespace OpenRCT2::Ui
         if (static_cast<int32_t>(widget.image.GetIndex()) == -2)
         {
             // Draw border with no fill
-            GfxFillRectInset(dpi, rect, colour, press | INSET_RECT_FLAG_FILL_NONE);
+            GfxFillRectInset(rt, rect, colour, press | INSET_RECT_FLAG_FILL_NONE);
             return;
         }
 
         // Draw the border with fill
-        GfxFillRectInset(dpi, rect, colour, press);
+        GfxFillRectInset(rt, rect, colour, press);
 
-        WidgetDrawImage(dpi, w, widgetIndex);
+        WidgetDrawImage(rt, w, widgetIndex);
     }
 
     /**
      *
      *  rct2: 0x006EB806
      */
-    static void WidgetTabDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetTabDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         auto& widget = w.widgets[widgetIndex];
@@ -243,13 +243,13 @@ namespace OpenRCT2::Ui
         // Draw widgets that aren't explicitly disabled.
         if (!WidgetIsDisabled(w, widgetIndex))
         {
-            WidgetDrawImage(dpi, w, widgetIndex);
+            WidgetDrawImage(rt, w, widgetIndex);
             return;
         }
 
         if (widget.type != WindowWidgetType::TrnBtn)
         {
-            WidgetDrawImage(dpi, w, widgetIndex);
+            WidgetDrawImage(rt, w, widgetIndex);
             return;
         }
 
@@ -262,18 +262,18 @@ namespace OpenRCT2::Ui
         auto image = widget.image.WithIndex(newIndex).WithPrimary(colour);
 
         // Draw disabled image
-        GfxDrawSprite(dpi, image, leftTop);
+        GfxDrawSprite(rt, image, leftTop);
     }
 
     /**
      *
      *  rct2: 0x006EB861
      */
-    static void WidgetFlatButtonDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetFlatButtonDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
     {
         if (!WidgetIsDisabled(w, widgetIndex) && WidgetIsHighlighted(w, widgetIndex))
         {
-            WidgetButtonDraw(dpi, w, widgetIndex);
+            WidgetButtonDraw(rt, w, widgetIndex);
             return;
         }
 
@@ -293,23 +293,23 @@ namespace OpenRCT2::Ui
             if (static_cast<int32_t>(widget.image.GetIndex()) == -2)
             {
                 // Draw border with no fill
-                GfxFillRectInset(dpi, rect, colour, INSET_RECT_FLAG_BORDER_INSET | INSET_RECT_FLAG_FILL_NONE);
+                GfxFillRectInset(rt, rect, colour, INSET_RECT_FLAG_BORDER_INSET | INSET_RECT_FLAG_FILL_NONE);
                 return;
             }
 
             // Draw the border with fill
-            GfxFillRectInset(dpi, rect, colour, INSET_RECT_FLAG_BORDER_INSET);
+            GfxFillRectInset(rt, rect, colour, INSET_RECT_FLAG_BORDER_INSET);
         }
 
         // Draw image
-        WidgetDrawImage(dpi, w, widgetIndex);
+        WidgetDrawImage(rt, w, widgetIndex);
     }
 
     /**
      *
      *  rct2: 0x006EBBEB
      */
-    static void WidgetTextButton(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetTextButton(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -322,16 +322,16 @@ namespace OpenRCT2::Ui
 
         // Border
         uint8_t press = WidgetIsPressed(w, widgetIndex) || isToolActive(w, widgetIndex) ? INSET_RECT_FLAG_BORDER_INSET : 0;
-        GfxFillRectInset(dpi, rect, colour, press);
+        GfxFillRectInset(rt, rect, colour, press);
 
         // Button caption
         if (widget.type != WindowWidgetType::TableHeader)
         {
-            WidgetTextCentred(dpi, w, widgetIndex);
+            WidgetTextCentred(rt, w, widgetIndex);
         }
         else
         {
-            WidgetText(dpi, w, widgetIndex);
+            WidgetText(rt, w, widgetIndex);
         }
     }
 
@@ -339,7 +339,7 @@ namespace OpenRCT2::Ui
      *
      *  rct2: 0x006EBC41
      */
-    static void WidgetTextCentred(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetTextCentred(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -372,11 +372,11 @@ namespace OpenRCT2::Ui
         ScreenCoordsXY coords = { (topLeft.x + r + 1) / 2 - 1, topLeft.y };
         if (widget.type == WindowWidgetType::LabelCentred)
         {
-            DrawTextWrapped(dpi, coords, widget.width() - 2, stringId, ft, { colour, TextAlignment::CENTRE });
+            DrawTextWrapped(rt, coords, widget.width() - 2, stringId, ft, { colour, TextAlignment::CENTRE });
         }
         else
         {
-            DrawTextEllipsised(dpi, coords, widget.width() - 2, stringId, ft, { colour, TextAlignment::CENTRE });
+            DrawTextEllipsised(rt, coords, widget.width() - 2, stringId, ft, { colour, TextAlignment::CENTRE });
         }
     }
 
@@ -384,7 +384,7 @@ namespace OpenRCT2::Ui
      *
      *  rct2: 0x006EBD52
      */
-    static void WidgetText(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetText(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -420,11 +420,11 @@ namespace OpenRCT2::Ui
         ScreenCoordsXY coords = { l + 1, t };
         if (widget.type == WindowWidgetType::LabelCentred)
         {
-            DrawTextWrapped(dpi, coords, r - l, stringId, ft, { colour, TextAlignment::CENTRE });
+            DrawTextWrapped(rt, coords, r - l, stringId, ft, { colour, TextAlignment::CENTRE });
         }
         else
         {
-            DrawTextEllipsised(dpi, coords, r - l, stringId, ft, colour);
+            DrawTextEllipsised(rt, coords, r - l, stringId, ft, colour);
         }
     }
 
@@ -432,7 +432,7 @@ namespace OpenRCT2::Ui
      *
      *  rct2: 0x006EBD1F
      */
-    static void WidgetTextInset(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetTextInset(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -443,15 +443,15 @@ namespace OpenRCT2::Ui
 
         auto colour = w.colours[widget.colour];
 
-        GfxFillRectInset(dpi, rect, colour, INSET_RECT_F_60);
-        WidgetText(dpi, w, widgetIndex);
+        GfxFillRectInset(rt, rect, colour, INSET_RECT_F_60);
+        WidgetText(rt, w, widgetIndex);
     }
 
     /**
      *
      *  rct2: 0x006EB535
      */
-    static void WidgetGroupboxDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetGroupboxDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -488,7 +488,7 @@ namespace OpenRCT2::Ui
 
             auto ft = Formatter();
             ft.Add<utf8*>(buffer);
-            DrawTextBasic(dpi, { l, t }, STR_STRING, ft, { colour });
+            DrawTextBasic(rt, { l, t }, STR_STRING, ft, { colour });
             textRight = l + GfxGetStringWidth(buffer, FontStyle::Medium) + 1;
         }
 
@@ -502,31 +502,31 @@ namespace OpenRCT2::Ui
         uint8_t colour = w.colours[widget.colour].colour;
 
         // Border left of text
-        GfxFillRect(dpi, { { l, t }, { l + 4, t } }, ColourMapA[colour].mid_dark);
-        GfxFillRect(dpi, { { l + 1, t + 1 }, { l + 4, t + 1 } }, ColourMapA[colour].lighter);
+        GfxFillRect(rt, { { l, t }, { l + 4, t } }, ColourMapA[colour].mid_dark);
+        GfxFillRect(rt, { { l + 1, t + 1 }, { l + 4, t + 1 } }, ColourMapA[colour].lighter);
 
         // Border right of text
-        GfxFillRect(dpi, { { textRight, t }, { r - 1, t } }, ColourMapA[colour].mid_dark);
-        GfxFillRect(dpi, { { textRight, t + 1 }, { r - 2, t + 1 } }, ColourMapA[colour].lighter);
+        GfxFillRect(rt, { { textRight, t }, { r - 1, t } }, ColourMapA[colour].mid_dark);
+        GfxFillRect(rt, { { textRight, t + 1 }, { r - 2, t + 1 } }, ColourMapA[colour].lighter);
 
         // Border right
-        GfxFillRect(dpi, { { r - 1, t + 1 }, { r - 1, b - 1 } }, ColourMapA[colour].mid_dark);
-        GfxFillRect(dpi, { { r, t }, { r, b } }, ColourMapA[colour].lighter);
+        GfxFillRect(rt, { { r - 1, t + 1 }, { r - 1, b - 1 } }, ColourMapA[colour].mid_dark);
+        GfxFillRect(rt, { { r, t }, { r, b } }, ColourMapA[colour].lighter);
 
         // Border bottom
-        GfxFillRect(dpi, { { l, b - 1 }, { r - 2, b - 1 } }, ColourMapA[colour].mid_dark);
-        GfxFillRect(dpi, { { l, b }, { r - 1, b } }, ColourMapA[colour].lighter);
+        GfxFillRect(rt, { { l, b - 1 }, { r - 2, b - 1 } }, ColourMapA[colour].mid_dark);
+        GfxFillRect(rt, { { l, b }, { r - 1, b } }, ColourMapA[colour].lighter);
 
         // Border left
-        GfxFillRect(dpi, { { l, t + 1 }, { l, b - 2 } }, ColourMapA[colour].mid_dark);
-        GfxFillRect(dpi, { { l + 1, t + 2 }, { l + 1, b - 2 } }, ColourMapA[colour].lighter);
+        GfxFillRect(rt, { { l, t + 1 }, { l, b - 2 } }, ColourMapA[colour].mid_dark);
+        GfxFillRect(rt, { { l + 1, t + 2 }, { l + 1, b - 2 } }, ColourMapA[colour].lighter);
     }
 
     /**
      *
      *  rct2: 0x006EB2F9
      */
-    static void WidgetCaptionDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetCaptionDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto* widget = &w.widgets[widgetIndex];
@@ -541,16 +541,16 @@ namespace OpenRCT2::Ui
         if (w.flags & WF_10)
             press |= INSET_RECT_FLAG_FILL_MID_LIGHT;
 
-        GfxFillRectInset(dpi, { topLeft, bottomRight }, colour, press);
+        GfxFillRectInset(rt, { topLeft, bottomRight }, colour, press);
 
         // Black caption bars look slightly green, this fixes that
         if (colour.colour == COLOUR_BLACK)
             GfxFillRect(
-                dpi, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } },
+                rt, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } },
                 ColourMapA[colour.colour].dark);
         else
             GfxFilterRect(
-                dpi, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } },
+                rt, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } },
                 FilterPaletteID::PaletteDarken3);
 
         // Draw text
@@ -572,7 +572,7 @@ namespace OpenRCT2::Ui
             topLeft.y += kTitleHeightLarge / 4;
 
         DrawTextEllipsised(
-            dpi, topLeft, width, widget->text, Formatter::Common(),
+            rt, topLeft, width, widget->text, Formatter::Common(),
             { ColourWithFlags{ COLOUR_WHITE }.withFlag(ColourFlag::withOutline, true), TextAlignment::CENTRE });
     }
 
@@ -580,7 +580,7 @@ namespace OpenRCT2::Ui
      *
      *  rct2: 0x006EBB85
      */
-    static void WidgetCloseboxDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetCloseboxDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -599,7 +599,7 @@ namespace OpenRCT2::Ui
         auto colour = w.colours[widget.colour];
 
         // Draw the button
-        GfxFillRectInset(dpi, { topLeft, bottomRight }, colour, press);
+        GfxFillRectInset(rt, { topLeft, bottomRight }, colour, press);
 
         if (widget.string == nullptr)
             return;
@@ -609,14 +609,14 @@ namespace OpenRCT2::Ui
         if (WidgetIsDisabled(w, widgetIndex))
             colour.setFlag(ColourFlag::inset, true);
 
-        DrawText(dpi, topLeft, { colour, TextAlignment::CENTRE }, widget.string);
+        DrawText(rt, topLeft, { colour, TextAlignment::CENTRE }, widget.string);
     }
 
     /**
      *
      *  rct2: 0x006EBAD9
      */
-    static void WidgetCheckboxDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetCheckboxDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -629,7 +629,7 @@ namespace OpenRCT2::Ui
         auto colour = w.colours[widget.colour];
 
         // checkbox
-        GfxFillRectInset(dpi, { midLeft - ScreenCoordsXY{ 0, 5 }, midLeft + ScreenCoordsXY{ 9, 4 } }, colour, INSET_RECT_F_60);
+        GfxFillRectInset(rt, { midLeft - ScreenCoordsXY{ 0, 5 }, midLeft + ScreenCoordsXY{ 9, 4 } }, colour, INSET_RECT_F_60);
 
         if (WidgetIsDisabled(w, widgetIndex))
         {
@@ -640,7 +640,7 @@ namespace OpenRCT2::Ui
         if (WidgetIsPressed(w, widgetIndex))
         {
             DrawText(
-                dpi, { midLeft - ScreenCoordsXY{ 0, 5 } }, { colour.withFlag(ColourFlag::translucent, false) },
+                rt, { midLeft - ScreenCoordsXY{ 0, 5 } }, { colour.withFlag(ColourFlag::translucent, false) },
                 kCheckMarkString);
         }
 
@@ -657,14 +657,14 @@ namespace OpenRCT2::Ui
         }
 
         DrawTextEllipsised(
-            dpi, w.windowPos + ScreenCoordsXY{ widget.left + 14, widget.textTop() }, widget.width() - 14, stringId, ft, colour);
+            rt, w.windowPos + ScreenCoordsXY{ widget.left + 14, widget.textTop() }, widget.width() - 14, stringId, ft, colour);
     }
 
     /**
      *
      *  rct2: 0x006EBD96
      */
-    static void WidgetScrollDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetScrollDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         int32_t scrollIndex = WindowGetScrollDataIndex(w, widgetIndex);
@@ -678,7 +678,7 @@ namespace OpenRCT2::Ui
         auto colour = w.colours[widget.colour];
 
         // Draw the border
-        GfxFillRectInset(dpi, { topLeft, bottomRight }, colour, INSET_RECT_F_60);
+        GfxFillRectInset(rt, { topLeft, bottomRight }, colour, INSET_RECT_F_60);
 
         // Inflate by -1
         topLeft.x++;
@@ -693,7 +693,7 @@ namespace OpenRCT2::Ui
         if (hScrollNeeded)
         {
             WidgetHScrollbarDraw(
-                dpi, scroll, topLeft.x, bottomRight.y - kScrollBarWidth,
+                rt, scroll, topLeft.x, bottomRight.y - kScrollBarWidth,
                 ((scroll.flags & VSCROLLBAR_VISIBLE) ? bottomRight.x - (kScrollBarWidth + 1) : bottomRight.x), bottomRight.y,
                 colour);
         }
@@ -702,7 +702,7 @@ namespace OpenRCT2::Ui
         if (vScrollNeeded)
         {
             WidgetVScrollbarDraw(
-                dpi, scroll, bottomRight.x - kScrollBarWidth, topLeft.y, bottomRight.x,
+                rt, scroll, bottomRight.x - kScrollBarWidth, topLeft.y, bottomRight.x,
                 ((scroll.flags & HSCROLLBAR_VISIBLE) ? bottomRight.y - (kScrollBarWidth + 1) : bottomRight.y), colour);
         }
 
@@ -716,50 +716,50 @@ namespace OpenRCT2::Ui
         bottomRight.x++;
 
         // Create a new inner scroll dpi
-        RenderTarget scroll_dpi = dpi;
+        RenderTarget scrollRT = rt;
 
         // Clip the scroll dpi against the outer dpi
-        int32_t cl = std::max<int32_t>(dpi.x, topLeft.x);
-        int32_t ct = std::max<int32_t>(dpi.y, topLeft.y);
-        int32_t cr = std::min<int32_t>(dpi.x + dpi.width, bottomRight.x);
-        int32_t cb = std::min<int32_t>(dpi.y + dpi.height, bottomRight.y);
+        int32_t cl = std::max<int32_t>(rt.x, topLeft.x);
+        int32_t ct = std::max<int32_t>(rt.y, topLeft.y);
+        int32_t cr = std::min<int32_t>(rt.x + rt.width, bottomRight.x);
+        int32_t cb = std::min<int32_t>(rt.y + rt.height, bottomRight.y);
 
         // Set the respective dpi attributes
-        scroll_dpi.x = cl - topLeft.x + scroll.contentOffsetX;
-        scroll_dpi.y = ct - topLeft.y + scroll.contentOffsetY;
-        scroll_dpi.width = cr - cl;
-        scroll_dpi.height = cb - ct;
-        scroll_dpi.bits += cl - dpi.x;
-        scroll_dpi.bits += (ct - dpi.y) * dpi.LineStride();
-        scroll_dpi.pitch = dpi.LineStride() - scroll_dpi.width;
+        scrollRT.x = cl - topLeft.x + scroll.contentOffsetX;
+        scrollRT.y = ct - topLeft.y + scroll.contentOffsetY;
+        scrollRT.width = cr - cl;
+        scrollRT.height = cb - ct;
+        scrollRT.bits += cl - rt.x;
+        scrollRT.bits += (ct - rt.y) * rt.LineStride();
+        scrollRT.pitch = rt.LineStride() - scrollRT.width;
 
         // Draw the scroll contents
-        if (scroll_dpi.width > 0 && scroll_dpi.height > 0)
-            w.OnScrollDraw(scrollIndex, scroll_dpi);
+        if (scrollRT.width > 0 && scrollRT.height > 0)
+            w.OnScrollDraw(scrollIndex, scrollRT);
     }
 
     static void WidgetHScrollbarDraw(
-        RenderTarget& dpi, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour)
+        RenderTarget& rt, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour)
     {
         colour.setFlag(ColourFlag::translucent, false);
 
         // Trough
-        GfxFillRect(dpi, { { l + kScrollBarWidth, t }, { r - kScrollBarWidth, b } }, ColourMapA[colour.colour].lighter);
+        GfxFillRect(rt, { { l + kScrollBarWidth, t }, { r - kScrollBarWidth, b } }, ColourMapA[colour.colour].lighter);
         GfxFillRect(
-            dpi, { { l + kScrollBarWidth, t }, { r - kScrollBarWidth, b } }, 0x1000000 | ColourMapA[colour.colour].mid_dark);
+            rt, { { l + kScrollBarWidth, t }, { r - kScrollBarWidth, b } }, 0x1000000 | ColourMapA[colour.colour].mid_dark);
         GfxFillRect(
-            dpi, { { l + kScrollBarWidth, t + 2 }, { r - kScrollBarWidth, t + 2 } }, ColourMapA[colour.colour].mid_dark);
-        GfxFillRect(dpi, { { l + kScrollBarWidth, t + 3 }, { r - kScrollBarWidth, t + 3 } }, ColourMapA[colour.colour].lighter);
+            rt, { { l + kScrollBarWidth, t + 2 }, { r - kScrollBarWidth, t + 2 } }, ColourMapA[colour.colour].mid_dark);
+        GfxFillRect(rt, { { l + kScrollBarWidth, t + 3 }, { r - kScrollBarWidth, t + 3 } }, ColourMapA[colour.colour].lighter);
         GfxFillRect(
-            dpi, { { l + kScrollBarWidth, t + 7 }, { r - kScrollBarWidth, t + 7 } }, ColourMapA[colour.colour].mid_dark);
-        GfxFillRect(dpi, { { l + kScrollBarWidth, t + 8 }, { r - kScrollBarWidth, t + 8 } }, ColourMapA[colour.colour].lighter);
+            rt, { { l + kScrollBarWidth, t + 7 }, { r - kScrollBarWidth, t + 7 } }, ColourMapA[colour.colour].mid_dark);
+        GfxFillRect(rt, { { l + kScrollBarWidth, t + 8 }, { r - kScrollBarWidth, t + 8 } }, ColourMapA[colour.colour].lighter);
 
         // Left button
         {
             uint8_t flags = (scroll.flags & HSCROLLBAR_LEFT_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
-            GfxFillRectInset(dpi, { { l, t }, { l + (kScrollBarWidth - 1), b } }, colour, flags);
-            DrawText(dpi, { l + 1, t }, {}, kBlackLeftArrowString);
+            GfxFillRectInset(rt, { { l, t }, { l + (kScrollBarWidth - 1), b } }, colour, flags);
+            DrawText(rt, { l + 1, t }, {}, kBlackLeftArrowString);
         }
 
         // Thumb
@@ -768,59 +768,59 @@ namespace OpenRCT2::Ui
             int16_t right = std::min(r - kScrollBarWidth, l + scroll.hThumbRight - 1);
             uint8_t flags = (scroll.flags & HSCROLLBAR_THUMB_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
-            GfxFillRectInset(dpi, { { left, t }, { right, b } }, colour, flags);
+            GfxFillRectInset(rt, { { left, t }, { right, b } }, colour, flags);
         }
 
         // Right button
         {
             uint8_t flags = (scroll.flags & HSCROLLBAR_RIGHT_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
-            GfxFillRectInset(dpi, { { r - (kScrollBarWidth - 1), t }, { r, b } }, colour, flags);
-            DrawText(dpi, { r - 6, t }, {}, kBlackRightArrowString);
+            GfxFillRectInset(rt, { { r - (kScrollBarWidth - 1), t }, { r, b } }, colour, flags);
+            DrawText(rt, { r - 6, t }, {}, kBlackRightArrowString);
         }
     }
 
     static void WidgetVScrollbarDraw(
-        RenderTarget& dpi, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour)
+        RenderTarget& rt, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour)
     {
         colour.setFlag(ColourFlag::translucent, false);
 
         // Trough
-        GfxFillRect(dpi, { { l, t + kScrollBarWidth }, { r, b - kScrollBarWidth } }, ColourMapA[colour.colour].lighter);
+        GfxFillRect(rt, { { l, t + kScrollBarWidth }, { r, b - kScrollBarWidth } }, ColourMapA[colour.colour].lighter);
         GfxFillRect(
-            dpi, { { l, t + kScrollBarWidth }, { r, b - kScrollBarWidth } }, 0x1000000 | ColourMapA[colour.colour].mid_dark);
+            rt, { { l, t + kScrollBarWidth }, { r, b - kScrollBarWidth } }, 0x1000000 | ColourMapA[colour.colour].mid_dark);
         GfxFillRect(
-            dpi, { { l + 2, t + kScrollBarWidth }, { l + 2, b - kScrollBarWidth } }, ColourMapA[colour.colour].mid_dark);
-        GfxFillRect(dpi, { { l + 3, t + kScrollBarWidth }, { l + 3, b - kScrollBarWidth } }, ColourMapA[colour.colour].lighter);
+            rt, { { l + 2, t + kScrollBarWidth }, { l + 2, b - kScrollBarWidth } }, ColourMapA[colour.colour].mid_dark);
+        GfxFillRect(rt, { { l + 3, t + kScrollBarWidth }, { l + 3, b - kScrollBarWidth } }, ColourMapA[colour.colour].lighter);
         GfxFillRect(
-            dpi, { { l + 7, t + kScrollBarWidth }, { l + 7, b - kScrollBarWidth } }, ColourMapA[colour.colour].mid_dark);
-        GfxFillRect(dpi, { { l + 8, t + kScrollBarWidth }, { l + 8, b - kScrollBarWidth } }, ColourMapA[colour.colour].lighter);
+            rt, { { l + 7, t + kScrollBarWidth }, { l + 7, b - kScrollBarWidth } }, ColourMapA[colour.colour].mid_dark);
+        GfxFillRect(rt, { { l + 8, t + kScrollBarWidth }, { l + 8, b - kScrollBarWidth } }, ColourMapA[colour.colour].lighter);
 
         // Up button
         GfxFillRectInset(
-            dpi, { { l, t }, { r, t + (kScrollBarWidth - 1) } }, colour,
+            rt, { { l, t }, { r, t + (kScrollBarWidth - 1) } }, colour,
             ((scroll.flags & VSCROLLBAR_UP_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
-        DrawText(dpi, { l + 1, t - 1 }, {}, kBlackUpArrowString);
+        DrawText(rt, { l + 1, t - 1 }, {}, kBlackUpArrowString);
 
         // Thumb
         GfxFillRectInset(
-            dpi,
+            rt,
             { { l, std::max(t + kScrollBarWidth, t + scroll.vThumbTop - 1) },
               { r, std::min(b - kScrollBarWidth, t + scroll.vThumbBottom - 1) } },
             { colour }, ((scroll.flags & VSCROLLBAR_THUMB_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
 
         // Down button
         GfxFillRectInset(
-            dpi, { { l, b - (kScrollBarWidth - 1) }, { r, b } }, colour,
+            rt, { { l, b - (kScrollBarWidth - 1) }, { r, b } }, colour,
             ((scroll.flags & VSCROLLBAR_DOWN_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
-        DrawText(dpi, { l + 1, b - (kScrollBarWidth - 1) }, {}, kBlackDownArrowString);
+        DrawText(rt, { l + 1, b - (kScrollBarWidth - 1) }, {}, kBlackDownArrowString);
     }
 
     /**
      *
      *  rct2: 0x006EB951
      */
-    static void WidgetDrawImage(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetDrawImage(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -843,11 +843,11 @@ namespace OpenRCT2::Ui
         {
             // Draw greyed out (light border bottom right shadow)
             auto mappedColour = ColourMapA[colour].lighter;
-            GfxDrawSpriteSolid(dpi, image, screenCoords + ScreenCoordsXY{ 1, 1 }, mappedColour);
+            GfxDrawSpriteSolid(rt, image, screenCoords + ScreenCoordsXY{ 1, 1 }, mappedColour);
 
             // Draw greyed out (dark)
             mappedColour = ColourMapA[colour].mid_light;
-            GfxDrawSpriteSolid(dpi, image, screenCoords, mappedColour);
+            GfxDrawSpriteSolid(rt, image, screenCoords, mappedColour);
         }
         else
         {
@@ -861,7 +861,7 @@ namespace OpenRCT2::Ui
             else
                 image = image.WithPrimary(colour);
 
-            GfxDrawSprite(dpi, image, screenCoords);
+            GfxDrawSprite(rt, image, screenCoords);
         }
     }
 
@@ -1122,7 +1122,7 @@ namespace OpenRCT2::Ui
         WidgetSetPressed(w, widgetIndex, value);
     }
 
-    static void WidgetTextBoxDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetTextBoxDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -1136,7 +1136,7 @@ namespace OpenRCT2::Ui
             && widgetIndex == tbIdent.widget_index;
 
         // GfxFillRectInset(dpi, l, t, r, b, colour, 0x20 | (!active ? 0x40 : 0x00));
-        GfxFillRectInset(dpi, { topLeft, bottomRight }, w.colours[widget.colour], INSET_RECT_F_60);
+        GfxFillRectInset(rt, { topLeft, bottomRight }, w.colours[widget.colour], INSET_RECT_F_60);
 
         // Figure out where the text should be positioned vertically.
         topLeft.y = w.windowPos.y + widget.textTop();
@@ -1148,7 +1148,7 @@ namespace OpenRCT2::Ui
             {
                 u8string wrappedString;
                 GfxWrapString(widget.string, bottomRight.x - topLeft.x - 5, FontStyle::Medium, &wrappedString, nullptr);
-                DrawText(dpi, { topLeft.x + 2, topLeft.y }, { w.colours[1] }, wrappedString.c_str(), true);
+                DrawText(rt, { topLeft.x + 2, topLeft.y }, { w.colours[1] }, wrappedString.c_str(), true);
             }
             return;
         }
@@ -1158,7 +1158,7 @@ namespace OpenRCT2::Ui
         u8string wrappedString;
         GfxWrapString(*textInput->Buffer, bottomRight.x - topLeft.x - 5 - 6, FontStyle::Medium, &wrappedString, nullptr);
 
-        DrawText(dpi, { topLeft.x + 2, topLeft.y }, { w.colours[1] }, wrappedString.c_str(), true);
+        DrawText(rt, { topLeft.x + 2, topLeft.y }, { w.colours[1] }, wrappedString.c_str(), true);
 
         // Make a trimmed view of the string for measuring the width.
         int32_t curX = topLeft.x
@@ -1182,11 +1182,11 @@ namespace OpenRCT2::Ui
         {
             auto colour = ColourMapA[w.colours[1].colour].mid_light;
             auto y = topLeft.y + 1 + widget.height() - 4;
-            GfxFillRect(dpi, { { curX, y }, { curX + width, y } }, colour + 5);
+            GfxFillRect(rt, { { curX, y }, { curX + width, y } }, colour + 5);
         }
     }
 
-    static void WidgetProgressBarDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex)
+    static void WidgetProgressBarDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
     {
         const auto& widget = w.widgets[widgetIndex];
 
@@ -1200,7 +1200,7 @@ namespace OpenRCT2::Ui
         auto isBlinking = (lowerBlinkBounds != upperBlinkBounds) && (percentage >= lowerBlinkBounds)
             && (percentage <= upperBlinkBounds);
 
-        GfxFillRectInset(dpi, { topLeft, bottomRight }, w.colours[1], INSET_RECT_F_30);
+        GfxFillRectInset(rt, { topLeft, bottomRight }, w.colours[1], INSET_RECT_F_30);
         if (isBlinking)
         {
             if (GameIsNotPaused() && (gCurrentRealTimeTicks & 8))
@@ -1212,17 +1212,17 @@ namespace OpenRCT2::Ui
         if (fillSize > 0)
         {
             GfxFillRectInset(
-                dpi, { topLeft + ScreenCoordsXY{ 1, 1 }, topLeft + ScreenCoordsXY{ fillSize + 1, widget.height() - 1 } },
+                rt, { topLeft + ScreenCoordsXY{ 1, 1 }, topLeft + ScreenCoordsXY{ fillSize + 1, widget.height() - 1 } },
                 { widget.colour }, 0);
         }
     }
 
-    static void WidgetHorizontalSeparatorDraw(RenderTarget& dpi, WindowBase& w, const Widget& widget)
+    static void WidgetHorizontalSeparatorDraw(RenderTarget& rt, WindowBase& w, const Widget& widget)
     {
         ScreenCoordsXY topLeft{ w.windowPos + ScreenCoordsXY{ widget.left, widget.top } };
         ScreenCoordsXY bottomRight{ w.windowPos + ScreenCoordsXY{ widget.right, widget.bottom } };
 
-        GfxFillRectInset(dpi, { topLeft, bottomRight }, w.colours[1], INSET_RECT_FLAG_BORDER_INSET);
+        GfxFillRectInset(rt, { topLeft, bottomRight }, w.colours[1], INSET_RECT_FLAG_BORDER_INSET);
     }
 
     ImageId GetColourButtonImage(colour_t colour)

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -715,7 +715,7 @@ namespace OpenRCT2::Ui
         bottomRight.y++;
         bottomRight.x++;
 
-        // Create a new inner scroll dpi
+        // Create a new inner scroll render target
         RenderTarget scrollRT = rt;
 
         // Clip the scroll dpi against the outer dpi
@@ -724,7 +724,7 @@ namespace OpenRCT2::Ui
         int32_t cr = std::min<int32_t>(rt.x + rt.width, bottomRight.x);
         int32_t cb = std::min<int32_t>(rt.y + rt.height, bottomRight.y);
 
-        // Set the respective dpi attributes
+        // Set the respective render target attributes
         scrollRT.x = cl - topLeft.x + scroll.contentOffsetX;
         scrollRT.y = ct - topLeft.y + scroll.contentOffsetY;
         scrollRT.width = cr - cl;
@@ -1135,7 +1135,7 @@ namespace OpenRCT2::Ui
         bool active = w.classification == tbIdent.window.classification && w.number == tbIdent.window.number
             && widgetIndex == tbIdent.widget_index;
 
-        // GfxFillRectInset(dpi, l, t, r, b, colour, 0x20 | (!active ? 0x40 : 0x00));
+        // GfxFillRectInset(rt, l, t, r, b, colour, 0x20 | (!active ? 0x40 : 0x00));
         GfxFillRectInset(rt, { topLeft, bottomRight }, w.colours[widget.colour], INSET_RECT_F_60);
 
         // Figure out where the text should be positioned vertically.

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -747,11 +747,9 @@ namespace OpenRCT2::Ui
         GfxFillRect(rt, { { l + kScrollBarWidth, t }, { r - kScrollBarWidth, b } }, ColourMapA[colour.colour].lighter);
         GfxFillRect(
             rt, { { l + kScrollBarWidth, t }, { r - kScrollBarWidth, b } }, 0x1000000 | ColourMapA[colour.colour].mid_dark);
-        GfxFillRect(
-            rt, { { l + kScrollBarWidth, t + 2 }, { r - kScrollBarWidth, t + 2 } }, ColourMapA[colour.colour].mid_dark);
+        GfxFillRect(rt, { { l + kScrollBarWidth, t + 2 }, { r - kScrollBarWidth, t + 2 } }, ColourMapA[colour.colour].mid_dark);
         GfxFillRect(rt, { { l + kScrollBarWidth, t + 3 }, { r - kScrollBarWidth, t + 3 } }, ColourMapA[colour.colour].lighter);
-        GfxFillRect(
-            rt, { { l + kScrollBarWidth, t + 7 }, { r - kScrollBarWidth, t + 7 } }, ColourMapA[colour.colour].mid_dark);
+        GfxFillRect(rt, { { l + kScrollBarWidth, t + 7 }, { r - kScrollBarWidth, t + 7 } }, ColourMapA[colour.colour].mid_dark);
         GfxFillRect(rt, { { l + kScrollBarWidth, t + 8 }, { r - kScrollBarWidth, t + 8 } }, ColourMapA[colour.colour].lighter);
 
         // Left button
@@ -789,11 +787,9 @@ namespace OpenRCT2::Ui
         GfxFillRect(rt, { { l, t + kScrollBarWidth }, { r, b - kScrollBarWidth } }, ColourMapA[colour.colour].lighter);
         GfxFillRect(
             rt, { { l, t + kScrollBarWidth }, { r, b - kScrollBarWidth } }, 0x1000000 | ColourMapA[colour.colour].mid_dark);
-        GfxFillRect(
-            rt, { { l + 2, t + kScrollBarWidth }, { l + 2, b - kScrollBarWidth } }, ColourMapA[colour.colour].mid_dark);
+        GfxFillRect(rt, { { l + 2, t + kScrollBarWidth }, { l + 2, b - kScrollBarWidth } }, ColourMapA[colour.colour].mid_dark);
         GfxFillRect(rt, { { l + 3, t + kScrollBarWidth }, { l + 3, b - kScrollBarWidth } }, ColourMapA[colour.colour].lighter);
-        GfxFillRect(
-            rt, { { l + 7, t + kScrollBarWidth }, { l + 7, b - kScrollBarWidth } }, ColourMapA[colour.colour].mid_dark);
+        GfxFillRect(rt, { { l + 7, t + kScrollBarWidth }, { l + 7, b - kScrollBarWidth } }, ColourMapA[colour.colour].mid_dark);
         GfxFillRect(rt, { { l + 8, t + kScrollBarWidth }, { l + 8, b - kScrollBarWidth } }, ColourMapA[colour.colour].lighter);
 
         // Up button

--- a/src/openrct2-ui/interface/Widget.h
+++ b/src/openrct2-ui/interface/Widget.h
@@ -173,7 +173,7 @@ namespace OpenRCT2::Ui
         return MakeWidget({ xPos, yPos }, { width, height }, WindowWidgetType::Button, colour, STR_DROPDOWN_GLYPH, tooltip);
     }
 
-    void WidgetDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
+    void WidgetDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
 
     bool WidgetIsDisabled(const WindowBase& w, WidgetIndex widgetIndex);
     bool WidgetIsHoldable(const WindowBase& w, WidgetIndex widgetIndex);

--- a/src/openrct2-ui/interface/Widget.h
+++ b/src/openrct2-ui/interface/Widget.h
@@ -173,7 +173,7 @@ namespace OpenRCT2::Ui
         return MakeWidget({ xPos, yPos }, { width, height }, WindowWidgetType::Button, colour, STR_DROPDOWN_GLYPH, tooltip);
     }
 
-    void WidgetDraw(RenderTarget& dpi, WindowBase& w, WidgetIndex widgetIndex);
+    void WidgetDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
 
     bool WidgetIsDisabled(const WindowBase& w, WidgetIndex widgetIndex);
     bool WidgetIsHoldable(const WindowBase& w, WidgetIndex widgetIndex);

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -351,12 +351,12 @@ namespace OpenRCT2
             WindowScrollToLocation(*mainWindow, newCoords);
     }
 
-    void Window::OnDraw(DrawPixelInfo& dpi)
+    void Window::OnDraw(RenderTarget& dpi)
     {
         Windows::WindowDrawWidgets(*this, dpi);
     }
 
-    void Window::OnDrawWidget(WidgetIndex widgetIndex, DrawPixelInfo& dpi)
+    void Window::OnDrawWidget(WidgetIndex widgetIndex, RenderTarget& dpi)
     {
         WidgetDraw(dpi, *this, widgetIndex);
     }
@@ -412,7 +412,7 @@ namespace OpenRCT2
         SetWidgetPressed(widgetIndex, value);
     }
 
-    void Window::DrawWidgets(DrawPixelInfo& dpi)
+    void Window::DrawWidgets(RenderTarget& dpi)
     {
         Windows::WindowDrawWidgets(*this, dpi);
     }
@@ -1041,7 +1041,7 @@ namespace OpenRCT2::Ui::Windows
      * @param dpi (edi)
      * @param w (esi)
      */
-    void WindowDrawViewport(DrawPixelInfo& dpi, WindowBase& w)
+    void WindowDrawViewport(RenderTarget& dpi, WindowBase& w)
     {
         ViewportRender(dpi, w.viewport);
     }
@@ -1050,7 +1050,7 @@ namespace OpenRCT2::Ui::Windows
      *
      *  rct2: 0x006EB15C
      */
-    void WindowDrawWidgets(WindowBase& w, DrawPixelInfo& dpi)
+    void WindowDrawWidgets(WindowBase& w, RenderTarget& dpi)
     {
         if ((w.flags & WF_TRANSPARENT) && !(w.flags & WF_NO_BACKGROUND))
             GfxFilterRect(

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -351,14 +351,14 @@ namespace OpenRCT2
             WindowScrollToLocation(*mainWindow, newCoords);
     }
 
-    void Window::OnDraw(RenderTarget& dpi)
+    void Window::OnDraw(RenderTarget& rt)
     {
-        Windows::WindowDrawWidgets(*this, dpi);
+        Windows::WindowDrawWidgets(*this, rt);
     }
 
-    void Window::OnDrawWidget(WidgetIndex widgetIndex, RenderTarget& dpi)
+    void Window::OnDrawWidget(WidgetIndex widgetIndex, RenderTarget& rt)
     {
-        WidgetDraw(dpi, *this, widgetIndex);
+        WidgetDraw(rt, *this, widgetIndex);
     }
 
     void Window::InitScrollWidgets()
@@ -412,9 +412,9 @@ namespace OpenRCT2
         SetWidgetPressed(widgetIndex, value);
     }
 
-    void Window::DrawWidgets(RenderTarget& dpi)
+    void Window::DrawWidgets(RenderTarget& rt)
     {
-        Windows::WindowDrawWidgets(*this, dpi);
+        Windows::WindowDrawWidgets(*this, rt);
     }
 
     void Window::Close()
@@ -1041,20 +1041,20 @@ namespace OpenRCT2::Ui::Windows
      * @param dpi (edi)
      * @param w (esi)
      */
-    void WindowDrawViewport(RenderTarget& dpi, WindowBase& w)
+    void WindowDrawViewport(RenderTarget& rt, WindowBase& w)
     {
-        ViewportRender(dpi, w.viewport);
+        ViewportRender(rt, w.viewport);
     }
 
     /**
      *
      *  rct2: 0x006EB15C
      */
-    void WindowDrawWidgets(WindowBase& w, RenderTarget& dpi)
+    void WindowDrawWidgets(WindowBase& w, RenderTarget& rt)
     {
         if ((w.flags & WF_TRANSPARENT) && !(w.flags & WF_NO_BACKGROUND))
             GfxFilterRect(
-                dpi, { w.windowPos, w.windowPos + ScreenCoordsXY{ w.width - 1, w.height - 1 } }, FilterPaletteID::Palette51);
+                rt, { w.windowPos, w.windowPos + ScreenCoordsXY{ w.width - 1, w.height - 1 } }, FilterPaletteID::Palette51);
 
         // todo: some code missing here? Between 006EB18C and 006EB260
         for (WidgetIndex widgetIndex = 0; widgetIndex < w.widgets.size(); widgetIndex++)
@@ -1066,11 +1066,11 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Check if widget is outside the draw region
-            if (w.windowPos.x + widget.left < dpi.x + dpi.width && w.windowPos.x + widget.right >= dpi.x)
+            if (w.windowPos.x + widget.left < rt.x + rt.width && w.windowPos.x + widget.right >= rt.x)
             {
-                if (w.windowPos.y + widget.top < dpi.y + dpi.height && w.windowPos.y + widget.bottom >= dpi.y)
+                if (w.windowPos.y + widget.top < rt.y + rt.height && w.windowPos.y + widget.bottom >= rt.y)
                 {
-                    w.OnDrawWidget(widgetIndex, dpi);
+                    w.OnDrawWidget(widgetIndex, rt);
                 }
             }
         }
@@ -1080,7 +1080,7 @@ namespace OpenRCT2::Ui::Windows
         if (w.flags & WF_WHITE_BORDER_MASK)
         {
             GfxFillRectInset(
-                dpi, { w.windowPos, w.windowPos + ScreenCoordsXY{ w.width - 1, w.height - 1 } }, { COLOUR_WHITE },
+                rt, { w.windowPos, w.windowPos + ScreenCoordsXY{ w.width - 1, w.height - 1 } }, { COLOUR_WHITE },
                 INSET_RECT_FLAG_FILL_NONE);
         }
     }

--- a/src/openrct2-ui/interface/Window.h
+++ b/src/openrct2-ui/interface/Window.h
@@ -20,8 +20,8 @@ namespace OpenRCT2
 
     struct Window : WindowBase
     {
-        void OnDraw(RenderTarget& dpi) override;
-        void OnDrawWidget(WidgetIndex widgetIndex, RenderTarget& dpi) override;
+        void OnDraw(RenderTarget& rt) override;
+        void OnDrawWidget(WidgetIndex widgetIndex, RenderTarget& rt) override;
 
         void ScrollToViewport();
         void InitScrollWidgets();
@@ -33,7 +33,7 @@ namespace OpenRCT2
         void SetWidgetDisabledAndInvalidate(WidgetIndex widgetIndex, bool value);
         void SetWidgetPressed(WidgetIndex widgetIndex, bool value);
         void SetCheckboxValue(WidgetIndex widgetIndex, bool value);
-        void DrawWidgets(RenderTarget& dpi);
+        void DrawWidgets(RenderTarget& rt);
         void Close();
         void CloseOthers();
         void CloseOthersOfThisClass();
@@ -84,8 +84,8 @@ namespace OpenRCT2::Ui::Windows
 
     void InvalidateAllWindowsAfterInput();
 
-    void WindowDrawWidgets(WindowBase& w, RenderTarget& dpi);
-    void WindowDrawViewport(RenderTarget& dpi, WindowBase& w);
+    void WindowDrawWidgets(WindowBase& w, RenderTarget& rt);
+    void WindowDrawViewport(RenderTarget& rt, WindowBase& w);
 
     void WindowZoomIn(WindowBase& w, bool atCursor);
     void WindowZoomOut(WindowBase& w, bool atCursor);

--- a/src/openrct2-ui/interface/Window.h
+++ b/src/openrct2-ui/interface/Window.h
@@ -20,8 +20,8 @@ namespace OpenRCT2
 
     struct Window : WindowBase
     {
-        void OnDraw(DrawPixelInfo& dpi) override;
-        void OnDrawWidget(WidgetIndex widgetIndex, DrawPixelInfo& dpi) override;
+        void OnDraw(RenderTarget& dpi) override;
+        void OnDrawWidget(WidgetIndex widgetIndex, RenderTarget& dpi) override;
 
         void ScrollToViewport();
         void InitScrollWidgets();
@@ -33,7 +33,7 @@ namespace OpenRCT2
         void SetWidgetDisabledAndInvalidate(WidgetIndex widgetIndex, bool value);
         void SetWidgetPressed(WidgetIndex widgetIndex, bool value);
         void SetCheckboxValue(WidgetIndex widgetIndex, bool value);
-        void DrawWidgets(DrawPixelInfo& dpi);
+        void DrawWidgets(RenderTarget& dpi);
         void Close();
         void CloseOthers();
         void CloseOthersOfThisClass();
@@ -84,8 +84,8 @@ namespace OpenRCT2::Ui::Windows
 
     void InvalidateAllWindowsAfterInput();
 
-    void WindowDrawWidgets(WindowBase& w, DrawPixelInfo& dpi);
-    void WindowDrawViewport(DrawPixelInfo& dpi, WindowBase& w);
+    void WindowDrawWidgets(WindowBase& w, RenderTarget& dpi);
+    void WindowDrawViewport(RenderTarget& dpi, WindowBase& w);
 
     void WindowZoomIn(WindowBase& w, bool atCursor);
     void WindowZoomOut(WindowBase& w, bool atCursor);

--- a/src/openrct2-ui/scripting/CustomImages.cpp
+++ b/src/openrct2-ui/scripting/CustomImages.cpp
@@ -434,7 +434,7 @@ namespace OpenRCT2::Scripting
         auto plugin = scriptEngine.GetExecInfo().GetCurrentPlugin();
 
         auto drawingEngine = std::make_unique<X8DrawingEngine>(GetContext()->GetUiContext());
-        DrawPixelInfo dpi;
+        RenderTarget dpi;
         dpi.DrawingEngine = drawingEngine.get();
         dpi.width = size.width;
         dpi.height = size.height;

--- a/src/openrct2-ui/scripting/CustomImages.cpp
+++ b/src/openrct2-ui/scripting/CustomImages.cpp
@@ -434,10 +434,10 @@ namespace OpenRCT2::Scripting
         auto plugin = scriptEngine.GetExecInfo().GetCurrentPlugin();
 
         auto drawingEngine = std::make_unique<X8DrawingEngine>(GetContext()->GetUiContext());
-        RenderTarget dpi;
-        dpi.DrawingEngine = drawingEngine.get();
-        dpi.width = size.width;
-        dpi.height = size.height;
+        RenderTarget rt;
+        rt.DrawingEngine = drawingEngine.get();
+        rt.width = size.width;
+        rt.height = size.height;
 
         auto createNewImage = false;
         auto g1 = GfxGetG1Element(id);
@@ -449,22 +449,22 @@ namespace OpenRCT2::Scripting
         if (createNewImage)
         {
             auto bufferSize = size.width * size.height;
-            dpi.bits = new uint8_t[bufferSize];
-            std::memset(dpi.bits, 0, bufferSize);
+            rt.bits = new uint8_t[bufferSize];
+            std::memset(rt.bits, 0, bufferSize);
 
             drawingEngine->BeginDraw();
 
             // Draw the original image if we are creating a new one
-            GfxDrawSprite(dpi, ImageId(id), { 0, 0 });
+            GfxDrawSprite(rt, ImageId(id), { 0, 0 });
 
             drawingEngine->EndDraw();
         }
         else
         {
-            dpi.bits = g1->offset;
+            rt.bits = g1->offset;
         }
 
-        auto dukG = GetObjectAsDukValue(ctx, std::make_shared<ScGraphicsContext>(ctx, dpi));
+        auto dukG = GetObjectAsDukValue(ctx, std::make_shared<ScGraphicsContext>(ctx, rt));
         scriptEngine.ExecutePluginCall(plugin, callback, { dukG }, false);
 
         if (createNewImage)
@@ -475,7 +475,7 @@ namespace OpenRCT2::Scripting
                 delete[] g1->offset;
                 newg1 = *g1;
             }
-            newg1.offset = dpi.bits;
+            newg1.offset = rt.bits;
             newg1.width = size.width;
             newg1.height = size.height;
             newg1.flags = 0;

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -595,14 +595,12 @@ void CustomListView::Paint(WindowBase* w, RenderTarget& rt, const ScrollArea* sc
                 if (isSelected)
                 {
                     GfxFilterRect(
-                        rt, { { rt.x, y }, { rt.x + rt.width, y + (kListRowHeight - 1) } },
-                        FilterPaletteID::PaletteDarken2);
+                        rt, { { rt.x, y }, { rt.x + rt.width, y + (kListRowHeight - 1) } }, FilterPaletteID::PaletteDarken2);
                 }
                 else if (isHighlighted)
                 {
                     GfxFilterRect(
-                        rt, { { rt.x, y }, { rt.x + rt.width, y + (kListRowHeight - 1) } },
-                        FilterPaletteID::PaletteDarken2);
+                        rt, { { rt.x, y }, { rt.x + rt.width, y + (kListRowHeight - 1) } }, FilterPaletteID::PaletteDarken2);
                 }
                 else if (isStriped)
                 {
@@ -705,8 +703,7 @@ void CustomListView::PaintHeading(
     }
 }
 
-void CustomListView::PaintSeperator(
-    RenderTarget& rt, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text) const
+void CustomListView::PaintSeperator(RenderTarget& rt, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text) const
 {
     auto hasText = text != nullptr && text[0] != '\0';
     auto left = pos.x + 4;

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -561,21 +561,21 @@ void CustomListView::MouseUp(const ScreenCoordsXY& pos)
     }
 }
 
-void CustomListView::Paint(WindowBase* w, RenderTarget& dpi, const ScrollArea* scroll) const
+void CustomListView::Paint(WindowBase* w, RenderTarget& rt, const ScrollArea* scroll) const
 {
     auto paletteIndex = ColourMapA[w->colours[1].colour].mid_light;
-    GfxFillRect(dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width, dpi.y + dpi.height } }, paletteIndex);
+    GfxFillRect(rt, { { rt.x, rt.y }, { rt.x + rt.width, rt.y + rt.height } }, paletteIndex);
 
     int32_t y = ShowColumnHeaders ? kColumnHeaderHeight : 0;
     for (size_t i = 0; i < Items.size(); i++)
     {
-        if (y > dpi.y + dpi.height)
+        if (y > rt.y + rt.height)
         {
             // Past the scroll view area
             break;
         }
 
-        if (y + kListRowHeight >= dpi.y)
+        if (y + kListRowHeight >= rt.y)
         {
             const auto& itemIndex = static_cast<int32_t>(SortedItems[i]);
             const auto& item = Items[itemIndex];
@@ -584,7 +584,7 @@ void CustomListView::Paint(WindowBase* w, RenderTarget& dpi, const ScrollArea* s
             {
                 const auto& text = item.Cells[0];
                 ScreenSize cellSize = { LastKnownSize.width, kListRowHeight };
-                PaintSeperator(dpi, { 0, y }, cellSize, text.c_str());
+                PaintSeperator(rt, { 0, y }, cellSize, text.c_str());
             }
             else
             {
@@ -595,19 +595,19 @@ void CustomListView::Paint(WindowBase* w, RenderTarget& dpi, const ScrollArea* s
                 if (isSelected)
                 {
                     GfxFilterRect(
-                        dpi, { { dpi.x, y }, { dpi.x + dpi.width, y + (kListRowHeight - 1) } },
+                        rt, { { rt.x, y }, { rt.x + rt.width, y + (kListRowHeight - 1) } },
                         FilterPaletteID::PaletteDarken2);
                 }
                 else if (isHighlighted)
                 {
                     GfxFilterRect(
-                        dpi, { { dpi.x, y }, { dpi.x + dpi.width, y + (kListRowHeight - 1) } },
+                        rt, { { rt.x, y }, { rt.x + rt.width, y + (kListRowHeight - 1) } },
                         FilterPaletteID::PaletteDarken2);
                 }
                 else if (isStriped)
                 {
                     GfxFillRect(
-                        dpi, { { dpi.x, y }, { dpi.x + dpi.width, y + (kListRowHeight - 1) } },
+                        rt, { { rt.x, y }, { rt.x + rt.width, y + (kListRowHeight - 1) } },
                         ColourMapA[w->colours[1].colour].lighter | 0x1000000);
                 }
 
@@ -620,7 +620,7 @@ void CustomListView::Paint(WindowBase* w, RenderTarget& dpi, const ScrollArea* s
                         if (!text.empty())
                         {
                             ScreenSize cellSize = { std::numeric_limits<int32_t>::max(), kListRowHeight };
-                            PaintCell(dpi, { 0, y }, cellSize, text.c_str(), isHighlighted);
+                            PaintCell(rt, { 0, y }, cellSize, text.c_str(), isHighlighted);
                         }
                     }
                 }
@@ -636,7 +636,7 @@ void CustomListView::Paint(WindowBase* w, RenderTarget& dpi, const ScrollArea* s
                             if (!text.empty())
                             {
                                 ScreenSize cellSize = { column.Width, kListRowHeight };
-                                PaintCell(dpi, { x, y }, cellSize, text.c_str(), isHighlighted);
+                                PaintCell(rt, { x, y }, cellSize, text.c_str(), isHighlighted);
                             }
                         }
                         x += column.Width;
@@ -653,7 +653,7 @@ void CustomListView::Paint(WindowBase* w, RenderTarget& dpi, const ScrollArea* s
         y = scroll->contentOffsetY;
 
         auto bgColour = ColourMapA[w->colours[1].colour].mid_light;
-        GfxFillRect(dpi, { { dpi.x, y }, { dpi.x + dpi.width, y + 12 } }, bgColour);
+        GfxFillRect(rt, { { rt.x, y }, { rt.x + rt.width, y + 12 } }, bgColour);
 
         int32_t x = 0;
         for (int32_t j = 0; j < static_cast<int32_t>(Columns.size()); j++)
@@ -669,7 +669,7 @@ void CustomListView::Paint(WindowBase* w, RenderTarget& dpi, const ScrollArea* s
                 }
 
                 bool isPressed = ColumnHeaderPressed == j && ColumnHeaderPressedCurrentState;
-                PaintHeading(w, dpi, { x, y }, { column.Width, kListRowHeight }, column.Header, sortOrder, isPressed);
+                PaintHeading(w, rt, { x, y }, { column.Width, kListRowHeight }, column.Header, sortOrder, isPressed);
                 x += columnWidth;
             }
         }
@@ -677,7 +677,7 @@ void CustomListView::Paint(WindowBase* w, RenderTarget& dpi, const ScrollArea* s
 }
 
 void CustomListView::PaintHeading(
-    WindowBase* w, RenderTarget& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const std::string& text,
+    WindowBase* w, RenderTarget& rt, const ScreenCoordsXY& pos, const ScreenSize& size, const std::string& text,
     ColumnSortOrder sortOrder, bool isPressed) const
 {
     auto boxFlags = 0;
@@ -685,28 +685,28 @@ void CustomListView::PaintHeading(
     {
         boxFlags = INSET_RECT_FLAG_BORDER_INSET;
     }
-    GfxFillRectInset(dpi, { pos, pos + ScreenCoordsXY{ size.width - 1, size.height - 1 } }, w->colours[1], boxFlags);
+    GfxFillRectInset(rt, { pos, pos + ScreenCoordsXY{ size.width - 1, size.height - 1 } }, w->colours[1], boxFlags);
     if (!text.empty())
     {
-        PaintCell(dpi, pos, size, text.c_str(), false);
+        PaintCell(rt, pos, size, text.c_str(), false);
     }
 
     if (sortOrder == ColumnSortOrder::Ascending)
     {
         auto ft = Formatter();
         ft.Add<StringId>(STR_UP);
-        DrawTextBasic(dpi, pos + ScreenCoordsXY{ size.width - 1, 0 }, STR_BLACK_STRING, ft, { TextAlignment::RIGHT });
+        DrawTextBasic(rt, pos + ScreenCoordsXY{ size.width - 1, 0 }, STR_BLACK_STRING, ft, { TextAlignment::RIGHT });
     }
     else if (sortOrder == ColumnSortOrder::Descending)
     {
         auto ft = Formatter();
         ft.Add<StringId>(STR_DOWN);
-        DrawTextBasic(dpi, pos + ScreenCoordsXY{ size.width - 1, 0 }, STR_BLACK_STRING, ft, { TextAlignment::RIGHT });
+        DrawTextBasic(rt, pos + ScreenCoordsXY{ size.width - 1, 0 }, STR_BLACK_STRING, ft, { TextAlignment::RIGHT });
     }
 }
 
 void CustomListView::PaintSeperator(
-    RenderTarget& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text) const
+    RenderTarget& rt, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text) const
 {
     auto hasText = text != nullptr && text[0] != '\0';
     auto left = pos.x + 4;
@@ -724,7 +724,7 @@ void CustomListView::PaintSeperator(
         // Draw string
         Formatter ft;
         ft.Add<const char*>(text);
-        DrawTextBasic(dpi, { centreX, pos.y }, STR_STRING, ft, { baseColour, TextAlignment::CENTRE });
+        DrawTextBasic(rt, { centreX, pos.y }, STR_STRING, ft, { baseColour, TextAlignment::CENTRE });
 
         // Get string dimensions
         utf8 stringBuffer[512]{};
@@ -736,44 +736,44 @@ void CustomListView::PaintSeperator(
         // Draw light horizontal rule
         auto lightLineLeftTop1 = ScreenCoordsXY{ left, lineY0 };
         auto lightLineRightBottom1 = ScreenCoordsXY{ strLeft, lineY0 };
-        GfxDrawLine(dpi, { lightLineLeftTop1, lightLineRightBottom1 }, lightColour);
+        GfxDrawLine(rt, { lightLineLeftTop1, lightLineRightBottom1 }, lightColour);
 
         auto lightLineLeftTop2 = ScreenCoordsXY{ strRight, lineY0 };
         auto lightLineRightBottom2 = ScreenCoordsXY{ right, lineY0 };
-        GfxDrawLine(dpi, { lightLineLeftTop2, lightLineRightBottom2 }, lightColour);
+        GfxDrawLine(rt, { lightLineLeftTop2, lightLineRightBottom2 }, lightColour);
 
         // Draw dark horizontal rule
         auto darkLineLeftTop1 = ScreenCoordsXY{ left, lineY1 };
         auto darkLineRightBottom1 = ScreenCoordsXY{ strLeft, lineY1 };
-        GfxDrawLine(dpi, { darkLineLeftTop1, darkLineRightBottom1 }, darkColour);
+        GfxDrawLine(rt, { darkLineLeftTop1, darkLineRightBottom1 }, darkColour);
 
         auto darkLineLeftTop2 = ScreenCoordsXY{ strRight, lineY1 };
         auto darkLineRightBottom2 = ScreenCoordsXY{ right, lineY1 };
-        GfxDrawLine(dpi, { darkLineLeftTop2, darkLineRightBottom2 }, darkColour);
+        GfxDrawLine(rt, { darkLineLeftTop2, darkLineRightBottom2 }, darkColour);
     }
     else
     {
         // Draw light horizontal rule
         auto lightLineLeftTop1 = ScreenCoordsXY{ left, lineY0 };
         auto lightLineRightBottom1 = ScreenCoordsXY{ right, lineY0 };
-        GfxDrawLine(dpi, { lightLineLeftTop1, lightLineRightBottom1 }, lightColour);
+        GfxDrawLine(rt, { lightLineLeftTop1, lightLineRightBottom1 }, lightColour);
 
         // Draw dark horizontal rule
         auto darkLineLeftTop1 = ScreenCoordsXY{ left, lineY1 };
         auto darkLineRightBottom1 = ScreenCoordsXY{ right, lineY1 };
-        GfxDrawLine(dpi, { darkLineLeftTop1, darkLineRightBottom1 }, darkColour);
+        GfxDrawLine(rt, { darkLineLeftTop1, darkLineRightBottom1 }, darkColour);
     }
 }
 
 void CustomListView::PaintCell(
-    RenderTarget& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text, bool isHighlighted) const
+    RenderTarget& rt, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text, bool isHighlighted) const
 {
     StringId stringId = isHighlighted ? STR_WINDOW_COLOUR_2_STRINGID : STR_BLACK_STRING;
 
     auto ft = Formatter();
     ft.Add<StringId>(STR_STRING);
     ft.Add<const char*>(text);
-    DrawTextEllipsised(dpi, pos, size.width, stringId, ft, {});
+    DrawTextEllipsised(rt, pos, size.width, stringId, ft, {});
 }
 
 std::optional<RowColumn> CustomListView::GetItemIndexAt(const ScreenCoordsXY& pos)

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -561,7 +561,7 @@ void CustomListView::MouseUp(const ScreenCoordsXY& pos)
     }
 }
 
-void CustomListView::Paint(WindowBase* w, DrawPixelInfo& dpi, const ScrollArea* scroll) const
+void CustomListView::Paint(WindowBase* w, RenderTarget& dpi, const ScrollArea* scroll) const
 {
     auto paletteIndex = ColourMapA[w->colours[1].colour].mid_light;
     GfxFillRect(dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width, dpi.y + dpi.height } }, paletteIndex);
@@ -677,7 +677,7 @@ void CustomListView::Paint(WindowBase* w, DrawPixelInfo& dpi, const ScrollArea* 
 }
 
 void CustomListView::PaintHeading(
-    WindowBase* w, DrawPixelInfo& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const std::string& text,
+    WindowBase* w, RenderTarget& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const std::string& text,
     ColumnSortOrder sortOrder, bool isPressed) const
 {
     auto boxFlags = 0;
@@ -706,7 +706,7 @@ void CustomListView::PaintHeading(
 }
 
 void CustomListView::PaintSeperator(
-    DrawPixelInfo& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text) const
+    RenderTarget& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text) const
 {
     auto hasText = text != nullptr && text[0] != '\0';
     auto left = pos.x + 4;
@@ -766,7 +766,7 @@ void CustomListView::PaintSeperator(
 }
 
 void CustomListView::PaintCell(
-    DrawPixelInfo& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text, bool isHighlighted) const
+    RenderTarget& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text, bool isHighlighted) const
 {
     StringId stringId = isHighlighted ? STR_WINDOW_COLOUR_2_STRINGID : STR_BLACK_STRING;
 

--- a/src/openrct2-ui/scripting/CustomListView.h
+++ b/src/openrct2-ui/scripting/CustomListView.h
@@ -138,15 +138,15 @@ namespace OpenRCT2::Ui::Windows
         void MouseOver(const ScreenCoordsXY& pos, bool isMouseDown);
         void MouseDown(const ScreenCoordsXY& pos);
         void MouseUp(const ScreenCoordsXY& pos);
-        void Paint(WindowBase* w, RenderTarget& dpi, const ScrollArea* scroll) const;
+        void Paint(WindowBase* w, RenderTarget& rt, const ScrollArea* scroll) const;
 
     private:
         void PaintHeading(
-            WindowBase* w, RenderTarget& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const std::string& text,
+            WindowBase* w, RenderTarget& rt, const ScreenCoordsXY& pos, const ScreenSize& size, const std::string& text,
             ColumnSortOrder sortOrder, bool isPressed) const;
-        void PaintSeperator(RenderTarget& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text) const;
+        void PaintSeperator(RenderTarget& rt, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text) const;
         void PaintCell(
-            RenderTarget& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text, bool isHighlighted) const;
+            RenderTarget& rt, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text, bool isHighlighted) const;
         std::optional<RowColumn> GetItemIndexAt(const ScreenCoordsXY& pos);
         Widget* GetWidget() const;
         void Invalidate();

--- a/src/openrct2-ui/scripting/CustomListView.h
+++ b/src/openrct2-ui/scripting/CustomListView.h
@@ -138,15 +138,15 @@ namespace OpenRCT2::Ui::Windows
         void MouseOver(const ScreenCoordsXY& pos, bool isMouseDown);
         void MouseDown(const ScreenCoordsXY& pos);
         void MouseUp(const ScreenCoordsXY& pos);
-        void Paint(WindowBase* w, DrawPixelInfo& dpi, const ScrollArea* scroll) const;
+        void Paint(WindowBase* w, RenderTarget& dpi, const ScrollArea* scroll) const;
 
     private:
         void PaintHeading(
-            WindowBase* w, DrawPixelInfo& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const std::string& text,
+            WindowBase* w, RenderTarget& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const std::string& text,
             ColumnSortOrder sortOrder, bool isPressed) const;
-        void PaintSeperator(DrawPixelInfo& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text) const;
+        void PaintSeperator(RenderTarget& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text) const;
         void PaintCell(
-            DrawPixelInfo& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text, bool isHighlighted) const;
+            RenderTarget& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text, bool isHighlighted) const;
         std::optional<RowColumn> GetItemIndexAt(const ScreenCoordsXY& pos);
         Widget* GetWidget() const;
         void Invalidate();

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -534,7 +534,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             WindowDrawWidgets(*this, dpi);
             DrawTabImages(dpi);
@@ -548,7 +548,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDrawWidget(WidgetIndex widgetIndex, DrawPixelInfo& dpi) override
+        void OnDrawWidget(WidgetIndex widgetIndex, RenderTarget& dpi) override
         {
             const auto& widget = widgets[widgetIndex];
             const auto widgetDesc = _info.GetCustomWidgetDesc(this, widgetIndex);
@@ -557,7 +557,7 @@ namespace OpenRCT2::Ui::Windows
                 auto& onDraw = widgetDesc->OnDraw;
                 if (onDraw.is_function())
                 {
-                    DrawPixelInfo widgetDpi;
+                    RenderTarget widgetDpi;
                     if (ClipDrawPixelInfo(
                             widgetDpi, dpi, { windowPos.x + widget.left, windowPos.y + widget.top }, widget.width(),
                             widget.height()))
@@ -748,7 +748,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             if (scrollIndex < static_cast<int32_t>(_info.ListViews.size()))
             {
@@ -854,7 +854,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImages(DrawPixelInfo& dpi)
+        void DrawTabImages(RenderTarget& dpi)
         {
             const auto& tabs = _info.Desc.Tabs;
             size_t tabIndex = 0;

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -534,21 +534,21 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            WindowDrawWidgets(*this, dpi);
-            DrawTabImages(dpi);
+            WindowDrawWidgets(*this, rt);
+            DrawTabImages(rt);
             if (viewport != nullptr)
             {
                 auto widgetIndex = GetViewportWidgetIndex();
                 if (WidgetIsVisible(*this, widgetIndex.value_or(false)))
                 {
-                    WindowDrawViewport(dpi, *this);
+                    WindowDrawViewport(rt, *this);
                 }
             }
         }
 
-        void OnDrawWidget(WidgetIndex widgetIndex, RenderTarget& dpi) override
+        void OnDrawWidget(WidgetIndex widgetIndex, RenderTarget& rt) override
         {
             const auto& widget = widgets[widgetIndex];
             const auto widgetDesc = _info.GetCustomWidgetDesc(this, widgetIndex);
@@ -559,7 +559,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     RenderTarget widgetDpi;
                     if (ClipDrawPixelInfo(
-                            widgetDpi, dpi, { windowPos.x + widget.left, windowPos.y + widget.top }, widget.width(),
+                            widgetDpi, rt, { windowPos.x + widget.left, windowPos.y + widget.top }, widget.width(),
                             widget.height()))
                     {
                         auto ctx = onDraw.context();
@@ -572,7 +572,7 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                Window::OnDrawWidget(widgetIndex, dpi);
+                Window::OnDrawWidget(widgetIndex, rt);
             }
         }
 
@@ -748,11 +748,11 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             if (scrollIndex < static_cast<int32_t>(_info.ListViews.size()))
             {
-                _info.ListViews[scrollIndex].Paint(this, dpi, &scrolls[scrollIndex]);
+                _info.ListViews[scrollIndex].Paint(this, rt, &scrolls[scrollIndex]);
             }
         }
 
@@ -854,7 +854,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImages(RenderTarget& dpi)
+        void DrawTabImages(RenderTarget& rt)
         {
             const auto& tabs = _info.Desc.Tabs;
             size_t tabIndex = 0;
@@ -872,7 +872,7 @@ namespace OpenRCT2::Ui::Windows
                         auto imageOffset = frame % tab.imageFrameCount;
                         image = image.WithIndex(image.GetIndex() + imageOffset);
                     }
-                    GfxDrawSprite(dpi, image, leftTop);
+                    GfxDrawSprite(rt, image, leftTop);
                 }
                 tabIndex++;
             }

--- a/src/openrct2-ui/scripting/ScGraphicsContext.hpp
+++ b/src/openrct2-ui/scripting/ScGraphicsContext.hpp
@@ -22,7 +22,7 @@ namespace OpenRCT2::Scripting
     {
     private:
         duk_context* _ctx{};
-        DrawPixelInfo _dpi{};
+        RenderTarget _dpi{};
 
         std::optional<colour_t> _colour{};
         std::optional<colour_t> _secondaryColour{};
@@ -32,7 +32,7 @@ namespace OpenRCT2::Scripting
         uint8_t _fill{};
 
     public:
-        ScGraphicsContext(duk_context* ctx, const DrawPixelInfo& dpi)
+        ScGraphicsContext(duk_context* ctx, const RenderTarget& dpi)
             : _ctx(ctx)
             , _dpi(dpi)
         {
@@ -180,7 +180,7 @@ namespace OpenRCT2::Scripting
 
         void clip(int32_t x, int32_t y, int32_t width, int32_t height)
         {
-            DrawPixelInfo newDpi;
+            RenderTarget newDpi;
             ClipDrawPixelInfo(newDpi, _dpi, { x, y }, width, height);
             _dpi = newDpi;
         }

--- a/src/openrct2-ui/scripting/ScGraphicsContext.hpp
+++ b/src/openrct2-ui/scripting/ScGraphicsContext.hpp
@@ -22,7 +22,7 @@ namespace OpenRCT2::Scripting
     {
     private:
         duk_context* _ctx{};
-        RenderTarget _dpi{};
+        RenderTarget _rt{};
 
         std::optional<colour_t> _colour{};
         std::optional<colour_t> _secondaryColour{};
@@ -32,9 +32,9 @@ namespace OpenRCT2::Scripting
         uint8_t _fill{};
 
     public:
-        ScGraphicsContext(duk_context* ctx, const RenderTarget& dpi)
+        ScGraphicsContext(duk_context* ctx, const RenderTarget& rt)
             : _ctx(ctx)
-            , _dpi(dpi)
+            , _rt(rt)
         {
         }
 
@@ -141,12 +141,12 @@ namespace OpenRCT2::Scripting
 
         int32_t width_get() const
         {
-            return _dpi.width;
+            return _rt.width;
         }
 
         int32_t height_get() const
         {
-            return _dpi.height;
+            return _rt.height;
         }
 
         DukValue getImage(uint32_t id)
@@ -163,26 +163,26 @@ namespace OpenRCT2::Scripting
 
         void box(int32_t x, int32_t y, int32_t width, int32_t height)
         {
-            GfxFillRectInset(_dpi, { x, y, x + width - 1, y + height - 1 }, { _colour.value_or(0) }, 0);
+            GfxFillRectInset(_rt, { x, y, x + width - 1, y + height - 1 }, { _colour.value_or(0) }, 0);
         }
 
         void well(int32_t x, int32_t y, int32_t width, int32_t height)
         {
             GfxFillRectInset(
-                _dpi, { x, y, x + width - 1, y + height - 1 }, { _colour.value_or(0) },
+                _rt, { x, y, x + width - 1, y + height - 1 }, { _colour.value_or(0) },
                 INSET_RECT_FLAG_BORDER_INSET | INSET_RECT_FLAG_FILL_DONT_LIGHTEN);
         }
 
         void clear()
         {
-            GfxClear(_dpi, _fill);
+            GfxClear(_rt, _fill);
         }
 
         void clip(int32_t x, int32_t y, int32_t width, int32_t height)
         {
             RenderTarget newDpi;
-            ClipDrawPixelInfo(newDpi, _dpi, { x, y }, width, height);
-            _dpi = newDpi;
+            ClipDrawPixelInfo(newDpi, _rt, { x, y }, width, height);
+            _rt = newDpi;
         }
 
         void image(uint32_t id, int32_t x, int32_t y)
@@ -205,12 +205,12 @@ namespace OpenRCT2::Scripting
                 }
             }
 
-            GfxDrawSprite(_dpi, img.WithTertiary(_tertiaryColour.value_or(0)), { x, y });
+            GfxDrawSprite(_rt, img.WithTertiary(_tertiaryColour.value_or(0)), { x, y });
         }
 
         void line(int32_t x1, int32_t y1, int32_t x2, int32_t y2)
         {
-            GfxDrawLine(_dpi, { { x1, y1 }, { x2, y2 } }, _stroke);
+            GfxDrawLine(_rt, { { x1, y1 }, { x2, y2 } }, _stroke);
         }
 
         void rect(int32_t x, int32_t y, int32_t width, int32_t height)
@@ -229,13 +229,13 @@ namespace OpenRCT2::Scripting
             }
             if (_fill != 0)
             {
-                GfxFillRect(_dpi, { x, y, x + width - 1, y + height - 1 }, _fill);
+                GfxFillRect(_rt, { x, y, x + width - 1, y + height - 1 }, _fill);
             }
         }
 
         void text(const std::string& text, int32_t x, int32_t y)
         {
-            DrawText(_dpi, { x, y }, { _colour.value_or(0) }, text.c_str());
+            DrawText(_rt, { x, y }, { _colour.value_or(0) }, text.c_str());
         }
     };
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -149,7 +149,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
 
@@ -221,7 +221,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        int32_t DrawOpenRCT2Info(DrawPixelInfo& dpi)
+        int32_t DrawOpenRCT2Info(RenderTarget& dpi)
         {
             // Draw logo on placeholder widget
             const auto& logoWidget = widgets[WIDX_OPENRCT2_LOGO];
@@ -254,7 +254,7 @@ namespace OpenRCT2::Ui::Windows
             return textCoords.y - windowPos.y;
         }
 
-        int32_t DrawRCT2Info(DrawPixelInfo& dpi)
+        int32_t DrawRCT2Info(RenderTarget& dpi)
         {
             auto& backgroundWidget = widgets[WIDX_PAGE_BACKGROUND];
             auto textCoords = windowPos + ScreenCoordsXY{ backgroundWidget.midX(), backgroundWidget.top + kPadding };

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -149,9 +149,9 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             const auto& aboutOpenRCT2 = widgets[WIDX_TAB_ABOUT_OPENRCT2];
             const auto& aboutRCT2 = widgets[WIDX_TAB_ABOUT_RCT2];
@@ -166,7 +166,7 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<StringId>(STR_TITLE_SEQUENCE_OPENRCT2);
                 DrawTextWrapped(
-                    dpi, aboutOpenRCT2Coords, 87, STR_WINDOW_COLOUR_2_STRINGID, ft,
+                    rt, aboutOpenRCT2Coords, 87, STR_WINDOW_COLOUR_2_STRINGID, ft,
                     { COLOUR_AQUAMARINE, TextAlignment::CENTRE });
             }
             {
@@ -174,17 +174,17 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<StringId>(STR_TITLE_SEQUENCE_RCT2);
                 DrawTextWrapped(
-                    dpi, aboutRCT2Coords, 87, STR_WINDOW_COLOUR_2_STRINGID, ft, { COLOUR_AQUAMARINE, TextAlignment::CENTRE });
+                    rt, aboutRCT2Coords, 87, STR_WINDOW_COLOUR_2_STRINGID, ft, { COLOUR_AQUAMARINE, TextAlignment::CENTRE });
             }
 
             int32_t newHeight = 0;
             if (page == WINDOW_ABOUT_PAGE_OPENRCT2)
             {
-                newHeight = DrawOpenRCT2Info(dpi) + kPadding;
+                newHeight = DrawOpenRCT2Info(rt) + kPadding;
             }
             else if (page == WINDOW_ABOUT_PAGE_RCT2)
             {
-                newHeight = DrawRCT2Info(dpi) + kPadding;
+                newHeight = DrawRCT2Info(rt) + kPadding;
             }
 
             if (newHeight != height)
@@ -221,12 +221,12 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        int32_t DrawOpenRCT2Info(RenderTarget& dpi)
+        int32_t DrawOpenRCT2Info(RenderTarget& rt)
         {
             // Draw logo on placeholder widget
             const auto& logoWidget = widgets[WIDX_OPENRCT2_LOGO];
             auto logoCoords = windowPos + ScreenCoordsXY(logoWidget.left, logoWidget.top);
-            GfxDrawSprite(dpi, ImageId(SPR_G2_LOGO), logoCoords);
+            GfxDrawSprite(rt, ImageId(SPR_G2_LOGO), logoCoords);
 
             u8string versionInfo = gVersionInfoFull;
             auto ft = Formatter();
@@ -236,7 +236,7 @@ namespace OpenRCT2::Ui::Windows
             auto centreX = versionWidget.midX();
             auto centreY = versionWidget.midY() - FontGetLineHeight(FontStyle::Medium) / 2;
             auto centrePos = windowPos + ScreenCoordsXY(centreX, centreY);
-            DrawTextWrapped(dpi, centrePos, versionWidget.width(), STR_STRING, ft, { colours[1], TextAlignment::CENTRE });
+            DrawTextWrapped(rt, centrePos, versionWidget.width(), STR_STRING, ft, { colours[1], TextAlignment::CENTRE });
 
             // Shows the update available button
             if (OpenRCT2::GetContext()->HasNewVersionInfo())
@@ -249,12 +249,12 @@ namespace OpenRCT2::Ui::Windows
             auto textCoords = windowPos + ScreenCoordsXY((width / 2) - 1, 240);
             auto textWidth = WW - (kPadding * 2);
             for (auto stringId : _OpenRCT2InfoStrings)
-                textCoords.y += DrawTextWrapped(dpi, textCoords, textWidth, stringId, {}, tp) + 5;
+                textCoords.y += DrawTextWrapped(rt, textCoords, textWidth, stringId, {}, tp) + 5;
 
             return textCoords.y - windowPos.y;
         }
 
-        int32_t DrawRCT2Info(RenderTarget& dpi)
+        int32_t DrawRCT2Info(RenderTarget& rt)
         {
             auto& backgroundWidget = widgets[WIDX_PAGE_BACKGROUND];
             auto textCoords = windowPos + ScreenCoordsXY{ backgroundWidget.midX(), backgroundWidget.top + kPadding };
@@ -270,14 +270,14 @@ namespace OpenRCT2::Ui::Windows
                     continue;
                 }
 
-                textCoords.y += DrawTextWrapped(dpi, textCoords, textWidth, stringId, {}, tp);
+                textCoords.y += DrawTextWrapped(rt, textCoords, textWidth, stringId, {}, tp);
                 if (stringId == STR_COPYRIGHT_CS)
                     textCoords.y += 74;
             }
 
             // Draw images
             auto imageCoords = windowPos + ScreenCoordsXY{ 92, backgroundWidget.top + 5 + 24 };
-            GfxDrawSprite(dpi, ImageId(SPR_CREDITS_CHRIS_SAWYER_SMALL), imageCoords);
+            GfxDrawSprite(rt, ImageId(SPR_CREDITS_CHRIS_SAWYER_SMALL), imageCoords);
 
             return textCoords.y - windowPos.y;
         }

--- a/src/openrct2-ui/windows/AssetPacks.cpp
+++ b/src/openrct2-ui/windows/AssetPacks.cpp
@@ -185,12 +185,12 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_APPLY].top = widgets[WIDX_APPLY].bottom - 24;
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
         }
 
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
             GfxFillRect(
@@ -235,7 +235,7 @@ namespace OpenRCT2::Ui::Windows
         }
 
     private:
-        void PaintItem(DrawPixelInfo& dpi, int32_t y, Formatter& ft, bool isChecked, bool isSelected, bool isHighlighted)
+        void PaintItem(RenderTarget& dpi, int32_t y, Formatter& ft, bool isChecked, bool isSelected, bool isHighlighted)
         {
             auto listWidth = widgets[WIDX_LIST].right - widgets[WIDX_LIST].left;
             auto stringId = STR_BLACK_STRING;
@@ -256,7 +256,7 @@ namespace OpenRCT2::Ui::Windows
             PaintCheckbox(dpi, { { 2, y + 1 }, { 2 + checkboxSize + 1, y + 1 + checkboxSize } }, isChecked);
         }
 
-        void PaintCheckbox(DrawPixelInfo& dpi, const ScreenRect& rect, bool checked)
+        void PaintCheckbox(RenderTarget& dpi, const ScreenRect& rect, bool checked)
         {
             GfxFillRectInset(dpi, rect, colours[1], INSET_RECT_F_E0);
             if (checked)

--- a/src/openrct2-ui/windows/AssetPacks.cpp
+++ b/src/openrct2-ui/windows/AssetPacks.cpp
@@ -185,16 +185,16 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_APPLY].top = widgets[WIDX_APPLY].bottom - 24;
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
         }
 
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
-            auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
+            auto dpiCoords = ScreenCoordsXY{ rt.x, rt.y };
             GfxFillRect(
-                dpi, { dpiCoords, dpiCoords + ScreenCoordsXY{ dpi.width - 1, dpi.height - 1 } },
+                rt, { dpiCoords, dpiCoords + ScreenCoordsXY{ rt.width - 1, rt.height - 1 } },
                 ColourMapA[colours[1].colour].mid_light);
 
             auto assetPackManager = GetContext()->GetAssetPackManager();
@@ -205,9 +205,9 @@ namespace OpenRCT2::Ui::Windows
             auto y = 0;
             for (size_t i = 0; i <= numAssetPacks; i++)
             {
-                if (y > dpi.y + dpi.height)
+                if (y > rt.y + rt.height)
                     break;
-                if (y + 11 < dpi.y)
+                if (y + 11 < rt.y)
                     continue;
 
                 auto isSelected = i == _selectedIndex;
@@ -216,7 +216,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     auto ft = Formatter();
                     ft.Add<StringId>(STR_BASE_GRAPHICS_MUSIC_SOUND);
-                    PaintItem(dpi, y, ft, true, isSelected, isHighlighted);
+                    PaintItem(rt, y, ft, true, isSelected, isHighlighted);
                 }
                 else
                 {
@@ -227,7 +227,7 @@ namespace OpenRCT2::Ui::Windows
                         auto ft = Formatter();
                         ft.Add<StringId>(STR_STRING);
                         ft.Add<const char*>(assetPack->Name.c_str());
-                        PaintItem(dpi, y, ft, isChecked, isSelected, isHighlighted);
+                        PaintItem(rt, y, ft, isChecked, isSelected, isHighlighted);
                     }
                 }
                 y += ItemHeight;
@@ -235,37 +235,37 @@ namespace OpenRCT2::Ui::Windows
         }
 
     private:
-        void PaintItem(RenderTarget& dpi, int32_t y, Formatter& ft, bool isChecked, bool isSelected, bool isHighlighted)
+        void PaintItem(RenderTarget& rt, int32_t y, Formatter& ft, bool isChecked, bool isSelected, bool isHighlighted)
         {
             auto listWidth = widgets[WIDX_LIST].right - widgets[WIDX_LIST].left;
             auto stringId = STR_BLACK_STRING;
             auto fillRectangle = ScreenRect{ { 0, y }, { listWidth, y + ItemHeight - 1 } };
             if (isSelected)
             {
-                GfxFillRect(dpi, fillRectangle, ColourMapA[colours[1].colour].mid_dark);
+                GfxFillRect(rt, fillRectangle, ColourMapA[colours[1].colour].mid_dark);
                 stringId = STR_WINDOW_COLOUR_2_STRINGID;
             }
             else if (isHighlighted)
             {
-                GfxFillRect(dpi, fillRectangle, ColourMapA[colours[1].colour].mid_dark);
+                GfxFillRect(rt, fillRectangle, ColourMapA[colours[1].colour].mid_dark);
             }
 
-            DrawTextEllipsised(dpi, { 16, y + 1 }, listWidth, stringId, ft);
+            DrawTextEllipsised(rt, { 16, y + 1 }, listWidth, stringId, ft);
 
             auto checkboxSize = ItemHeight - 3;
-            PaintCheckbox(dpi, { { 2, y + 1 }, { 2 + checkboxSize + 1, y + 1 + checkboxSize } }, isChecked);
+            PaintCheckbox(rt, { { 2, y + 1 }, { 2 + checkboxSize + 1, y + 1 + checkboxSize } }, isChecked);
         }
 
-        void PaintCheckbox(RenderTarget& dpi, const ScreenRect& rect, bool checked)
+        void PaintCheckbox(RenderTarget& rt, const ScreenRect& rect, bool checked)
         {
-            GfxFillRectInset(dpi, rect, colours[1], INSET_RECT_F_E0);
+            GfxFillRectInset(rt, rect, colours[1], INSET_RECT_F_E0);
             if (checked)
             {
                 auto checkmark = Formatter();
                 checkmark.Add<StringId>(STR_STRING);
                 checkmark.Add<char*>(kCheckMarkString);
                 DrawTextBasic(
-                    dpi, ScreenCoordsXY{ rect.GetLeft() + 1, rect.GetTop() }, STR_WINDOW_COLOUR_2_STRINGID, checkmark);
+                    rt, ScreenCoordsXY{ rect.GetLeft() + 1, rect.GetTop() }, STR_WINDOW_COLOUR_2_STRINGID, checkmark);
             }
         }
 

--- a/src/openrct2-ui/windows/AssetPacks.cpp
+++ b/src/openrct2-ui/windows/AssetPacks.cpp
@@ -192,9 +192,9 @@ namespace OpenRCT2::Ui::Windows
 
         void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
-            auto dpiCoords = ScreenCoordsXY{ rt.x, rt.y };
+            auto rtCoords = ScreenCoordsXY{ rt.x, rt.y };
             GfxFillRect(
-                rt, { dpiCoords, dpiCoords + ScreenCoordsXY{ rt.width - 1, rt.height - 1 } },
+                rt, { rtCoords, rtCoords + ScreenCoordsXY{ rt.width - 1, rt.height - 1 } },
                 ColourMapA[colours[1].colour].mid_light);
 
             auto assetPackManager = GetContext()->GetAssetPackManager();
@@ -264,8 +264,7 @@ namespace OpenRCT2::Ui::Windows
                 auto checkmark = Formatter();
                 checkmark.Add<StringId>(STR_STRING);
                 checkmark.Add<char*>(kCheckMarkString);
-                DrawTextBasic(
-                    rt, ScreenCoordsXY{ rect.GetLeft() + 1, rect.GetTop() }, STR_WINDOW_COLOUR_2_STRINGID, checkmark);
+                DrawTextBasic(rt, ScreenCoordsXY{ rect.GetLeft() + 1, rect.GetTop() }, STR_WINDOW_COLOUR_2_STRINGID, checkmark);
             }
         }
 

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -262,13 +262,13 @@ namespace OpenRCT2::Ui::Windows
             CreateViewport();
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             if (viewport != nullptr)
             {
-                WindowDrawViewport(dpi, *this);
+                WindowDrawViewport(rt, *this);
             }
         }
 

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -262,7 +262,7 @@ namespace OpenRCT2::Ui::Windows
             CreateViewport();
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
 

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -175,7 +175,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             const int32_t lineHeight = FontGetLineHeight(FontStyle::Medium);
 

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -175,7 +175,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             const int32_t lineHeight = FontGetLineHeight(FontStyle::Medium);
 
@@ -183,10 +183,10 @@ namespace OpenRCT2::Ui::Windows
             for (const auto& line : _changelogLines)
             {
                 screenCoords.y += lineHeight;
-                if (screenCoords.y + lineHeight < dpi.y || screenCoords.y >= dpi.y + dpi.height)
+                if (screenCoords.y + lineHeight < rt.y || screenCoords.y >= rt.y + rt.height)
                     continue;
 
-                DrawText(dpi, screenCoords, { colours[0] }, line.c_str());
+                DrawText(rt, screenCoords, { colours[0] }, line.c_str());
             }
         }
 

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -600,7 +600,7 @@ static StringId window_cheats_page_titles[] = {
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -789,7 +789,7 @@ static StringId window_cheats_page_titles[] = {
             }
         }
 
-        void DrawTabImages(DrawPixelInfo& dpi)
+        void DrawTabImages(RenderTarget& dpi)
         {
             // Money tab
             if (!IsWidgetDisabled(WIDX_TAB_1))

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -834,8 +834,7 @@ static StringId window_cheats_page_titles[] = {
             if (!IsWidgetDisabled(WIDX_TAB_5))
             {
                 GfxDrawSprite(
-                    rt, ImageId(SPR_TAB_PARK),
-                    windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_5].left, widgets[WIDX_TAB_5].top });
+                    rt, ImageId(SPR_TAB_PARK), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_5].left, widgets[WIDX_TAB_5].top });
             }
 
             // Rides tab

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -600,10 +600,10 @@ static StringId window_cheats_page_titles[] = {
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             static constexpr int16_t _xLcol = 14;
             static constexpr int16_t _xRcol = 208;
@@ -620,36 +620,36 @@ static StringId window_cheats_page_titles[] = {
 
                 auto& widget = widgets[WIDX_MONEY_SPINNER];
                 DrawTextBasic(
-                    dpi, windowPos + ScreenCoordsXY{ _xLcol, widget.top + 2 }, STR_BOTTOM_TOOLBAR_CASH, ft, { colour });
+                    rt, windowPos + ScreenCoordsXY{ _xLcol, widget.top + 2 }, STR_BOTTOM_TOOLBAR_CASH, ft, { colour });
             }
             else if (page == WINDOW_CHEATS_PAGE_DATE)
             {
                 auto& yearBox = widgets[WIDX_YEAR_BOX];
-                DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ _xLcol, yearBox.top + 2 }, STR_YEAR);
+                DrawTextBasic(rt, windowPos + ScreenCoordsXY{ _xLcol, yearBox.top + 2 }, STR_YEAR);
 
                 auto& monthBox = widgets[WIDX_MONTH_BOX];
-                DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ _xLcol, monthBox.top + 2 }, STR_MONTH);
+                DrawTextBasic(rt, windowPos + ScreenCoordsXY{ _xLcol, monthBox.top + 2 }, STR_MONTH);
 
                 auto& dayBox = widgets[WIDX_DAY_BOX];
-                DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ _xLcol, dayBox.top + 2 }, STR_DAY);
+                DrawTextBasic(rt, windowPos + ScreenCoordsXY{ _xLcol, dayBox.top + 2 }, STR_DAY);
 
                 auto ft = Formatter();
                 ft.Add<int32_t>(_yearSpinnerValue);
                 DrawTextBasic(
-                    dpi, windowPos + ScreenCoordsXY{ _xRcol, yearBox.top + 2 }, STR_FORMAT_INTEGER, ft,
+                    rt, windowPos + ScreenCoordsXY{ _xRcol, yearBox.top + 2 }, STR_FORMAT_INTEGER, ft,
                     { colours[1], TextAlignment::RIGHT });
 
                 ft = Formatter();
                 int32_t actual_month = _monthSpinnerValue - 1;
                 ft.Add<int32_t>(actual_month);
                 DrawTextBasic(
-                    dpi, windowPos + ScreenCoordsXY{ _xRcol, monthBox.top + 2 }, STR_FORMAT_MONTH, ft,
+                    rt, windowPos + ScreenCoordsXY{ _xRcol, monthBox.top + 2 }, STR_FORMAT_MONTH, ft,
                     { colours[1], TextAlignment::RIGHT });
 
                 ft = Formatter();
                 ft.Add<int32_t>(_daySpinnerValue);
                 DrawTextBasic(
-                    dpi, windowPos + ScreenCoordsXY{ _xRcol, dayBox.top + 2 }, STR_FORMAT_INTEGER, ft,
+                    rt, windowPos + ScreenCoordsXY{ _xRcol, dayBox.top + 2 }, STR_FORMAT_INTEGER, ft,
                     { colours[1], TextAlignment::RIGHT });
             }
             else if (page == WINDOW_CHEATS_PAGE_PARK)
@@ -660,7 +660,7 @@ static StringId window_cheats_page_titles[] = {
 
                     auto& widget = widgets[WIDX_PARK_RATING_SPINNER];
                     DrawTextBasic(
-                        dpi, windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 2 }, STR_FORMAT_INTEGER, ft,
+                        rt, windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 2 }, STR_FORMAT_INTEGER, ft,
                         { colours[1] });
                 }
             }
@@ -668,51 +668,51 @@ static StringId window_cheats_page_titles[] = {
             {
                 {
                     auto& widget = widgets[WIDX_STAFF_SPEED];
-                    DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ _xLcol - 3, widget.top + 1 }, STR_CHEAT_STAFF_SPEED);
+                    DrawTextBasic(rt, windowPos + ScreenCoordsXY{ _xLcol - 3, widget.top + 1 }, STR_CHEAT_STAFF_SPEED);
                 }
             }
             else if (page == WINDOW_CHEATS_PAGE_GUESTS)
             {
                 {
                     auto& widget = widgets[WIDX_GUEST_HAPPINESS_MIN];
-                    DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ _xLcol - 3, widget.top + 2 }, STR_CHEAT_GUEST_HAPPINESS);
+                    DrawTextBasic(rt, windowPos + ScreenCoordsXY{ _xLcol - 3, widget.top + 2 }, STR_CHEAT_GUEST_HAPPINESS);
                 }
                 {
                     auto& widget = widgets[WIDX_GUEST_ENERGY_MIN];
-                    DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ _xLcol - 3, widget.top + 2 }, STR_CHEAT_GUEST_ENERGY);
+                    DrawTextBasic(rt, windowPos + ScreenCoordsXY{ _xLcol - 3, widget.top + 2 }, STR_CHEAT_GUEST_ENERGY);
                 }
                 {
                     auto& widget = widgets[WIDX_GUEST_HUNGER_MIN];
-                    DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ _xLcol - 3, widget.top + 2 }, STR_CHEAT_GUEST_HUNGER);
+                    DrawTextBasic(rt, windowPos + ScreenCoordsXY{ _xLcol - 3, widget.top + 2 }, STR_CHEAT_GUEST_HUNGER);
                 }
                 {
                     auto& widget = widgets[WIDX_GUEST_THIRST_MIN];
-                    DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ _xLcol - 3, widget.top + 2 }, STR_CHEAT_GUEST_THIRST);
+                    DrawTextBasic(rt, windowPos + ScreenCoordsXY{ _xLcol - 3, widget.top + 2 }, STR_CHEAT_GUEST_THIRST);
                 }
                 {
                     auto& widget = widgets[WIDX_GUEST_NAUSEA_MIN];
-                    DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ _xLcol - 3, widget.top + 2 }, STR_CHEAT_GUEST_NAUSEA);
+                    DrawTextBasic(rt, windowPos + ScreenCoordsXY{ _xLcol - 3, widget.top + 2 }, STR_CHEAT_GUEST_NAUSEA);
                 }
                 {
                     auto& widget = widgets[WIDX_GUEST_NAUSEA_TOLERANCE_MIN];
                     DrawTextBasic(
-                        dpi, windowPos + ScreenCoordsXY{ _xLcol - 3, widget.top + 2 }, STR_CHEAT_GUEST_NAUSEA_TOLERANCE);
+                        rt, windowPos + ScreenCoordsXY{ _xLcol - 3, widget.top + 2 }, STR_CHEAT_GUEST_NAUSEA_TOLERANCE);
                 }
                 {
                     auto& widget = widgets[WIDX_GUEST_TOILET_MIN];
-                    DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ _xLcol - 3, widget.top + 2 }, STR_CHEAT_GUEST_TOILET);
+                    DrawTextBasic(rt, windowPos + ScreenCoordsXY{ _xLcol - 3, widget.top + 2 }, STR_CHEAT_GUEST_TOILET);
                 }
                 {
                     auto& widget = widgets[WIDX_GUEST_RIDE_INTENSITY_LESS_THAN_15];
                     DrawTextBasic(
-                        dpi, windowPos + ScreenCoordsXY{ _xLcol - 3, widget.top - 17 }, STR_CHEAT_GUEST_PREFERRED_INTENSITY);
+                        rt, windowPos + ScreenCoordsXY{ _xLcol - 3, widget.top - 17 }, STR_CHEAT_GUEST_PREFERRED_INTENSITY);
                 }
             }
             else if (page == WINDOW_CHEATS_PAGE_WEATHER)
             {
                 {
                     auto& widget = widgets[WIDX_WEATHER];
-                    DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ _xLcol - 3, widget.top + 1 }, STR_CHANGE_WEATHER);
+                    DrawTextBasic(rt, windowPos + ScreenCoordsXY{ _xLcol - 3, widget.top + 1 }, STR_CHANGE_WEATHER);
                 }
             }
         }
@@ -789,7 +789,7 @@ static StringId window_cheats_page_titles[] = {
             }
         }
 
-        void DrawTabImages(RenderTarget& dpi)
+        void DrawTabImages(RenderTarget& rt)
         {
             // Money tab
             if (!IsWidgetDisabled(WIDX_TAB_1))
@@ -798,7 +798,7 @@ static StringId window_cheats_page_titles[] = {
                 if (page == WINDOW_CHEATS_PAGE_MONEY)
                     sprite_idx += (frame_no / 2) % 8;
                 GfxDrawSprite(
-                    dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_1].left, widgets[WIDX_TAB_1].top });
+                    rt, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_1].left, widgets[WIDX_TAB_1].top });
             }
 
             // Date tab
@@ -808,7 +808,7 @@ static StringId window_cheats_page_titles[] = {
                 if (page == WINDOW_CHEATS_PAGE_DATE)
                     sprite_idx += (frame_no / 8) % 8;
                 GfxDrawSprite(
-                    dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left, widgets[WIDX_TAB_2].top });
+                    rt, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left, widgets[WIDX_TAB_2].top });
             }
 
             // Guests tab
@@ -818,7 +818,7 @@ static StringId window_cheats_page_titles[] = {
                 if (page == WINDOW_CHEATS_PAGE_GUESTS)
                     sprite_idx += (frame_no / 3) % 8;
                 GfxDrawSprite(
-                    dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_3].left, widgets[WIDX_TAB_3].top });
+                    rt, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_3].left, widgets[WIDX_TAB_3].top });
             }
 
             // Staff tab
@@ -826,7 +826,7 @@ static StringId window_cheats_page_titles[] = {
             {
                 uint32_t sprite_idx = SPR_MECHANIC;
                 GfxDrawSprite(
-                    dpi, ImageId(sprite_idx),
+                    rt, ImageId(sprite_idx),
                     windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_4].left + 2, widgets[WIDX_TAB_4].top + 1 });
             }
 
@@ -834,7 +834,7 @@ static StringId window_cheats_page_titles[] = {
             if (!IsWidgetDisabled(WIDX_TAB_5))
             {
                 GfxDrawSprite(
-                    dpi, ImageId(SPR_TAB_PARK),
+                    rt, ImageId(SPR_TAB_PARK),
                     windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_5].left, widgets[WIDX_TAB_5].top });
             }
 
@@ -845,7 +845,7 @@ static StringId window_cheats_page_titles[] = {
                 if (page == WINDOW_CHEATS_PAGE_RIDES)
                     sprite_idx += (frame_no / 4) % 16;
                 GfxDrawSprite(
-                    dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_6].left, widgets[WIDX_TAB_6].top });
+                    rt, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_6].left, widgets[WIDX_TAB_6].top });
             }
 
             // Nature/weather tab
@@ -853,7 +853,7 @@ static StringId window_cheats_page_titles[] = {
             {
                 uint32_t sprite_idx = SPR_WEATHER_SUN_CLOUD;
                 GfxDrawSprite(
-                    dpi, ImageId(sprite_idx),
+                    rt, ImageId(sprite_idx),
                     windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_7].left + 2, widgets[WIDX_TAB_7].top + 4 });
             }
         }

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -181,9 +181,9 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_PREVIEW].image = ImageId(LandTool::SizeToSpriteIndex(gLandToolSize));
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             // Draw number for tool sizes bigger than 7
             ScreenCoordsXY screenCoords = { windowPos.x + widgets[WIDX_PREVIEW].midX(),
@@ -193,7 +193,7 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<uint16_t>(gLandToolSize);
                 DrawTextBasic(
-                    dpi, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, ft, { TextAlignment::CENTRE });
+                    rt, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, ft, { TextAlignment::CENTRE });
             }
 
             // Draw cost amount
@@ -204,7 +204,7 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<money64>(_clearSceneryCost);
                 screenCoords.x = widgets[WIDX_PREVIEW].midX() + windowPos.x;
                 screenCoords.y = widgets[WIDX_PREVIEW].bottom + windowPos.y + 5 + 27;
-                DrawTextBasic(dpi, screenCoords, STR_COST_AMOUNT, ft, { TextAlignment::CENTRE });
+                DrawTextBasic(rt, screenCoords, STR_COST_AMOUNT, ft, { TextAlignment::CENTRE });
             }
         }
 

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -181,7 +181,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_PREVIEW].image = ImageId(LandTool::SizeToSpriteIndex(gLandToolSize));
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
 

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -191,36 +191,36 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             auto ft = Formatter::Common();
             ft.Add<money64>(10.00_GBP);
 
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             auto screenCoords = windowPos + ScreenCoordsXY{ 10, 18 + widgets[WIDX_TITLE].height() };
 
-            DrawTextBasic(dpi, screenCoords, STR_RATE, {}, { colours[1] });
+            DrawTextBasic(rt, screenCoords, STR_RATE, {}, { colours[1] });
 
             int32_t baseExchange = CurrencyDescriptors[EnumValue(CurrencyType::Pounds)].rate;
             ft = Formatter();
             ft.Add<int32_t>(baseExchange);
-            DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 200, 0 }, STR_CUSTOM_CURRENCY_EQUIVALENCY, ft, { colours[1] });
+            DrawTextBasic(rt, screenCoords + ScreenCoordsXY{ 200, 0 }, STR_CUSTOM_CURRENCY_EQUIVALENCY, ft, { colours[1] });
 
             screenCoords.y += 20;
 
-            DrawTextBasic(dpi, screenCoords, STR_CURRENCY_SYMBOL_TEXT, {}, { colours[1] });
+            DrawTextBasic(rt, screenCoords, STR_CURRENCY_SYMBOL_TEXT, {}, { colours[1] });
 
             screenCoords = windowPos + ScreenCoordsXY{ widgets[WIDX_SYMBOL_TEXT].left + 1, widgets[WIDX_SYMBOL_TEXT].top };
 
-            DrawText(dpi, screenCoords, { colours[1] }, CurrencyDescriptors[EnumValue(CurrencyType::Custom)].symbol_unicode);
+            DrawText(rt, screenCoords, { colours[1] }, CurrencyDescriptors[EnumValue(CurrencyType::Custom)].symbol_unicode);
 
             auto drawPos = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_AFFIX_DROPDOWN].left + 1, widgets[WIDX_AFFIX_DROPDOWN].top };
             StringId stringId = (CurrencyDescriptors[EnumValue(CurrencyType::Custom)].affix_unicode == CurrencyAffix::Prefix)
                 ? STR_PREFIX
                 : STR_SUFFIX;
-            DrawTextBasic(dpi, drawPos, stringId, {}, { colours[1] });
+            DrawTextBasic(rt, drawPos, stringId, {}, { colours[1] });
         }
     };
 

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -191,7 +191,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             auto ft = Formatter::Common();
             ft.Add<money64>(10.00_GBP);

--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -146,7 +146,7 @@ namespace OpenRCT2::Ui::Windows
             WidgetSetCheckboxValue(*this, WIDX_TOGGLE_STABLE_PAINT_SORT, gPaintStableSort);
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
         }

--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -146,9 +146,9 @@ namespace OpenRCT2::Ui::Windows
             WidgetSetCheckboxValue(*this, WIDX_TOGGLE_STABLE_PAINT_SORT, gPaintStableSort);
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
         }
     };
 

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -75,9 +75,9 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            WindowDrawWidgets(*this, dpi);
+            WindowDrawWidgets(*this, rt);
 
             auto currentRide = GetRide(rideId);
             if (currentRide != nullptr)
@@ -89,7 +89,7 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<money64>(_demolishRideCost);
 
                 ScreenCoordsXY stringCoords(windowPos.x + WW / 2, windowPos.y + (WH / 2) - 3);
-                DrawTextWrapped(dpi, stringCoords, WW - 4, stringId, ft, { TextAlignment::CENTRE });
+                DrawTextWrapped(rt, stringCoords, WW - 4, stringId, ft, { TextAlignment::CENTRE });
             }
         }
     };

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -75,7 +75,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             WindowDrawWidgets(*this, dpi);
 

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -97,7 +97,7 @@ namespace OpenRCT2::Ui::Windows
             return Config::Get().interface.EnlargedUi ? 6 : 0;
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
 

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -129,8 +129,7 @@ namespace OpenRCT2::Ui::Windows
                     {
                         GfxFillRect(rt, { leftTop, rightBottom }, ColourMapA[colours[0].colour].mid_dark);
                         GfxFillRect(
-                            rt, { leftTop + shadowOffset, rightBottom + shadowOffset },
-                            ColourMapA[colours[0].colour].lightest);
+                            rt, { leftTop + shadowOffset, rightBottom + shadowOffset }, ColourMapA[colours[0].colour].lightest);
                     }
                 }
                 else

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -97,9 +97,9 @@ namespace OpenRCT2::Ui::Windows
             return Config::Get().interface.EnlargedUi ? 6 : 0;
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             int32_t highlightedIndex = gDropdownHighlightedIndex;
             for (int32_t i = 0; i < gDropdownNumItems; i++)
@@ -122,14 +122,14 @@ namespace OpenRCT2::Ui::Windows
                     if (colours[0].hasFlag(ColourFlag::translucent))
                     {
                         TranslucentWindowPalette palette = TranslucentWindowPalettes[colours[0].colour];
-                        GfxFilterRect(dpi, { leftTop, rightBottom }, palette.highlight);
-                        GfxFilterRect(dpi, { leftTop + shadowOffset, rightBottom + shadowOffset }, palette.shadow);
+                        GfxFilterRect(rt, { leftTop, rightBottom }, palette.highlight);
+                        GfxFilterRect(rt, { leftTop + shadowOffset, rightBottom + shadowOffset }, palette.shadow);
                     }
                     else
                     {
-                        GfxFillRect(dpi, { leftTop, rightBottom }, ColourMapA[colours[0].colour].mid_dark);
+                        GfxFillRect(rt, { leftTop, rightBottom }, ColourMapA[colours[0].colour].mid_dark);
                         GfxFillRect(
-                            dpi, { leftTop + shadowOffset, rightBottom + shadowOffset },
+                            rt, { leftTop + shadowOffset, rightBottom + shadowOffset },
                             ColourMapA[colours[0].colour].lightest);
                     }
                 }
@@ -139,7 +139,7 @@ namespace OpenRCT2::Ui::Windows
                     {
                         // Darken the cell's background slightly when highlighted
                         const ScreenCoordsXY rightBottom = screenCoords + ScreenCoordsXY{ ItemWidth - 1, ItemHeight - 1 };
-                        GfxFilterRect(dpi, { screenCoords, rightBottom }, FilterPaletteID::PaletteDarken3);
+                        GfxFilterRect(rt, { screenCoords, rightBottom }, FilterPaletteID::PaletteDarken3);
                     }
 
                     StringId item = gDropdownItems[i].Format;
@@ -150,7 +150,7 @@ namespace OpenRCT2::Ui::Windows
                                                : ImageId(static_cast<uint32_t>(gDropdownItems[i].Args));
                         if (item == Dropdown::kFormatColourPicker && highlightedIndex == i)
                             image = image.WithIndexOffset(1);
-                        GfxDrawSprite(dpi, image, screenCoords);
+                        GfxDrawSprite(rt, image, screenCoords);
                     }
                     else
                     {
@@ -169,7 +169,7 @@ namespace OpenRCT2::Ui::Windows
                         auto yOffset = GetAdditionalRowPadding();
                         Formatter ft(reinterpret_cast<uint8_t*>(&gDropdownItems[i].Args));
                         DrawTextEllipsised(
-                            dpi, { screenCoords.x + 2, screenCoords.y + yOffset }, width - 7, item, ft, { colour });
+                            rt, { screenCoords.x + 2, screenCoords.y + yOffset }, width - 7, item, ft, { colour });
                     }
                 }
             }

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -117,7 +117,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             auto drawPreviousButton = widgets[WIDX_PREVIOUS_STEP_BUTTON].type != WindowWidgetType::Empty;
             auto drawNextButton = widgets[WIDX_NEXT_STEP_BUTTON].type != WindowWidgetType::Empty;
@@ -326,7 +326,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_NEXT_IMAGE].type = WindowWidgetType::Empty;
         }
 
-        void DrawLeftButtonBack(DrawPixelInfo& dpi)
+        void DrawLeftButtonBack(RenderTarget& dpi)
         {
             auto previousWidget = widgets[WIDX_PREVIOUS_IMAGE];
             auto leftTop = windowPos + ScreenCoordsXY{ previousWidget.left, previousWidget.top };
@@ -334,7 +334,7 @@ namespace OpenRCT2::Ui::Windows
             GfxFilterRect(dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
         }
 
-        void DrawLeftButton(DrawPixelInfo& dpi)
+        void DrawLeftButton(RenderTarget& dpi)
         {
             const auto topLeft = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_PREVIOUS_IMAGE].left + 1, widgets[WIDX_PREVIOUS_IMAGE].top + 1 };
@@ -364,7 +364,7 @@ namespace OpenRCT2::Ui::Windows
             DrawTextBasic(dpi, { textX, textY + 10 }, stringId, {}, { textColour, TextAlignment::CENTRE });
         }
 
-        void DrawRightButtonBack(DrawPixelInfo& dpi)
+        void DrawRightButtonBack(RenderTarget& dpi)
         {
             auto nextWidget = widgets[WIDX_NEXT_IMAGE];
             auto leftTop = windowPos + ScreenCoordsXY{ nextWidget.left, nextWidget.top };
@@ -372,7 +372,7 @@ namespace OpenRCT2::Ui::Windows
             GfxFilterRect(dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
         }
 
-        void DrawRightButton(DrawPixelInfo& dpi)
+        void DrawRightButton(RenderTarget& dpi)
         {
             const auto topLeft = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_NEXT_IMAGE].left + 1, widgets[WIDX_NEXT_IMAGE].top + 1 };
@@ -403,7 +403,7 @@ namespace OpenRCT2::Ui::Windows
             DrawTextBasic(dpi, { textX, textY + 10 }, stringId, {}, { textColour, TextAlignment::CENTRE });
         }
 
-        void DrawStepText(DrawPixelInfo& dpi)
+        void DrawStepText(RenderTarget& dpi)
         {
             int16_t stateX = (widgets[WIDX_PREVIOUS_IMAGE].right + widgets[WIDX_NEXT_IMAGE].left) / 2 + windowPos.x;
             int16_t stateY = height - 0x0C + windowPos.y;

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -117,26 +117,26 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             auto drawPreviousButton = widgets[WIDX_PREVIOUS_STEP_BUTTON].type != WindowWidgetType::Empty;
             auto drawNextButton = widgets[WIDX_NEXT_STEP_BUTTON].type != WindowWidgetType::Empty;
 
             if (drawPreviousButton)
-                DrawLeftButtonBack(dpi);
+                DrawLeftButtonBack(rt);
 
             if (drawNextButton)
-                DrawRightButtonBack(dpi);
+                DrawRightButtonBack(rt);
 
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             if (drawPreviousButton)
-                DrawLeftButton(dpi);
+                DrawLeftButton(rt);
 
             if (drawNextButton)
-                DrawRightButton(dpi);
+                DrawRightButton(rt);
 
-            DrawStepText(dpi);
+            DrawStepText(rt);
         }
 
         void OnMouseUp(WidgetIndex widgetIndex) override
@@ -326,24 +326,24 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_NEXT_IMAGE].type = WindowWidgetType::Empty;
         }
 
-        void DrawLeftButtonBack(RenderTarget& dpi)
+        void DrawLeftButtonBack(RenderTarget& rt)
         {
             auto previousWidget = widgets[WIDX_PREVIOUS_IMAGE];
             auto leftTop = windowPos + ScreenCoordsXY{ previousWidget.left, previousWidget.top };
             auto rightBottom = windowPos + ScreenCoordsXY{ previousWidget.right, previousWidget.bottom };
-            GfxFilterRect(dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
+            GfxFilterRect(rt, { leftTop, rightBottom }, FilterPaletteID::Palette51);
         }
 
-        void DrawLeftButton(RenderTarget& dpi)
+        void DrawLeftButton(RenderTarget& rt)
         {
             const auto topLeft = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_PREVIOUS_IMAGE].left + 1, widgets[WIDX_PREVIOUS_IMAGE].top + 1 };
             const auto bottomRight = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_PREVIOUS_IMAGE].right - 1, widgets[WIDX_PREVIOUS_IMAGE].bottom - 1 };
-            GfxFillRectInset(dpi, { topLeft, bottomRight }, colours[1], INSET_RECT_F_30);
+            GfxFillRectInset(rt, { topLeft, bottomRight }, colours[1], INSET_RECT_F_30);
 
             GfxDrawSprite(
-                dpi, ImageId(SPR_PREVIOUS),
+                rt, ImageId(SPR_PREVIOUS),
                 windowPos + ScreenCoordsXY{ widgets[WIDX_PREVIOUS_IMAGE].left + 6, widgets[WIDX_PREVIOUS_IMAGE].top + 6 });
 
             colour_t textColour = colours[1].colour;
@@ -360,28 +360,28 @@ namespace OpenRCT2::Ui::Windows
             if (gLegacyScene == LegacyScene::trackDesigner)
                 stringId = STR_EDITOR_STEP_OBJECT_SELECTION;
 
-            DrawTextBasic(dpi, { textX, textY }, STR_BACK_TO_PREVIOUS_STEP, {}, { textColour, TextAlignment::CENTRE });
-            DrawTextBasic(dpi, { textX, textY + 10 }, stringId, {}, { textColour, TextAlignment::CENTRE });
+            DrawTextBasic(rt, { textX, textY }, STR_BACK_TO_PREVIOUS_STEP, {}, { textColour, TextAlignment::CENTRE });
+            DrawTextBasic(rt, { textX, textY + 10 }, stringId, {}, { textColour, TextAlignment::CENTRE });
         }
 
-        void DrawRightButtonBack(RenderTarget& dpi)
+        void DrawRightButtonBack(RenderTarget& rt)
         {
             auto nextWidget = widgets[WIDX_NEXT_IMAGE];
             auto leftTop = windowPos + ScreenCoordsXY{ nextWidget.left, nextWidget.top };
             auto rightBottom = windowPos + ScreenCoordsXY{ nextWidget.right, nextWidget.bottom };
-            GfxFilterRect(dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
+            GfxFilterRect(rt, { leftTop, rightBottom }, FilterPaletteID::Palette51);
         }
 
-        void DrawRightButton(RenderTarget& dpi)
+        void DrawRightButton(RenderTarget& rt)
         {
             const auto topLeft = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_NEXT_IMAGE].left + 1, widgets[WIDX_NEXT_IMAGE].top + 1 };
             const auto bottomRight = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_NEXT_IMAGE].right - 1, widgets[WIDX_NEXT_IMAGE].bottom - 1 };
-            GfxFillRectInset(dpi, { topLeft, bottomRight }, colours[1], INSET_RECT_F_30);
+            GfxFillRectInset(rt, { topLeft, bottomRight }, colours[1], INSET_RECT_F_30);
 
             GfxDrawSprite(
-                dpi, ImageId(SPR_NEXT),
+                rt, ImageId(SPR_NEXT),
                 windowPos + ScreenCoordsXY{ widgets[WIDX_NEXT_IMAGE].right - 29, widgets[WIDX_NEXT_IMAGE].top + 6 });
 
             colour_t textColour = colours[1].colour;
@@ -399,17 +399,17 @@ namespace OpenRCT2::Ui::Windows
             if (gLegacyScene == LegacyScene::trackDesigner)
                 stringId = STR_EDITOR_STEP_ROLLERCOASTER_DESIGNER;
 
-            DrawTextBasic(dpi, { textX, textY }, STR_FORWARD_TO_NEXT_STEP, {}, { textColour, TextAlignment::CENTRE });
-            DrawTextBasic(dpi, { textX, textY + 10 }, stringId, {}, { textColour, TextAlignment::CENTRE });
+            DrawTextBasic(rt, { textX, textY }, STR_FORWARD_TO_NEXT_STEP, {}, { textColour, TextAlignment::CENTRE });
+            DrawTextBasic(rt, { textX, textY + 10 }, stringId, {}, { textColour, TextAlignment::CENTRE });
         }
 
-        void DrawStepText(RenderTarget& dpi)
+        void DrawStepText(RenderTarget& rt)
         {
             int16_t stateX = (widgets[WIDX_PREVIOUS_IMAGE].right + widgets[WIDX_NEXT_IMAGE].left) / 2 + windowPos.x;
             int16_t stateY = height - 0x0C + windowPos.y;
             auto colour = colours[2].withFlag(ColourFlag::translucent, false).withFlag(ColourFlag::withOutline, true);
             DrawTextBasic(
-                dpi, { stateX, stateY }, kEditorStepNames[EnumValue(getGameState().editorStep)], {},
+                rt, { stateX, stateY }, kEditorStepNames[EnumValue(getGameState().editorStep)], {},
                 { colour, TextAlignment::CENTRE });
         }
 

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -101,7 +101,7 @@ namespace OpenRCT2::Ui::Windows
     }
 
     static void DrawResearchItem(
-        DrawPixelInfo& dpi, const ResearchItem& researchItem, const int16_t& width, const ScreenCoordsXY& screenCoords,
+        RenderTarget& dpi, const ResearchItem& researchItem, const int16_t& width, const ScreenCoordsXY& screenCoords,
         StringId format, TextPaint textPaint)
     {
         const StringId itemNameId = researchItem.GetName();
@@ -268,7 +268,7 @@ namespace OpenRCT2::Ui::Windows
             WindowEditorInventionsListDragOpen(researchItem, windowPos, widgets[WIDX_PRE_RESEARCHED_SCROLL].right);
         }
 
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             const auto& gameState = getGameState();
 
@@ -353,7 +353,7 @@ namespace OpenRCT2::Ui::Windows
             return fallback;
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
 
@@ -399,7 +399,7 @@ namespace OpenRCT2::Ui::Windows
             const auto* object = ObjectEntryGetObject(objectEntryType, researchItem->entryIndex);
             if (object != nullptr)
             {
-                DrawPixelInfo clipDPI;
+                RenderTarget clipDPI;
                 screenPos = windowPos + ScreenCoordsXY{ bkWidget.left + 1, bkWidget.top + 1 };
                 const auto clipWidth = bkWidget.width() - 1;
                 const auto clipHeight = bkWidget.height() - 1;
@@ -655,7 +655,7 @@ namespace OpenRCT2::Ui::Windows
             Close();
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             auto screenCoords = windowPos + ScreenCoordsXY{ 0, 2 };
 

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -101,7 +101,7 @@ namespace OpenRCT2::Ui::Windows
     }
 
     static void DrawResearchItem(
-        RenderTarget& dpi, const ResearchItem& researchItem, const int16_t& width, const ScreenCoordsXY& screenCoords,
+        RenderTarget& rt, const ResearchItem& researchItem, const int16_t& width, const ScreenCoordsXY& screenCoords,
         StringId format, TextPaint textPaint)
     {
         const StringId itemNameId = researchItem.GetName();
@@ -117,20 +117,20 @@ namespace OpenRCT2::Ui::Windows
             // Draw group name
             auto ft = Formatter();
             ft.Add<StringId>(rideTypeName);
-            DrawTextEllipsised(dpi, screenCoords, columnSplitOffset - 11, format, ft, textPaint);
+            DrawTextEllipsised(rt, screenCoords, columnSplitOffset - 11, format, ft, textPaint);
 
             // Draw vehicle name
             ft = Formatter();
             ft.Add<StringId>(itemNameId);
             DrawTextEllipsised(
-                dpi, { screenCoords + ScreenCoordsXY{ columnSplitOffset, 0 } }, columnSplitOffset - 11, format, ft, textPaint);
+                rt, { screenCoords + ScreenCoordsXY{ columnSplitOffset, 0 } }, columnSplitOffset - 11, format, ft, textPaint);
         }
         else
         {
             // Scenery group, flat ride or shopdis
             auto ft = Formatter();
             ft.Add<StringId>(itemNameId);
-            DrawTextEllipsised(dpi, screenCoords, width, format, ft, textPaint);
+            DrawTextEllipsised(rt, screenCoords, width, format, ft, textPaint);
         }
     }
 
@@ -268,13 +268,13 @@ namespace OpenRCT2::Ui::Windows
             WindowEditorInventionsListDragOpen(researchItem, windowPos, widgets[WIDX_PRE_RESEARCHED_SCROLL].right);
         }
 
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             const auto& gameState = getGameState();
 
             // Draw background
             uint8_t paletteIndex = ColourMapA[colours[1].colour].mid_light;
-            GfxClear(dpi, paletteIndex);
+            GfxClear(rt, paletteIndex);
 
             int16_t boxWidth = widgets[WIDX_RESEARCH_ORDER_SCROLL].width();
             int32_t itemY = -kScrollableRowHeight;
@@ -284,7 +284,7 @@ namespace OpenRCT2::Ui::Windows
             for (const auto& researchItem : researchList)
             {
                 itemY += kScrollableRowHeight;
-                if (itemY + kScrollableRowHeight < dpi.y || itemY >= dpi.y + dpi.height)
+                if (itemY + kScrollableRowHeight < rt.y || itemY >= rt.y + rt.height)
                     continue;
 
                 if (_selectedResearchItem == &researchItem)
@@ -303,7 +303,7 @@ namespace OpenRCT2::Ui::Windows
                         bottom = itemY;
                     }
 
-                    GfxFilterRect(dpi, { 0, top, boxWidth, bottom }, FilterPaletteID::PaletteDarken1);
+                    GfxFilterRect(rt, { 0, top, boxWidth, bottom }, FilterPaletteID::PaletteDarken1);
                 }
 
                 if (dragItem != nullptr && researchItem == *dragItem)
@@ -324,7 +324,7 @@ namespace OpenRCT2::Ui::Windows
                     colour = colours[1].withFlag(ColourFlag::inset, true);
                 }
 
-                DrawResearchItem(dpi, researchItem, boxWidth, { 1, itemY }, STR_BLACK_STRING, { colour, fontStyle, darkness });
+                DrawResearchItem(rt, researchItem, boxWidth, { 1, itemY }, STR_BLACK_STRING, { colour, fontStyle, darkness });
             }
         }
 
@@ -353,28 +353,28 @@ namespace OpenRCT2::Ui::Windows
             return fallback;
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             // Tab image
             auto screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_1].left, widgets[WIDX_TAB_1].top };
-            GfxDrawSprite(dpi, ImageId(SPR_TAB_FINANCES_RESEARCH_0 + (frame_no / 2) % 8), screenPos);
+            GfxDrawSprite(rt, ImageId(SPR_TAB_FINANCES_RESEARCH_0 + (frame_no / 2) % 8), screenPos);
 
             // Pre-researched items label
             screenPos = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_PRE_RESEARCHED_SCROLL].left, widgets[WIDX_PRE_RESEARCHED_SCROLL].top - 11 };
-            DrawTextBasic(dpi, screenPos - ScreenCoordsXY{ 0, 1 }, STR_INVENTION_PREINVENTED_ITEMS);
+            DrawTextBasic(rt, screenPos - ScreenCoordsXY{ 0, 1 }, STR_INVENTION_PREINVENTED_ITEMS);
 
             // Research order label
             screenPos = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_RESEARCH_ORDER_SCROLL].left, widgets[WIDX_RESEARCH_ORDER_SCROLL].top - 11 };
-            DrawTextBasic(dpi, screenPos - ScreenCoordsXY{ 0, 1 }, STR_INVENTION_TO_BE_INVENTED_ITEMS);
+            DrawTextBasic(rt, screenPos - ScreenCoordsXY{ 0, 1 }, STR_INVENTION_TO_BE_INVENTED_ITEMS);
 
             // Preview background
             auto& bkWidget = widgets[WIDX_PREVIEW];
             GfxFillRect(
-                dpi,
+                rt,
                 { windowPos + ScreenCoordsXY{ bkWidget.left + 1, bkWidget.top + 1 },
                   windowPos + ScreenCoordsXY{ bkWidget.right - 1, bkWidget.bottom - 1 } },
                 ColourMapA[colours[1].colour].darkest);
@@ -403,7 +403,7 @@ namespace OpenRCT2::Ui::Windows
                 screenPos = windowPos + ScreenCoordsXY{ bkWidget.left + 1, bkWidget.top + 1 };
                 const auto clipWidth = bkWidget.width() - 1;
                 const auto clipHeight = bkWidget.height() - 1;
-                if (ClipDrawPixelInfo(clipDPI, dpi, screenPos, clipWidth, clipHeight))
+                if (ClipDrawPixelInfo(clipDPI, rt, screenPos, clipWidth, clipHeight))
                 {
                     object->DrawPreview(clipDPI, clipWidth, clipHeight);
                 }
@@ -432,14 +432,14 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<StringId>(stringId);
             }
 
-            DrawTextEllipsised(dpi, screenPos, itemWidth, drawString, ft, { TextAlignment::CENTRE });
+            DrawTextEllipsised(rt, screenPos, itemWidth, drawString, ft, { TextAlignment::CENTRE });
             screenPos.y += 15;
 
             // Item category
             screenPos.x = windowPos.x + widgets[WIDX_RESEARCH_ORDER_SCROLL].right + 4;
             ft = Formatter();
             ft.Add<StringId>(researchItem->GetCategoryInventionString());
-            DrawTextBasic(dpi, screenPos, STR_INVENTION_RESEARCH_GROUP, ft);
+            DrawTextBasic(rt, screenPos, STR_INVENTION_RESEARCH_GROUP, ft);
         }
 
         void OnPrepareDraw() override
@@ -655,12 +655,12 @@ namespace OpenRCT2::Ui::Windows
             Close();
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             auto screenCoords = windowPos + ScreenCoordsXY{ 0, 2 };
 
             DrawResearchItem(
-                dpi, _draggedItem, width, screenCoords, STR_WINDOW_COLOUR_2_STRINGID,
+                rt, _draggedItem, width, screenCoords, STR_WINDOW_COLOUR_2_STRINGID,
                 { ColourWithFlags{ COLOUR_BLACK }.withFlag(ColourFlag::withOutline, true) });
         }
 

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -722,7 +722,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             // ScrollPaint
             ScreenCoordsXY screenCoords;
@@ -1003,7 +1003,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_PREVIEW].right = widgets[WIDX_PREVIEW].left + kPreviewSize;
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
 
@@ -1104,7 +1104,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Draw preview
             {
-                DrawPixelInfo clipDPI;
+                RenderTarget clipDPI;
                 auto screenPos = windowPos + ScreenCoordsXY{ previewWidget.left + 1, previewWidget.top + 1 };
                 int32_t previewWidth = previewWidget.width() - 1;
                 int32_t previewHeight = previewWidget.height() - 1;
@@ -1241,7 +1241,7 @@ namespace OpenRCT2::Ui::Windows
             _listItems.shrink_to_fit();
         }
 
-        void DrawDescriptions(DrawPixelInfo& dpi)
+        void DrawDescriptions(RenderTarget& dpi)
         {
             auto screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_PREVIEW].midX(), widgets[WIDX_PREVIEW].bottom + 3 };
             auto descriptionWidth = width - widgets[WIDX_LIST].right - 12;
@@ -1349,7 +1349,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawDebugData(DrawPixelInfo& dpi)
+        void DrawDebugData(RenderTarget& dpi)
         {
             ObjectListItem* listItem = &_listItems[selected_list_item];
             auto screenPos = windowPos + ScreenCoordsXY{ width - 5, height - (kListRowHeight * 6) };

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -722,25 +722,25 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             // ScrollPaint
             ScreenCoordsXY screenCoords;
             bool ridePage = (GetSelectedObjectType() == ObjectType::ride);
 
             uint8_t paletteIndex = ColourMapA[colours[1].colour].mid_light;
-            GfxClear(dpi, paletteIndex);
+            GfxClear(rt, paletteIndex);
 
             screenCoords.y = 0;
             for (size_t i = 0; i < _listItems.size(); i++)
             {
                 const auto& listItem = _listItems[i];
-                if (screenCoords.y + kScrollableRowHeight >= dpi.y && screenCoords.y <= dpi.y + dpi.height)
+                if (screenCoords.y + kScrollableRowHeight >= rt.y && screenCoords.y <= rt.y + rt.height)
                 {
                     // Draw checkbox
                     if (!(gLegacyScene == LegacyScene::trackDesignsManager) && !(*listItem.flags & 0x20))
                         GfxFillRectInset(
-                            dpi, { { 2, screenCoords.y }, { 11, screenCoords.y + 10 } }, colours[1], INSET_RECT_F_E0);
+                            rt, { { 2, screenCoords.y }, { 11, screenCoords.y + 10 } }, colours[1], INSET_RECT_F_E0);
 
                     // Highlight background
                     auto highlighted = i == static_cast<size_t>(selected_list_item)
@@ -748,7 +748,7 @@ namespace OpenRCT2::Ui::Windows
                     if (highlighted)
                     {
                         auto bottom = screenCoords.y + (kScrollableRowHeight - 1);
-                        GfxFilterRect(dpi, { 0, screenCoords.y, width, bottom }, FilterPaletteID::PaletteDarken1);
+                        GfxFilterRect(rt, { 0, screenCoords.y, width, bottom }, FilterPaletteID::PaletteDarken1);
                     }
 
                     // Draw checkmark
@@ -761,7 +761,7 @@ namespace OpenRCT2::Ui::Windows
                         if (*listItem.flags & (ObjectSelectionFlags::InUse | ObjectSelectionFlags::AlwaysRequired))
                             colour2.setFlag(ColourFlag::inset, true);
 
-                        DrawText(dpi, screenCoords, { colour2, FontStyle::Medium, darkness }, kCheckMarkString);
+                        DrawText(rt, screenCoords, { colour2, FontStyle::Medium, darkness }, kCheckMarkString);
                     }
 
                     screenCoords.x = gLegacyScene == LegacyScene::trackDesignsManager ? 0 : 15;
@@ -789,7 +789,7 @@ namespace OpenRCT2::Ui::Windows
                         auto ft = Formatter();
                         ft.Add<const char*>(itemBuffer);
                         DrawTextEllipsised(
-                            dpi, screenCoords, width_limit - 15, STR_STRING, ft, { colour, FontStyle::Medium, darkness });
+                            rt, screenCoords, width_limit - 15, STR_STRING, ft, { colour, FontStyle::Medium, darkness });
                         screenCoords.x = widgets[WIDX_LIST_SORT_RIDE].left - widgets[WIDX_LIST].left;
                     }
 
@@ -804,7 +804,7 @@ namespace OpenRCT2::Ui::Windows
                     }
                     auto ft = Formatter();
                     ft.Add<const char*>(itemBuffer);
-                    DrawTextEllipsised(dpi, screenCoords, width_limit, STR_STRING, ft, { colour, FontStyle::Medium, darkness });
+                    DrawTextEllipsised(rt, screenCoords, width_limit, STR_STRING, ft, { colour, FontStyle::Medium, darkness });
                 }
                 screenCoords.y += kScrollableRowHeight;
             }
@@ -1003,9 +1003,9 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_PREVIEW].right = widgets[WIDX_PREVIEW].left + kPreviewSize;
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             // Draw main tab images
             for (size_t i = 0; i < std::size(ObjectSelectionPages); i++)
@@ -1015,7 +1015,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     auto image = ImageId(ObjectSelectionPages[i].Image);
                     auto screenPos = windowPos + ScreenCoordsXY{ widget.left, widget.top };
-                    GfxDrawSprite(dpi, image, screenPos);
+                    GfxDrawSprite(rt, image, screenPos);
                 }
             }
 
@@ -1051,14 +1051,14 @@ namespace OpenRCT2::Ui::Windows
                     if (spriteIndex == SPR_WEATHER_SUN_CLOUD)
                         screenPos += { 2, 4 };
 
-                    GfxDrawSprite(dpi, ImageId(spriteIndex, colours[1].colour), screenPos);
+                    GfxDrawSprite(rt, ImageId(spriteIndex, colours[1].colour), screenPos);
                 }
             }
 
             // Preview background
             const auto& previewWidget = widgets[WIDX_PREVIEW];
             GfxFillRect(
-                dpi,
+                rt,
                 { windowPos + ScreenCoordsXY{ previewWidget.left + 1, previewWidget.top + 1 },
                   windowPos + ScreenCoordsXY{ previewWidget.right - 1, previewWidget.bottom - 1 } },
                 ColourMapA[colours[1].colour].darkest);
@@ -1074,7 +1074,7 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<uint16_t>(numSelected);
                 ft.Add<uint16_t>(totalSelectable);
-                DrawTextBasic(dpi, screenPos, STR_OBJECT_SELECTION_SELECTION_SIZE, ft);
+                DrawTextBasic(rt, screenPos, STR_OBJECT_SELECTION_SELECTION_SIZE, ft);
             }
 
             // Draw sort button text
@@ -1086,7 +1086,7 @@ namespace OpenRCT2::Ui::Windows
                                                                 : kStringIdNone;
                 ft.Add<StringId>(stringId);
                 auto screenPos = windowPos + ScreenCoordsXY{ listSortTypeWidget.left + 1, listSortTypeWidget.top + 1 };
-                DrawTextEllipsised(dpi, screenPos, listSortTypeWidget.width(), STR_OBJECTS_SORT_TYPE, ft, { colours[1] });
+                DrawTextEllipsised(rt, screenPos, listSortTypeWidget.width(), STR_OBJECTS_SORT_TYPE, ft, { colours[1] });
             }
             const auto& listSortRideWidget = widgets[WIDX_LIST_SORT_RIDE];
             if (listSortRideWidget.type != WindowWidgetType::Empty)
@@ -1096,7 +1096,7 @@ namespace OpenRCT2::Ui::Windows
                                                                 : kStringIdNone;
                 ft.Add<StringId>(stringId);
                 auto screenPos = windowPos + ScreenCoordsXY{ listSortRideWidget.left + 1, listSortRideWidget.top + 1 };
-                DrawTextEllipsised(dpi, screenPos, listSortRideWidget.width(), STR_OBJECTS_SORT_RIDE, ft, { colours[1] });
+                DrawTextEllipsised(rt, screenPos, listSortRideWidget.width(), STR_OBJECTS_SORT_RIDE, ft, { colours[1] });
             }
 
             if (selected_list_item == -1 || _loadedObject == nullptr)
@@ -1108,14 +1108,14 @@ namespace OpenRCT2::Ui::Windows
                 auto screenPos = windowPos + ScreenCoordsXY{ previewWidget.left + 1, previewWidget.top + 1 };
                 int32_t previewWidth = previewWidget.width() - 1;
                 int32_t previewHeight = previewWidget.height() - 1;
-                if (ClipDrawPixelInfo(clipDPI, dpi, screenPos, previewWidth, previewHeight))
+                if (ClipDrawPixelInfo(clipDPI, rt, screenPos, previewWidth, previewHeight))
                 {
                     _loadedObject->DrawPreview(clipDPI, previewWidth, previewHeight);
                 }
             }
 
-            DrawDescriptions(dpi);
-            DrawDebugData(dpi);
+            DrawDescriptions(rt);
+            DrawDebugData(rt);
         }
 
         void GoToTab(ObjectType objectType)
@@ -1241,7 +1241,7 @@ namespace OpenRCT2::Ui::Windows
             _listItems.shrink_to_fit();
         }
 
-        void DrawDescriptions(RenderTarget& dpi)
+        void DrawDescriptions(RenderTarget& rt)
         {
             auto screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_PREVIEW].midX(), widgets[WIDX_PREVIEW].bottom + 3 };
             auto descriptionWidth = width - widgets[WIDX_LIST].right - 12;
@@ -1254,7 +1254,7 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<StringId>(STR_STRING);
                 ft.Add<const char*>(listItem->repositoryItem->Name.c_str());
                 screenPos.y += DrawTextWrapped(
-                    dpi, screenPos, descriptionWidth, STR_WINDOW_COLOUR_2_STRINGID, ft, { TextAlignment::CENTRE });
+                    rt, screenPos, descriptionWidth, STR_WINDOW_COLOUR_2_STRINGID, ft, { TextAlignment::CENTRE });
 
                 // Leave some space between name and description
                 screenPos.y += kListRowHeight;
@@ -1266,7 +1266,7 @@ namespace OpenRCT2::Ui::Windows
             if (_loadedObject->IsCompatibilityObject())
             {
                 screenPos.y += DrawTextWrapped(
-                                   dpi, screenPos, descriptionWidth, STR_OBJECT_SELECTION_COMPAT_OBJECT_DESCRIPTION, {},
+                                   rt, screenPos, descriptionWidth, STR_OBJECT_SELECTION_COMPAT_OBJECT_DESCRIPTION, {},
                                    { COLOUR_BRIGHT_RED })
                     + kListRowHeight;
             }
@@ -1278,7 +1278,7 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<StringId>(STR_STRING);
                 ft.Add<const char*>(description.c_str());
 
-                screenPos.y += DrawTextWrapped(dpi, screenPos, descriptionWidth, STR_WINDOW_COLOUR_2_STRINGID, ft);
+                screenPos.y += DrawTextWrapped(rt, screenPos, descriptionWidth, STR_WINDOW_COLOUR_2_STRINGID, ft);
                 screenPos.y += kListRowHeight;
             }
 
@@ -1301,7 +1301,7 @@ namespace OpenRCT2::Ui::Windows
                     }
                     auto ft = Formatter();
                     ft.Add<const char*>(sells.c_str());
-                    screenPos.y += DrawTextWrapped(dpi, screenPos, descriptionWidth, STR_RIDE_OBJECT_SHOP_SELLS, ft) + 2;
+                    screenPos.y += DrawTextWrapped(rt, screenPos, descriptionWidth, STR_RIDE_OBJECT_SHOP_SELLS, ft) + 2;
                 }
             }
             else if (GetSelectedObjectType() == ObjectType::sceneryGroup)
@@ -1309,11 +1309,11 @@ namespace OpenRCT2::Ui::Windows
                 const auto* sceneryGroupObject = reinterpret_cast<SceneryGroupObject*>(_loadedObject.get());
                 auto ft = Formatter();
                 ft.Add<uint16_t>(sceneryGroupObject->GetNumIncludedObjects());
-                screenPos.y += DrawTextWrapped(dpi, screenPos, descriptionWidth, STR_INCLUDES_X_OBJECTS, ft) + 2;
+                screenPos.y += DrawTextWrapped(rt, screenPos, descriptionWidth, STR_INCLUDES_X_OBJECTS, ft) + 2;
             }
             else if (GetSelectedObjectType() == ObjectType::music)
             {
-                screenPos.y += DrawTextWrapped(dpi, screenPos, descriptionWidth, STR_MUSIC_OBJECT_TRACK_HEADER) + 2;
+                screenPos.y += DrawTextWrapped(rt, screenPos, descriptionWidth, STR_MUSIC_OBJECT_TRACK_HEADER) + 2;
                 const auto* musicObject = reinterpret_cast<MusicObject*>(_loadedObject.get());
                 for (size_t i = 0; i < musicObject->GetTrackCount(); i++)
                 {
@@ -1326,7 +1326,7 @@ namespace OpenRCT2::Ui::Windows
                     auto ft = Formatter();
                     ft.Add<const char*>(track->Name.c_str());
                     ft.Add<const char*>(track->Composer.c_str());
-                    screenPos.y += DrawTextWrapped(dpi, screenPos + ScreenCoordsXY{ 10, 0 }, descriptionWidth, stringId, ft);
+                    screenPos.y += DrawTextWrapped(rt, screenPos + ScreenCoordsXY{ 10, 0 }, descriptionWidth, stringId, ft);
                 }
             }
         }
@@ -1349,7 +1349,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawDebugData(RenderTarget& dpi)
+        void DrawDebugData(RenderTarget& rt)
         {
             ObjectListItem* listItem = &_listItems[selected_list_item];
             auto screenPos = windowPos + ScreenCoordsXY{ width - 5, height - (kListRowHeight * 6) };
@@ -1357,7 +1357,7 @@ namespace OpenRCT2::Ui::Windows
             // Draw fallback image warning
             if (_loadedObject && _loadedObject->UsesFallbackImages())
             {
-                DrawTextBasic(dpi, screenPos, STR_OBJECT_USES_FALLBACK_IMAGES, {}, { COLOUR_WHITE, TextAlignment::RIGHT });
+                DrawTextBasic(rt, screenPos, STR_OBJECT_USES_FALLBACK_IMAGES, {}, { COLOUR_WHITE, TextAlignment::RIGHT });
             }
             screenPos.y += kListRowHeight;
 
@@ -1365,7 +1365,7 @@ namespace OpenRCT2::Ui::Windows
             if (GetSelectedObjectType() == ObjectType::ride)
             {
                 auto stringId = GetRideTypeStringId(listItem->repositoryItem);
-                DrawTextBasic(dpi, screenPos, stringId, {}, { COLOUR_WHITE, TextAlignment::RIGHT });
+                DrawTextBasic(rt, screenPos, stringId, {}, { COLOUR_WHITE, TextAlignment::RIGHT });
             }
 
             // Draw peep animation object type
@@ -1373,14 +1373,14 @@ namespace OpenRCT2::Ui::Windows
             {
                 auto* animObj = reinterpret_cast<PeepAnimationsObject*>(_loadedObject.get());
                 auto stringId = GetAnimationPeepTypeStringId(animObj->GetPeepType());
-                DrawTextBasic(dpi, screenPos, stringId, {}, { COLOUR_WHITE, TextAlignment::RIGHT });
+                DrawTextBasic(rt, screenPos, stringId, {}, { COLOUR_WHITE, TextAlignment::RIGHT });
             }
 
             screenPos.y += kListRowHeight;
 
             // Draw object source
             auto stringId = ObjectManagerGetSourceGameString(listItem->repositoryItem->GetFirstSourceGame());
-            DrawTextBasic(dpi, screenPos, stringId, {}, { COLOUR_WHITE, TextAlignment::RIGHT });
+            DrawTextBasic(rt, screenPos, stringId, {}, { COLOUR_WHITE, TextAlignment::RIGHT });
             screenPos.y += kListRowHeight;
 
             // Draw object filename
@@ -1390,7 +1390,7 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<StringId>(STR_STRING);
                 ft.Add<const utf8*>(path.c_str());
                 DrawTextBasic(
-                    dpi, { windowPos.x + this->width - 5, screenPos.y }, STR_WINDOW_COLOUR_2_STRINGID, ft,
+                    rt, { windowPos.x + this->width - 5, screenPos.y }, STR_WINDOW_COLOUR_2_STRINGID, ft,
                     { COLOUR_BLACK, TextAlignment::RIGHT });
                 screenPos.y += kListRowHeight;
             }
@@ -1410,7 +1410,7 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<StringId>(STR_STRING);
                 ft.Add<const char*>(authorsString.c_str());
                 DrawTextEllipsised(
-                    dpi, { windowPos.x + width - 5, screenPos.y }, width - widgets[WIDX_LIST].right - 4,
+                    rt, { windowPos.x + width - 5, screenPos.y }, width - widgets[WIDX_LIST].right - 4,
                     STR_WINDOW_COLOUR_2_STRINGID, ft, { TextAlignment::RIGHT });
             }
         }

--- a/src/openrct2-ui/windows/EditorParkEntrance.cpp
+++ b/src/openrct2-ui/windows/EditorParkEntrance.cpp
@@ -98,31 +98,31 @@ namespace OpenRCT2::Ui::Windows
             return numRows;
         }
 
-        void PaintPreview(RenderTarget& dpi, ImageIndex imageStart, ScreenCoordsXY screenCoords, Direction direction)
+        void PaintPreview(RenderTarget& rt, ImageIndex imageStart, ScreenCoordsXY screenCoords, Direction direction)
         {
             imageStart += (direction * 3);
 
             switch (direction)
             {
                 case 0:
-                    GfxDrawSprite(dpi, ImageId(imageStart + 1), screenCoords + ScreenCoordsXY{ -32, 14 });
-                    GfxDrawSprite(dpi, ImageId(imageStart + 0), screenCoords + ScreenCoordsXY{ 0, 28 });
-                    GfxDrawSprite(dpi, ImageId(imageStart + 2), screenCoords + ScreenCoordsXY{ 32, 44 });
+                    GfxDrawSprite(rt, ImageId(imageStart + 1), screenCoords + ScreenCoordsXY{ -32, 14 });
+                    GfxDrawSprite(rt, ImageId(imageStart + 0), screenCoords + ScreenCoordsXY{ 0, 28 });
+                    GfxDrawSprite(rt, ImageId(imageStart + 2), screenCoords + ScreenCoordsXY{ 32, 44 });
                     break;
                 case 1:
-                    GfxDrawSprite(dpi, ImageId(imageStart + 1), screenCoords + ScreenCoordsXY{ 32, 14 });
-                    GfxDrawSprite(dpi, ImageId(imageStart + 0), screenCoords + ScreenCoordsXY{ 0, 28 });
-                    GfxDrawSprite(dpi, ImageId(imageStart + 2), screenCoords + ScreenCoordsXY{ -32, 44 });
+                    GfxDrawSprite(rt, ImageId(imageStart + 1), screenCoords + ScreenCoordsXY{ 32, 14 });
+                    GfxDrawSprite(rt, ImageId(imageStart + 0), screenCoords + ScreenCoordsXY{ 0, 28 });
+                    GfxDrawSprite(rt, ImageId(imageStart + 2), screenCoords + ScreenCoordsXY{ -32, 44 });
                     break;
                 case 2:
-                    GfxDrawSprite(dpi, ImageId(imageStart + 2), screenCoords + ScreenCoordsXY{ -32, 14 });
-                    GfxDrawSprite(dpi, ImageId(imageStart + 0), screenCoords + ScreenCoordsXY{ 0, 28 });
-                    GfxDrawSprite(dpi, ImageId(imageStart + 1), screenCoords + ScreenCoordsXY{ 32, 44 });
+                    GfxDrawSprite(rt, ImageId(imageStart + 2), screenCoords + ScreenCoordsXY{ -32, 14 });
+                    GfxDrawSprite(rt, ImageId(imageStart + 0), screenCoords + ScreenCoordsXY{ 0, 28 });
+                    GfxDrawSprite(rt, ImageId(imageStart + 1), screenCoords + ScreenCoordsXY{ 32, 44 });
                     break;
                 case 3:
-                    GfxDrawSprite(dpi, ImageId(imageStart + 2), screenCoords + ScreenCoordsXY{ 32, 14 });
-                    GfxDrawSprite(dpi, ImageId(imageStart + 0), screenCoords + ScreenCoordsXY{ 0, 28 });
-                    GfxDrawSprite(dpi, ImageId(imageStart + 1), screenCoords + ScreenCoordsXY{ -32, 44 });
+                    GfxDrawSprite(rt, ImageId(imageStart + 2), screenCoords + ScreenCoordsXY{ 32, 14 });
+                    GfxDrawSprite(rt, ImageId(imageStart + 0), screenCoords + ScreenCoordsXY{ 0, 28 });
+                    GfxDrawSprite(rt, ImageId(imageStart + 1), screenCoords + ScreenCoordsXY{ -32, 44 });
                     break;
             }
         }
@@ -288,17 +288,17 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_LIST].bottom = height - 5;
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
             GfxDrawSprite(
-                dpi, ImageId(SPR_TAB_PARK_ENTRANCE),
+                rt, ImageId(SPR_TAB_PARK_ENTRANCE),
                 windowPos + ScreenCoordsXY{ widgets[WIDX_TAB].left, widgets[WIDX_TAB].top });
         }
 
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
-            GfxClear(dpi, ColourMapA[colours[1].colour].mid_light);
+            GfxClear(rt, ColourMapA[colours[1].colour].mid_light);
 
             ScreenCoordsXY coords{ 1, 1 };
 
@@ -313,13 +313,13 @@ namespace OpenRCT2::Ui::Windows
 
                 if (buttonFlags != 0)
                     GfxFillRectInset(
-                        dpi, { coords, coords + ScreenCoordsXY{ kImageSize - 1, kImageSize - 1 } }, colours[1],
+                        rt, { coords, coords + ScreenCoordsXY{ kImageSize - 1, kImageSize - 1 } }, colours[1],
                         INSET_RECT_FLAG_FILL_MID_LIGHT | buttonFlags);
 
                 RenderTarget clipDPI;
                 auto screenPos = coords + ScreenCoordsXY{ kScrollPadding, kScrollPadding };
                 if (ClipDrawPixelInfo(
-                        clipDPI, dpi, screenPos, kImageSize - (2 * kScrollPadding), kImageSize - (2 * kScrollPadding)))
+                        clipDPI, rt, screenPos, kImageSize - (2 * kScrollPadding), kImageSize - (2 * kScrollPadding)))
                 {
                     PaintPreview(
                         clipDPI, entranceType.imageId, ScreenCoordsXY{ kImageSize / 2, kImageSize / 2 },

--- a/src/openrct2-ui/windows/EditorParkEntrance.cpp
+++ b/src/openrct2-ui/windows/EditorParkEntrance.cpp
@@ -98,7 +98,7 @@ namespace OpenRCT2::Ui::Windows
             return numRows;
         }
 
-        void PaintPreview(DrawPixelInfo& dpi, ImageIndex imageStart, ScreenCoordsXY screenCoords, Direction direction)
+        void PaintPreview(RenderTarget& dpi, ImageIndex imageStart, ScreenCoordsXY screenCoords, Direction direction)
         {
             imageStart += (direction * 3);
 
@@ -288,7 +288,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_LIST].bottom = height - 5;
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
             GfxDrawSprite(
@@ -296,7 +296,7 @@ namespace OpenRCT2::Ui::Windows
                 windowPos + ScreenCoordsXY{ widgets[WIDX_TAB].left, widgets[WIDX_TAB].top });
         }
 
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             GfxClear(dpi, ColourMapA[colours[1].colour].mid_light);
 
@@ -316,7 +316,7 @@ namespace OpenRCT2::Ui::Windows
                         dpi, { coords, coords + ScreenCoordsXY{ kImageSize - 1, kImageSize - 1 } }, colours[1],
                         INSET_RECT_FLAG_FILL_MID_LIGHT | buttonFlags);
 
-                DrawPixelInfo clipDPI;
+                RenderTarget clipDPI;
                 auto screenPos = coords + ScreenCoordsXY{ kScrollPadding, kScrollPadding };
                 if (ClipDrawPixelInfo(
                         clipDPI, dpi, screenPos, kImageSize - (2 * kScrollPadding), kImageSize - (2 * kScrollPadding)))

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -444,7 +444,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             switch (page)
             {
@@ -502,7 +502,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             if (page == WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_RIDES)
             {
@@ -576,7 +576,7 @@ namespace OpenRCT2::Ui::Windows
             SetWidgetPressed(WIDX_TAB_1 + page, true);
         }
 
-        void DrawTabImages(DrawPixelInfo& dpi)
+        void DrawTabImages(RenderTarget& dpi)
         {
             Widget* widget;
             int32_t spriteIndex;
@@ -1087,7 +1087,7 @@ namespace OpenRCT2::Ui::Windows
          *
          *  rct2: 0x0067161C
          */
-        void ObjectiveOnDraw(DrawPixelInfo& dpi)
+        void ObjectiveOnDraw(RenderTarget& dpi)
         {
             const auto& gameState = getGameState();
             StringId stringId;
@@ -1250,7 +1250,7 @@ namespace OpenRCT2::Ui::Windows
             SetPressedTab();
         }
 
-        void ScenarioDetailsOnDraw(DrawPixelInfo& dpi)
+        void ScenarioDetailsOnDraw(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -1656,7 +1656,7 @@ namespace OpenRCT2::Ui::Windows
                                                                                    : WindowWidgetType::CloseBox;
         }
 
-        void FinancialDraw(DrawPixelInfo& dpi)
+        void FinancialDraw(RenderTarget& dpi)
         {
             ScreenCoordsXY screenCoords{};
 
@@ -1943,7 +1943,7 @@ namespace OpenRCT2::Ui::Windows
             SetWidgetPressed(WIDX_HARD_GUEST_GENERATION, gameState.park.Flags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION);
         }
 
-        void GuestsDraw(DrawPixelInfo& dpi)
+        void GuestsDraw(RenderTarget& dpi)
         {
             ScreenCoordsXY screenCoords{};
 
@@ -2142,7 +2142,7 @@ namespace OpenRCT2::Ui::Windows
                                                                                    : WindowWidgetType::CloseBox;
         }
 
-        void LandDraw(DrawPixelInfo& dpi)
+        void LandDraw(RenderTarget& dpi)
         {
             ScreenCoordsXY screenCoords{};
 
@@ -2277,7 +2277,7 @@ namespace OpenRCT2::Ui::Windows
          *
          *  rct2: 0x00672340
          */
-        void RidesOnDraw(DrawPixelInfo& dpi)
+        void RidesOnDraw(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -2287,7 +2287,7 @@ namespace OpenRCT2::Ui::Windows
          *
          *  rct2: 0x0067236F
          */
-        void RidesOnScrollDraw(DrawPixelInfo& dpi, int32_t scrollIndex)
+        void RidesOnScrollDraw(RenderTarget& dpi, int32_t scrollIndex)
         {
             int32_t colour = ColourMapA[colours[1].colour].mid_light;
             GfxFillRect(dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, colour);

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -444,22 +444,22 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             switch (page)
             {
                 case WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_OBJECTIVE:
-                    return ObjectiveOnDraw(dpi);
+                    return ObjectiveOnDraw(rt);
                 case WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_SCENARIO_DETAILS:
-                    return ScenarioDetailsOnDraw(dpi);
+                    return ScenarioDetailsOnDraw(rt);
                 case WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_FINANCIAL:
-                    return FinancialDraw(dpi);
+                    return FinancialDraw(rt);
                 case WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_GUESTS:
-                    return GuestsDraw(dpi);
+                    return GuestsDraw(rt);
                 case WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_PARK:
-                    return LandDraw(dpi);
+                    return LandDraw(rt);
                 case WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_RIDES:
-                    return RidesOnDraw(dpi);
+                    return RidesOnDraw(rt);
             }
         }
 
@@ -502,11 +502,11 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             if (page == WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_RIDES)
             {
-                RidesOnScrollDraw(dpi, scrollIndex);
+                RidesOnScrollDraw(rt, scrollIndex);
             }
         }
 
@@ -576,7 +576,7 @@ namespace OpenRCT2::Ui::Windows
             SetWidgetPressed(WIDX_TAB_1 + page, true);
         }
 
-        void DrawTabImages(RenderTarget& dpi)
+        void DrawTabImages(RenderTarget& rt)
         {
             Widget* widget;
             int32_t spriteIndex;
@@ -589,7 +589,7 @@ namespace OpenRCT2::Ui::Windows
                 if (page == WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_OBJECTIVE)
                     spriteIndex += (frame_no / 4) % 16;
 
-                GfxDrawSprite(dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
+                GfxDrawSprite(rt, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
             }
 
             // Tab 2
@@ -600,7 +600,7 @@ namespace OpenRCT2::Ui::Windows
                 if (page == WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_SCENARIO_DETAILS)
                     spriteIndex += (frame_no / 4) % 8;
 
-                GfxDrawSprite(dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
+                GfxDrawSprite(rt, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
             }
 
             // Tab 3
@@ -611,7 +611,7 @@ namespace OpenRCT2::Ui::Windows
                 if (page == WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_FINANCIAL)
                     spriteIndex += (frame_no / 2) % 8;
 
-                GfxDrawSprite(dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
+                GfxDrawSprite(rt, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
             }
 
             // Tab 4
@@ -622,7 +622,7 @@ namespace OpenRCT2::Ui::Windows
                 if (page == WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_GUESTS)
                     spriteIndex += (frame_no / 4) % 8;
 
-                GfxDrawSprite(dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
+                GfxDrawSprite(rt, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
             }
 
             // Tab 5
@@ -630,7 +630,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 widget = &widgets[WIDX_TAB_5];
                 spriteIndex = SPR_G2_MAP_GEN_TERRAIN_TAB;
-                GfxDrawSprite(dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
+                GfxDrawSprite(rt, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
             }
 
             // Tab 6
@@ -641,7 +641,7 @@ namespace OpenRCT2::Ui::Windows
                 if (page == WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_RIDES)
                     spriteIndex += (frame_no / 4) % 16;
 
-                GfxDrawSprite(dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
+                GfxDrawSprite(rt, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
             }
         }
 
@@ -1087,23 +1087,23 @@ namespace OpenRCT2::Ui::Windows
          *
          *  rct2: 0x0067161C
          */
-        void ObjectiveOnDraw(RenderTarget& dpi)
+        void ObjectiveOnDraw(RenderTarget& rt)
         {
             const auto& gameState = getGameState();
             StringId stringId;
 
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             // Objective label
             auto screenCoords = windowPos + ScreenCoordsXY{ 8, widgets[WIDX_OBJECTIVE].top };
-            DrawTextBasic(dpi, screenCoords, STR_OBJECTIVE_DROPDOWN_LABEL);
+            DrawTextBasic(rt, screenCoords, STR_OBJECTIVE_DROPDOWN_LABEL);
 
             // Objective value
             screenCoords = windowPos + ScreenCoordsXY{ widgets[WIDX_OBJECTIVE].left + 1, widgets[WIDX_OBJECTIVE].top };
             auto ft = Formatter();
             ft.Add<StringId>(ObjectiveDropdownOptionNames[gameState.scenarioObjective.Type]);
-            DrawTextBasic(dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
+            DrawTextBasic(rt, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
 
             if (widgets[WIDX_OBJECTIVE_ARG_1].type != WindowWidgetType::Empty)
             {
@@ -1132,7 +1132,7 @@ namespace OpenRCT2::Ui::Windows
                         stringId = STR_WINDOW_OBJECTIVE_EXCITEMENT_RATING;
                         break;
                 }
-                DrawTextBasic(dpi, screenCoords, stringId);
+                DrawTextBasic(rt, screenCoords, stringId);
 
                 // Objective argument 1 value
                 screenCoords = windowPos
@@ -1165,21 +1165,21 @@ namespace OpenRCT2::Ui::Windows
                         ft.Add<money64>(gameState.scenarioObjective.Currency);
                         break;
                 }
-                DrawTextBasic(dpi, screenCoords, stringId, ft, { COLOUR_BLACK });
+                DrawTextBasic(rt, screenCoords, stringId, ft, { COLOUR_BLACK });
             }
 
             if (widgets[WIDX_OBJECTIVE_ARG_2].type != WindowWidgetType::Empty)
             {
                 // Objective argument 2 label
                 screenCoords = windowPos + ScreenCoordsXY{ 28, widgets[WIDX_OBJECTIVE_ARG_2].top };
-                DrawTextBasic(dpi, screenCoords, STR_WINDOW_OBJECTIVE_DATE);
+                DrawTextBasic(rt, screenCoords, STR_WINDOW_OBJECTIVE_DATE);
 
                 // Objective argument 2 value
                 screenCoords = windowPos
                     + ScreenCoordsXY{ widgets[WIDX_OBJECTIVE_ARG_2].left + 1, widgets[WIDX_OBJECTIVE_ARG_2].top };
                 ft = Formatter();
                 ft.Add<uint16_t>((gameState.scenarioObjective.Year * MONTH_COUNT) - 1);
-                DrawTextBasic(dpi, screenCoords, STR_WINDOW_OBJECTIVE_VALUE_DATE, ft);
+                DrawTextBasic(rt, screenCoords, STR_WINDOW_OBJECTIVE_VALUE_DATE, ft);
             }
         }
 
@@ -1250,10 +1250,10 @@ namespace OpenRCT2::Ui::Windows
             SetPressedTab();
         }
 
-        void ScenarioDetailsOnDraw(RenderTarget& dpi)
+        void ScenarioDetailsOnDraw(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             const auto& gameState = getGameState();
 
@@ -1267,7 +1267,7 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<StringId>(STR_STRING);
                 ft.Add<const char*>(parkName);
-                DrawTextEllipsised(dpi, screenCoords, widthToSet, STR_WINDOW_PARK_NAME, ft);
+                DrawTextEllipsised(rt, screenCoords, widthToSet, STR_WINDOW_PARK_NAME, ft);
             }
 
             // Scenario name
@@ -1277,11 +1277,11 @@ namespace OpenRCT2::Ui::Windows
             auto ft = Formatter();
             ft.Add<StringId>(STR_STRING);
             ft.Add<const char*>(gameState.scenarioName.c_str());
-            DrawTextEllipsised(dpi, screenCoords, widthToSet, STR_WINDOW_SCENARIO_NAME, ft);
+            DrawTextEllipsised(rt, screenCoords, widthToSet, STR_WINDOW_SCENARIO_NAME, ft);
 
             // Scenario details label
             screenCoords = windowPos + ScreenCoordsXY{ 8, widgets[WIDX_DETAILS].top };
-            DrawTextBasic(dpi, screenCoords, STR_WINDOW_PARK_DETAILS);
+            DrawTextBasic(rt, screenCoords, STR_WINDOW_PARK_DETAILS);
 
             // Scenario details value
             screenCoords = windowPos + ScreenCoordsXY{ 16, widgets[WIDX_DETAILS].top + 10 };
@@ -1290,17 +1290,17 @@ namespace OpenRCT2::Ui::Windows
             ft = Formatter();
             ft.Add<StringId>(STR_STRING);
             ft.Add<const char*>(gameState.scenarioDetails.c_str());
-            DrawTextWrapped(dpi, screenCoords, widthToSet, STR_BLACK_STRING, ft);
+            DrawTextWrapped(rt, screenCoords, widthToSet, STR_BLACK_STRING, ft);
 
             // Scenario category label
             screenCoords = windowPos + ScreenCoordsXY{ 8, widgets[WIDX_CATEGORY].top };
-            DrawTextBasic(dpi, screenCoords, STR_WINDOW_SCENARIO_GROUP);
+            DrawTextBasic(rt, screenCoords, STR_WINDOW_SCENARIO_GROUP);
 
             // Scenario category value
             screenCoords = windowPos + ScreenCoordsXY{ widgets[WIDX_CATEGORY].left + 1, widgets[WIDX_CATEGORY].top };
             ft = Formatter();
             ft.Add<StringId>(kScenarioCategoryStringIds[EnumValue(gameState.scenarioCategory)]);
-            DrawTextBasic(dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
+            DrawTextBasic(rt, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
         }
 
         /**
@@ -1656,12 +1656,12 @@ namespace OpenRCT2::Ui::Windows
                                                                                    : WindowWidgetType::CloseBox;
         }
 
-        void FinancialDraw(RenderTarget& dpi)
+        void FinancialDraw(RenderTarget& rt)
         {
             ScreenCoordsXY screenCoords{};
 
-            WindowDrawWidgets(*this, dpi);
-            DrawTabImages(dpi);
+            WindowDrawWidgets(*this, rt);
+            DrawTabImages(rt);
 
             auto& gameState = getGameState();
 
@@ -1671,7 +1671,7 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords = windowPos + ScreenCoordsXY{ initialCashWidget.left + 1, initialCashWidget.top };
                 auto ft = Formatter();
                 ft.Add<money64>(getGameState().initialCash);
-                DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
+                DrawTextBasic(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
             }
 
             const auto& initialLoanWidget = widgets[WIDX_INITIAL_LOAN];
@@ -1680,7 +1680,7 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords = windowPos + ScreenCoordsXY{ initialLoanWidget.left + 1, initialLoanWidget.top };
                 auto ft = Formatter();
                 ft.Add<money64>(gameState.bankLoan);
-                DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
+                DrawTextBasic(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
             }
 
             const auto& maximumLoanWidget = widgets[WIDX_MAXIMUM_LOAN];
@@ -1689,7 +1689,7 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords = windowPos + ScreenCoordsXY{ maximumLoanWidget.left + 1, maximumLoanWidget.top };
                 auto ft = Formatter();
                 ft.Add<money64>(getGameState().maxBankLoan);
-                DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
+                DrawTextBasic(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
             }
 
             const auto& interestRateWidget = widgets[WIDX_INTEREST_RATE];
@@ -1700,7 +1700,7 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<int16_t>(
                     std::clamp<int16_t>(static_cast<int16_t>(gameState.bankLoanInterestRate), INT16_MIN, INT16_MAX));
-                DrawTextBasic(dpi, screenCoords, STR_PERCENT_FORMAT_LABEL, ft);
+                DrawTextBasic(rt, screenCoords, STR_PERCENT_FORMAT_LABEL, ft);
             }
 
             const auto& payForParkOrRidesWidget = widgets[WIDX_PAY_FOR_PARK_OR_RIDES];
@@ -1718,7 +1718,7 @@ namespace OpenRCT2::Ui::Windows
                 else
                     ft.Add<StringId>(STR_PAY_PARK_ENTER);
 
-                DrawTextBasic(dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
+                DrawTextBasic(rt, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
             }
 
             const auto& entryPriceWidget = widgets[WIDX_ENTRY_PRICE];
@@ -1728,7 +1728,7 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords = windowPos + ScreenCoordsXY{ entryPriceWidget.left + 1, entryPriceWidget.top };
                 auto ft = Formatter();
                 ft.Add<money64>(gameState.park.EntranceFee);
-                DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
+                DrawTextBasic(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
             }
         }
 
@@ -1943,12 +1943,12 @@ namespace OpenRCT2::Ui::Windows
             SetWidgetPressed(WIDX_HARD_GUEST_GENERATION, gameState.park.Flags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION);
         }
 
-        void GuestsDraw(RenderTarget& dpi)
+        void GuestsDraw(RenderTarget& rt)
         {
             ScreenCoordsXY screenCoords{};
 
-            WindowDrawWidgets(*this, dpi);
-            DrawTabImages(dpi);
+            WindowDrawWidgets(*this, rt);
+            DrawTabImages(rt);
             auto& gameState = getGameState();
 
             const auto& cashPerGuestWidget = widgets[WIDX_CASH_PER_GUEST];
@@ -1958,7 +1958,7 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords = windowPos + ScreenCoordsXY{ cashPerGuestWidget.left + 1, cashPerGuestWidget.top };
                 auto ft = Formatter();
                 ft.Add<money64>(gameState.guestInitialCash);
-                DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
+                DrawTextBasic(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
             }
 
             // Guest initial happiness value
@@ -1966,21 +1966,21 @@ namespace OpenRCT2::Ui::Windows
             screenCoords = windowPos + ScreenCoordsXY{ initialHappinessWidget.left + 1, initialHappinessWidget.top };
             auto ft = Formatter();
             ft.Add<uint16_t>((gameState.guestInitialHappiness * 100) / 255);
-            DrawTextBasic(dpi, screenCoords, STR_PERCENT_FORMAT_LABEL, ft);
+            DrawTextBasic(rt, screenCoords, STR_PERCENT_FORMAT_LABEL, ft);
 
             // Guest initial hunger value
             const auto& initialHungerWidget = widgets[WIDX_GUEST_INITIAL_HUNGER];
             screenCoords = windowPos + ScreenCoordsXY{ initialHungerWidget.left + 1, initialHungerWidget.top };
             ft = Formatter();
             ft.Add<uint16_t>(((255 - gameState.guestInitialHunger) * 100) / 255);
-            DrawTextBasic(dpi, screenCoords, STR_PERCENT_FORMAT_LABEL, ft);
+            DrawTextBasic(rt, screenCoords, STR_PERCENT_FORMAT_LABEL, ft);
 
             // Guest initial thirst value
             const auto& initialThirstWidget = widgets[WIDX_GUEST_INITIAL_THIRST];
             screenCoords = windowPos + ScreenCoordsXY{ initialThirstWidget.left + 1, initialThirstWidget.top };
             ft = Formatter();
             ft.Add<uint16_t>(((255 - gameState.guestInitialThirst) * 100) / 255);
-            DrawTextBasic(dpi, screenCoords, STR_PERCENT_FORMAT_LABEL, ft);
+            DrawTextBasic(rt, screenCoords, STR_PERCENT_FORMAT_LABEL, ft);
 
             // Guests' intensity value
             {
@@ -2000,7 +2000,7 @@ namespace OpenRCT2::Ui::Windows
 
                 ft = Formatter();
                 ft.Add<StringId>(prefString);
-                DrawTextBasic(dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
+                DrawTextBasic(rt, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
             }
         }
 
@@ -2142,12 +2142,12 @@ namespace OpenRCT2::Ui::Windows
                                                                                    : WindowWidgetType::CloseBox;
         }
 
-        void LandDraw(RenderTarget& dpi)
+        void LandDraw(RenderTarget& rt)
         {
             ScreenCoordsXY screenCoords{};
 
-            WindowDrawWidgets(*this, dpi);
-            DrawTabImages(dpi);
+            WindowDrawWidgets(*this, rt);
+            DrawTabImages(rt);
 
             const auto& gameState = getGameState();
             const auto& landCostWidget = widgets[WIDX_LAND_COST];
@@ -2157,7 +2157,7 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords = windowPos + ScreenCoordsXY{ landCostWidget.left + 1, landCostWidget.top };
                 auto ft = Formatter();
                 ft.Add<money64>(gameState.landPrice);
-                DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
+                DrawTextBasic(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
             }
 
             const auto& constructionRightsCostWidget = widgets[WIDX_CONSTRUCTION_RIGHTS_COST];
@@ -2168,7 +2168,7 @@ namespace OpenRCT2::Ui::Windows
                     + ScreenCoordsXY{ constructionRightsCostWidget.left + 1, constructionRightsCostWidget.top };
                 auto ft = Formatter();
                 ft.Add<money64>(gameState.constructionRightsPrice);
-                DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
+                DrawTextBasic(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
             }
         }
 
@@ -2277,10 +2277,10 @@ namespace OpenRCT2::Ui::Windows
          *
          *  rct2: 0x00672340
          */
-        void RidesOnDraw(RenderTarget& dpi)
+        void RidesOnDraw(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
         }
 
         /**

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -2287,27 +2287,27 @@ namespace OpenRCT2::Ui::Windows
          *
          *  rct2: 0x0067236F
          */
-        void RidesOnScrollDraw(RenderTarget& dpi, int32_t scrollIndex)
+        void RidesOnScrollDraw(RenderTarget& rt, int32_t scrollIndex)
         {
             int32_t colour = ColourMapA[colours[1].colour].mid_light;
-            GfxFillRect(dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, colour);
+            GfxFillRect(rt, { { rt.x, rt.y }, { rt.x + rt.width - 1, rt.y + rt.height - 1 } }, colour);
 
             for (int32_t i = 0; i < static_cast<int32_t>(_rideableRides.size()); i++)
             {
                 int32_t y = i * 12;
 
-                if (y + 12 < dpi.y || y >= dpi.y + dpi.height)
+                if (y + 12 < rt.y || y >= rt.y + rt.height)
                     continue;
 
                 // Checkbox
-                GfxFillRectInset(dpi, { { 2, y }, { 11, y + 10 } }, colours[1], INSET_RECT_F_E0);
+                GfxFillRectInset(rt, { { 2, y }, { 11, y + 10 } }, colours[1], INSET_RECT_F_E0);
 
                 // Highlighted
                 auto stringId = STR_BLACK_STRING;
                 if (i == selected_list_item)
                 {
                     stringId = STR_WINDOW_COLOUR_2_STRINGID;
-                    GfxFilterRect(dpi, { 0, y, width, y + 11 }, FilterPaletteID::PaletteDarken1);
+                    GfxFilterRect(rt, { 0, y, width, y + 11 }, FilterPaletteID::PaletteDarken1);
                 }
 
                 // Checkbox mark
@@ -2318,7 +2318,7 @@ namespace OpenRCT2::Ui::Windows
                     {
                         auto darkness = stringId == STR_WINDOW_COLOUR_2_STRINGID ? TextDarkness::ExtraDark : TextDarkness::Dark;
                         DrawText(
-                            dpi, { 2, y }, { colours[1].withFlag(ColourFlag::translucent, false), FontStyle::Medium, darkness },
+                            rt, { 2, y }, { colours[1].withFlag(ColourFlag::translucent, false), FontStyle::Medium, darkness },
                             kCheckMarkString);
                     }
 
@@ -2326,7 +2326,7 @@ namespace OpenRCT2::Ui::Windows
 
                     Formatter ft;
                     currentRide->formatNameTo(ft);
-                    DrawTextBasic(dpi, { 15, y }, stringId, ft);
+                    DrawTextBasic(rt, { 15, y }, stringId, ft);
                 }
             }
         }

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -66,12 +66,12 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            WindowDrawWidgets(*this, dpi);
+            WindowDrawWidgets(*this, rt);
 
             auto screenCoords = windowPos + ScreenCoordsXY{ (width + 1) / 2 - 1, kPadding - 1 };
-            DrawStringCentredRaw(dpi, screenCoords, _numLines, _text.data(), FontStyle::Medium);
+            DrawStringCentredRaw(rt, screenCoords, _numLines, _text.data(), FontStyle::Medium);
         }
 
         void OnPeriodicUpdate() override

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -66,7 +66,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             WindowDrawWidgets(*this, dpi);
 

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -348,15 +348,15 @@ namespace OpenRCT2::Ui::Windows
             OnPrepareDrawGraph(graphPageWidget, centredGraph);
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             switch (page)
             {
                 case WINDOW_FINANCES_PAGE_SUMMARY:
-                    OnDrawSummary(dpi);
+                    OnDrawSummary(rt);
                     break;
                 case WINDOW_FINANCES_PAGE_FINANCIAL_GRAPH:
                 {
@@ -364,25 +364,25 @@ namespace OpenRCT2::Ui::Windows
                     const auto cashLessLoan = gameState.cash - gameState.bankLoan;
                     const auto fmt = cashLessLoan >= 0 ? STR_FINANCES_FINANCIAL_GRAPH_CASH_LESS_LOAN_POSITIVE
                                                        : STR_FINANCES_FINANCIAL_GRAPH_CASH_LESS_LOAN_NEGATIVE;
-                    OnDrawGraph(dpi, cashLessLoan, fmt);
+                    OnDrawGraph(rt, cashLessLoan, fmt);
                     break;
                 }
                 case WINDOW_FINANCES_PAGE_VALUE_GRAPH:
-                    OnDrawGraph(dpi, getGameState().park.Value, STR_FINANCES_PARK_VALUE);
+                    OnDrawGraph(rt, getGameState().park.Value, STR_FINANCES_PARK_VALUE);
                     break;
                 case WINDOW_FINANCES_PAGE_PROFIT_GRAPH:
                 {
                     auto& gameState = getGameState();
                     const auto fmt = gameState.currentProfit >= 0 ? STR_FINANCES_WEEKLY_PROFIT_POSITIVE
                                                                   : STR_FINANCES_WEEKLY_PROFIT_LOSS;
-                    OnDrawGraph(dpi, gameState.currentProfit, fmt);
+                    OnDrawGraph(rt, gameState.currentProfit, fmt);
                     break;
                 }
                 case WINDOW_FINANCES_PAGE_MARKETING:
-                    OnDrawMarketing(dpi);
+                    OnDrawMarketing(rt);
                     break;
                 case WINDOW_FINANCES_PAGE_RESEARCH:
-                    WindowResearchFundingDraw(this, dpi);
+                    WindowResearchFundingDraw(this, rt);
                     break;
             }
         }
@@ -397,7 +397,7 @@ namespace OpenRCT2::Ui::Windows
             return {};
         }
 
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             if (page != WINDOW_FINANCES_PAGE_SUMMARY)
                 return;
@@ -413,7 +413,7 @@ namespace OpenRCT2::Ui::Windows
                 // Darken every even row
                 if (i % 2 == 0)
                     GfxFillRect(
-                        dpi,
+                        rt,
                         { screenCoords - ScreenCoordsXY{ 0, 1 },
                           screenCoords + ScreenCoordsXY{ row_width, (kTableCellHeight - 2) } },
                         ColourMapA[colours[1].colour].lighter | 0x1000000);
@@ -435,7 +435,7 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<StringId>(STR_FINANCES_SUMMARY_MONTH_HEADING);
                 ft.Add<uint16_t>(monthyear);
                 DrawTextBasic(
-                    dpi, screenCoords + ScreenCoordsXY{ EXPENDITURE_COLUMN_WIDTH, 0 },
+                    rt, screenCoords + ScreenCoordsXY{ EXPENDITURE_COLUMN_WIDTH, 0 },
                     monthyear == currentMonthYear ? STR_WINDOW_COLOUR_2_STRINGID : STR_BLACK_STRING, ft,
                     { TextUnderline::On, TextAlignment::RIGHT });
                 screenCoords.y += 14;
@@ -453,7 +453,7 @@ namespace OpenRCT2::Ui::Windows
                         ft = Formatter();
                         ft.Add<money64>(expenditure);
                         DrawTextBasic(
-                            dpi, screenCoords + ScreenCoordsXY{ EXPENDITURE_COLUMN_WIDTH, 0 }, format, ft,
+                            rt, screenCoords + ScreenCoordsXY{ EXPENDITURE_COLUMN_WIDTH, 0 }, format, ft,
                             { TextAlignment::RIGHT });
                     }
                     screenCoords.y += kTableCellHeight;
@@ -465,10 +465,10 @@ namespace OpenRCT2::Ui::Windows
                 ft = Formatter();
                 ft.Add<money64>(profit);
                 DrawTextBasic(
-                    dpi, screenCoords + ScreenCoordsXY{ EXPENDITURE_COLUMN_WIDTH, 0 }, format, ft, { TextAlignment::RIGHT });
+                    rt, screenCoords + ScreenCoordsXY{ EXPENDITURE_COLUMN_WIDTH, 0 }, format, ft, { TextAlignment::RIGHT });
 
                 GfxFillRect(
-                    dpi,
+                    rt,
                     { screenCoords + ScreenCoordsXY{ 10, -2 }, screenCoords + ScreenCoordsXY{ EXPENDITURE_COLUMN_WIDTH, -2 } },
                     PaletteIndex::pi10);
 
@@ -590,7 +590,7 @@ namespace OpenRCT2::Ui::Windows
                 InitialiseScrollPosition(WIDX_SUMMARY_SCROLL, 0);
         }
 
-        void OnDrawSummary(RenderTarget& dpi)
+        void OnDrawSummary(RenderTarget& rt)
         {
             auto titleBarBottom = widgets[WIDX_TITLE].bottom;
             auto screenCoords = windowPos + ScreenCoordsXY{ 8, titleBarBottom + 37 };
@@ -598,7 +598,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Expenditure / Income heading
             DrawTextBasic(
-                dpi, screenCoords, STR_FINANCES_SUMMARY_EXPENDITURE_INCOME, {},
+                rt, screenCoords, STR_FINANCES_SUMMARY_EXPENDITURE_INCOME, {},
                 { COLOUR_BLACK, TextUnderline::On, TextAlignment::LEFT });
             screenCoords.y += 14;
 
@@ -608,36 +608,36 @@ namespace OpenRCT2::Ui::Windows
                 // Darken every even row
                 if (i % 2 == 0)
                     GfxFillRect(
-                        dpi,
+                        rt,
                         { screenCoords - ScreenCoordsXY{ 0, 1 }, screenCoords + ScreenCoordsXY{ 121, (kTableCellHeight - 2) } },
                         ColourMapA[colours[1].colour].lighter | 0x1000000);
 
-                DrawTextBasic(dpi, screenCoords - ScreenCoordsXY{ 0, 1 }, _windowFinancesSummaryRowLabels[i]);
+                DrawTextBasic(rt, screenCoords - ScreenCoordsXY{ 0, 1 }, _windowFinancesSummaryRowLabels[i]);
                 screenCoords.y += kTableCellHeight;
             }
 
             // Horizontal rule below expenditure / income table
             GfxFillRectInset(
-                dpi,
+                rt,
                 { windowPos + ScreenCoordsXY{ 8, titleBarBottom + 258 },
                   windowPos + ScreenCoordsXY{ 8 + 513, titleBarBottom + 258 + 1 } },
                 colours[1], INSET_RECT_FLAG_BORDER_INSET);
 
             // Loan and interest rate
-            DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ 8, titleBarBottom + 265 }, STR_FINANCES_SUMMARY_LOAN);
+            DrawTextBasic(rt, windowPos + ScreenCoordsXY{ 8, titleBarBottom + 265 }, STR_FINANCES_SUMMARY_LOAN);
             if (!(gameState.park.Flags & PARK_FLAGS_RCT1_INTEREST))
             {
                 auto ft = Formatter();
                 ft.Add<uint16_t>(gameState.bankLoanInterestRate);
                 DrawTextBasic(
-                    dpi, windowPos + ScreenCoordsXY{ 167, titleBarBottom + 265 }, STR_FINANCES_SUMMARY_AT_X_PER_YEAR, ft);
+                    rt, windowPos + ScreenCoordsXY{ 167, titleBarBottom + 265 }, STR_FINANCES_SUMMARY_AT_X_PER_YEAR, ft);
             }
 
             // Current cash
             auto ft = Formatter();
             ft.Add<money64>(gameState.cash);
             StringId stringId = gameState.cash >= 0 ? STR_CASH_LABEL : STR_CASH_NEGATIVE_LABEL;
-            DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ 8, titleBarBottom + 280 }, stringId, ft);
+            DrawTextBasic(rt, windowPos + ScreenCoordsXY{ 8, titleBarBottom + 280 }, stringId, ft);
 
             // Objective related financial information
             if (gameState.scenarioObjective.Type == OBJECTIVE_MONTHLY_FOOD_INCOME)
@@ -646,7 +646,7 @@ namespace OpenRCT2::Ui::Windows
                 ft = Formatter();
                 ft.Add<money64>(lastMonthProfit);
                 DrawTextBasic(
-                    dpi, windowPos + ScreenCoordsXY{ 280, titleBarBottom + 265 },
+                    rt, windowPos + ScreenCoordsXY{ 280, titleBarBottom + 265 },
                     STR_LAST_MONTH_PROFIT_FROM_FOOD_DRINK_MERCHANDISE_SALES_LABEL, ft);
             }
             else
@@ -654,10 +654,10 @@ namespace OpenRCT2::Ui::Windows
                 // Park value and company value
                 ft = Formatter();
                 ft.Add<money64>(gameState.park.Value);
-                DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ 280, titleBarBottom + 265 }, STR_PARK_VALUE_LABEL, ft);
+                DrawTextBasic(rt, windowPos + ScreenCoordsXY{ 280, titleBarBottom + 265 }, STR_PARK_VALUE_LABEL, ft);
                 ft = Formatter();
                 ft.Add<money64>(gameState.companyValue);
-                DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ 280, titleBarBottom + 280 }, STR_COMPANY_VALUE_LABEL, ft);
+                DrawTextBasic(rt, windowPos + ScreenCoordsXY{ 280, titleBarBottom + 280 }, STR_COMPANY_VALUE_LABEL, ft);
             }
         }
 
@@ -708,7 +708,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDrawMarketing(RenderTarget& dpi)
+        void OnDrawMarketing(RenderTarget& rt)
         {
             auto screenCoords = windowPos + ScreenCoordsXY{ 8, widgets[WIDX_TAB_1].top + 45 };
             int32_t noCampaignsActive = 1;
@@ -749,14 +749,14 @@ namespace OpenRCT2::Ui::Windows
                     }
                 }
                 // Advertisement
-                DrawTextEllipsised(dpi, screenCoords + ScreenCoordsXY{ 4, 0 }, 296, kMarketingCampaignNames[i][1], ft);
+                DrawTextEllipsised(rt, screenCoords + ScreenCoordsXY{ 4, 0 }, 296, kMarketingCampaignNames[i][1], ft);
 
                 // Duration
                 uint16_t weeksRemaining = marketingCampaign->WeeksLeft;
                 ft = Formatter();
                 ft.Add<uint16_t>(weeksRemaining);
                 DrawTextBasic(
-                    dpi, screenCoords + ScreenCoordsXY{ 304, 0 },
+                    rt, screenCoords + ScreenCoordsXY{ 304, 0 },
                     weeksRemaining == 1 ? STR_1_WEEK_REMAINING : STR_X_WEEKS_REMAINING, ft);
 
                 screenCoords.y += kListRowHeight;
@@ -764,7 +764,7 @@ namespace OpenRCT2::Ui::Windows
 
             if (noCampaignsActive)
             {
-                DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 4, 0 }, STR_MARKETING_CAMPAIGNS_NONE);
+                DrawTextBasic(rt, screenCoords + ScreenCoordsXY{ 4, 0 }, STR_MARKETING_CAMPAIGNS_NONE);
             }
 
             // Draw campaign button text
@@ -775,10 +775,10 @@ namespace OpenRCT2::Ui::Windows
                 {
                     // Draw button text
                     screenCoords = windowPos + ScreenCoordsXY{ campaignButton->left, campaignButton->textTop() };
-                    DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 4, 0 }, kMarketingCampaignNames[i][0]);
+                    DrawTextBasic(rt, screenCoords + ScreenCoordsXY{ 4, 0 }, kMarketingCampaignNames[i][0]);
                     auto ft = Formatter();
                     ft.Add<money64>(AdvertisingCampaignPricePerWeek[i]);
-                    DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ kCostPerWeekOffset, 0 }, STR_MARKETING_PER_WEEK, ft);
+                    DrawTextBasic(rt, screenCoords + ScreenCoordsXY{ kCostPerWeekOffset, 0 }, STR_MARKETING_PER_WEEK, ft);
                 }
             }
         }
@@ -787,22 +787,22 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Graph Events
 
-        void OnDrawGraph(RenderTarget& dpi, const money64 currentValue, const StringId fmt) const
+        void OnDrawGraph(RenderTarget& rt, const money64 currentValue, const StringId fmt) const
         {
             Formatter ft;
             ft.Add<money64>(currentValue);
-            DrawTextBasic(dpi, _graphBounds.Point1 - ScreenCoordsXY{ 0, 11 }, fmt, ft);
+            DrawTextBasic(rt, _graphBounds.Point1 - ScreenCoordsXY{ 0, 11 }, fmt, ft);
 
             // Graph
-            GfxFillRectInset(dpi, _graphBounds, colours[1], INSET_RECT_F_30);
+            GfxFillRectInset(rt, _graphBounds, colours[1], INSET_RECT_F_30);
             // hide resize widget on graph area
             constexpr ScreenCoordsXY offset{ 1, 1 };
             constexpr ScreenCoordsXY bigOffset{ 5, 5 };
             GfxFillRectInset(
-                dpi, { _graphBounds.Point2 - bigOffset, _graphBounds.Point2 - offset }, colours[1],
+                rt, { _graphBounds.Point2 - bigOffset, _graphBounds.Point2 - offset }, colours[1],
                 INSET_RECT_FLAG_FILL_DONT_LIGHTEN | INSET_RECT_FLAG_BORDER_NONE);
 
-            Graph::DrawFinanceGraph(dpi, _graphProps);
+            Graph::DrawFinanceGraph(rt, _graphProps);
         }
 
         void OnPrepareDrawGraph(const Widget* graphPageWidget, const bool centredGraph)
@@ -852,7 +852,7 @@ namespace OpenRCT2::Ui::Windows
             WidgetScrollUpdateThumbs(*this, widgetIndex);
         }
 
-        void DrawTabImage(RenderTarget& dpi, int32_t tabPage, int32_t spriteIndex)
+        void DrawTabImage(RenderTarget& rt, int32_t tabPage, int32_t spriteIndex)
         {
             WidgetIndex widgetIndex = WIDX_TAB_1 + tabPage;
 
@@ -865,19 +865,19 @@ namespace OpenRCT2::Ui::Windows
                 }
 
                 GfxDrawSprite(
-                    dpi, ImageId(spriteIndex),
+                    rt, ImageId(spriteIndex),
                     windowPos + ScreenCoordsXY{ widgets[widgetIndex].left, widgets[widgetIndex].top });
             }
         }
 
-        void DrawTabImages(RenderTarget& dpi)
+        void DrawTabImages(RenderTarget& rt)
         {
-            DrawTabImage(dpi, WINDOW_FINANCES_PAGE_SUMMARY, SPR_TAB_FINANCES_SUMMARY_0);
-            DrawTabImage(dpi, WINDOW_FINANCES_PAGE_FINANCIAL_GRAPH, SPR_TAB_FINANCES_FINANCIAL_GRAPH_0);
-            DrawTabImage(dpi, WINDOW_FINANCES_PAGE_VALUE_GRAPH, SPR_TAB_FINANCES_VALUE_GRAPH_0);
-            DrawTabImage(dpi, WINDOW_FINANCES_PAGE_PROFIT_GRAPH, SPR_TAB_FINANCES_PROFIT_GRAPH_0);
-            DrawTabImage(dpi, WINDOW_FINANCES_PAGE_MARKETING, SPR_TAB_FINANCES_MARKETING_0);
-            DrawTabImage(dpi, WINDOW_FINANCES_PAGE_RESEARCH, SPR_TAB_FINANCES_RESEARCH_0);
+            DrawTabImage(rt, WINDOW_FINANCES_PAGE_SUMMARY, SPR_TAB_FINANCES_SUMMARY_0);
+            DrawTabImage(rt, WINDOW_FINANCES_PAGE_FINANCIAL_GRAPH, SPR_TAB_FINANCES_FINANCIAL_GRAPH_0);
+            DrawTabImage(rt, WINDOW_FINANCES_PAGE_VALUE_GRAPH, SPR_TAB_FINANCES_VALUE_GRAPH_0);
+            DrawTabImage(rt, WINDOW_FINANCES_PAGE_PROFIT_GRAPH, SPR_TAB_FINANCES_PROFIT_GRAPH_0);
+            DrawTabImage(rt, WINDOW_FINANCES_PAGE_MARKETING, SPR_TAB_FINANCES_MARKETING_0);
+            DrawTabImage(rt, WINDOW_FINANCES_PAGE_RESEARCH, SPR_TAB_FINANCES_RESEARCH_0);
         }
     };
 

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -348,7 +348,7 @@ namespace OpenRCT2::Ui::Windows
             OnPrepareDrawGraph(graphPageWidget, centredGraph);
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -397,7 +397,7 @@ namespace OpenRCT2::Ui::Windows
             return {};
         }
 
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             if (page != WINDOW_FINANCES_PAGE_SUMMARY)
                 return;
@@ -590,7 +590,7 @@ namespace OpenRCT2::Ui::Windows
                 InitialiseScrollPosition(WIDX_SUMMARY_SCROLL, 0);
         }
 
-        void OnDrawSummary(DrawPixelInfo& dpi)
+        void OnDrawSummary(RenderTarget& dpi)
         {
             auto titleBarBottom = widgets[WIDX_TITLE].bottom;
             auto screenCoords = windowPos + ScreenCoordsXY{ 8, titleBarBottom + 37 };
@@ -708,7 +708,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDrawMarketing(DrawPixelInfo& dpi)
+        void OnDrawMarketing(RenderTarget& dpi)
         {
             auto screenCoords = windowPos + ScreenCoordsXY{ 8, widgets[WIDX_TAB_1].top + 45 };
             int32_t noCampaignsActive = 1;
@@ -787,7 +787,7 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Graph Events
 
-        void OnDrawGraph(DrawPixelInfo& dpi, const money64 currentValue, const StringId fmt) const
+        void OnDrawGraph(RenderTarget& dpi, const money64 currentValue, const StringId fmt) const
         {
             Formatter ft;
             ft.Add<money64>(currentValue);
@@ -852,7 +852,7 @@ namespace OpenRCT2::Ui::Windows
             WidgetScrollUpdateThumbs(*this, widgetIndex);
         }
 
-        void DrawTabImage(DrawPixelInfo& dpi, int32_t tabPage, int32_t spriteIndex)
+        void DrawTabImage(RenderTarget& dpi, int32_t tabPage, int32_t spriteIndex)
         {
             WidgetIndex widgetIndex = WIDX_TAB_1 + tabPage;
 
@@ -870,7 +870,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImages(DrawPixelInfo& dpi)
+        void DrawTabImages(RenderTarget& dpi)
         {
             DrawTabImage(dpi, WINDOW_FINANCES_PAGE_SUMMARY, SPR_TAB_FINANCES_SUMMARY_0);
             DrawTabImage(dpi, WINDOW_FINANCES_PAGE_FINANCIAL_GRAPH, SPR_TAB_FINANCES_FINANCIAL_GRAPH_0);

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -466,11 +466,11 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             ScreenCoordsXY screenCoords;
-            WindowDrawWidgets(*this, dpi);
-            WindowFootpathDrawDropdownButtons(dpi);
+            WindowDrawWidgets(*this, rt);
+            WindowFootpathDrawDropdownButtons(rt);
 
             if (!IsWidgetDisabled(WIDX_CONSTRUCT))
             {
@@ -517,13 +517,13 @@ namespace OpenRCT2::Ui::Windows
                     // Draw construction image
                     screenCoords = this->windowPos
                         + ScreenCoordsXY{ widgets[WIDX_CONSTRUCT].midX(), widgets[WIDX_CONSTRUCT].bottom - 60 };
-                    GfxDrawSprite(dpi, ImageId(image), screenCoords);
+                    GfxDrawSprite(rt, ImageId(image), screenCoords);
                 }
 
                 // Draw build this... label
                 screenCoords = this->windowPos
                     + ScreenCoordsXY{ widgets[WIDX_CONSTRUCT].midX(), widgets[WIDX_CONSTRUCT].bottom - 23 };
-                DrawTextBasic(dpi, screenCoords, STR_BUILD_THIS, {}, { TextAlignment::CENTRE });
+                DrawTextBasic(rt, screenCoords, STR_BUILD_THIS, {}, { TextAlignment::CENTRE });
             }
 
             // Draw cost
@@ -535,7 +535,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     auto ft = Formatter();
                     ft.Add<money64>(_windowFootpathCost);
-                    DrawTextBasic(dpi, screenCoords, STR_COST_LABEL, ft, { TextAlignment::CENTRE });
+                    DrawTextBasic(rt, screenCoords, STR_COST_LABEL, ft, { TextAlignment::CENTRE });
                 }
             }
         }
@@ -601,7 +601,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void WindowFootpathDrawDropdownButtons(RenderTarget& dpi)
+        void WindowFootpathDrawDropdownButtons(RenderTarget& rt)
         {
             if (gFootpathSelection.LegacyPath == kObjectEntryIndexNull)
             {
@@ -620,8 +620,8 @@ namespace OpenRCT2::Ui::Windows
                     queueImage = pathEntry->PreviewImageId;
                 }
 
-                WindowFootpathDrawDropdownButton(dpi, WIDX_FOOTPATH_TYPE, pathImage);
-                WindowFootpathDrawDropdownButton(dpi, WIDX_QUEUELINE_TYPE, queueImage);
+                WindowFootpathDrawDropdownButton(rt, WIDX_FOOTPATH_TYPE, pathImage);
+                WindowFootpathDrawDropdownButton(rt, WIDX_QUEUELINE_TYPE, queueImage);
 
                 // Set railing
                 auto railingsImage = kSpriteIdNull;
@@ -630,7 +630,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     railingsImage = railingsEntry->PreviewImageId;
                 }
-                WindowFootpathDrawDropdownButton(dpi, WIDX_RAILINGS_TYPE, railingsImage);
+                WindowFootpathDrawDropdownButton(rt, WIDX_RAILINGS_TYPE, railingsImage);
             }
             else
             {
@@ -647,15 +647,15 @@ namespace OpenRCT2::Ui::Windows
                     queueImage = pathEntry->GetQueuePreviewImage();
                 }
 
-                WindowFootpathDrawDropdownButton(dpi, WIDX_FOOTPATH_TYPE, pathImage);
-                WindowFootpathDrawDropdownButton(dpi, WIDX_QUEUELINE_TYPE, queueImage);
+                WindowFootpathDrawDropdownButton(rt, WIDX_FOOTPATH_TYPE, pathImage);
+                WindowFootpathDrawDropdownButton(rt, WIDX_QUEUELINE_TYPE, queueImage);
             }
         }
 
-        void WindowFootpathDrawDropdownButton(RenderTarget& dpi, WidgetIndex widgetIndex, ImageIndex image)
+        void WindowFootpathDrawDropdownButton(RenderTarget& rt, WidgetIndex widgetIndex, ImageIndex image)
         {
             const auto& widget = widgets[widgetIndex];
-            GfxDrawSprite(dpi, ImageId(image), { windowPos.x + widget.left, windowPos.y + widget.top });
+            GfxDrawSprite(rt, ImageId(image), { windowPos.x + widget.left, windowPos.y + widget.top });
         }
 
         /**

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -466,7 +466,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             ScreenCoordsXY screenCoords;
             WindowDrawWidgets(*this, dpi);
@@ -601,7 +601,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void WindowFootpathDrawDropdownButtons(DrawPixelInfo& dpi)
+        void WindowFootpathDrawDropdownButtons(RenderTarget& dpi)
         {
             if (gFootpathSelection.LegacyPath == kObjectEntryIndexNull)
             {
@@ -652,7 +652,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void WindowFootpathDrawDropdownButton(DrawPixelInfo& dpi, WidgetIndex widgetIndex, ImageIndex image)
+        void WindowFootpathDrawDropdownButton(RenderTarget& dpi, WidgetIndex widgetIndex, ImageIndex image)
         {
             const auto& widget = widgets[widgetIndex];
             GfxDrawSprite(dpi, ImageId(image), { windowPos.x + widget.left, windowPos.y + widget.top });

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -85,14 +85,14 @@ namespace OpenRCT2::Ui::Windows
                     : colours[0].colour);
         }
 
-        void DrawLeftPanel(RenderTarget& dpi)
+        void DrawLeftPanel(RenderTarget& rt)
         {
             const auto& leftPanelWidget = widgets[WIDX_LEFT_OUTSET];
 
             const auto topLeft = windowPos + ScreenCoordsXY{ leftPanelWidget.left + 1, leftPanelWidget.top + 1 };
             const auto bottomRight = windowPos + ScreenCoordsXY{ leftPanelWidget.right - 1, leftPanelWidget.bottom - 1 };
             // Draw green inset rectangle on panel
-            GfxFillRectInset(dpi, { topLeft, bottomRight }, colours[1], INSET_RECT_F_30);
+            GfxFillRectInset(rt, { topLeft, bottomRight }, colours[1], INSET_RECT_F_30);
 
             // Figure out how much line height we have to work with.
             uint32_t line_height = FontGetLineHeight(FontStyle::Medium);
@@ -110,7 +110,7 @@ namespace OpenRCT2::Ui::Windows
                 StringId stringId = gameState.cash < 0 ? STR_BOTTOM_TOOLBAR_CASH_NEGATIVE : STR_BOTTOM_TOOLBAR_CASH;
                 auto ft = Formatter();
                 ft.Add<money64>(gameState.cash);
-                DrawTextBasic(dpi, screenCoords, stringId, ft, { colour, TextAlignment::CENTRE });
+                DrawTextBasic(rt, screenCoords, stringId, ft, { colour, TextAlignment::CENTRE });
             }
 
             static constexpr StringId _guestCountFormats[] = {
@@ -135,7 +135,7 @@ namespace OpenRCT2::Ui::Windows
                 auto colour = GetHoverWidgetColour(WIDX_GUESTS);
                 auto ft = Formatter();
                 ft.Add<uint32_t>(gameState.numGuestsInPark);
-                DrawTextBasic(dpi, screenCoords, stringId, ft, { colour, TextAlignment::CENTRE });
+                DrawTextBasic(rt, screenCoords, stringId, ft, { colour, TextAlignment::CENTRE });
             }
 
             // Draw park rating
@@ -143,38 +143,38 @@ namespace OpenRCT2::Ui::Windows
                 const auto& widget = widgets[WIDX_PARK_RATING];
                 auto screenCoords = windowPos + ScreenCoordsXY{ widget.left + 11, widget.midY() - 5 };
 
-                DrawParkRating(dpi, colours[3].colour, screenCoords, std::max(10, ((gameState.park.Rating / 4) * 263) / 256));
+                DrawParkRating(rt, colours[3].colour, screenCoords, std::max(10, ((gameState.park.Rating / 4) * 263) / 256));
             }
         }
 
-        void DrawParkRating(RenderTarget& dpi, int32_t colour, const ScreenCoordsXY& coords, uint8_t factor)
+        void DrawParkRating(RenderTarget& rt, int32_t colour, const ScreenCoordsXY& coords, uint8_t factor)
         {
             int16_t bar_width = (factor * 114) / 255;
             GfxFillRectInset(
-                dpi, { coords + ScreenCoordsXY{ 1, 1 }, coords + ScreenCoordsXY{ 114, 9 } }, colours[1], INSET_RECT_F_30);
+                rt, { coords + ScreenCoordsXY{ 1, 1 }, coords + ScreenCoordsXY{ 114, 9 } }, colours[1], INSET_RECT_F_30);
             if (!(colour & kBarBlink) || GameIsPaused() || (gCurrentRealTimeTicks & 8))
             {
                 if (bar_width > 2)
                 {
                     GfxFillRectInset(
-                        dpi, { coords + ScreenCoordsXY{ 2, 2 }, coords + ScreenCoordsXY{ bar_width - 1, 8 } },
+                        rt, { coords + ScreenCoordsXY{ 2, 2 }, coords + ScreenCoordsXY{ bar_width - 1, 8 } },
                         ColourWithFlags{ static_cast<uint8_t>(colour) }, 0);
                 }
             }
 
             // Draw thumbs on the sides
-            GfxDrawSprite(dpi, ImageId(SPR_RATING_LOW), coords - ScreenCoordsXY{ 14, 0 });
-            GfxDrawSprite(dpi, ImageId(SPR_RATING_HIGH), coords + ScreenCoordsXY{ 114, 0 });
+            GfxDrawSprite(rt, ImageId(SPR_RATING_LOW), coords - ScreenCoordsXY{ 14, 0 });
+            GfxDrawSprite(rt, ImageId(SPR_RATING_HIGH), coords + ScreenCoordsXY{ 114, 0 });
         }
 
-        void DrawRightPanel(RenderTarget& dpi)
+        void DrawRightPanel(RenderTarget& rt)
         {
             const auto& rightPanelWidget = widgets[WIDX_RIGHT_OUTSET];
 
             const auto topLeft = windowPos + ScreenCoordsXY{ rightPanelWidget.left + 1, rightPanelWidget.top + 1 };
             const auto bottomRight = windowPos + ScreenCoordsXY{ rightPanelWidget.right - 1, rightPanelWidget.bottom - 1 };
             // Draw green inset rectangle on panel
-            GfxFillRectInset(dpi, { topLeft, bottomRight }, colours[1], INSET_RECT_F_30);
+            GfxFillRectInset(rt, { topLeft, bottomRight }, colours[1], INSET_RECT_F_30);
 
             auto screenCoords = ScreenCoordsXY{ (rightPanelWidget.left + rightPanelWidget.right) / 2 + windowPos.x,
                                                 rightPanelWidget.top + windowPos.y + 2 };
@@ -191,7 +191,7 @@ namespace OpenRCT2::Ui::Windows
             ft.Add<StringId>(DateDayNames[day]);
             ft.Add<int16_t>(month);
             ft.Add<int16_t>(year);
-            DrawTextBasic(dpi, screenCoords, stringId, ft, { colour, TextAlignment::CENTRE });
+            DrawTextBasic(rt, screenCoords, stringId, ft, { colour, TextAlignment::CENTRE });
 
             // Figure out how much line height we have to work with.
             uint32_t line_height = FontGetLineHeight(FontStyle::Medium);
@@ -208,12 +208,12 @@ namespace OpenRCT2::Ui::Windows
             }
             ft = Formatter();
             ft.Add<int16_t>(temperature);
-            DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 0, 6 }, format, ft);
+            DrawTextBasic(rt, screenCoords + ScreenCoordsXY{ 0, 6 }, format, ft);
             screenCoords.x += 30;
 
             // Current weather
             auto currentWeatherSpriteId = ClimateGetWeatherSpriteId(getGameState().weatherCurrent.weatherType);
-            GfxDrawSprite(dpi, ImageId(currentWeatherSpriteId), screenCoords);
+            GfxDrawSprite(rt, ImageId(currentWeatherSpriteId), screenCoords);
 
             // Next weather
             auto nextWeatherSpriteId = ClimateGetWeatherSpriteId(getGameState().weatherNext.weatherType);
@@ -221,20 +221,20 @@ namespace OpenRCT2::Ui::Windows
             {
                 if (getGameState().weatherUpdateTimer < 960)
                 {
-                    GfxDrawSprite(dpi, ImageId(SPR_NEXT_WEATHER), screenCoords + ScreenCoordsXY{ 27, 5 });
-                    GfxDrawSprite(dpi, ImageId(nextWeatherSpriteId), screenCoords + ScreenCoordsXY{ 40, 0 });
+                    GfxDrawSprite(rt, ImageId(SPR_NEXT_WEATHER), screenCoords + ScreenCoordsXY{ 27, 5 });
+                    GfxDrawSprite(rt, ImageId(nextWeatherSpriteId), screenCoords + ScreenCoordsXY{ 40, 0 });
                 }
             }
         }
 
-        void DrawNewsItem(RenderTarget& dpi)
+        void DrawNewsItem(RenderTarget& rt)
         {
             const auto& middleOutsetWidget = widgets[WIDX_MIDDLE_OUTSET];
             auto* newsItem = News::GetItem(0);
 
             // Current news item
             GfxFillRectInset(
-                dpi,
+                rt,
 
                 { windowPos + ScreenCoordsXY{ middleOutsetWidget.left + 1, middleOutsetWidget.top + 1 },
                   windowPos + ScreenCoordsXY{ middleOutsetWidget.right - 1, middleOutsetWidget.bottom - 1 } },
@@ -244,7 +244,7 @@ namespace OpenRCT2::Ui::Windows
             auto screenCoords = windowPos + ScreenCoordsXY{ middleOutsetWidget.midX(), middleOutsetWidget.top + 11 };
             int32_t itemWidth = middleOutsetWidget.width() - 62;
             DrawNewsTicker(
-                dpi, screenCoords, itemWidth, COLOUR_BRIGHT_GREEN, STR_BOTTOM_TOOLBAR_NEWS_TEXT, newsItem->Text,
+                rt, screenCoords, itemWidth, COLOUR_BRIGHT_GREEN, STR_BOTTOM_TOOLBAR_NEWS_TEXT, newsItem->Text,
                 newsItem->Ticks);
 
             const auto& newsSubjectWidget = widgets[WIDX_NEWS_SUBJECT];
@@ -252,7 +252,7 @@ namespace OpenRCT2::Ui::Windows
             switch (newsItem->Type)
             {
                 case News::ItemType::Ride:
-                    GfxDrawSprite(dpi, ImageId(SPR_RIDE), screenCoords);
+                    GfxDrawSprite(rt, ImageId(SPR_RIDE), screenCoords);
                     break;
                 case News::ItemType::PeepOnRide:
                 case News::ItemType::Peep:
@@ -260,8 +260,8 @@ namespace OpenRCT2::Ui::Windows
                     if (newsItem->HasButton())
                         break;
 
-                    RenderTarget clipped_dpi;
-                    if (!ClipDrawPixelInfo(clipped_dpi, dpi, screenCoords + ScreenCoordsXY{ 1, 1 }, 22, 22))
+                    RenderTarget clippedRT;
+                    if (!ClipDrawPixelInfo(clippedRT, rt, screenCoords + ScreenCoordsXY{ 1, 1 }, 22, 22))
                     {
                         break;
                     }
@@ -285,7 +285,7 @@ namespace OpenRCT2::Ui::Windows
                     image_id_base++;
 
                     auto image_id = ImageId(image_id_base, peep->TshirtColour, peep->TrousersColour);
-                    GfxDrawSprite(clipped_dpi, image_id, clipCoords);
+                    GfxDrawSprite(clippedRT, image_id, clipCoords);
 
                     auto* guest = peep->As<Guest>();
                     if (guest == nullptr)
@@ -299,7 +299,7 @@ namespace OpenRCT2::Ui::Windows
                     {
                         auto itemOffset = kPeepSpriteHatItemStart + 1;
                         auto imageId = ImageId(itemOffset + itemFrame * 4, guest->HatColour);
-                        GfxDrawSprite(clipped_dpi, imageId, clipCoords);
+                        GfxDrawSprite(clippedRT, imageId, clipCoords);
                         return;
                     }
 
@@ -307,7 +307,7 @@ namespace OpenRCT2::Ui::Windows
                     {
                         auto itemOffset = kPeepSpriteBalloonItemStart + 1;
                         auto imageId = ImageId(itemOffset + itemFrame * 4, guest->BalloonColour);
-                        GfxDrawSprite(clipped_dpi, imageId, clipCoords);
+                        GfxDrawSprite(clippedRT, imageId, clipCoords);
                         return;
                     }
 
@@ -315,26 +315,26 @@ namespace OpenRCT2::Ui::Windows
                     {
                         auto itemOffset = kPeepSpriteUmbrellaItemStart + 1;
                         auto imageId = ImageId(itemOffset + itemFrame * 4, guest->UmbrellaColour);
-                        GfxDrawSprite(clipped_dpi, imageId, clipCoords);
+                        GfxDrawSprite(clippedRT, imageId, clipCoords);
                         return;
                     }
                     break;
                 }
                 case News::ItemType::Money:
                 case News::ItemType::Campaign:
-                    GfxDrawSprite(dpi, ImageId(SPR_FINANCE), screenCoords);
+                    GfxDrawSprite(rt, ImageId(SPR_FINANCE), screenCoords);
                     break;
                 case News::ItemType::Research:
-                    GfxDrawSprite(dpi, ImageId(newsItem->Assoc < 0x10000 ? SPR_NEW_SCENERY : SPR_NEW_RIDE), screenCoords);
+                    GfxDrawSprite(rt, ImageId(newsItem->Assoc < 0x10000 ? SPR_NEW_SCENERY : SPR_NEW_RIDE), screenCoords);
                     break;
                 case News::ItemType::Peeps:
-                    GfxDrawSprite(dpi, ImageId(SPR_GUESTS), screenCoords);
+                    GfxDrawSprite(rt, ImageId(SPR_GUESTS), screenCoords);
                     break;
                 case News::ItemType::Award:
-                    GfxDrawSprite(dpi, ImageId(SPR_AWARD), screenCoords);
+                    GfxDrawSprite(rt, ImageId(SPR_AWARD), screenCoords);
                     break;
                 case News::ItemType::Graph:
-                    GfxDrawSprite(dpi, ImageId(SPR_GRAPH), screenCoords);
+                    GfxDrawSprite(rt, ImageId(SPR_GRAPH), screenCoords);
                     break;
                 case News::ItemType::Null:
                 case News::ItemType::Blank:
@@ -343,12 +343,12 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawMiddlePanel(RenderTarget& dpi)
+        void DrawMiddlePanel(RenderTarget& rt)
         {
             Widget* middleOutsetWidget = &widgets[WIDX_MIDDLE_OUTSET];
 
             GfxFillRectInset(
-                dpi,
+                rt,
                 { windowPos + ScreenCoordsXY{ middleOutsetWidget->left + 1, middleOutsetWidget->top + 1 },
                   windowPos + ScreenCoordsXY{ middleOutsetWidget->right - 1, middleOutsetWidget->bottom - 1 } },
                 colours[1], INSET_RECT_F_30);
@@ -368,13 +368,12 @@ namespace OpenRCT2::Ui::Windows
             {
                 // TODO: this string probably shouldn't be reused for this
                 DrawTextWrapped(
-                    dpi, middleWidgetCoords, panelWidth, STR_TITLE_SEQUENCE_OPENRCT2, ft,
-                    { colours[0], TextAlignment::CENTRE });
+                    rt, middleWidgetCoords, panelWidth, STR_TITLE_SEQUENCE_OPENRCT2, ft, { colours[0], TextAlignment::CENTRE });
             }
             else
             {
                 // Show tooltip in bottom toolbar
-                DrawTextWrapped(dpi, middleWidgetCoords, panelWidth, STR_STRINGID, ft, { colours[0], TextAlignment::CENTRE });
+                DrawTextWrapped(rt, middleWidgetCoords, panelWidth, STR_STRINGID, ft, { colours[0], TextAlignment::CENTRE });
             }
         }
 
@@ -611,7 +610,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             auto leftWidget = widgets[WIDX_LEFT_OUTSET];
             auto rightWidget = widgets[WIDX_RIGHT_OUTSET];
@@ -620,32 +619,32 @@ namespace OpenRCT2::Ui::Windows
             // Draw panel grey backgrounds
             auto leftTop = windowPos + ScreenCoordsXY{ leftWidget.left, leftWidget.top };
             auto rightBottom = windowPos + ScreenCoordsXY{ leftWidget.right, leftWidget.bottom };
-            GfxFilterRect(dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
+            GfxFilterRect(rt, { leftTop, rightBottom }, FilterPaletteID::Palette51);
 
             leftTop = windowPos + ScreenCoordsXY{ rightWidget.left, rightWidget.top };
             rightBottom = windowPos + ScreenCoordsXY{ rightWidget.right, rightWidget.bottom };
-            GfxFilterRect(dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
+            GfxFilterRect(rt, { leftTop, rightBottom }, FilterPaletteID::Palette51);
 
             if (ThemeGetFlags() & UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR)
             {
                 // Draw grey background
                 leftTop = windowPos + ScreenCoordsXY{ middleWidget.left, middleWidget.top };
                 rightBottom = windowPos + ScreenCoordsXY{ middleWidget.right, middleWidget.bottom };
-                GfxFilterRect(dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
+                GfxFilterRect(rt, { leftTop, rightBottom }, FilterPaletteID::Palette51);
             }
 
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
-            DrawLeftPanel(dpi);
-            DrawRightPanel(dpi);
+            DrawLeftPanel(rt);
+            DrawRightPanel(rt);
 
             if (!News::IsQueueEmpty())
             {
-                DrawNewsItem(dpi);
+                DrawNewsItem(rt);
             }
             else if (ThemeGetFlags() & UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR)
             {
-                DrawMiddlePanel(dpi);
+                DrawMiddlePanel(rt);
             }
         }
 

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -85,7 +85,7 @@ namespace OpenRCT2::Ui::Windows
                     : colours[0].colour);
         }
 
-        void DrawLeftPanel(DrawPixelInfo& dpi)
+        void DrawLeftPanel(RenderTarget& dpi)
         {
             const auto& leftPanelWidget = widgets[WIDX_LEFT_OUTSET];
 
@@ -147,7 +147,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawParkRating(DrawPixelInfo& dpi, int32_t colour, const ScreenCoordsXY& coords, uint8_t factor)
+        void DrawParkRating(RenderTarget& dpi, int32_t colour, const ScreenCoordsXY& coords, uint8_t factor)
         {
             int16_t bar_width = (factor * 114) / 255;
             GfxFillRectInset(
@@ -167,7 +167,7 @@ namespace OpenRCT2::Ui::Windows
             GfxDrawSprite(dpi, ImageId(SPR_RATING_HIGH), coords + ScreenCoordsXY{ 114, 0 });
         }
 
-        void DrawRightPanel(DrawPixelInfo& dpi)
+        void DrawRightPanel(RenderTarget& dpi)
         {
             const auto& rightPanelWidget = widgets[WIDX_RIGHT_OUTSET];
 
@@ -227,7 +227,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawNewsItem(DrawPixelInfo& dpi)
+        void DrawNewsItem(RenderTarget& dpi)
         {
             const auto& middleOutsetWidget = widgets[WIDX_MIDDLE_OUTSET];
             auto* newsItem = News::GetItem(0);
@@ -260,7 +260,7 @@ namespace OpenRCT2::Ui::Windows
                     if (newsItem->HasButton())
                         break;
 
-                    DrawPixelInfo clipped_dpi;
+                    RenderTarget clipped_dpi;
                     if (!ClipDrawPixelInfo(clipped_dpi, dpi, screenCoords + ScreenCoordsXY{ 1, 1 }, 22, 22))
                     {
                         break;
@@ -343,7 +343,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawMiddlePanel(DrawPixelInfo& dpi)
+        void DrawMiddlePanel(RenderTarget& dpi)
         {
             Widget* middleOutsetWidget = &widgets[WIDX_MIDDLE_OUTSET];
 
@@ -611,7 +611,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             auto leftWidget = widgets[WIDX_LEFT_OUTSET];
             auto rightWidget = widgets[WIDX_RIGHT_OUTSET];

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -352,30 +352,30 @@ namespace OpenRCT2::Ui::Windows
                 OnViewportRotateOverview();
             }
         }
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             switch (page)
             {
                 case WINDOW_GUEST_OVERVIEW:
-                    OnDrawOverview(dpi);
+                    OnDrawOverview(rt);
                     break;
                 case WINDOW_GUEST_STATS:
-                    OnDrawStats(dpi);
+                    OnDrawStats(rt);
                     break;
                 case WINDOW_GUEST_RIDES:
-                    OnDrawRides(dpi);
+                    OnDrawRides(rt);
                     break;
                 case WINDOW_GUEST_FINANCE:
-                    OnDrawFinance(dpi);
+                    OnDrawFinance(rt);
                     break;
                 case WINDOW_GUEST_THOUGHTS:
-                    OnDrawThoughts(dpi);
+                    OnDrawThoughts(rt);
                     break;
                 case WINDOW_GUEST_INVENTORY:
-                    OnDrawInventory(dpi);
+                    OnDrawInventory(rt);
                     break;
                 case WINDOW_GUEST_DEBUG:
-                    OnDrawDebug(dpi);
+                    OnDrawDebug(rt);
                     break;
             }
         }
@@ -415,11 +415,11 @@ namespace OpenRCT2::Ui::Windows
                 OnScrollMouseDownRides(scrollIndex, screenCoords);
             }
         }
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             if (page == WINDOW_GUEST_RIDES)
             {
-                OnScrollDrawRides(scrollIndex, dpi);
+                OnScrollDrawRides(scrollIndex, rt);
             }
         }
 
@@ -539,7 +539,7 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Overview
 
-        void OverviewTabDraw(RenderTarget& dpi)
+        void OverviewTabDraw(RenderTarget& rt)
         {
             if (WidgetIsDisabled(*this, WIDX_TAB_1))
                 return;
@@ -552,7 +552,7 @@ namespace OpenRCT2::Ui::Windows
                 widgHeight++;
 
             RenderTarget clipDpi;
-            if (!ClipDrawPixelInfo(clipDpi, dpi, screenCoords, widgWidth, widgHeight))
+            if (!ClipDrawPixelInfo(clipDpi, rt, screenCoords, widgWidth, widgHeight))
             {
                 return;
             }
@@ -771,24 +771,24 @@ namespace OpenRCT2::Ui::Windows
             Invalidate();
         }
 
-        void OnDrawOverview(RenderTarget& dpi)
+        void OnDrawOverview(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            OverviewTabDraw(dpi);
-            StatsTabDraw(dpi);
-            RidesTabDraw(dpi);
-            FinanceTabDraw(dpi);
-            ThoughtsTabDraw(dpi);
-            InventoryTabDraw(dpi);
-            DebugTabDraw(dpi);
+            DrawWidgets(rt);
+            OverviewTabDraw(rt);
+            StatsTabDraw(rt);
+            RidesTabDraw(rt);
+            FinanceTabDraw(rt);
+            ThoughtsTabDraw(rt);
+            InventoryTabDraw(rt);
+            DebugTabDraw(rt);
 
             // Draw the viewport no sound sprite
             if (viewport != nullptr)
             {
-                WindowDrawViewport(dpi, *this);
+                WindowDrawViewport(rt, *this);
                 if (viewport->flags & VIEWPORT_FLAG_SOUND_ON)
                 {
-                    GfxDrawSprite(dpi, ImageId(SPR_HEARING_VIEWPORT), WindowGetViewportSoundIconPos(*this));
+                    GfxDrawSprite(rt, ImageId(SPR_HEARING_VIEWPORT), WindowGetViewportSoundIconPos(*this));
                 }
             }
 
@@ -806,7 +806,7 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 peep->FormatActionTo(ft);
                 int32_t textWidth = actionLabelWidget.width();
-                DrawTextEllipsised(dpi, screenPos, textWidth, STR_BLACK_STRING, ft, { TextAlignment::CENTRE });
+                DrawTextEllipsised(rt, screenPos, textWidth, STR_BLACK_STRING, ft, { TextAlignment::CENTRE });
             }
 
             // Draw the marquee thought
@@ -815,8 +815,8 @@ namespace OpenRCT2::Ui::Windows
             int32_t left = marqueeWidget.left + 2 + windowPos.x;
             int32_t top = marqueeWidget.top + windowPos.y;
             int32_t marqHeight = marqueeWidget.height();
-            RenderTarget dpiMarquee;
-            if (!ClipDrawPixelInfo(dpiMarquee, dpi, { left, top }, marqWidth, marqHeight))
+            RenderTarget rtMarquee;
+            if (!ClipDrawPixelInfo(rtMarquee, rt, { left, top }, marqWidth, marqHeight))
             {
                 return;
             }
@@ -844,7 +844,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 auto ft = Formatter();
                 PeepThoughtSetFormatArgs(&peep->Thoughts[i], ft);
-                DrawTextBasic(dpiMarquee, { screenPos.x, 0 }, STR_WINDOW_COLOUR_2_STRINGID, ft, { FontStyle::Small });
+                DrawTextBasic(rtMarquee, { screenPos.x, 0 }, STR_WINDOW_COLOUR_2_STRINGID, ft, { FontStyle::Small });
             }
         }
 
@@ -1027,7 +1027,7 @@ namespace OpenRCT2::Ui::Windows
 #pragma endregion
 
 #pragma region Stats
-        void StatsTabDraw(RenderTarget& dpi)
+        void StatsTabDraw(RenderTarget& rt)
         {
             if (WidgetIsDisabled(*this, WIDX_TAB_2))
                 return;
@@ -1058,7 +1058,7 @@ namespace OpenRCT2::Ui::Windows
                         break;
                 }
             }
-            GfxDrawSprite(dpi, ImageId(imageId), screenCoords);
+            GfxDrawSprite(rt, ImageId(imageId), screenCoords);
         }
 
         void OnUpdateStats()
@@ -1084,7 +1084,7 @@ namespace OpenRCT2::Ui::Windows
             return std::clamp(newValue, newMin, 100);
         }
 
-        void OnDrawStats(RenderTarget& dpi)
+        void OnDrawStats(RenderTarget& rt)
         {
             // ebx
             const auto peep = GetGuest();
@@ -1114,14 +1114,14 @@ namespace OpenRCT2::Ui::Windows
             int32_t toiletPercentage = NormalizeGuestStatValue(peep->Toilet - 64, 178, 0);
             WidgetProgressBarSetNewPercentage(widgets[WIDX_TOILET_BAR], toiletPercentage);
 
-            DrawWidgets(dpi);
-            OverviewTabDraw(dpi);
-            StatsTabDraw(dpi);
-            RidesTabDraw(dpi);
-            FinanceTabDraw(dpi);
-            ThoughtsTabDraw(dpi);
-            InventoryTabDraw(dpi);
-            DebugTabDraw(dpi);
+            DrawWidgets(rt);
+            OverviewTabDraw(rt);
+            StatsTabDraw(rt);
+            RidesTabDraw(rt);
+            FinanceTabDraw(rt);
+            ThoughtsTabDraw(rt);
+            InventoryTabDraw(rt);
+            DebugTabDraw(rt);
 
             auto screenCoords = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_PAGE_BACKGROUND].left + 4,
@@ -1134,13 +1134,13 @@ namespace OpenRCT2::Ui::Windows
                 int32_t timeInPark = (getGameState().currentTicks - guestEntryTime) >> 11;
                 auto ft = Formatter();
                 ft.Add<uint16_t>(timeInPark & 0xFFFF);
-                DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_TIME_IN_PARK, ft);
+                DrawTextBasic(rt, screenCoords, STR_GUEST_STAT_TIME_IN_PARK, ft);
             }
 
             screenCoords.y += kListRowHeight + 9;
 
             // Preferred Ride
-            DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_PREFERRED_RIDE);
+            DrawTextBasic(rt, screenCoords, STR_GUEST_STAT_PREFERRED_RIDE);
             screenCoords.y += kListRowHeight;
 
             // Intensity
@@ -1161,7 +1161,7 @@ namespace OpenRCT2::Ui::Windows
                     ft.Add<uint16_t>(maxIntensity);
                 }
 
-                DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 4, 0 }, string_id, ft);
+                DrawTextBasic(rt, screenCoords + ScreenCoordsXY{ 4, 0 }, string_id, ft);
             }
 
             // Nausea tolerance
@@ -1176,14 +1176,14 @@ namespace OpenRCT2::Ui::Windows
                 auto nausea_tolerance = EnumValue(peep->NauseaTolerance) & 0x3;
                 auto ft = Formatter();
                 ft.Add<StringId>(_nauseaTolerances[nausea_tolerance]);
-                DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_NAUSEA_TOLERANCE, ft);
+                DrawTextBasic(rt, screenCoords, STR_GUEST_STAT_NAUSEA_TOLERANCE, ft);
             }
         }
 
 #pragma endregion
 
 #pragma region Rides
-        void RidesTabDraw(RenderTarget& dpi)
+        void RidesTabDraw(RenderTarget& rt)
         {
             if (WidgetIsDisabled(*this, WIDX_TAB_3))
                 return;
@@ -1198,7 +1198,7 @@ namespace OpenRCT2::Ui::Windows
                 imageId += (frame_no / 4) & 0xF;
             }
 
-            GfxDrawSprite(dpi, ImageId(imageId), screenCoords);
+            GfxDrawSprite(rt, ImageId(imageId), screenCoords);
         }
 
         void OnUpdateRides()
@@ -1290,16 +1290,16 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_RIDE_SCROLL].bottom = height - 15;
         }
 
-        void OnDrawRides(RenderTarget& dpi)
+        void OnDrawRides(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            OverviewTabDraw(dpi);
-            StatsTabDraw(dpi);
-            RidesTabDraw(dpi);
-            FinanceTabDraw(dpi);
-            ThoughtsTabDraw(dpi);
-            InventoryTabDraw(dpi);
-            DebugTabDraw(dpi);
+            DrawWidgets(rt);
+            OverviewTabDraw(rt);
+            StatsTabDraw(rt);
+            RidesTabDraw(rt);
+            FinanceTabDraw(rt);
+            ThoughtsTabDraw(rt);
+            InventoryTabDraw(rt);
+            DebugTabDraw(rt);
 
             const auto peep = GetGuest();
             if (peep == nullptr)
@@ -1324,13 +1324,13 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<StringId>(STR_PEEP_FAVOURITE_RIDE_NOT_AVAILABLE);
             }
 
-            DrawTextEllipsised(dpi, screenCoords, width - 14, STR_FAVOURITE_RIDE, ft);
+            DrawTextEllipsised(rt, screenCoords, width - 14, STR_FAVOURITE_RIDE, ft);
         }
 
-        void OnScrollDrawRides(int32_t scrollIndex, RenderTarget& dpi)
+        void OnScrollDrawRides(int32_t scrollIndex, RenderTarget& rt)
         {
             auto colour = ColourMapA[colours[1].colour].mid_light;
-            GfxFillRect(dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, colour);
+            GfxFillRect(rt, { { rt.x, rt.y }, { rt.x + rt.width - 1, rt.y + rt.height - 1 } }, colour);
 
             for (int32_t listIndex = 0; listIndex < static_cast<int32_t>(_riddenRides.size()); listIndex++)
             {
@@ -1338,7 +1338,7 @@ namespace OpenRCT2::Ui::Windows
                 StringId stringId = STR_BLACK_STRING;
                 if (listIndex == selected_list_item)
                 {
-                    GfxFilterRect(dpi, { 0, y, 800, y + 9 }, FilterPaletteID::PaletteDarken1);
+                    GfxFilterRect(rt, { 0, y, 800, y + 9 }, FilterPaletteID::PaletteDarken1);
                     stringId = STR_WINDOW_COLOUR_2_STRINGID;
                 }
 
@@ -1347,14 +1347,14 @@ namespace OpenRCT2::Ui::Windows
                 {
                     auto ft = Formatter();
                     r->formatNameTo(ft);
-                    DrawTextBasic(dpi, { 0, y - 1 }, stringId, ft);
+                    DrawTextBasic(rt, { 0, y - 1 }, stringId, ft);
                 }
             }
         }
 #pragma endregion
 
 #pragma region Finance
-        void FinanceTabDraw(RenderTarget& dpi)
+        void FinanceTabDraw(RenderTarget& rt)
         {
             if (WidgetIsDisabled(*this, WIDX_TAB_4))
                 return;
@@ -1369,7 +1369,7 @@ namespace OpenRCT2::Ui::Windows
                 imageId += (frame_no / 2) & 0x7;
             }
 
-            GfxDrawSprite(dpi, ImageId(imageId), screenCoords);
+            GfxDrawSprite(rt, ImageId(imageId), screenCoords);
         }
 
         void OnUpdateFinance()
@@ -1380,16 +1380,16 @@ namespace OpenRCT2::Ui::Windows
             InvalidateWidget(WIDX_TAB_4);
         }
 
-        void OnDrawFinance(RenderTarget& dpi)
+        void OnDrawFinance(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            OverviewTabDraw(dpi);
-            StatsTabDraw(dpi);
-            RidesTabDraw(dpi);
-            FinanceTabDraw(dpi);
-            ThoughtsTabDraw(dpi);
-            InventoryTabDraw(dpi);
-            DebugTabDraw(dpi);
+            DrawWidgets(rt);
+            OverviewTabDraw(rt);
+            StatsTabDraw(rt);
+            RidesTabDraw(rt);
+            FinanceTabDraw(rt);
+            ThoughtsTabDraw(rt);
+            InventoryTabDraw(rt);
+            DebugTabDraw(rt);
 
             const auto peep = GetGuest();
             if (peep == nullptr)
@@ -1405,7 +1405,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 auto ft = Formatter();
                 ft.Add<money64>(peep->CashInPocket);
-                DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_CASH_IN_POCKET, ft);
+                DrawTextBasic(rt, screenCoords, STR_GUEST_STAT_CASH_IN_POCKET, ft);
                 screenCoords.y += kListRowHeight;
             }
 
@@ -1413,19 +1413,19 @@ namespace OpenRCT2::Ui::Windows
             {
                 auto ft = Formatter();
                 ft.Add<money64>(peep->CashSpent);
-                DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_CASH_SPENT, ft);
+                DrawTextBasic(rt, screenCoords, STR_GUEST_STAT_CASH_SPENT, ft);
                 screenCoords.y += kListRowHeight * 2;
             }
 
             GfxFillRectInset(
-                dpi, { screenCoords - ScreenCoordsXY{ 0, 6 }, screenCoords + ScreenCoordsXY{ 179, -5 } }, colours[1],
+                rt, { screenCoords - ScreenCoordsXY{ 0, 6 }, screenCoords + ScreenCoordsXY{ 179, -5 } }, colours[1],
                 INSET_RECT_FLAG_BORDER_INSET);
 
             // Paid to enter
             {
                 auto ft = Formatter();
                 ft.Add<money64>(peep->PaidToEnter);
-                DrawTextBasic(dpi, screenCoords, STR_GUEST_EXPENSES_ENTRANCE_FEE, ft);
+                DrawTextBasic(rt, screenCoords, STR_GUEST_EXPENSES_ENTRANCE_FEE, ft);
                 screenCoords.y += kListRowHeight;
             }
             // Paid on rides
@@ -1435,11 +1435,11 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<uint16_t>(peep->GuestNumRides);
                 if (peep->GuestNumRides != 1)
                 {
-                    DrawTextBasic(dpi, screenCoords, STR_GUEST_EXPENSES_RIDE_PLURAL, ft);
+                    DrawTextBasic(rt, screenCoords, STR_GUEST_EXPENSES_RIDE_PLURAL, ft);
                 }
                 else
                 {
-                    DrawTextBasic(dpi, screenCoords, STR_GUEST_EXPENSES_RIDE, ft);
+                    DrawTextBasic(rt, screenCoords, STR_GUEST_EXPENSES_RIDE, ft);
                 }
                 screenCoords.y += kListRowHeight;
             }
@@ -1450,11 +1450,11 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<uint16_t>(peep->AmountOfFood);
                 if (peep->AmountOfFood != 1)
                 {
-                    DrawTextBasic(dpi, screenCoords, STR_GUEST_EXPENSES_FOOD_PLURAL, ft);
+                    DrawTextBasic(rt, screenCoords, STR_GUEST_EXPENSES_FOOD_PLURAL, ft);
                 }
                 else
                 {
-                    DrawTextBasic(dpi, screenCoords, STR_GUEST_EXPENSES_FOOD, ft);
+                    DrawTextBasic(rt, screenCoords, STR_GUEST_EXPENSES_FOOD, ft);
                 }
                 screenCoords.y += kListRowHeight;
             }
@@ -1466,11 +1466,11 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<uint16_t>(peep->AmountOfDrinks);
                 if (peep->AmountOfDrinks != 1)
                 {
-                    DrawTextBasic(dpi, screenCoords, STR_GUEST_EXPENSES_DRINK_PLURAL, ft);
+                    DrawTextBasic(rt, screenCoords, STR_GUEST_EXPENSES_DRINK_PLURAL, ft);
                 }
                 else
                 {
-                    DrawTextBasic(dpi, screenCoords, STR_GUEST_EXPENSES_DRINK, ft);
+                    DrawTextBasic(rt, screenCoords, STR_GUEST_EXPENSES_DRINK, ft);
                 }
                 screenCoords.y += kListRowHeight;
             }
@@ -1481,18 +1481,18 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<uint16_t>(peep->AmountOfSouvenirs);
                 if (peep->AmountOfSouvenirs != 1)
                 {
-                    DrawTextBasic(dpi, screenCoords, STR_GUEST_EXPENSES_SOUVENIR_PLURAL, ft);
+                    DrawTextBasic(rt, screenCoords, STR_GUEST_EXPENSES_SOUVENIR_PLURAL, ft);
                 }
                 else
                 {
-                    DrawTextBasic(dpi, screenCoords, STR_GUEST_EXPENSES_SOUVENIR, ft);
+                    DrawTextBasic(rt, screenCoords, STR_GUEST_EXPENSES_SOUVENIR, ft);
                 }
             }
         }
 #pragma endregion
 
 #pragma region Thoughts
-        void ThoughtsTabDraw(RenderTarget& dpi)
+        void ThoughtsTabDraw(RenderTarget& rt)
         {
             if (WidgetIsDisabled(*this, WIDX_TAB_5))
                 return;
@@ -1507,7 +1507,7 @@ namespace OpenRCT2::Ui::Windows
                 imageId += (frame_no / 2) & 0x7;
             }
 
-            GfxDrawSprite(dpi, ImageId(imageId), screenCoords);
+            GfxDrawSprite(rt, ImageId(imageId), screenCoords);
         }
 
         void OnUpdateThoughts()
@@ -1529,16 +1529,16 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDrawThoughts(RenderTarget& dpi)
+        void OnDrawThoughts(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            OverviewTabDraw(dpi);
-            StatsTabDraw(dpi);
-            RidesTabDraw(dpi);
-            FinanceTabDraw(dpi);
-            ThoughtsTabDraw(dpi);
-            InventoryTabDraw(dpi);
-            DebugTabDraw(dpi);
+            DrawWidgets(rt);
+            OverviewTabDraw(rt);
+            StatsTabDraw(rt);
+            RidesTabDraw(rt);
+            FinanceTabDraw(rt);
+            ThoughtsTabDraw(rt);
+            InventoryTabDraw(rt);
+            DebugTabDraw(rt);
 
             const auto peep = GetGuest();
             if (peep == nullptr)
@@ -1560,7 +1560,7 @@ namespace OpenRCT2::Ui::Windows
 
                 auto ft = Formatter();
                 PeepThoughtSetFormatArgs(&thought, ft);
-                screenCoords.y += DrawTextWrapped(dpi, screenCoords, widgWidth, STR_BLACK_STRING, ft, { FontStyle::Small });
+                screenCoords.y += DrawTextWrapped(rt, screenCoords, widgWidth, STR_BLACK_STRING, ft, { FontStyle::Small });
 
                 // If this is the last visible line end drawing.
                 if (screenCoords.y > windowPos.y + widgets[WIDX_PAGE_BACKGROUND].bottom - 32)
@@ -1570,7 +1570,7 @@ namespace OpenRCT2::Ui::Windows
 #pragma endregion
 
 #pragma region Inventory
-        void InventoryTabDraw(RenderTarget& dpi)
+        void InventoryTabDraw(RenderTarget& rt)
         {
             if (WidgetIsDisabled(*this, WIDX_TAB_6))
                 return;
@@ -1578,7 +1578,7 @@ namespace OpenRCT2::Ui::Windows
             const auto& widget = widgets[WIDX_TAB_6];
             auto screenCoords = windowPos + ScreenCoordsXY{ widget.left, widget.top };
 
-            GfxDrawSprite(dpi, ImageId(SPR_TAB_GUEST_INVENTORY), screenCoords);
+            GfxDrawSprite(rt, ImageId(SPR_TAB_GUEST_INVENTORY), screenCoords);
         }
 
         void OnUpdateInventory()
@@ -1710,16 +1710,16 @@ namespace OpenRCT2::Ui::Windows
             return std::make_pair(itemImage, ft);
         }
 
-        void OnDrawInventory(RenderTarget& dpi)
+        void OnDrawInventory(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            OverviewTabDraw(dpi);
-            StatsTabDraw(dpi);
-            RidesTabDraw(dpi);
-            FinanceTabDraw(dpi);
-            ThoughtsTabDraw(dpi);
-            InventoryTabDraw(dpi);
-            DebugTabDraw(dpi);
+            DrawWidgets(rt);
+            OverviewTabDraw(rt);
+            StatsTabDraw(rt);
+            RidesTabDraw(rt);
+            FinanceTabDraw(rt);
+            ThoughtsTabDraw(rt);
+            InventoryTabDraw(rt);
+            DebugTabDraw(rt);
 
             const auto guest = GetGuest();
             if (guest == nullptr)
@@ -1742,11 +1742,11 @@ namespace OpenRCT2::Ui::Windows
                     continue;
 
                 auto [imageId, ft] = InventoryFormatItem(*guest, item);
-                GfxDrawSprite(dpi, imageId, screenCoords);
+                GfxDrawSprite(rt, imageId, screenCoords);
 
                 screenCoords.x += 16;
                 screenCoords.y += 1;
-                screenCoords.y += DrawTextWrapped(dpi, screenCoords, itemNameWidth, STR_BLACK_STRING, ft);
+                screenCoords.y += DrawTextWrapped(rt, screenCoords, itemNameWidth, STR_BLACK_STRING, ft);
 
                 screenCoords.x -= 16;
                 numItems++;
@@ -1754,13 +1754,13 @@ namespace OpenRCT2::Ui::Windows
 
             if (numItems == 0)
             {
-                DrawTextBasic(dpi, screenCoords, STR_NOTHING);
+                DrawTextBasic(rt, screenCoords, STR_NOTHING);
             }
         }
 #pragma endregion
 
 #pragma region Debug
-        void DebugTabDraw(RenderTarget& dpi)
+        void DebugTabDraw(RenderTarget& rt)
         {
             if (WidgetIsDisabled(*this, WIDX_TAB_7))
                 return;
@@ -1774,7 +1774,7 @@ namespace OpenRCT2::Ui::Windows
                 imageId += (frame_no / 2) & 0x3;
             }
 
-            GfxDrawSprite(dpi, ImageId(imageId), screenCoords);
+            GfxDrawSprite(rt, ImageId(imageId), screenCoords);
         }
 
         void OnUpdateDebug()
@@ -1783,19 +1783,19 @@ namespace OpenRCT2::Ui::Windows
             Invalidate();
         }
 
-        void OnDrawDebug(RenderTarget& dpi)
+        void OnDrawDebug(RenderTarget& rt)
         {
             char buffer[512]{};
             char buffer2[512]{};
 
-            DrawWidgets(dpi);
-            OverviewTabDraw(dpi);
-            StatsTabDraw(dpi);
-            RidesTabDraw(dpi);
-            FinanceTabDraw(dpi);
-            ThoughtsTabDraw(dpi);
-            InventoryTabDraw(dpi);
-            DebugTabDraw(dpi);
+            DrawWidgets(rt);
+            OverviewTabDraw(rt);
+            StatsTabDraw(rt);
+            RidesTabDraw(rt);
+            FinanceTabDraw(rt);
+            ThoughtsTabDraw(rt);
+            InventoryTabDraw(rt);
+            DebugTabDraw(rt);
 
             const auto peep = GetGuest();
             if (peep == nullptr)
@@ -1807,7 +1807,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 auto ft = Formatter();
                 ft.Add<uint32_t>(peep->Id);
-                DrawTextBasic(dpi, screenCoords, STR_PEEP_DEBUG_SPRITE_INDEX, ft);
+                DrawTextBasic(rt, screenCoords, STR_PEEP_DEBUG_SPRITE_INDEX, ft);
             }
             screenCoords.y += kListRowHeight;
             {
@@ -1815,7 +1815,7 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<int32_t>(peep->x);
                 ft.Add<int32_t>(peep->y);
                 ft.Add<int32_t>(peep->z);
-                DrawTextBasic(dpi, screenCoords, STR_PEEP_DEBUG_POSITION, ft);
+                DrawTextBasic(rt, screenCoords, STR_PEEP_DEBUG_POSITION, ft);
             }
             screenCoords.y += kListRowHeight;
             {
@@ -1836,7 +1836,7 @@ namespace OpenRCT2::Ui::Windows
                     OpenRCT2::FormatStringLegacy(buffer2, sizeof(buffer2), STR_PEEP_DEBUG_NEXT_SLOPE, ft2.Data());
                     String::safeConcat(buffer, buffer2, sizeof(buffer));
                 }
-                DrawText(dpi, screenCoords, {}, buffer);
+                DrawText(rt, screenCoords, {}, buffer);
             }
             screenCoords.y += kListRowHeight;
             {
@@ -1844,7 +1844,7 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<int32_t>(peep->DestinationX);
                 ft.Add<int32_t>(peep->DestinationY);
                 ft.Add<int32_t>(peep->DestinationTolerance);
-                DrawTextBasic(dpi, screenCoords, STR_PEEP_DEBUG_DEST, ft);
+                DrawTextBasic(rt, screenCoords, STR_PEEP_DEBUG_DEST, ft);
             }
             screenCoords.y += kListRowHeight;
             {
@@ -1853,10 +1853,10 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<int32_t>(peep->PathfindGoal.y);
                 ft.Add<int32_t>(peep->PathfindGoal.z);
                 ft.Add<int32_t>(peep->PathfindGoal.direction);
-                DrawTextBasic(dpi, screenCoords, STR_PEEP_DEBUG_PATHFIND_GOAL, ft);
+                DrawTextBasic(rt, screenCoords, STR_PEEP_DEBUG_PATHFIND_GOAL, ft);
             }
             screenCoords.y += kListRowHeight;
-            DrawTextBasic(dpi, screenCoords, STR_PEEP_DEBUG_PATHFIND_HISTORY);
+            DrawTextBasic(rt, screenCoords, STR_PEEP_DEBUG_PATHFIND_HISTORY);
             screenCoords.y += kListRowHeight;
 
             screenCoords.x += 10;
@@ -1867,7 +1867,7 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<int32_t>(point.y);
                 ft.Add<int32_t>(point.z);
                 ft.Add<int32_t>(point.direction);
-                DrawTextBasic(dpi, screenCoords, STR_PEEP_DEBUG_PATHFIND_HISTORY_ITEM, ft);
+                DrawTextBasic(rt, screenCoords, STR_PEEP_DEBUG_PATHFIND_HISTORY_ITEM, ft);
                 screenCoords.y += kListRowHeight;
             }
             screenCoords.x -= 10;

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -352,7 +352,7 @@ namespace OpenRCT2::Ui::Windows
                 OnViewportRotateOverview();
             }
         }
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             switch (page)
             {
@@ -415,7 +415,7 @@ namespace OpenRCT2::Ui::Windows
                 OnScrollMouseDownRides(scrollIndex, screenCoords);
             }
         }
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             if (page == WINDOW_GUEST_RIDES)
             {
@@ -539,7 +539,7 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Overview
 
-        void OverviewTabDraw(DrawPixelInfo& dpi)
+        void OverviewTabDraw(RenderTarget& dpi)
         {
             if (WidgetIsDisabled(*this, WIDX_TAB_1))
                 return;
@@ -551,7 +551,7 @@ namespace OpenRCT2::Ui::Windows
             if (page == WINDOW_GUEST_OVERVIEW)
                 widgHeight++;
 
-            DrawPixelInfo clipDpi;
+            RenderTarget clipDpi;
             if (!ClipDrawPixelInfo(clipDpi, dpi, screenCoords, widgWidth, widgHeight))
             {
                 return;
@@ -771,7 +771,7 @@ namespace OpenRCT2::Ui::Windows
             Invalidate();
         }
 
-        void OnDrawOverview(DrawPixelInfo& dpi)
+        void OnDrawOverview(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             OverviewTabDraw(dpi);
@@ -815,7 +815,7 @@ namespace OpenRCT2::Ui::Windows
             int32_t left = marqueeWidget.left + 2 + windowPos.x;
             int32_t top = marqueeWidget.top + windowPos.y;
             int32_t marqHeight = marqueeWidget.height();
-            DrawPixelInfo dpiMarquee;
+            RenderTarget dpiMarquee;
             if (!ClipDrawPixelInfo(dpiMarquee, dpi, { left, top }, marqWidth, marqHeight))
             {
                 return;
@@ -1027,7 +1027,7 @@ namespace OpenRCT2::Ui::Windows
 #pragma endregion
 
 #pragma region Stats
-        void StatsTabDraw(DrawPixelInfo& dpi)
+        void StatsTabDraw(RenderTarget& dpi)
         {
             if (WidgetIsDisabled(*this, WIDX_TAB_2))
                 return;
@@ -1084,7 +1084,7 @@ namespace OpenRCT2::Ui::Windows
             return std::clamp(newValue, newMin, 100);
         }
 
-        void OnDrawStats(DrawPixelInfo& dpi)
+        void OnDrawStats(RenderTarget& dpi)
         {
             // ebx
             const auto peep = GetGuest();
@@ -1183,7 +1183,7 @@ namespace OpenRCT2::Ui::Windows
 #pragma endregion
 
 #pragma region Rides
-        void RidesTabDraw(DrawPixelInfo& dpi)
+        void RidesTabDraw(RenderTarget& dpi)
         {
             if (WidgetIsDisabled(*this, WIDX_TAB_3))
                 return;
@@ -1290,7 +1290,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_RIDE_SCROLL].bottom = height - 15;
         }
 
-        void OnDrawRides(DrawPixelInfo& dpi)
+        void OnDrawRides(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             OverviewTabDraw(dpi);
@@ -1327,7 +1327,7 @@ namespace OpenRCT2::Ui::Windows
             DrawTextEllipsised(dpi, screenCoords, width - 14, STR_FAVOURITE_RIDE, ft);
         }
 
-        void OnScrollDrawRides(int32_t scrollIndex, DrawPixelInfo& dpi)
+        void OnScrollDrawRides(int32_t scrollIndex, RenderTarget& dpi)
         {
             auto colour = ColourMapA[colours[1].colour].mid_light;
             GfxFillRect(dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, colour);
@@ -1354,7 +1354,7 @@ namespace OpenRCT2::Ui::Windows
 #pragma endregion
 
 #pragma region Finance
-        void FinanceTabDraw(DrawPixelInfo& dpi)
+        void FinanceTabDraw(RenderTarget& dpi)
         {
             if (WidgetIsDisabled(*this, WIDX_TAB_4))
                 return;
@@ -1380,7 +1380,7 @@ namespace OpenRCT2::Ui::Windows
             InvalidateWidget(WIDX_TAB_4);
         }
 
-        void OnDrawFinance(DrawPixelInfo& dpi)
+        void OnDrawFinance(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             OverviewTabDraw(dpi);
@@ -1492,7 +1492,7 @@ namespace OpenRCT2::Ui::Windows
 #pragma endregion
 
 #pragma region Thoughts
-        void ThoughtsTabDraw(DrawPixelInfo& dpi)
+        void ThoughtsTabDraw(RenderTarget& dpi)
         {
             if (WidgetIsDisabled(*this, WIDX_TAB_5))
                 return;
@@ -1529,7 +1529,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDrawThoughts(DrawPixelInfo& dpi)
+        void OnDrawThoughts(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             OverviewTabDraw(dpi);
@@ -1570,7 +1570,7 @@ namespace OpenRCT2::Ui::Windows
 #pragma endregion
 
 #pragma region Inventory
-        void InventoryTabDraw(DrawPixelInfo& dpi)
+        void InventoryTabDraw(RenderTarget& dpi)
         {
             if (WidgetIsDisabled(*this, WIDX_TAB_6))
                 return;
@@ -1710,7 +1710,7 @@ namespace OpenRCT2::Ui::Windows
             return std::make_pair(itemImage, ft);
         }
 
-        void OnDrawInventory(DrawPixelInfo& dpi)
+        void OnDrawInventory(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             OverviewTabDraw(dpi);
@@ -1760,7 +1760,7 @@ namespace OpenRCT2::Ui::Windows
 #pragma endregion
 
 #pragma region Debug
-        void DebugTabDraw(DrawPixelInfo& dpi)
+        void DebugTabDraw(RenderTarget& dpi)
         {
             if (WidgetIsDisabled(*this, WIDX_TAB_7))
                 return;
@@ -1783,7 +1783,7 @@ namespace OpenRCT2::Ui::Windows
             Invalidate();
         }
 
-        void OnDrawDebug(DrawPixelInfo& dpi)
+        void OnDrawDebug(RenderTarget& dpi)
         {
             char buffer[512]{};
             char buffer2[512]{};

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -429,7 +429,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -575,7 +575,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             GfxFillRect(
                 dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } },
@@ -629,7 +629,7 @@ namespace OpenRCT2::Ui::Windows
         }
 
     private:
-        void DrawTabImages(DrawPixelInfo& dpi)
+        void DrawTabImages(RenderTarget& dpi)
         {
             // Tab 1 image
             auto i = (_selectedTab == TabId::Individual ? _tabAnimationIndex & ~3 : 0);
@@ -646,7 +646,7 @@ namespace OpenRCT2::Ui::Windows
                 windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left, widgets[WIDX_TAB_2].top });
         }
 
-        void DrawScrollIndividual(DrawPixelInfo& dpi)
+        void DrawScrollIndividual(RenderTarget& dpi)
         {
             size_t index = 0;
             auto y = static_cast<int32_t>(_selectedPage) * -GUEST_PAGE_HEIGHT;
@@ -713,7 +713,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawScrollSummarised(DrawPixelInfo& dpi)
+        void DrawScrollSummarised(RenderTarget& dpi)
         {
             size_t index = 0;
             auto y = 0;

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -429,10 +429,10 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             // Filter description
             StringId format;
@@ -462,7 +462,7 @@ namespace OpenRCT2::Ui::Windows
 
             {
                 Formatter ft(_filterArguments.args);
-                DrawTextEllipsised(dpi, screenCoords, 310, format, ft);
+                DrawTextEllipsised(rt, screenCoords, 310, format, ft);
             }
 
             // Number of guests (list items)
@@ -472,7 +472,7 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<int32_t>(static_cast<int32_t>(_guestList.size()));
                 DrawTextBasic(
-                    dpi, screenCoords, (_guestList.size() == 1 ? STR_FORMAT_NUM_GUESTS_SINGULAR : STR_FORMAT_NUM_GUESTS_PLURAL),
+                    rt, screenCoords, (_guestList.size() == 1 ? STR_FORMAT_NUM_GUESTS_SINGULAR : STR_FORMAT_NUM_GUESTS_PLURAL),
                     ft);
             }
         }
@@ -575,18 +575,17 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             GfxFillRect(
-                dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } },
-                ColourMapA[colours[1].colour].mid_light);
+                rt, { { rt.x, rt.y }, { rt.x + rt.width - 1, rt.y + rt.height - 1 } }, ColourMapA[colours[1].colour].mid_light);
             switch (_selectedTab)
             {
                 case TabId::Individual:
-                    DrawScrollIndividual(dpi);
+                    DrawScrollIndividual(rt);
                     break;
                 case TabId::Summarised:
-                    DrawScrollSummarised(dpi);
+                    DrawScrollSummarised(rt);
                     break;
             }
         }
@@ -629,38 +628,38 @@ namespace OpenRCT2::Ui::Windows
         }
 
     private:
-        void DrawTabImages(RenderTarget& dpi)
+        void DrawTabImages(RenderTarget& rt)
         {
             // Tab 1 image
             auto i = (_selectedTab == TabId::Individual ? _tabAnimationIndex & ~3 : 0);
             auto* animObj = findPeepAnimationsObjectForType(AnimationPeepType::Guest);
             i += animObj->GetPeepAnimation(PeepAnimationGroup::Normal).base_image + 1;
             GfxDrawSprite(
-                dpi, ImageId(i, COLOUR_GREY, COLOUR_DARK_OLIVE_GREEN),
+                rt, ImageId(i, COLOUR_GREY, COLOUR_DARK_OLIVE_GREEN),
                 windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_1].midX(), widgets[WIDX_TAB_1].bottom - 6 });
 
             // Tab 2 image
             i = (_selectedTab == TabId::Summarised ? _tabAnimationIndex / 4 : 0);
             GfxDrawSprite(
-                dpi, ImageId(SPR_TAB_GUESTS_0 + i),
+                rt, ImageId(SPR_TAB_GUESTS_0 + i),
                 windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left, widgets[WIDX_TAB_2].top });
         }
 
-        void DrawScrollIndividual(RenderTarget& dpi)
+        void DrawScrollIndividual(RenderTarget& rt)
         {
             size_t index = 0;
             auto y = static_cast<int32_t>(_selectedPage) * -GUEST_PAGE_HEIGHT;
             for (const auto& guestItem : _guestList)
             {
                 // Check if y is beyond the scroll control
-                if (y + kScrollableRowHeight + 1 >= -0x7FFF && y + kScrollableRowHeight + 1 > dpi.y && y < 0x7FFF
-                    && y < dpi.y + dpi.height)
+                if (y + kScrollableRowHeight + 1 >= -0x7FFF && y + kScrollableRowHeight + 1 > rt.y && y < 0x7FFF
+                    && y < rt.y + rt.height)
                 {
                     // Highlight backcolour and text colour (format)
                     StringId format = STR_BLACK_STRING;
                     if (index == _highlightedIndex)
                     {
-                        GfxFilterRect(dpi, { 0, y, 800, y + kScrollableRowHeight - 1 }, FilterPaletteID::PaletteDarken1);
+                        GfxFilterRect(rt, { 0, y, 800, y + kScrollableRowHeight - 1 }, FilterPaletteID::PaletteDarken1);
                         format = STR_WINDOW_COLOUR_2_STRINGID;
                     }
 
@@ -672,22 +671,22 @@ namespace OpenRCT2::Ui::Windows
                     }
                     auto ft = Formatter();
                     peep->FormatNameTo(ft);
-                    DrawTextEllipsised(dpi, { 0, y }, 113, format, ft);
+                    DrawTextEllipsised(rt, { 0, y }, 113, format, ft);
 
                     switch (_selectedView)
                     {
                         case GuestViewType::Actions:
                             // Guest face
-                            GfxDrawSprite(dpi, ImageId(GetPeepFaceSpriteSmall(peep)), { 118, y + 1 });
+                            GfxDrawSprite(rt, ImageId(GetPeepFaceSpriteSmall(peep)), { 118, y + 1 });
 
                             // Tracking icon
                             if (peep->PeepFlags & PEEP_FLAGS_TRACKING)
-                                GfxDrawSprite(dpi, ImageId(STR_ENTER_SELECTION_SIZE), { 112, y + 1 });
+                                GfxDrawSprite(rt, ImageId(STR_ENTER_SELECTION_SIZE), { 112, y + 1 });
 
                             // Action
                             ft = Formatter();
                             peep->FormatActionTo(ft);
-                            DrawTextEllipsised(dpi, { 133, y }, 314, format, ft);
+                            DrawTextEllipsised(rt, { 133, y }, 314, format, ft);
                             break;
                         case GuestViewType::Thoughts:
                             // For each thought
@@ -702,7 +701,7 @@ namespace OpenRCT2::Ui::Windows
 
                                 ft = Formatter();
                                 PeepThoughtSetFormatArgs(&thought, ft);
-                                DrawTextEllipsised(dpi, { 118, y }, 329, format, ft, { FontStyle::Small });
+                                DrawTextEllipsised(rt, { 118, y }, 329, format, ft, { FontStyle::Small });
                                 break;
                             }
                             break;
@@ -713,24 +712,24 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawScrollSummarised(RenderTarget& dpi)
+        void DrawScrollSummarised(RenderTarget& rt)
         {
             size_t index = 0;
             auto y = 0;
             for (auto& group : _groups)
             {
                 // Check if y is beyond the scroll control
-                if (y + SUMMARISED_GUEST_ROW_HEIGHT + 1 >= dpi.y)
+                if (y + SUMMARISED_GUEST_ROW_HEIGHT + 1 >= rt.y)
                 {
                     // Check if y is beyond the scroll control
-                    if (y >= dpi.y + dpi.height)
+                    if (y >= rt.y + rt.height)
                         break;
 
                     // Highlight backcolour and text colour (format)
                     StringId format = STR_BLACK_STRING;
                     if (index == _highlightedIndex)
                     {
-                        GfxFilterRect(dpi, { 0, y, 800, y + SUMMARISED_GUEST_ROW_HEIGHT }, FilterPaletteID::PaletteDarken1);
+                        GfxFilterRect(rt, { 0, y, 800, y + SUMMARISED_GUEST_ROW_HEIGHT }, FilterPaletteID::PaletteDarken1);
                         format = STR_WINDOW_COLOUR_2_STRINGID;
                     }
 
@@ -738,7 +737,7 @@ namespace OpenRCT2::Ui::Windows
                     for (uint32_t j = 0; j < std::size(group.Faces) && j < group.NumGuests; j++)
                     {
                         GfxDrawSprite(
-                            dpi, ImageId(group.Faces[j] + SPR_PEEP_SMALL_FACE_VERY_VERY_UNHAPPY),
+                            rt, ImageId(group.Faces[j] + SPR_PEEP_SMALL_FACE_VERY_VERY_UNHAPPY),
                             { static_cast<int32_t>(j) * 8, y + 12 });
                     }
 
@@ -747,18 +746,18 @@ namespace OpenRCT2::Ui::Windows
                     // Draw small font if displaying guests
                     if (_selectedView == GuestViewType::Thoughts)
                     {
-                        DrawTextEllipsised(dpi, { 0, y }, 414, format, ft, { FontStyle::Small });
+                        DrawTextEllipsised(rt, { 0, y }, 414, format, ft, { FontStyle::Small });
                     }
                     else
                     {
-                        DrawTextEllipsised(dpi, { 0, y }, 414, format, ft);
+                        DrawTextEllipsised(rt, { 0, y }, 414, format, ft);
                     }
 
                     // Draw guest count
                     ft = Formatter();
                     ft.Add<StringId>(STR_GUESTS_COUNT_COMMA_SEP);
                     ft.Add<uint32_t>(group.NumGuests);
-                    DrawTextBasic(dpi, { 326, y }, format, ft, { TextAlignment::RIGHT });
+                    DrawTextBasic(rt, { 326, y }, format, ft, { TextAlignment::RIGHT });
                 }
                 y += SUMMARISED_GUEST_ROW_HEIGHT;
                 index++;

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -147,7 +147,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
 

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -147,15 +147,15 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             // Track preview
             Widget* widget = &widgets[WIDX_TRACK_PREVIEW];
             auto screenPos = windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
             int32_t colour = ColourMapA[colours[0].colour].darkest;
-            GfxFillRect(dpi, { screenPos, screenPos + ScreenCoordsXY{ 369, 216 } }, colour);
+            GfxFillRect(rt, { screenPos, screenPos + ScreenCoordsXY{ 369, 216 } }, colour);
 
             G1Element g1temp = {};
             g1temp.offset = _trackDesignPreviewPixels.data() + (_currentTrackPieceDirection * kTrackPreviewImageSize);
@@ -164,7 +164,7 @@ namespace OpenRCT2::Ui::Windows
             g1temp.flags = G1_FLAG_HAS_TRANSPARENCY;
             GfxSetG1Element(SPR_TEMP, &g1temp);
             DrawingEngineInvalidateImage(SPR_TEMP);
-            GfxDrawSprite(dpi, ImageId(SPR_TEMP), screenPos);
+            GfxDrawSprite(rt, ImageId(SPR_TEMP), screenPos);
 
             screenPos = windowPos + ScreenCoordsXY{ widget->midX(), widget->bottom - 12 };
 
@@ -176,7 +176,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     // Scenery not available
                     DrawTextEllipsised(
-                        dpi, screenPos, 308, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, {}, { TextAlignment::CENTRE });
+                        rt, screenPos, 308, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, {}, { TextAlignment::CENTRE });
                     screenPos.y -= kListRowHeight;
                 }
             }
@@ -190,7 +190,7 @@ namespace OpenRCT2::Ui::Windows
                 auto trackName = _trackName.c_str();
                 auto ft = Formatter();
                 ft.Add<const char*>(trackName);
-                DrawTextBasic(dpi, screenPos - ScreenCoordsXY{ 1, 0 }, STR_TRACK_DESIGN_NAME, ft);
+                DrawTextBasic(rt, screenPos - ScreenCoordsXY{ 1, 0 }, STR_TRACK_DESIGN_NAME, ft);
                 screenPos.y += kListRowHeight;
             }
 
@@ -211,7 +211,7 @@ namespace OpenRCT2::Ui::Windows
                     ft.Add<StringId>(GetRideTypeDescriptor(td.trackAndVehicle.rtdIndex).Naming.Name);
                 }
 
-                DrawTextBasic(dpi, screenPos, STR_TRACK_DESIGN_TYPE, ft);
+                DrawTextBasic(rt, screenPos, STR_TRACK_DESIGN_TYPE, ft);
                 screenPos.y += kListRowHeight + 4;
             }
 
@@ -220,21 +220,21 @@ namespace OpenRCT2::Ui::Windows
                 fixed32_2dp rating = td.statistics.ratings.excitement;
                 auto ft = Formatter();
                 ft.Add<int32_t>(rating);
-                DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_EXCITEMENT_RATING, ft);
+                DrawTextBasic(rt, screenPos, STR_TRACK_LIST_EXCITEMENT_RATING, ft);
                 screenPos.y += kListRowHeight;
             }
             {
                 fixed32_2dp rating = td.statistics.ratings.intensity;
                 auto ft = Formatter();
                 ft.Add<int32_t>(rating);
-                DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_INTENSITY_RATING, ft);
+                DrawTextBasic(rt, screenPos, STR_TRACK_LIST_INTENSITY_RATING, ft);
                 screenPos.y += kListRowHeight;
             }
             {
                 fixed32_2dp rating = td.statistics.ratings.nausea;
                 auto ft = Formatter();
                 ft.Add<int32_t>(rating);
-                DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_NAUSEA_RATING, ft);
+                DrawTextBasic(rt, screenPos, STR_TRACK_LIST_NAUSEA_RATING, ft);
                 screenPos.y += kListRowHeight + 4;
             }
 
@@ -246,7 +246,7 @@ namespace OpenRCT2::Ui::Windows
                     // Holes
                     auto ft = Formatter();
                     ft.Add<uint16_t>(td.statistics.holes);
-                    DrawTextBasic(dpi, screenPos, STR_HOLES, ft);
+                    DrawTextBasic(rt, screenPos, STR_HOLES, ft);
                     screenPos.y += kListRowHeight;
                 }
                 else
@@ -256,7 +256,7 @@ namespace OpenRCT2::Ui::Windows
                         uint16_t speed = ToHumanReadableSpeed(td.statistics.maxSpeed << 16);
                         auto ft = Formatter();
                         ft.Add<uint16_t>(speed);
-                        DrawTextBasic(dpi, screenPos, STR_MAX_SPEED, ft);
+                        DrawTextBasic(rt, screenPos, STR_MAX_SPEED, ft);
                         screenPos.y += kListRowHeight;
                     }
                     // Average speed
@@ -264,7 +264,7 @@ namespace OpenRCT2::Ui::Windows
                         uint16_t speed = ToHumanReadableSpeed(td.statistics.averageSpeed << 16);
                         auto ft = Formatter();
                         ft.Add<uint16_t>(speed);
-                        DrawTextBasic(dpi, screenPos, STR_AVERAGE_SPEED, ft);
+                        DrawTextBasic(rt, screenPos, STR_AVERAGE_SPEED, ft);
                         screenPos.y += kListRowHeight;
                     }
                 }
@@ -273,7 +273,7 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<StringId>(STR_RIDE_LENGTH_ENTRY);
                 ft.Add<uint16_t>(td.statistics.rideLength);
-                DrawTextEllipsised(dpi, screenPos, 214, STR_TRACK_LIST_RIDE_LENGTH, ft);
+                DrawTextEllipsised(rt, screenPos, 214, STR_TRACK_LIST_RIDE_LENGTH, ft);
                 screenPos.y += kListRowHeight;
             }
 
@@ -284,7 +284,7 @@ namespace OpenRCT2::Ui::Windows
                     int32_t gForces = td.statistics.maxPositiveVerticalG;
                     auto ft = Formatter();
                     ft.Add<int32_t>(gForces);
-                    DrawTextBasic(dpi, screenPos, STR_MAX_POSITIVE_VERTICAL_G, ft);
+                    DrawTextBasic(rt, screenPos, STR_MAX_POSITIVE_VERTICAL_G, ft);
                     screenPos.y += kListRowHeight;
                 }
                 // Maximum negative vertical Gs
@@ -292,7 +292,7 @@ namespace OpenRCT2::Ui::Windows
                     int32_t gForces = td.statistics.maxNegativeVerticalG;
                     auto ft = Formatter();
                     ft.Add<int32_t>(gForces);
-                    DrawTextBasic(dpi, screenPos, STR_MAX_NEGATIVE_VERTICAL_G, ft);
+                    DrawTextBasic(rt, screenPos, STR_MAX_NEGATIVE_VERTICAL_G, ft);
                     screenPos.y += kListRowHeight;
                 }
                 // Maximum lateral Gs
@@ -300,7 +300,7 @@ namespace OpenRCT2::Ui::Windows
                     int32_t gForces = td.statistics.maxLateralG;
                     auto ft = Formatter();
                     ft.Add<int32_t>(gForces);
-                    DrawTextBasic(dpi, screenPos, STR_MAX_LATERAL_G, ft);
+                    DrawTextBasic(rt, screenPos, STR_MAX_LATERAL_G, ft);
                     screenPos.y += kListRowHeight;
                 }
                 if (td.statistics.totalAirTime != 0)
@@ -308,7 +308,7 @@ namespace OpenRCT2::Ui::Windows
                     int32_t airTime = ToHumanReadableAirTime(td.statistics.totalAirTime);
                     auto ft = Formatter();
                     ft.Add<int32_t>(airTime);
-                    DrawTextBasic(dpi, screenPos, STR_TOTAL_AIR_TIME, ft);
+                    DrawTextBasic(rt, screenPos, STR_TOTAL_AIR_TIME, ft);
                     screenPos.y += kListRowHeight;
                 }
             }
@@ -317,11 +317,11 @@ namespace OpenRCT2::Ui::Windows
             {
                 auto ft = Formatter();
                 ft.Add<uint16_t>(td.statistics.drops);
-                DrawTextBasic(dpi, screenPos, STR_DROPS, ft);
+                DrawTextBasic(rt, screenPos, STR_DROPS, ft);
                 screenPos.y += kListRowHeight;
 
                 // Drop height is multiplied by 0.75
-                DrawTextBasic(dpi, screenPos, STR_HIGHEST_DROP_HEIGHT, ft);
+                DrawTextBasic(rt, screenPos, STR_HIGHEST_DROP_HEIGHT, ft);
                 screenPos.y += kListRowHeight;
             }
 
@@ -330,7 +330,7 @@ namespace OpenRCT2::Ui::Windows
                 // Inversions
                 auto ft = Formatter();
                 ft.Add<uint16_t>(td.statistics.inversions);
-                DrawTextBasic(dpi, screenPos, STR_INVERSIONS, ft);
+                DrawTextBasic(rt, screenPos, STR_INVERSIONS, ft);
                 screenPos.y += kListRowHeight;
             }
 
@@ -342,7 +342,7 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<uint16_t>(td.statistics.spaceRequired.x);
                 ft.Add<uint16_t>(td.statistics.spaceRequired.y);
-                DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_SPACE_REQUIRED, ft);
+                DrawTextBasic(rt, screenPos, STR_TRACK_LIST_SPACE_REQUIRED, ft);
                 screenPos.y += kListRowHeight;
             }
 
@@ -350,7 +350,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 auto ft = Formatter();
                 ft.Add<money64>(td.gameStateData.cost);
-                DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_COST_AROUND, ft);
+                DrawTextBasic(rt, screenPos, STR_TRACK_LIST_COST_AROUND, ft);
             }
         }
 

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -251,7 +251,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_PREVIEW].image = ImageId(LandTool::SizeToSpriteIndex(gLandToolSize));
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             ScreenCoordsXY screenCoords;
             int32_t numTiles;
@@ -835,7 +835,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawDropdownButtons(DrawPixelInfo& dpi)
+        void DrawDropdownButtons(RenderTarget& dpi)
         {
             auto& objManager = GetContext()->GetObjectManager();
             const auto* surfaceObj = objManager.GetLoadedObject<TerrainSurfaceObject>(_selectedFloorTexture);
@@ -858,7 +858,7 @@ namespace OpenRCT2::Ui::Windows
             DrawDropdownButton(dpi, WIDX_WALL, edgeImage);
         }
 
-        void DrawDropdownButton(DrawPixelInfo& dpi, WidgetIndex widgetIndex, ImageId image)
+        void DrawDropdownButton(RenderTarget& dpi, WidgetIndex widgetIndex, ImageId image)
         {
             const auto& widget = widgets[widgetIndex];
             GfxDrawSprite(dpi, image, { windowPos.x + widget.left, windowPos.y + widget.top });

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -251,15 +251,15 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_PREVIEW].image = ImageId(LandTool::SizeToSpriteIndex(gLandToolSize));
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             ScreenCoordsXY screenCoords;
             int32_t numTiles;
             money64 price;
             Widget* previewWidget = &widgets[WIDX_PREVIEW];
 
-            DrawWidgets(dpi);
-            DrawDropdownButtons(dpi);
+            DrawWidgets(rt);
+            DrawDropdownButtons(rt);
 
             // Draw number for tool sizes bigger than 7
             if (gLandToolSize > kLandToolMaximumSizeWithSprite)
@@ -268,15 +268,15 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<uint16_t>(gLandToolSize);
                 screenCoords = { windowPos.x + previewWidget->midX(), windowPos.y + previewWidget->midY() };
                 DrawTextBasic(
-                    dpi, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, ft, { TextAlignment::CENTRE });
+                    rt, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, ft, { TextAlignment::CENTRE });
             }
             else if (_landToolMountainMode)
             {
                 screenCoords = { windowPos.x + previewWidget->left, windowPos.y + previewWidget->top };
                 auto sprite = ImageId(gLandToolSize % 2 == 0 ? SPR_G2_MOUNTAIN_TOOL_EVEN : SPR_G2_MOUNTAIN_TOOL_ODD);
-                GfxDrawSprite(dpi, sprite, screenCoords);
-                WidgetDraw(dpi, *this, WIDX_DECREMENT);
-                WidgetDraw(dpi, *this, WIDX_INCREMENT);
+                GfxDrawSprite(rt, sprite, screenCoords);
+                WidgetDraw(rt, *this, WIDX_DECREMENT);
+                WidgetDraw(rt, *this, WIDX_INCREMENT);
             }
 
             screenCoords = { windowPos.x + previewWidget->midX(), windowPos.y + previewWidget->bottom + 5 };
@@ -288,7 +288,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     auto ft = Formatter();
                     ft.Add<money64>(_landToolRaiseCost);
-                    DrawTextBasic(dpi, screenCoords, STR_RAISE_COST_AMOUNT, ft, { TextAlignment::CENTRE });
+                    DrawTextBasic(rt, screenCoords, STR_RAISE_COST_AMOUNT, ft, { TextAlignment::CENTRE });
                 }
                 screenCoords.y += 10;
 
@@ -297,7 +297,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     auto ft = Formatter();
                     ft.Add<money64>(_landToolLowerCost);
-                    DrawTextBasic(dpi, screenCoords, STR_LOWER_COST_AMOUNT, ft, { TextAlignment::CENTRE });
+                    DrawTextBasic(rt, screenCoords, STR_LOWER_COST_AMOUNT, ft, { TextAlignment::CENTRE });
                 }
                 screenCoords.y += 50;
 
@@ -321,7 +321,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     auto ft = Formatter();
                     ft.Add<money64>(price);
-                    DrawTextBasic(dpi, screenCoords, STR_COST_AMOUNT, ft, { TextAlignment::CENTRE });
+                    DrawTextBasic(rt, screenCoords, STR_COST_AMOUNT, ft, { TextAlignment::CENTRE });
                 }
             }
         }
@@ -835,7 +835,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawDropdownButtons(RenderTarget& dpi)
+        void DrawDropdownButtons(RenderTarget& rt)
         {
             auto& objManager = GetContext()->GetObjectManager();
             const auto* surfaceObj = objManager.GetLoadedObject<TerrainSurfaceObject>(_selectedFloorTexture);
@@ -854,14 +854,14 @@ namespace OpenRCT2::Ui::Windows
                 edgeImage = ImageId(edgeObj->IconImageId);
             }
 
-            DrawDropdownButton(dpi, WIDX_FLOOR, surfaceImage);
-            DrawDropdownButton(dpi, WIDX_WALL, edgeImage);
+            DrawDropdownButton(rt, WIDX_FLOOR, surfaceImage);
+            DrawDropdownButton(rt, WIDX_WALL, edgeImage);
         }
 
-        void DrawDropdownButton(RenderTarget& dpi, WidgetIndex widgetIndex, ImageId image)
+        void DrawDropdownButton(RenderTarget& rt, WidgetIndex widgetIndex, ImageId image)
         {
             const auto& widget = widgets[widgetIndex];
-            GfxDrawSprite(dpi, image, { windowPos.x + widget.left, windowPos.y + widget.top });
+            GfxDrawSprite(rt, image, { windowPos.x + widget.left, windowPos.y + widget.top });
         }
     };
 

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -392,19 +392,19 @@ namespace OpenRCT2::Ui::Windows
             Invalidate();
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             auto screenCoords = ScreenCoordsXY{ windowPos.x + widgets[WIDX_PREVIEW].midX(),
                                                 windowPos.y + widgets[WIDX_PREVIEW].midY() };
 
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
             // Draw number for tool sizes bigger than 7
             if (gLandToolSize > kLandToolMaximumSizeWithSprite)
             {
                 auto ft = Formatter();
                 ft.Add<uint16_t>(gLandToolSize);
                 DrawTextBasic(
-                    dpi, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, ft, { TextAlignment::CENTRE });
+                    rt, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, ft, { TextAlignment::CENTRE });
             }
 
             // Draw cost amount
@@ -418,7 +418,7 @@ namespace OpenRCT2::Ui::Windows
 
                 screenCoords = { widgets[WIDX_PREVIEW].midX() + windowPos.x,
                                  widgets[WIDX_PREVIEW].bottom + windowPos.y + offset };
-                DrawTextBasic(dpi, screenCoords, STR_COST_AMOUNT, ft, { TextAlignment::CENTRE });
+                DrawTextBasic(rt, screenCoords, STR_COST_AMOUNT, ft, { TextAlignment::CENTRE });
             }
         }
 

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -392,7 +392,7 @@ namespace OpenRCT2::Ui::Windows
             Invalidate();
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             auto screenCoords = ScreenCoordsXY{ windowPos.x + widgets[WIDX_PREVIEW].midX(),
                                                 windowPos.y + widgets[WIDX_PREVIEW].midY() };

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -385,7 +385,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawPreview(DrawPixelInfo& dpi)
+        void DrawPreview(RenderTarget& dpi)
         {
             constexpr auto kPreviewHeight = kPreviewWidth / 5 * 4;
 
@@ -690,7 +690,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
 
@@ -729,7 +729,7 @@ namespace OpenRCT2::Ui::Windows
                     auto ft = Formatter();
                     ft.Add<StringId>(indicatorId);
 
-                    auto cdpi = const_cast<const DrawPixelInfo&>(dpi);
+                    auto cdpi = const_cast<const RenderTarget&>(dpi);
                     DrawTextEllipsised(
                         cdpi, windowPos + ScreenCoordsXY{ widget.left + 5, widget.top + 1 }, widget.width(), strId, ft,
                         { COLOUR_GREY });
@@ -1029,7 +1029,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             GfxFillRect(
                 dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } },

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -1032,8 +1032,7 @@ namespace OpenRCT2::Ui::Windows
         void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             GfxFillRect(
-                rt, { { rt.x, rt.y }, { rt.x + rt.width - 1, rt.y + rt.height - 1 } },
-                ColourMapA[colours[1].colour].mid_light);
+                rt, { { rt.x, rt.y }, { rt.x + rt.width - 1, rt.y + rt.height - 1 } }, ColourMapA[colours[1].colour].mid_light);
 
             const int32_t listWidth = widgets[WIDX_SCROLL].width();
             const auto sizeColumnLeft = widgets[WIDX_SORT_SIZE].left;

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -385,7 +385,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawPreview(RenderTarget& dpi)
+        void DrawPreview(RenderTarget& rt)
         {
             constexpr auto kPreviewHeight = kPreviewWidth / 5 * 4;
 
@@ -393,7 +393,7 @@ namespace OpenRCT2::Ui::Windows
             auto& widget = widgets[WIDX_SCROLL];
             auto frameStartPos = windowPos + ScreenCoordsXY(width - kPreviewWidth - kPadding - 1, widget.top);
             auto frameEndPos = frameStartPos + ScreenCoordsXY(kPreviewWidth + 1, kPreviewHeight + 1);
-            GfxFillRectInset(dpi, { frameStartPos, frameEndPos }, colours[1], INSET_RECT_F_60 | INSET_RECT_FLAG_FILL_MID_LIGHT);
+            GfxFillRectInset(rt, { frameStartPos, frameEndPos }, colours[1], INSET_RECT_F_60 | INSET_RECT_FLAG_FILL_MID_LIGHT);
 
             // Draw park name
             {
@@ -401,7 +401,7 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<StringId>(STR_STRING);
                 ft.Add<const char*>(_preview.parkName.c_str());
-                DrawTextEllipsised(dpi, namePos, kPreviewWidth, STR_WINDOW_COLOUR_2_STRINGID, ft, { TextAlignment::CENTRE });
+                DrawTextEllipsised(rt, namePos, kPreviewWidth, STR_WINDOW_COLOUR_2_STRINGID, ft, { TextAlignment::CENTRE });
             }
 
             // Draw image, if available
@@ -411,7 +411,7 @@ namespace OpenRCT2::Ui::Windows
                 if (image.type == PreviewImageType::screenshot)
                 {
                     auto imagePos = frameStartPos + ScreenCoordsXY(1, 1);
-                    drawPreviewImage(image, dpi, imagePos);
+                    drawPreviewImage(image, rt, imagePos);
                     foundImage = true;
                     break;
                 }
@@ -422,7 +422,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 auto imagePos = frameStartPos + ScreenCoordsXY(1, 1);
                 auto colour = ColourMapA[colours[1].colour].dark;
-                GfxDrawSpriteSolid(dpi, ImageId(SPR_G2_LOGO_MONO_DITHERED), imagePos, colour);
+                GfxDrawSpriteSolid(rt, ImageId(SPR_G2_LOGO_MONO_DITHERED), imagePos, colour);
 
                 auto textPos = imagePos + ScreenCoordsXY(kPreviewWidth / 2, kPreviewHeight / 2 - 6);
 
@@ -434,7 +434,7 @@ namespace OpenRCT2::Ui::Windows
                 }
 
                 DrawTextBasic(
-                    dpi, textPos, previewText, {},
+                    rt, textPos, previewText, {},
                     { ColourWithFlags{ COLOUR_WHITE }.withFlag(ColourFlag::withOutline, true), TextAlignment::CENTRE });
                 return;
             }
@@ -448,7 +448,7 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<StringId>(DateDayNames[_preview.day]);
                 ft.Add<int16_t>(_preview.month);
                 ft.Add<int16_t>(_preview.year + 1);
-                DrawTextBasic(dpi, summaryCoords, STR_SUMMARY_DATE, ft);
+                DrawTextBasic(rt, summaryCoords, STR_SUMMARY_DATE, ft);
                 summaryCoords.y += kListRowHeight;
             }
 
@@ -456,7 +456,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 auto ft = Formatter();
                 ft.Add<money64>(_preview.parkRating);
-                DrawTextBasic(dpi, summaryCoords, STR_SUMMARY_PARK_RATING, ft);
+                DrawTextBasic(rt, summaryCoords, STR_SUMMARY_PARK_RATING, ft);
                 summaryCoords.y += kListRowHeight;
             }
 
@@ -465,7 +465,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 auto ft = Formatter();
                 ft.Add<money64>(_preview.cash);
-                DrawTextBasic(dpi, summaryCoords, STR_SUMMARY_CASH, ft);
+                DrawTextBasic(rt, summaryCoords, STR_SUMMARY_CASH, ft);
                 summaryCoords.y += kListRowHeight;
             }
 
@@ -473,7 +473,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 auto ft = Formatter();
                 ft.Add<money64>(_preview.numRides);
-                DrawTextBasic(dpi, summaryCoords, STR_SUMMARY_NUM_RIDES, ft);
+                DrawTextBasic(rt, summaryCoords, STR_SUMMARY_NUM_RIDES, ft);
                 summaryCoords.y += kListRowHeight;
             }
 
@@ -481,7 +481,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 auto ft = Formatter();
                 ft.Add<money64>(_preview.numGuests);
-                DrawTextBasic(dpi, summaryCoords, STR_SUMMARY_NUM_GUESTS, ft);
+                DrawTextBasic(rt, summaryCoords, STR_SUMMARY_NUM_GUESTS, ft);
                 summaryCoords.y += kListRowHeight;
             }
         }
@@ -690,12 +690,12 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             if (ShowPreviews())
-                DrawPreview(dpi);
+                DrawPreview(rt);
 
             {
                 const auto& widget = widgets[WIDX_PARENT_FOLDER];
@@ -715,11 +715,11 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<const char*>(normalisedPathC);
 
                 auto pathPos = windowPos + ScreenCoordsXY{ 4, widget.top + 4 };
-                DrawTextEllipsised(dpi, pathPos, pathWidth, STR_STRING, ft);
+                DrawTextEllipsised(rt, pathPos, pathWidth, STR_STRING, ft);
             }
 
             const auto drawButtonCaption =
-                [dpi, this](Widget& widget, StringId strId, FileBrowserSort ascSort, FileBrowserSort descSort) {
+                [rt, this](Widget& widget, StringId strId, FileBrowserSort ascSort, FileBrowserSort descSort) {
                     StringId indicatorId = kStringIdNone;
                     if (Config::Get().general.LoadSaveSort == ascSort)
                         indicatorId = STR_UP;
@@ -729,7 +729,7 @@ namespace OpenRCT2::Ui::Windows
                     auto ft = Formatter();
                     ft.Add<StringId>(indicatorId);
 
-                    auto cdpi = const_cast<const RenderTarget&>(dpi);
+                    auto cdpi = const_cast<const RenderTarget&>(rt);
                     DrawTextEllipsised(
                         cdpi, windowPos + ScreenCoordsXY{ widget.left + 5, widget.top + 1 }, widget.width(), strId, ft,
                         { COLOUR_GREY });
@@ -752,7 +752,7 @@ namespace OpenRCT2::Ui::Windows
             if (action == LoadSaveAction::save)
             {
                 auto& widget = widgets[WIDX_FILENAME_TEXTBOX];
-                DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ 5, widget.top + 2 }, STR_FILENAME_LABEL, {}, { COLOUR_GREY });
+                DrawTextBasic(rt, windowPos + ScreenCoordsXY{ 5, widget.top + 2 }, STR_FILENAME_LABEL, {}, { COLOUR_GREY });
             }
         }
 
@@ -1029,10 +1029,10 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             GfxFillRect(
-                dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } },
+                rt, { { rt.x, rt.y }, { rt.x + rt.width - 1, rt.y + rt.height - 1 } },
                 ColourMapA[colours[1].colour].mid_light);
 
             const int32_t listWidth = widgets[WIDX_SCROLL].width();
@@ -1045,10 +1045,10 @@ namespace OpenRCT2::Ui::Windows
             for (int32_t i = 0; i < no_list_items; i++)
             {
                 int32_t y = i * kScrollableRowHeight;
-                if (y > dpi.y + dpi.height)
+                if (y > rt.y + rt.height)
                     break;
 
-                if (y + kScrollableRowHeight < dpi.y)
+                if (y + kScrollableRowHeight < rt.y)
                     continue;
 
                 StringId stringId = STR_BLACK_STRING;
@@ -1057,20 +1057,20 @@ namespace OpenRCT2::Ui::Windows
                 if (i == selected_list_item)
                 {
                     stringId = STR_WINDOW_COLOUR_2_STRINGID;
-                    GfxFilterRect(dpi, { 0, y, listWidth, y + kScrollableRowHeight }, FilterPaletteID::PaletteDarken1);
+                    GfxFilterRect(rt, { 0, y, listWidth, y + kScrollableRowHeight }, FilterPaletteID::PaletteDarken1);
                 }
                 // display a marker next to the currently loaded game file
                 if (_listItems[i].loaded)
                 {
                     auto ft = Formatter();
                     ft.Add<StringId>(STR_RIGHTGUILLEMET);
-                    DrawTextBasic(dpi, { 0, y }, stringId, ft);
+                    DrawTextBasic(rt, { 0, y }, stringId, ft);
                 }
 
                 // Folders get a folder icon
                 if (_listItems[i].type == FileType::directory)
                 {
-                    GfxDrawSprite(dpi, ImageId(SPR_G2_FOLDER), { 1, y });
+                    GfxDrawSprite(rt, ImageId(SPR_G2_FOLDER), { 1, y });
                 }
 
                 // Print filename
@@ -1078,7 +1078,7 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<StringId>(STR_STRING);
                 ft.Add<char*>(_listItems[i].name.c_str());
                 int32_t max_file_width = widgets[WIDX_SORT_NAME].width() - 15;
-                DrawTextEllipsised(dpi, { 15, y }, max_file_width, stringId, ft);
+                DrawTextEllipsised(rt, { 15, y }, max_file_width, stringId, ft);
 
                 // Print formatted modified date, if this is a file
                 if (_listItems[i].type != FileType::file)
@@ -1090,7 +1090,7 @@ namespace OpenRCT2::Ui::Windows
                     ft.Add<StringId>(STR_FILEBROWSER_FILE_SIZE_VALUE);
                     ft.Add<uint32_t>(_listItems[i].fileSizeFormatted);
                     ft.Add<StringId>(_listItems[i].fileSizeUnit);
-                    DrawTextEllipsised(dpi, { sizeColumnLeft + 2, y }, maxDateWidth + maxTimeWidth, stringId, ft);
+                    DrawTextEllipsised(rt, { sizeColumnLeft + 2, y }, maxDateWidth + maxTimeWidth, stringId, ft);
                 }
 
                 if (config.FileBrowserShowDateColumn)
@@ -1099,12 +1099,12 @@ namespace OpenRCT2::Ui::Windows
                     ft.Add<StringId>(STR_STRING);
                     ft.Add<char*>(_listItems[i].dateFormatted.c_str());
                     DrawTextEllipsised(
-                        dpi, { dateAnchor - kDateTimeGap, y }, maxDateWidth, stringId, ft, { TextAlignment::RIGHT });
+                        rt, { dateAnchor - kDateTimeGap, y }, maxDateWidth, stringId, ft, { TextAlignment::RIGHT });
 
                     ft = Formatter();
                     ft.Add<StringId>(STR_STRING);
                     ft.Add<char*>(_listItems[i].timeFormatted.c_str());
-                    DrawTextEllipsised(dpi, { dateAnchor + kDateTimeGap, y }, maxTimeWidth, stringId, ft);
+                    DrawTextEllipsised(rt, { dateAnchor + kDateTimeGap, y }, maxTimeWidth, stringId, ft);
                 }
             }
         }

--- a/src/openrct2-ui/windows/Main.cpp
+++ b/src/openrct2-ui/windows/Main.cpp
@@ -46,9 +46,9 @@ namespace OpenRCT2::Ui::Windows
             WindowFootpathResetSelectedPath();
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            ViewportRender(dpi, viewport);
+            ViewportRender(rt, viewport);
         }
 
     private:

--- a/src/openrct2-ui/windows/Main.cpp
+++ b/src/openrct2-ui/windows/Main.cpp
@@ -46,7 +46,7 @@ namespace OpenRCT2::Ui::Windows
             WindowFootpathResetSelectedPath();
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             ViewportRender(dpi, viewport);
         }

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -566,9 +566,9 @@ namespace OpenRCT2::Ui::Windows
             OnScrollMouseDown(scrollIndex, screenCoords);
         }
 
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
-            GfxClear(dpi, PaletteIndex::pi10);
+            GfxClear(rt, PaletteIndex::pi10);
 
             // Ensure small maps are centred
             auto screenOffset = ScreenCoordsXY(0, 0);
@@ -582,17 +582,17 @@ namespace OpenRCT2::Ui::Windows
             g1temp.height = getMiniMapWidth();
             GfxSetG1Element(SPR_TEMP, &g1temp);
             DrawingEngineInvalidateImage(SPR_TEMP);
-            GfxDrawSprite(dpi, ImageId(SPR_TEMP), screenOffset);
+            GfxDrawSprite(rt, ImageId(SPR_TEMP), screenOffset);
 
             if (selected_tab == PAGE_PEEPS)
             {
-                PaintPeepOverlay(dpi, screenOffset);
+                PaintPeepOverlay(rt, screenOffset);
             }
             else
             {
-                PaintTrainOverlay(dpi, screenOffset);
+                PaintTrainOverlay(rt, screenOffset);
             }
-            PaintHudRectangle(dpi, screenOffset);
+            PaintHudRectangle(rt, screenOffset);
         }
 
         void OnPrepareDraw() override
@@ -661,10 +661,10 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             if (!isEditorOrSandbox())
             {
@@ -678,9 +678,9 @@ namespace OpenRCT2::Ui::Windows
                     for (uint32_t i = 0; i < std::size(RideKeyColours); i++)
                     {
                         GfxFillRect(
-                            dpi, { screenCoords + ScreenCoordsXY{ 0, 2 }, screenCoords + ScreenCoordsXY{ 6, 8 } },
+                            rt, { screenCoords + ScreenCoordsXY{ 0, 2 }, screenCoords + ScreenCoordsXY{ 6, 8 } },
                             RideKeyColours[i]);
-                        DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ kListRowHeight, 0 }, MapLabels[i], {});
+                        DrawTextBasic(rt, screenCoords + ScreenCoordsXY{ kListRowHeight, 0 }, MapLabels[i], {});
                         screenCoords.y += kListRowHeight;
                         if (i == 3)
                         {
@@ -692,7 +692,7 @@ namespace OpenRCT2::Ui::Windows
             else if (!isToolActive(*this, WIDX_SET_LAND_RIGHTS))
             {
                 DrawTextBasic(
-                    dpi, windowPos + ScreenCoordsXY{ 4, widgets[WIDX_MAP_SIZE_SPINNER_Y].top + 1 }, STR_MAP_SIZE, {},
+                    rt, windowPos + ScreenCoordsXY{ 4, widgets[WIDX_MAP_SIZE_SPINNER_Y].top + 1 }, STR_MAP_SIZE, {},
                     { colours[1] });
             }
         }
@@ -951,21 +951,21 @@ namespace OpenRCT2::Ui::Windows
             return colourB;
         }
 
-        void PaintPeepOverlay(RenderTarget& dpi, const ScreenCoordsXY& offset)
+        void PaintPeepOverlay(RenderTarget& rt, const ScreenCoordsXY& offset)
         {
             auto flashColour = GetGuestFlashColour();
             for (auto guest : EntityList<Guest>())
             {
-                DrawMapPeepPixel(guest, flashColour, dpi, offset);
+                DrawMapPeepPixel(guest, flashColour, rt, offset);
             }
             flashColour = GetStaffFlashColour();
             for (auto staff : EntityList<Staff>())
             {
-                DrawMapPeepPixel(staff, flashColour, dpi, offset);
+                DrawMapPeepPixel(staff, flashColour, rt, offset);
             }
         }
 
-        void DrawMapPeepPixel(Peep* peep, const uint8_t flashColour, RenderTarget& dpi, const ScreenCoordsXY& offset)
+        void DrawMapPeepPixel(Peep* peep, const uint8_t flashColour, RenderTarget& rt, const ScreenCoordsXY& offset)
         {
             if (peep->x == kLocationNull)
                 return;
@@ -984,7 +984,7 @@ namespace OpenRCT2::Ui::Windows
                 }
             }
 
-            GfxFillRect(dpi, { leftTop, rightBottom }, colour);
+            GfxFillRect(rt, { leftTop, rightBottom }, colour);
         }
 
         uint8_t GetGuestFlashColour() const
@@ -1011,7 +1011,7 @@ namespace OpenRCT2::Ui::Windows
             return colour;
         }
 
-        void PaintTrainOverlay(RenderTarget& dpi, const ScreenCoordsXY& offset)
+        void PaintTrainOverlay(RenderTarget& rt, const ScreenCoordsXY& offset)
         {
             for (auto train : TrainManager::View())
             {
@@ -1023,7 +1023,7 @@ namespace OpenRCT2::Ui::Windows
                     auto mapCoord = TransformToMapCoords({ vehicle->x, vehicle->y });
                     auto pixelCoord = ScreenCoordsXY{ mapCoord.x, mapCoord.y } + offset;
 
-                    GfxFillRect(dpi, { pixelCoord, pixelCoord }, PaletteIndex::pi171);
+                    GfxFillRect(rt, { pixelCoord, pixelCoord }, PaletteIndex::pi171);
                 }
             }
         }
@@ -1032,7 +1032,7 @@ namespace OpenRCT2::Ui::Windows
          * The call to GfxFillRect was originally wrapped in Sub68DABD which made sure that arguments were ordered correctly,
          * but it doesn't look like it's ever necessary here so the call was removed.
          */
-        void PaintHudRectangle(RenderTarget& dpi, const ScreenCoordsXY& widgetOffset)
+        void PaintHudRectangle(RenderTarget& rt, const ScreenCoordsXY& widgetOffset)
         {
             WindowBase* mainWindow = WindowGetMain();
             if (mainWindow == nullptr)
@@ -1054,23 +1054,23 @@ namespace OpenRCT2::Ui::Windows
             auto leftBottom = ScreenCoordsXY{ leftTop.x, rightBottom.y };
 
             // top horizontal lines
-            GfxFillRect(dpi, { leftTop, leftTop + ScreenCoordsXY{ 3, 0 } }, PaletteIndex::pi56);
-            GfxFillRect(dpi, { rightTop - ScreenCoordsXY{ 3, 0 }, rightTop }, PaletteIndex::pi56);
+            GfxFillRect(rt, { leftTop, leftTop + ScreenCoordsXY{ 3, 0 } }, PaletteIndex::pi56);
+            GfxFillRect(rt, { rightTop - ScreenCoordsXY{ 3, 0 }, rightTop }, PaletteIndex::pi56);
 
             // left vertical lines
-            GfxFillRect(dpi, { leftTop, leftTop + ScreenCoordsXY{ 0, 3 } }, PaletteIndex::pi56);
-            GfxFillRect(dpi, { leftBottom - ScreenCoordsXY{ 0, 3 }, leftBottom }, PaletteIndex::pi56);
+            GfxFillRect(rt, { leftTop, leftTop + ScreenCoordsXY{ 0, 3 } }, PaletteIndex::pi56);
+            GfxFillRect(rt, { leftBottom - ScreenCoordsXY{ 0, 3 }, leftBottom }, PaletteIndex::pi56);
 
             // bottom horizontal lines
-            GfxFillRect(dpi, { leftBottom, leftBottom + ScreenCoordsXY{ 3, 0 } }, PaletteIndex::pi56);
-            GfxFillRect(dpi, { rightBottom - ScreenCoordsXY{ 3, 0 }, rightBottom }, PaletteIndex::pi56);
+            GfxFillRect(rt, { leftBottom, leftBottom + ScreenCoordsXY{ 3, 0 } }, PaletteIndex::pi56);
+            GfxFillRect(rt, { rightBottom - ScreenCoordsXY{ 3, 0 }, rightBottom }, PaletteIndex::pi56);
 
             // right vertical lines
-            GfxFillRect(dpi, { rightTop, rightTop + ScreenCoordsXY{ 0, 3 } }, PaletteIndex::pi56);
-            GfxFillRect(dpi, { rightBottom - ScreenCoordsXY{ 0, 3 }, rightBottom }, PaletteIndex::pi56);
+            GfxFillRect(rt, { rightTop, rightTop + ScreenCoordsXY{ 0, 3 } }, PaletteIndex::pi56);
+            GfxFillRect(rt, { rightBottom - ScreenCoordsXY{ 0, 3 }, rightBottom }, PaletteIndex::pi56);
         }
 
-        void DrawTabImages(RenderTarget& dpi)
+        void DrawTabImages(RenderTarget& rt)
         {
             // Guest tab image (animated)
             uint32_t guestTabImage = SPR_TAB_GUESTS_0;
@@ -1078,7 +1078,7 @@ namespace OpenRCT2::Ui::Windows
                 guestTabImage += list_information_type / 4;
 
             GfxDrawSprite(
-                dpi, ImageId(guestTabImage),
+                rt, ImageId(guestTabImage),
                 windowPos + ScreenCoordsXY{ widgets[WIDX_PEOPLE_TAB].left, widgets[WIDX_PEOPLE_TAB].top });
 
             // Ride/stall tab image (animated)
@@ -1087,7 +1087,7 @@ namespace OpenRCT2::Ui::Windows
                 rideTabImage += list_information_type / 4;
 
             GfxDrawSprite(
-                dpi, ImageId(rideTabImage),
+                rt, ImageId(rideTabImage),
                 windowPos + ScreenCoordsXY{ widgets[WIDX_RIDES_TAB].left, widgets[WIDX_RIDES_TAB].top });
         }
 

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -566,7 +566,7 @@ namespace OpenRCT2::Ui::Windows
             OnScrollMouseDown(scrollIndex, screenCoords);
         }
 
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             GfxClear(dpi, PaletteIndex::pi10);
 
@@ -661,7 +661,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -951,7 +951,7 @@ namespace OpenRCT2::Ui::Windows
             return colourB;
         }
 
-        void PaintPeepOverlay(DrawPixelInfo& dpi, const ScreenCoordsXY& offset)
+        void PaintPeepOverlay(RenderTarget& dpi, const ScreenCoordsXY& offset)
         {
             auto flashColour = GetGuestFlashColour();
             for (auto guest : EntityList<Guest>())
@@ -965,7 +965,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawMapPeepPixel(Peep* peep, const uint8_t flashColour, DrawPixelInfo& dpi, const ScreenCoordsXY& offset)
+        void DrawMapPeepPixel(Peep* peep, const uint8_t flashColour, RenderTarget& dpi, const ScreenCoordsXY& offset)
         {
             if (peep->x == kLocationNull)
                 return;
@@ -1011,7 +1011,7 @@ namespace OpenRCT2::Ui::Windows
             return colour;
         }
 
-        void PaintTrainOverlay(DrawPixelInfo& dpi, const ScreenCoordsXY& offset)
+        void PaintTrainOverlay(RenderTarget& dpi, const ScreenCoordsXY& offset)
         {
             for (auto train : TrainManager::View())
             {
@@ -1032,7 +1032,7 @@ namespace OpenRCT2::Ui::Windows
          * The call to GfxFillRect was originally wrapped in Sub68DABD which made sure that arguments were ordered correctly,
          * but it doesn't look like it's ever necessary here so the call was removed.
          */
-        void PaintHudRectangle(DrawPixelInfo& dpi, const ScreenCoordsXY& widgetOffset)
+        void PaintHudRectangle(RenderTarget& dpi, const ScreenCoordsXY& widgetOffset)
         {
             WindowBase* mainWindow = WindowGetMain();
             if (mainWindow == nullptr)
@@ -1070,7 +1070,7 @@ namespace OpenRCT2::Ui::Windows
             GfxFillRect(dpi, { rightBottom - ScreenCoordsXY{ 0, 3 }, rightBottom }, PaletteIndex::pi56);
         }
 
-        void DrawTabImages(DrawPixelInfo& dpi)
+        void DrawTabImages(RenderTarget& dpi)
         {
             // Guest tab image (animated)
             uint32_t guestTabImage = SPR_TAB_GUESTS_0;

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -297,7 +297,7 @@ namespace OpenRCT2::Ui::Windows
             pressed_widgets |= 1LL << (WIDX_TAB_1 + page);
         }
 
-        void DrawTabImage(DrawPixelInfo& dpi, int32_t newPage, int32_t spriteIndex)
+        void DrawTabImage(RenderTarget& dpi, int32_t newPage, int32_t spriteIndex)
         {
             WidgetIndex widgetIndex = WIDX_TAB_1 + newPage;
 
@@ -315,7 +315,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImages(DrawPixelInfo& dpi)
+        void DrawTabImages(RenderTarget& dpi)
         {
             DrawTabImage(dpi, WINDOW_MAPGEN_PAGE_BASE, SPR_TAB_GEARS_0);
             DrawTabImage(dpi, WINDOW_MAPGEN_PAGE_TERRAIN, SPR_G2_MAP_GEN_TERRAIN_TAB);
@@ -595,7 +595,7 @@ namespace OpenRCT2::Ui::Windows
             // clang-format on
         }
 
-        void BaseDraw(DrawPixelInfo& dpi)
+        void BaseDraw(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -757,7 +757,7 @@ namespace OpenRCT2::Ui::Windows
             SetWidgetDisabled(WIDX_TREE_ALTITUDE_MAX_DOWN, !_settings.trees || isFlatland);
         }
 
-        void ForestsDraw(DrawPixelInfo& dpi)
+        void ForestsDraw(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -862,7 +862,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void SimplexDraw(DrawPixelInfo& dpi)
+        void SimplexDraw(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -973,7 +973,7 @@ namespace OpenRCT2::Ui::Windows
             SetCheckboxValue(WIDX_HEIGHTMAP_NORMALIZE, _settings.normalize_height);
         }
 
-        void HeightmapDraw(DrawPixelInfo& dpi)
+        void HeightmapDraw(RenderTarget& dpi)
         {
             const auto enabledColour = colours[1];
             const auto disabledColour = enabledColour.withFlag(ColourFlag::inset, true);
@@ -1159,7 +1159,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawDropdownButton(DrawPixelInfo& dpi, WidgetIndex widgetIndex, ImageId image)
+        void DrawDropdownButton(RenderTarget& dpi, WidgetIndex widgetIndex, ImageId image)
         {
             const auto& widget = widgets[widgetIndex];
             ScreenCoordsXY pos = { windowPos.x + widget.left, windowPos.y + widget.top };
@@ -1181,7 +1181,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawDropdownButtons(DrawPixelInfo& dpi, WidgetIndex floorWidgetIndex, WidgetIndex edgeWidgetIndex)
+        void DrawDropdownButtons(RenderTarget& dpi, WidgetIndex floorWidgetIndex, WidgetIndex edgeWidgetIndex)
         {
             auto& objManager = GetContext()->GetObjectManager();
             const auto* surfaceObj = objManager.GetLoadedObject<TerrainSurfaceObject>(_settings.landTexture);
@@ -1223,7 +1223,7 @@ namespace OpenRCT2::Ui::Windows
             SetPressedTab();
         }
 
-        void TerrainDraw(DrawPixelInfo& dpi)
+        void TerrainDraw(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -1334,7 +1334,7 @@ namespace OpenRCT2::Ui::Windows
             SetPressedTab();
         }
 
-        void WaterDraw(DrawPixelInfo& dpi)
+        void WaterDraw(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -1446,7 +1446,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             switch (page)
             {

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -775,14 +775,13 @@ namespace OpenRCT2::Ui::Windows
             auto ft = Formatter();
             ft.Add<uint16_t>(_settings.treeToLandRatio);
             DrawTextBasic(
-                rt,
-                windowPos + ScreenCoordsXY{ widgets[WIDX_TREE_LAND_RATIO].left + 1, widgets[WIDX_TREE_LAND_RATIO].top + 1 },
+                rt, windowPos + ScreenCoordsXY{ widgets[WIDX_TREE_LAND_RATIO].left + 1, widgets[WIDX_TREE_LAND_RATIO].top + 1 },
                 STR_MAPGEN_TREE_TO_LAND_RATIO_PCT, ft, { textColour });
 
             // Minimum tree altitude, label and value
             DrawTextBasic(
-                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_TREE_ALTITUDE_MIN].top + 1 }, STR_MAPGEN_TREE_MIN_ALTITUDE,
-                {}, { textColour });
+                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_TREE_ALTITUDE_MIN].top + 1 }, STR_MAPGEN_TREE_MIN_ALTITUDE, {},
+                { textColour });
 
             ft = Formatter();
             ft.Add<int16_t>(BaseZToMetres(_settings.minTreeAltitude));
@@ -796,8 +795,8 @@ namespace OpenRCT2::Ui::Windows
             const auto maxTreeTextColour = _settings.trees && !isFlatland ? enabledColour : disabledColour;
 
             DrawTextBasic(
-                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_TREE_ALTITUDE_MAX].top + 1 }, STR_MAPGEN_TREE_MAX_ALTITUDE,
-                {}, { maxTreeTextColour });
+                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_TREE_ALTITUDE_MAX].top + 1 }, STR_MAPGEN_TREE_MAX_ALTITUDE, {},
+                { maxTreeTextColour });
 
             ft = Formatter();
             ft.Add<int16_t>(BaseZToMetres(_settings.maxTreeAltitude));
@@ -886,8 +885,7 @@ namespace OpenRCT2::Ui::Windows
             ft = Formatter();
             ft.Add<uint16_t>(_settings.simplex_octaves);
             DrawTextBasic(
-                rt,
-                windowPos + ScreenCoordsXY{ widgets[WIDX_SIMPLEX_OCTAVES].left + 1, widgets[WIDX_SIMPLEX_OCTAVES].top + 1 },
+                rt, windowPos + ScreenCoordsXY{ widgets[WIDX_SIMPLEX_OCTAVES].left + 1, widgets[WIDX_SIMPLEX_OCTAVES].top + 1 },
                 STR_COMMA16, ft, { textColour });
         }
 

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -297,7 +297,7 @@ namespace OpenRCT2::Ui::Windows
             pressed_widgets |= 1LL << (WIDX_TAB_1 + page);
         }
 
-        void DrawTabImage(RenderTarget& dpi, int32_t newPage, int32_t spriteIndex)
+        void DrawTabImage(RenderTarget& rt, int32_t newPage, int32_t spriteIndex)
         {
             WidgetIndex widgetIndex = WIDX_TAB_1 + newPage;
 
@@ -310,17 +310,17 @@ namespace OpenRCT2::Ui::Windows
                 }
 
                 GfxDrawSprite(
-                    dpi, ImageId(spriteIndex),
+                    rt, ImageId(spriteIndex),
                     windowPos + ScreenCoordsXY{ widgets[widgetIndex].left, widgets[widgetIndex].top });
             }
         }
 
-        void DrawTabImages(RenderTarget& dpi)
+        void DrawTabImages(RenderTarget& rt)
         {
-            DrawTabImage(dpi, WINDOW_MAPGEN_PAGE_BASE, SPR_TAB_GEARS_0);
-            DrawTabImage(dpi, WINDOW_MAPGEN_PAGE_TERRAIN, SPR_G2_MAP_GEN_TERRAIN_TAB);
-            DrawTabImage(dpi, WINDOW_MAPGEN_PAGE_WATER, SPR_TAB_WATER);
-            DrawTabImage(dpi, WINDOW_MAPGEN_PAGE_FORESTS, SPR_TAB_SCENERY_TREES);
+            DrawTabImage(rt, WINDOW_MAPGEN_PAGE_BASE, SPR_TAB_GEARS_0);
+            DrawTabImage(rt, WINDOW_MAPGEN_PAGE_TERRAIN, SPR_G2_MAP_GEN_TERRAIN_TAB);
+            DrawTabImage(rt, WINDOW_MAPGEN_PAGE_WATER, SPR_TAB_WATER);
+            DrawTabImage(rt, WINDOW_MAPGEN_PAGE_FORESTS, SPR_TAB_SCENERY_TREES);
         }
 
         void ChangeMapSize(int32_t sizeOffset)
@@ -595,16 +595,16 @@ namespace OpenRCT2::Ui::Windows
             // clang-format on
         }
 
-        void BaseDraw(RenderTarget& dpi)
+        void BaseDraw(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             if (_settings.algorithm == MapGenerator::Algorithm::simplexNoise)
-                SimplexDraw(dpi);
+                SimplexDraw(rt);
 
             else if (_settings.algorithm == MapGenerator::Algorithm::heightmapImage)
-                HeightmapDraw(dpi);
+                HeightmapDraw(rt);
 
             const auto enabledColour = colours[1];
             const auto disabledColour = enabledColour.withFlag(ColourFlag::inset, true);
@@ -612,13 +612,13 @@ namespace OpenRCT2::Ui::Windows
             {
                 auto textColour = IsWidgetDisabled(WIDX_MAP_SIZE_Y) ? disabledColour : enabledColour;
                 DrawTextBasic(
-                    dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_MAP_SIZE_Y].top + 1 }, STR_MAP_SIZE, {}, { textColour });
+                    rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_MAP_SIZE_Y].top + 1 }, STR_MAP_SIZE, {}, { textColour });
             }
 
             {
                 auto textColour = enabledColour;
                 DrawTextBasic(
-                    dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_HEIGHTMAP_SOURCE].top + 1 }, STR_HEIGHTMAP_SOURCE, {},
+                    rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_HEIGHTMAP_SOURCE].top + 1 }, STR_HEIGHTMAP_SOURCE, {},
                     { textColour });
             }
         }
@@ -757,10 +757,10 @@ namespace OpenRCT2::Ui::Windows
             SetWidgetDisabled(WIDX_TREE_ALTITUDE_MAX_DOWN, !_settings.trees || isFlatland);
         }
 
-        void ForestsDraw(RenderTarget& dpi)
+        void ForestsDraw(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             const auto enabledColour = colours[1];
             const auto disabledColour = enabledColour.withFlag(ColourFlag::inset, true);
@@ -769,25 +769,25 @@ namespace OpenRCT2::Ui::Windows
 
             // Tree to land ratio, label and value
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_TREE_LAND_RATIO].top + 1 }, STR_MAPGEN_TREE_TO_LAND_RATIO, {},
+                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_TREE_LAND_RATIO].top + 1 }, STR_MAPGEN_TREE_TO_LAND_RATIO, {},
                 { textColour });
 
             auto ft = Formatter();
             ft.Add<uint16_t>(_settings.treeToLandRatio);
             DrawTextBasic(
-                dpi,
+                rt,
                 windowPos + ScreenCoordsXY{ widgets[WIDX_TREE_LAND_RATIO].left + 1, widgets[WIDX_TREE_LAND_RATIO].top + 1 },
                 STR_MAPGEN_TREE_TO_LAND_RATIO_PCT, ft, { textColour });
 
             // Minimum tree altitude, label and value
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_TREE_ALTITUDE_MIN].top + 1 }, STR_MAPGEN_TREE_MIN_ALTITUDE,
+                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_TREE_ALTITUDE_MIN].top + 1 }, STR_MAPGEN_TREE_MIN_ALTITUDE,
                 {}, { textColour });
 
             ft = Formatter();
             ft.Add<int16_t>(BaseZToMetres(_settings.minTreeAltitude));
             DrawTextBasic(
-                dpi,
+                rt,
                 windowPos + ScreenCoordsXY{ widgets[WIDX_TREE_ALTITUDE_MIN].left + 1, widgets[WIDX_TREE_ALTITUDE_MIN].top + 1 },
                 STR_RIDE_LENGTH_ENTRY, ft, { textColour });
 
@@ -796,13 +796,13 @@ namespace OpenRCT2::Ui::Windows
             const auto maxTreeTextColour = _settings.trees && !isFlatland ? enabledColour : disabledColour;
 
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_TREE_ALTITUDE_MAX].top + 1 }, STR_MAPGEN_TREE_MAX_ALTITUDE,
+                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_TREE_ALTITUDE_MAX].top + 1 }, STR_MAPGEN_TREE_MAX_ALTITUDE,
                 {}, { maxTreeTextColour });
 
             ft = Formatter();
             ft.Add<int16_t>(BaseZToMetres(_settings.maxTreeAltitude));
             DrawTextBasic(
-                dpi,
+                rt,
                 windowPos + ScreenCoordsXY{ widgets[WIDX_TREE_ALTITUDE_MAX].left + 1, widgets[WIDX_TREE_ALTITUDE_MAX].top + 1 },
                 STR_RIDE_LENGTH_ENTRY, ft, { maxTreeTextColour });
         }
@@ -862,31 +862,31 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void SimplexDraw(RenderTarget& dpi)
+        void SimplexDraw(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             const auto textColour = colours[1];
 
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_SIMPLEX_BASE_FREQ].top + 1 },
+                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_SIMPLEX_BASE_FREQ].top + 1 },
                 STR_MAPGEN_SIMPLEX_NOISE_BASE_FREQUENCY, {}, { textColour });
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_SIMPLEX_OCTAVES].top + 1 }, STR_MAPGEN_SIMPLEX_NOISE_OCTAVES,
+                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_SIMPLEX_OCTAVES].top + 1 }, STR_MAPGEN_SIMPLEX_NOISE_OCTAVES,
                 {}, { textColour });
 
             auto ft = Formatter();
             ft.Add<uint16_t>(_settings.simplex_base_freq);
             DrawTextBasic(
-                dpi,
+                rt,
                 windowPos + ScreenCoordsXY{ widgets[WIDX_SIMPLEX_BASE_FREQ].left + 1, widgets[WIDX_SIMPLEX_BASE_FREQ].top + 1 },
                 STR_WINDOW_COLOUR_2_COMMA2DP32, ft, { textColour });
 
             ft = Formatter();
             ft.Add<uint16_t>(_settings.simplex_octaves);
             DrawTextBasic(
-                dpi,
+                rt,
                 windowPos + ScreenCoordsXY{ widgets[WIDX_SIMPLEX_OCTAVES].left + 1, widgets[WIDX_SIMPLEX_OCTAVES].top + 1 },
                 STR_COMMA16, ft, { textColour });
         }
@@ -973,7 +973,7 @@ namespace OpenRCT2::Ui::Windows
             SetCheckboxValue(WIDX_HEIGHTMAP_NORMALIZE, _settings.normalize_height);
         }
 
-        void HeightmapDraw(RenderTarget& dpi)
+        void HeightmapDraw(RenderTarget& rt)
         {
             const auto enabledColour = colours[1];
             const auto disabledColour = enabledColour.withFlag(ColourFlag::inset, true);
@@ -984,14 +984,14 @@ namespace OpenRCT2::Ui::Windows
 
             // Smooth strength label
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ 24, widgets[WIDX_HEIGHTMAP_STRENGTH].top + 1 }, STR_MAPGEN_SMOOTH_STRENGTH, {},
+                rt, windowPos + ScreenCoordsXY{ 24, widgets[WIDX_HEIGHTMAP_STRENGTH].top + 1 }, STR_MAPGEN_SMOOTH_STRENGTH, {},
                 { strengthColour });
 
             // Smooth strength value
             auto ft = Formatter();
             ft.Add<uint16_t>(_settings.smooth_strength);
             auto pos = ScreenCoordsXY{ widgets[WIDX_HEIGHTMAP_STRENGTH].left + 1, widgets[WIDX_HEIGHTMAP_STRENGTH].top + 1 };
-            DrawTextBasic(dpi, windowPos + pos, STR_COMMA16, ft, { strengthColour });
+            DrawTextBasic(rt, windowPos + pos, STR_COMMA16, ft, { strengthColour });
 
             // Current heightmap image filename
             ft = Formatter();
@@ -1002,7 +1002,7 @@ namespace OpenRCT2::Ui::Windows
 
             pos = ScreenCoordsXY{ 10, widgets[WIDX_HEIGHTMAP_BROWSE].top + 1 };
             auto textWidth = widgets[WIDX_HEIGHTMAP_BROWSE].left - 11;
-            DrawTextEllipsised(dpi, windowPos + pos, textWidth, STR_MAPGEN_CURRENT_HEIGHTMAP_FILE, ft);
+            DrawTextEllipsised(rt, windowPos + pos, textWidth, STR_MAPGEN_CURRENT_HEIGHTMAP_FILE, ft);
         }
 
         void HeightmapTextInput(WidgetIndex widgetIndex, int32_t value)
@@ -1159,7 +1159,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawDropdownButton(RenderTarget& dpi, WidgetIndex widgetIndex, ImageId image)
+        void DrawDropdownButton(RenderTarget& rt, WidgetIndex widgetIndex, ImageId image)
         {
             const auto& widget = widgets[widgetIndex];
             ScreenCoordsXY pos = { windowPos.x + widget.left, windowPos.y + widget.top };
@@ -1168,20 +1168,20 @@ namespace OpenRCT2::Ui::Windows
                 // Draw greyed out (light border bottom right shadow)
                 auto colour = colours[widget.colour].colour;
                 colour = ColourMapA[colour].lighter;
-                GfxDrawSpriteSolid(dpi, image, pos + ScreenCoordsXY{ 1, 1 }, colour);
+                GfxDrawSpriteSolid(rt, image, pos + ScreenCoordsXY{ 1, 1 }, colour);
 
                 // Draw greyed out (dark)
                 colour = colours[widget.colour].colour;
                 colour = ColourMapA[colour].mid_light;
-                GfxDrawSpriteSolid(dpi, image, pos, colour);
+                GfxDrawSpriteSolid(rt, image, pos, colour);
             }
             else
             {
-                GfxDrawSprite(dpi, image, pos);
+                GfxDrawSprite(rt, image, pos);
             }
         }
 
-        void DrawDropdownButtons(RenderTarget& dpi, WidgetIndex floorWidgetIndex, WidgetIndex edgeWidgetIndex)
+        void DrawDropdownButtons(RenderTarget& rt, WidgetIndex floorWidgetIndex, WidgetIndex edgeWidgetIndex)
         {
             auto& objManager = GetContext()->GetObjectManager();
             const auto* surfaceObj = objManager.GetLoadedObject<TerrainSurfaceObject>(_settings.landTexture);
@@ -1202,8 +1202,8 @@ namespace OpenRCT2::Ui::Windows
                 edgeImage = ImageId(edgeObj->IconImageId);
             }
 
-            DrawDropdownButton(dpi, floorWidgetIndex, surfaceImage);
-            DrawDropdownButton(dpi, edgeWidgetIndex, edgeImage);
+            DrawDropdownButton(rt, floorWidgetIndex, surfaceImage);
+            DrawDropdownButton(rt, edgeWidgetIndex, edgeImage);
         }
 
         void TerrainPrepareDraw()
@@ -1223,42 +1223,42 @@ namespace OpenRCT2::Ui::Windows
             SetPressedTab();
         }
 
-        void TerrainDraw(RenderTarget& dpi)
+        void TerrainDraw(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
-            DrawDropdownButtons(dpi, WIDX_FLOOR_TEXTURE, WIDX_WALL_TEXTURE);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
+            DrawDropdownButtons(rt, WIDX_FLOOR_TEXTURE, WIDX_WALL_TEXTURE);
 
             const auto enabledColour = colours[1];
             const auto disabledColour = enabledColour.withFlag(ColourFlag::inset, true);
 
             // Floor texture label
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_FLOOR_TEXTURE].top + 1 }, STR_TERRAIN_LABEL, {},
+                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_FLOOR_TEXTURE].top + 1 }, STR_TERRAIN_LABEL, {},
                 { enabledColour });
 
             // Minimum land height label and value
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_HEIGHTMAP_LOW].top + 1 }, STR_MAPGEN_MIN_LAND_HEIGHT, {},
+                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_HEIGHTMAP_LOW].top + 1 }, STR_MAPGEN_MIN_LAND_HEIGHT, {},
                 { enabledColour });
 
             auto ft = Formatter();
             ft.Add<int32_t>(BaseZToMetres(_settings.heightmapLow));
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ widgets[WIDX_HEIGHTMAP_LOW].left + 1, widgets[WIDX_HEIGHTMAP_LOW].top + 1 },
+                rt, windowPos + ScreenCoordsXY{ widgets[WIDX_HEIGHTMAP_LOW].left + 1, widgets[WIDX_HEIGHTMAP_LOW].top + 1 },
                 STR_RIDE_LENGTH_ENTRY, ft, { enabledColour });
 
             const auto maxLandColour = IsWidgetDisabled(WIDX_HEIGHTMAP_HIGH) ? disabledColour : enabledColour;
 
             // Maximum land height label and value
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_HEIGHTMAP_HIGH].top + 1 }, STR_MAPGEN_MAX_LAND_HEIGHT, {},
+                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_HEIGHTMAP_HIGH].top + 1 }, STR_MAPGEN_MAX_LAND_HEIGHT, {},
                 { maxLandColour });
 
             ft = Formatter();
             ft.Add<int32_t>(BaseZToMetres(_settings.heightmapHigh));
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ widgets[WIDX_HEIGHTMAP_HIGH].left + 1, widgets[WIDX_HEIGHTMAP_HIGH].top + 1 },
+                rt, windowPos + ScreenCoordsXY{ widgets[WIDX_HEIGHTMAP_HIGH].left + 1, widgets[WIDX_HEIGHTMAP_HIGH].top + 1 },
                 STR_RIDE_LENGTH_ENTRY, ft, { maxLandColour });
         }
 
@@ -1334,21 +1334,21 @@ namespace OpenRCT2::Ui::Windows
             SetPressedTab();
         }
 
-        void WaterDraw(RenderTarget& dpi)
+        void WaterDraw(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             const auto textColour = colours[1];
 
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_WATER_LEVEL].top + 1 }, STR_WATER_LEVEL_LABEL, {},
+                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_WATER_LEVEL].top + 1 }, STR_WATER_LEVEL_LABEL, {},
                 { textColour });
 
             auto ft = Formatter();
             ft.Add<int32_t>(BaseZToMetres(_settings.waterLevel));
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ widgets[WIDX_WATER_LEVEL].left + 1, widgets[WIDX_WATER_LEVEL].top + 1 },
+                rt, windowPos + ScreenCoordsXY{ widgets[WIDX_WATER_LEVEL].left + 1, widgets[WIDX_WATER_LEVEL].top + 1 },
                 STR_RIDE_LENGTH_ENTRY, ft, { colours[1] });
         }
 
@@ -1446,18 +1446,18 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             switch (page)
             {
                 case WINDOW_MAPGEN_PAGE_BASE:
-                    return BaseDraw(dpi);
+                    return BaseDraw(rt);
                 case WINDOW_MAPGEN_PAGE_FORESTS:
-                    return ForestsDraw(dpi);
+                    return ForestsDraw(rt);
                 case WINDOW_MAPGEN_PAGE_TERRAIN:
-                    return TerrainDraw(dpi);
+                    return TerrainDraw(rt);
                 case WINDOW_MAPGEN_PAGE_WATER:
-                    return WaterDraw(dpi);
+                    return WaterDraw(rt);
             }
         }
 

--- a/src/openrct2-ui/windows/MapTooltip.cpp
+++ b/src/openrct2-ui/windows/MapTooltip.cpp
@@ -46,7 +46,7 @@ namespace OpenRCT2::Ui::Windows
             Invalidate();
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             StringId stringId;
             std::memcpy(&stringId, _mapTooltipArgs.Data(), sizeof(StringId));
@@ -56,7 +56,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             auto stringCoords = windowPos + ScreenCoordsXY{ width / 2, height / 2 };
-            DrawTextWrapped(dpi, stringCoords, width, STR_MAP_TOOLTIP_STRINGID, _mapTooltipArgs, { TextAlignment::CENTRE });
+            DrawTextWrapped(rt, stringCoords, width, STR_MAP_TOOLTIP_STRINGID, _mapTooltipArgs, { TextAlignment::CENTRE });
         }
     };
 

--- a/src/openrct2-ui/windows/MapTooltip.cpp
+++ b/src/openrct2-ui/windows/MapTooltip.cpp
@@ -46,7 +46,7 @@ namespace OpenRCT2::Ui::Windows
             Invalidate();
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             StringId stringId;
             std::memcpy(&stringId, _mapTooltipArgs.Data(), sizeof(StringId));

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -300,9 +300,9 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
         }
 
     private:

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -300,7 +300,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
         }

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -892,8 +892,7 @@ namespace OpenRCT2::Ui::Windows
             if (i == selected_list_item)
             {
                 GfxFilterRect(
-                    rt, { 0, screenCoords.y, 800, screenCoords.y + kScrollableRowHeight - 1 },
-                    FilterPaletteID::PaletteDarken1);
+                    rt, { 0, screenCoords.y, 800, screenCoords.y + kScrollableRowHeight - 1 }, FilterPaletteID::PaletteDarken1);
             }
             if (screenCoords.y > rt.y + rt.height)
             {

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -146,15 +146,15 @@ namespace OpenRCT2::Ui::Windows
     private:
         void ResetPressedWidgets();
 
-        void InformationPaint(RenderTarget& dpi);
-        void PlayersPaint(RenderTarget& dpi);
-        void GroupsPaint(RenderTarget& dpi);
+        void InformationPaint(RenderTarget& rt);
+        void PlayersPaint(RenderTarget& rt);
+        void GroupsPaint(RenderTarget& rt);
 
-        void DrawTabImage(RenderTarget& dpi, int32_t page_number, int32_t spriteIndex);
-        void DrawTabImages(RenderTarget& dpi);
+        void DrawTabImage(RenderTarget& rt, int32_t page_number, int32_t spriteIndex);
+        void DrawTabImages(RenderTarget& rt);
 
-        void PlayersScrollPaint(int32_t scrollIndex, RenderTarget& dpi) const;
-        void GroupsScrollPaint(int32_t scrollIndex, RenderTarget& dpi) const;
+        void PlayersScrollPaint(int32_t scrollIndex, RenderTarget& rt) const;
+        void GroupsScrollPaint(int32_t scrollIndex, RenderTarget& rt) const;
 
         void ShowGroupDropdown(WidgetIndex widgetIndex);
         ScreenSize InformationGetSize();
@@ -168,7 +168,7 @@ namespace OpenRCT2::Ui::Windows
         void OnResize() override;
         void OnUpdate() override;
         void OnPrepareDraw() override;
-        void OnDraw(RenderTarget& dpi) override;
+        void OnDraw(RenderTarget& rt) override;
 
         void OnDropdown(WidgetIndex widgetIndex, int32_t selectedIndex) override;
         void OnTextInput(WidgetIndex widgetIndex, std::string_view text) override;
@@ -177,7 +177,7 @@ namespace OpenRCT2::Ui::Windows
         ScreenSize OnScrollGetSize(int32_t scrollIndex) override;
         void OnScrollMouseDown(int32_t scrollIndex, const ScreenCoordsXY& screenCoords) override;
         void OnScrollMouseOver(int32_t scrollIndex, const ScreenCoordsXY& screenCoords) override;
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override;
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override;
     };
 
     WindowBase* MultiplayerOpen()
@@ -439,25 +439,25 @@ namespace OpenRCT2::Ui::Windows
         }
     }
 
-    void MultiplayerWindow::OnDraw(RenderTarget& dpi)
+    void MultiplayerWindow::OnDraw(RenderTarget& rt)
     {
-        DrawWidgets(dpi);
-        DrawTabImages(dpi);
+        DrawWidgets(rt);
+        DrawTabImages(rt);
         switch (page)
         {
             case WINDOW_MULTIPLAYER_PAGE_INFORMATION:
             {
-                InformationPaint(dpi);
+                InformationPaint(rt);
                 break;
             }
             case WINDOW_MULTIPLAYER_PAGE_PLAYERS:
             {
-                PlayersPaint(dpi);
+                PlayersPaint(rt);
                 break;
             }
             case WINDOW_MULTIPLAYER_PAGE_GROUPS:
             {
-                GroupsPaint(dpi);
+                GroupsPaint(rt);
                 break;
             }
         }
@@ -658,24 +658,24 @@ namespace OpenRCT2::Ui::Windows
         }
     }
 
-    void MultiplayerWindow::OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi)
+    void MultiplayerWindow::OnScrollDraw(int32_t scrollIndex, RenderTarget& rt)
     {
         switch (page)
         {
             case WINDOW_MULTIPLAYER_PAGE_PLAYERS:
-                PlayersScrollPaint(scrollIndex, dpi);
+                PlayersScrollPaint(scrollIndex, rt);
                 break;
 
             case WINDOW_MULTIPLAYER_PAGE_GROUPS:
-                GroupsScrollPaint(scrollIndex, dpi);
+                GroupsScrollPaint(scrollIndex, rt);
                 break;
         }
     }
 
-    void MultiplayerWindow::InformationPaint(RenderTarget& dpi)
+    void MultiplayerWindow::InformationPaint(RenderTarget& rt)
     {
         RenderTarget clippedDPI;
-        if (ClipDrawPixelInfo(clippedDPI, dpi, windowPos, width, height))
+        if (ClipDrawPixelInfo(clippedDPI, rt, windowPos, width, height))
         {
             auto screenCoords = ScreenCoordsXY{ 3, widgets[WIDX_CONTENT_PANEL].top + 7 };
             int32_t newWidth = width - 6;
@@ -725,17 +725,17 @@ namespace OpenRCT2::Ui::Windows
         }
     }
 
-    void MultiplayerWindow::PlayersPaint(RenderTarget& dpi)
+    void MultiplayerWindow::PlayersPaint(RenderTarget& rt)
     {
         // Number of players
         StringId stringId = no_list_items == 1 ? STR_MULTIPLAYER_PLAYER_COUNT : STR_MULTIPLAYER_PLAYER_COUNT_PLURAL;
         auto screenCoords = windowPos + ScreenCoordsXY{ 4, widgets[WIDX_LIST].bottom + 2 };
         auto ft = Formatter();
         ft.Add<uint16_t>(no_list_items);
-        DrawTextBasic(dpi, screenCoords, stringId, ft, { colours[2] });
+        DrawTextBasic(rt, screenCoords, stringId, ft, { colours[2] });
     }
 
-    void MultiplayerWindow::PlayersScrollPaint(int32_t scrollIndex, RenderTarget& dpi) const
+    void MultiplayerWindow::PlayersScrollPaint(int32_t scrollIndex, RenderTarget& rt) const
     {
         ScreenCoordsXY screenCoords;
         screenCoords.y = 0;
@@ -745,12 +745,12 @@ namespace OpenRCT2::Ui::Windows
 
         for (int32_t player = firstPlayerInList; player < NetworkGetNumPlayers(); player++)
         {
-            if (screenCoords.y > dpi.y + dpi.height)
+            if (screenCoords.y > rt.y + rt.height)
             {
                 break;
             }
 
-            if (screenCoords.y + kScrollableRowHeight + 1 >= dpi.y)
+            if (screenCoords.y + kScrollableRowHeight + 1 >= rt.y)
             {
                 thread_local std::string _buffer;
                 _buffer.reserve(512);
@@ -761,7 +761,7 @@ namespace OpenRCT2::Ui::Windows
                 if (listPosition == selected_list_item)
                 {
                     GfxFilterRect(
-                        dpi, { 0, screenCoords.y, 800, screenCoords.y + kScrollableRowHeight - 1 },
+                        rt, { 0, screenCoords.y, 800, screenCoords.y + kScrollableRowHeight - 1 },
                         FilterPaletteID::PaletteDarken1);
                     _buffer += NetworkGetPlayerName(player);
                     colour = colours[2];
@@ -780,7 +780,7 @@ namespace OpenRCT2::Ui::Windows
                 }
                 screenCoords.x = 0;
                 GfxClipString(_buffer.data(), 230, FontStyle::Medium);
-                DrawText(dpi, screenCoords, { colour }, _buffer.c_str());
+                DrawText(rt, screenCoords, { colour }, _buffer.c_str());
 
                 // Draw group name
                 _buffer.resize(0);
@@ -791,7 +791,7 @@ namespace OpenRCT2::Ui::Windows
                     screenCoords.x = 173;
                     _buffer += NetworkGetGroupName(group);
                     GfxClipString(_buffer.data(), 80, FontStyle::Medium);
-                    DrawText(dpi, screenCoords, { colour }, _buffer.c_str());
+                    DrawText(rt, screenCoords, { colour }, _buffer.c_str());
                 }
 
                 // Draw last action
@@ -805,7 +805,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     ft.Add<StringId>(STR_ACTION_NA);
                 }
-                DrawTextEllipsised(dpi, { 256, screenCoords.y }, 100, STR_BLACK_STRING, ft);
+                DrawTextEllipsised(rt, { 256, screenCoords.y }, 100, STR_BLACK_STRING, ft);
 
                 // Draw ping
                 _buffer.resize(0);
@@ -828,14 +828,14 @@ namespace OpenRCT2::Ui::Windows
                 _buffer += pingBuffer;
 
                 screenCoords.x = 356;
-                DrawText(dpi, screenCoords, { colour }, _buffer.c_str());
+                DrawText(rt, screenCoords, { colour }, _buffer.c_str());
             }
             screenCoords.y += kScrollableRowHeight;
             listPosition++;
         }
     }
 
-    void MultiplayerWindow::GroupsPaint(RenderTarget& dpi)
+    void MultiplayerWindow::GroupsPaint(RenderTarget& rt)
     {
         thread_local std::string _buffer;
 
@@ -849,19 +849,19 @@ namespace OpenRCT2::Ui::Windows
             auto ft = Formatter();
             ft.Add<const char*>(_buffer.c_str());
             DrawTextEllipsised(
-                dpi, windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 8, STR_STRING, ft,
+                rt, windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 8, STR_STRING, ft,
                 { TextAlignment::CENTRE });
         }
 
         auto screenPos = windowPos
             + ScreenCoordsXY{ widgets[WIDX_CONTENT_PANEL].left + 4, widgets[WIDX_CONTENT_PANEL].top + 4 };
 
-        DrawTextBasic(dpi, screenPos, STR_DEFAULT_GROUP, {}, { colours[2] });
+        DrawTextBasic(rt, screenPos, STR_DEFAULT_GROUP, {}, { colours[2] });
 
         screenPos.y += 20;
 
         GfxFillRectInset(
-            dpi, { screenPos - ScreenCoordsXY{ 0, 6 }, screenPos + ScreenCoordsXY{ 310, -5 } }, colours[1],
+            rt, { screenPos - ScreenCoordsXY{ 0, 6 }, screenPos + ScreenCoordsXY{ 310, -5 } }, colours[1],
             INSET_RECT_FLAG_BORDER_INSET);
 
         widget = &widgets[WIDX_SELECTED_GROUP];
@@ -873,18 +873,18 @@ namespace OpenRCT2::Ui::Windows
             auto ft = Formatter();
             ft.Add<const char*>(_buffer.c_str());
             DrawTextEllipsised(
-                dpi, windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 8, STR_STRING, ft,
+                rt, windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 8, STR_STRING, ft,
                 { TextAlignment::CENTRE });
         }
     }
 
-    void MultiplayerWindow::GroupsScrollPaint(int32_t scrollIndex, RenderTarget& dpi) const
+    void MultiplayerWindow::GroupsScrollPaint(int32_t scrollIndex, RenderTarget& rt) const
     {
         auto screenCoords = ScreenCoordsXY{ 0, 0 };
 
-        auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
+        auto rtCoords = ScreenCoordsXY{ rt.x, rt.y };
         GfxFillRect(
-            dpi, { dpiCoords, dpiCoords + ScreenCoordsXY{ dpi.width - 1, dpi.height - 1 } },
+            rt, { rtCoords, rtCoords + ScreenCoordsXY{ rt.width - 1, rt.height - 1 } },
             ColourMapA[colours[1].colour].mid_light);
 
         for (int32_t i = 0; i < NetworkGetNumActions(); i++)
@@ -892,15 +892,15 @@ namespace OpenRCT2::Ui::Windows
             if (i == selected_list_item)
             {
                 GfxFilterRect(
-                    dpi, { 0, screenCoords.y, 800, screenCoords.y + kScrollableRowHeight - 1 },
+                    rt, { 0, screenCoords.y, 800, screenCoords.y + kScrollableRowHeight - 1 },
                     FilterPaletteID::PaletteDarken1);
             }
-            if (screenCoords.y > dpi.y + dpi.height)
+            if (screenCoords.y > rt.y + rt.height)
             {
                 break;
             }
 
-            if (screenCoords.y + kScrollableRowHeight + 1 >= dpi.y)
+            if (screenCoords.y + kScrollableRowHeight + 1 >= rt.y)
             {
                 int32_t groupindex = NetworkGetGroupIndex(_selectedGroup);
                 if (groupindex != -1)
@@ -908,20 +908,20 @@ namespace OpenRCT2::Ui::Windows
                     if (NetworkCanPerformAction(groupindex, static_cast<NetworkPermission>(i)))
                     {
                         screenCoords.x = 0;
-                        DrawText(dpi, screenCoords, {}, u8"{WINDOW_COLOUR_2}✓");
+                        DrawText(rt, screenCoords, {}, u8"{WINDOW_COLOUR_2}✓");
                     }
                 }
 
                 // Draw action name
                 auto ft = Formatter();
                 ft.Add<uint16_t>(NetworkGetActionNameStringID(i));
-                DrawTextBasic(dpi, { 10, screenCoords.y }, STR_WINDOW_COLOUR_2_STRINGID, ft);
+                DrawTextBasic(rt, { 10, screenCoords.y }, STR_WINDOW_COLOUR_2_STRINGID, ft);
             }
             screenCoords.y += kScrollableRowHeight;
         }
     }
 
-    void MultiplayerWindow::DrawTabImage(RenderTarget& dpi, int32_t page_number, int32_t spriteIndex)
+    void MultiplayerWindow::DrawTabImage(RenderTarget& rt, int32_t page_number, int32_t spriteIndex)
     {
         WidgetIndex widgetIndex = WIDX_TAB1 + page_number;
 
@@ -938,15 +938,15 @@ namespace OpenRCT2::Ui::Windows
             }
 
             GfxDrawSprite(
-                dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widgets[widgetIndex].left, widgets[widgetIndex].top });
+                rt, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widgets[widgetIndex].left, widgets[widgetIndex].top });
         }
     }
 
-    void MultiplayerWindow::DrawTabImages(RenderTarget& dpi)
+    void MultiplayerWindow::DrawTabImages(RenderTarget& rt)
     {
-        DrawTabImage(dpi, WINDOW_MULTIPLAYER_PAGE_INFORMATION, SPR_TAB_KIOSKS_AND_FACILITIES_0);
-        DrawTabImage(dpi, WINDOW_MULTIPLAYER_PAGE_PLAYERS, SPR_TAB_GUESTS_0);
-        DrawTabImage(dpi, WINDOW_MULTIPLAYER_PAGE_GROUPS, SPR_TAB_STAFF_OPTIONS_0);
-        DrawTabImage(dpi, WINDOW_MULTIPLAYER_PAGE_OPTIONS, SPR_TAB_GEARS_0);
+        DrawTabImage(rt, WINDOW_MULTIPLAYER_PAGE_INFORMATION, SPR_TAB_KIOSKS_AND_FACILITIES_0);
+        DrawTabImage(rt, WINDOW_MULTIPLAYER_PAGE_PLAYERS, SPR_TAB_GUESTS_0);
+        DrawTabImage(rt, WINDOW_MULTIPLAYER_PAGE_GROUPS, SPR_TAB_STAFF_OPTIONS_0);
+        DrawTabImage(rt, WINDOW_MULTIPLAYER_PAGE_OPTIONS, SPR_TAB_GEARS_0);
     }
 } // namespace OpenRCT2::Ui::Windows

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -146,15 +146,15 @@ namespace OpenRCT2::Ui::Windows
     private:
         void ResetPressedWidgets();
 
-        void InformationPaint(DrawPixelInfo& dpi);
-        void PlayersPaint(DrawPixelInfo& dpi);
-        void GroupsPaint(DrawPixelInfo& dpi);
+        void InformationPaint(RenderTarget& dpi);
+        void PlayersPaint(RenderTarget& dpi);
+        void GroupsPaint(RenderTarget& dpi);
 
-        void DrawTabImage(DrawPixelInfo& dpi, int32_t page_number, int32_t spriteIndex);
-        void DrawTabImages(DrawPixelInfo& dpi);
+        void DrawTabImage(RenderTarget& dpi, int32_t page_number, int32_t spriteIndex);
+        void DrawTabImages(RenderTarget& dpi);
 
-        void PlayersScrollPaint(int32_t scrollIndex, DrawPixelInfo& dpi) const;
-        void GroupsScrollPaint(int32_t scrollIndex, DrawPixelInfo& dpi) const;
+        void PlayersScrollPaint(int32_t scrollIndex, RenderTarget& dpi) const;
+        void GroupsScrollPaint(int32_t scrollIndex, RenderTarget& dpi) const;
 
         void ShowGroupDropdown(WidgetIndex widgetIndex);
         ScreenSize InformationGetSize();
@@ -168,7 +168,7 @@ namespace OpenRCT2::Ui::Windows
         void OnResize() override;
         void OnUpdate() override;
         void OnPrepareDraw() override;
-        void OnDraw(DrawPixelInfo& dpi) override;
+        void OnDraw(RenderTarget& dpi) override;
 
         void OnDropdown(WidgetIndex widgetIndex, int32_t selectedIndex) override;
         void OnTextInput(WidgetIndex widgetIndex, std::string_view text) override;
@@ -177,7 +177,7 @@ namespace OpenRCT2::Ui::Windows
         ScreenSize OnScrollGetSize(int32_t scrollIndex) override;
         void OnScrollMouseDown(int32_t scrollIndex, const ScreenCoordsXY& screenCoords) override;
         void OnScrollMouseOver(int32_t scrollIndex, const ScreenCoordsXY& screenCoords) override;
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override;
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override;
     };
 
     WindowBase* MultiplayerOpen()
@@ -439,7 +439,7 @@ namespace OpenRCT2::Ui::Windows
         }
     }
 
-    void MultiplayerWindow::OnDraw(DrawPixelInfo& dpi)
+    void MultiplayerWindow::OnDraw(RenderTarget& dpi)
     {
         DrawWidgets(dpi);
         DrawTabImages(dpi);
@@ -658,7 +658,7 @@ namespace OpenRCT2::Ui::Windows
         }
     }
 
-    void MultiplayerWindow::OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi)
+    void MultiplayerWindow::OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi)
     {
         switch (page)
         {
@@ -672,9 +672,9 @@ namespace OpenRCT2::Ui::Windows
         }
     }
 
-    void MultiplayerWindow::InformationPaint(DrawPixelInfo& dpi)
+    void MultiplayerWindow::InformationPaint(RenderTarget& dpi)
     {
-        DrawPixelInfo clippedDPI;
+        RenderTarget clippedDPI;
         if (ClipDrawPixelInfo(clippedDPI, dpi, windowPos, width, height))
         {
             auto screenCoords = ScreenCoordsXY{ 3, widgets[WIDX_CONTENT_PANEL].top + 7 };
@@ -725,7 +725,7 @@ namespace OpenRCT2::Ui::Windows
         }
     }
 
-    void MultiplayerWindow::PlayersPaint(DrawPixelInfo& dpi)
+    void MultiplayerWindow::PlayersPaint(RenderTarget& dpi)
     {
         // Number of players
         StringId stringId = no_list_items == 1 ? STR_MULTIPLAYER_PLAYER_COUNT : STR_MULTIPLAYER_PLAYER_COUNT_PLURAL;
@@ -735,7 +735,7 @@ namespace OpenRCT2::Ui::Windows
         DrawTextBasic(dpi, screenCoords, stringId, ft, { colours[2] });
     }
 
-    void MultiplayerWindow::PlayersScrollPaint(int32_t scrollIndex, DrawPixelInfo& dpi) const
+    void MultiplayerWindow::PlayersScrollPaint(int32_t scrollIndex, RenderTarget& dpi) const
     {
         ScreenCoordsXY screenCoords;
         screenCoords.y = 0;
@@ -835,7 +835,7 @@ namespace OpenRCT2::Ui::Windows
         }
     }
 
-    void MultiplayerWindow::GroupsPaint(DrawPixelInfo& dpi)
+    void MultiplayerWindow::GroupsPaint(RenderTarget& dpi)
     {
         thread_local std::string _buffer;
 
@@ -878,7 +878,7 @@ namespace OpenRCT2::Ui::Windows
         }
     }
 
-    void MultiplayerWindow::GroupsScrollPaint(int32_t scrollIndex, DrawPixelInfo& dpi) const
+    void MultiplayerWindow::GroupsScrollPaint(int32_t scrollIndex, RenderTarget& dpi) const
     {
         auto screenCoords = ScreenCoordsXY{ 0, 0 };
 
@@ -921,7 +921,7 @@ namespace OpenRCT2::Ui::Windows
         }
     }
 
-    void MultiplayerWindow::DrawTabImage(DrawPixelInfo& dpi, int32_t page_number, int32_t spriteIndex)
+    void MultiplayerWindow::DrawTabImage(RenderTarget& dpi, int32_t page_number, int32_t spriteIndex)
     {
         WidgetIndex widgetIndex = WIDX_TAB1 + page_number;
 
@@ -942,7 +942,7 @@ namespace OpenRCT2::Ui::Windows
         }
     }
 
-    void MultiplayerWindow::DrawTabImages(DrawPixelInfo& dpi)
+    void MultiplayerWindow::DrawTabImages(RenderTarget& dpi)
     {
         DrawTabImage(dpi, WINDOW_MULTIPLAYER_PAGE_INFORMATION, SPR_TAB_KIOSKS_AND_FACILITIES_0);
         DrawTabImage(dpi, WINDOW_MULTIPLAYER_PAGE_PLAYERS, SPR_TAB_GUESTS_0);

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -85,9 +85,9 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            WindowDrawWidgets(*this, dpi);
+            WindowDrawWidgets(*this, rt);
             thread_local std::string _buffer;
 
             _buffer.assign("{WHITE}");
@@ -96,7 +96,7 @@ namespace OpenRCT2::Ui::Windows
 
             ScreenCoordsXY screenCoords(windowPos.x + (width / 2), windowPos.y + (height / 2));
             screenCoords.x -= GfxGetStringWidth(_buffer, FontStyle::Medium) / 2;
-            DrawText(dpi, screenCoords, { COLOUR_BLACK }, _buffer.c_str());
+            DrawText(rt, screenCoords, { COLOUR_BLACK }, _buffer.c_str());
         }
 
         void SetCloseCallBack(CloseCallback onClose)

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -85,7 +85,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             WindowDrawWidgets(*this, dpi);
             thread_local std::string _buffer;

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -362,18 +362,18 @@ namespace OpenRCT2::Ui::Windows
                 WidgetSetDisabled(*this, WIDX_START_BUTTON, true);
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             ScreenCoordsXY screenCoords{};
 
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             // Number of weeks
             Widget* spinnerWidget = &widgets[WIDX_WEEKS_SPINNER];
             auto ft = Formatter();
             ft.Add<int16_t>(Campaign.no_weeks);
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ spinnerWidget->left + 1, spinnerWidget->top },
+                rt, windowPos + ScreenCoordsXY{ spinnerWidget->left + 1, spinnerWidget->top },
                 Campaign.no_weeks == 1 ? STR_MARKETING_1_WEEK : STR_X_WEEKS, ft, { colours[0] });
 
             screenCoords = windowPos + ScreenCoordsXY{ 14, spinnerWidget->bottom + 6 };
@@ -381,13 +381,13 @@ namespace OpenRCT2::Ui::Windows
             // Price per week
             ft = Formatter();
             ft.Add<money64>(AdvertisingCampaignPricePerWeek[Campaign.campaign_type]);
-            DrawTextBasic(dpi, screenCoords, STR_MARKETING_COST_PER_WEEK, ft);
+            DrawTextBasic(rt, screenCoords, STR_MARKETING_COST_PER_WEEK, ft);
             screenCoords.y += 13;
 
             // Total price
             ft = Formatter();
             ft.Add<money64>(AdvertisingCampaignPricePerWeek[Campaign.campaign_type] * Campaign.no_weeks);
-            DrawTextBasic(dpi, screenCoords, STR_MARKETING_TOTAL_COST, ft);
+            DrawTextBasic(rt, screenCoords, STR_MARKETING_TOTAL_COST, ft);
         }
 
         int16_t GetCampaignType() const

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -362,7 +362,7 @@ namespace OpenRCT2::Ui::Windows
                 WidgetSetDisabled(*this, WIDX_START_BUTTON, true);
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             ScreenCoordsXY screenCoords{};
 

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -418,20 +418,20 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_GROUP_BY_TRACK_TYPE].left = width - 8 - localizedGroupByTrackTypeWidth;
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             if (_currentTab != RESEARCH_TAB)
             {
                 RideSelection item = _newRideVars.HighlightedRide;
                 if (item.Type != kRideTypeNull || item.EntryIndex != kObjectEntryIndexNull)
-                    DrawRideInformation(dpi, item, windowPos + ScreenCoordsXY{ 3, height - 64 }, width - 6);
+                    DrawRideInformation(rt, item, windowPos + ScreenCoordsXY{ 3, height - 64 }, width - 6);
             }
             else
             {
-                WindowResearchDevelopmentDraw(this, dpi, WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP);
+                WindowResearchDevelopmentDraw(this, rt, WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP);
             }
         }
 
@@ -475,14 +475,14 @@ namespace OpenRCT2::Ui::Windows
             Invalidate();
         }
 
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             if (_currentTab == RESEARCH_TAB)
             {
                 return;
             }
 
-            GfxClear(dpi, ColourMapA[colours[1].colour].mid_light);
+            GfxClear(rt, ColourMapA[colours[1].colour].mid_light);
 
             ScreenCoordsXY coords{ 1, 1 };
             RideSelection* listItem = _windowNewRideListItems;
@@ -494,13 +494,13 @@ namespace OpenRCT2::Ui::Windows
                     buttonFlags |= INSET_RECT_FLAG_BORDER_INSET;
                 if (_newRideVars.HighlightedRide == *listItem || buttonFlags != 0)
                     GfxFillRectInset(
-                        dpi, { coords, coords + ScreenCoordsXY{ 115, 115 } }, colours[1],
+                        rt, { coords, coords + ScreenCoordsXY{ 115, 115 } }, colours[1],
                         INSET_RECT_FLAG_FILL_MID_LIGHT | buttonFlags);
 
                 // Draw ride image with feathered border
                 auto mask = ImageId(SPR_NEW_RIDE_MASK);
                 auto rideImage = ImageId(GetRideImage(*listItem));
-                GfxDrawSpriteRawMasked(dpi, coords + ScreenCoordsXY{ 2, 2 }, mask, rideImage);
+                GfxDrawSpriteRawMasked(rt, coords + ScreenCoordsXY{ 2, 2 }, mask, rideImage);
 
                 // Next position
                 coords.x += 116;
@@ -919,7 +919,7 @@ namespace OpenRCT2::Ui::Windows
             WidgetScrollUpdateThumbs(*this, WIDX_RIDE_LIST);
         }
 
-        void DrawRideInformation(RenderTarget& dpi, RideSelection item, const ScreenCoordsXY& screenPos, int32_t textWidth)
+        void DrawRideInformation(RenderTarget& rt, RideSelection item, const ScreenCoordsXY& screenPos, int32_t textWidth)
         {
             auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
             const auto* rideObj = objMgr.GetLoadedObject<RideObject>(item.EntryIndex);
@@ -932,7 +932,7 @@ namespace OpenRCT2::Ui::Windows
             // Ride name and description
             ft.Add<StringId>(rideNaming.Name);
             ft.Add<StringId>(rideNaming.Description);
-            DrawTextWrapped(dpi, screenPos, textWidth, STR_NEW_RIDE_NAME_AND_DESCRIPTION, ft);
+            DrawTextWrapped(rt, screenPos, textWidth, STR_NEW_RIDE_NAME_AND_DESCRIPTION, ft);
 
             if (!_vehicleAvailability.empty())
             {
@@ -941,13 +941,13 @@ namespace OpenRCT2::Ui::Windows
                     ft = Formatter();
                     ft.Add<StringId>(rideEntry.naming.Name);
                     DrawTextEllipsised(
-                        dpi, screenPos + ScreenCoordsXY{ 0, 39 }, WindowWidth - 2, STR_NEW_RIDE_VEHICLE_NAME, ft);
+                        rt, screenPos + ScreenCoordsXY{ 0, 39 }, WindowWidth - 2, STR_NEW_RIDE_VEHICLE_NAME, ft);
                 }
                 else
                 {
                     ft = Formatter();
                     ft.Add<const utf8*>(_vehicleAvailability.c_str());
-                    DrawTextEllipsised(dpi, screenPos + ScreenCoordsXY{ 0, 39 }, WindowWidth - 2, STR_AVAILABLE_VEHICLES, ft);
+                    DrawTextEllipsised(rt, screenPos + ScreenCoordsXY{ 0, 39 }, WindowWidth - 2, STR_AVAILABLE_VEHICLES, ft);
                 }
             }
 
@@ -955,7 +955,7 @@ namespace OpenRCT2::Ui::Windows
             auto designCountStringId = GetDesignsAvailableStringId(count);
             ft = Formatter();
             ft.Add<int32_t>(count);
-            DrawTextBasic(dpi, screenPos + ScreenCoordsXY{ 0, 51 }, designCountStringId, ft);
+            DrawTextBasic(rt, screenPos + ScreenCoordsXY{ 0, 51 }, designCountStringId, ft);
 
             // Price
             if (!(getGameState().park.Flags & PARK_FLAGS_NO_MONEY))
@@ -974,7 +974,7 @@ namespace OpenRCT2::Ui::Windows
 
                 ft = Formatter();
                 ft.Add<money64>(price);
-                DrawTextBasic(dpi, screenPos + ScreenCoordsXY{ textWidth, 51 }, stringId, ft, { TextAlignment::RIGHT });
+                DrawTextBasic(rt, screenPos + ScreenCoordsXY{ textWidth, 51 }, stringId, ft, { TextAlignment::RIGHT });
             }
 
             // Draw object author(s) if debugging tools are active
@@ -998,12 +998,12 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<const char*>(authorsString.c_str());
 
                 DrawTextEllipsised(
-                    dpi, screenPos + ScreenCoordsXY{ textWidth, 0 }, WindowWidth - 2, STR_WINDOW_COLOUR_2_STRINGID, ft,
+                    rt, screenPos + ScreenCoordsXY{ textWidth, 0 }, WindowWidth - 2, STR_WINDOW_COLOUR_2_STRINGID, ft,
                     { TextAlignment::RIGHT });
             }
         }
 
-        void DrawTabImage(RenderTarget& dpi, NewRideTabId tab, int32_t spriteIndex)
+        void DrawTabImage(RenderTarget& rt, NewRideTabId tab, int32_t spriteIndex)
         {
             WidgetIndex widgetIndex = WIDX_TAB_1 + static_cast<int32_t>(tab);
 
@@ -1016,20 +1016,20 @@ namespace OpenRCT2::Ui::Windows
                 spriteIndex += tab == THRILL_TAB ? ThrillRidesTabAnimationSequence[frame] : frame;
 
                 GfxDrawSprite(
-                    dpi, ImageId(spriteIndex, colours[1].colour),
+                    rt, ImageId(spriteIndex, colours[1].colour),
                     windowPos + ScreenCoordsXY{ widgets[widgetIndex].left, widgets[widgetIndex].top });
             }
         }
 
-        void DrawTabImages(RenderTarget& dpi)
+        void DrawTabImages(RenderTarget& rt)
         {
-            DrawTabImage(dpi, TRANSPORT_TAB, SPR_TAB_RIDES_TRANSPORT_0);
-            DrawTabImage(dpi, GENTLE_TAB, SPR_TAB_RIDES_GENTLE_0);
-            DrawTabImage(dpi, ROLLER_COASTER_TAB, SPR_TAB_RIDES_ROLLER_COASTERS_0);
-            DrawTabImage(dpi, THRILL_TAB, SPR_TAB_RIDES_THRILL_0);
-            DrawTabImage(dpi, WATER_TAB, SPR_TAB_RIDES_WATER_0);
-            DrawTabImage(dpi, SHOP_TAB, SPR_TAB_RIDES_SHOP_0);
-            DrawTabImage(dpi, RESEARCH_TAB, SPR_TAB_FINANCES_RESEARCH_0);
+            DrawTabImage(rt, TRANSPORT_TAB, SPR_TAB_RIDES_TRANSPORT_0);
+            DrawTabImage(rt, GENTLE_TAB, SPR_TAB_RIDES_GENTLE_0);
+            DrawTabImage(rt, ROLLER_COASTER_TAB, SPR_TAB_RIDES_ROLLER_COASTERS_0);
+            DrawTabImage(rt, THRILL_TAB, SPR_TAB_RIDES_THRILL_0);
+            DrawTabImage(rt, WATER_TAB, SPR_TAB_RIDES_WATER_0);
+            DrawTabImage(rt, SHOP_TAB, SPR_TAB_RIDES_SHOP_0);
+            DrawTabImage(rt, RESEARCH_TAB, SPR_TAB_FINANCES_RESEARCH_0);
         }
 
         StringId GetDesignsAvailableStringId(int32_t count)

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -940,8 +940,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     ft = Formatter();
                     ft.Add<StringId>(rideEntry.naming.Name);
-                    DrawTextEllipsised(
-                        rt, screenPos + ScreenCoordsXY{ 0, 39 }, WindowWidth - 2, STR_NEW_RIDE_VEHICLE_NAME, ft);
+                    DrawTextEllipsised(rt, screenPos + ScreenCoordsXY{ 0, 39 }, WindowWidth - 2, STR_NEW_RIDE_VEHICLE_NAME, ft);
                 }
                 else
                 {

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -418,7 +418,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_GROUP_BY_TRACK_TYPE].left = width - 8 - localizedGroupByTrackTypeWidth;
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -475,7 +475,7 @@ namespace OpenRCT2::Ui::Windows
             Invalidate();
         }
 
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             if (_currentTab == RESEARCH_TAB)
             {
@@ -919,7 +919,7 @@ namespace OpenRCT2::Ui::Windows
             WidgetScrollUpdateThumbs(*this, WIDX_RIDE_LIST);
         }
 
-        void DrawRideInformation(DrawPixelInfo& dpi, RideSelection item, const ScreenCoordsXY& screenPos, int32_t textWidth)
+        void DrawRideInformation(RenderTarget& dpi, RideSelection item, const ScreenCoordsXY& screenPos, int32_t textWidth)
         {
             auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
             const auto* rideObj = objMgr.GetLoadedObject<RideObject>(item.EntryIndex);
@@ -1003,7 +1003,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImage(DrawPixelInfo& dpi, NewRideTabId tab, int32_t spriteIndex)
+        void DrawTabImage(RenderTarget& dpi, NewRideTabId tab, int32_t spriteIndex)
         {
             WidgetIndex widgetIndex = WIDX_TAB_1 + static_cast<int32_t>(tab);
 
@@ -1021,7 +1021,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImages(DrawPixelInfo& dpi)
+        void DrawTabImages(RenderTarget& dpi)
         {
             DrawTabImage(dpi, TRANSPORT_TAB, SPR_TAB_RIDES_TRANSPORT_0);
             DrawTabImage(dpi, GENTLE_TAB, SPR_TAB_RIDES_GENTLE_0);

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -169,12 +169,12 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
         }
 
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             int32_t lineHeight = FontGetLineHeight(FontStyle::Small);
             int32_t itemHeight = CalculateItemHeight();
@@ -183,9 +183,9 @@ namespace OpenRCT2::Ui::Windows
 
             for (const auto& newsItem : getGameState().newsItems.GetArchived())
             {
-                if (y >= dpi.y + dpi.height)
+                if (y >= rt.y + rt.height)
                     break;
-                if (y + itemHeight < dpi.y)
+                if (y + itemHeight < rt.y)
                 {
                     y += itemHeight;
                     i++;
@@ -194,7 +194,7 @@ namespace OpenRCT2::Ui::Windows
 
                 // Background
                 GfxFillRectInset(
-                    dpi, { -1, y, 383, y + itemHeight - 1 }, colours[1],
+                    rt, { -1, y, 383, y + itemHeight - 1 }, colours[1],
                     (INSET_RECT_FLAG_BORDER_INSET | INSET_RECT_FLAG_FILL_GREY));
 
                 // Date text
@@ -202,14 +202,14 @@ namespace OpenRCT2::Ui::Windows
                     auto ft = Formatter();
                     ft.Add<StringId>(DateDayNames[newsItem.Day - 1]);
                     ft.Add<StringId>(DateGameMonthNames[DateGetMonth(newsItem.MonthYear)]);
-                    DrawTextBasic(dpi, { 2, y }, STR_NEWS_DATE_FORMAT, ft, { COLOUR_WHITE, FontStyle::Small });
+                    DrawTextBasic(rt, { 2, y }, STR_NEWS_DATE_FORMAT, ft, { COLOUR_WHITE, FontStyle::Small });
                 }
                 // Item text
                 {
                     auto ft = Formatter();
                     ft.Add<const char*>(newsItem.Text.c_str());
                     DrawTextWrapped(
-                        dpi, { 2, y + lineHeight }, 325, STR_BOTTOM_TOOLBAR_NEWS_TEXT, ft,
+                        rt, { 2, y + lineHeight }, 325, STR_BOTTOM_TOOLBAR_NEWS_TEXT, ft,
                         { COLOUR_BRIGHT_GREEN, FontStyle::Small });
                 }
                 // Subject button
@@ -226,18 +226,18 @@ namespace OpenRCT2::Ui::Windows
                             press = INSET_RECT_FLAG_BORDER_INSET;
                         }
                     }
-                    GfxFillRectInset(dpi, { screenCoords, screenCoords + ScreenCoordsXY{ 23, 23 } }, colours[2], press);
+                    GfxFillRectInset(rt, { screenCoords, screenCoords + ScreenCoordsXY{ 23, 23 } }, colours[2], press);
 
                     switch (newsItem.Type)
                     {
                         case News::ItemType::Ride:
-                            GfxDrawSprite(dpi, ImageId(SPR_RIDE), screenCoords);
+                            GfxDrawSprite(rt, ImageId(SPR_RIDE), screenCoords);
                             break;
                         case News::ItemType::Peep:
                         case News::ItemType::PeepOnRide:
                         {
-                            RenderTarget cliped_dpi;
-                            if (!ClipDrawPixelInfo(cliped_dpi, dpi, screenCoords + ScreenCoordsXY{ 1, 1 }, 22, 22))
+                            RenderTarget clippedRT;
+                            if (!ClipDrawPixelInfo(clippedRT, rt, screenCoords + ScreenCoordsXY{ 1, 1 }, 22, 22))
                             {
                                 break;
                             }
@@ -268,25 +268,25 @@ namespace OpenRCT2::Ui::Windows
 
                             ImageIndex imageId = animObj->GetPeepAnimation(spriteType).base_image + 1;
                             auto image = ImageId(imageId, peep->TshirtColour, peep->TrousersColour);
-                            GfxDrawSprite(cliped_dpi, image, clipCoords);
+                            GfxDrawSprite(clippedRT, image, clipCoords);
                             break;
                         }
                         case News::ItemType::Money:
                         case News::ItemType::Campaign:
-                            GfxDrawSprite(dpi, ImageId(SPR_FINANCE), screenCoords);
+                            GfxDrawSprite(rt, ImageId(SPR_FINANCE), screenCoords);
                             break;
                         case News::ItemType::Research:
                             GfxDrawSprite(
-                                dpi, ImageId(newsItem.Assoc < 0x10000 ? SPR_NEW_SCENERY : SPR_NEW_RIDE), screenCoords);
+                                rt, ImageId(newsItem.Assoc < 0x10000 ? SPR_NEW_SCENERY : SPR_NEW_RIDE), screenCoords);
                             break;
                         case News::ItemType::Peeps:
-                            GfxDrawSprite(dpi, ImageId(SPR_GUESTS), screenCoords);
+                            GfxDrawSprite(rt, ImageId(SPR_GUESTS), screenCoords);
                             break;
                         case News::ItemType::Award:
-                            GfxDrawSprite(dpi, ImageId(SPR_AWARD), screenCoords);
+                            GfxDrawSprite(rt, ImageId(SPR_AWARD), screenCoords);
                             break;
                         case News::ItemType::Graph:
-                            GfxDrawSprite(dpi, ImageId(SPR_GRAPH), screenCoords);
+                            GfxDrawSprite(rt, ImageId(SPR_GRAPH), screenCoords);
                             break;
                         case News::ItemType::Null:
                         case News::ItemType::Blank:
@@ -307,8 +307,8 @@ namespace OpenRCT2::Ui::Windows
                         if (i == _pressedNewsItemIndex && _pressedButtonIndex == 2)
                             press = 0x20;
                     }
-                    GfxFillRectInset(dpi, { screenCoords, screenCoords + ScreenCoordsXY{ 23, 23 } }, colours[2], press);
-                    GfxDrawSprite(dpi, ImageId(SPR_LOCATE), screenCoords);
+                    GfxFillRectInset(rt, { screenCoords, screenCoords + ScreenCoordsXY{ 23, 23 } }, colours[2], press);
+                    GfxDrawSprite(rt, ImageId(SPR_LOCATE), screenCoords);
                 }
 
                 y += itemHeight;

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -276,8 +276,7 @@ namespace OpenRCT2::Ui::Windows
                             GfxDrawSprite(rt, ImageId(SPR_FINANCE), screenCoords);
                             break;
                         case News::ItemType::Research:
-                            GfxDrawSprite(
-                                rt, ImageId(newsItem.Assoc < 0x10000 ? SPR_NEW_SCENERY : SPR_NEW_RIDE), screenCoords);
+                            GfxDrawSprite(rt, ImageId(newsItem.Assoc < 0x10000 ? SPR_NEW_SCENERY : SPR_NEW_RIDE), screenCoords);
                             break;
                         case News::ItemType::Peeps:
                             GfxDrawSprite(rt, ImageId(SPR_GUESTS), screenCoords);

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -169,12 +169,12 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
         }
 
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             int32_t lineHeight = FontGetLineHeight(FontStyle::Small);
             int32_t itemHeight = CalculateItemHeight();
@@ -236,7 +236,7 @@ namespace OpenRCT2::Ui::Windows
                         case News::ItemType::Peep:
                         case News::ItemType::PeepOnRide:
                         {
-                            DrawPixelInfo cliped_dpi;
+                            RenderTarget cliped_dpi;
                             if (!ClipDrawPixelInfo(cliped_dpi, dpi, screenCoords + ScreenCoordsXY{ 1, 1 }, 22, 22))
                             {
                                 break;

--- a/src/openrct2-ui/windows/NewsOptions.cpp
+++ b/src/openrct2-ui/windows/NewsOptions.cpp
@@ -205,10 +205,10 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
         }
 
     private:
@@ -222,14 +222,14 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImages(RenderTarget& dpi)
+        void DrawTabImages(RenderTarget& rt)
         {
-            DrawTabImage(dpi, NOTIFICATION_CATEGORY_PARK, SPR_TAB_PARK);
-            DrawTabImage(dpi, NOTIFICATION_CATEGORY_RIDE, SPR_TAB_RIDE_0);
-            DrawTabImage(dpi, NOTIFICATION_CATEGORY_GUEST, SPR_TAB_GUESTS_0);
+            DrawTabImage(rt, NOTIFICATION_CATEGORY_PARK, SPR_TAB_PARK);
+            DrawTabImage(rt, NOTIFICATION_CATEGORY_RIDE, SPR_TAB_RIDE_0);
+            DrawTabImage(rt, NOTIFICATION_CATEGORY_GUEST, SPR_TAB_GUESTS_0);
         }
 
-        void DrawTabImage(RenderTarget& dpi, int32_t p, int32_t spriteIndex)
+        void DrawTabImage(RenderTarget& rt, int32_t p, int32_t spriteIndex)
         {
             WidgetIndex widgetIndex = WIDX_FIRST_TAB + p;
 
@@ -246,7 +246,7 @@ namespace OpenRCT2::Ui::Windows
                 }
 
                 const auto& widget = widgets[widgetIndex];
-                GfxDrawSprite(dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget.left, widget.top });
+                GfxDrawSprite(rt, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget.left, widget.top });
             }
         }
 

--- a/src/openrct2-ui/windows/NewsOptions.cpp
+++ b/src/openrct2-ui/windows/NewsOptions.cpp
@@ -205,7 +205,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -222,14 +222,14 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImages(DrawPixelInfo& dpi)
+        void DrawTabImages(RenderTarget& dpi)
         {
             DrawTabImage(dpi, NOTIFICATION_CATEGORY_PARK, SPR_TAB_PARK);
             DrawTabImage(dpi, NOTIFICATION_CATEGORY_RIDE, SPR_TAB_RIDE_0);
             DrawTabImage(dpi, NOTIFICATION_CATEGORY_GUEST, SPR_TAB_GUESTS_0);
         }
 
-        void DrawTabImage(DrawPixelInfo& dpi, int32_t p, int32_t spriteIndex)
+        void DrawTabImage(RenderTarget& dpi, int32_t p, int32_t spriteIndex)
         {
             WidgetIndex widgetIndex = WIDX_FIRST_TAB + p;
 

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -489,27 +489,27 @@ namespace OpenRCT2::Ui::Windows
             InvalidateWidget(WIDX_SCROLL);
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            WindowDrawWidgets(*this, dpi);
+            WindowDrawWidgets(*this, rt);
 
             // Draw explanatory message
             auto ft = Formatter();
             ft.Add<StringId>(STR_OBJECT_ERROR_WINDOW_EXPLANATION);
-            DrawTextWrapped(dpi, windowPos + ScreenCoordsXY{ 5, 18 }, WW - 10, STR_BLACK_STRING, ft);
+            DrawTextWrapped(rt, windowPos + ScreenCoordsXY{ 5, 18 }, WW - 10, STR_BLACK_STRING, ft);
 
             // Draw file name
             ft = Formatter();
             ft.Add<StringId>(STR_OBJECT_ERROR_WINDOW_FILE);
             ft.Add<utf8*>(_filePath.c_str());
-            DrawTextEllipsised(dpi, { windowPos.x + 5, windowPos.y + 43 }, WW - 5, STR_BLACK_STRING, ft);
+            DrawTextEllipsised(rt, { windowPos.x + 5, windowPos.y + 43 }, WW - 5, STR_BLACK_STRING, ft);
         }
 
-        void OnScrollDraw(const int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(const int32_t scrollIndex, RenderTarget& rt) override
         {
-            auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
+            auto rtCoords = ScreenCoordsXY{ rt.x, rt.y };
             GfxFillRect(
-                dpi, { dpiCoords, dpiCoords + ScreenCoordsXY{ dpi.width - 1, dpi.height - 1 } },
+                rt, { rtCoords, rtCoords + ScreenCoordsXY{ rt.width - 1, rt.height - 1 } },
                 ColourMapA[colours[1].colour].mid_light);
             const int32_t listWidth = widgets[WIDX_SCROLL].width();
 
@@ -517,21 +517,21 @@ namespace OpenRCT2::Ui::Windows
             {
                 ScreenCoordsXY screenCoords;
                 screenCoords.y = i * kScrollableRowHeight;
-                if (screenCoords.y > dpi.y + dpi.height)
+                if (screenCoords.y > rt.y + rt.height)
                     break;
 
-                if (screenCoords.y + kScrollableRowHeight < dpi.y)
+                if (screenCoords.y + kScrollableRowHeight < rt.y)
                     continue;
 
                 const auto screenRect = ScreenRect{ { 0, screenCoords.y },
                                                     { listWidth, screenCoords.y + kScrollableRowHeight - 1 } };
                 // If hovering over item, change the color and fill the backdrop.
                 if (i == selected_list_item)
-                    GfxFillRect(dpi, screenRect, ColourMapA[colours[1].colour].darker);
+                    GfxFillRect(rt, screenRect, ColourMapA[colours[1].colour].darker);
                 else if (i == _highlightedIndex)
-                    GfxFillRect(dpi, screenRect, ColourMapA[colours[1].colour].mid_dark);
+                    GfxFillRect(rt, screenRect, ColourMapA[colours[1].colour].mid_dark);
                 else if ((i & 1) != 0) // odd / even check
-                    GfxFillRect(dpi, screenRect, ColourMapA[colours[1].colour].light);
+                    GfxFillRect(rt, screenRect, ColourMapA[colours[1].colour].light);
 
                 // Draw the actual object entry's name...
                 screenCoords.x = NAME_COL_LEFT - 3;
@@ -541,18 +541,18 @@ namespace OpenRCT2::Ui::Windows
                 auto name = entry.GetName();
                 char buffer[256];
                 String::set(buffer, sizeof(buffer), name.data(), name.size());
-                DrawText(dpi, screenCoords, { COLOUR_DARK_GREEN }, buffer);
+                DrawText(rt, screenCoords, { COLOUR_DARK_GREEN }, buffer);
 
                 if (entry.Generation == ObjectGeneration::DAT)
                 {
                     // ... source game ...
                     const auto sourceStringId = ObjectManagerGetSourceGameString(entry.Entry.GetSourceGame());
-                    DrawTextBasic(dpi, { SOURCE_COL_LEFT - 3, screenCoords.y }, sourceStringId, {}, { COLOUR_DARK_GREEN });
+                    DrawTextBasic(rt, { SOURCE_COL_LEFT - 3, screenCoords.y }, sourceStringId, {}, { COLOUR_DARK_GREEN });
                 }
 
                 // ... and type
                 const auto type = GetStringFromObjectType(entry.GetType());
-                DrawTextBasic(dpi, { TYPE_COL_LEFT - 3, screenCoords.y }, type, {}, { COLOUR_DARK_GREEN });
+                DrawTextBasic(rt, { TYPE_COL_LEFT - 3, screenCoords.y }, type, {}, { COLOUR_DARK_GREEN });
             }
         }
 

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -489,7 +489,7 @@ namespace OpenRCT2::Ui::Windows
             InvalidateWidget(WIDX_SCROLL);
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             WindowDrawWidgets(*this, dpi);
 
@@ -505,7 +505,7 @@ namespace OpenRCT2::Ui::Windows
             DrawTextEllipsised(dpi, { windowPos.x + 5, windowPos.y + 43 }, WW - 5, STR_BLACK_STRING, ft);
         }
 
-        void OnScrollDraw(const int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(const int32_t scrollIndex, RenderTarget& dpi) override
         {
             auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
             GfxFillRect(

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -607,18 +607,18 @@ namespace OpenRCT2::Ui::Windows
             CommonPrepareDrawAfter();
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             switch (page)
             {
                 case WINDOW_OPTIONS_PAGE_DISPLAY:
-                    DisplayDraw(dpi);
+                    DisplayDraw(rt);
                     break;
                 case WINDOW_OPTIONS_PAGE_ADVANCED:
-                    AdvancedDraw(dpi);
+                    AdvancedDraw(rt);
                     break;
                 default:
                     break;
@@ -943,12 +943,12 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_DRAWING_ENGINE].text = kDrawingEngineStringIds[EnumValue(Config::Get().general.DrawingEngine)];
         }
 
-        void DisplayDraw(RenderTarget& dpi)
+        void DisplayDraw(RenderTarget& rt)
         {
             auto ft = Formatter();
             ft.Add<int32_t>(static_cast<int32_t>(Config::Get().general.WindowScale * 100));
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ widgets[WIDX_SCALE].left + 1, widgets[WIDX_SCALE].top + 1 },
+                rt, windowPos + ScreenCoordsXY{ widgets[WIDX_SCALE].left + 1, widgets[WIDX_SCALE].top + 1 },
                 STR_WINDOW_COLOUR_2_COMMA2DP32, ft, { colours[1] });
         }
 #pragma endregion
@@ -2133,13 +2133,12 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_ASSET_PACKS].bottom = widgets[WIDX_GROUP_ADVANCED].bottom - 6;
         }
 
-        void AdvancedDraw(RenderTarget& dpi)
+        void AdvancedDraw(RenderTarget& rt)
         {
             auto ft = Formatter();
             ft.Add<int32_t>(static_cast<int32_t>(Config::Get().general.AutosaveAmount));
             DrawTextBasic(
-                dpi,
-                windowPos + ScreenCoordsXY{ widgets[WIDX_AUTOSAVE_AMOUNT].left + 1, widgets[WIDX_AUTOSAVE_AMOUNT].top + 1 },
+                rt, windowPos + ScreenCoordsXY{ widgets[WIDX_AUTOSAVE_AMOUNT].left + 1, widgets[WIDX_AUTOSAVE_AMOUNT].top + 1 },
                 STR_WINDOW_COLOUR_2_COMMA32, ft, { colours[1] });
 
             // Format RCT1 path
@@ -2156,7 +2155,7 @@ namespace OpenRCT2::Ui::Windows
             int32_t padding = widgetHeight > lineHeight ? (widgetHeight - lineHeight) / 2 : 0;
 
             auto screenCoords = windowPos + ScreenCoordsXY{ pathWidget.left + 1, pathWidget.top + padding };
-            DrawTextEllipsised(dpi, screenCoords, pathWidget.width(), STR_BLACK_STRING, ft);
+            DrawTextEllipsised(rt, screenCoords, pathWidget.width(), STR_BLACK_STRING, ft);
         }
 
         OpenRCT2String AdvancedTooltip(WidgetIndex widgetIndex, StringId fallback)
@@ -2211,19 +2210,19 @@ namespace OpenRCT2::Ui::Windows
                 Dropdown::Flag::StayOpen, num_items, widget->width() - 3);
         }
 
-        void DrawTabImages(RenderTarget& dpi)
+        void DrawTabImages(RenderTarget& rt)
         {
-            DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_DISPLAY, SPR_G2_MONITOR_TAB_START);
-            DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_RENDERING, SPR_G2_TAB_TREE);
-            DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_CULTURE, SPR_TAB_TIMER_0);
-            DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_AUDIO, SPR_TAB_MUSIC_0);
-            DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_INTERFACE, SPR_TAB_PAINT_0);
-            DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_CONTROLS, SPR_G2_CONTROLS_TAB_START);
-            DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_MISC, SPR_TAB_RIDE_0);
-            DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_ADVANCED, SPR_TAB_WRENCH_0);
+            DrawTabImage(rt, WINDOW_OPTIONS_PAGE_DISPLAY, SPR_G2_MONITOR_TAB_START);
+            DrawTabImage(rt, WINDOW_OPTIONS_PAGE_RENDERING, SPR_G2_TAB_TREE);
+            DrawTabImage(rt, WINDOW_OPTIONS_PAGE_CULTURE, SPR_TAB_TIMER_0);
+            DrawTabImage(rt, WINDOW_OPTIONS_PAGE_AUDIO, SPR_TAB_MUSIC_0);
+            DrawTabImage(rt, WINDOW_OPTIONS_PAGE_INTERFACE, SPR_TAB_PAINT_0);
+            DrawTabImage(rt, WINDOW_OPTIONS_PAGE_CONTROLS, SPR_G2_CONTROLS_TAB_START);
+            DrawTabImage(rt, WINDOW_OPTIONS_PAGE_MISC, SPR_TAB_RIDE_0);
+            DrawTabImage(rt, WINDOW_OPTIONS_PAGE_ADVANCED, SPR_TAB_WRENCH_0);
         }
 
-        void DrawTabImage(RenderTarget& dpi, int32_t p, int32_t spriteIndex)
+        void DrawTabImage(RenderTarget& rt, int32_t p, int32_t spriteIndex)
         {
             WidgetIndex widgetIndex = WIDX_FIRST_TAB + p;
             Widget* widget = &widgets[widgetIndex];
@@ -2239,7 +2238,7 @@ namespace OpenRCT2::Ui::Windows
                 }
 
                 // Draw normal, enabled sprite.
-                GfxDrawSprite(dpi, ImageId(spriteIndex), screenCoords);
+                GfxDrawSprite(rt, ImageId(spriteIndex), screenCoords);
             }
             else
             {
@@ -2248,10 +2247,10 @@ namespace OpenRCT2::Ui::Windows
 
                 // Draw greyed out (light border bottom right shadow)
                 GfxDrawSpriteSolid(
-                    dpi, ImageId(spriteIndex), screenCoords + ScreenCoordsXY{ 1, 1 }, ColourMapA[windowColour].lighter);
+                    rt, ImageId(spriteIndex), screenCoords + ScreenCoordsXY{ 1, 1 }, ColourMapA[windowColour].lighter);
 
                 // Draw greyed out (dark)
-                GfxDrawSpriteSolid(dpi, ImageId(spriteIndex), screenCoords, ColourMapA[windowColour].mid_light);
+                GfxDrawSpriteSolid(rt, ImageId(spriteIndex), screenCoords, ColourMapA[windowColour].mid_light);
             }
         }
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -607,7 +607,7 @@ namespace OpenRCT2::Ui::Windows
             CommonPrepareDrawAfter();
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -943,7 +943,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_DRAWING_ENGINE].text = kDrawingEngineStringIds[EnumValue(Config::Get().general.DrawingEngine)];
         }
 
-        void DisplayDraw(DrawPixelInfo& dpi)
+        void DisplayDraw(RenderTarget& dpi)
         {
             auto ft = Formatter();
             ft.Add<int32_t>(static_cast<int32_t>(Config::Get().general.WindowScale * 100));
@@ -2133,7 +2133,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_ASSET_PACKS].bottom = widgets[WIDX_GROUP_ADVANCED].bottom - 6;
         }
 
-        void AdvancedDraw(DrawPixelInfo& dpi)
+        void AdvancedDraw(RenderTarget& dpi)
         {
             auto ft = Formatter();
             ft.Add<int32_t>(static_cast<int32_t>(Config::Get().general.AutosaveAmount));
@@ -2211,7 +2211,7 @@ namespace OpenRCT2::Ui::Windows
                 Dropdown::Flag::StayOpen, num_items, widget->width() - 3);
         }
 
-        void DrawTabImages(DrawPixelInfo& dpi)
+        void DrawTabImages(RenderTarget& dpi)
         {
             DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_DISPLAY, SPR_G2_MONITOR_TAB_START);
             DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_RENDERING, SPR_G2_TAB_TREE);
@@ -2223,7 +2223,7 @@ namespace OpenRCT2::Ui::Windows
             DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_ADVANCED, SPR_TAB_WRENCH_0);
         }
 
-        void DrawTabImage(DrawPixelInfo& dpi, int32_t p, int32_t spriteIndex)
+        void DrawTabImage(RenderTarget& dpi, int32_t p, int32_t spriteIndex)
         {
             WidgetIndex widgetIndex = WIDX_FIRST_TAB + p;
             Widget* widget = &widgets[widgetIndex];

--- a/src/openrct2-ui/windows/OverwritePrompt.cpp
+++ b/src/openrct2-ui/windows/OverwritePrompt.cpp
@@ -86,7 +86,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
 

--- a/src/openrct2-ui/windows/OverwritePrompt.cpp
+++ b/src/openrct2-ui/windows/OverwritePrompt.cpp
@@ -86,16 +86,16 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             auto ft = Formatter();
             ft.Add<StringId>(STR_STRING);
             ft.Add<char*>(_name.c_str());
 
             ScreenCoordsXY stringCoords(windowPos.x + width / 2, windowPos.y + (height / 2) - 3);
-            DrawTextWrapped(dpi, stringCoords, width - 4, STR_FILEBROWSER_OVERWRITE_PROMPT, ft, { TextAlignment::CENTRE });
+            DrawTextWrapped(rt, stringCoords, width - 4, STR_FILEBROWSER_OVERWRITE_PROMPT, ft, { TextAlignment::CENTRE });
         }
     };
 

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -616,8 +616,8 @@ namespace OpenRCT2::Ui::Windows
 
             auto* labelWidget = &widgets[WIDX_STATUS];
             DrawTextEllipsised(
-                rt, windowPos + ScreenCoordsXY{ labelWidget->midX(), labelWidget->top }, labelWidget->width(),
-                STR_BLACK_STRING, ft, { TextAlignment::CENTRE });
+                rt, windowPos + ScreenCoordsXY{ labelWidget->midX(), labelWidget->top }, labelWidget->width(), STR_BLACK_STRING,
+                ft, { TextAlignment::CENTRE });
         }
 
         void InitViewport()

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -375,30 +375,30 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             switch (page)
             {
                 case WINDOW_PARK_PAGE_ENTRANCE:
-                    OnDrawEntrance(dpi);
+                    OnDrawEntrance(rt);
                     break;
                 case WINDOW_PARK_PAGE_RATING:
-                    OnDrawRating(dpi);
+                    OnDrawRating(rt);
                     break;
                 case WINDOW_PARK_PAGE_GUESTS:
-                    OnDrawGuests(dpi);
+                    OnDrawGuests(rt);
                     break;
                 case WINDOW_PARK_PAGE_PRICE:
-                    OnDrawPrice(dpi);
+                    OnDrawPrice(rt);
                     break;
                 case WINDOW_PARK_PAGE_STATS:
-                    OnDrawStats(dpi);
+                    OnDrawStats(rt);
                     break;
                 case WINDOW_PARK_PAGE_OBJECTIVE:
-                    OnDrawObjective(dpi);
+                    OnDrawObjective(rt);
                     break;
                 case WINDOW_PARK_PAGE_AWARDS:
-                    OnDrawAwards(dpi);
+                    OnDrawAwards(rt);
                     break;
             }
         }
@@ -597,17 +597,17 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDrawEntrance(RenderTarget& dpi)
+        void OnDrawEntrance(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             // Draw viewport
             if (viewport != nullptr)
             {
-                WindowDrawViewport(dpi, *this);
+                WindowDrawViewport(rt, *this);
                 if (viewport->flags & VIEWPORT_FLAG_SOUND_ON)
-                    GfxDrawSprite(dpi, ImageId(SPR_HEARING_VIEWPORT), WindowGetViewportSoundIconPos(*this));
+                    GfxDrawSprite(rt, ImageId(SPR_HEARING_VIEWPORT), WindowGetViewportSoundIconPos(*this));
             }
 
             // Draw park closed / open label
@@ -616,7 +616,7 @@ namespace OpenRCT2::Ui::Windows
 
             auto* labelWidget = &widgets[WIDX_STATUS];
             DrawTextEllipsised(
-                dpi, windowPos + ScreenCoordsXY{ labelWidget->midX(), labelWidget->top }, labelWidget->width(),
+                rt, windowPos + ScreenCoordsXY{ labelWidget->midX(), labelWidget->top }, labelWidget->width(),
                 STR_BLACK_STRING, ft, { TextAlignment::CENTRE });
         }
 
@@ -712,28 +712,28 @@ namespace OpenRCT2::Ui::Windows
                 kGraphNumYLabels, kParkRatingHistorySize);
         }
 
-        void OnDrawRating(RenderTarget& dpi)
+        void OnDrawRating(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             Widget* widget = &widgets[WIDX_PAGE_BACKGROUND];
 
             // Current value
             Formatter ft;
             ft.Add<uint16_t>(getGameState().park.Rating);
-            DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ widget->left + 3, widget->top + 2 }, STR_PARK_RATING_LABEL, ft);
+            DrawTextBasic(rt, windowPos + ScreenCoordsXY{ widget->left + 3, widget->top + 2 }, STR_PARK_RATING_LABEL, ft);
 
             // Graph border
-            GfxFillRectInset(dpi, _ratingGraphBounds, colours[1], INSET_RECT_F_30);
+            GfxFillRectInset(rt, _ratingGraphBounds, colours[1], INSET_RECT_F_30);
             // hide resize widget on graph area
             constexpr ScreenCoordsXY offset{ 1, 1 };
             constexpr ScreenCoordsXY bigOffset{ 5, 5 };
             GfxFillRectInset(
-                dpi, { _ratingGraphBounds.Point2 - bigOffset, _ratingGraphBounds.Point2 - offset }, colours[1],
+                rt, { _ratingGraphBounds.Point2 - bigOffset, _ratingGraphBounds.Point2 - offset }, colours[1],
                 INSET_RECT_FLAG_FILL_DONT_LIGHTEN | INSET_RECT_FLAG_BORDER_NONE);
 
-            Graph::DrawRatingGraph(dpi, _ratingProps);
+            Graph::DrawRatingGraph(rt, _ratingProps);
         }
 
 #pragma endregion
@@ -791,28 +791,28 @@ namespace OpenRCT2::Ui::Windows
                 kGraphNumYLabels, kGuestsInParkHistorySize);
         }
 
-        void OnDrawGuests(RenderTarget& dpi)
+        void OnDrawGuests(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             Widget* widget = &widgets[WIDX_PAGE_BACKGROUND];
 
             // Current value
             Formatter ft;
             ft.Add<uint32_t>(getGameState().numGuestsInPark);
-            DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ widget->left + 3, widget->top + 2 }, STR_GUESTS_IN_PARK_LABEL, ft);
+            DrawTextBasic(rt, windowPos + ScreenCoordsXY{ widget->left + 3, widget->top + 2 }, STR_GUESTS_IN_PARK_LABEL, ft);
 
             // Graph border
-            GfxFillRectInset(dpi, _guestGraphBounds, colours[1], INSET_RECT_F_30);
+            GfxFillRectInset(rt, _guestGraphBounds, colours[1], INSET_RECT_F_30);
             // hide resize widget on graph area
             constexpr ScreenCoordsXY offset{ 1, 1 };
             constexpr ScreenCoordsXY bigOffset{ 5, 5 };
             GfxFillRectInset(
-                dpi, { _guestGraphBounds.Point2 - bigOffset, _guestGraphBounds.Point2 - offset }, colours[1],
+                rt, { _guestGraphBounds.Point2 - bigOffset, _guestGraphBounds.Point2 - offset }, colours[1],
                 INSET_RECT_FLAG_FILL_DONT_LIGHTEN | INSET_RECT_FLAG_BORDER_NONE);
 
-            Graph::DrawGuestGraph(dpi, _guestProps);
+            Graph::DrawGuestGraph(rt, _guestProps);
         }
 
 #pragma endregion
@@ -890,16 +890,16 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
         }
 
-        void OnDrawPrice(RenderTarget& dpi)
+        void OnDrawPrice(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             auto screenCoords = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_PAGE_BACKGROUND].left + 4, widgets[WIDX_PAGE_BACKGROUND].top + 30 };
             auto ft = Formatter();
             ft.Add<money64>(getGameState().totalIncomeFromAdmissions);
-            DrawTextBasic(dpi, screenCoords, STR_INCOME_FROM_ADMISSIONS, ft);
+            DrawTextBasic(rt, screenCoords, STR_INCOME_FROM_ADMISSIONS, ft);
 
             money64 parkEntranceFee = Park::GetEntranceFee();
             ft = Formatter();
@@ -910,7 +910,7 @@ namespace OpenRCT2::Ui::Windows
                 stringId = STR_FREE;
 
             screenCoords = windowPos + ScreenCoordsXY{ widgets[WIDX_PRICE].left + 1, widgets[WIDX_PRICE].top + 1 };
-            DrawTextBasic(dpi, screenCoords, stringId, ft, { colours[1] });
+            DrawTextBasic(rt, screenCoords, stringId, ft, { colours[1] });
         }
 #pragma endregion
 
@@ -950,10 +950,10 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
         }
 
-        void OnDrawStats(RenderTarget& dpi)
+        void OnDrawStats(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             auto screenCoords = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_PAGE_BACKGROUND].left + 4, widgets[WIDX_PAGE_BACKGROUND].top + 4 };
@@ -969,7 +969,7 @@ namespace OpenRCT2::Ui::Windows
             }
             auto ft = Formatter();
             ft.Add<uint32_t>(parkSize);
-            DrawTextBasic(dpi, screenCoords, stringIndex, ft);
+            DrawTextBasic(rt, screenCoords, stringIndex, ft);
             screenCoords.y += kListRowHeight;
 
             // Draw number of rides / attractions
@@ -977,7 +977,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 ft = Formatter();
                 ft.Add<uint32_t>(_numberOfRides);
-                DrawTextBasic(dpi, screenCoords, STR_NUMBER_OF_RIDES_LABEL, ft);
+                DrawTextBasic(rt, screenCoords, STR_NUMBER_OF_RIDES_LABEL, ft);
             }
             screenCoords.y += kListRowHeight;
 
@@ -986,19 +986,19 @@ namespace OpenRCT2::Ui::Windows
             {
                 ft = Formatter();
                 ft.Add<uint32_t>(_numberOfStaff);
-                DrawTextBasic(dpi, screenCoords, STR_STAFF_LABEL, ft);
+                DrawTextBasic(rt, screenCoords, STR_STAFF_LABEL, ft);
             }
             screenCoords.y += kListRowHeight;
 
             // Draw number of guests in park
             ft = Formatter();
             ft.Add<uint32_t>(gameState.numGuestsInPark);
-            DrawTextBasic(dpi, screenCoords, STR_GUESTS_IN_PARK_LABEL, ft);
+            DrawTextBasic(rt, screenCoords, STR_GUESTS_IN_PARK_LABEL, ft);
             screenCoords.y += kListRowHeight;
 
             ft = Formatter();
             ft.Add<uint32_t>(gameState.totalAdmissions);
-            DrawTextBasic(dpi, screenCoords, STR_TOTAL_ADMISSIONS, ft);
+            DrawTextBasic(rt, screenCoords, STR_TOTAL_ADMISSIONS, ft);
         }
 #pragma endregion
 
@@ -1076,11 +1076,11 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
         }
 
-        void OnDrawObjective(RenderTarget& dpi)
+        void OnDrawObjective(RenderTarget& rt)
         {
             auto& gameState = getGameState();
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             // Scenario description
             auto screenCoords = windowPos
@@ -1088,18 +1088,18 @@ namespace OpenRCT2::Ui::Windows
             auto ft = Formatter();
             ft.Add<StringId>(STR_STRING);
             ft.Add<const char*>(gameState.scenarioDetails.c_str());
-            screenCoords.y += DrawTextWrapped(dpi, screenCoords, 222, STR_BLACK_STRING, ft);
+            screenCoords.y += DrawTextWrapped(rt, screenCoords, 222, STR_BLACK_STRING, ft);
             screenCoords.y += 5;
 
             // Your objective:
-            DrawTextBasic(dpi, screenCoords, STR_OBJECTIVE_LABEL);
+            DrawTextBasic(rt, screenCoords, STR_OBJECTIVE_LABEL);
             screenCoords.y += kListRowHeight;
 
             // Objective
             ft = Formatter();
             formatObjective(ft, gameState.scenarioObjective);
 
-            screenCoords.y += DrawTextWrapped(dpi, screenCoords, 221, kObjectiveNames[gameState.scenarioObjective.Type], ft);
+            screenCoords.y += DrawTextWrapped(rt, screenCoords, 221, kObjectiveNames[gameState.scenarioObjective.Type], ft);
             screenCoords.y += 5;
 
             // Objective outcome
@@ -1108,14 +1108,14 @@ namespace OpenRCT2::Ui::Windows
                 if (gameState.scenarioCompletedCompanyValue == kCompanyValueOnFailedObjective)
                 {
                     // Objective failed
-                    DrawTextWrapped(dpi, screenCoords, 222, STR_OBJECTIVE_FAILED);
+                    DrawTextWrapped(rt, screenCoords, 222, STR_OBJECTIVE_FAILED);
                 }
                 else
                 {
                     // Objective completed
                     ft = Formatter();
                     ft.Add<money64>(gameState.scenarioCompletedCompanyValue);
-                    DrawTextWrapped(dpi, screenCoords, 222, STR_OBJECTIVE_ACHIEVED, ft);
+                    DrawTextWrapped(rt, screenCoords, 222, STR_OBJECTIVE_ACHIEVED, ft);
                 }
             }
         }
@@ -1141,10 +1141,10 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
         }
 
-        void OnDrawAwards(RenderTarget& dpi)
+        void OnDrawAwards(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             auto screenCoords = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_PAGE_BACKGROUND].left + 4, widgets[WIDX_PAGE_BACKGROUND].top + 4 };
@@ -1153,14 +1153,14 @@ namespace OpenRCT2::Ui::Windows
 
             for (const auto& award : currentAwards)
             {
-                GfxDrawSprite(dpi, ImageId(_parkAwards[EnumValue(award.Type)].sprite), screenCoords);
-                DrawTextWrapped(dpi, screenCoords + ScreenCoordsXY{ 34, 6 }, 180, _parkAwards[EnumValue(award.Type)].text);
+                GfxDrawSprite(rt, ImageId(_parkAwards[EnumValue(award.Type)].sprite), screenCoords);
+                DrawTextWrapped(rt, screenCoords + ScreenCoordsXY{ 34, 6 }, 180, _parkAwards[EnumValue(award.Type)].text);
 
                 screenCoords.y += 32;
             }
 
             if (currentAwards.empty())
-                DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 6, 6 }, STR_NO_RECENT_AWARDS);
+                DrawTextBasic(rt, screenCoords + ScreenCoordsXY{ 6, 6 }, STR_NO_RECENT_AWARDS);
         }
 #pragma endregion
 
@@ -1215,13 +1215,13 @@ namespace OpenRCT2::Ui::Windows
             pressed_widgets |= 1LL << (WIDX_TAB_1 + page);
         }
 
-        void DrawTabImages(RenderTarget& dpi)
+        void DrawTabImages(RenderTarget& rt)
         {
             // Entrance tab
             if (!WidgetIsDisabled(*this, WIDX_TAB_1))
             {
                 GfxDrawSprite(
-                    dpi, ImageId(SPR_TAB_PARK_ENTRANCE),
+                    rt, ImageId(SPR_TAB_PARK_ENTRANCE),
                     windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_1].left, widgets[WIDX_TAB_1].top });
             }
 
@@ -1231,12 +1231,12 @@ namespace OpenRCT2::Ui::Windows
                 ImageId spriteIdx(SPR_TAB_GRAPH_0);
                 if (page == WINDOW_PARK_PAGE_RATING)
                     spriteIdx = spriteIdx.WithIndexOffset((frame_no / 8) % 8);
-                GfxDrawSprite(dpi, spriteIdx, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left, widgets[WIDX_TAB_2].top });
+                GfxDrawSprite(rt, spriteIdx, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left, widgets[WIDX_TAB_2].top });
                 GfxDrawSprite(
-                    dpi, ImageId(SPR_RATING_HIGH),
+                    rt, ImageId(SPR_RATING_HIGH),
                     windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left + 7, widgets[WIDX_TAB_2].top + 1 });
                 GfxDrawSprite(
-                    dpi, ImageId(SPR_RATING_LOW),
+                    rt, ImageId(SPR_RATING_LOW),
                     windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left + 16, widgets[WIDX_TAB_2].top + 12 });
             }
 
@@ -1246,7 +1246,7 @@ namespace OpenRCT2::Ui::Windows
                 ImageId spriteIdx(SPR_TAB_GRAPH_0);
                 if (page == WINDOW_PARK_PAGE_GUESTS)
                     spriteIdx = spriteIdx.WithIndexOffset((frame_no / 8) % 8);
-                GfxDrawSprite(dpi, spriteIdx, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_3].left, widgets[WIDX_TAB_3].top });
+                GfxDrawSprite(rt, spriteIdx, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_3].left, widgets[WIDX_TAB_3].top });
 
                 auto* animObj = findPeepAnimationsObjectForType(AnimationPeepType::Guest);
                 ImageId peepImage(
@@ -1255,7 +1255,7 @@ namespace OpenRCT2::Ui::Windows
                     peepImage = peepImage.WithIndexOffset(_peepAnimationFrame & 0xFFFFFFFC);
 
                 GfxDrawSprite(
-                    dpi, peepImage, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_3].midX(), widgets[WIDX_TAB_3].bottom - 9 });
+                    rt, peepImage, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_3].midX(), widgets[WIDX_TAB_3].bottom - 9 });
             }
 
             // Price tab
@@ -1264,7 +1264,7 @@ namespace OpenRCT2::Ui::Windows
                 ImageId spriteIdx(SPR_TAB_ADMISSION_0);
                 if (page == WINDOW_PARK_PAGE_PRICE)
                     spriteIdx = spriteIdx.WithIndexOffset((frame_no / 2) % 8);
-                GfxDrawSprite(dpi, spriteIdx, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_4].left, widgets[WIDX_TAB_4].top });
+                GfxDrawSprite(rt, spriteIdx, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_4].left, widgets[WIDX_TAB_4].top });
             }
 
             // Statistics tab
@@ -1273,7 +1273,7 @@ namespace OpenRCT2::Ui::Windows
                 ImageId spriteIdx(SPR_TAB_STATS_0);
                 if (page == WINDOW_PARK_PAGE_STATS)
                     spriteIdx = spriteIdx.WithIndexOffset((frame_no / 4) % 7);
-                GfxDrawSprite(dpi, spriteIdx, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_5].left, widgets[WIDX_TAB_5].top });
+                GfxDrawSprite(rt, spriteIdx, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_5].left, widgets[WIDX_TAB_5].top });
             }
 
             // Objective tab
@@ -1282,14 +1282,14 @@ namespace OpenRCT2::Ui::Windows
                 ImageId spriteIdx(SPR_TAB_OBJECTIVE_0);
                 if (page == WINDOW_PARK_PAGE_OBJECTIVE)
                     spriteIdx = spriteIdx.WithIndexOffset((frame_no / 4) % 16);
-                GfxDrawSprite(dpi, spriteIdx, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_6].left, widgets[WIDX_TAB_6].top });
+                GfxDrawSprite(rt, spriteIdx, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_6].left, widgets[WIDX_TAB_6].top });
             }
 
             // Awards tab
             if (!WidgetIsDisabled(*this, WIDX_TAB_7))
             {
                 GfxDrawSprite(
-                    dpi, ImageId(SPR_TAB_AWARDS),
+                    rt, ImageId(SPR_TAB_AWARDS),
                     windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_7].left, widgets[WIDX_TAB_7].top });
             }
         }

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -375,7 +375,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             switch (page)
             {
@@ -597,7 +597,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDrawEntrance(DrawPixelInfo& dpi)
+        void OnDrawEntrance(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -712,7 +712,7 @@ namespace OpenRCT2::Ui::Windows
                 kGraphNumYLabels, kParkRatingHistorySize);
         }
 
-        void OnDrawRating(DrawPixelInfo& dpi)
+        void OnDrawRating(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -791,7 +791,7 @@ namespace OpenRCT2::Ui::Windows
                 kGraphNumYLabels, kGuestsInParkHistorySize);
         }
 
-        void OnDrawGuests(DrawPixelInfo& dpi)
+        void OnDrawGuests(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -890,7 +890,7 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
         }
 
-        void OnDrawPrice(DrawPixelInfo& dpi)
+        void OnDrawPrice(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -950,7 +950,7 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
         }
 
-        void OnDrawStats(DrawPixelInfo& dpi)
+        void OnDrawStats(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -1076,7 +1076,7 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
         }
 
-        void OnDrawObjective(DrawPixelInfo& dpi)
+        void OnDrawObjective(RenderTarget& dpi)
         {
             auto& gameState = getGameState();
             DrawWidgets(dpi);
@@ -1141,7 +1141,7 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
         }
 
-        void OnDrawAwards(DrawPixelInfo& dpi)
+        void OnDrawAwards(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -1215,7 +1215,7 @@ namespace OpenRCT2::Ui::Windows
             pressed_widgets |= 1LL << (WIDX_TAB_1 + page);
         }
 
-        void DrawTabImages(DrawPixelInfo& dpi)
+        void DrawTabImages(RenderTarget& dpi)
         {
             // Entrance tab
             if (!WidgetIsDisabled(*this, WIDX_TAB_1))

--- a/src/openrct2-ui/windows/PatrolArea.cpp
+++ b/src/openrct2-ui/windows/PatrolArea.cpp
@@ -135,9 +135,9 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_PREVIEW].image = ImageId(LandTool::SizeToSpriteIndex(gLandToolSize));
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             // Draw number for tool sizes bigger than 7
             if (gLandToolSize > kLandToolMaximumSizeWithSprite)
@@ -147,7 +147,7 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<uint16_t>(gLandToolSize);
                 DrawTextBasic(
-                    dpi, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, ft, { TextAlignment::CENTRE });
+                    rt, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, ft, { TextAlignment::CENTRE });
             }
         }
 

--- a/src/openrct2-ui/windows/PatrolArea.cpp
+++ b/src/openrct2-ui/windows/PatrolArea.cpp
@@ -135,7 +135,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_PREVIEW].image = ImageId(LandTool::SizeToSpriteIndex(gLandToolSize));
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
 

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -147,16 +147,16 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             switch (page)
             {
                 case WINDOW_PLAYER_PAGE_OVERVIEW:
-                    OnDrawOverview(dpi);
+                    OnDrawOverview(rt);
                     break;
 
                 case WINDOW_PLAYER_PAGE_STATISTICS:
-                    OnDrawStatistics(dpi);
+                    OnDrawStatistics(rt);
                     break;
             }
         }
@@ -247,7 +247,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImages(RenderTarget& dpi)
+        void DrawTabImages(RenderTarget& rt)
         {
             Widget* widget;
 
@@ -256,7 +256,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 widget = &this->widgets[WIDX_TAB_1];
                 auto screenCoords = windowPos + ScreenCoordsXY{ widget->left, widget->top };
-                GfxDrawSprite(dpi, ImageId(SPR_PEEP_LARGE_FACE_NORMAL), screenCoords);
+                GfxDrawSprite(rt, ImageId(SPR_PEEP_LARGE_FACE_NORMAL), screenCoords);
             }
 
             // Tab 2
@@ -271,7 +271,7 @@ namespace OpenRCT2::Ui::Windows
                     imageId += (frame_no / 2) & 7;
                 }
 
-                GfxDrawSprite(dpi, ImageId(imageId), screenCoords);
+                GfxDrawSprite(rt, ImageId(imageId), screenCoords);
             }
         }
 
@@ -410,10 +410,10 @@ namespace OpenRCT2::Ui::Windows
             WidgetSetEnabled(*this, WIDX_KICK, canKick && !isOwnWindow && !isServer);
         }
 
-        void OnDrawOverview(RenderTarget& dpi)
+        void OnDrawOverview(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             int32_t player = NetworkGetPlayerIndex(static_cast<uint8_t>(number));
             if (player == -1)
@@ -434,7 +434,7 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<const char*>(_buffer.c_str());
 
                 DrawTextEllipsised(
-                    dpi, windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 8, STR_STRING, ft,
+                    rt, windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 8, STR_STRING, ft,
                     { TextAlignment::CENTRE });
             }
 
@@ -443,10 +443,10 @@ namespace OpenRCT2::Ui::Windows
 
             auto ft = Formatter();
             ft.Add<StringId>(STR_PING);
-            DrawTextBasic(dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
+            DrawTextBasic(rt, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
             char ping[64];
             snprintf(ping, 64, "%d ms", NetworkGetPlayerPing(player));
-            DrawText(dpi, screenCoords + ScreenCoordsXY(30, 0), { colours[2] }, ping);
+            DrawText(rt, screenCoords + ScreenCoordsXY(30, 0), { colours[2] }, ping);
 
             // Draw last action
             screenCoords = windowPos + ScreenCoordsXY{ width / 2, height - 13 };
@@ -461,11 +461,11 @@ namespace OpenRCT2::Ui::Windows
             {
                 ft.Add<StringId>(STR_ACTION_NA);
             }
-            DrawTextEllipsised(dpi, screenCoords, updatedWidth, STR_LAST_ACTION_RAN, ft, { TextAlignment::CENTRE });
+            DrawTextEllipsised(rt, screenCoords, updatedWidth, STR_LAST_ACTION_RAN, ft, { TextAlignment::CENTRE });
 
             if (viewport != nullptr && _drawViewport)
             {
-                WindowDrawViewport(dpi, *this);
+                WindowDrawViewport(rt, *this);
             }
         }
 
@@ -594,10 +594,10 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_2);
         }
 
-        void OnDrawStatistics(RenderTarget& dpi)
+        void OnDrawStatistics(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             int32_t player = NetworkGetPlayerIndex(static_cast<uint8_t>(number));
             if (player == -1)
@@ -610,13 +610,13 @@ namespace OpenRCT2::Ui::Windows
 
             auto ft = Formatter();
             ft.Add<uint32_t>(NetworkGetPlayerCommandsRan(player));
-            DrawTextBasic(dpi, screenCoords, STR_COMMANDS_RAN, ft);
+            DrawTextBasic(rt, screenCoords, STR_COMMANDS_RAN, ft);
 
             screenCoords.y += kListRowHeight;
 
             ft = Formatter();
             ft.Add<uint32_t>(NetworkGetPlayerMoneySpent(player));
-            DrawTextBasic(dpi, screenCoords, STR_MONEY_SPENT, ft);
+            DrawTextBasic(rt, screenCoords, STR_MONEY_SPENT, ft);
         }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -147,7 +147,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             switch (page)
             {
@@ -247,7 +247,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImages(DrawPixelInfo& dpi)
+        void DrawTabImages(RenderTarget& dpi)
         {
             Widget* widget;
 
@@ -410,7 +410,7 @@ namespace OpenRCT2::Ui::Windows
             WidgetSetEnabled(*this, WIDX_KICK, canKick && !isOwnWindow && !isServer);
         }
 
-        void OnDrawOverview(DrawPixelInfo& dpi)
+        void OnDrawOverview(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -594,7 +594,7 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_2);
         }
 
-        void OnDrawStatistics(DrawPixelInfo& dpi)
+        void OnDrawStatistics(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);

--- a/src/openrct2-ui/windows/ProgressWindow.cpp
+++ b/src/openrct2-ui/windows/ProgressWindow.cpp
@@ -167,15 +167,15 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            WindowDrawWidgets(*this, dpi);
+            WindowDrawWidgets(*this, rt);
 
             auto& widget = widgets[WIDX_TITLE];
             auto screenCoords = windowPos + ScreenCoordsXY{ widget.left, widget.bottom + 1 };
 
             RenderTarget clipDPI;
-            if (!ClipDrawPixelInfo(clipDPI, dpi, screenCoords, width - 3, height - widget.bottom - 3))
+            if (!ClipDrawPixelInfo(clipDPI, rt, screenCoords, width - 3, height - widget.bottom - 3))
                 return;
 
             auto& variant = kVehicleStyles[style];

--- a/src/openrct2-ui/windows/ProgressWindow.cpp
+++ b/src/openrct2-ui/windows/ProgressWindow.cpp
@@ -167,14 +167,14 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             WindowDrawWidgets(*this, dpi);
 
             auto& widget = widgets[WIDX_TITLE];
             auto screenCoords = windowPos + ScreenCoordsXY{ widget.left, widget.bottom + 1 };
 
-            DrawPixelInfo clipDPI;
+            RenderTarget clipDPI;
             if (!ClipDrawPixelInfo(clipDPI, dpi, screenCoords, width - 3, height - widget.bottom - 3))
                 return;
 

--- a/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
@@ -74,7 +74,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             WindowDrawWidgets(*this, dpi);
 

--- a/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
@@ -74,9 +74,9 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            WindowDrawWidgets(*this, dpi);
+            WindowDrawWidgets(*this, rt);
 
             auto currentRide = GetRide(rideId);
             if (currentRide != nullptr)
@@ -88,7 +88,7 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<money64>(_demolishRideCost / 2);
 
                 ScreenCoordsXY stringCoords(windowPos.x + WW / 2, windowPos.y + (WH / 2) - 3);
-                DrawTextWrapped(dpi, stringCoords, WW - 4, stringId, ft, { TextAlignment::CENTRE });
+                DrawTextWrapped(rt, stringCoords, WW - 4, stringId, ft, { TextAlignment::CENTRE });
             }
         }
     };

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -248,7 +248,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -268,7 +268,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImage(DrawPixelInfo& dpi, int32_t tabPage, int32_t spriteIndex)
+        void DrawTabImage(RenderTarget& dpi, int32_t tabPage, int32_t spriteIndex)
         {
             WidgetIndex widgetIndex = WIDX_TAB_1 + tabPage;
 
@@ -288,7 +288,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImages(DrawPixelInfo& dpi)
+        void DrawTabImages(RenderTarget& dpi)
         {
             DrawTabImage(dpi, WINDOW_RESEARCH_PAGE_DEVELOPMENT, SPR_TAB_FINANCES_RESEARCH_0);
             DrawTabImage(dpi, WINDOW_RESEARCH_PAGE_FUNDING, SPR_TAB_FINANCES_SUMMARY_0);
@@ -341,7 +341,7 @@ namespace OpenRCT2::Ui::Windows
         }
     }
 
-    void WindowResearchDevelopmentDraw(WindowBase* w, DrawPixelInfo& dpi, WidgetIndex baseWidgetIndex)
+    void WindowResearchDevelopmentDraw(WindowBase* w, RenderTarget& dpi, WidgetIndex baseWidgetIndex)
     {
         const auto& gameState = getGameState();
 
@@ -574,7 +574,7 @@ namespace OpenRCT2::Ui::Windows
         }
     }
 
-    void WindowResearchFundingDraw(WindowBase* w, DrawPixelInfo& dpi)
+    void WindowResearchFundingDraw(WindowBase* w, RenderTarget& dpi)
     {
         const auto& gameState = getGameState();
         if (gameState.park.Flags & PARK_FLAGS_NO_MONEY)

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -248,27 +248,27 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             switch (page)
             {
                 case WINDOW_RESEARCH_PAGE_DEVELOPMENT:
                 {
-                    WindowResearchDevelopmentDraw(this, dpi, WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP);
+                    WindowResearchDevelopmentDraw(this, rt, WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP);
                     break;
                 }
                 case WINDOW_RESEARCH_PAGE_FUNDING:
                 {
-                    WindowResearchFundingDraw(this, dpi);
+                    WindowResearchFundingDraw(this, rt);
                     break;
                 }
             }
         }
 
-        void DrawTabImage(RenderTarget& dpi, int32_t tabPage, int32_t spriteIndex)
+        void DrawTabImage(RenderTarget& rt, int32_t tabPage, int32_t spriteIndex)
         {
             WidgetIndex widgetIndex = WIDX_TAB_1 + tabPage;
 
@@ -283,15 +283,15 @@ namespace OpenRCT2::Ui::Windows
                 }
 
                 GfxDrawSprite(
-                    dpi, ImageId(spriteIndex),
+                    rt, ImageId(spriteIndex),
                     windowPos + ScreenCoordsXY{ widgets[widgetIndex].left, widgets[widgetIndex].top });
             }
         }
 
-        void DrawTabImages(RenderTarget& dpi)
+        void DrawTabImages(RenderTarget& rt)
         {
-            DrawTabImage(dpi, WINDOW_RESEARCH_PAGE_DEVELOPMENT, SPR_TAB_FINANCES_RESEARCH_0);
-            DrawTabImage(dpi, WINDOW_RESEARCH_PAGE_FUNDING, SPR_TAB_FINANCES_SUMMARY_0);
+            DrawTabImage(rt, WINDOW_RESEARCH_PAGE_DEVELOPMENT, SPR_TAB_FINANCES_RESEARCH_0);
+            DrawTabImage(rt, WINDOW_RESEARCH_PAGE_FUNDING, SPR_TAB_FINANCES_SUMMARY_0);
         }
     };
 
@@ -341,7 +341,7 @@ namespace OpenRCT2::Ui::Windows
         }
     }
 
-    void WindowResearchDevelopmentDraw(WindowBase* w, RenderTarget& dpi, WidgetIndex baseWidgetIndex)
+    void WindowResearchDevelopmentDraw(WindowBase* w, RenderTarget& rt, WidgetIndex baseWidgetIndex)
     {
         const auto& gameState = getGameState();
 
@@ -354,19 +354,19 @@ namespace OpenRCT2::Ui::Windows
             // Research type
             auto ft = Formatter();
             ft.Add<StringId>(STR_RESEARCH_UNKNOWN);
-            DrawTextWrapped(dpi, screenCoords, 296, STR_RESEARCH_TYPE_LABEL, ft);
+            DrawTextWrapped(rt, screenCoords, 296, STR_RESEARCH_TYPE_LABEL, ft);
             screenCoords.y += 25;
 
             // Progress
             ft = Formatter();
             ft.Add<StringId>(STR_RESEARCH_COMPLETED_AL);
-            DrawTextWrapped(dpi, screenCoords, 296, STR_RESEARCH_PROGRESS_LABEL, ft);
+            DrawTextWrapped(rt, screenCoords, 296, STR_RESEARCH_PROGRESS_LABEL, ft);
             screenCoords.y += 15;
 
             // Expected
             ft = Formatter();
             ft.Add<StringId>(STR_RESEARCH_STAGE_UNKNOWN);
-            DrawTextBasic(dpi, screenCoords, STR_RESEARCH_EXPECTED_LABEL, ft);
+            DrawTextBasic(rt, screenCoords, STR_RESEARCH_EXPECTED_LABEL, ft);
         }
         else
         {
@@ -403,13 +403,13 @@ namespace OpenRCT2::Ui::Windows
             {
                 ft.Add<StringId>(gameState.researchNextItem->GetName());
             }
-            DrawTextWrapped(dpi, screenCoords, 296, label, ft);
+            DrawTextWrapped(rt, screenCoords, 296, label, ft);
             screenCoords.y += 25;
 
             // Progress
             ft = Formatter();
             ft.Add<StringId>(ResearchStageNames[gameState.researchProgressStage]);
-            DrawTextWrapped(dpi, screenCoords, 296, STR_RESEARCH_PROGRESS_LABEL, ft);
+            DrawTextWrapped(rt, screenCoords, 296, STR_RESEARCH_PROGRESS_LABEL, ft);
             screenCoords.y += 15;
 
             // Expected
@@ -425,7 +425,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 ft.Add<StringId>(STR_RESEARCH_STAGE_UNKNOWN);
             }
-            DrawTextBasic(dpi, screenCoords, STR_RESEARCH_EXPECTED_LABEL, ft);
+            DrawTextBasic(rt, screenCoords, STR_RESEARCH_EXPECTED_LABEL, ft);
         }
 
         // Last development
@@ -460,7 +460,7 @@ namespace OpenRCT2::Ui::Windows
                 }
             }
 
-            DrawTextWrapped(dpi, screenCoords, 266, lastDevelopmentFormat, ft);
+            DrawTextWrapped(rt, screenCoords, 266, lastDevelopmentFormat, ft);
         }
     }
 
@@ -574,7 +574,7 @@ namespace OpenRCT2::Ui::Windows
         }
     }
 
-    void WindowResearchFundingDraw(WindowBase* w, RenderTarget& dpi)
+    void WindowResearchFundingDraw(WindowBase* w, RenderTarget& rt)
     {
         const auto& gameState = getGameState();
         if (gameState.park.Flags & PARK_FLAGS_NO_MONEY)
@@ -584,7 +584,7 @@ namespace OpenRCT2::Ui::Windows
         auto ft = Formatter();
         ft.Add<money64>(research_cost_table[currentResearchLevel]);
         DrawTextBasic(
-            dpi, w->windowPos + ScreenCoordsXY{ 10, w->widgets[WIDX_TAB_1].top + 60 }, STR_RESEARCH_COST_PER_MONTH, ft);
+            rt, w->windowPos + ScreenCoordsXY{ 10, w->widgets[WIDX_TAB_1].top + 60 }, STR_RESEARCH_COST_PER_MONTH, ft);
     }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -889,7 +889,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
             }
         }
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             switch (page)
             {
@@ -1068,7 +1068,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
             }
         }
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             switch (page)
             {
@@ -1200,7 +1200,7 @@ namespace OpenRCT2::Ui::Windows
         }
 
     private:
-        void DrawTabImage(DrawPixelInfo& dpi, int32_t tab, int32_t spriteIndex)
+        void DrawTabImage(RenderTarget& dpi, int32_t tab, int32_t spriteIndex)
         {
             WidgetIndex widgetIndex = WIDX_TAB_1 + tab;
 
@@ -1217,7 +1217,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabMain(DrawPixelInfo& dpi)
+        void DrawTabMain(RenderTarget& dpi)
         {
             WidgetIndex widgetIndex = WIDX_TAB_1 + static_cast<int32_t>(WINDOW_RIDE_PAGE_MAIN);
             if (!WidgetIsDisabled(*this, widgetIndex))
@@ -1251,7 +1251,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabVehicle(DrawPixelInfo& dpi)
+        void DrawTabVehicle(RenderTarget& dpi)
         {
             WidgetIndex widgetIndex = WIDX_TAB_1 + static_cast<int32_t>(WINDOW_RIDE_PAGE_VEHICLE);
             const auto& widget = widgets[widgetIndex];
@@ -1266,7 +1266,7 @@ namespace OpenRCT2::Ui::Windows
 
                 screenCoords += windowPos;
 
-                DrawPixelInfo clipDPI;
+                RenderTarget clipDPI;
                 if (!ClipDrawPixelInfo(clipDPI, dpi, screenCoords, clipWidth, clipHeight))
                 {
                     return;
@@ -1316,7 +1316,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabCustomer(DrawPixelInfo& dpi)
+        void DrawTabCustomer(RenderTarget& dpi)
         {
             WidgetIndex widgetIndex = WIDX_TAB_1 + static_cast<int32_t>(WINDOW_RIDE_PAGE_CUSTOMER);
 
@@ -1336,7 +1336,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImages(DrawPixelInfo& dpi)
+        void DrawTabImages(RenderTarget& dpi)
         {
             DrawTabVehicle(dpi);
             DrawTabImage(dpi, WINDOW_RIDE_PAGE_OPERATING, SPR_TAB_GEARS_0);
@@ -2576,7 +2576,7 @@ namespace OpenRCT2::Ui::Windows
             return GetStatusStation(ft);
         }
 
-        void MainOnDraw(DrawPixelInfo& dpi)
+        void MainOnDraw(RenderTarget& dpi)
         {
             WindowDrawWidgets(*this, dpi);
             DrawTabImages(dpi);
@@ -2865,7 +2865,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void VehicleOnDraw(DrawPixelInfo& dpi)
+        void VehicleOnDraw(RenderTarget& dpi)
         {
             WindowDrawWidgets(*this, dpi);
             DrawTabImages(dpi);
@@ -2952,7 +2952,7 @@ namespace OpenRCT2::Ui::Windows
             ImageId imageId;
         };
 
-        void VehicleOnScrollDraw(DrawPixelInfo& dpi, int32_t scrollIndex)
+        void VehicleOnScrollDraw(RenderTarget& dpi, int32_t scrollIndex)
         {
             auto ride = GetRide(rideId);
             if (ride == nullptr)
@@ -3683,7 +3683,7 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
         }
 
-        void OperatingOnDraw(DrawPixelInfo& dpi)
+        void OperatingOnDraw(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -4026,7 +4026,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void MaintenanceOnDraw(DrawPixelInfo& dpi)
+        void MaintenanceOnDraw(RenderTarget& dpi)
         {
             auto ride = GetRide(rideId);
             if (ride == nullptr)
@@ -4812,10 +4812,10 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
         }
 
-        void ColourOnDraw(DrawPixelInfo& dpi)
+        void ColourOnDraw(RenderTarget& dpi)
         {
             // TODO: This should use lists and identified sprites
-            DrawPixelInfo clippedDpi;
+            RenderTarget clippedDpi;
 
             auto ride = GetRide(rideId);
             if (ride == nullptr)
@@ -4931,7 +4931,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void ColourOnScrollDraw(DrawPixelInfo& dpi, int32_t scrollIndex) const
+        void ColourOnScrollDraw(RenderTarget& dpi, int32_t scrollIndex) const
         {
             auto ride = GetRide(rideId);
             if (ride == nullptr)
@@ -5237,7 +5237,7 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
         }
 
-        void MusicOnDraw(DrawPixelInfo& dpi)
+        void MusicOnDraw(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -5266,7 +5266,7 @@ namespace OpenRCT2::Ui::Windows
             int32_t clipHeight = previewWidget.height() - 1;
 
             // Draw the preview image
-            DrawPixelInfo clipDPI;
+            RenderTarget clipDPI;
             auto screenPos = windowPos + ScreenCoordsXY{ previewWidget.left + 1, previewWidget.top + 1 };
             if (ClipDrawPixelInfo(clipDPI, dpi, screenPos, clipWidth, clipHeight))
             {
@@ -5274,7 +5274,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void MusicOnScrollDraw(DrawPixelInfo& dpi, int32_t scrollIndex)
+        void MusicOnScrollDraw(RenderTarget& dpi, int32_t scrollIndex)
         {
             auto ride = GetRide(rideId);
             if (ride == nullptr)
@@ -5609,7 +5609,7 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
         }
 
-        void MeasurementsOnDraw(DrawPixelInfo& dpi)
+        void MeasurementsOnDraw(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -6053,13 +6053,13 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
         }
 
-        void GraphsOnDraw(DrawPixelInfo& dpi)
+        void GraphsOnDraw(RenderTarget& dpi)
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
         }
 
-        void GraphsOnScrollDraw(DrawPixelInfo& dpi, int32_t scrollIndex)
+        void GraphsOnScrollDraw(RenderTarget& dpi, int32_t scrollIndex)
         {
             GfxClear(dpi, ColourMapA[COLOUR_SATURATED_GREEN].darker);
 
@@ -6614,7 +6614,7 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
         }
 
-        void IncomeOnDraw(DrawPixelInfo& dpi)
+        void IncomeOnDraw(RenderTarget& dpi)
         {
             StringId stringId;
             money64 profit;
@@ -6813,7 +6813,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void CustomerOnDraw(DrawPixelInfo& dpi)
+        void CustomerOnDraw(RenderTarget& dpi)
         {
             ShopItem shopItem;
             int16_t popularity, satisfaction, queueTime;

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -889,39 +889,39 @@ namespace OpenRCT2::Ui::Windows
                     break;
             }
         }
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             switch (page)
             {
                 case WINDOW_RIDE_PAGE_MAIN:
-                    MainOnDraw(dpi);
+                    MainOnDraw(rt);
                     break;
                 case WINDOW_RIDE_PAGE_VEHICLE:
-                    VehicleOnDraw(dpi);
+                    VehicleOnDraw(rt);
                     break;
                 case WINDOW_RIDE_PAGE_OPERATING:
-                    OperatingOnDraw(dpi);
+                    OperatingOnDraw(rt);
                     break;
                 case WINDOW_RIDE_PAGE_MAINTENANCE:
-                    MaintenanceOnDraw(dpi);
+                    MaintenanceOnDraw(rt);
                     break;
                 case WINDOW_RIDE_PAGE_COLOUR:
-                    ColourOnDraw(dpi);
+                    ColourOnDraw(rt);
                     break;
                 case WINDOW_RIDE_PAGE_MUSIC:
-                    MusicOnDraw(dpi);
+                    MusicOnDraw(rt);
                     break;
                 case WINDOW_RIDE_PAGE_MEASUREMENTS:
-                    MeasurementsOnDraw(dpi);
+                    MeasurementsOnDraw(rt);
                     break;
                 case WINDOW_RIDE_PAGE_GRAPHS:
-                    GraphsOnDraw(dpi);
+                    GraphsOnDraw(rt);
                     break;
                 case WINDOW_RIDE_PAGE_INCOME:
-                    IncomeOnDraw(dpi);
+                    IncomeOnDraw(rt);
                     break;
                 case WINDOW_RIDE_PAGE_CUSTOMER:
-                    CustomerOnDraw(dpi);
+                    CustomerOnDraw(rt);
                     break;
             }
         }
@@ -1068,21 +1068,21 @@ namespace OpenRCT2::Ui::Windows
                     break;
             }
         }
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             switch (page)
             {
                 case WINDOW_RIDE_PAGE_VEHICLE:
-                    VehicleOnScrollDraw(dpi, scrollIndex);
+                    VehicleOnScrollDraw(rt, scrollIndex);
                     break;
                 case WINDOW_RIDE_PAGE_COLOUR:
-                    ColourOnScrollDraw(dpi, scrollIndex);
+                    ColourOnScrollDraw(rt, scrollIndex);
                     break;
                 case WINDOW_RIDE_PAGE_GRAPHS:
-                    GraphsOnScrollDraw(dpi, scrollIndex);
+                    GraphsOnScrollDraw(rt, scrollIndex);
                     break;
                 case WINDOW_RIDE_PAGE_MUSIC:
-                    MusicOnScrollDraw(dpi, scrollIndex);
+                    MusicOnScrollDraw(rt, scrollIndex);
                     break;
             }
         }
@@ -1200,7 +1200,7 @@ namespace OpenRCT2::Ui::Windows
         }
 
     private:
-        void DrawTabImage(RenderTarget& dpi, int32_t tab, int32_t spriteIndex)
+        void DrawTabImage(RenderTarget& rt, int32_t tab, int32_t spriteIndex)
         {
             WidgetIndex widgetIndex = WIDX_TAB_1 + tab;
 
@@ -1213,11 +1213,11 @@ namespace OpenRCT2::Ui::Windows
                 }
 
                 const auto& widget = widgets[widgetIndex];
-                GfxDrawSprite(dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget.left, widget.top });
+                GfxDrawSprite(rt, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget.left, widget.top });
             }
         }
 
-        void DrawTabMain(RenderTarget& dpi)
+        void DrawTabMain(RenderTarget& rt)
         {
             WidgetIndex widgetIndex = WIDX_TAB_1 + static_cast<int32_t>(WINDOW_RIDE_PAGE_MAIN);
             if (!WidgetIsDisabled(*this, widgetIndex))
@@ -1246,12 +1246,12 @@ namespace OpenRCT2::Ui::Windows
                     }
 
                     const auto& widget = widgets[widgetIndex];
-                    GfxDrawSprite(dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget.left, widget.top });
+                    GfxDrawSprite(rt, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget.left, widget.top });
                 }
             }
         }
 
-        void DrawTabVehicle(RenderTarget& dpi)
+        void DrawTabVehicle(RenderTarget& rt)
         {
             WidgetIndex widgetIndex = WIDX_TAB_1 + static_cast<int32_t>(WINDOW_RIDE_PAGE_VEHICLE);
             const auto& widget = widgets[widgetIndex];
@@ -1267,7 +1267,7 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords += windowPos;
 
                 RenderTarget clipDPI;
-                if (!ClipDrawPixelInfo(clipDPI, dpi, screenCoords, clipWidth, clipHeight))
+                if (!ClipDrawPixelInfo(clipDPI, rt, screenCoords, clipWidth, clipHeight))
                 {
                     return;
                 }
@@ -1316,7 +1316,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabCustomer(RenderTarget& dpi)
+        void DrawTabCustomer(RenderTarget& rt)
         {
             WidgetIndex widgetIndex = WIDX_TAB_1 + static_cast<int32_t>(WINDOW_RIDE_PAGE_CUSTOMER);
 
@@ -1331,23 +1331,23 @@ namespace OpenRCT2::Ui::Windows
                 spriteIndex += animObj->GetPeepAnimation(PeepAnimationGroup::Normal).base_image + 1;
 
                 GfxDrawSprite(
-                    dpi, ImageId(spriteIndex, COLOUR_BRIGHT_RED, COLOUR_TEAL),
+                    rt, ImageId(spriteIndex, COLOUR_BRIGHT_RED, COLOUR_TEAL),
                     windowPos + ScreenCoordsXY{ widget.midX(), widget.bottom - 6 });
             }
         }
 
-        void DrawTabImages(RenderTarget& dpi)
+        void DrawTabImages(RenderTarget& rt)
         {
-            DrawTabVehicle(dpi);
-            DrawTabImage(dpi, WINDOW_RIDE_PAGE_OPERATING, SPR_TAB_GEARS_0);
-            DrawTabImage(dpi, WINDOW_RIDE_PAGE_MAINTENANCE, SPR_TAB_WRENCH_0);
-            DrawTabImage(dpi, WINDOW_RIDE_PAGE_INCOME, SPR_TAB_ADMISSION_0);
-            DrawTabMain(dpi);
-            DrawTabImage(dpi, WINDOW_RIDE_PAGE_MEASUREMENTS, SPR_TAB_TIMER_0);
-            DrawTabImage(dpi, WINDOW_RIDE_PAGE_COLOUR, SPR_TAB_PAINT_0);
-            DrawTabImage(dpi, WINDOW_RIDE_PAGE_GRAPHS, SPR_TAB_GRAPH_A_0);
-            DrawTabCustomer(dpi);
-            DrawTabImage(dpi, WINDOW_RIDE_PAGE_MUSIC, SPR_TAB_MUSIC_0);
+            DrawTabVehicle(rt);
+            DrawTabImage(rt, WINDOW_RIDE_PAGE_OPERATING, SPR_TAB_GEARS_0);
+            DrawTabImage(rt, WINDOW_RIDE_PAGE_MAINTENANCE, SPR_TAB_WRENCH_0);
+            DrawTabImage(rt, WINDOW_RIDE_PAGE_INCOME, SPR_TAB_ADMISSION_0);
+            DrawTabMain(rt);
+            DrawTabImage(rt, WINDOW_RIDE_PAGE_MEASUREMENTS, SPR_TAB_TIMER_0);
+            DrawTabImage(rt, WINDOW_RIDE_PAGE_COLOUR, SPR_TAB_PAINT_0);
+            DrawTabImage(rt, WINDOW_RIDE_PAGE_GRAPHS, SPR_TAB_GRAPH_A_0);
+            DrawTabCustomer(rt);
+            DrawTabImage(rt, WINDOW_RIDE_PAGE_MUSIC, SPR_TAB_MUSIC_0);
         }
 
         void DisableTabs()
@@ -2576,17 +2576,17 @@ namespace OpenRCT2::Ui::Windows
             return GetStatusStation(ft);
         }
 
-        void MainOnDraw(RenderTarget& dpi)
+        void MainOnDraw(RenderTarget& rt)
         {
-            WindowDrawWidgets(*this, dpi);
-            DrawTabImages(dpi);
+            WindowDrawWidgets(*this, rt);
+            DrawTabImages(rt);
 
             // Viewport and ear icon
             if (viewport != nullptr)
             {
-                WindowDrawViewport(dpi, *this);
+                WindowDrawViewport(rt, *this);
                 if (viewport->flags & VIEWPORT_FLAG_SOUND_ON)
-                    GfxDrawSprite(dpi, ImageId(SPR_HEARING_VIEWPORT), WindowGetViewportSoundIconPos(*this));
+                    GfxDrawSprite(rt, ImageId(SPR_HEARING_VIEWPORT), WindowGetViewportSoundIconPos(*this));
             }
 
             // View dropdown
@@ -2615,7 +2615,7 @@ namespace OpenRCT2::Ui::Windows
 
             auto* widget = &widgets[WIDX_VIEW];
             DrawTextBasic(
-                dpi, { windowPos.x + (widget->left + widget->right - 11) / 2, windowPos.y + widget->top },
+                rt, { windowPos.x + (widget->left + widget->right - 11) / 2, windowPos.y + widget->top },
                 STR_WINDOW_COLOUR_2_STRINGID, ft, { TextAlignment::CENTRE });
 
             // Status
@@ -2623,7 +2623,7 @@ namespace OpenRCT2::Ui::Windows
             widget = &widgets[WIDX_STATUS];
             StringId rideStatus = GetStatus(ft);
             DrawTextEllipsised(
-                dpi, windowPos + ScreenCoordsXY{ (widget->left + widget->right) / 2, widget->top }, widget->width(), rideStatus,
+                rt, windowPos + ScreenCoordsXY{ (widget->left + widget->right) / 2, widget->top }, widget->width(), rideStatus,
                 ft, { TextAlignment::CENTRE });
         }
 
@@ -2865,10 +2865,10 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void VehicleOnDraw(RenderTarget& dpi)
+        void VehicleOnDraw(RenderTarget& rt)
         {
-            WindowDrawWidgets(*this, dpi);
-            DrawTabImages(dpi);
+            WindowDrawWidgets(*this, rt);
+            DrawTabImages(rt);
 
             auto ride = GetRide(rideId);
             if (ride == nullptr)
@@ -2882,13 +2882,13 @@ namespace OpenRCT2::Ui::Windows
             // Description
             auto ft = Formatter();
             ft.Add<StringId>(rideEntry->naming.Description);
-            screenCoords.y += DrawTextWrapped(dpi, screenCoords, 300, STR_BLACK_STRING, ft, { TextAlignment::LEFT });
+            screenCoords.y += DrawTextWrapped(rt, screenCoords, 300, STR_BLACK_STRING, ft, { TextAlignment::LEFT });
             screenCoords.y += 2;
 
             // Capacity
             ft = Formatter();
             ft.Add<StringId>(rideEntry->capacity);
-            DrawTextBasic(dpi, screenCoords, STR_CAPACITY, ft);
+            DrawTextBasic(rt, screenCoords, STR_CAPACITY, ft);
 
             // Excitement Factor
             if (rideEntry->excitement_multiplier != 0)
@@ -2899,7 +2899,7 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<int16_t>(abs(rideEntry->excitement_multiplier));
                 StringId stringId = rideEntry->excitement_multiplier > 0 ? STR_EXCITEMENT_FACTOR
                                                                          : STR_EXCITEMENT_FACTOR_NEGATIVE;
-                DrawTextBasic(dpi, screenCoords, stringId, ft);
+                DrawTextBasic(rt, screenCoords, stringId, ft);
             }
 
             // Intensity Factor
@@ -2914,7 +2914,7 @@ namespace OpenRCT2::Ui::Windows
                 ft = Formatter();
                 ft.Add<int16_t>(abs(rideEntry->intensity_multiplier));
                 StringId stringId = rideEntry->intensity_multiplier > 0 ? STR_INTENSITY_FACTOR : STR_INTENSITY_FACTOR_NEGATIVE;
-                DrawTextBasic(dpi, screenCoords, stringId, ft);
+                DrawTextBasic(rt, screenCoords, stringId, ft);
 
                 if (lineHeight != 10)
                     screenCoords.x -= 150;
@@ -2928,7 +2928,7 @@ namespace OpenRCT2::Ui::Windows
                 ft = Formatter();
                 ft.Add<int16_t>(abs(rideEntry->nausea_multiplier));
                 StringId stringId = rideEntry->nausea_multiplier > 0 ? STR_NAUSEA_FACTOR : STR_NAUSEA_FACTOR_NEGATIVE;
-                DrawTextBasic(dpi, screenCoords, stringId, ft);
+                DrawTextBasic(rt, screenCoords, stringId, ft);
             }
 
             const auto minimumPreviewStart = screenCoords.y - windowPos.y + kListRowHeight + 5;
@@ -2952,7 +2952,7 @@ namespace OpenRCT2::Ui::Windows
             ImageId imageId;
         };
 
-        void VehicleOnScrollDraw(RenderTarget& dpi, int32_t scrollIndex)
+        void VehicleOnScrollDraw(RenderTarget& rt, int32_t scrollIndex)
         {
             auto ride = GetRide(rideId);
             if (ride == nullptr)
@@ -2961,7 +2961,7 @@ namespace OpenRCT2::Ui::Windows
             const auto* rideEntry = ride->getRideEntry();
 
             // Background
-            GfxFillRect(dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width, dpi.y + dpi.height } }, PaletteIndex::pi12);
+            GfxFillRect(rt, { { rt.x, rt.y }, { rt.x + rt.width, rt.y + rt.height } }, PaletteIndex::pi12);
 
             Widget* widget = &widgets[WIDX_VEHICLE_TRAINS_PREVIEW];
             int32_t startX = std::max(2, (widget->width() - ((ride->numTrains - 1) * 36)) / 2 - 25);
@@ -3042,7 +3042,7 @@ namespace OpenRCT2::Ui::Windows
 
                 VehicleDrawInfo* current = nextSpriteToDraw;
                 while (--current >= trainCarImages)
-                    GfxDrawSprite(dpi, current->imageId, { current->x, current->y });
+                    GfxDrawSprite(rt, current->imageId, { current->x, current->y });
 
                 startX += 36;
             }
@@ -3683,10 +3683,10 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
         }
 
-        void OperatingOnDraw(RenderTarget& dpi)
+        void OperatingOnDraw(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             auto ride = GetRide(rideId);
             if (ride == nullptr)
@@ -3695,7 +3695,7 @@ namespace OpenRCT2::Ui::Windows
             // Horizontal rule between mode settings and depart settings
             auto ruleStart = widgets[WIDX_LOAD_DROPDOWN].top - 8;
             GfxFillRectInset(
-                dpi,
+                rt,
                 { windowPos + ScreenCoordsXY{ widgets[WIDX_PAGE_BACKGROUND].left + 4, ruleStart },
                   windowPos + ScreenCoordsXY{ widgets[WIDX_PAGE_BACKGROUND].right - 5, ruleStart + 1 } },
                 colours[1], INSET_RECT_FLAG_BORDER_INSET);
@@ -3707,7 +3707,7 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<uint16_t>(ride->numBlockBrakes + ride->numStations);
                 auto underWidget = ride->mode == RideMode::poweredLaunchBlockSectioned ? WIDX_MODE_TWEAK : WIDX_MODE;
                 DrawTextBasic(
-                    dpi, windowPos + ScreenCoordsXY{ 21, widgets[underWidget].bottom + 3 }, STR_BLOCK_SECTIONS, ft,
+                    rt, windowPos + ScreenCoordsXY{ 21, widgets[underWidget].bottom + 3 }, STR_BLOCK_SECTIONS, ft,
                     { COLOUR_BLACK });
             }
         }
@@ -4026,7 +4026,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void MaintenanceOnDraw(RenderTarget& dpi)
+        void MaintenanceOnDraw(RenderTarget& rt)
         {
             auto ride = GetRide(rideId);
             if (ride == nullptr)
@@ -4038,19 +4038,19 @@ namespace OpenRCT2::Ui::Windows
             uint16_t downTime = ride->downtime;
             WidgetProgressBarSetNewPercentage(widgets[WIDX_DOWN_TIME_BAR], downTime);
 
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             // Locate mechanic button image
             Widget* widget = &widgets[WIDX_LOCATE_MECHANIC];
             auto screenCoords = windowPos + ScreenCoordsXY{ widget->left, widget->top };
             auto image = ImageId(SPR_MECHANIC, COLOUR_BLACK, getGameState().staffMechanicColour);
-            GfxDrawSprite(dpi, image, screenCoords);
+            GfxDrawSprite(rt, image, screenCoords);
 
             // Inspection label
             widget = &widgets[WIDX_INSPECTION_INTERVAL];
             screenCoords = windowPos + ScreenCoordsXY{ 4, widget->top + 1 };
-            DrawTextBasic(dpi, screenCoords, STR_INSPECTION);
+            DrawTextBasic(rt, screenCoords, STR_INSPECTION);
 
             // Reliability
             widget = &widgets[WIDX_PAGE_BACKGROUND];
@@ -4058,12 +4058,12 @@ namespace OpenRCT2::Ui::Windows
 
             auto ft = Formatter();
             ft.Add<uint16_t>(reliability);
-            DrawTextBasic(dpi, screenCoords, STR_RELIABILITY_LABEL_1757, ft);
+            DrawTextBasic(rt, screenCoords, STR_RELIABILITY_LABEL_1757, ft);
             screenCoords.y += 11;
 
             ft = Formatter();
             ft.Add<uint16_t>(downTime);
-            DrawTextBasic(dpi, screenCoords, STR_DOWN_TIME_LABEL_1889, ft);
+            DrawTextBasic(rt, screenCoords, STR_DOWN_TIME_LABEL_1889, ft);
             screenCoords.y += 26;
 
             // Last inspection
@@ -4077,7 +4077,7 @@ namespace OpenRCT2::Ui::Windows
 
             ft = Formatter();
             ft.Add<uint16_t>(ride->lastInspection);
-            DrawTextBasic(dpi, screenCoords, stringId, ft);
+            DrawTextBasic(rt, screenCoords, stringId, ft);
             screenCoords.y += 12;
 
             // Last / current breakdown
@@ -4087,7 +4087,7 @@ namespace OpenRCT2::Ui::Windows
             stringId = (ride->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN) ? STR_CURRENT_BREAKDOWN : STR_LAST_BREAKDOWN;
             ft = Formatter();
             ft.Add<StringId>(RideBreakdownReasonNames[ride->breakdownReason]);
-            DrawTextBasic(dpi, screenCoords, stringId, ft);
+            DrawTextBasic(rt, screenCoords, stringId, ft);
             screenCoords.y += 12;
 
             // Mechanic status
@@ -4125,7 +4125,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     if (stringId == STR_CALLING_MECHANIC || stringId == STR_NO_MECHANICS_ARE_HIRED_MESSAGE)
                     {
-                        DrawTextWrapped(dpi, screenCoords, 280, stringId, {}, { TextAlignment::LEFT });
+                        DrawTextWrapped(rt, screenCoords, 280, stringId, {}, { TextAlignment::LEFT });
                     }
                     else
                     {
@@ -4134,7 +4134,7 @@ namespace OpenRCT2::Ui::Windows
                         {
                             ft = Formatter();
                             staff->FormatNameTo(ft);
-                            DrawTextWrapped(dpi, screenCoords, 280, stringId, ft, { TextAlignment::LEFT });
+                            DrawTextWrapped(rt, screenCoords, 280, stringId, ft, { TextAlignment::LEFT });
                         }
                     }
                 }
@@ -4812,7 +4812,7 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
         }
 
-        void ColourOnDraw(RenderTarget& dpi)
+        void ColourOnDraw(RenderTarget& rt)
         {
             // TODO: This should use lists and identified sprites
             RenderTarget clippedDpi;
@@ -4821,14 +4821,14 @@ namespace OpenRCT2::Ui::Windows
             if (ride == nullptr)
                 return;
 
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             // Track / shop item preview
             const auto& trackPreviewWidget = widgets[WIDX_TRACK_PREVIEW];
             if (trackPreviewWidget.type != WindowWidgetType::Empty)
                 GfxFillRect(
-                    dpi,
+                    rt,
                     { { windowPos + ScreenCoordsXY{ trackPreviewWidget.left + 1, trackPreviewWidget.top + 1 } },
                       { windowPos + ScreenCoordsXY{ trackPreviewWidget.right - 1, trackPreviewWidget.bottom - 1 } } },
                     PaletteIndex::pi12);
@@ -4845,7 +4845,7 @@ namespace OpenRCT2::Ui::Windows
                 const auto& rtd = ride->getRideTypeDescriptor();
                 if (rtd.specialType == RtdSpecialType::maze)
                 {
-                    GfxDrawSprite(dpi, ImageId(MazeOptions[trackColour.supports].sprite), screenCoords);
+                    GfxDrawSprite(rt, ImageId(MazeOptions[trackColour.supports].sprite), screenCoords);
                 }
                 else
                 {
@@ -4853,14 +4853,14 @@ namespace OpenRCT2::Ui::Windows
                     int32_t spriteIndex = typeDescriptor.ColourPreview.Track;
                     if (spriteIndex != 0)
                     {
-                        GfxDrawSprite(dpi, ImageId(spriteIndex, trackColour.main, trackColour.additional), screenCoords);
+                        GfxDrawSprite(rt, ImageId(spriteIndex, trackColour.main, trackColour.additional), screenCoords);
                     }
 
                     // Supports
                     spriteIndex = typeDescriptor.ColourPreview.Supports;
                     if (spriteIndex != 0)
                     {
-                        GfxDrawSprite(dpi, ImageId(spriteIndex, trackColour.supports), screenCoords);
+                        GfxDrawSprite(rt, ImageId(spriteIndex, trackColour.supports), screenCoords);
                     }
                 }
             }
@@ -4885,12 +4885,12 @@ namespace OpenRCT2::Ui::Windows
                         }
                     }
 
-                    GfxDrawSprite(dpi, ImageId(GetShopItemDescriptor(shopItem).Image, spriteColour), screenCoords);
+                    GfxDrawSprite(rt, ImageId(GetShopItemDescriptor(shopItem).Image, spriteColour), screenCoords);
                 }
                 else
                 {
                     GfxDrawSprite(
-                        dpi, ImageId(GetShopItemDescriptor(shopItem).Image, ride->trackColours[0].main), screenCoords);
+                        rt, ImageId(GetShopItemDescriptor(shopItem).Image, ride->trackColours[0].main), screenCoords);
                 }
             }
 
@@ -4900,7 +4900,7 @@ namespace OpenRCT2::Ui::Windows
             if (entrancePreviewWidget.type != WindowWidgetType::Empty)
             {
                 if (ClipDrawPixelInfo(
-                        clippedDpi, dpi,
+                        clippedDpi, rt,
                         windowPos + ScreenCoordsXY{ entrancePreviewWidget.left + 1, entrancePreviewWidget.top + 1 },
                         entrancePreviewWidget.width(), entrancePreviewWidget.height()))
                 {
@@ -4927,11 +4927,11 @@ namespace OpenRCT2::Ui::Windows
                 }
 
                 auto labelPos = windowPos + ScreenCoordsXY{ 3, widgets[WIDX_ENTRANCE_STYLE].top };
-                DrawTextEllipsised(dpi, labelPos, 97, STR_STATION_STYLE, {});
+                DrawTextEllipsised(rt, labelPos, 97, STR_STATION_STYLE, {});
             }
         }
 
-        void ColourOnScrollDraw(RenderTarget& dpi, int32_t scrollIndex) const
+        void ColourOnScrollDraw(RenderTarget& rt, int32_t scrollIndex) const
         {
             auto ride = GetRide(rideId);
             if (ride == nullptr)
@@ -4945,7 +4945,7 @@ namespace OpenRCT2::Ui::Windows
             auto vehicleColour = RideGetVehicleColour(*ride, _vehicleIndex);
 
             // Background colour
-            GfxFillRect(dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, PaletteIndex::pi12);
+            GfxFillRect(rt, { { rt.x, rt.y }, { rt.x + rt.width - 1, rt.y + rt.height - 1 } }, PaletteIndex::pi12);
 
             // ?
             auto screenCoords = ScreenCoordsXY{ vehiclePreviewWidget->width() / 2, vehiclePreviewWidget->height() - 15 };
@@ -4966,7 +4966,7 @@ namespace OpenRCT2::Ui::Windows
             imageIndex *= carEntry.base_num_frames;
             imageIndex += carEntry.base_image_id;
             auto imageId = ImageId(imageIndex, vehicleColour.Body, vehicleColour.Trim, vehicleColour.Tertiary);
-            GfxDrawSprite(dpi, imageId, screenCoords);
+            GfxDrawSprite(rt, imageId, screenCoords);
         }
 
 #pragma endregion
@@ -5237,10 +5237,10 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
         }
 
-        void MusicOnDraw(RenderTarget& dpi)
+        void MusicOnDraw(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
             auto ride = GetRide(rideId);
             if (ride == nullptr)
                 return;
@@ -5252,7 +5252,7 @@ namespace OpenRCT2::Ui::Windows
 
             // 'Tracks' caption
             auto trackLabelPos = windowPos + ScreenCoordsXY{ widgets[WIDX_MUSIC_DATA].left, widgets[WIDX_MUSIC_DATA].top - 13 };
-            DrawTextWrapped(dpi, trackLabelPos, width, STR_MUSIC_OBJECT_TRACK_HEADER, {}, { TextAlignment::LEFT });
+            DrawTextWrapped(rt, trackLabelPos, width, STR_MUSIC_OBJECT_TRACK_HEADER, {}, { TextAlignment::LEFT });
 
             // Do we have a preview image to draw?
             auto musicObj = ride->getMusicObject();
@@ -5268,13 +5268,13 @@ namespace OpenRCT2::Ui::Windows
             // Draw the preview image
             RenderTarget clipDPI;
             auto screenPos = windowPos + ScreenCoordsXY{ previewWidget.left + 1, previewWidget.top + 1 };
-            if (ClipDrawPixelInfo(clipDPI, dpi, screenPos, clipWidth, clipHeight))
+            if (ClipDrawPixelInfo(clipDPI, rt, screenPos, clipWidth, clipHeight))
             {
                 musicObj->DrawPreview(clipDPI, clipWidth, clipHeight);
             }
         }
 
-        void MusicOnScrollDraw(RenderTarget& dpi, int32_t scrollIndex)
+        void MusicOnScrollDraw(RenderTarget& rt, int32_t scrollIndex)
         {
             auto ride = GetRide(rideId);
             if (ride == nullptr)
@@ -5286,7 +5286,7 @@ namespace OpenRCT2::Ui::Windows
                 return;
 
             uint8_t paletteIndex = ColourMapA[colours[1].colour].mid_light;
-            GfxClear(dpi, paletteIndex);
+            GfxClear(rt, paletteIndex);
 
             auto* musicObj = ride->getMusicObject();
             if (musicObj == nullptr)
@@ -5297,7 +5297,7 @@ namespace OpenRCT2::Ui::Windows
             for (size_t i = 0; i < musicObj->GetTrackCount(); i++)
             {
                 // Skip invisible items
-                if (y + kScrollableRowHeight < dpi.y || y > dpi.y + dpi.height)
+                if (y + kScrollableRowHeight < rt.y || y > rt.y + rt.height)
                 {
                     y += kScrollableRowHeight;
                     continue;
@@ -5318,7 +5318,7 @@ namespace OpenRCT2::Ui::Windows
                                                         : STR_MUSIC_OBJECT_TRACK_LIST_ITEM_WITH_COMPOSER;
 
                 // Draw the track
-                DrawTextBasic(dpi, { 0, y }, stringId, ft, { FontStyle::Small });
+                DrawTextBasic(rt, { 0, y }, stringId, ft, { FontStyle::Small });
                 y += kScrollableRowHeight;
             }
         }
@@ -5609,10 +5609,10 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
         }
 
-        void MeasurementsOnDraw(RenderTarget& dpi)
+        void MeasurementsOnDraw(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             if (widgets[WIDX_SAVE_DESIGN].type == WindowWidgetType::Button)
             {
@@ -5620,12 +5620,12 @@ namespace OpenRCT2::Ui::Windows
 
                 ScreenCoordsXY widgetCoords(windowPos.x + widget->width() / 2, windowPos.y + widget->top + 40);
                 DrawTextWrapped(
-                    dpi, widgetCoords, width - 8, STR_CLICK_ITEMS_OF_SCENERY_TO_SELECT, {}, { TextAlignment::CENTRE });
+                    rt, widgetCoords, width - 8, STR_CLICK_ITEMS_OF_SCENERY_TO_SELECT, {}, { TextAlignment::CENTRE });
 
                 widgetCoords.x = windowPos.x + 4;
                 widgetCoords.y = windowPos.y + widgets[WIDX_SELECT_NEARBY_SCENERY].bottom + 17;
                 GfxFillRectInset(
-                    dpi, { widgetCoords, { windowPos.x + 312, widgetCoords.y + 1 } }, colours[1], INSET_RECT_FLAG_BORDER_INSET);
+                    rt, { widgetCoords, { windowPos.x + 312, widgetCoords.y + 1 } }, colours[1], INSET_RECT_FLAG_BORDER_INSET);
             }
             else
             {
@@ -5645,7 +5645,7 @@ namespace OpenRCT2::Ui::Windows
                     ft.Add<StringId>(ratingName);
                     StringId stringId = !RideHasRatings(*ride) ? STR_EXCITEMENT_RATING_NOT_YET_AVAILABLE
                                                                : STR_EXCITEMENT_RATING;
-                    DrawTextBasic(dpi, screenCoords, stringId, ft);
+                    DrawTextBasic(rt, screenCoords, stringId, ft);
                     screenCoords.y += kListRowHeight;
 
                     // Intensity
@@ -5660,7 +5660,7 @@ namespace OpenRCT2::Ui::Windows
                     else if (ride->ratings.intensity >= MakeRideRating(10, 00))
                         stringId = STR_INTENSITY_RATING_RED;
 
-                    DrawTextBasic(dpi, screenCoords, stringId, ft);
+                    DrawTextBasic(rt, screenCoords, stringId, ft);
                     screenCoords.y += kListRowHeight;
 
                     // Nausea
@@ -5669,12 +5669,12 @@ namespace OpenRCT2::Ui::Windows
                     ft.Add<uint32_t>(ride->ratings.nausea);
                     ft.Add<StringId>(ratingName);
                     stringId = !RideHasRatings(*ride) ? STR_NAUSEA_RATING_NOT_YET_AVAILABLE : STR_NAUSEA_RATING;
-                    DrawTextBasic(dpi, screenCoords, stringId, ft);
+                    DrawTextBasic(rt, screenCoords, stringId, ft);
                     screenCoords.y += 2 * kListRowHeight;
 
                     // Horizontal rule
                     GfxFillRectInset(
-                        dpi, { screenCoords - ScreenCoordsXY{ 0, 6 }, screenCoords + ScreenCoordsXY{ 303, -5 } }, colours[1],
+                        rt, { screenCoords - ScreenCoordsXY{ 0, 6 }, screenCoords + ScreenCoordsXY{ 303, -5 } }, colours[1],
                         INSET_RECT_FLAG_BORDER_INSET);
 
                     if (!(ride->lifecycleFlags & RIDE_LIFECYCLE_NO_RAW_STATS))
@@ -5684,7 +5684,7 @@ namespace OpenRCT2::Ui::Windows
                             // Holes
                             ft = Formatter();
                             ft.Add<uint16_t>(ride->numHoles);
-                            DrawTextBasic(dpi, screenCoords, STR_HOLES, ft);
+                            DrawTextBasic(rt, screenCoords, STR_HOLES, ft);
                             screenCoords.y += kListRowHeight;
                         }
                         else
@@ -5692,13 +5692,13 @@ namespace OpenRCT2::Ui::Windows
                             // Max speed
                             ft = Formatter();
                             ft.Add<int32_t>(ToHumanReadableSpeed(ride->maxSpeed));
-                            DrawTextBasic(dpi, screenCoords, STR_MAX_SPEED, ft);
+                            DrawTextBasic(rt, screenCoords, STR_MAX_SPEED, ft);
                             screenCoords.y += kListRowHeight;
 
                             // Average speed
                             ft = Formatter();
                             ft.Add<int32_t>(ToHumanReadableSpeed(ride->averageSpeed));
-                            DrawTextBasic(dpi, screenCoords, STR_AVERAGE_SPEED, ft);
+                            DrawTextBasic(rt, screenCoords, STR_AVERAGE_SPEED, ft);
                             screenCoords.y += kListRowHeight;
 
                             // Ride time
@@ -5738,7 +5738,7 @@ namespace OpenRCT2::Ui::Windows
                             ft.Add<uint16_t>(0);
                             ft.Add<uint16_t>(0);
                             ft.Add<uint16_t>(0);
-                            DrawTextEllipsised(dpi, screenCoords, 308, STR_RIDE_TIME, ft);
+                            DrawTextEllipsised(rt, screenCoords, 308, STR_RIDE_TIME, ft);
                             screenCoords.y += kListRowHeight;
                         }
 
@@ -5778,7 +5778,7 @@ namespace OpenRCT2::Ui::Windows
                         ft.Add<uint16_t>(0);
                         ft.Add<uint16_t>(0);
                         ft.Add<uint16_t>(0);
-                        DrawTextEllipsised(dpi, screenCoords, 308, STR_RIDE_LENGTH, ft);
+                        DrawTextEllipsised(rt, screenCoords, 308, STR_RIDE_LENGTH, ft);
 
                         screenCoords.y += kListRowHeight;
 
@@ -5789,7 +5789,7 @@ namespace OpenRCT2::Ui::Windows
 
                             ft = Formatter();
                             ft.Add<fixed16_2dp>(ride->maxPositiveVerticalG);
-                            DrawTextBasic(dpi, screenCoords, stringId, ft);
+                            DrawTextBasic(rt, screenCoords, stringId, ft);
                             screenCoords.y += kListRowHeight;
 
                             // Max. negative vertical G's
@@ -5798,20 +5798,20 @@ namespace OpenRCT2::Ui::Windows
                                 : STR_MAX_NEGATIVE_VERTICAL_G;
                             ft = Formatter();
                             ft.Add<int32_t>(ride->maxNegativeVerticalG);
-                            DrawTextBasic(dpi, screenCoords, stringId, ft);
+                            DrawTextBasic(rt, screenCoords, stringId, ft);
                             screenCoords.y += kListRowHeight;
 
                             // Max lateral G's
                             stringId = ride->maxLateralG > kRideGForcesRedLateral ? STR_MAX_LATERAL_G_RED : STR_MAX_LATERAL_G;
                             ft = Formatter();
                             ft.Add<fixed16_2dp>(ride->maxLateralG);
-                            DrawTextBasic(dpi, screenCoords, stringId, ft);
+                            DrawTextBasic(rt, screenCoords, stringId, ft);
                             screenCoords.y += kListRowHeight;
 
                             // Total 'air' time
                             ft = Formatter();
                             ft.Add<fixed32_2dp>(ToHumanReadableAirTime(ride->totalAirTime));
-                            DrawTextBasic(dpi, screenCoords, STR_TOTAL_AIR_TIME, ft);
+                            DrawTextBasic(rt, screenCoords, STR_TOTAL_AIR_TIME, ft);
                             screenCoords.y += kListRowHeight;
                         }
 
@@ -5819,14 +5819,14 @@ namespace OpenRCT2::Ui::Windows
                         {
                             ft = Formatter();
                             ft.Add<uint16_t>(ride->numDrops);
-                            DrawTextBasic(dpi, screenCoords, STR_DROPS, ft);
+                            DrawTextBasic(rt, screenCoords, STR_DROPS, ft);
                             screenCoords.y += kListRowHeight;
 
                             // Highest drop height
                             auto highestDropHeight = (ride->highestDropHeight * 3) / 4;
                             ft = Formatter();
                             ft.Add<int32_t>(highestDropHeight);
-                            DrawTextBasic(dpi, screenCoords, STR_HIGHEST_DROP_HEIGHT, ft);
+                            DrawTextBasic(rt, screenCoords, STR_HIGHEST_DROP_HEIGHT, ft);
                             screenCoords.y += kListRowHeight;
                         }
 
@@ -5837,7 +5837,7 @@ namespace OpenRCT2::Ui::Windows
                             {
                                 ft = Formatter();
                                 ft.Add<uint16_t>(ride->numInversions);
-                                DrawTextBasic(dpi, screenCoords, STR_INVERSIONS, ft);
+                                DrawTextBasic(rt, screenCoords, STR_INVERSIONS, ft);
                                 screenCoords.y += kListRowHeight;
                             }
                         }
@@ -5845,7 +5845,7 @@ namespace OpenRCT2::Ui::Windows
                 }
                 else
                 {
-                    DrawTextBasic(dpi, screenCoords, STR_NO_TEST_RESULTS_YET);
+                    DrawTextBasic(rt, screenCoords, STR_NO_TEST_RESULTS_YET);
                 }
             }
         }
@@ -6053,15 +6053,15 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
         }
 
-        void GraphsOnDraw(RenderTarget& dpi)
+        void GraphsOnDraw(RenderTarget& rt)
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
         }
 
-        void GraphsOnScrollDraw(RenderTarget& dpi, int32_t scrollIndex)
+        void GraphsOnScrollDraw(RenderTarget& rt, int32_t scrollIndex)
         {
-            GfxClear(dpi, ColourMapA[COLOUR_SATURATED_GREEN].darker);
+            GfxClear(rt, ColourMapA[COLOUR_SATURATED_GREEN].darker);
 
             auto widget = &widgets[WIDX_GRAPH];
             auto ride = GetRide(rideId);
@@ -6077,7 +6077,7 @@ namespace OpenRCT2::Ui::Windows
                 // No measurement message
                 ScreenCoordsXY stringCoords(widget->width() / 2, widget->height() / 2 - 5);
                 int32_t txtWidth = widget->width() - 2;
-                DrawTextWrapped(dpi, stringCoords, txtWidth, message.str, message.args, { TextAlignment::CENTRE });
+                DrawTextWrapped(rt, stringCoords, txtWidth, message.str, message.args, { TextAlignment::CENTRE });
                 return;
             }
 
@@ -6086,17 +6086,17 @@ namespace OpenRCT2::Ui::Windows
             const uint8_t darkColour = ColourMapA[COLOUR_SATURATED_GREEN].mid_dark;
 
             int32_t time = 0;
-            for (int32_t x = 0; x < dpi.x + dpi.width; x += 80)
+            for (int32_t x = 0; x < rt.x + rt.width; x += 80)
             {
-                if (x + 80 >= dpi.x)
+                if (x + 80 >= rt.x)
                 {
-                    auto coord1 = ScreenCoordsXY{ x, dpi.y };
-                    auto coord2 = ScreenCoordsXY{ x, dpi.y + dpi.height - 1 };
-                    GfxFillRect(dpi, { coord1, coord2 }, lightColour);
-                    GfxFillRect(dpi, { coord1 + ScreenCoordsXY{ 16, 0 }, coord2 + ScreenCoordsXY{ 16, 0 } }, darkColour);
-                    GfxFillRect(dpi, { coord1 + ScreenCoordsXY{ 32, 0 }, coord2 + ScreenCoordsXY{ 32, 0 } }, darkColour);
-                    GfxFillRect(dpi, { coord1 + ScreenCoordsXY{ 48, 0 }, coord2 + ScreenCoordsXY{ 48, 0 } }, darkColour);
-                    GfxFillRect(dpi, { coord1 + ScreenCoordsXY{ 64, 0 }, coord2 + ScreenCoordsXY{ 64, 0 } }, darkColour);
+                    auto coord1 = ScreenCoordsXY{ x, rt.y };
+                    auto coord2 = ScreenCoordsXY{ x, rt.y + rt.height - 1 };
+                    GfxFillRect(rt, { coord1, coord2 }, lightColour);
+                    GfxFillRect(rt, { coord1 + ScreenCoordsXY{ 16, 0 }, coord2 + ScreenCoordsXY{ 16, 0 } }, darkColour);
+                    GfxFillRect(rt, { coord1 + ScreenCoordsXY{ 32, 0 }, coord2 + ScreenCoordsXY{ 32, 0 } }, darkColour);
+                    GfxFillRect(rt, { coord1 + ScreenCoordsXY{ 48, 0 }, coord2 + ScreenCoordsXY{ 48, 0 } }, darkColour);
+                    GfxFillRect(rt, { coord1 + ScreenCoordsXY{ 64, 0 }, coord2 + ScreenCoordsXY{ 64, 0 } }, darkColour);
                 }
                 time += 5;
             }
@@ -6118,7 +6118,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 // Minor / major line
                 int32_t colour = yUnit == 0 ? lightColour : darkColour;
-                GfxFillRect(dpi, { { dpi.x, y }, { dpi.x + dpi.width - 1, y } }, colour);
+                GfxFillRect(rt, { { rt.x, y }, { rt.x + rt.width - 1, y } }, colour);
 
                 int16_t scaled_yUnit = yUnit;
                 // Scale modifier
@@ -6128,28 +6128,28 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<int16_t>(scaled_yUnit);
 
-                DrawTextBasic(dpi, { scrolls[0].contentOffsetX + 1, y - 4 }, stringID, ft, { FontStyle::Small });
+                DrawTextBasic(rt, { scrolls[0].contentOffsetX + 1, y - 4 }, stringID, ft, { FontStyle::Small });
             }
 
             // Time marks
             time = 0;
-            for (int32_t x = 0; x < dpi.x + dpi.width; x += 80)
+            for (int32_t x = 0; x < rt.x + rt.width; x += 80)
             {
                 auto ft = Formatter();
                 ft.Add<int32_t>(time);
-                if (x + 80 >= dpi.x)
-                    DrawTextBasic(dpi, { x + 2, 1 }, STR_RIDE_STATS_TIME, ft, { FontStyle::Small });
+                if (x + 80 >= rt.x)
+                    DrawTextBasic(rt, { x + 2, 1 }, STR_RIDE_STATS_TIME, ft, { FontStyle::Small });
                 time += 5;
             }
 
             // Plot
-            int32_t x = dpi.x;
+            int32_t x = rt.x;
             int32_t firstPoint, secondPoint;
             // Uses the force limits (used to draw extreme G's in red on measurement tab) to determine if line should be drawn
             // red.
             int32_t intensityThresholdPositive = 0;
             int32_t intensityThresholdNegative = 0;
-            for (int32_t graphWidth = 0; graphWidth < dpi.width; graphWidth++, x++)
+            for (int32_t graphWidth = 0; graphWidth < rt.width; graphWidth++, x++)
             {
                 if (x < 0 || x >= measurement->num_items - 1)
                     continue;
@@ -6203,7 +6203,7 @@ namespace OpenRCT2::Ui::Windows
 
                 // Draw the current line in grey.
                 GfxFillRect(
-                    dpi, { { x, firstPoint }, { x, secondPoint } },
+                    rt, { { x, firstPoint }, { x, secondPoint } },
                     previousMeasurement ? PaletteIndex::pi17 : PaletteIndex::pi21);
 
                 // Draw red over extreme values (if supported by graph type).
@@ -6216,7 +6216,7 @@ namespace OpenRCT2::Ui::Windows
                     {
                         const auto redLineTop = ScreenCoordsXY{ x, std::max(firstPoint, intensityThresholdNegative) };
                         const auto redLineBottom = ScreenCoordsXY{ x, std::max(secondPoint, intensityThresholdNegative) };
-                        GfxFillRect(dpi, { redLineTop, redLineBottom }, redLineColour);
+                        GfxFillRect(rt, { redLineTop, redLineBottom }, redLineColour);
                     }
 
                     // Line exceeds positive threshold (at top of graph).
@@ -6224,7 +6224,7 @@ namespace OpenRCT2::Ui::Windows
                     {
                         const auto redLineTop = ScreenCoordsXY{ x, std::min(firstPoint, intensityThresholdPositive) };
                         const auto redLineBottom = ScreenCoordsXY{ x, std::min(secondPoint, intensityThresholdPositive) };
-                        GfxFillRect(dpi, { redLineTop, redLineBottom }, redLineColour);
+                        GfxFillRect(rt, { redLineTop, redLineBottom }, redLineColour);
                     }
                 }
             }
@@ -6614,14 +6614,14 @@ namespace OpenRCT2::Ui::Windows
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
         }
 
-        void IncomeOnDraw(RenderTarget& dpi)
+        void IncomeOnDraw(RenderTarget& rt)
         {
             StringId stringId;
             money64 profit;
             ShopItem primaryItem, secondaryItem;
 
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             auto ride = GetRide(rideId);
             if (ride == nullptr)
@@ -6651,7 +6651,7 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<money64>(profit);
 
-                DrawTextBasic(dpi, screenCoords, stringId, ft);
+                DrawTextBasic(rt, screenCoords, stringId, ft);
             }
             screenCoords.y += 44;
 
@@ -6675,7 +6675,7 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<money64>(profit);
 
-                DrawTextBasic(dpi, screenCoords, stringId, ft);
+                DrawTextBasic(rt, screenCoords, stringId, ft);
             }
             screenCoords.y += 18;
 
@@ -6685,7 +6685,7 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<money64>(ride->incomePerHour);
 
-                DrawTextBasic(dpi, screenCoords, STR_INCOME_PER_HOUR, ft);
+                DrawTextBasic(rt, screenCoords, STR_INCOME_PER_HOUR, ft);
                 screenCoords.y += kListRowHeight;
             }
 
@@ -6694,7 +6694,7 @@ namespace OpenRCT2::Ui::Windows
             stringId = ride->upkeepCost == kMoney64Undefined ? STR_RUNNING_COST_UNKNOWN : STR_RUNNING_COST_PER_HOUR;
             auto ft = Formatter();
             ft.Add<money64>(costPerHour);
-            DrawTextBasic(dpi, screenCoords, stringId, ft);
+            DrawTextBasic(rt, screenCoords, stringId, ft);
             screenCoords.y += kListRowHeight;
 
             // Profit per hour
@@ -6702,7 +6702,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 ft = Formatter();
                 ft.Add<money64>(ride->profit);
-                DrawTextBasic(dpi, screenCoords, STR_PROFIT_PER_HOUR, ft);
+                DrawTextBasic(rt, screenCoords, STR_PROFIT_PER_HOUR, ft);
                 screenCoords.y += kListRowHeight;
             }
             screenCoords.y += 5;
@@ -6710,7 +6710,7 @@ namespace OpenRCT2::Ui::Windows
             // Total profit
             ft = Formatter();
             ft.Add<money64>(ride->totalProfit);
-            DrawTextBasic(dpi, screenCoords, STR_TOTAL_PROFIT, ft);
+            DrawTextBasic(rt, screenCoords, STR_TOTAL_PROFIT, ft);
         }
 
 #pragma endregion
@@ -6813,14 +6813,14 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void CustomerOnDraw(RenderTarget& dpi)
+        void CustomerOnDraw(RenderTarget& rt)
         {
             ShopItem shopItem;
             int16_t popularity, satisfaction, queueTime;
             StringId stringId;
 
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             auto ride = GetRide(rideId);
             if (ride == nullptr)
@@ -6834,14 +6834,14 @@ namespace OpenRCT2::Ui::Windows
             {
                 auto ft = Formatter();
                 ft.Add<int16_t>(ride->numRiders);
-                DrawTextBasic(dpi, screenCoords, STR_CUSTOMERS_ON_RIDE, ft);
+                DrawTextBasic(rt, screenCoords, STR_CUSTOMERS_ON_RIDE, ft);
                 screenCoords.y += kListRowHeight;
             }
 
             // Customers per hour
             auto ft = Formatter();
             ft.Add<int32_t>(RideCustomersPerHour(*ride));
-            DrawTextBasic(dpi, screenCoords, STR_CUSTOMERS_PER_HOUR, ft);
+            DrawTextBasic(rt, screenCoords, STR_CUSTOMERS_PER_HOUR, ft);
             screenCoords.y += kListRowHeight;
 
             // Popularity
@@ -6857,7 +6857,7 @@ namespace OpenRCT2::Ui::Windows
             }
             ft = Formatter();
             ft.Add<int16_t>(popularity);
-            DrawTextBasic(dpi, screenCoords, stringId, ft);
+            DrawTextBasic(rt, screenCoords, stringId, ft);
             screenCoords.y += kListRowHeight;
 
             // Satisfaction
@@ -6873,7 +6873,7 @@ namespace OpenRCT2::Ui::Windows
             }
             ft = Formatter();
             ft.Add<int16_t>(satisfaction);
-            DrawTextBasic(dpi, screenCoords, stringId, ft);
+            DrawTextBasic(rt, screenCoords, stringId, ft);
             screenCoords.y += kListRowHeight;
 
             // Queue time
@@ -6883,7 +6883,7 @@ namespace OpenRCT2::Ui::Windows
                 stringId = queueTime == 1 ? STR_QUEUE_TIME_MINUTE : STR_QUEUE_TIME_MINUTES;
                 ft = Formatter();
                 ft.Add<int32_t>(queueTime);
-                screenCoords.y += DrawTextWrapped(dpi, screenCoords, 308, stringId, ft, { TextAlignment::LEFT });
+                screenCoords.y += DrawTextWrapped(rt, screenCoords, 308, stringId, ft, { TextAlignment::LEFT });
                 screenCoords.y += 5;
             }
 
@@ -6894,7 +6894,7 @@ namespace OpenRCT2::Ui::Windows
                 ft = Formatter();
                 ft.Add<StringId>(GetShopItemDescriptor(shopItem).Naming.Plural);
                 ft.Add<uint32_t>(ride->numPrimaryItemsSold);
-                DrawTextBasic(dpi, screenCoords, STR_ITEMS_SOLD, ft);
+                DrawTextBasic(rt, screenCoords, STR_ITEMS_SOLD, ft);
                 screenCoords.y += kListRowHeight;
             }
 
@@ -6906,14 +6906,14 @@ namespace OpenRCT2::Ui::Windows
                 ft = Formatter();
                 ft.Add<StringId>(GetShopItemDescriptor(shopItem).Naming.Plural);
                 ft.Add<uint32_t>(ride->numSecondaryItemsSold);
-                DrawTextBasic(dpi, screenCoords, STR_ITEMS_SOLD, ft);
+                DrawTextBasic(rt, screenCoords, STR_ITEMS_SOLD, ft);
                 screenCoords.y += kListRowHeight;
             }
 
             // Total customers
             ft = Formatter();
             ft.Add<uint32_t>(ride->totalCustomers);
-            DrawTextBasic(dpi, screenCoords, STR_TOTAL_CUSTOMERS, ft);
+            DrawTextBasic(rt, screenCoords, STR_TOTAL_CUSTOMERS, ft);
             screenCoords.y += kListRowHeight;
 
             // Guests favourite
@@ -6922,7 +6922,7 @@ namespace OpenRCT2::Ui::Windows
                 ft = Formatter();
                 ft.Add<uint32_t>(ride->guestsFavourite);
                 stringId = ride->guestsFavourite == 1 ? STR_FAVOURITE_RIDE_OF_GUEST : STR_FAVOURITE_RIDE_OF_GUESTS;
-                DrawTextBasic(dpi, screenCoords, stringId, ft);
+                DrawTextBasic(rt, screenCoords, stringId, ft);
                 screenCoords.y += kListRowHeight;
             }
             screenCoords.y += 2;
@@ -6933,7 +6933,7 @@ namespace OpenRCT2::Ui::Windows
             stringId = age == 0 ? STR_BUILT_THIS_YEAR : age == 1 ? STR_BUILT_LAST_YEAR : STR_BUILT_YEARS_AGO;
             ft = Formatter();
             ft.Add<int16_t>(age);
-            DrawTextBasic(dpi, screenCoords, stringId, ft);
+            DrawTextBasic(rt, screenCoords, stringId, ft);
         }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4889,8 +4889,7 @@ namespace OpenRCT2::Ui::Windows
                 }
                 else
                 {
-                    GfxDrawSprite(
-                        rt, ImageId(GetShopItemDescriptor(shopItem).Image, ride->trackColours[0].main), screenCoords);
+                    GfxDrawSprite(rt, ImageId(GetShopItemDescriptor(shopItem).Image, ride->trackColours[0].main), screenCoords);
                 }
             }
 

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2638,7 +2638,7 @@ namespace OpenRCT2::Ui::Windows
         }
 
         void DrawTrackPiece(
-            RenderTarget& dpi, RideId rideIndex, OpenRCT2::TrackElemType trackType, int32_t trackDirection,
+            RenderTarget& rt, RideId rideIndex, OpenRCT2::TrackElemType trackType, int32_t trackDirection,
             SelectedLiftAndInverted liftHillAndInvertedState, int32_t widgetWidth, int32_t widgetHeight)
         {
             auto currentRide = GetRide(rideIndex);
@@ -2667,15 +2667,15 @@ namespace OpenRCT2::Ui::Windows
 
             const ScreenCoordsXY rotatedScreenCoords = Translate3DTo2DWithZ(GetCurrentRotation(), mapCoords);
 
-            dpi.x += rotatedScreenCoords.x - widgetWidth / 2;
-            dpi.y += rotatedScreenCoords.y - widgetHeight / 2 - 16;
+            rt.x += rotatedScreenCoords.x - widgetWidth / 2;
+            rt.y += rotatedScreenCoords.y - widgetHeight / 2 - 16;
 
-            dpi.cullingX = dpi.x;
-            dpi.cullingY = dpi.y;
-            dpi.cullingWidth = dpi.width;
-            dpi.cullingHeight = dpi.height;
+            rt.cullingX = rt.x;
+            rt.cullingY = rt.y;
+            rt.cullingWidth = rt.width;
+            rt.cullingHeight = rt.height;
 
-            DrawTrackPieceHelper(dpi, rideIndex, trackType, trackDirection, liftHillAndInvertedState, { 4096, 4096 }, 1024);
+            DrawTrackPieceHelper(rt, rideIndex, trackType, trackDirection, liftHillAndInvertedState, { 4096, 4096 }, 1024);
         }
 
         void DrawTrackPieceHelper(

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1623,13 +1623,13 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_O_TRACK].tooltip = trackDrawerDescriptor.Covered.tooltip;
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            RenderTarget clipdpi;
+            RenderTarget clippedRT;
             Widget* widget;
             int32_t widgetWidth, widgetHeight;
 
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             widget = &widgets[WIDX_CONSTRUCT];
             if (widget->type == WindowWidgetType::Empty)
@@ -1647,23 +1647,23 @@ namespace OpenRCT2::Ui::Windows
             auto screenCoords = ScreenCoordsXY{ windowPos.x + widget->left + 1, windowPos.y + widget->top + 1 };
             widgetWidth = widget->width() - 1;
             widgetHeight = widget->height() - 1;
-            if (ClipDrawPixelInfo(clipdpi, dpi, screenCoords, widgetWidth, widgetHeight))
+            if (ClipDrawPixelInfo(clippedRT, rt, screenCoords, widgetWidth, widgetHeight))
             {
                 DrawTrackPiece(
-                    clipdpi, rideIndex, trackType, trackDirection, liftHillAndInvertedState, widgetWidth, widgetHeight);
+                    clippedRT, rideIndex, trackType, trackDirection, liftHillAndInvertedState, widgetWidth, widgetHeight);
             }
 
             // Draw cost
             screenCoords = { windowPos.x + widget->midX(), windowPos.y + widget->bottom - 23 };
             if (_rideConstructionState != RideConstructionState::Place)
-                DrawTextBasic(dpi, screenCoords, STR_BUILD_THIS, {}, { TextAlignment::CENTRE });
+                DrawTextBasic(rt, screenCoords, STR_BUILD_THIS, {}, { TextAlignment::CENTRE });
 
             screenCoords.y += 11;
             if (_currentTrackPrice != kMoney64Undefined && !(getGameState().park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
                 ft.Add<money64>(_currentTrackPrice);
-                DrawTextBasic(dpi, screenCoords, STR_COST_LABEL, ft, { TextAlignment::CENTRE });
+                DrawTextBasic(rt, screenCoords, STR_COST_LABEL, ft, { TextAlignment::CENTRE });
             }
         }
 
@@ -2679,13 +2679,13 @@ namespace OpenRCT2::Ui::Windows
         }
 
         void DrawTrackPieceHelper(
-            RenderTarget& dpi, RideId rideIndex, OpenRCT2::TrackElemType trackType, int32_t trackDirection,
+            RenderTarget& rt, RideId rideIndex, OpenRCT2::TrackElemType trackType, int32_t trackDirection,
             SelectedLiftAndInverted liftHillAndInvertedState, const CoordsXY& originCoords, int32_t originZ)
         {
             TileElement tempSideTrackTileElement{ 0x80, 0x8F, 128, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
             TileElement tempTrackTileElement{};
             TileElement* backupTileElementArrays[5]{};
-            PaintSession* session = PaintSessionAlloc(dpi, 0, GetCurrentRotation());
+            PaintSession* session = PaintSessionAlloc(rt, 0, GetCurrentRotation());
             trackDirection &= 3;
 
             auto currentRide = GetRide(rideIndex);

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1623,9 +1623,9 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_O_TRACK].tooltip = trackDrawerDescriptor.Covered.tooltip;
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
-            DrawPixelInfo clipdpi;
+            RenderTarget clipdpi;
             Widget* widget;
             int32_t widgetWidth, widgetHeight;
 
@@ -2638,7 +2638,7 @@ namespace OpenRCT2::Ui::Windows
         }
 
         void DrawTrackPiece(
-            DrawPixelInfo& dpi, RideId rideIndex, OpenRCT2::TrackElemType trackType, int32_t trackDirection,
+            RenderTarget& dpi, RideId rideIndex, OpenRCT2::TrackElemType trackType, int32_t trackDirection,
             SelectedLiftAndInverted liftHillAndInvertedState, int32_t widgetWidth, int32_t widgetHeight)
         {
             auto currentRide = GetRide(rideIndex);
@@ -2679,7 +2679,7 @@ namespace OpenRCT2::Ui::Windows
         }
 
         void DrawTrackPieceHelper(
-            DrawPixelInfo& dpi, RideId rideIndex, OpenRCT2::TrackElemType trackType, int32_t trackDirection,
+            RenderTarget& dpi, RideId rideIndex, OpenRCT2::TrackElemType trackType, int32_t trackDirection,
             SelectedLiftAndInverted liftHillAndInvertedState, const CoordsXY& originCoords, int32_t originZ)
         {
             TileElement tempSideTrackTileElement{ 0x80, 0x8F, 128, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -541,8 +541,7 @@ namespace OpenRCT2::Ui::Windows
         {
             auto rtCoords = ScreenCoordsXY{ rt.x, rt.y };
             GfxFillRect(
-                rt, { rtCoords, rtCoords + ScreenCoordsXY{ rt.width, rt.height } },
-                ColourMapA[colours[1].colour].mid_light);
+                rt, { rtCoords, rtCoords + ScreenCoordsXY{ rt.width, rt.height } }, ColourMapA[colours[1].colour].mid_light);
 
             auto y = 0;
             for (size_t i = 0; i < _rideList.size(); i++)

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -520,7 +520,7 @@ namespace OpenRCT2::Ui::Windows
          *
          *  rct2: 0x006B3235
          */
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             WindowDrawWidgets(*this, dpi);
             DrawTabImages(dpi);
@@ -537,7 +537,7 @@ namespace OpenRCT2::Ui::Windows
          *
          *  rct2: 0x006B3240
          */
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
             GfxFillRect(
@@ -760,7 +760,7 @@ namespace OpenRCT2::Ui::Windows
          *
          *  rct2: 0x006B38EA
          */
-        void DrawTabImages(DrawPixelInfo& dpi)
+        void DrawTabImages(RenderTarget& dpi)
         {
             int32_t sprite_idx;
 

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -520,16 +520,16 @@ namespace OpenRCT2::Ui::Windows
          *
          *  rct2: 0x006B3235
          */
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            WindowDrawWidgets(*this, dpi);
-            DrawTabImages(dpi);
+            WindowDrawWidgets(*this, rt);
+            DrawTabImages(rt);
 
             // Draw number of attractions on bottom
             auto ft = Formatter();
             ft.Add<uint16_t>(static_cast<uint16_t>(_rideList.size()));
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ 4, widgets[WIDX_LIST].bottom + 2 }, ride_list_statusbar_count_strings[page],
+                rt, windowPos + ScreenCoordsXY{ 4, widgets[WIDX_LIST].bottom + 2 }, ride_list_statusbar_count_strings[page],
                 ft);
         }
 
@@ -537,11 +537,11 @@ namespace OpenRCT2::Ui::Windows
          *
          *  rct2: 0x006B3240
          */
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
-            auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
+            auto rtCoords = ScreenCoordsXY{ rt.x, rt.y };
             GfxFillRect(
-                dpi, { dpiCoords, dpiCoords + ScreenCoordsXY{ dpi.width, dpi.height } },
+                rt, { rtCoords, rtCoords + ScreenCoordsXY{ rt.width, rt.height } },
                 ColourMapA[colours[1].colour].mid_light);
 
             auto y = 0;
@@ -554,7 +554,7 @@ namespace OpenRCT2::Ui::Windows
                 if (i == static_cast<size_t>(selected_list_item))
                 {
                     // Background highlight
-                    GfxFilterRect(dpi, { 0, y, 800, y + kScrollableRowHeight - 1 }, FilterPaletteID::PaletteDarken1);
+                    GfxFilterRect(rt, { 0, y, 800, y + kScrollableRowHeight - 1 }, FilterPaletteID::PaletteDarken1);
                     format = STR_WINDOW_COLOUR_2_STRINGID;
                     if (_quickDemolishMode)
                         format = STR_LIGHTPINK_STRINGID;
@@ -568,7 +568,7 @@ namespace OpenRCT2::Ui::Windows
                 // Ride name
                 auto ft = Formatter();
                 ridePtr->formatNameTo(ft);
-                DrawTextEllipsised(dpi, { 0, y - 1 }, 159, format, ft);
+                DrawTextEllipsised(rt, { 0, y - 1 }, 159, format, ft);
 
                 // Ride information
                 ft = Formatter();
@@ -745,7 +745,7 @@ namespace OpenRCT2::Ui::Windows
                     ft.Rewind();
                     ft.Add<StringId>(formatSecondary);
                 }
-                DrawTextEllipsised(dpi, { 160, y - 1 }, 157, format, ft);
+                DrawTextEllipsised(rt, { 160, y - 1 }, 157, format, ft);
                 y += kScrollableRowHeight;
             }
         }
@@ -760,7 +760,7 @@ namespace OpenRCT2::Ui::Windows
          *
          *  rct2: 0x006B38EA
          */
-        void DrawTabImages(RenderTarget& dpi)
+        void DrawTabImages(RenderTarget& rt)
         {
             int32_t sprite_idx;
 
@@ -769,21 +769,21 @@ namespace OpenRCT2::Ui::Windows
             if (page == PAGE_RIDES)
                 sprite_idx += frame_no / 4;
             GfxDrawSprite(
-                dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_1].left, widgets[WIDX_TAB_1].top });
+                rt, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_1].left, widgets[WIDX_TAB_1].top });
 
             // Shops and stalls tab
             sprite_idx = SPR_TAB_SHOPS_AND_STALLS_0;
             if (page == PAGE_SHOPS_AND_STALLS)
                 sprite_idx += frame_no / 4;
             GfxDrawSprite(
-                dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left, widgets[WIDX_TAB_2].top });
+                rt, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left, widgets[WIDX_TAB_2].top });
 
             // Information kiosks and facilities tab
             sprite_idx = SPR_TAB_KIOSKS_AND_FACILITIES_0;
             if (page == PAGE_KIOSKS_AND_FACILITIES)
                 sprite_idx += (frame_no / 4) % 8;
             GfxDrawSprite(
-                dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_3].left, widgets[WIDX_TAB_3].top });
+                rt, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_3].left, widgets[WIDX_TAB_3].top });
         }
 
         /**

--- a/src/openrct2-ui/windows/SavePrompt.cpp
+++ b/src/openrct2-ui/windows/SavePrompt.cpp
@@ -192,9 +192,9 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
         }
     };
 

--- a/src/openrct2-ui/windows/SavePrompt.cpp
+++ b/src/openrct2-ui/windows/SavePrompt.cpp
@@ -192,7 +192,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
         }

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -299,8 +299,7 @@ namespace OpenRCT2::Ui::Windows
 
                 auto ft = Formatter();
                 ft.Add<utf8*>(shortPath.c_str());
-                DrawTextBasic(
-                    rt, windowPos + ScreenCoordsXY{ kTabWidth + 3, height - 3 - 11 }, STR_STRING, ft, { colours[1] });
+                DrawTextBasic(rt, windowPos + ScreenCoordsXY{ kTabWidth + 3, height - 3 - 11 }, STR_STRING, ft, { colours[1] });
             }
 
             // Scenario name

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -204,7 +204,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        ScreenCoordsXY DrawPreview(RenderTarget& dpi, ScreenCoordsXY screenPos)
+        ScreenCoordsXY DrawPreview(RenderTarget& rt, ScreenCoordsXY screenPos)
         {
             // Find minimap image to draw, if available
             PreviewImage* image = nullptr;
@@ -224,18 +224,18 @@ namespace OpenRCT2::Ui::Windows
             auto startFrameX = width - (kPreviewPaneWidth / 2) - (image->width / 2);
             auto frameStartPos = ScreenCoordsXY(windowPos.x + startFrameX, screenPos.y + 15);
             auto frameEndPos = frameStartPos + ScreenCoordsXY(image->width + 1, image->height + 1);
-            GfxFillRectInset(dpi, { frameStartPos, frameEndPos }, colours[1], INSET_RECT_F_60 | INSET_RECT_FLAG_FILL_MID_LIGHT);
+            GfxFillRectInset(rt, { frameStartPos, frameEndPos }, colours[1], INSET_RECT_F_60 | INSET_RECT_FLAG_FILL_MID_LIGHT);
 
             // Draw image, if available
             auto imagePos = frameStartPos + ScreenCoordsXY(1, 1);
-            drawPreviewImage(*image, dpi, imagePos);
+            drawPreviewImage(*image, rt, imagePos);
 
             return frameEndPos;
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             StringId format = STR_WINDOW_COLOUR_2_STRINGID;
             FontStyle fontStyle = FontStyle::Medium;
@@ -264,7 +264,7 @@ namespace OpenRCT2::Ui::Windows
                 }
 
                 auto stringCoords = windowPos + ScreenCoordsXY{ widget.midX(), widget.midY() - 3 };
-                DrawTextWrapped(dpi, stringCoords, 87, format, ft, { COLOUR_AQUAMARINE, fontStyle, TextAlignment::CENTRE });
+                DrawTextWrapped(rt, stringCoords, 87, format, ft, { COLOUR_AQUAMARINE, fontStyle, TextAlignment::CENTRE });
             }
 
             // Return if no scenario highlighted
@@ -277,9 +277,9 @@ namespace OpenRCT2::Ui::Windows
                     auto screenPos = windowPos
                         + ScreenCoordsXY{ widgets[WIDX_SCENARIOLIST].right + 4, widgets[WIDX_TABCONTENT].top + 5 };
                     DrawTextEllipsised(
-                        dpi, screenPos + ScreenCoordsXY{ 85, 0 }, 170, STR_SCENARIO_LOCKED, {}, { TextAlignment::CENTRE });
+                        rt, screenPos + ScreenCoordsXY{ 85, 0 }, 170, STR_SCENARIO_LOCKED, {}, { TextAlignment::CENTRE });
 
-                    DrawTextWrapped(dpi, screenPos + ScreenCoordsXY{ 0, 15 }, 170, STR_SCENARIO_LOCKED_DESC);
+                    DrawTextWrapped(rt, screenPos + ScreenCoordsXY{ 0, 15 }, 170, STR_SCENARIO_LOCKED_DESC);
                 }
                 else
                 {
@@ -287,7 +287,7 @@ namespace OpenRCT2::Ui::Windows
                     auto screenPos = windowPos
                         + ScreenCoordsXY{ widgets[WIDX_SCENARIOLIST].right + 4, widgets[WIDX_TABCONTENT].top + 5 };
 
-                    DrawTextWrapped(dpi, screenPos + ScreenCoordsXY{ 0, 15 }, 170, STR_SCENARIO_HOVER_HINT);
+                    DrawTextWrapped(rt, screenPos + ScreenCoordsXY{ 0, 15 }, 170, STR_SCENARIO_HOVER_HINT);
                 }
                 return;
             }
@@ -300,7 +300,7 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<utf8*>(shortPath.c_str());
                 DrawTextBasic(
-                    dpi, windowPos + ScreenCoordsXY{ kTabWidth + 3, height - 3 - 11 }, STR_STRING, ft, { colours[1] });
+                    rt, windowPos + ScreenCoordsXY{ kTabWidth + 3, height - 3 - 11 }, STR_STRING, ft, { colours[1] });
             }
 
             // Scenario name
@@ -310,17 +310,17 @@ namespace OpenRCT2::Ui::Windows
             ft.Add<StringId>(STR_STRING);
             ft.Add<const char*>(scenario->Name.c_str());
             DrawTextEllipsised(
-                dpi, screenPos + ScreenCoordsXY{ 85, 0 }, 170, STR_WINDOW_COLOUR_2_STRINGID, ft, { TextAlignment::CENTRE });
+                rt, screenPos + ScreenCoordsXY{ 85, 0 }, 170, STR_WINDOW_COLOUR_2_STRINGID, ft, { TextAlignment::CENTRE });
 
             // Draw preview
-            auto previewEnd = DrawPreview(dpi, screenPos);
+            auto previewEnd = DrawPreview(rt, screenPos);
             screenPos.y = previewEnd.y + 15;
 
             // Scenario details
             ft = Formatter();
             ft.Add<StringId>(STR_STRING);
             ft.Add<const char*>(scenario->Details.c_str());
-            screenPos.y += DrawTextWrapped(dpi, screenPos, 170, STR_BLACK_STRING, ft) + 5;
+            screenPos.y += DrawTextWrapped(rt, screenPos, 170, STR_BLACK_STRING, ft) + 5;
 
             // Scenario objective
             Objective objective = { .Type = scenario->ObjectiveType,
@@ -331,7 +331,7 @@ namespace OpenRCT2::Ui::Windows
             ft = Formatter();
             ft.Add<StringId>(kObjectiveNames[scenario->ObjectiveType]);
             formatObjective(ft, objective);
-            screenPos.y += DrawTextWrapped(dpi, screenPos, 170, STR_OBJECTIVE, ft) + 5;
+            screenPos.y += DrawTextWrapped(rt, screenPos, 170, STR_OBJECTIVE, ft) + 5;
 
             // Scenario score
             if (scenario->Highscore != nullptr)
@@ -346,7 +346,7 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<StringId>(STR_STRING);
                 ft.Add<const char*>(completedByName.c_str());
                 ft.Add<money64>(scenario->Highscore->company_value);
-                screenPos.y += DrawTextWrapped(dpi, screenPos, 170, STR_COMPLETED_BY_WITH_COMPANY_VALUE, ft);
+                screenPos.y += DrawTextWrapped(rt, screenPos, 170, STR_COMPLETED_BY_WITH_COMPANY_VALUE, ft);
             }
         }
 
@@ -464,10 +464,10 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             uint8_t paletteIndex = ColourMapA[colours[1].colour].mid_light;
-            GfxClear(dpi, paletteIndex);
+            GfxClear(rt, paletteIndex);
 
             StringId highlighted_format = STR_WINDOW_COLOUR_2_STRINGID;
             StringId unhighlighted_format = STR_BLACK_STRING;
@@ -488,7 +488,7 @@ namespace OpenRCT2::Ui::Windows
             int32_t y = 0;
             for (const auto& listItem : _listItems)
             {
-                if (y > dpi.y + dpi.height)
+                if (y > rt.y + rt.height)
                 {
                     continue;
                 }
@@ -499,7 +499,7 @@ namespace OpenRCT2::Ui::Windows
                     {
                         const int32_t horizontalRuleMargin = 4;
                         DrawCategoryHeading(
-                            dpi, horizontalRuleMargin, listWidth - horizontalRuleMargin, y + 2, listItem.heading.string_id);
+                            rt, horizontalRuleMargin, listWidth - horizontalRuleMargin, y + 2, listItem.heading.string_id);
                         y += 18;
                         break;
                     }
@@ -510,7 +510,7 @@ namespace OpenRCT2::Ui::Windows
                         bool isHighlighted = _highlightedScenario == scenario;
                         if (isHighlighted)
                         {
-                            GfxFilterRect(dpi, { 0, y, width, y + scenarioItemHeight - 1 }, FilterPaletteID::PaletteDarken1);
+                            GfxFilterRect(rt, { 0, y, width, y + scenarioItemHeight - 1 }, FilterPaletteID::PaletteDarken1);
                         }
 
                         bool isCompleted = scenario->Highscore != nullptr;
@@ -528,14 +528,14 @@ namespace OpenRCT2::Ui::Windows
                         const auto scrollCentre = widgets[WIDX_SCENARIOLIST].width() / 2;
 
                         DrawTextBasic(
-                            dpi, { scrollCentre, y + 1 }, format, ft,
+                            rt, { scrollCentre, y + 1 }, format, ft,
                             { colour, FontStyle::Medium, TextAlignment::CENTRE, darkness });
 
                         // Check if scenario is completed
                         if (isCompleted)
                         {
                             // Draw completion tick
-                            GfxDrawSprite(dpi, ImageId(SPR_MENU_CHECKMARK), { widgets[WIDX_SCENARIOLIST].width() - 45, y + 1 });
+                            GfxDrawSprite(rt, ImageId(SPR_MENU_CHECKMARK), { widgets[WIDX_SCENARIOLIST].width() - 45, y + 1 });
 
                             // Draw completion score
                             u8string completedByName = "???";
@@ -548,7 +548,7 @@ namespace OpenRCT2::Ui::Windows
                             ft.Add<StringId>(STR_STRING);
                             ft.Add<const char*>(completedByName.c_str());
                             DrawTextBasic(
-                                dpi, { scrollCentre, y + scenarioTitleHeight + 1 }, format, ft,
+                                rt, { scrollCentre, y + scenarioTitleHeight + 1 }, format, ft,
                                 { FontStyle::Small, TextAlignment::CENTRE });
                         }
 
@@ -560,7 +560,7 @@ namespace OpenRCT2::Ui::Windows
         }
 
     private:
-        void DrawCategoryHeading(RenderTarget& dpi, int32_t left, int32_t right, int32_t y, StringId stringId) const
+        void DrawCategoryHeading(RenderTarget& rt, int32_t left, int32_t right, int32_t y, StringId stringId) const
         {
             auto baseColour = colours[1];
             colour_t lightColour = ColourMapA[baseColour.colour].lighter;
@@ -568,7 +568,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Draw string
             int32_t centreX = (left + right) / 2;
-            DrawTextBasic(dpi, { centreX, y }, stringId, {}, { baseColour, TextAlignment::CENTRE });
+            DrawTextBasic(rt, { centreX, y }, stringId, {}, { baseColour, TextAlignment::CENTRE });
 
             // Get string dimensions
             utf8 buffer[512];
@@ -582,21 +582,21 @@ namespace OpenRCT2::Ui::Windows
             int32_t lineY = y + 4;
             auto lightLineLeftTop1 = ScreenCoordsXY{ left, lineY };
             auto lightLineRightBottom1 = ScreenCoordsXY{ strLeft, lineY };
-            GfxDrawLine(dpi, { lightLineLeftTop1, lightLineRightBottom1 }, lightColour);
+            GfxDrawLine(rt, { lightLineLeftTop1, lightLineRightBottom1 }, lightColour);
 
             auto lightLineLeftTop2 = ScreenCoordsXY{ strRight, lineY };
             auto lightLineRightBottom2 = ScreenCoordsXY{ right, lineY };
-            GfxDrawLine(dpi, { lightLineLeftTop2, lightLineRightBottom2 }, lightColour);
+            GfxDrawLine(rt, { lightLineLeftTop2, lightLineRightBottom2 }, lightColour);
 
             // Draw dark horizontal rule
             lineY++;
             auto darkLineLeftTop1 = ScreenCoordsXY{ left, lineY };
             auto darkLineRightBottom1 = ScreenCoordsXY{ strLeft, lineY };
-            GfxDrawLine(dpi, { darkLineLeftTop1, darkLineRightBottom1 }, darkColour);
+            GfxDrawLine(rt, { darkLineLeftTop1, darkLineRightBottom1 }, darkColour);
 
             auto darkLineLeftTop2 = ScreenCoordsXY{ strRight, lineY };
             auto darkLineRightBottom2 = ScreenCoordsXY{ right, lineY };
-            GfxDrawLine(dpi, { darkLineLeftTop2, darkLineRightBottom2 }, darkColour);
+            GfxDrawLine(rt, { darkLineLeftTop2, darkLineRightBottom2 }, darkColour);
         }
 
         void InitialiseListItems()

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -204,7 +204,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        ScreenCoordsXY DrawPreview(DrawPixelInfo& dpi, ScreenCoordsXY screenPos)
+        ScreenCoordsXY DrawPreview(RenderTarget& dpi, ScreenCoordsXY screenPos)
         {
             // Find minimap image to draw, if available
             PreviewImage* image = nullptr;
@@ -233,7 +233,7 @@ namespace OpenRCT2::Ui::Windows
             return frameEndPos;
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
 
@@ -464,7 +464,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             uint8_t paletteIndex = ColourMapA[colours[1].colour].mid_light;
             GfxClear(dpi, paletteIndex);
@@ -560,7 +560,7 @@ namespace OpenRCT2::Ui::Windows
         }
 
     private:
-        void DrawCategoryHeading(DrawPixelInfo& dpi, int32_t left, int32_t right, int32_t y, StringId stringId) const
+        void DrawCategoryHeading(RenderTarget& dpi, int32_t left, int32_t right, int32_t y, StringId stringId) const
         {
             auto baseColour = colours[1];
             colour_t lightColour = ColourMapA[baseColour.colour].lighter;

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -834,7 +834,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_SCENERY_BUILD_CLUSTER_BUTTON].type = canFit ? WindowWidgetType::FlatBtn : WindowWidgetType::Empty;
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
             DrawTabs(dpi, windowPos);
@@ -894,7 +894,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             if (scrollIndex == SceneryContentScrollIndex)
             {
@@ -1580,7 +1580,7 @@ namespace OpenRCT2::Ui::Windows
             return { name, price };
         }
 
-        void DrawTabs(DrawPixelInfo& dpi, const ScreenCoordsXY& offset)
+        void DrawTabs(RenderTarget& dpi, const ScreenCoordsXY& offset)
         {
             for (size_t tabIndex = 0; tabIndex < _tabEntries.size(); tabIndex++)
             {
@@ -1595,7 +1595,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawSceneryItem(DrawPixelInfo& dpi, ScenerySelection scenerySelection)
+        void DrawSceneryItem(RenderTarget& dpi, ScenerySelection scenerySelection)
         {
             if (scenerySelection.SceneryType == SCENERY_TYPE_BANNER)
             {
@@ -1699,7 +1699,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void ContentScrollDraw(DrawPixelInfo& dpi)
+        void ContentScrollDraw(RenderTarget& dpi)
         {
             GfxClear(dpi, ColourMapA[colours[1].colour].mid_light);
 
@@ -1742,7 +1742,7 @@ namespace OpenRCT2::Ui::Windows
                     }
                 }
 
-                DrawPixelInfo clipdpi;
+                RenderTarget clipdpi;
                 if (ClipDrawPixelInfo(
                         clipdpi, dpi, topLeft + ScreenCoordsXY{ 1, 1 }, SCENERY_BUTTON_WIDTH - 2, SCENERY_BUTTON_HEIGHT - 2))
                 {

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -834,10 +834,10 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_SCENERY_BUILD_CLUSTER_BUTTON].type = canFit ? WindowWidgetType::FlatBtn : WindowWidgetType::Empty;
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
-            DrawTabs(dpi, windowPos);
+            DrawWidgets(rt);
+            DrawTabs(rt, windowPos);
 
             auto selectedSceneryEntry = _selectedScenery;
             if (selectedSceneryEntry.IsUndefined())
@@ -860,12 +860,12 @@ namespace OpenRCT2::Ui::Windows
 
                 // -14
                 DrawTextBasic(
-                    dpi, windowPos + ScreenCoordsXY{ width - 0x1A, height - 13 }, STR_COST_LABEL, ft, { TextAlignment::RIGHT });
+                    rt, windowPos + ScreenCoordsXY{ width - 0x1A, height - 13 }, STR_COST_LABEL, ft, { TextAlignment::RIGHT });
             }
 
             auto ft = Formatter();
             ft.Add<StringId>(name);
-            DrawTextEllipsised(dpi, { windowPos.x + 3, windowPos.y + height - 23 }, width - 19, STR_BLACK_STRING, ft);
+            DrawTextEllipsised(rt, { windowPos.x + 3, windowPos.y + height - 23 }, width - 19, STR_BLACK_STRING, ft);
 
             // Draw object author(s) if debugging tools are active
             if (Config::Get().general.DebuggingTools)
@@ -888,17 +888,17 @@ namespace OpenRCT2::Ui::Windows
                     ft = Formatter();
                     ft.Add<const char*>(authorsString.c_str());
                     DrawTextEllipsised(
-                        dpi, windowPos + ScreenCoordsXY{ 3, height - 13 }, width - 19,
+                        rt, windowPos + ScreenCoordsXY{ 3, height - 13 }, width - 19,
                         (sceneryObject->GetAuthors().size() == 1 ? STR_SCENERY_AUTHOR : STR_SCENERY_AUTHOR_PLURAL), ft);
                 }
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             if (scrollIndex == SceneryContentScrollIndex)
             {
-                ContentScrollDraw(dpi);
+                ContentScrollDraw(rt);
             }
         }
 
@@ -1580,7 +1580,7 @@ namespace OpenRCT2::Ui::Windows
             return { name, price };
         }
 
-        void DrawTabs(RenderTarget& dpi, const ScreenCoordsXY& offset)
+        void DrawTabs(RenderTarget& rt, const ScreenCoordsXY& offset)
         {
             for (size_t tabIndex = 0; tabIndex < _tabEntries.size(); tabIndex++)
             {
@@ -1590,19 +1590,19 @@ namespace OpenRCT2::Ui::Windows
                 if (_tabEntries[tabIndex].IsAll())
                 {
                     auto imageId = ImageId(SPR_G2_INFINITY, FilterPaletteID::PaletteNull);
-                    GfxDrawSprite(dpi, imageId, offset + widgetCoordsXY);
+                    GfxDrawSprite(rt, imageId, offset + widgetCoordsXY);
                 }
             }
         }
 
-        void DrawSceneryItem(RenderTarget& dpi, ScenerySelection scenerySelection)
+        void DrawSceneryItem(RenderTarget& rt, ScenerySelection scenerySelection)
         {
             if (scenerySelection.SceneryType == SCENERY_TYPE_BANNER)
             {
                 auto bannerEntry = OpenRCT2::ObjectManager::GetObjectEntry<BannerSceneryEntry>(scenerySelection.EntryIndex);
                 auto imageId = ImageId(bannerEntry->image + gWindowSceneryRotation * 2, _sceneryPrimaryColour);
-                GfxDrawSprite(dpi, imageId, { 33, 40 });
-                GfxDrawSprite(dpi, imageId.WithIndexOffset(1), { 33, 40 });
+                GfxDrawSprite(rt, imageId, { 33, 40 });
+                GfxDrawSprite(rt, imageId.WithIndexOffset(1), { 33, 40 });
             }
             else if (scenerySelection.SceneryType == SCENERY_TYPE_LARGE)
             {
@@ -1614,7 +1614,7 @@ namespace OpenRCT2::Ui::Windows
                     imageId = imageId.WithSecondary(_scenerySecondaryColour);
                 if (sceneryEntry->flags & LARGE_SCENERY_FLAG_HAS_TERTIARY_COLOUR)
                     imageId = imageId.WithTertiary(_sceneryTertiaryColour);
-                GfxDrawSprite(dpi, imageId, { 33, 0 });
+                GfxDrawSprite(rt, imageId, { 33, 0 });
             }
             else if (scenerySelection.SceneryType == SCENERY_TYPE_WALL)
             {
@@ -1628,10 +1628,10 @@ namespace OpenRCT2::Ui::Windows
                     {
                         imageId = imageId.WithSecondary(_scenerySecondaryColour);
                     }
-                    GfxDrawSprite(dpi, imageId, { 47, spriteTop });
+                    GfxDrawSprite(rt, imageId, { 47, spriteTop });
 
                     auto glassImageId = ImageId(wallEntry->image + 6).WithTransparency(_sceneryPrimaryColour);
-                    GfxDrawSprite(dpi, glassImageId, { 47, spriteTop });
+                    GfxDrawSprite(rt, glassImageId, { 47, spriteTop });
                 }
                 else
                 {
@@ -1644,11 +1644,11 @@ namespace OpenRCT2::Ui::Windows
                             imageId = imageId.WithTertiary(_sceneryTertiaryColour);
                         }
                     }
-                    GfxDrawSprite(dpi, imageId, { 47, spriteTop });
+                    GfxDrawSprite(rt, imageId, { 47, spriteTop });
 
                     if (wallEntry->flags & WALL_SCENERY_IS_DOOR)
                     {
-                        GfxDrawSprite(dpi, imageId.WithIndexOffset(1), { 47, spriteTop });
+                        GfxDrawSprite(rt, imageId.WithIndexOffset(1), { 47, spriteTop });
                     }
                 }
             }
@@ -1657,7 +1657,7 @@ namespace OpenRCT2::Ui::Windows
                 auto* pathAdditionEntry = OpenRCT2::ObjectManager::GetObjectEntry<PathAdditionEntry>(
                     scenerySelection.EntryIndex);
                 auto imageId = ImageId(pathAdditionEntry->image);
-                GfxDrawSprite(dpi, imageId, { 11, 16 });
+                GfxDrawSprite(rt, imageId, { 11, 16 });
             }
             else
             {
@@ -1683,25 +1683,25 @@ namespace OpenRCT2::Ui::Windows
                     spriteTop -= 12;
                 }
 
-                GfxDrawSprite(dpi, imageId, { 32, spriteTop });
+                GfxDrawSprite(rt, imageId, { 32, spriteTop });
 
                 if (sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_HAS_GLASS))
                 {
                     imageId = ImageId(sceneryEntry->image + 4 + gWindowSceneryRotation).WithTransparency(_sceneryPrimaryColour);
-                    GfxDrawSprite(dpi, imageId, { 32, spriteTop });
+                    GfxDrawSprite(rt, imageId, { 32, spriteTop });
                 }
 
                 if (sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_ANIMATED_FG))
                 {
                     imageId = ImageId(sceneryEntry->image + 4 + gWindowSceneryRotation);
-                    GfxDrawSprite(dpi, imageId, { 32, spriteTop });
+                    GfxDrawSprite(rt, imageId, { 32, spriteTop });
                 }
             }
         }
 
-        void ContentScrollDraw(RenderTarget& dpi)
+        void ContentScrollDraw(RenderTarget& rt)
         {
-            GfxClear(dpi, ColourMapA[colours[1].colour].mid_light);
+            GfxClear(rt, ColourMapA[colours[1].colour].mid_light);
 
             auto numColumns = GetNumColumns();
             auto tabIndex = _activeTabIndex;
@@ -1722,7 +1722,7 @@ namespace OpenRCT2::Ui::Windows
                     if (_selectedScenery == currentSceneryGlobal)
                     {
                         GfxFillRectInset(
-                            dpi, { topLeft, topLeft + ScreenCoordsXY{ SCENERY_BUTTON_WIDTH - 1, SCENERY_BUTTON_HEIGHT - 1 } },
+                            rt, { topLeft, topLeft + ScreenCoordsXY{ SCENERY_BUTTON_WIDTH - 1, SCENERY_BUTTON_HEIGHT - 1 } },
                             colours[1], INSET_RECT_FLAG_FILL_MID_LIGHT);
                     }
                 }
@@ -1731,22 +1731,22 @@ namespace OpenRCT2::Ui::Windows
                     if (tabSelectedScenery == currentSceneryGlobal)
                     {
                         GfxFillRectInset(
-                            dpi, { topLeft, topLeft + ScreenCoordsXY{ SCENERY_BUTTON_WIDTH - 1, SCENERY_BUTTON_HEIGHT - 1 } },
+                            rt, { topLeft, topLeft + ScreenCoordsXY{ SCENERY_BUTTON_WIDTH - 1, SCENERY_BUTTON_HEIGHT - 1 } },
                             colours[1], (INSET_RECT_FLAG_BORDER_INSET | INSET_RECT_FLAG_FILL_MID_LIGHT));
                     }
                     else if (_selectedScenery == currentSceneryGlobal)
                     {
                         GfxFillRectInset(
-                            dpi, { topLeft, topLeft + ScreenCoordsXY{ SCENERY_BUTTON_WIDTH - 1, SCENERY_BUTTON_HEIGHT - 1 } },
+                            rt, { topLeft, topLeft + ScreenCoordsXY{ SCENERY_BUTTON_WIDTH - 1, SCENERY_BUTTON_HEIGHT - 1 } },
                             colours[1], INSET_RECT_FLAG_FILL_MID_LIGHT);
                     }
                 }
 
-                RenderTarget clipdpi;
+                RenderTarget clippedRT;
                 if (ClipDrawPixelInfo(
-                        clipdpi, dpi, topLeft + ScreenCoordsXY{ 1, 1 }, SCENERY_BUTTON_WIDTH - 2, SCENERY_BUTTON_HEIGHT - 2))
+                        clippedRT, rt, topLeft + ScreenCoordsXY{ 1, 1 }, SCENERY_BUTTON_WIDTH - 2, SCENERY_BUTTON_HEIGHT - 2))
                 {
-                    DrawSceneryItem(clipdpi, currentSceneryGlobal);
+                    DrawSceneryItem(clippedRT, currentSceneryGlobal);
                 }
 
                 topLeft.x += SCENERY_BUTTON_WIDTH;

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -179,9 +179,9 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_PREVIEW].image = ImageId(LandTool::SizeToSpriteIndex(gWindowSceneryScatterSize));
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            WindowDrawWidgets(*this, dpi);
+            WindowDrawWidgets(*this, rt);
 
             // Draw area as a number for tool sizes bigger than 7
             if (gWindowSceneryScatterSize > kLandToolMaximumSizeWithSprite)
@@ -191,7 +191,7 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<uint16_t>(gWindowSceneryScatterSize);
                 DrawTextBasic(
-                    dpi, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, ft, { TextAlignment::CENTRE });
+                    rt, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, ft, { TextAlignment::CENTRE });
             }
         }
     };

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -179,7 +179,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_PREVIEW].image = ImageId(LandTool::SizeToSpriteIndex(gWindowSceneryScatterSize));
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             WindowDrawWidgets(*this, dpi);
 

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -307,7 +307,7 @@ namespace OpenRCT2::Ui::Windows
             return { fallback, ft };
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
 
@@ -328,7 +328,7 @@ namespace OpenRCT2::Ui::Windows
             DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ 8, height - 15 }, _statusText, ft, { COLOUR_WHITE });
         }
 
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             uint8_t paletteIndex = ColourMapA[colours[1].colour].mid_light;
             GfxClear(dpi, paletteIndex);

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -307,12 +307,12 @@ namespace OpenRCT2::Ui::Windows
             return { fallback, ft };
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_PLAYER_NAME_INPUT].top }, STR_PLAYER_NAME, {},
+                rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_PLAYER_NAME_INPUT].top }, STR_PLAYER_NAME, {},
                 { COLOUR_WHITE });
 
             // Draw version number
@@ -320,18 +320,18 @@ namespace OpenRCT2::Ui::Windows
             auto ft = Formatter();
             ft.Add<const char*>(version.c_str());
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ 324, widgets[WIDX_START_SERVER].top + 1 }, STR_NETWORK_VERSION, ft,
+                rt, windowPos + ScreenCoordsXY{ 324, widgets[WIDX_START_SERVER].top + 1 }, STR_NETWORK_VERSION, ft,
                 { COLOUR_WHITE });
 
             ft = Formatter();
             ft.Add<uint32_t>(_numPlayersOnline);
-            DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ 8, height - 15 }, _statusText, ft, { COLOUR_WHITE });
+            DrawTextBasic(rt, windowPos + ScreenCoordsXY{ 8, height - 15 }, _statusText, ft, { COLOUR_WHITE });
         }
 
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             uint8_t paletteIndex = ColourMapA[colours[1].colour].mid_light;
-            GfxClear(dpi, paletteIndex);
+            GfxClear(rt, paletteIndex);
 
             auto& listWidget = widgets[WIDX_LIST];
             int32_t listWidgetWidth = listWidget.width();
@@ -340,7 +340,7 @@ namespace OpenRCT2::Ui::Windows
             screenCoords.y = 0;
             for (int32_t i = 0; i < no_list_items; i++)
             {
-                if (screenCoords.y >= dpi.y + dpi.height)
+                if (screenCoords.y >= rt.y + rt.height)
                     continue;
 
                 const auto& serverDetails = _serverList.GetServer(i);
@@ -350,7 +350,7 @@ namespace OpenRCT2::Ui::Windows
                 if (highlighted)
                 {
                     GfxFilterRect(
-                        dpi, { 0, screenCoords.y, listWidgetWidth, screenCoords.y + kItemHeight },
+                        rt, { 0, screenCoords.y, listWidgetWidth, screenCoords.y + kItemHeight },
                         FilterPaletteID::PaletteDarken1);
                     _version = serverDetails.Version;
                 }
@@ -389,7 +389,7 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<const char*>(serverInfoToShow);
                 DrawTextEllipsised(
-                    dpi, screenCoords + ScreenCoordsXY{ 0, 3 }, spaceAvailableForInfo, STR_STRING, ft, { colour });
+                    rt, screenCoords + ScreenCoordsXY{ 0, 3 }, spaceAvailableForInfo, STR_STRING, ft, { colour });
 
                 int32_t right = listWidgetWidth - 7 - kScrollBarWidth;
 
@@ -407,20 +407,20 @@ namespace OpenRCT2::Ui::Windows
                     bool correctVersion = serverDetails.Version == NetworkGetVersion();
                     compatibilitySpriteId = correctVersion ? SPR_G2_RCT1_OPEN_BUTTON_2 : SPR_G2_RCT1_CLOSE_BUTTON_2;
                 }
-                GfxDrawSprite(dpi, ImageId(compatibilitySpriteId), { right, screenCoords.y + 1 });
+                GfxDrawSprite(rt, ImageId(compatibilitySpriteId), { right, screenCoords.y + 1 });
                 right -= 4;
 
                 // Draw lock icon
                 right -= 8;
                 if (serverDetails.RequiresPassword)
                 {
-                    GfxDrawSprite(dpi, ImageId(SPR_G2_LOCKED), { right, screenCoords.y + 4 });
+                    GfxDrawSprite(rt, ImageId(SPR_G2_LOCKED), { right, screenCoords.y + 4 });
                 }
                 right -= 6;
 
                 // Draw number of players
                 screenCoords.x = right - numPlayersStringWidth;
-                DrawText(dpi, screenCoords + ScreenCoordsXY{ 0, 3 }, { colours[1] }, players);
+                DrawText(rt, screenCoords + ScreenCoordsXY{ 0, 3 }, { colours[1] }, players);
 
                 screenCoords.y += kItemHeight;
             }

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -230,22 +230,22 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
-            DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_PORT_INPUT].top }, STR_PORT, {}, { colours[1] });
+            DrawWidgets(rt);
+            DrawTextBasic(rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_PORT_INPUT].top }, STR_PORT, {}, { colours[1] });
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_NAME_INPUT].top }, STR_SERVER_NAME, {}, { colours[1] });
+                rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_NAME_INPUT].top }, STR_SERVER_NAME, {}, { colours[1] });
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_DESCRIPTION_INPUT].top }, STR_SERVER_DESCRIPTION, {},
+                rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_DESCRIPTION_INPUT].top }, STR_SERVER_DESCRIPTION, {},
                 { colours[1] });
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_GREETING_INPUT].top }, STR_SERVER_GREETING, {},
+                rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_GREETING_INPUT].top }, STR_SERVER_GREETING, {},
                 { colours[1] });
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_PASSWORD_INPUT].top }, STR_PASSWORD, {}, { colours[1] });
+                rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_PASSWORD_INPUT].top }, STR_PASSWORD, {}, { colours[1] });
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_MAXPLAYERS].top }, STR_MAX_PLAYERS, {}, { colours[1] });
+                rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_MAXPLAYERS].top }, STR_MAX_PLAYERS, {}, { colours[1] });
         }
 
     private:

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -230,7 +230,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
             DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_PORT_INPUT].top }, STR_PORT, {}, { colours[1] });

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -240,8 +240,7 @@ namespace OpenRCT2::Ui::Windows
                 rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_DESCRIPTION_INPUT].top }, STR_SERVER_DESCRIPTION, {},
                 { colours[1] });
             DrawTextBasic(
-                rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_GREETING_INPUT].top }, STR_SERVER_GREETING, {},
-                { colours[1] });
+                rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_GREETING_INPUT].top }, STR_SERVER_GREETING, {}, { colours[1] });
             DrawTextBasic(
                 rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_PASSWORD_INPUT].top }, STR_PASSWORD, {}, { colours[1] });
             DrawTextBasic(

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -122,9 +122,9 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             ScreenCoordsXY stringCoords(windowPos.x + 125, windowPos.y + widgets[WIDX_TITLE].bottom + 16);
 
@@ -138,7 +138,7 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<StringId>(STR_STRING);
                 ft.Add<const char*>(_shortcutCustomName.c_str());
             }
-            DrawTextWrapped(dpi, stringCoords, 242, STR_SHORTCUT_CHANGE_PROMPT, ft, { TextAlignment::CENTRE });
+            DrawTextWrapped(rt, stringCoords, 242, STR_SHORTCUT_CHANGE_PROMPT, ft, { TextAlignment::CENTRE });
         }
 
     private:
@@ -252,10 +252,10 @@ namespace OpenRCT2::Ui::Windows
             SetWidgetPressed(static_cast<WidgetIndex>(WIDX_TAB_0 + _currentTabIndex), true);
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
         }
 
         ScreenSize OnScrollGetSize(int32_t scrollIndex) override
@@ -298,11 +298,11 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
-            auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
+            auto rtCoords = ScreenCoordsXY{ rt.x, rt.y };
             GfxFillRect(
-                dpi, { dpiCoords, dpiCoords + ScreenCoordsXY{ dpi.width - 1, dpi.height - 1 } },
+                rt, { rtCoords, rtCoords + ScreenCoordsXY{ rt.width - 1, rt.height - 1 } },
                 ColourMapA[colours[1].colour].mid_light);
 
             // TODO: the line below is a workaround for what is presumably a bug with dpi->width
@@ -312,12 +312,12 @@ namespace OpenRCT2::Ui::Windows
             for (size_t i = 0; i < _list.size(); ++i)
             {
                 auto y = static_cast<int32_t>(1 + i * kScrollableRowHeight);
-                if (y > dpi.y + dpi.height)
+                if (y > rt.y + rt.height)
                 {
                     break;
                 }
 
-                if (y + kScrollableRowHeight < dpi.y)
+                if (y + kScrollableRowHeight < rt.y)
                 {
                     continue;
                 }
@@ -325,12 +325,12 @@ namespace OpenRCT2::Ui::Windows
                 // Is this a separator?
                 if (_list[i].ShortcutId.empty())
                 {
-                    DrawSeparator(dpi, y, scrollWidth);
+                    DrawSeparator(rt, y, scrollWidth);
                 }
                 else
                 {
                     auto isHighlighted = _highlightedItem == static_cast<int_fast16_t>(i);
-                    DrawItem(dpi, y, scrollWidth, _list[i], isHighlighted);
+                    DrawItem(rt, y, scrollWidth, _list[i], isHighlighted);
                 }
             }
         }
@@ -468,15 +468,15 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImages(RenderTarget& dpi) const
+        void DrawTabImages(RenderTarget& rt) const
         {
             for (size_t i = 0; i < _tabs.size(); i++)
             {
-                DrawTabImage(dpi, i);
+                DrawTabImage(rt, i);
             }
         }
 
-        void DrawTabImage(RenderTarget& dpi, size_t tabIndex) const
+        void DrawTabImage(RenderTarget& rt, size_t tabIndex) const
         {
             const auto& tabDesc = _tabs[tabIndex];
             auto widgetIndex = static_cast<WidgetIndex>(WIDX_TAB_0 + tabIndex);
@@ -492,26 +492,26 @@ namespace OpenRCT2::Ui::Windows
                     }
 
                     const auto& widget = widgets[widgetIndex];
-                    GfxDrawSprite(dpi, ImageId(imageId), windowPos + ScreenCoordsXY{ widget.left, widget.top });
+                    GfxDrawSprite(rt, ImageId(imageId), windowPos + ScreenCoordsXY{ widget.left, widget.top });
                 }
             }
         }
 
-        void DrawSeparator(RenderTarget& dpi, int32_t y, int32_t scrollWidth)
+        void DrawSeparator(RenderTarget& rt, int32_t y, int32_t scrollWidth)
         {
             const int32_t top = y + (kScrollableRowHeight / 2) - 1;
-            GfxFillRect(dpi, { { 0, top }, { scrollWidth, top } }, ColourMapA[colours[0].colour].mid_dark);
-            GfxFillRect(dpi, { { 0, top + 1 }, { scrollWidth, top + 1 } }, ColourMapA[colours[0].colour].lightest);
+            GfxFillRect(rt, { { 0, top }, { scrollWidth, top } }, ColourMapA[colours[0].colour].mid_dark);
+            GfxFillRect(rt, { { 0, top + 1 }, { scrollWidth, top + 1 } }, ColourMapA[colours[0].colour].lightest);
         }
 
         void DrawItem(
-            RenderTarget& dpi, int32_t y, int32_t scrollWidth, const ShortcutStringPair& shortcut, bool isHighlighted)
+            RenderTarget& rt, int32_t y, int32_t scrollWidth, const ShortcutStringPair& shortcut, bool isHighlighted)
         {
             auto format = STR_BLACK_STRING;
             if (isHighlighted)
             {
                 format = STR_WINDOW_COLOUR_2_STRINGID;
-                GfxFilterRect(dpi, { 0, y - 1, scrollWidth, y + (kScrollableRowHeight - 2) }, FilterPaletteID::PaletteDarken1);
+                GfxFilterRect(rt, { 0, y - 1, scrollWidth, y + (kScrollableRowHeight - 2) }, FilterPaletteID::PaletteDarken1);
             }
 
             auto bindingOffset = (scrollWidth * 2) / 3;
@@ -526,14 +526,14 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<StringId>(STR_STRING);
                 ft.Add<const char*>(shortcut.CustomString.c_str());
             }
-            DrawTextEllipsised(dpi, { 0, y - 1 }, bindingOffset, format, ft);
+            DrawTextEllipsised(rt, { 0, y - 1 }, bindingOffset, format, ft);
 
             if (!shortcut.Binding.empty())
             {
                 ft = Formatter();
                 ft.Add<StringId>(STR_STRING);
                 ft.Add<const char*>(shortcut.Binding.c_str());
-                DrawTextEllipsised(dpi, { bindingOffset, y - 1 }, 150, format, ft);
+                DrawTextEllipsised(rt, { bindingOffset, y - 1 }, 150, format, ft);
             }
         }
     };

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -504,8 +504,7 @@ namespace OpenRCT2::Ui::Windows
             GfxFillRect(rt, { { 0, top + 1 }, { scrollWidth, top + 1 } }, ColourMapA[colours[0].colour].lightest);
         }
 
-        void DrawItem(
-            RenderTarget& rt, int32_t y, int32_t scrollWidth, const ShortcutStringPair& shortcut, bool isHighlighted)
+        void DrawItem(RenderTarget& rt, int32_t y, int32_t scrollWidth, const ShortcutStringPair& shortcut, bool isHighlighted)
         {
             auto format = STR_BLACK_STRING;
             if (isHighlighted)

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -122,7 +122,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
 
@@ -252,7 +252,7 @@ namespace OpenRCT2::Ui::Windows
             SetWidgetPressed(static_cast<WidgetIndex>(WIDX_TAB_0 + _currentTabIndex), true);
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -298,7 +298,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
             GfxFillRect(
@@ -468,7 +468,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImages(DrawPixelInfo& dpi) const
+        void DrawTabImages(RenderTarget& dpi) const
         {
             for (size_t i = 0; i < _tabs.size(); i++)
             {
@@ -476,7 +476,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImage(DrawPixelInfo& dpi, size_t tabIndex) const
+        void DrawTabImage(RenderTarget& dpi, size_t tabIndex) const
         {
             const auto& tabDesc = _tabs[tabIndex];
             auto widgetIndex = static_cast<WidgetIndex>(WIDX_TAB_0 + tabIndex);
@@ -497,7 +497,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawSeparator(DrawPixelInfo& dpi, int32_t y, int32_t scrollWidth)
+        void DrawSeparator(RenderTarget& dpi, int32_t y, int32_t scrollWidth)
         {
             const int32_t top = y + (kScrollableRowHeight / 2) - 1;
             GfxFillRect(dpi, { { 0, top }, { scrollWidth, top } }, ColourMapA[colours[0].colour].mid_dark);
@@ -505,7 +505,7 @@ namespace OpenRCT2::Ui::Windows
         }
 
         void DrawItem(
-            DrawPixelInfo& dpi, int32_t y, int32_t scrollWidth, const ShortcutStringPair& shortcut, bool isHighlighted)
+            RenderTarget& dpi, int32_t y, int32_t scrollWidth, const ShortcutStringPair& shortcut, bool isHighlighted)
         {
             auto format = STR_BLACK_STRING;
             if (isHighlighted)

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -291,13 +291,13 @@ namespace OpenRCT2::Ui::Windows
             text_colour_btn->image = GetColourButtonImage(_textColour);
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             if (viewport != nullptr)
             {
-                WindowDrawViewport(dpi, *this);
+                WindowDrawViewport(rt, *this);
             }
         }
 

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -291,7 +291,7 @@ namespace OpenRCT2::Ui::Windows
             text_colour_btn->image = GetColourButtonImage(_textColour);
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
 

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -225,7 +225,7 @@ namespace OpenRCT2::Ui::Windows
             CommonPrepareDrawAfter();
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -533,7 +533,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_FIRE].right = width - 2;
         }
 
-        void OverviewDraw(DrawPixelInfo& dpi)
+        void OverviewDraw(RenderTarget& dpi)
         {
             // Draw the viewport no sound sprite
             if (viewport != nullptr)
@@ -560,7 +560,7 @@ namespace OpenRCT2::Ui::Windows
             DrawTextEllipsised(dpi, screenPos, widgetWidth, STR_BLACK_STRING, ft, { TextAlignment::CENTRE });
         }
 
-        void DrawOverviewTabImage(DrawPixelInfo& dpi)
+        void DrawOverviewTabImage(RenderTarget& dpi)
         {
             if (IsWidgetDisabled(WIDX_TAB_1))
                 return;
@@ -572,7 +572,7 @@ namespace OpenRCT2::Ui::Windows
             if (page == WINDOW_STAFF_OVERVIEW)
                 widgetHeight++;
 
-            DrawPixelInfo clip_dpi;
+            RenderTarget clip_dpi;
             if (!ClipDrawPixelInfo(clip_dpi, dpi, screenCoords, widgetWidth, widgetHeight))
             {
                 return;
@@ -919,7 +919,7 @@ namespace OpenRCT2::Ui::Windows
 #pragma endregion
 
 #pragma region Statistics tab events
-        void StatsDraw(DrawPixelInfo& dpi)
+        void StatsDraw(RenderTarget& dpi)
         {
             auto staff = GetStaff();
             if (staff == nullptr)
@@ -1176,14 +1176,14 @@ namespace OpenRCT2::Ui::Windows
             WindowFollowSprite(*main, EntityId::FromUnderlying(number));
         }
 
-        void DrawTabImages(DrawPixelInfo& dpi)
+        void DrawTabImages(RenderTarget& dpi)
         {
             DrawOverviewTabImage(dpi);
             DrawTabImage(dpi, WINDOW_STAFF_OPTIONS, SPR_TAB_STAFF_OPTIONS_0);
             DrawTabImage(dpi, WINDOW_STAFF_STATISTICS, SPR_TAB_STATS_0);
         }
 
-        void DrawTabImage(DrawPixelInfo& dpi, int32_t p, int32_t baseImageId)
+        void DrawTabImage(RenderTarget& dpi, int32_t p, int32_t baseImageId)
         {
             WidgetIndex widgetIndex = WIDX_TAB_1 + p;
             Widget* widget = &widgets[widgetIndex];

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -225,18 +225,18 @@ namespace OpenRCT2::Ui::Windows
             CommonPrepareDrawAfter();
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             switch (page)
             {
                 case WINDOW_STAFF_OVERVIEW:
-                    OverviewDraw(dpi);
+                    OverviewDraw(rt);
                     break;
                 case WINDOW_STAFF_STATISTICS:
-                    StatsDraw(dpi);
+                    StatsDraw(rt);
                     break;
             }
         }
@@ -533,16 +533,16 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_FIRE].right = width - 2;
         }
 
-        void OverviewDraw(RenderTarget& dpi)
+        void OverviewDraw(RenderTarget& rt)
         {
             // Draw the viewport no sound sprite
             if (viewport != nullptr)
             {
-                WindowDrawViewport(dpi, *this);
+                WindowDrawViewport(rt, *this);
 
                 if (viewport->flags & VIEWPORT_FLAG_SOUND_ON)
                 {
-                    GfxDrawSprite(dpi, ImageId(SPR_HEARING_VIEWPORT), WindowGetViewportSoundIconPos(*this));
+                    GfxDrawSprite(rt, ImageId(SPR_HEARING_VIEWPORT), WindowGetViewportSoundIconPos(*this));
                 }
             }
 
@@ -557,10 +557,10 @@ namespace OpenRCT2::Ui::Windows
             const auto& widget = widgets[WIDX_BTM_LABEL];
             auto screenPos = windowPos + ScreenCoordsXY{ widget.midX(), widget.top };
             int32_t widgetWidth = widget.width();
-            DrawTextEllipsised(dpi, screenPos, widgetWidth, STR_BLACK_STRING, ft, { TextAlignment::CENTRE });
+            DrawTextEllipsised(rt, screenPos, widgetWidth, STR_BLACK_STRING, ft, { TextAlignment::CENTRE });
         }
 
-        void DrawOverviewTabImage(RenderTarget& dpi)
+        void DrawOverviewTabImage(RenderTarget& rt)
         {
             if (IsWidgetDisabled(WIDX_TAB_1))
                 return;
@@ -572,8 +572,8 @@ namespace OpenRCT2::Ui::Windows
             if (page == WINDOW_STAFF_OVERVIEW)
                 widgetHeight++;
 
-            RenderTarget clip_dpi;
-            if (!ClipDrawPixelInfo(clip_dpi, dpi, screenCoords, widgetWidth, widgetHeight))
+            RenderTarget clippedRT;
+            if (!ClipDrawPixelInfo(clippedRT, rt, screenCoords, widgetWidth, widgetHeight))
             {
                 return;
             }
@@ -598,7 +598,7 @@ namespace OpenRCT2::Ui::Windows
                 animFrame = _tabAnimationOffset / 4;
 
             auto imageIndex = anim.base_image + 1 + anim.frame_offsets[animFrame] * 4;
-            GfxDrawSprite(clip_dpi, ImageId(imageIndex, staff->TshirtColour, staff->TrousersColour), screenCoords);
+            GfxDrawSprite(clippedRT, ImageId(imageIndex, staff->TshirtColour, staff->TrousersColour), screenCoords);
         }
 
         void OverviewResize()
@@ -919,7 +919,7 @@ namespace OpenRCT2::Ui::Windows
 #pragma endregion
 
 #pragma region Statistics tab events
-        void StatsDraw(RenderTarget& dpi)
+        void StatsDraw(RenderTarget& rt)
         {
             auto staff = GetStaff();
             if (staff == nullptr)
@@ -933,13 +933,13 @@ namespace OpenRCT2::Ui::Windows
             {
                 auto ft = Formatter();
                 ft.Add<money64>(GetStaffWage(staff->AssignedStaffType));
-                DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_WAGES, ft);
+                DrawTextBasic(rt, screenCoords, STR_STAFF_STAT_WAGES, ft);
                 screenCoords.y += kListRowHeight;
             }
 
             auto ft = Formatter();
             ft.Add<int32_t>(staff->GetHireDate());
-            DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_EMPLOYED_FOR, ft);
+            DrawTextBasic(rt, screenCoords, STR_STAFF_STAT_EMPLOYED_FOR, ft);
             screenCoords.y += kListRowHeight;
 
             switch (staff->AssignedStaffType)
@@ -947,37 +947,37 @@ namespace OpenRCT2::Ui::Windows
                 case StaffType::Handyman:
                     ft = Formatter();
                     ft.Add<uint32_t>(staff->StaffLawnsMown);
-                    DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_LAWNS_MOWN, ft);
+                    DrawTextBasic(rt, screenCoords, STR_STAFF_STAT_LAWNS_MOWN, ft);
                     screenCoords.y += kListRowHeight;
 
                     ft = Formatter();
                     ft.Add<uint32_t>(staff->StaffGardensWatered);
-                    DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_GARDENS_WATERED, ft);
+                    DrawTextBasic(rt, screenCoords, STR_STAFF_STAT_GARDENS_WATERED, ft);
                     screenCoords.y += kListRowHeight;
 
                     ft = Formatter();
                     ft.Add<uint32_t>(staff->StaffLitterSwept);
-                    DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_LITTER_SWEPT, ft);
+                    DrawTextBasic(rt, screenCoords, STR_STAFF_STAT_LITTER_SWEPT, ft);
                     screenCoords.y += kListRowHeight;
 
                     ft = Formatter();
                     ft.Add<uint32_t>(staff->StaffBinsEmptied);
-                    DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_BINS_EMPTIED, ft);
+                    DrawTextBasic(rt, screenCoords, STR_STAFF_STAT_BINS_EMPTIED, ft);
                     break;
                 case StaffType::Mechanic:
                     ft = Formatter();
                     ft.Add<uint32_t>(staff->StaffRidesInspected);
-                    DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_RIDES_INSPECTED, ft);
+                    DrawTextBasic(rt, screenCoords, STR_STAFF_STAT_RIDES_INSPECTED, ft);
                     screenCoords.y += kListRowHeight;
 
                     ft = Formatter();
                     ft.Add<uint32_t>(staff->StaffRidesFixed);
-                    DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_RIDES_FIXED, ft);
+                    DrawTextBasic(rt, screenCoords, STR_STAFF_STAT_RIDES_FIXED, ft);
                     break;
                 case StaffType::Security:
                     ft = Formatter();
                     ft.Add<uint32_t>(staff->StaffVandalsStopped);
-                    DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_VANDALS_STOPPED, ft);
+                    DrawTextBasic(rt, screenCoords, STR_STAFF_STAT_VANDALS_STOPPED, ft);
                     break;
                 case StaffType::Entertainer:
                 case StaffType::Count:
@@ -1176,14 +1176,14 @@ namespace OpenRCT2::Ui::Windows
             WindowFollowSprite(*main, EntityId::FromUnderlying(number));
         }
 
-        void DrawTabImages(RenderTarget& dpi)
+        void DrawTabImages(RenderTarget& rt)
         {
-            DrawOverviewTabImage(dpi);
-            DrawTabImage(dpi, WINDOW_STAFF_OPTIONS, SPR_TAB_STAFF_OPTIONS_0);
-            DrawTabImage(dpi, WINDOW_STAFF_STATISTICS, SPR_TAB_STATS_0);
+            DrawOverviewTabImage(rt);
+            DrawTabImage(rt, WINDOW_STAFF_OPTIONS, SPR_TAB_STAFF_OPTIONS_0);
+            DrawTabImage(rt, WINDOW_STAFF_STATISTICS, SPR_TAB_STATS_0);
         }
 
-        void DrawTabImage(RenderTarget& dpi, int32_t p, int32_t baseImageId)
+        void DrawTabImage(RenderTarget& rt, int32_t p, int32_t baseImageId)
         {
             WidgetIndex widgetIndex = WIDX_TAB_1 + p;
             Widget* widget = &widgets[widgetIndex];
@@ -1199,7 +1199,7 @@ namespace OpenRCT2::Ui::Windows
                 }
 
                 // Draw normal, enabled sprite.
-                GfxDrawSprite(dpi, ImageId(baseImageId), screenCoords);
+                GfxDrawSprite(rt, ImageId(baseImageId), screenCoords);
             }
         }
 

--- a/src/openrct2-ui/windows/StaffFirePrompt.cpp
+++ b/src/openrct2-ui/windows/StaffFirePrompt.cpp
@@ -73,7 +73,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
 

--- a/src/openrct2-ui/windows/StaffFirePrompt.cpp
+++ b/src/openrct2-ui/windows/StaffFirePrompt.cpp
@@ -73,9 +73,9 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             Peep* peep = GetEntity<Staff>(EntityId::FromUnderlying(number));
             // The staff member may have been fired in the meantime.
@@ -87,7 +87,7 @@ namespace OpenRCT2::Ui::Windows
             peep->FormatNameTo(ft);
 
             ScreenCoordsXY textCoords(windowPos + ScreenCoordsXY{ WW / 2, (WH / 2) - 3 });
-            DrawTextWrapped(dpi, textCoords, WW - 4, STR_FIRE_STAFF_ID, ft, { TextAlignment::CENTRE });
+            DrawTextWrapped(rt, textCoords, WW - 4, STR_FIRE_STAFF_ID, ft, { TextAlignment::CENTRE });
         }
     };
 

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -270,7 +270,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_STAFF_LIST_HIRE_BUTTON].right = width - 11;
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
             DrawTabImages(dpi);
@@ -362,7 +362,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
             GfxFillRect(
@@ -586,7 +586,7 @@ namespace OpenRCT2::Ui::Windows
             return static_cast<StaffType>(_selectedTab);
         }
 
-        void DrawTabImages(DrawPixelInfo& dpi) const
+        void DrawTabImages(RenderTarget& dpi) const
         {
             const auto& gameState = getGameState();
             DrawTabImage(dpi, WINDOW_STAFF_LIST_TAB_HANDYMEN, AnimationPeepType::Handyman, gameState.staffHandymanColour);
@@ -595,7 +595,7 @@ namespace OpenRCT2::Ui::Windows
             DrawTabImage(dpi, WINDOW_STAFF_LIST_TAB_ENTERTAINERS, AnimationPeepType::Entertainer);
         }
 
-        void DrawTabImage(DrawPixelInfo& dpi, int32_t tabIndex, AnimationPeepType type, colour_t colour) const
+        void DrawTabImage(RenderTarget& dpi, int32_t tabIndex, AnimationPeepType type, colour_t colour) const
         {
             PeepAnimationsObject* animObj = findPeepAnimationsObjectForType(type);
             if (animObj == nullptr)
@@ -613,7 +613,7 @@ namespace OpenRCT2::Ui::Windows
                 windowPos + ScreenCoordsXY{ (widget.left + widget.right) / 2, widget.bottom - 6 });
         }
 
-        void DrawTabImage(DrawPixelInfo& dpi, int32_t tabIndex, AnimationPeepType type) const
+        void DrawTabImage(RenderTarget& dpi, int32_t tabIndex, AnimationPeepType type) const
         {
             PeepAnimationsObject* animObj = findPeepAnimationsObjectForType(type);
             if (animObj == nullptr)
@@ -622,7 +622,7 @@ namespace OpenRCT2::Ui::Windows
             auto widgetIndex = WIDX_STAFF_LIST_HANDYMEN_TAB + tabIndex;
             const auto& widget = widgets[widgetIndex];
 
-            DrawPixelInfo clippedDpi;
+            RenderTarget clippedDpi;
             if (ClipDrawPixelInfo(
                     clippedDpi, dpi, windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 1 },
                     widget.right - widget.left - 1, widget.bottom - widget.top - 1))

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -270,23 +270,23 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_STAFF_LIST_HIRE_BUTTON].right = width - 11;
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
-            DrawTabImages(dpi);
+            DrawWidgets(rt);
+            DrawTabImages(rt);
 
             if (!(getGameState().park.Flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
                 ft.Add<money64>(GetStaffWage(GetSelectedStaffType()));
                 auto y = widgets[WIDX_STAFF_LIST_TITLE].bottom + 17;
-                DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ width - 155, y }, STR_COST_PER_MONTH, ft);
+                DrawTextBasic(rt, windowPos + ScreenCoordsXY{ width - 155, y }, STR_COST_PER_MONTH, ft);
             }
 
             if (GetSelectedStaffType() != StaffType::Entertainer)
             {
                 DrawTextBasic(
-                    dpi, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER].top + 1 },
+                    rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER].top + 1 },
                     STR_UNIFORM_COLOUR);
             }
 
@@ -298,7 +298,7 @@ namespace OpenRCT2::Ui::Windows
             ft.Add<StringId>(staffTypeStringId);
 
             DrawTextBasic(
-                dpi, windowPos + ScreenCoordsXY{ 4, widgets[WIDX_STAFF_LIST_LIST].bottom + 2 }, STR_STAFF_LIST_COUNTER, ft);
+                rt, windowPos + ScreenCoordsXY{ 4, widgets[WIDX_STAFF_LIST_LIST].bottom + 2 }, STR_STAFF_LIST_COUNTER, ft);
         }
 
         ScreenSize OnScrollGetSize(int32_t scrollIndex) override
@@ -362,11 +362,11 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
-            auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
+            auto rtCoords = ScreenCoordsXY{ rt.x, rt.y };
             GfxFillRect(
-                dpi, { dpiCoords, dpiCoords + ScreenCoordsXY{ dpi.width - 1, dpi.height - 1 } },
+                rt, { rtCoords, rtCoords + ScreenCoordsXY{ rt.width - 1, rt.height - 1 } },
                 ColourMapA[colours[1].colour].mid_light);
 
             // How much space do we have for the name and action columns? (Discount scroll area and icons.)
@@ -379,12 +379,12 @@ namespace OpenRCT2::Ui::Windows
             size_t i = 0;
             for (const auto& entry : _staffList)
             {
-                if (y > dpi.y + dpi.height)
+                if (y > rt.y + rt.height)
                 {
                     break;
                 }
 
-                if (y + 11 >= dpi.y)
+                if (y + 11 >= rt.y)
                 {
                     const auto* peep = GetEntity<Staff>(entry.Id);
                     if (peep == nullptr)
@@ -398,7 +398,7 @@ namespace OpenRCT2::Ui::Windows
 
                     if (i == _highlightedIndex)
                     {
-                        GfxFilterRect(dpi, { 0, y, 800, y + (kScrollableRowHeight - 1) }, FilterPaletteID::PaletteDarken1);
+                        GfxFilterRect(rt, { 0, y, 800, y + (kScrollableRowHeight - 1) }, FilterPaletteID::PaletteDarken1);
 
                         format = STR_WINDOW_COLOUR_2_STRINGID;
                         if (_quickFireMode)
@@ -407,16 +407,16 @@ namespace OpenRCT2::Ui::Windows
 
                     auto ft = Formatter();
                     peep->FormatNameTo(ft);
-                    DrawTextEllipsised(dpi, { 0, y }, nameColumnSize, format, ft);
+                    DrawTextEllipsised(rt, { 0, y }, nameColumnSize, format, ft);
 
                     ft = Formatter();
                     peep->FormatActionTo(ft);
-                    DrawTextEllipsised(dpi, { actionOffset, y }, actionColumnSize, format, ft);
+                    DrawTextEllipsised(rt, { actionOffset, y }, actionColumnSize, format, ft);
 
                     // True if a patrol path is set for the worker
                     if (peep->HasPatrolArea())
                     {
-                        GfxDrawSprite(dpi, ImageId(SPR_STAFF_PATROL_PATH), { nameColumnSize + 5, y });
+                        GfxDrawSprite(rt, ImageId(SPR_STAFF_PATROL_PATH), { nameColumnSize + 5, y });
                     }
 
                     auto staffOrderIcon_x = nameColumnSize + 20;
@@ -429,7 +429,7 @@ namespace OpenRCT2::Ui::Windows
                         {
                             if (staffOrders & 1)
                             {
-                                GfxDrawSprite(dpi, ImageId(staffOrderSprite), { staffOrderIcon_x, y });
+                                GfxDrawSprite(rt, ImageId(staffOrderSprite), { staffOrderIcon_x, y });
                             }
                             staffOrders = staffOrders >> 1;
                             staffOrderIcon_x += 9;
@@ -439,7 +439,7 @@ namespace OpenRCT2::Ui::Windows
                     }
                     else
                     {
-                        GfxDrawSprite(dpi, GetCostumeInlineSprite(peep->AnimationObjectIndex), { staffOrderIcon_x, y });
+                        GfxDrawSprite(rt, GetCostumeInlineSprite(peep->AnimationObjectIndex), { staffOrderIcon_x, y });
                     }
                 }
 
@@ -586,16 +586,16 @@ namespace OpenRCT2::Ui::Windows
             return static_cast<StaffType>(_selectedTab);
         }
 
-        void DrawTabImages(RenderTarget& dpi) const
+        void DrawTabImages(RenderTarget& rt) const
         {
             const auto& gameState = getGameState();
-            DrawTabImage(dpi, WINDOW_STAFF_LIST_TAB_HANDYMEN, AnimationPeepType::Handyman, gameState.staffHandymanColour);
-            DrawTabImage(dpi, WINDOW_STAFF_LIST_TAB_MECHANICS, AnimationPeepType::Mechanic, gameState.staffMechanicColour);
-            DrawTabImage(dpi, WINDOW_STAFF_LIST_TAB_SECURITY, AnimationPeepType::Security, gameState.staffSecurityColour);
-            DrawTabImage(dpi, WINDOW_STAFF_LIST_TAB_ENTERTAINERS, AnimationPeepType::Entertainer);
+            DrawTabImage(rt, WINDOW_STAFF_LIST_TAB_HANDYMEN, AnimationPeepType::Handyman, gameState.staffHandymanColour);
+            DrawTabImage(rt, WINDOW_STAFF_LIST_TAB_MECHANICS, AnimationPeepType::Mechanic, gameState.staffMechanicColour);
+            DrawTabImage(rt, WINDOW_STAFF_LIST_TAB_SECURITY, AnimationPeepType::Security, gameState.staffSecurityColour);
+            DrawTabImage(rt, WINDOW_STAFF_LIST_TAB_ENTERTAINERS, AnimationPeepType::Entertainer);
         }
 
-        void DrawTabImage(RenderTarget& dpi, int32_t tabIndex, AnimationPeepType type, colour_t colour) const
+        void DrawTabImage(RenderTarget& rt, int32_t tabIndex, AnimationPeepType type, colour_t colour) const
         {
             PeepAnimationsObject* animObj = findPeepAnimationsObjectForType(type);
             if (animObj == nullptr)
@@ -609,11 +609,11 @@ namespace OpenRCT2::Ui::Windows
             auto imageId = anim.base_image + 1 + anim.frame_offsets[frame] * 4;
 
             GfxDrawSprite(
-                dpi, ImageId(imageId, colour),
+                rt, ImageId(imageId, colour),
                 windowPos + ScreenCoordsXY{ (widget.left + widget.right) / 2, widget.bottom - 6 });
         }
 
-        void DrawTabImage(RenderTarget& dpi, int32_t tabIndex, AnimationPeepType type) const
+        void DrawTabImage(RenderTarget& rt, int32_t tabIndex, AnimationPeepType type) const
         {
             PeepAnimationsObject* animObj = findPeepAnimationsObjectForType(type);
             if (animObj == nullptr)
@@ -624,7 +624,7 @@ namespace OpenRCT2::Ui::Windows
 
             RenderTarget clippedDpi;
             if (ClipDrawPixelInfo(
-                    clippedDpi, dpi, windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 1 },
+                    clippedDpi, rt, windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 1 },
                     widget.right - widget.left - 1, widget.bottom - widget.top - 1))
             {
                 auto frame = _selectedTab == tabIndex ? _tabAnimationIndex / 4 : 0;

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -194,9 +194,9 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             auto screenCoords = windowPos + ScreenCoordsXY{ WW / 2, widgets[WIDX_TITLE].bottom + 13 };
 
@@ -206,12 +206,12 @@ namespace OpenRCT2::Ui::Windows
             {
                 auto ft = Formatter();
                 ft.Add<const char*>(_description.c_str());
-                DrawTextWrapped(dpi, screenCoords, WW, STR_STRING, ft, { colours[1], TextAlignment::CENTRE });
+                DrawTextWrapped(rt, screenCoords, WW, STR_STRING, ft, { colours[1], TextAlignment::CENTRE });
             }
             else
             {
                 DrawTextWrapped(
-                    dpi, screenCoords, WW, _descriptionStringId, _descriptionArgs, { colours[1], TextAlignment::CENTRE });
+                    rt, screenCoords, WW, _descriptionStringId, _descriptionArgs, { colours[1], TextAlignment::CENTRE });
             }
 
             screenCoords.y += 25;
@@ -223,7 +223,7 @@ namespace OpenRCT2::Ui::Windows
                 u8string_view{ _buffer.data(), _buffer.size() }, WW - (24 + 13), FontStyle::Medium, &wrappedString, &no_lines);
 
             GfxFillRectInset(
-                dpi,
+                rt,
                 { { windowPos.x + 10, screenCoords.y }, { windowPos.x + WW - 10, screenCoords.y + 10 * (no_lines + 1) + 3 } },
                 colours[1], INSET_RECT_F_60);
 
@@ -239,7 +239,7 @@ namespace OpenRCT2::Ui::Windows
             for (int32_t line = 0; line <= no_lines; line++)
             {
                 screenCoords.x = windowPos.x + 12;
-                DrawText(dpi, screenCoords, { colours[1], FontStyle::Medium, TextAlignment::LEFT }, wrapPointer, true);
+                DrawText(rt, screenCoords, { colours[1], FontStyle::Medium, TextAlignment::LEFT }, wrapPointer, true);
 
                 size_t string_length = GetStringSize(wrapPointer) - 1;
                 if (!cur_drawn && (textInput->SelectionStart <= char_count + string_length))
@@ -266,7 +266,7 @@ namespace OpenRCT2::Ui::Windows
                         uint8_t colour = ColourMapA[colours[1].colour].mid_light;
                         // TODO: palette index addition
                         GfxFillRect(
-                            dpi, { { cursorX, screenCoords.y + 9 }, { cursorX + textWidth, screenCoords.y + 9 } }, colour + 5);
+                            rt, { { cursorX, screenCoords.y + 9 }, { cursorX + textWidth, screenCoords.y + 9 } }, colour + 5);
                     }
 
                     cur_drawn++;
@@ -283,7 +283,7 @@ namespace OpenRCT2::Ui::Windows
 
             if (!cur_drawn)
             {
-                cursorX = dpi.lastStringPos.x;
+                cursorX = rt.lastStringPos.x;
                 cursorY = screenCoords.y - 10;
             }
 

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -194,7 +194,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
 

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -380,7 +380,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             // Widgets
             WindowDrawWidgets(*this, dpi);
@@ -695,7 +695,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             ScreenCoordsXY screenCoords;
 
@@ -884,7 +884,7 @@ namespace OpenRCT2::Ui::Windows
             return 0;
         }
 
-        void WindowThemesDrawTabImages(DrawPixelInfo& dpi)
+        void WindowThemesDrawTabImages(RenderTarget& dpi)
         {
             for (int32_t i = 0; i < WINDOW_THEMES_TAB_COUNT; i++)
             {

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -380,16 +380,16 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             // Widgets
-            WindowDrawWidgets(*this, dpi);
-            WindowThemesDrawTabImages(dpi);
+            WindowDrawWidgets(*this, rt);
+            WindowThemesDrawTabImages(rt);
 
             if (_selected_tab == WINDOW_THEMES_TAB_SETTINGS)
             {
                 DrawTextBasic(
-                    dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_THEMES_PRESETS].top + 1 }, STR_THEMES_LABEL_CURRENT_THEME,
+                    rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_THEMES_PRESETS].top + 1 }, STR_THEMES_LABEL_CURRENT_THEME,
                     {}, { colours[1] });
 
                 size_t activeAvailableThemeIndex = ThemeManagerGetAvailableThemeIndex();
@@ -402,7 +402,7 @@ namespace OpenRCT2::Ui::Windows
                 auto newWidth = windowPos.x + widgets[WIDX_THEMES_PRESETS_DROPDOWN].left - widgets[WIDX_THEMES_PRESETS].left
                     - 4;
 
-                DrawTextEllipsised(dpi, screenPos, newWidth, STR_STRING, ft, { colours[1] });
+                DrawTextEllipsised(rt, screenPos, newWidth, STR_STRING, ft, { colours[1] });
             }
         }
 
@@ -695,7 +695,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             ScreenCoordsXY screenCoords;
 
@@ -705,7 +705,7 @@ namespace OpenRCT2::Ui::Windows
             if (!colours[1].hasFlag(ColourFlag::translucent))
                 // GfxFillRect(dpi, dpi->x, dpi->y, dpi->x + dpi->width - 1, dpi->y + dpi->height - 1,
                 // ColourMapA[colours[1].colour].mid_light);
-                GfxClear(dpi, ColourMapA[colours[1].colour].mid_light);
+                GfxClear(rt, ColourMapA[colours[1].colour].mid_light);
             screenCoords.y = 0;
             for (int32_t i = 0; i < GetColourSchemeTabCount(); i++)
             {
@@ -723,11 +723,11 @@ namespace OpenRCT2::Ui::Windows
                     emptyRow = true;
                 }
 
-                if (screenCoords.y > dpi.y + dpi.height)
+                if (screenCoords.y > rt.y + rt.height)
                 {
                     break;
                 }
-                if (screenCoords.y + _max_row_height >= dpi.y)
+                if (screenCoords.y + _max_row_height >= rt.y)
                 {
                     if (i + 1 < GetColourSchemeTabCount())
                     {
@@ -744,23 +744,23 @@ namespace OpenRCT2::Ui::Windows
                         {
                             TranslucentWindowPalette windowPalette = TranslucentWindowPalettes[colour.colour];
 
-                            GfxFilterRect(dpi, { leftTop, rightBottom }, windowPalette.highlight);
-                            GfxFilterRect(dpi, { leftTop + yPixelOffset, rightBottom + yPixelOffset }, windowPalette.shadow);
+                            GfxFilterRect(rt, { leftTop, rightBottom }, windowPalette.highlight);
+                            GfxFilterRect(rt, { leftTop + yPixelOffset, rightBottom + yPixelOffset }, windowPalette.shadow);
                         }
                         else
                         {
                             colour = ColourMapA[colours[1].colour].mid_dark;
-                            GfxFillRect(dpi, { leftTop, rightBottom }, colour.colour);
+                            GfxFillRect(rt, { leftTop, rightBottom }, colour.colour);
 
                             colour = ColourMapA[colours[1].colour].lightest;
-                            GfxFillRect(dpi, { leftTop + yPixelOffset, rightBottom + yPixelOffset }, colour.colour);
+                            GfxFillRect(rt, { leftTop + yPixelOffset, rightBottom + yPixelOffset }, colour.colour);
                         }
                     }
 
                     for (uint8_t j = 0; j < numColours; j++)
                     {
                         DrawTextWrapped(
-                            dpi, { 2, screenCoords.y + 4 }, kWindowHeaderWidth, ThemeDescGetName(wc), {}, { colours[1] });
+                            rt, { 2, screenCoords.y + 4 }, kWindowHeaderWidth, ThemeDescGetName(wc), {}, { colours[1] });
 
                         // Don't draw the empty row
                         if (emptyRow && j == 1)
@@ -772,16 +772,16 @@ namespace OpenRCT2::Ui::Windows
                         const bool isPressed = (i == _classIndex && j == _buttonIndex);
                         auto image = ImageId(isPressed ? SPR_PALETTE_BTN_PRESSED : SPR_PALETTE_BTN, colour.colour);
                         GfxDrawSprite(
-                            dpi, image, { _button_offset_x, screenCoords.y + _button_offset_y + _button_size * j + 1 });
+                            rt, image, { _button_offset_x, screenCoords.y + _button_offset_y + _button_size * j + 1 });
 
                         ScreenCoordsXY topLeft{ _check_offset_x, screenCoords.y + _check_offset_y + _button_size * j };
                         ScreenCoordsXY bottomRight{ _check_offset_x + 10,
                                                     screenCoords.y + _check_offset_y + 11 + _button_size * j };
-                        GfxFillRectInset(dpi, { topLeft, bottomRight }, colours[1], INSET_RECT_F_E0);
+                        GfxFillRectInset(rt, { topLeft, bottomRight }, colours[1], INSET_RECT_F_E0);
                         if (colour.hasFlag(ColourFlag::translucent))
                         {
                             DrawText(
-                                dpi, topLeft, { colours[1].colour, FontStyle::Medium, TextDarkness::Dark }, kCheckMarkString);
+                                rt, topLeft, { colours[1].colour, FontStyle::Medium, TextDarkness::Dark }, kCheckMarkString);
                         }
                     }
                 }
@@ -884,7 +884,7 @@ namespace OpenRCT2::Ui::Windows
             return 0;
         }
 
-        void WindowThemesDrawTabImages(RenderTarget& dpi)
+        void WindowThemesDrawTabImages(RenderTarget& rt)
         {
             for (int32_t i = 0; i < WINDOW_THEMES_TAB_COUNT; i++)
             {
@@ -892,7 +892,7 @@ namespace OpenRCT2::Ui::Windows
                 if (_selected_tab == i)
                     sprite_idx += frame_no / window_themes_tab_animation_divisor[_selected_tab];
                 GfxDrawSprite(
-                    dpi, ImageId(sprite_idx),
+                    rt, ImageId(sprite_idx),
                     windowPos
                         + ScreenCoordsXY{ widgets[WIDX_THEMES_SETTINGS_TAB + i].left,
                                           widgets[WIDX_THEMES_SETTINGS_TAB + i].top });

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1045,7 +1045,7 @@ static uint64_t PageDisabledWidgets[] = {
             InvalidateWidget(WIDX_LIST);
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
             ScreenCoordsXY screenCoords(windowPos.x, windowPos.y);
@@ -1585,7 +1585,7 @@ static uint64_t PageDisabledWidgets[] = {
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
         {
             const int32_t listWidth = widgets[WIDX_LIST].width();
             GfxFillRect(

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1166,8 +1166,7 @@ static uint64_t PageDisabledWidgets[] = {
                             {
                                 auto ft = Formatter();
                                 ft.Add<StringId>(surfaceObj->NameStringId);
-                                DrawTextBasic(
-                                    rt, screenCoords, STR_TILE_INSPECTOR_FOOTPATH_SURFACE_NAME, ft, { COLOUR_WHITE });
+                                DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_FOOTPATH_SURFACE_NAME, ft, { COLOUR_WHITE });
                             }
 
                             // Railings name
@@ -1255,8 +1254,7 @@ static uint64_t PageDisabledWidgets[] = {
                         ft = Formatter();
                         ft.Add<StringId>(rtd.Naming.Name);
                         DrawTextBasic(
-                            rt, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_TRACK_RIDE_TYPE, ft,
-                            { colours[1] });
+                            rt, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_TRACK_RIDE_TYPE, ft, { colours[1] });
 
                         // Track
                         ft = Formatter();
@@ -1589,8 +1587,7 @@ static uint64_t PageDisabledWidgets[] = {
         {
             const int32_t listWidth = widgets[WIDX_LIST].width();
             GfxFillRect(
-                rt, { { rt.x, rt.y }, { rt.x + rt.width - 1, rt.y + rt.height - 1 } },
-                ColourMapA[colours[1].colour].mid_light);
+                rt, { { rt.x, rt.y }, { rt.x + rt.width - 1, rt.y + rt.height - 1 } }, ColourMapA[colours[1].colour].mid_light);
 
             // Show usage hint when nothing is selected
             if (!_tileSelected)
@@ -1737,8 +1734,7 @@ static uint64_t PageDisabledWidgets[] = {
 
                 // Checkmarks for ghost and last for tile
                 if (ghost)
-                    DrawTextBasic(
-                        rt, screenCoords + ScreenCoordsXY{ GhostFlagColumnXY.x, 0 }, stringFormat, checkboxFormatter);
+                    DrawTextBasic(rt, screenCoords + ScreenCoordsXY{ GhostFlagColumnXY.x, 0 }, stringFormat, checkboxFormatter);
                 if (last)
                     DrawTextBasic(rt, screenCoords + ScreenCoordsXY{ LastFlagColumnXY.x, 0 }, stringFormat, checkboxFormatter);
 

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1045,9 +1045,9 @@ static uint64_t PageDisabledWidgets[] = {
             InvalidateWidget(WIDX_LIST);
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
             ScreenCoordsXY screenCoords(windowPos.x, windowPos.y);
 
             // Draw coordinates
@@ -1058,18 +1058,18 @@ static uint64_t PageDisabledWidgets[] = {
                 auto ft = Formatter();
                 ft.Add<int32_t>(tileCoords.x);
                 DrawTextBasic(
-                    dpi, screenCoords + ScreenCoordsXY{ 43, yOffset }, STR_FORMAT_INTEGER, ft,
+                    rt, screenCoords + ScreenCoordsXY{ 43, yOffset }, STR_FORMAT_INTEGER, ft,
                     { colours[1], TextAlignment::RIGHT });
                 ft = Formatter();
                 ft.Add<int32_t>(tileCoords.y);
                 DrawTextBasic(
-                    dpi, screenCoords + ScreenCoordsXY{ 113, yOffset }, STR_FORMAT_INTEGER, ft,
+                    rt, screenCoords + ScreenCoordsXY{ 113, yOffset }, STR_FORMAT_INTEGER, ft,
                     { colours[1], TextAlignment::RIGHT });
             }
             else
             {
-                DrawText(dpi, screenCoords + ScreenCoordsXY(43 - 7, yOffset), { colours[1] }, "-");
-                DrawText(dpi, screenCoords + ScreenCoordsXY(113 - 7, yOffset), { colours[1] }, "-");
+                DrawText(rt, screenCoords + ScreenCoordsXY(43 - 7, yOffset), { colours[1] }, "-");
+                DrawText(rt, screenCoords + ScreenCoordsXY(113 - 7, yOffset), { colours[1] }, "-");
             }
 
             if (windowTileInspectorSelectedIndex != -1)
@@ -1095,7 +1095,7 @@ static uint64_t PageDisabledWidgets[] = {
                             terrainNameId = surfaceStyle->NameStringId;
                         auto ft = Formatter();
                         ft.Add<StringId>(terrainNameId);
-                        DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_SURFACE_TERAIN, ft, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_SURFACE_TERAIN, ft, { colours[1] });
 
                         // Edge texture name
                         StringId terrainEdgeNameId = kStringIdEmpty;
@@ -1105,7 +1105,7 @@ static uint64_t PageDisabledWidgets[] = {
                         ft = Formatter();
                         ft.Add<StringId>(terrainEdgeNameId);
                         DrawTextBasic(
-                            dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_SURFACE_EDGE, ft, { colours[1] });
+                            rt, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_SURFACE_EDGE, ft, { colours[1] });
 
                         // Land ownership
                         StringId landOwnership;
@@ -1123,14 +1123,14 @@ static uint64_t PageDisabledWidgets[] = {
                         ft = Formatter();
                         ft.Add<StringId>(landOwnership);
                         DrawTextBasic(
-                            dpi, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_SURFACE_OWNERSHIP, ft,
+                            rt, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_SURFACE_OWNERSHIP, ft,
                             { colours[1] });
 
                         // Water level
                         ft = Formatter();
                         ft.Add<uint32_t>(tileElement->AsSurface()->GetWaterHeight());
                         DrawTextBasic(
-                            dpi, screenCoords + ScreenCoordsXY{ 0, 33 }, STR_TILE_INSPECTOR_SURFACE_WATER_LEVEL, ft,
+                            rt, screenCoords + ScreenCoordsXY{ 0, 33 }, STR_TILE_INSPECTOR_SURFACE_WATER_LEVEL, ft,
                             { colours[1] });
 
                         // Properties
@@ -1138,19 +1138,19 @@ static uint64_t PageDisabledWidgets[] = {
                         screenCoords = windowPos
                             + ScreenCoordsXY{ widgets[WIDX_GROUPBOX_DETAILS].left + 7,
                                               widgets[WIDX_SURFACE_SPINNER_HEIGHT].top };
-                        DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
 
                         // Current base height
                         screenCoords.x = windowPos.x + widgets[WIDX_SURFACE_SPINNER_HEIGHT].left + 3;
                         ft = Formatter();
                         ft.Add<int32_t>(tileElement->BaseHeight);
-                        DrawTextBasic(dpi, screenCoords, STR_FORMAT_INTEGER, ft, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_FORMAT_INTEGER, ft, { colours[1] });
 
                         // Raised corners
                         screenCoords = windowPos
                             + ScreenCoordsXY{ widgets[WIDX_GROUPBOX_DETAILS].left + 7,
                                               widgets[WIDX_SURFACE_CHECK_CORNER_E].top };
-                        DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_SURFACE_CORNERS, {}, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_SURFACE_CORNERS, {}, { colours[1] });
                         break;
                     }
                     case TileElementType::Path:
@@ -1167,7 +1167,7 @@ static uint64_t PageDisabledWidgets[] = {
                                 auto ft = Formatter();
                                 ft.Add<StringId>(surfaceObj->NameStringId);
                                 DrawTextBasic(
-                                    dpi, screenCoords, STR_TILE_INSPECTOR_FOOTPATH_SURFACE_NAME, ft, { COLOUR_WHITE });
+                                    rt, screenCoords, STR_TILE_INSPECTOR_FOOTPATH_SURFACE_NAME, ft, { COLOUR_WHITE });
                             }
 
                             // Railings name
@@ -1177,7 +1177,7 @@ static uint64_t PageDisabledWidgets[] = {
                                 auto ft = Formatter();
                                 ft.Add<StringId>(railingsObj->NameStringId);
                                 DrawTextBasic(
-                                    dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_FOOTPATH_RAILINGS_NAME, ft,
+                                    rt, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_FOOTPATH_RAILINGS_NAME, ft,
                                     { COLOUR_WHITE });
                             }
                         }
@@ -1187,7 +1187,7 @@ static uint64_t PageDisabledWidgets[] = {
                             auto footpathEntry = reinterpret_cast<const FootpathEntry*>(footpathObj->GetLegacyData());
                             auto ft = Formatter();
                             ft.Add<StringId>(footpathEntry->string_idx);
-                            DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_PATH_NAME, ft, { COLOUR_WHITE });
+                            DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_PATH_NAME, ft, { COLOUR_WHITE });
                         }
 
                         // Path addition
@@ -1200,13 +1200,13 @@ static uint64_t PageDisabledWidgets[] = {
                             auto ft = Formatter();
                             ft.Add<StringId>(additionNameId);
                             DrawTextBasic(
-                                dpi, screenCoords + ScreenCoordsXY{ 0, 2 * 11 }, STR_TILE_INSPECTOR_PATH_ADDITIONS, ft,
+                                rt, screenCoords + ScreenCoordsXY{ 0, 2 * 11 }, STR_TILE_INSPECTOR_PATH_ADDITIONS, ft,
                                 { COLOUR_WHITE });
                         }
                         else
                         {
                             DrawTextBasic(
-                                dpi, screenCoords + ScreenCoordsXY{ 0, 2 * 11 }, STR_TILE_INSPECTOR_PATH_ADDITIONS_NONE, {},
+                                rt, screenCoords + ScreenCoordsXY{ 0, 2 * 11 }, STR_TILE_INSPECTOR_PATH_ADDITIONS_NONE, {},
                                 { COLOUR_WHITE });
                         }
 
@@ -1214,18 +1214,18 @@ static uint64_t PageDisabledWidgets[] = {
                         // Raise / lower label
                         screenCoords = windowPos
                             + ScreenCoordsXY{ widgets[WIDX_GROUPBOX_DETAILS].left + 7, widgets[WIDX_PATH_SPINNER_HEIGHT].top };
-                        DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
 
                         // Current base height
                         screenCoords.x = windowPos.x + widgets[WIDX_PATH_SPINNER_HEIGHT].left + 3;
                         auto ft = Formatter();
                         ft.Add<int32_t>(tileElement->BaseHeight);
-                        DrawTextBasic(dpi, screenCoords, STR_FORMAT_INTEGER, ft, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_FORMAT_INTEGER, ft, { colours[1] });
 
                         // Path connections
                         screenCoords = windowPos
                             + ScreenCoordsXY{ widgets[WIDX_GROUPBOX_DETAILS].left + 7, widgets[WIDX_PATH_CHECK_EDGE_W].top };
-                        DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_PATH_CONNECTED_EDGES, {}, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_PATH_CONNECTED_EDGES, {}, { colours[1] });
                         break;
                     }
 
@@ -1238,7 +1238,7 @@ static uint64_t PageDisabledWidgets[] = {
                         // Ride ID
                         auto ft = Formatter();
                         ft.Add<int16_t>(id);
-                        DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_TRACK_RIDE_ID, ft, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_TRACK_RIDE_ID, ft, { colours[1] });
 
                         // Ride name
                         if (rideTile != nullptr)
@@ -1246,7 +1246,7 @@ static uint64_t PageDisabledWidgets[] = {
                             ft = Formatter();
                             rideTile->formatNameTo(ft);
                             DrawTextBasic(
-                                dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_TRACK_RIDE_NAME, ft,
+                                rt, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_TRACK_RIDE_NAME, ft,
                                 { colours[1] });
                         }
 
@@ -1255,19 +1255,19 @@ static uint64_t PageDisabledWidgets[] = {
                         ft = Formatter();
                         ft.Add<StringId>(rtd.Naming.Name);
                         DrawTextBasic(
-                            dpi, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_TRACK_RIDE_TYPE, ft,
+                            rt, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_TRACK_RIDE_TYPE, ft,
                             { colours[1] });
 
                         // Track
                         ft = Formatter();
                         ft.Add<uint16_t>(trackElement->GetTrackType());
                         DrawTextBasic(
-                            dpi, screenCoords + ScreenCoordsXY{ 0, 33 }, STR_TILE_INSPECTOR_TRACK_PIECE_ID, ft, { colours[1] });
+                            rt, screenCoords + ScreenCoordsXY{ 0, 33 }, STR_TILE_INSPECTOR_TRACK_PIECE_ID, ft, { colours[1] });
 
                         ft = Formatter();
                         ft.Add<uint16_t>(trackElement->GetSequenceIndex());
                         DrawTextBasic(
-                            dpi, screenCoords + ScreenCoordsXY{ 0, 44 }, STR_TILE_INSPECTOR_TRACK_SEQUENCE, ft, { colours[1] });
+                            rt, screenCoords + ScreenCoordsXY{ 0, 44 }, STR_TILE_INSPECTOR_TRACK_SEQUENCE, ft, { colours[1] });
                         if (trackElement->IsStation())
                         {
                             auto stationIndex = trackElement->GetStationIndex();
@@ -1275,7 +1275,7 @@ static uint64_t PageDisabledWidgets[] = {
                             ft.Add<StringId>(STR_COMMA16);
                             ft.Add<int16_t>(stationIndex.ToUnderlying());
                             DrawTextBasic(
-                                dpi, screenCoords + ScreenCoordsXY{ 0, 55 }, STR_TILE_INSPECTOR_STATION_INDEX, ft,
+                                rt, screenCoords + ScreenCoordsXY{ 0, 55 }, STR_TILE_INSPECTOR_STATION_INDEX, ft,
                                 { colours[1] });
                         }
                         else
@@ -1285,25 +1285,25 @@ static uint64_t PageDisabledWidgets[] = {
                             ft.Add<StringId>(STR_STRING);
                             ft.Add<char*>(stationNone);
                             DrawTextBasic(
-                                dpi, screenCoords + ScreenCoordsXY{ 0, 55 }, STR_TILE_INSPECTOR_STATION_INDEX, ft,
+                                rt, screenCoords + ScreenCoordsXY{ 0, 55 }, STR_TILE_INSPECTOR_STATION_INDEX, ft,
                                 { colours[1] });
                         }
 
                         ft = Formatter();
                         ft.Add<StringId>(ColourSchemeNames[trackElement->GetColourScheme()]);
                         DrawTextBasic(
-                            dpi, screenCoords + ScreenCoordsXY{ 0, 66 }, STR_TILE_INSPECTOR_COLOUR_SCHEME, ft, { colours[1] });
+                            rt, screenCoords + ScreenCoordsXY{ 0, 66 }, STR_TILE_INSPECTOR_COLOUR_SCHEME, ft, { colours[1] });
 
                         // Properties
                         // Raise / lower label
                         screenCoords.y = windowPos.y + widgets[WIDX_TRACK_SPINNER_HEIGHT].top;
-                        DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
 
                         // Current base height
                         screenCoords.x = windowPos.x + widgets[WIDX_TRACK_SPINNER_HEIGHT].left + 3;
                         ft = Formatter();
                         ft.Add<int32_t>(tileElement->BaseHeight);
-                        DrawTextBasic(dpi, screenCoords, STR_FORMAT_INTEGER, ft, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_FORMAT_INTEGER, ft, { colours[1] });
                         break;
                     }
 
@@ -1313,7 +1313,7 @@ static uint64_t PageDisabledWidgets[] = {
                         // Age
                         auto ft = Formatter();
                         ft.Add<int16_t>(tileElement->AsSmallScenery()->GetAge());
-                        DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_SCENERY_AGE, ft, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_SCENERY_AGE, ft, { colours[1] });
 
                         // Quadrant value
                         const auto* sceneryEntry = tileElement->AsSmallScenery()->GetEntry();
@@ -1329,7 +1329,7 @@ static uint64_t PageDisabledWidgets[] = {
                             ft = Formatter();
                             ft.Add<StringId>(_quadrantStringIdx[quadrant]);
                             DrawTextBasic(
-                                dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_SCENERY_QUADRANT, ft,
+                                rt, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_SCENERY_QUADRANT, ft,
                                 { colours[1] });
                         }
 
@@ -1337,29 +1337,29 @@ static uint64_t PageDisabledWidgets[] = {
                         ft = Formatter();
                         ft.Add<ObjectEntryIndex>(tileElement->AsSmallScenery()->GetEntryIndex());
                         DrawTextBasic(
-                            dpi, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_SCENERY_ENTRY_IDX, ft,
+                            rt, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_SCENERY_ENTRY_IDX, ft,
                             { colours[1] });
 
                         // Properties
                         // Raise / Lower
                         screenCoords.y = windowPos.y + widgets[WIDX_SCENERY_SPINNER_HEIGHT].top;
-                        DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
 
                         // Current base height
                         screenCoords.x = windowPos.x + widgets[WIDX_SCENERY_SPINNER_HEIGHT].left + 3;
                         ft = Formatter();
                         ft.Add<int32_t>(tileElement->BaseHeight);
-                        DrawTextBasic(dpi, screenCoords, STR_FORMAT_INTEGER, ft, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_FORMAT_INTEGER, ft, { colours[1] });
 
                         // Quarter tile
                         screenCoords = windowPos
                             + ScreenCoordsXY{ widgets[WIDX_GROUPBOX_DETAILS].left + 7,
                                               widgets[WIDX_SCENERY_CHECK_QUARTER_E].top };
-                        DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_SCENERY_QUADRANT_LABEL, {}, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_SCENERY_QUADRANT_LABEL, {}, { colours[1] });
 
                         // Collision
                         screenCoords.y = windowPos.y + widgets[WIDX_SCENERY_CHECK_COLLISION_E].top;
-                        DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_COLLISSION, {}, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_COLLISSION, {}, { colours[1] });
                         break;
                     }
 
@@ -1369,7 +1369,7 @@ static uint64_t PageDisabledWidgets[] = {
                         // Entrance type
                         auto ft = Formatter();
                         ft.Add<StringId>(EntranceTypeStringIds[tileElement->AsEntrance()->GetEntranceType()]);
-                        DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_ENTRANCE_TYPE, ft, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_ENTRANCE_TYPE, ft, { colours[1] });
 
                         if (tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_PARK_ENTRANCE)
                         {
@@ -1377,7 +1377,7 @@ static uint64_t PageDisabledWidgets[] = {
                             ft = Formatter();
                             ft.Add<StringId>(ParkEntranceGetIndex({ _toolMap, tileElement->GetBaseZ() }));
                             DrawTextBasic(
-                                dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_ENTRANCE_ENTRANCE_ID, ft,
+                                rt, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_ENTRANCE_ENTRANCE_ID, ft,
                                 { colours[1] });
                         }
                         else
@@ -1388,14 +1388,14 @@ static uint64_t PageDisabledWidgets[] = {
                             {
                                 // Ride entrance ID
                                 DrawTextBasic(
-                                    dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_ENTRANCE_ENTRANCE_ID, ft,
+                                    rt, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_ENTRANCE_ENTRANCE_ID, ft,
                                     { colours[1] });
                             }
                             else
                             {
                                 // Ride exit ID
                                 DrawTextBasic(
-                                    dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_ENTRANCE_EXIT_ID, ft,
+                                    rt, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_ENTRANCE_EXIT_ID, ft,
                                     { colours[1] });
                             }
                         }
@@ -1406,7 +1406,7 @@ static uint64_t PageDisabledWidgets[] = {
                             ft = Formatter();
                             ft.Add<StringId>(ParkEntrancePartStringIds[tileElement->AsEntrance()->GetSequenceIndex()]);
                             DrawTextBasic(
-                                dpi, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_ENTRANCE_PART, ft,
+                                rt, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_ENTRANCE_PART, ft,
                                 { colours[1] });
                         }
                         else
@@ -1415,7 +1415,7 @@ static uint64_t PageDisabledWidgets[] = {
                             ft = Formatter();
                             ft.Add<RideId>(tileElement->AsEntrance()->GetRideIndex());
                             DrawTextBasic(
-                                dpi, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_ENTRANCE_RIDE_ID, ft,
+                                rt, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_ENTRANCE_RIDE_ID, ft,
                                 { colours[1] });
                             // Station index
                             auto stationIndex = tileElement->AsEntrance()->GetStationIndex();
@@ -1423,20 +1423,20 @@ static uint64_t PageDisabledWidgets[] = {
                             ft.Add<StringId>(STR_COMMA16);
                             ft.Add<int16_t>(stationIndex.ToUnderlying());
                             DrawTextBasic(
-                                dpi, screenCoords + ScreenCoordsXY{ 0, 33 }, STR_TILE_INSPECTOR_STATION_INDEX, ft,
+                                rt, screenCoords + ScreenCoordsXY{ 0, 33 }, STR_TILE_INSPECTOR_STATION_INDEX, ft,
                                 { colours[1] });
                         }
 
                         // Properties
                         // Raise / Lower
                         screenCoords.y = windowPos.y + widgets[WIDX_ENTRANCE_SPINNER_HEIGHT].top;
-                        DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
 
                         // Current base height
                         screenCoords.x = windowPos.x + widgets[WIDX_ENTRANCE_SPINNER_HEIGHT].left + 3;
                         ft = Formatter();
                         ft.Add<int32_t>(tileElement->BaseHeight);
-                        DrawTextBasic(dpi, screenCoords, STR_FORMAT_INTEGER, ft, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_FORMAT_INTEGER, ft, { colours[1] });
                         break;
                     }
 
@@ -1446,7 +1446,7 @@ static uint64_t PageDisabledWidgets[] = {
                         // Type
                         auto ft = Formatter();
                         ft.Add<ObjectEntryIndex>(tileElement->AsWall()->GetEntryIndex());
-                        DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_WALL_TYPE, ft, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_WALL_TYPE, ft, { colours[1] });
 
                         // Banner info
                         auto banner = tileElement->AsWall()->GetBanner();
@@ -1455,35 +1455,35 @@ static uint64_t PageDisabledWidgets[] = {
                             ft = Formatter();
                             banner->FormatTextTo(ft);
                             DrawTextBasic(
-                                dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_ENTRY_BANNER_TEXT, ft,
+                                rt, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_ENTRY_BANNER_TEXT, ft,
                                 { colours[1] });
                         }
                         else
                         {
                             DrawTextBasic(
-                                dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_ENTRY_BANNER_NONE, {},
+                                rt, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_ENTRY_BANNER_NONE, {},
                                 { colours[1] });
                         }
 
                         // Properties
                         // Raise / lower label
                         screenCoords.y = windowPos.y + widgets[WIDX_WALL_SPINNER_HEIGHT].top;
-                        DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
 
                         // Current base height
                         screenCoords.x = windowPos.x + widgets[WIDX_WALL_SPINNER_HEIGHT].left + 3;
                         ft = Formatter();
                         ft.Add<int32_t>(tileElement->BaseHeight);
-                        DrawTextBasic(dpi, screenCoords, STR_FORMAT_INTEGER, ft, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_FORMAT_INTEGER, ft, { colours[1] });
 
                         // Slope label
                         screenCoords = windowPos
                             + ScreenCoordsXY{ widgets[WIDX_GROUPBOX_DETAILS].left + 7, widgets[WIDX_WALL_DROPDOWN_SLOPE].top };
-                        DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_WALL_SLOPE, {}, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_WALL_SLOPE, {}, { colours[1] });
 
                         // Animation frame label
                         screenCoords.y = windowPos.y + widgets[WIDX_WALL_SPINNER_ANIMATION_FRAME].top;
-                        DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_WALL_ANIMATION_FRAME, {}, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_WALL_ANIMATION_FRAME, {}, { colours[1] });
 
                         // Current animation frame
                         auto colour = colours[1];
@@ -1494,7 +1494,7 @@ static uint64_t PageDisabledWidgets[] = {
                         screenCoords.x = windowPos.x + widgets[WIDX_WALL_SPINNER_ANIMATION_FRAME].left + 3;
                         ft = Formatter();
                         ft.Add<int32_t>(tileElement->AsWall()->GetAnimationFrame());
-                        DrawTextBasic(dpi, screenCoords, STR_FORMAT_INTEGER, ft, { colour });
+                        DrawTextBasic(rt, screenCoords, STR_FORMAT_INTEGER, ft, { colour });
                         break;
                     }
 
@@ -1506,13 +1506,13 @@ static uint64_t PageDisabledWidgets[] = {
                         ObjectEntryIndex largeSceneryType = sceneryElement->GetEntryIndex();
                         auto ft = Formatter();
                         ft.Add<ObjectEntryIndex>(largeSceneryType);
-                        DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_LARGE_SCENERY_TYPE, ft, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_LARGE_SCENERY_TYPE, ft, { colours[1] });
 
                         // Part ID
                         ft = Formatter();
                         ft.Add<int16_t>(sceneryElement->GetSequenceIndex());
                         DrawTextBasic(
-                            dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_LARGE_SCENERY_PIECE_ID, ft,
+                            rt, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_LARGE_SCENERY_PIECE_ID, ft,
                             { colours[1] });
 
                         // Banner info
@@ -1525,27 +1525,27 @@ static uint64_t PageDisabledWidgets[] = {
                                 ft = Formatter();
                                 banner->FormatTextTo(ft);
                                 DrawTextBasic(
-                                    dpi, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_ENTRY_BANNER_TEXT, ft,
+                                    rt, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_ENTRY_BANNER_TEXT, ft,
                                     { colours[1] });
                             }
                         }
                         else
                         {
                             DrawTextBasic(
-                                dpi, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_ENTRY_BANNER_NONE, {},
+                                rt, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_ENTRY_BANNER_NONE, {},
                                 { colours[1] });
                         }
 
                         // Properties
                         // Raise / lower label
                         screenCoords.y = windowPos.y + widgets[WIDX_LARGE_SCENERY_SPINNER_HEIGHT].top;
-                        DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
 
                         // Current base height
                         screenCoords.x = windowPos.x + widgets[WIDX_LARGE_SCENERY_SPINNER_HEIGHT].left + 3;
                         ft = Formatter();
                         ft.Add<int32_t>(tileElement->BaseHeight);
-                        DrawTextBasic(dpi, screenCoords, STR_FORMAT_INTEGER, ft, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_FORMAT_INTEGER, ft, { colours[1] });
                         break;
                     }
 
@@ -1558,24 +1558,24 @@ static uint64_t PageDisabledWidgets[] = {
                         {
                             Formatter ft;
                             banner->FormatTextTo(ft);
-                            DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_ENTRY_BANNER_TEXT, ft, { colours[1] });
+                            DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_ENTRY_BANNER_TEXT, ft, { colours[1] });
                         }
 
                         // Properties
                         // Raise / lower label
                         screenCoords.y = windowPos.y + widgets[WIDX_BANNER_SPINNER_HEIGHT].top;
-                        DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
 
                         // Current base height
                         screenCoords.x = windowPos.x + widgets[WIDX_BANNER_SPINNER_HEIGHT].left + 3;
                         auto ft = Formatter();
                         ft.Add<int32_t>(tileElement->BaseHeight);
-                        DrawTextBasic(dpi, screenCoords, STR_FORMAT_INTEGER, ft, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_FORMAT_INTEGER, ft, { colours[1] });
 
                         // Blocked paths
                         screenCoords.y += 28;
                         screenCoords.x = windowPos.x + widgets[WIDX_GROUPBOX_DETAILS].left + 7;
-                        DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_BANNER_BLOCKED_PATHS, {}, { colours[1] });
+                        DrawTextBasic(rt, screenCoords, STR_TILE_INSPECTOR_BANNER_BLOCKED_PATHS, {}, { colours[1] });
                         break;
                     }
 
@@ -1585,11 +1585,11 @@ static uint64_t PageDisabledWidgets[] = {
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             const int32_t listWidth = widgets[WIDX_LIST].width();
             GfxFillRect(
-                dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } },
+                rt, { { rt.x, rt.y }, { rt.x + rt.width - 1, rt.y + rt.height - 1 } },
                 ColourMapA[colours[1].colour].mid_light);
 
             // Show usage hint when nothing is selected
@@ -1600,7 +1600,7 @@ static uint64_t PageDisabledWidgets[] = {
                                                  (listWidget.height() - FontGetLineHeight(FontStyle::Medium)) / 2 };
                 auto ft = Formatter{};
                 auto textPaint = TextPaint{ colours[1], TextAlignment::CENTRE };
-                DrawTextWrapped(dpi, centrePos, listWidth, STR_TILE_INSPECTOR_SELECT_TILE_HINT, ft, textPaint);
+                DrawTextWrapped(rt, centrePos, listWidth, STR_TILE_INSPECTOR_SELECT_TILE_HINT, ft, textPaint);
                 return;
             }
 
@@ -1624,12 +1624,12 @@ static uint64_t PageDisabledWidgets[] = {
                 auto fillRectangle = ScreenRect{ { 0, screenCoords.y },
                                                  { listWidth, screenCoords.y + kScrollableRowHeight - 1 } };
                 if (selectedRow)
-                    GfxFillRect(dpi, fillRectangle, ColourMapA[colours[1].colour].mid_dark);
+                    GfxFillRect(rt, fillRectangle, ColourMapA[colours[1].colour].mid_dark);
                 else if (hoveredRow)
-                    GfxFillRect(dpi, fillRectangle, ColourMapA[colours[1].colour].mid_dark | 0x1000000);
+                    GfxFillRect(rt, fillRectangle, ColourMapA[colours[1].colour].mid_dark | 0x1000000);
                 // Zebra stripes
                 else if (((windowTileInspectorElementCount - i) & 1) == 0)
-                    GfxFillRect(dpi, fillRectangle, ColourMapA[colours[1].colour].light | 0x1000000);
+                    GfxFillRect(rt, fillRectangle, ColourMapA[colours[1].colour].light | 0x1000000);
 
                 StringId stringFormat = STR_WINDOW_COLOUR_2_STRINGID;
                 if (selectedRow || hoveredRow)
@@ -1640,13 +1640,13 @@ static uint64_t PageDisabledWidgets[] = {
                 checkboxFormatter.Add<char*>(kCheckMarkString);
 
                 // Draw checkbox and check if visible
-                GfxFillRectInset(dpi, { { 2, screenCoords.y }, { 15, screenCoords.y + 11 } }, colours[1], INSET_RECT_F_E0);
+                GfxFillRectInset(rt, { { 2, screenCoords.y }, { 15, screenCoords.y + 11 } }, colours[1], INSET_RECT_F_E0);
                 if (!tileElement->IsInvisible())
                 {
                     auto eyeFormatter = Formatter();
                     eyeFormatter.Add<StringId>(STR_STRING);
                     eyeFormatter.Add<char*>(kEyeString);
-                    DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 2, 1 }, stringFormat, eyeFormatter);
+                    DrawTextBasic(rt, screenCoords + ScreenCoordsXY{ 2, 1 }, stringFormat, eyeFormatter);
                 }
 
                 const auto type = tileElement->GetType();
@@ -1715,32 +1715,32 @@ static uint64_t PageDisabledWidgets[] = {
                 ft.Add<StringId>(STR_STRING);
                 ft.Add<char*>(typeName);
                 DrawTextEllipsised(
-                    dpi, screenCoords + ScreenCoordsXY{ TypeColumnXY.x, 0 }, TypeColumnSize.width, stringFormat, ft);
+                    rt, screenCoords + ScreenCoordsXY{ TypeColumnXY.x, 0 }, TypeColumnSize.width, stringFormat, ft);
 
                 // Base height
                 ft = Formatter();
                 ft.Add<StringId>(STR_FORMAT_INTEGER);
                 ft.Add<int32_t>(tileElement->BaseHeight);
-                DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ BaseHeightColumnXY.x, 0 }, stringFormat, ft);
+                DrawTextBasic(rt, screenCoords + ScreenCoordsXY{ BaseHeightColumnXY.x, 0 }, stringFormat, ft);
 
                 // Clearance height
                 ft = Formatter();
                 ft.Add<StringId>(STR_FORMAT_INTEGER);
                 ft.Add<int32_t>(clearanceHeight);
-                DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ ClearanceHeightColumnXY.x, 0 }, stringFormat, ft);
+                DrawTextBasic(rt, screenCoords + ScreenCoordsXY{ ClearanceHeightColumnXY.x, 0 }, stringFormat, ft);
 
                 // Direction
                 ft = Formatter();
                 ft.Add<StringId>(STR_FORMAT_INTEGER);
                 ft.Add<int32_t>(tileElement->GetDirection());
-                DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ DirectionColumnXY.x, 0 }, stringFormat, ft);
+                DrawTextBasic(rt, screenCoords + ScreenCoordsXY{ DirectionColumnXY.x, 0 }, stringFormat, ft);
 
                 // Checkmarks for ghost and last for tile
                 if (ghost)
                     DrawTextBasic(
-                        dpi, screenCoords + ScreenCoordsXY{ GhostFlagColumnXY.x, 0 }, stringFormat, checkboxFormatter);
+                        rt, screenCoords + ScreenCoordsXY{ GhostFlagColumnXY.x, 0 }, stringFormat, checkboxFormatter);
                 if (last)
-                    DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ LastFlagColumnXY.x, 0 }, stringFormat, checkboxFormatter);
+                    DrawTextBasic(rt, screenCoords + ScreenCoordsXY{ LastFlagColumnXY.x, 0 }, stringFormat, checkboxFormatter);
 
                 screenCoords.y -= kScrollableRowHeight;
                 i++;

--- a/src/openrct2-ui/windows/TitleExit.cpp
+++ b/src/openrct2-ui/windows/TitleExit.cpp
@@ -43,9 +43,9 @@ namespace OpenRCT2::Ui::Windows
             };
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
         }
     };
 

--- a/src/openrct2-ui/windows/TitleExit.cpp
+++ b/src/openrct2-ui/windows/TitleExit.cpp
@@ -43,7 +43,7 @@ namespace OpenRCT2::Ui::Windows
             };
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
         }

--- a/src/openrct2-ui/windows/TitleLogo.cpp
+++ b/src/openrct2-ui/windows/TitleLogo.cpp
@@ -58,7 +58,7 @@ namespace OpenRCT2::Ui::Windows
          *
          *  rct2: 0x0066B872
          */
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             auto screenCoords = windowPos + ScreenCoordsXY{ 2, 2 };
             GfxDrawSprite(dpi, ImageId(SPR_G2_LOGO), screenCoords);

--- a/src/openrct2-ui/windows/TitleLogo.cpp
+++ b/src/openrct2-ui/windows/TitleLogo.cpp
@@ -58,11 +58,11 @@ namespace OpenRCT2::Ui::Windows
          *
          *  rct2: 0x0066B872
          */
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             auto screenCoords = windowPos + ScreenCoordsXY{ 2, 2 };
-            GfxDrawSprite(dpi, ImageId(SPR_G2_LOGO), screenCoords);
-            GfxDrawSprite(dpi, ImageId(SPR_G2_TITLE), screenCoords + ScreenCoordsXY{ 104, 18 });
+            GfxDrawSprite(rt, ImageId(SPR_G2_LOGO), screenCoords);
+            GfxDrawSprite(rt, ImageId(SPR_G2_TITLE), screenCoords + ScreenCoordsXY{ 104, 18 });
         }
     };
 

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -273,7 +273,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             GfxFilterRect(dpi, _filterRect, FilterPaletteID::Palette51);
             DrawWidgets(dpi);

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -273,10 +273,10 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            GfxFilterRect(dpi, _filterRect, FilterPaletteID::Palette51);
-            DrawWidgets(dpi);
+            GfxFilterRect(rt, _filterRect, FilterPaletteID::Palette51);
+            DrawWidgets(rt);
         }
     };
 

--- a/src/openrct2-ui/windows/TitleOptions.cpp
+++ b/src/openrct2-ui/windows/TitleOptions.cpp
@@ -42,7 +42,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
         }

--- a/src/openrct2-ui/windows/TitleOptions.cpp
+++ b/src/openrct2-ui/windows/TitleOptions.cpp
@@ -42,9 +42,9 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
         }
     };
 

--- a/src/openrct2-ui/windows/TitleVersion.cpp
+++ b/src/openrct2-ui/windows/TitleVersion.cpp
@@ -24,16 +24,16 @@ namespace OpenRCT2::Ui::Windows
 
     class TitleVersionWindow final : public Window
     {
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             // Write name and version information
             const auto whiteOutline = ColourWithFlags{ COLOUR_WHITE }.withFlag(ColourFlag::withOutline, true);
-            DrawText(dpi, windowPos, { whiteOutline }, gVersionInfoFull);
+            DrawText(rt, windowPos, { whiteOutline }, gVersionInfoFull);
             width = GfxGetStringWidth(gVersionInfoFull, FontStyle::Medium);
 
             // Write platform information
             constexpr const char platformInfo[] = OPENRCT2_PLATFORM " (" OPENRCT2_ARCHITECTURE ")";
-            DrawText(dpi, windowPos + ScreenCoordsXY(0, kListRowHeight), { whiteOutline }, platformInfo);
+            DrawText(rt, windowPos + ScreenCoordsXY(0, kListRowHeight), { whiteOutline }, platformInfo);
             width = std::max<int16_t>(width, GfxGetStringWidth(platformInfo, FontStyle::Medium)) + kTextOffset;
         }
     };

--- a/src/openrct2-ui/windows/TitleVersion.cpp
+++ b/src/openrct2-ui/windows/TitleVersion.cpp
@@ -24,7 +24,7 @@ namespace OpenRCT2::Ui::Windows
 
     class TitleVersionWindow final : public Window
     {
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             // Write name and version information
             const auto whiteOutline = ColourWithFlags{ COLOUR_WHITE }.withFlag(ColourFlag::withOutline, true);

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -101,7 +101,7 @@ namespace OpenRCT2::Ui::Windows
             UpdatePosition(gTooltipCursor);
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             int32_t left = windowPos.x;
             int32_t top = windowPos.y;
@@ -109,25 +109,25 @@ namespace OpenRCT2::Ui::Windows
             int32_t bottom = windowPos.y + height - 1;
 
             // Background
-            GfxFilterRect(dpi, { { left + 1, top + 1 }, { right - 1, bottom - 1 } }, FilterPaletteID::Palette45);
-            GfxFilterRect(dpi, { { left + 1, top + 1 }, { right - 1, bottom - 1 } }, FilterPaletteID::PaletteGlassLightOrange);
+            GfxFilterRect(rt, { { left + 1, top + 1 }, { right - 1, bottom - 1 } }, FilterPaletteID::Palette45);
+            GfxFilterRect(rt, { { left + 1, top + 1 }, { right - 1, bottom - 1 } }, FilterPaletteID::PaletteGlassLightOrange);
 
             // Sides
-            GfxFilterRect(dpi, { { left + 0, top + 2 }, { left + 0, bottom - 2 } }, FilterPaletteID::PaletteDarken3);
-            GfxFilterRect(dpi, { { right + 0, top + 2 }, { right + 0, bottom - 2 } }, FilterPaletteID::PaletteDarken3);
-            GfxFilterRect(dpi, { { left + 2, bottom + 0 }, { right - 2, bottom + 0 } }, FilterPaletteID::PaletteDarken3);
-            GfxFilterRect(dpi, { { left + 2, top + 0 }, { right - 2, top + 0 } }, FilterPaletteID::PaletteDarken3);
+            GfxFilterRect(rt, { { left + 0, top + 2 }, { left + 0, bottom - 2 } }, FilterPaletteID::PaletteDarken3);
+            GfxFilterRect(rt, { { right + 0, top + 2 }, { right + 0, bottom - 2 } }, FilterPaletteID::PaletteDarken3);
+            GfxFilterRect(rt, { { left + 2, bottom + 0 }, { right - 2, bottom + 0 } }, FilterPaletteID::PaletteDarken3);
+            GfxFilterRect(rt, { { left + 2, top + 0 }, { right - 2, top + 0 } }, FilterPaletteID::PaletteDarken3);
 
             // Corners
-            GfxFilterPixel(dpi, { left + 1, top + 1 }, FilterPaletteID::PaletteDarken3);
-            GfxFilterPixel(dpi, { right - 1, top + 1 }, FilterPaletteID::PaletteDarken3);
-            GfxFilterPixel(dpi, { left + 1, bottom - 1 }, FilterPaletteID::PaletteDarken3);
-            GfxFilterPixel(dpi, { right - 1, bottom - 1 }, FilterPaletteID::PaletteDarken3);
+            GfxFilterPixel(rt, { left + 1, top + 1 }, FilterPaletteID::PaletteDarken3);
+            GfxFilterPixel(rt, { right - 1, top + 1 }, FilterPaletteID::PaletteDarken3);
+            GfxFilterPixel(rt, { left + 1, bottom - 1 }, FilterPaletteID::PaletteDarken3);
+            GfxFilterPixel(rt, { right - 1, bottom - 1 }, FilterPaletteID::PaletteDarken3);
 
             // Text
             left = windowPos.x + ((width + 1) / 2) - 1;
             top = windowPos.y + 1;
-            DrawStringCentredRaw(dpi, { left, top }, _tooltipNumLines, _tooltipText.data(), FontStyle::Small);
+            DrawStringCentredRaw(rt, { left, top }, _tooltipNumLines, _tooltipText.data(), FontStyle::Small);
         }
 
     private:

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -101,7 +101,7 @@ namespace OpenRCT2::Ui::Windows
             UpdatePosition(gTooltipCursor);
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             int32_t left = windowPos.x;
             int32_t top = windowPos.y;

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -875,7 +875,7 @@ namespace OpenRCT2::Ui::Windows
                 AlignButtonsCentre();
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             const auto& gameState = getGameState();
             int32_t imgId;

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -875,12 +875,12 @@ namespace OpenRCT2::Ui::Windows
                 AlignButtonsCentre();
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             const auto& gameState = getGameState();
             int32_t imgId;
 
-            WindowDrawWidgets(*this, dpi);
+            WindowDrawWidgets(*this, rt);
 
             ScreenCoordsXY screenPos{};
             // Draw staff button image (setting masks to the staff colours)
@@ -890,7 +890,7 @@ namespace OpenRCT2::Ui::Windows
                 imgId = SPR_TOOLBAR_STAFF;
                 if (WidgetIsPressed(*this, WIDX_STAFF))
                     imgId++;
-                GfxDrawSprite(dpi, ImageId(imgId, gameState.staffHandymanColour, gameState.staffMechanicColour), screenPos);
+                GfxDrawSprite(rt, ImageId(imgId, gameState.staffHandymanColour, gameState.staffMechanicColour), screenPos);
             }
 
             // Draw fast forward button
@@ -900,15 +900,15 @@ namespace OpenRCT2::Ui::Windows
                               windowPos.y + widgets[WIDX_FASTFORWARD].top + 0 };
                 if (WidgetIsPressed(*this, WIDX_FASTFORWARD))
                     screenPos.y++;
-                GfxDrawSprite(dpi, ImageId(SPR_G2_FASTFORWARD), screenPos + ScreenCoordsXY{ 6, 3 });
+                GfxDrawSprite(rt, ImageId(SPR_G2_FASTFORWARD), screenPos + ScreenCoordsXY{ 6, 3 });
 
                 for (int32_t i = 0; i < gGameSpeed && gGameSpeed <= 4; i++)
                 {
-                    GfxDrawSprite(dpi, ImageId(SPR_G2_SPEED_ARROW), screenPos + ScreenCoordsXY{ 5 + i * 5, 15 });
+                    GfxDrawSprite(rt, ImageId(SPR_G2_SPEED_ARROW), screenPos + ScreenCoordsXY{ 5 + i * 5, 15 });
                 }
                 for (int32_t i = 0; i < 3 && i < gGameSpeed - 4 && gGameSpeed >= 5; i++)
                 {
-                    GfxDrawSprite(dpi, ImageId(SPR_G2_HYPER_ARROW), screenPos + ScreenCoordsXY{ 5 + i * 6, 15 });
+                    GfxDrawSprite(rt, ImageId(SPR_G2_HYPER_ARROW), screenPos + ScreenCoordsXY{ 5 + i * 6, 15 });
                 }
             }
 
@@ -918,14 +918,14 @@ namespace OpenRCT2::Ui::Windows
                 screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_CHEATS].left - 1, widgets[WIDX_CHEATS].top - 1 };
                 if (WidgetIsPressed(*this, WIDX_CHEATS))
                     screenPos.y++;
-                GfxDrawSprite(dpi, ImageId(SPR_G2_SANDBOX), screenPos);
+                GfxDrawSprite(rt, ImageId(SPR_G2_SANDBOX), screenPos);
 
                 // Draw an overlay if clearance checks are disabled
                 if (getGameState().cheats.disableClearanceChecks)
                 {
                     auto colour = ColourWithFlags{ COLOUR_DARK_ORANGE }.withFlag(ColourFlag::withOutline, true);
                     DrawTextBasic(
-                        dpi, screenPos + ScreenCoordsXY{ 26, 2 }, STR_OVERLAY_CLEARANCE_CHECKS_DISABLED, {},
+                        rt, screenPos + ScreenCoordsXY{ 26, 2 }, STR_OVERLAY_CLEARANCE_CHECKS_DISABLED, {},
                         { colour, TextAlignment::RIGHT });
                 }
             }
@@ -936,7 +936,7 @@ namespace OpenRCT2::Ui::Windows
                 screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_CHAT].left, widgets[WIDX_CHAT].top - 2 };
                 if (WidgetIsPressed(*this, WIDX_CHAT))
                     screenPos.y++;
-                GfxDrawSprite(dpi, ImageId(SPR_G2_CHAT), screenPos);
+                GfxDrawSprite(rt, ImageId(SPR_G2_CHAT), screenPos);
             }
 
             // Draw debug button
@@ -945,7 +945,7 @@ namespace OpenRCT2::Ui::Windows
                 screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_DEBUG].left, widgets[WIDX_DEBUG].top - 1 };
                 if (WidgetIsPressed(*this, WIDX_DEBUG))
                     screenPos.y++;
-                GfxDrawSprite(dpi, ImageId(SPR_TAB_GEARS_0), screenPos);
+                GfxDrawSprite(rt, ImageId(SPR_TAB_GEARS_0), screenPos);
             }
 
             // Draw research button
@@ -954,7 +954,7 @@ namespace OpenRCT2::Ui::Windows
                 screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_RESEARCH].left - 1, widgets[WIDX_RESEARCH].top };
                 if (WidgetIsPressed(*this, WIDX_RESEARCH))
                     screenPos.y++;
-                GfxDrawSprite(dpi, ImageId(SPR_TAB_FINANCES_RESEARCH_0), screenPos);
+                GfxDrawSprite(rt, ImageId(SPR_TAB_FINANCES_RESEARCH_0), screenPos);
             }
 
             // Draw finances button
@@ -963,7 +963,7 @@ namespace OpenRCT2::Ui::Windows
                 screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_FINANCES].left + 3, widgets[WIDX_FINANCES].top + 1 };
                 if (WidgetIsPressed(*this, WIDX_FINANCES))
                     screenPos.y++;
-                GfxDrawSprite(dpi, ImageId(SPR_FINANCE), screenPos);
+                GfxDrawSprite(rt, ImageId(SPR_FINANCE), screenPos);
             }
 
             // Draw news button
@@ -972,7 +972,7 @@ namespace OpenRCT2::Ui::Windows
                 screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_NEWS].left + 3, widgets[WIDX_NEWS].top + 0 };
                 if (WidgetIsPressed(*this, WIDX_NEWS))
                     screenPos.y++;
-                GfxDrawSprite(dpi, ImageId(SPR_G2_TAB_NEWS), screenPos);
+                GfxDrawSprite(rt, ImageId(SPR_G2_TAB_NEWS), screenPos);
             }
 
             // Draw network button
@@ -984,13 +984,13 @@ namespace OpenRCT2::Ui::Windows
 
                 // Draw (de)sync icon.
                 imgId = (NetworkIsDesynchronised() ? SPR_G2_MULTIPLAYER_DESYNC : SPR_G2_MULTIPLAYER_SYNC);
-                GfxDrawSprite(dpi, ImageId(imgId), screenPos + ScreenCoordsXY{ 3, 11 });
+                GfxDrawSprite(rt, ImageId(imgId), screenPos + ScreenCoordsXY{ 3, 11 });
 
                 // Draw number of players.
                 auto ft = Formatter();
                 ft.Add<int32_t>(NetworkGetNumVisiblePlayers());
                 auto colour = ColourWithFlags{ COLOUR_WHITE }.withFlag(ColourFlag::withOutline, true);
-                DrawTextBasic(dpi, screenPos + ScreenCoordsXY{ 23, 1 }, STR_COMMA16, ft, { colour, TextAlignment::RIGHT });
+                DrawTextBasic(rt, screenPos + ScreenCoordsXY{ 23, 1 }, STR_COMMA16, ft, { colour, TextAlignment::RIGHT });
             }
 
             if (widgets[WIDX_ROTATE_ANTI_CLOCKWISE].type != WindowWidgetType::Empty)
@@ -1000,7 +1000,7 @@ namespace OpenRCT2::Ui::Windows
                                       widgets[WIDX_ROTATE_ANTI_CLOCKWISE].top + 0 };
                 if (IsWidgetPressed(WIDX_ROTATE_ANTI_CLOCKWISE))
                     screenPos.y++;
-                GfxDrawSprite(dpi, ImageId(SPR_G2_ICON_ROTATE_ANTI_CLOCKWISE), screenPos);
+                GfxDrawSprite(rt, ImageId(SPR_G2_ICON_ROTATE_ANTI_CLOCKWISE), screenPos);
             }
         }
     };

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -71,7 +71,7 @@ namespace OpenRCT2::Ui::Windows
         void OnClose() override;
         void OnMouseUp(WidgetIndex widgetIndex) override;
         void OnTextInput(WidgetIndex widgetIndex, std::string_view text) override;
-        void OnDraw(DrawPixelInfo& dpi) override;
+        void OnDraw(RenderTarget& dpi) override;
     };
 
     class TrackDeletePromptWindow final : public Window
@@ -87,7 +87,7 @@ namespace OpenRCT2::Ui::Windows
 
         void OnOpen() override;
         void OnMouseUp(WidgetIndex widgetIndex) override;
-        void OnDraw(DrawPixelInfo& dpi) override;
+        void OnDraw(RenderTarget& dpi) override;
     };
 
     static void WindowTrackDeletePromptOpen(TrackDesignFileRef* tdFileRef);
@@ -174,7 +174,7 @@ namespace OpenRCT2::Ui::Windows
         }
     }
 
-    void TrackDesignManageWindow::OnDraw(DrawPixelInfo& dpi)
+    void TrackDesignManageWindow::OnDraw(RenderTarget& dpi)
     {
         Formatter::Common().Add<const utf8*>(_trackDesignFileReference->name.c_str());
         DrawWidgets(dpi);
@@ -228,7 +228,7 @@ namespace OpenRCT2::Ui::Windows
         }
     }
 
-    void TrackDeletePromptWindow::OnDraw(DrawPixelInfo& dpi)
+    void TrackDeletePromptWindow::OnDraw(RenderTarget& dpi)
     {
         DrawWidgets(dpi);
 

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -71,7 +71,7 @@ namespace OpenRCT2::Ui::Windows
         void OnClose() override;
         void OnMouseUp(WidgetIndex widgetIndex) override;
         void OnTextInput(WidgetIndex widgetIndex, std::string_view text) override;
-        void OnDraw(RenderTarget& dpi) override;
+        void OnDraw(RenderTarget& rt) override;
     };
 
     class TrackDeletePromptWindow final : public Window
@@ -87,7 +87,7 @@ namespace OpenRCT2::Ui::Windows
 
         void OnOpen() override;
         void OnMouseUp(WidgetIndex widgetIndex) override;
-        void OnDraw(RenderTarget& dpi) override;
+        void OnDraw(RenderTarget& rt) override;
     };
 
     static void WindowTrackDeletePromptOpen(TrackDesignFileRef* tdFileRef);
@@ -174,10 +174,10 @@ namespace OpenRCT2::Ui::Windows
         }
     }
 
-    void TrackDesignManageWindow::OnDraw(RenderTarget& dpi)
+    void TrackDesignManageWindow::OnDraw(RenderTarget& rt)
     {
         Formatter::Common().Add<const utf8*>(_trackDesignFileReference->name.c_str());
-        DrawWidgets(dpi);
+        DrawWidgets(rt);
     }
 
     /**
@@ -228,14 +228,14 @@ namespace OpenRCT2::Ui::Windows
         }
     }
 
-    void TrackDeletePromptWindow::OnDraw(RenderTarget& dpi)
+    void TrackDeletePromptWindow::OnDraw(RenderTarget& rt)
     {
-        DrawWidgets(dpi);
+        DrawWidgets(rt);
 
         auto ft = Formatter();
         ft.Add<const utf8*>(_trackDesignFileReference->name.c_str());
         DrawTextWrapped(
-            dpi, { windowPos.x + (WW_DELETE_PROMPT / 2), windowPos.y + ((WH_DELETE_PROMPT / 2) - 9) }, (WW_DELETE_PROMPT - 4),
+            rt, { windowPos.x + (WW_DELETE_PROMPT / 2), windowPos.y + ((WH_DELETE_PROMPT / 2) - 9) }, (WW_DELETE_PROMPT - 4),
             STR_ARE_YOU_SURE_YOU_WANT_TO_PERMANENTLY_DELETE_TRACK, ft, { TextAlignment::CENTRE });
     }
 } // namespace OpenRCT2::Ui::Windows

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -335,14 +335,14 @@ namespace OpenRCT2::Ui::Windows
             DrawMiniPreview(*_trackDesign);
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             auto ft = Formatter::Common();
             ft.Add<char*>(_trackDesign->gameStateData.name.c_str());
             WindowDrawWidgets(*this, dpi);
 
             // Draw mini tile preview
-            DrawPixelInfo clippedDpi;
+            RenderTarget clippedDpi;
             if (ClipDrawPixelInfo(clippedDpi, dpi, this->windowPos + ScreenCoordsXY{ 4, 18 }, 168, 78))
             {
                 G1Element g1temp = {};

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -335,15 +335,15 @@ namespace OpenRCT2::Ui::Windows
             DrawMiniPreview(*_trackDesign);
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             auto ft = Formatter::Common();
             ft.Add<char*>(_trackDesign->gameStateData.name.c_str());
-            WindowDrawWidgets(*this, dpi);
+            WindowDrawWidgets(*this, rt);
 
             // Draw mini tile preview
-            RenderTarget clippedDpi;
-            if (ClipDrawPixelInfo(clippedDpi, dpi, this->windowPos + ScreenCoordsXY{ 4, 18 }, 168, 78))
+            RenderTarget clippedRT;
+            if (ClipDrawPixelInfo(clippedRT, rt, this->windowPos + ScreenCoordsXY{ 4, 18 }, 168, 78))
             {
                 G1Element g1temp = {};
                 g1temp.offset = _miniPreview.data();
@@ -351,7 +351,7 @@ namespace OpenRCT2::Ui::Windows
                 g1temp.height = TRACK_MINI_PREVIEW_HEIGHT;
                 GfxSetG1Element(SPR_TEMP, &g1temp);
                 DrawingEngineInvalidateImage(SPR_TEMP);
-                GfxDrawSprite(clippedDpi, ImageId(SPR_TEMP, this->colours[0].colour), { 0, 0 });
+                GfxDrawSprite(clippedRT, ImageId(SPR_TEMP, this->colours[0].colour), { 0, 0 });
             }
 
             // Price
@@ -359,7 +359,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 ft = Formatter();
                 ft.Add<money64>(_placementCost);
-                DrawTextBasic(dpi, this->windowPos + ScreenCoordsXY{ 88, 94 }, STR_COST_LABEL, ft, { TextAlignment::CENTRE });
+                DrawTextBasic(rt, this->windowPos + ScreenCoordsXY{ 88, 94 }, STR_COST_LABEL, ft, { TextAlignment::CENTRE });
             }
         }
 

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -449,7 +449,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
 
@@ -670,7 +670,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(const int32_t scrollIndex, DrawPixelInfo& dpi) override
+        void OnScrollDraw(const int32_t scrollIndex, RenderTarget& dpi) override
         {
             uint8_t paletteIndex = ColourMapA[colours[0].colour].mid_light;
             GfxClear(dpi, paletteIndex);

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -449,9 +449,9 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             int32_t listItemIndex = selected_list_item;
             if ((gLegacyScene == LegacyScene::trackDesignsManager) == 0)
@@ -477,12 +477,12 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<utf8*>(shortPath.c_str());
                 DrawTextBasic(
-                    dpi, windowPos + ScreenCoordsXY{ 0, height - DEBUG_PATH_HEIGHT - 3 }, STR_STRING, ft,
+                    rt, windowPos + ScreenCoordsXY{ 0, height - DEBUG_PATH_HEIGHT - 3 }, STR_STRING, ft,
                     { colours[1] }); // TODO Check dpi
             }
 
             auto screenPos = windowPos + ScreenCoordsXY{ tdWidget.left + 1, tdWidget.top + 1 };
-            GfxFillRect(dpi, { screenPos, screenPos + ScreenCoordsXY{ 369, 216 } }, colour); // TODO Check dpi
+            GfxFillRect(rt, { screenPos, screenPos + ScreenCoordsXY{ 369, 216 } }, colour); // TODO Check dpi
 
             if (_loadedTrackDesignIndex != trackIndex)
             {
@@ -511,7 +511,7 @@ namespace OpenRCT2::Ui::Windows
             g1temp.flags = G1_FLAG_HAS_TRANSPARENCY;
             GfxSetG1Element(SPR_TEMP, &g1temp);
             DrawingEngineInvalidateImage(SPR_TEMP);
-            GfxDrawSprite(dpi, ImageId(SPR_TEMP), trackPreview);
+            GfxDrawSprite(rt, ImageId(SPR_TEMP), trackPreview);
 
             screenPos.y = windowPos.y + tdWidget.bottom - 12;
 
@@ -520,7 +520,7 @@ namespace OpenRCT2::Ui::Windows
                 && !(gLegacyScene == LegacyScene::trackDesignsManager))
             {
                 // Vehicle design not available
-                DrawTextEllipsised(dpi, screenPos, 368, STR_VEHICLE_DESIGN_UNAVAILABLE, {}, { TextAlignment::CENTRE });
+                DrawTextEllipsised(rt, screenPos, 368, STR_VEHICLE_DESIGN_UNAVAILABLE, {}, { TextAlignment::CENTRE });
                 screenPos.y -= kScrollableRowHeight;
             }
 
@@ -530,7 +530,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     // Scenery not available
                     DrawTextEllipsised(
-                        dpi, screenPos, 368, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, {}, { TextAlignment::CENTRE });
+                        rt, screenPos, 368, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, {}, { TextAlignment::CENTRE });
                     screenPos.y -= kScrollableRowHeight;
                 }
             }
@@ -538,7 +538,7 @@ namespace OpenRCT2::Ui::Windows
             // Track design name
             auto ft = Formatter();
             ft.Add<const utf8*>(_trackDesigns[trackIndex].name.c_str());
-            DrawTextEllipsised(dpi, screenPos, 368, STR_TRACK_PREVIEW_NAME_FORMAT, ft, { TextAlignment::CENTRE });
+            DrawTextEllipsised(rt, screenPos, 368, STR_TRACK_PREVIEW_NAME_FORMAT, ft, { TextAlignment::CENTRE });
 
             // Information
             screenPos = windowPos + ScreenCoordsXY{ tdWidget.left + 1, tdWidget.bottom + 2 };
@@ -546,17 +546,17 @@ namespace OpenRCT2::Ui::Windows
             // Stats
             ft = Formatter();
             ft.Add<fixed32_2dp>(_loadedTrackDesign->statistics.ratings.excitement);
-            DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_EXCITEMENT_RATING, ft);
+            DrawTextBasic(rt, screenPos, STR_TRACK_LIST_EXCITEMENT_RATING, ft);
             screenPos.y += kListRowHeight;
 
             ft = Formatter();
             ft.Add<fixed32_2dp>(_loadedTrackDesign->statistics.ratings.intensity);
-            DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_INTENSITY_RATING, ft);
+            DrawTextBasic(rt, screenPos, STR_TRACK_LIST_INTENSITY_RATING, ft);
             screenPos.y += kListRowHeight;
 
             ft = Formatter();
             ft.Add<fixed32_2dp>(_loadedTrackDesign->statistics.ratings.nausea);
-            DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_NAUSEA_RATING, ft);
+            DrawTextBasic(rt, screenPos, STR_TRACK_LIST_NAUSEA_RATING, ft);
             screenPos.y += kListRowHeight + 4;
 
             // Information for tracked rides.
@@ -570,7 +570,7 @@ namespace OpenRCT2::Ui::Windows
                         // Holes
                         ft = Formatter();
                         ft.Add<uint16_t>(_loadedTrackDesign->statistics.holes);
-                        DrawTextBasic(dpi, screenPos, STR_HOLES, ft);
+                        DrawTextBasic(rt, screenPos, STR_HOLES, ft);
                         screenPos.y += kListRowHeight;
                     }
                     else
@@ -578,13 +578,13 @@ namespace OpenRCT2::Ui::Windows
                         // Maximum speed
                         ft = Formatter();
                         ft.Add<uint16_t>(ToHumanReadableSpeed(_loadedTrackDesign->statistics.maxSpeed << 16));
-                        DrawTextBasic(dpi, screenPos, STR_MAX_SPEED, ft);
+                        DrawTextBasic(rt, screenPos, STR_MAX_SPEED, ft);
                         screenPos.y += kListRowHeight;
 
                         // Average speed
                         ft = Formatter();
                         ft.Add<uint16_t>(ToHumanReadableSpeed(_loadedTrackDesign->statistics.averageSpeed << 16));
-                        DrawTextBasic(dpi, screenPos, STR_AVERAGE_SPEED, ft);
+                        DrawTextBasic(rt, screenPos, STR_AVERAGE_SPEED, ft);
                         screenPos.y += kListRowHeight;
                     }
 
@@ -592,7 +592,7 @@ namespace OpenRCT2::Ui::Windows
                     ft = Formatter();
                     ft.Add<StringId>(STR_RIDE_LENGTH_ENTRY);
                     ft.Add<uint16_t>(_loadedTrackDesign->statistics.rideLength);
-                    DrawTextEllipsised(dpi, screenPos, 214, STR_TRACK_LIST_RIDE_LENGTH, ft);
+                    DrawTextEllipsised(rt, screenPos, 214, STR_TRACK_LIST_RIDE_LENGTH, ft);
                     screenPos.y += kListRowHeight;
                 }
 
@@ -601,19 +601,19 @@ namespace OpenRCT2::Ui::Windows
                     // Maximum positive vertical Gs
                     ft = Formatter();
                     ft.Add<int32_t>(_loadedTrackDesign->statistics.maxPositiveVerticalG);
-                    DrawTextBasic(dpi, screenPos, STR_MAX_POSITIVE_VERTICAL_G, ft);
+                    DrawTextBasic(rt, screenPos, STR_MAX_POSITIVE_VERTICAL_G, ft);
                     screenPos.y += kListRowHeight;
 
                     // Maximum negative vertical Gs
                     ft = Formatter();
                     ft.Add<int32_t>(_loadedTrackDesign->statistics.maxNegativeVerticalG);
-                    DrawTextBasic(dpi, screenPos, STR_MAX_NEGATIVE_VERTICAL_G, ft);
+                    DrawTextBasic(rt, screenPos, STR_MAX_NEGATIVE_VERTICAL_G, ft);
                     screenPos.y += kListRowHeight;
 
                     // Maximum lateral Gs
                     ft = Formatter();
                     ft.Add<int32_t>(_loadedTrackDesign->statistics.maxLateralG);
-                    DrawTextBasic(dpi, screenPos, STR_MAX_LATERAL_G, ft);
+                    DrawTextBasic(rt, screenPos, STR_MAX_LATERAL_G, ft);
                     screenPos.y += kListRowHeight;
 
                     if (_loadedTrackDesign->statistics.totalAirTime != 0)
@@ -621,7 +621,7 @@ namespace OpenRCT2::Ui::Windows
                         // Total air time
                         ft = Formatter();
                         ft.Add<int32_t>(ToHumanReadableAirTime(_loadedTrackDesign->statistics.totalAirTime));
-                        DrawTextBasic(dpi, screenPos, STR_TOTAL_AIR_TIME, ft);
+                        DrawTextBasic(rt, screenPos, STR_TOTAL_AIR_TIME, ft);
                         screenPos.y += kListRowHeight;
                     }
                 }
@@ -631,13 +631,13 @@ namespace OpenRCT2::Ui::Windows
                     // Drops
                     ft = Formatter();
                     ft.Add<uint16_t>(_loadedTrackDesign->statistics.drops);
-                    DrawTextBasic(dpi, screenPos, STR_DROPS, ft);
+                    DrawTextBasic(rt, screenPos, STR_DROPS, ft);
                     screenPos.y += kListRowHeight;
 
                     // Drop height is multiplied by 0.75
                     ft = Formatter();
                     ft.Add<uint16_t>((_loadedTrackDesign->statistics.highestDropHeight * 3) / 4);
-                    DrawTextBasic(dpi, screenPos, STR_HIGHEST_DROP_HEIGHT, ft);
+                    DrawTextBasic(rt, screenPos, STR_HIGHEST_DROP_HEIGHT, ft);
                     screenPos.y += kListRowHeight;
                 }
 
@@ -645,7 +645,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     ft = Formatter();
                     ft.Add<uint16_t>(_loadedTrackDesign->statistics.inversions);
-                    DrawTextBasic(dpi, screenPos, STR_INVERSIONS, ft);
+                    DrawTextBasic(rt, screenPos, STR_INVERSIONS, ft);
                     screenPos.y += kListRowHeight;
                 }
 
@@ -658,7 +658,7 @@ namespace OpenRCT2::Ui::Windows
                 ft = Formatter();
                 ft.Add<uint16_t>(_loadedTrackDesign->statistics.spaceRequired.x);
                 ft.Add<uint16_t>(_loadedTrackDesign->statistics.spaceRequired.y);
-                DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_SPACE_REQUIRED, ft);
+                DrawTextBasic(rt, screenPos, STR_TRACK_LIST_SPACE_REQUIRED, ft);
                 screenPos.y += kListRowHeight;
             }
 
@@ -666,14 +666,14 @@ namespace OpenRCT2::Ui::Windows
             {
                 ft = Formatter();
                 ft.Add<uint32_t>(_loadedTrackDesign->gameStateData.cost);
-                DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_COST_AROUND, ft);
+                DrawTextBasic(rt, screenPos, STR_TRACK_LIST_COST_AROUND, ft);
             }
         }
 
-        void OnScrollDraw(const int32_t scrollIndex, RenderTarget& dpi) override
+        void OnScrollDraw(const int32_t scrollIndex, RenderTarget& rt) override
         {
             uint8_t paletteIndex = ColourMapA[colours[0].colour].mid_light;
-            GfxClear(dpi, paletteIndex);
+            GfxClear(rt, paletteIndex);
 
             auto screenCoords = ScreenCoordsXY{ 0, 0 };
             size_t listIndex = 0;
@@ -682,7 +682,7 @@ namespace OpenRCT2::Ui::Windows
                 if (_trackDesigns.empty())
                 {
                     // No track designs
-                    DrawTextBasic(dpi, screenCoords - ScreenCoordsXY{ 0, 1 }, STR_NO_TRACK_DESIGNS_OF_THIS_TYPE);
+                    DrawTextBasic(rt, screenCoords - ScreenCoordsXY{ 0, 1 }, STR_NO_TRACK_DESIGNS_OF_THIS_TYPE);
                     return;
                 }
             }
@@ -694,7 +694,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     // Highlight
                     GfxFilterRect(
-                        dpi, { screenCoords, { width, screenCoords.y + kScrollableRowHeight - 1 } },
+                        rt, { screenCoords, { width, screenCoords.y + kScrollableRowHeight - 1 } },
                         FilterPaletteID::PaletteDarken1);
                     stringId = STR_WINDOW_COLOUR_2_STRINGID;
                 }
@@ -705,21 +705,21 @@ namespace OpenRCT2::Ui::Windows
 
                 auto ft = Formatter();
                 ft.Add<StringId>(STR_BUILD_CUSTOM_DESIGN);
-                DrawTextBasic(dpi, screenCoords - ScreenCoordsXY{ 0, 1 }, stringId, ft);
+                DrawTextBasic(rt, screenCoords - ScreenCoordsXY{ 0, 1 }, stringId, ft);
                 screenCoords.y += kScrollableRowHeight;
                 listIndex++;
             }
 
             for (auto i : _filteredTrackIds)
             {
-                if (screenCoords.y + kScrollableRowHeight >= dpi.y && screenCoords.y < dpi.y + dpi.height)
+                if (screenCoords.y + kScrollableRowHeight >= rt.y && screenCoords.y < rt.y + rt.height)
                 {
                     StringId stringId;
                     if (listIndex == static_cast<size_t>(selected_list_item))
                     {
                         // Highlight
                         GfxFilterRect(
-                            dpi, { screenCoords, { width, screenCoords.y + kScrollableRowHeight - 1 } },
+                            rt, { screenCoords, { width, screenCoords.y + kScrollableRowHeight - 1 } },
                             FilterPaletteID::PaletteDarken1);
                         stringId = STR_WINDOW_COLOUR_2_STRINGID;
                     }
@@ -732,7 +732,7 @@ namespace OpenRCT2::Ui::Windows
                     auto ft = Formatter();
                     ft.Add<StringId>(STR_TRACK_LIST_NAME_FORMAT);
                     ft.Add<const utf8*>(_trackDesigns[i].name.c_str());
-                    DrawTextBasic(dpi, screenCoords - ScreenCoordsXY{ 0, 1 }, stringId, ft);
+                    DrawTextBasic(rt, screenCoords - ScreenCoordsXY{ 0, 1 }, stringId, ft);
                 }
 
                 screenCoords.y += kScrollableRowHeight;

--- a/src/openrct2-ui/windows/Transparency.cpp
+++ b/src/openrct2-ui/windows/Transparency.cpp
@@ -143,14 +143,14 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
             // Locate mechanic button image
             const auto& widget = widgets[WIDX_HIDE_STAFF];
             auto screenCoords = windowPos + ScreenCoordsXY{ widget.left, widget.top };
             auto image = ImageId(SPR_MECHANIC, COLOUR_BLACK, getGameState().staffMechanicColour);
-            GfxDrawSprite(dpi, image, screenCoords);
+            GfxDrawSprite(rt, image, screenCoords);
         }
 
     private:

--- a/src/openrct2-ui/windows/Transparency.cpp
+++ b/src/openrct2-ui/windows/Transparency.cpp
@@ -143,7 +143,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
             // Locate mechanic button image

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -290,13 +290,13 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            WindowDrawWidgets(*this, dpi);
+            WindowDrawWidgets(*this, rt);
 
             // Clip height value
             auto screenCoords = this->windowPos + ScreenCoordsXY{ 8, this->widgets[WIDX_CLIP_HEIGHT_VALUE].top };
-            DrawTextBasic(dpi, screenCoords, STR_VIEW_CLIPPING_HEIGHT_VALUE, {}, { this->colours[0] });
+            DrawTextBasic(rt, screenCoords, STR_VIEW_CLIPPING_HEIGHT_VALUE, {}, { this->colours[0] });
 
             screenCoords = this->windowPos
                 + ScreenCoordsXY{ this->widgets[WIDX_CLIP_HEIGHT_VALUE].left + 1, this->widgets[WIDX_CLIP_HEIGHT_VALUE].top };
@@ -310,7 +310,7 @@ namespace OpenRCT2::Ui::Windows
                     ft.Add<int32_t>(static_cast<int32_t>(gClipHeight));
 
                     // Printing the raw value.
-                    DrawTextBasic(dpi, screenCoords, STR_FORMAT_INTEGER, ft, { this->colours[0] });
+                    DrawTextBasic(rt, screenCoords, STR_FORMAT_INTEGER, ft, { this->colours[0] });
                     break;
                 }
                 case DisplayType::DisplayUnits:
@@ -322,7 +322,7 @@ namespace OpenRCT2::Ui::Windows
                         auto ft = Formatter();
                         ft.Add<fixed16_1dp>((MakeFixed1dp<fixed16_1dp>(gClipHeight, 0) / 2 - MakeFixed1dp<fixed16_1dp>(7, 0)));
                         DrawTextBasic(
-                            dpi, screenCoords, STR_UNIT1DP_NO_SUFFIX, ft,
+                            rt, screenCoords, STR_UNIT1DP_NO_SUFFIX, ft,
                             { this->colours[0] }); // Printing the value in Height Units.
                     }
                     else
@@ -337,7 +337,7 @@ namespace OpenRCT2::Ui::Windows
                                 auto ft = Formatter();
                                 ft.Add<fixed32_2dp>(
                                     MakeFixed2dp<fixed32_2dp>(gClipHeight, 0) / 2 * 1.5f - MakeFixed2dp<fixed32_2dp>(10, 50));
-                                DrawTextBasic(dpi, screenCoords, STR_UNIT2DP_SUFFIX_METRES, ft, { this->colours[0] });
+                                DrawTextBasic(rt, screenCoords, STR_UNIT2DP_SUFFIX_METRES, ft, { this->colours[0] });
                                 break;
                             }
                             case MeasurementFormat::Imperial:
@@ -345,7 +345,7 @@ namespace OpenRCT2::Ui::Windows
                                 auto ft = Formatter();
                                 ft.Add<fixed16_1dp>(
                                     MakeFixed1dp<fixed16_1dp>(gClipHeight, 0) / 2.0f * 5 - MakeFixed1dp<fixed16_1dp>(35, 0));
-                                DrawTextBasic(dpi, screenCoords, STR_UNIT1DP_SUFFIX_FEET, ft, { this->colours[0] });
+                                DrawTextBasic(rt, screenCoords, STR_UNIT1DP_SUFFIX_FEET, ft, { this->colours[0] });
                                 break;
                             }
                         }

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -290,7 +290,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             WindowDrawWidgets(*this, dpi);
 

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -162,13 +162,13 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
 
             // Draw viewport
             if (viewport != nullptr)
-                WindowDrawViewport(dpi, *this);
+                WindowDrawViewport(rt, *this);
         }
 
         void OnResize() override

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -162,7 +162,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             DrawWidgets(dpi);
 

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -149,19 +149,19 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_PREVIEW].image = ImageId(LandTool::SizeToSpriteIndex(gLandToolSize));
         }
 
-        void OnDraw(RenderTarget& dpi) override
+        void OnDraw(RenderTarget& rt) override
         {
             auto screenCoords = ScreenCoordsXY{ windowPos.x + widgets[WIDX_PREVIEW].midX(),
                                                 windowPos.y + widgets[WIDX_PREVIEW].midY() };
 
-            DrawWidgets(dpi);
+            DrawWidgets(rt);
             // Draw number for tool sizes bigger than 7
             if (gLandToolSize > kLandToolMaximumSizeWithSprite)
             {
                 auto ft = Formatter();
                 ft.Add<uint16_t>(gLandToolSize);
                 DrawTextBasic(
-                    dpi, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, ft, { TextAlignment::CENTRE });
+                    rt, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, ft, { TextAlignment::CENTRE });
             }
 
             if (!(getGameState().park.Flags & PARK_FLAGS_NO_MONEY))
@@ -172,7 +172,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     auto ft = Formatter();
                     ft.Add<money64>(_waterToolRaiseCost);
-                    DrawTextBasic(dpi, screenCoords, STR_RAISE_COST_AMOUNT, ft, { TextAlignment::CENTRE });
+                    DrawTextBasic(rt, screenCoords, STR_RAISE_COST_AMOUNT, ft, { TextAlignment::CENTRE });
                 }
                 screenCoords.y += 10;
 
@@ -181,7 +181,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     auto ft = Formatter();
                     ft.Add<money64>(_waterToolLowerCost);
-                    DrawTextBasic(dpi, screenCoords, STR_LOWER_COST_AMOUNT, ft, { TextAlignment::CENTRE });
+                    DrawTextBasic(rt, screenCoords, STR_LOWER_COST_AMOUNT, ft, { TextAlignment::CENTRE });
                 }
             }
         }

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -149,7 +149,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_PREVIEW].image = ImageId(LandTool::SizeToSpriteIndex(gLandToolSize));
         }
 
-        void OnDraw(DrawPixelInfo& dpi) override
+        void OnDraw(RenderTarget& dpi) override
         {
             auto screenCoords = ScreenCoordsXY{ windowPos.x + widgets[WIDX_PREVIEW].midX(),
                                                 windowPos.y + widgets[WIDX_PREVIEW].midY() };

--- a/src/openrct2-ui/windows/Windows.h
+++ b/src/openrct2-ui/windows/Windows.h
@@ -216,12 +216,12 @@ namespace OpenRCT2::Ui::Windows
     WindowBase* ResearchOpen();
     void WindowResearchDevelopmentMouseUp(WidgetIndex widgetIndex, WidgetIndex baseWidgetIndex);
     void WindowResearchDevelopmentPrepareDraw(WindowBase* w, WidgetIndex baseWidgetIndex);
-    void WindowResearchDevelopmentDraw(WindowBase* w, DrawPixelInfo& dpi, WidgetIndex baseWidgetIndex);
+    void WindowResearchDevelopmentDraw(WindowBase* w, RenderTarget& dpi, WidgetIndex baseWidgetIndex);
     void WindowResearchFundingMouseDown(WindowBase* w, WidgetIndex widgetIndex, WidgetIndex baseWidgetIndex);
     void WindowResearchFundingMouseUp(WidgetIndex widgetIndex, WidgetIndex baseWidgetIndex);
     void WindowResearchFundingDropdown(WidgetIndex widgetIndex, int32_t selectedIndex, WidgetIndex baseWidgetIndex);
     void WindowResearchFundingPrepareDraw(WindowBase* w, WidgetIndex baseWidgetIndex);
-    void WindowResearchFundingDraw(WindowBase* w, DrawPixelInfo& dpi);
+    void WindowResearchFundingDraw(WindowBase* w, RenderTarget& dpi);
 
     // Ride
     WindowBase* RideMainOpen(const Ride& ride);

--- a/src/openrct2-ui/windows/Windows.h
+++ b/src/openrct2-ui/windows/Windows.h
@@ -216,7 +216,7 @@ namespace OpenRCT2::Ui::Windows
     WindowBase* ResearchOpen();
     void WindowResearchDevelopmentMouseUp(WidgetIndex widgetIndex, WidgetIndex baseWidgetIndex);
     void WindowResearchDevelopmentPrepareDraw(WindowBase* w, WidgetIndex baseWidgetIndex);
-    void WindowResearchDevelopmentDraw(WindowBase* w, RenderTarget& dpi, WidgetIndex baseWidgetIndex);
+    void WindowResearchDevelopmentDraw(WindowBase* w, RenderTarget& rt, WidgetIndex baseWidgetIndex);
     void WindowResearchFundingMouseDown(WindowBase* w, WidgetIndex widgetIndex, WidgetIndex baseWidgetIndex);
     void WindowResearchFundingMouseUp(WidgetIndex widgetIndex, WidgetIndex baseWidgetIndex);
     void WindowResearchFundingDropdown(WidgetIndex widgetIndex, int32_t selectedIndex, WidgetIndex baseWidgetIndex);

--- a/src/openrct2/CommandLineSprite.cpp
+++ b/src/openrct2/CommandLineSprite.cpp
@@ -192,7 +192,7 @@ static bool SpriteImageExport(const G1Element& spriteElement, u8string_view outP
     auto pixelBuffer = std::make_unique<uint8_t[]>(pixelBufferSize);
     auto pixels = pixelBuffer.get();
 
-    DrawPixelInfo dpi;
+    RenderTarget dpi;
     dpi.bits = pixels;
     dpi.x = 0;
     dpi.y = 0;

--- a/src/openrct2/CommandLineSprite.cpp
+++ b/src/openrct2/CommandLineSprite.cpp
@@ -192,28 +192,28 @@ static bool SpriteImageExport(const G1Element& spriteElement, u8string_view outP
     auto pixelBuffer = std::make_unique<uint8_t[]>(pixelBufferSize);
     auto pixels = pixelBuffer.get();
 
-    RenderTarget dpi;
-    dpi.bits = pixels;
-    dpi.x = 0;
-    dpi.y = 0;
-    dpi.width = spriteElement.width;
-    dpi.height = spriteElement.height;
-    dpi.pitch = 0;
-    dpi.zoom_level = ZoomLevel{ 0 };
+    RenderTarget rt;
+    rt.bits = pixels;
+    rt.x = 0;
+    rt.y = 0;
+    rt.width = spriteElement.width;
+    rt.height = spriteElement.height;
+    rt.pitch = 0;
+    rt.zoom_level = ZoomLevel{ 0 };
 
     DrawSpriteArgs args(
         ImageId(), PaletteMap::GetDefault(), spriteElement, 0, 0, spriteElement.width, spriteElement.height, pixels);
-    GfxSpriteToBuffer(dpi, args);
+    GfxSpriteToBuffer(rt, args);
 
-    auto const pixels8 = dpi.bits;
-    auto const pixelsLen = dpi.LineStride() * dpi.WorldHeight();
+    auto const pixels8 = rt.bits;
+    auto const pixelsLen = rt.LineStride() * rt.WorldHeight();
     try
     {
         Image image;
-        image.Width = dpi.width;
-        image.Height = dpi.height;
+        image.Width = rt.width;
+        image.Height = rt.height;
         image.Depth = 8;
-        image.Stride = dpi.LineStride();
+        image.Stride = rt.LineStride();
         image.Palette = StandardPalette;
         image.Pixels = std::vector<uint8_t>(pixels8, pixels8 + pixelsLen);
         Imaging::WriteToFile(outPath, image, ImageFormat::png);

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -632,8 +632,6 @@ namespace OpenRCT2
                 {
                     LOG_ERROR(ex.what());
                     LOG_ERROR("Unable to initialise drawing engine.");
-
-                    return nullptr;
                 }
                 return nullptr;
             };

--- a/src/openrct2/core/Imaging.h
+++ b/src/openrct2/core/Imaging.h
@@ -18,7 +18,7 @@
 #include <string_view>
 #include <vector>
 
-struct DrawPixelInfo;
+struct RenderTarget;
 
 enum class ImageFormat
 {

--- a/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
@@ -10,7 +10,7 @@
 #include "Drawing.h"
 
 template<DrawBlendOp TBlendOp>
-static void FASTCALL DrawBMPSpriteMagnify(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
+static void FASTCALL DrawBMPSpriteMagnify(RenderTarget& dpi, const DrawSpriteArgs& args)
 {
     auto& paletteMap = args.PalMap;
     auto src0 = args.SourceImage.offset;
@@ -36,7 +36,7 @@ static void FASTCALL DrawBMPSpriteMagnify(DrawPixelInfo& dpi, const DrawSpriteAr
 }
 
 template<DrawBlendOp TBlendOp>
-static void FASTCALL DrawBMPSpriteMinify(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
+static void FASTCALL DrawBMPSpriteMinify(RenderTarget& dpi, const DrawSpriteArgs& args)
 {
     auto& g1 = args.SourceImage;
     auto src = g1.offset + ((static_cast<size_t>(g1.width) * args.SrcY) + args.SrcX);
@@ -62,7 +62,7 @@ static void FASTCALL DrawBMPSpriteMinify(DrawPixelInfo& dpi, const DrawSpriteArg
 }
 
 template<DrawBlendOp TBlendOp>
-static void FASTCALL DrawBMPSprite(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
+static void FASTCALL DrawBMPSprite(RenderTarget& dpi, const DrawSpriteArgs& args)
 {
     if (dpi.zoom_level < ZoomLevel{ 0 })
     {
@@ -80,7 +80,7 @@ static void FASTCALL DrawBMPSprite(DrawPixelInfo& dpi, const DrawSpriteArgs& arg
  *  rct2: 0x0067A690
  * @param imageId Only flags are used.
  */
-void FASTCALL GfxBmpSpriteToBuffer(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
+void FASTCALL GfxBmpSpriteToBuffer(RenderTarget& dpi, const DrawSpriteArgs& args)
 {
     auto imageId = args.Image;
 

--- a/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
@@ -10,7 +10,7 @@
 #include "Drawing.h"
 
 template<DrawBlendOp TBlendOp>
-static void FASTCALL DrawBMPSpriteMagnify(RenderTarget& dpi, const DrawSpriteArgs& args)
+static void FASTCALL DrawBMPSpriteMagnify(RenderTarget& rt, const DrawSpriteArgs& args)
 {
     auto& paletteMap = args.PalMap;
     auto src0 = args.SourceImage.offset;
@@ -19,8 +19,8 @@ static void FASTCALL DrawBMPSpriteMagnify(RenderTarget& dpi, const DrawSpriteArg
     auto srcY = args.SrcY;
     auto width = args.Width;
     auto height = args.Height;
-    auto zoom = dpi.zoom_level;
-    auto dstLineWidth = dpi.LineStride();
+    auto zoom = rt.zoom_level;
+    auto dstLineWidth = rt.LineStride();
     auto srcLineWidth = args.SourceImage.width;
 
     for (int32_t y = 0; y < height; y++)
@@ -36,7 +36,7 @@ static void FASTCALL DrawBMPSpriteMagnify(RenderTarget& dpi, const DrawSpriteArg
 }
 
 template<DrawBlendOp TBlendOp>
-static void FASTCALL DrawBMPSpriteMinify(RenderTarget& dpi, const DrawSpriteArgs& args)
+static void FASTCALL DrawBMPSpriteMinify(RenderTarget& rt, const DrawSpriteArgs& args)
 {
     auto& g1 = args.SourceImage;
     auto src = g1.offset + ((static_cast<size_t>(g1.width) * args.SrcY) + args.SrcX);
@@ -44,9 +44,9 @@ static void FASTCALL DrawBMPSpriteMinify(RenderTarget& dpi, const DrawSpriteArgs
     auto& paletteMap = args.PalMap;
     auto width = args.Width;
     auto height = args.Height;
-    auto zoomLevel = dpi.zoom_level;
+    auto zoomLevel = rt.zoom_level;
     size_t srcLineWidth = zoomLevel.ApplyTo(g1.width);
-    size_t dstLineWidth = dpi.LineStride();
+    size_t dstLineWidth = rt.LineStride();
     uint8_t zoom = zoomLevel.ApplyTo(1);
     for (; height > 0; height -= zoom)
     {
@@ -62,15 +62,15 @@ static void FASTCALL DrawBMPSpriteMinify(RenderTarget& dpi, const DrawSpriteArgs
 }
 
 template<DrawBlendOp TBlendOp>
-static void FASTCALL DrawBMPSprite(RenderTarget& dpi, const DrawSpriteArgs& args)
+static void FASTCALL DrawBMPSprite(RenderTarget& rt, const DrawSpriteArgs& args)
 {
-    if (dpi.zoom_level < ZoomLevel{ 0 })
+    if (rt.zoom_level < ZoomLevel{ 0 })
     {
-        DrawBMPSpriteMagnify<TBlendOp>(dpi, args);
+        DrawBMPSpriteMagnify<TBlendOp>(rt, args);
     }
     else
     {
-        DrawBMPSpriteMinify<TBlendOp>(dpi, args);
+        DrawBMPSpriteMinify<TBlendOp>(rt, args);
     }
 }
 
@@ -80,7 +80,7 @@ static void FASTCALL DrawBMPSprite(RenderTarget& dpi, const DrawSpriteArgs& args
  *  rct2: 0x0067A690
  * @param imageId Only flags are used.
  */
-void FASTCALL GfxBmpSpriteToBuffer(RenderTarget& dpi, const DrawSpriteArgs& args)
+void FASTCALL GfxBmpSpriteToBuffer(RenderTarget& rt, const DrawSpriteArgs& args)
 {
     auto imageId = args.Image;
 
@@ -90,28 +90,28 @@ void FASTCALL GfxBmpSpriteToBuffer(RenderTarget& dpi, const DrawSpriteArgs& args
         if (imageId.IsBlended())
         {
             // Copy non-transparent bitmap data but blend src and dst pixel using the palette map.
-            DrawBMPSprite<kBlendTransparent | kBlendSrc | kBlendDst>(dpi, args);
+            DrawBMPSprite<kBlendTransparent | kBlendSrc | kBlendDst>(rt, args);
         }
         else
         {
             // Copy non-transparent bitmap data but re-colour using the palette map.
-            DrawBMPSprite<kBlendTransparent | kBlendSrc>(dpi, args);
+            DrawBMPSprite<kBlendTransparent | kBlendSrc>(rt, args);
         }
     }
     else if (imageId.IsBlended())
     {
         // Image is only a transparency mask. Just colour the pixels using the palette map.
         // Used for glass.
-        DrawBMPSprite<kBlendTransparent | kBlendDst>(dpi, args);
+        DrawBMPSprite<kBlendTransparent | kBlendDst>(rt, args);
     }
     else if (!(args.SourceImage.flags & G1_FLAG_HAS_TRANSPARENCY))
     {
         // Copy raw bitmap data to target
-        DrawBMPSprite<kBlendNone>(dpi, args);
+        DrawBMPSprite<kBlendNone>(rt, args);
     }
     else
     {
         // Copy raw bitmap data to target but exclude transparent pixels
-        DrawBMPSprite<kBlendTransparent>(dpi, args);
+        DrawBMPSprite<kBlendTransparent>(rt, args);
     }
 }

--- a/src/openrct2/drawing/Drawing.Sprite.RLE.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.RLE.cpp
@@ -13,7 +13,7 @@
 #include <cstring>
 
 template<DrawBlendOp TBlendOp>
-static void FASTCALL DrawRLESpriteMagnify(RenderTarget& dpi, const DrawSpriteArgs& args)
+static void FASTCALL DrawRLESpriteMagnify(RenderTarget& rt, const DrawSpriteArgs& args)
 {
     auto& paletteMap = args.PalMap;
     auto imgData = args.SourceImage.offset;
@@ -22,8 +22,8 @@ static void FASTCALL DrawRLESpriteMagnify(RenderTarget& dpi, const DrawSpriteArg
     auto srcY = args.SrcY;
     auto width = args.Width;
     auto height = args.Height;
-    auto zoom = dpi.zoom_level;
-    auto dstLineWidth = dpi.LineStride();
+    auto zoom = rt.zoom_level;
+    auto dstLineWidth = rt.LineStride();
 
     for (int32_t y = 0; y < height; y++)
     {
@@ -58,7 +58,7 @@ static void FASTCALL DrawRLESpriteMagnify(RenderTarget& dpi, const DrawSpriteArg
 }
 
 template<DrawBlendOp TBlendOp, size_t TZoom>
-static void FASTCALL DrawRLESpriteMinify(RenderTarget& dpi, const DrawSpriteArgs& args)
+static void FASTCALL DrawRLESpriteMinify(RenderTarget& rt, const DrawSpriteArgs& args)
 {
     auto src0 = args.SourceImage.offset;
     auto dst0 = args.DestinationBits;
@@ -67,7 +67,7 @@ static void FASTCALL DrawRLESpriteMinify(RenderTarget& dpi, const DrawSpriteArgs
     auto width = args.Width;
     auto height = args.Height;
     auto zoom = 1 << TZoom;
-    auto dstLineWidth = static_cast<size_t>(dpi.LineStride());
+    auto dstLineWidth = static_cast<size_t>(rt.LineStride());
 
     // Move up to the first line of the image if source_y_start is negative. Why does this even occur?
     if (srcY < 0)
@@ -153,26 +153,26 @@ static void FASTCALL DrawRLESpriteMinify(RenderTarget& dpi, const DrawSpriteArgs
 }
 
 template<DrawBlendOp TBlendOp>
-static void FASTCALL DrawRLESprite(RenderTarget& dpi, const DrawSpriteArgs& args)
+static void FASTCALL DrawRLESprite(RenderTarget& rt, const DrawSpriteArgs& args)
 {
-    auto zoom_level = static_cast<int8_t>(dpi.zoom_level);
+    auto zoom_level = static_cast<int8_t>(rt.zoom_level);
     switch (zoom_level)
     {
         case -2:
         case -1:
-            DrawRLESpriteMagnify<TBlendOp>(dpi, args);
+            DrawRLESpriteMagnify<TBlendOp>(rt, args);
             break;
         case 0:
-            DrawRLESpriteMinify<TBlendOp, 0>(dpi, args);
+            DrawRLESpriteMinify<TBlendOp, 0>(rt, args);
             break;
         case 1:
-            DrawRLESpriteMinify<TBlendOp, 1>(dpi, args);
+            DrawRLESpriteMinify<TBlendOp, 1>(rt, args);
             break;
         case 2:
-            DrawRLESpriteMinify<TBlendOp, 2>(dpi, args);
+            DrawRLESpriteMinify<TBlendOp, 2>(rt, args);
             break;
         case 3:
-            DrawRLESpriteMinify<TBlendOp, 3>(dpi, args);
+            DrawRLESpriteMinify<TBlendOp, 3>(rt, args);
             break;
         default:
             assert(false);
@@ -186,25 +186,25 @@ static void FASTCALL DrawRLESprite(RenderTarget& dpi, const DrawSpriteArgs& args
  *  rct2: 0x0067AA18
  * @param imageId Only flags are used.
  */
-void FASTCALL GfxRleSpriteToBuffer(RenderTarget& dpi, const DrawSpriteArgs& args)
+void FASTCALL GfxRleSpriteToBuffer(RenderTarget& rt, const DrawSpriteArgs& args)
 {
     if (args.Image.HasPrimary())
     {
         if (args.Image.IsBlended())
         {
-            DrawRLESprite<kBlendTransparent | kBlendSrc | kBlendDst>(dpi, args);
+            DrawRLESprite<kBlendTransparent | kBlendSrc | kBlendDst>(rt, args);
         }
         else
         {
-            DrawRLESprite<kBlendTransparent | kBlendSrc>(dpi, args);
+            DrawRLESprite<kBlendTransparent | kBlendSrc>(rt, args);
         }
     }
     else if (args.Image.IsBlended())
     {
-        DrawRLESprite<kBlendTransparent | kBlendDst>(dpi, args);
+        DrawRLESprite<kBlendTransparent | kBlendDst>(rt, args);
     }
     else
     {
-        DrawRLESprite<kBlendTransparent>(dpi, args);
+        DrawRLESprite<kBlendTransparent>(rt, args);
     }
 }

--- a/src/openrct2/drawing/Drawing.Sprite.RLE.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.RLE.cpp
@@ -13,7 +13,7 @@
 #include <cstring>
 
 template<DrawBlendOp TBlendOp>
-static void FASTCALL DrawRLESpriteMagnify(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
+static void FASTCALL DrawRLESpriteMagnify(RenderTarget& dpi, const DrawSpriteArgs& args)
 {
     auto& paletteMap = args.PalMap;
     auto imgData = args.SourceImage.offset;
@@ -58,7 +58,7 @@ static void FASTCALL DrawRLESpriteMagnify(DrawPixelInfo& dpi, const DrawSpriteAr
 }
 
 template<DrawBlendOp TBlendOp, size_t TZoom>
-static void FASTCALL DrawRLESpriteMinify(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
+static void FASTCALL DrawRLESpriteMinify(RenderTarget& dpi, const DrawSpriteArgs& args)
 {
     auto src0 = args.SourceImage.offset;
     auto dst0 = args.DestinationBits;
@@ -153,7 +153,7 @@ static void FASTCALL DrawRLESpriteMinify(DrawPixelInfo& dpi, const DrawSpriteArg
 }
 
 template<DrawBlendOp TBlendOp>
-static void FASTCALL DrawRLESprite(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
+static void FASTCALL DrawRLESprite(RenderTarget& dpi, const DrawSpriteArgs& args)
 {
     auto zoom_level = static_cast<int8_t>(dpi.zoom_level);
     switch (zoom_level)
@@ -186,7 +186,7 @@ static void FASTCALL DrawRLESprite(DrawPixelInfo& dpi, const DrawSpriteArgs& arg
  *  rct2: 0x0067AA18
  * @param imageId Only flags are used.
  */
-void FASTCALL GfxRleSpriteToBuffer(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
+void FASTCALL GfxRleSpriteToBuffer(RenderTarget& dpi, const DrawSpriteArgs& args)
 {
     if (args.Image.HasPrimary())
     {

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -717,7 +717,7 @@ static std::optional<PaletteMap> FASTCALL GfxDrawSpriteGetPalette(ImageId imageI
     return paletteMap;
 }
 
-void FASTCALL GfxDrawSpriteSoftware(DrawPixelInfo& dpi, const ImageId imageId, const ScreenCoordsXY& spriteCoords)
+void FASTCALL GfxDrawSpriteSoftware(RenderTarget& dpi, const ImageId imageId, const ScreenCoordsXY& spriteCoords)
 {
     if (imageId.HasValue())
     {
@@ -740,7 +740,7 @@ void FASTCALL GfxDrawSpriteSoftware(DrawPixelInfo& dpi, const ImageId imageId, c
  * y (dx)
  */
 void FASTCALL GfxDrawSpritePaletteSetSoftware(
-    DrawPixelInfo& dpi, const ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
+    RenderTarget& dpi, const ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
 {
     const auto zoomLevel = dpi.zoom_level;
     int32_t x = coords.x;
@@ -754,7 +754,7 @@ void FASTCALL GfxDrawSpritePaletteSetSoftware(
 
     if (zoomLevel > ZoomLevel{ 0 } && (g1->flags & G1_FLAG_HAS_ZOOM_SPRITE))
     {
-        DrawPixelInfo zoomed_dpi = dpi;
+        RenderTarget zoomed_dpi = dpi;
         zoomed_dpi.bits = dpi.bits;
         zoomed_dpi.x = dpi.x;
         zoomed_dpi.y = dpi.y;
@@ -920,7 +920,7 @@ void FASTCALL GfxDrawSpritePaletteSetSoftware(
     GfxSpriteToBuffer(dpi, args);
 }
 
-void FASTCALL GfxSpriteToBuffer(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
+void FASTCALL GfxSpriteToBuffer(RenderTarget& dpi, const DrawSpriteArgs& args)
 {
     if (args.SourceImage.flags & G1_FLAG_RLE_COMPRESSION)
     {
@@ -939,7 +939,7 @@ void FASTCALL GfxSpriteToBuffer(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
  *  rct2: 0x00681DE2
  */
 void FASTCALL GfxDrawSpriteRawMaskedSoftware(
-    DrawPixelInfo& dpi, const ScreenCoordsXY& scrCoords, const ImageId maskImage, const ImageId colourImage)
+    RenderTarget& dpi, const ScreenCoordsXY& scrCoords, const ImageId maskImage, const ImageId colourImage)
 {
     int32_t left, top, right, bottom, width, height;
     auto imgMask = GfxGetG1Element(maskImage);

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -717,7 +717,7 @@ static std::optional<PaletteMap> FASTCALL GfxDrawSpriteGetPalette(ImageId imageI
     return paletteMap;
 }
 
-void FASTCALL GfxDrawSpriteSoftware(RenderTarget& dpi, const ImageId imageId, const ScreenCoordsXY& spriteCoords)
+void FASTCALL GfxDrawSpriteSoftware(RenderTarget& rt, const ImageId imageId, const ScreenCoordsXY& spriteCoords)
 {
     if (imageId.HasValue())
     {
@@ -726,7 +726,7 @@ void FASTCALL GfxDrawSpriteSoftware(RenderTarget& dpi, const ImageId imageId, co
         {
             palette = PaletteMap::GetDefault();
         }
-        GfxDrawSpritePaletteSetSoftware(dpi, imageId, spriteCoords, *palette);
+        GfxDrawSpritePaletteSetSoftware(rt, imageId, spriteCoords, *palette);
     }
 }
 
@@ -740,9 +740,9 @@ void FASTCALL GfxDrawSpriteSoftware(RenderTarget& dpi, const ImageId imageId, co
  * y (dx)
  */
 void FASTCALL GfxDrawSpritePaletteSetSoftware(
-    RenderTarget& dpi, const ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
+    RenderTarget& rt, const ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
 {
-    const auto zoomLevel = dpi.zoom_level;
+    const auto zoomLevel = rt.zoom_level;
     int32_t x = coords.x;
     int32_t y = coords.y;
 
@@ -754,13 +754,13 @@ void FASTCALL GfxDrawSpritePaletteSetSoftware(
 
     if (zoomLevel > ZoomLevel{ 0 } && (g1->flags & G1_FLAG_HAS_ZOOM_SPRITE))
     {
-        RenderTarget zoomed_dpi = dpi;
-        zoomed_dpi.bits = dpi.bits;
-        zoomed_dpi.x = dpi.x;
-        zoomed_dpi.y = dpi.y;
-        zoomed_dpi.height = dpi.height;
-        zoomed_dpi.width = dpi.width;
-        zoomed_dpi.pitch = dpi.pitch;
+        RenderTarget zoomed_dpi = rt;
+        zoomed_dpi.bits = rt.bits;
+        zoomed_dpi.x = rt.x;
+        zoomed_dpi.y = rt.y;
+        zoomed_dpi.height = rt.height;
+        zoomed_dpi.width = rt.width;
+        zoomed_dpi.pitch = rt.pitch;
         zoomed_dpi.zoom_level = zoomLevel - 1;
 
         const auto spriteCoords = ScreenCoordsXY{ coords.x / 2, coords.y / 2 };
@@ -785,20 +785,20 @@ void FASTCALL GfxDrawSpritePaletteSetSoftware(
         ScreenCoordsXY spriteBottomLeft{ zoomLevel.ApplyInversedTo(coords.x + g1->x_offset + g1->width),
                                          zoomLevel.ApplyInversedTo(coords.y + g1->y_offset + g1->height) };
 
-        const int32_t width = std::min(spriteBottomLeft.x, dpi.x + dpi.width) - std::max(spriteTopLeft.x, dpi.x);
-        const int32_t height = std::min(spriteBottomLeft.y, dpi.y + dpi.height) - std::max(spriteTopLeft.y, dpi.y);
+        const int32_t width = std::min(spriteBottomLeft.x, rt.x + rt.width) - std::max(spriteTopLeft.x, rt.x);
+        const int32_t height = std::min(spriteBottomLeft.y, rt.y + rt.height) - std::max(spriteTopLeft.y, rt.y);
 
         if (width <= 0 || height <= 0)
             return;
 
-        const int32_t offsetX = dpi.x - spriteTopLeft.x;
-        const int32_t offsetY = dpi.y - spriteTopLeft.y;
+        const int32_t offsetX = rt.x - spriteTopLeft.x;
+        const int32_t offsetY = rt.y - spriteTopLeft.y;
         const int32_t srcX = std::max(0, offsetX);
         const int32_t srcY = std::max(0, offsetY);
-        uint8_t* dst = dpi.bits + std::max(0, -offsetX) + std::max(0, -offsetY) * dpi.LineStride();
+        uint8_t* dst = rt.bits + std::max(0, -offsetX) + std::max(0, -offsetY) * rt.LineStride();
 
         DrawSpriteArgs args(imageId, paletteMap, *g1, srcX, srcY, width, height, dst);
-        GfxSpriteToBuffer(dpi, args);
+        GfxSpriteToBuffer(rt, args);
         return;
     }
 
@@ -820,11 +820,11 @@ void FASTCALL GfxDrawSpritePaletteSetSoftware(
     // the zoom mask on the y coordinate but does on x.
     if (g1->flags & G1_FLAG_RLE_COMPRESSION)
     {
-        dest_start_y -= dpi.WorldY();
+        dest_start_y -= rt.WorldY();
     }
     else
     {
-        dest_start_y = (dest_start_y & zoom_mask) - dpi.WorldY();
+        dest_start_y = (dest_start_y & zoom_mask) - rt.WorldY();
     }
     // This is the start y coordinate on the source
     int32_t source_start_y = 0;
@@ -855,11 +855,11 @@ void FASTCALL GfxDrawSpritePaletteSetSoftware(
 
     int32_t dest_end_y = dest_start_y + height;
 
-    if (dest_end_y > dpi.WorldHeight())
+    if (dest_end_y > rt.WorldHeight())
     {
         // If the destination y is outside of the drawing
         // image reduce the height of the image
-        height -= dest_end_y - dpi.WorldHeight();
+        height -= dest_end_y - rt.WorldHeight();
     }
     // If the image no longer has anything to draw
     if (height <= 0)
@@ -873,7 +873,7 @@ void FASTCALL GfxDrawSpritePaletteSetSoftware(
     // This is the source start x coordinate
     int32_t source_start_x = 0;
     // This is the destination start x coordinate
-    int16_t dest_start_x = ((x + g1->x_offset + ~zoom_mask) & zoom_mask) - dpi.WorldX();
+    int16_t dest_start_x = ((x + g1->x_offset + ~zoom_mask) & zoom_mask) - rt.WorldX();
 
     if (dest_start_x < 0)
     {
@@ -900,11 +900,11 @@ void FASTCALL GfxDrawSpritePaletteSetSoftware(
 
     int32_t dest_end_x = dest_start_x + width;
 
-    if (dest_end_x > dpi.WorldWidth())
+    if (dest_end_x > rt.WorldWidth())
     {
         // If the destination x is outside of the drawing area
         // reduce the image width.
-        width -= dest_end_x - dpi.WorldWidth();
+        width -= dest_end_x - rt.WorldWidth();
         // If there is no image to draw.
         if (width <= 0)
             return;
@@ -912,12 +912,12 @@ void FASTCALL GfxDrawSpritePaletteSetSoftware(
 
     dest_start_x = zoomLevel.ApplyInversedTo(dest_start_x);
 
-    uint8_t* dest_pointer = dpi.bits;
+    uint8_t* dest_pointer = rt.bits;
     // Move the pointer to the start point of the destination
-    dest_pointer += (zoomLevel.ApplyInversedTo(dpi.WorldWidth()) + dpi.pitch) * dest_start_y + dest_start_x;
+    dest_pointer += (zoomLevel.ApplyInversedTo(rt.WorldWidth()) + rt.pitch) * dest_start_y + dest_start_x;
 
     DrawSpriteArgs args(imageId, paletteMap, *g1, source_start_x, source_start_y, width, height, dest_pointer);
-    GfxSpriteToBuffer(dpi, args);
+    GfxSpriteToBuffer(rt, args);
 }
 
 void FASTCALL GfxSpriteToBuffer(RenderTarget& dpi, const DrawSpriteArgs& args)
@@ -939,7 +939,7 @@ void FASTCALL GfxSpriteToBuffer(RenderTarget& dpi, const DrawSpriteArgs& args)
  *  rct2: 0x00681DE2
  */
 void FASTCALL GfxDrawSpriteRawMaskedSoftware(
-    RenderTarget& dpi, const ScreenCoordsXY& scrCoords, const ImageId maskImage, const ImageId colourImage)
+    RenderTarget& rt, const ScreenCoordsXY& scrCoords, const ImageId maskImage, const ImageId colourImage)
 {
     int32_t left, top, right, bottom, width, height;
     auto imgMask = GfxGetG1Element(maskImage);
@@ -952,12 +952,12 @@ void FASTCALL GfxDrawSpriteRawMaskedSoftware(
     // Must have transparency in order to pass check
     if (!(imgMask->flags & G1_FLAG_HAS_TRANSPARENCY) || !(imgColour->flags & G1_FLAG_HAS_TRANSPARENCY))
     {
-        GfxDrawSpriteSoftware(dpi, colourImage, scrCoords);
+        GfxDrawSpriteSoftware(rt, colourImage, scrCoords);
         return;
     }
 
-    ZoomLevel zoom = dpi.zoom_level;
-    if (dpi.zoom_level > ZoomLevel{ 0 })
+    ZoomLevel zoom = rt.zoom_level;
+    if (rt.zoom_level > ZoomLevel{ 0 })
     {
         assert(false);
     }
@@ -969,23 +969,23 @@ void FASTCALL GfxDrawSpriteRawMaskedSoftware(
     offsetCoords.x = zoom.ApplyInversedTo(offsetCoords.x);
     offsetCoords.y = zoom.ApplyInversedTo(offsetCoords.y);
 
-    left = std::max(dpi.x, offsetCoords.x);
-    top = std::max(dpi.y, offsetCoords.y);
-    right = std::min(dpi.x + dpi.width, offsetCoords.x + width);
-    bottom = std::min(dpi.y + dpi.height, offsetCoords.y + height);
+    left = std::max(rt.x, offsetCoords.x);
+    top = std::max(rt.y, offsetCoords.y);
+    right = std::min(rt.x + rt.width, offsetCoords.x + width);
+    bottom = std::min(rt.y + rt.height, offsetCoords.y + height);
 
     width = right - left;
     height = bottom - top;
     if (width < 0 || height < 0)
         return;
 
-    uint8_t* dst = dpi.bits + (left - dpi.x) + ((top - dpi.y) * dpi.LineStride());
+    uint8_t* dst = rt.bits + (left - rt.x) + ((top - rt.y) * rt.LineStride());
     int32_t skipX = left - offsetCoords.x;
     int32_t skipY = top - offsetCoords.y;
     if (zoom < ZoomLevel{ 0 })
     {
         MaskMagnify(
-            zoom, width, height, imgMask->offset, imgColour->offset, dst, imgMask->width, imgColour->width, dpi.LineStride(),
+            zoom, width, height, imgMask->offset, imgColour->offset, dst, imgMask->width, imgColour->width, rt.LineStride(),
             skipX, skipY);
         return;
     }
@@ -995,7 +995,7 @@ void FASTCALL GfxDrawSpriteRawMaskedSoftware(
 
     int32_t maskWrap = imgMask->width - width;
     int32_t colourWrap = imgColour->width - width;
-    int32_t dstWrap = dpi.LineStride() - width;
+    int32_t dstWrap = rt.LineStride() - width;
 
     MaskFn(width, height, maskSrc, colourSrc, dst, maskWrap, colourWrap, dstWrap);
 }

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -754,18 +754,18 @@ void FASTCALL GfxDrawSpritePaletteSetSoftware(
 
     if (zoomLevel > ZoomLevel{ 0 } && (g1->flags & G1_FLAG_HAS_ZOOM_SPRITE))
     {
-        RenderTarget zoomed_dpi = rt;
-        zoomed_dpi.bits = rt.bits;
-        zoomed_dpi.x = rt.x;
-        zoomed_dpi.y = rt.y;
-        zoomed_dpi.height = rt.height;
-        zoomed_dpi.width = rt.width;
-        zoomed_dpi.pitch = rt.pitch;
-        zoomed_dpi.zoom_level = zoomLevel - 1;
+        RenderTarget zoomedRT = rt;
+        zoomedRT.bits = rt.bits;
+        zoomedRT.x = rt.x;
+        zoomedRT.y = rt.y;
+        zoomedRT.height = rt.height;
+        zoomedRT.width = rt.width;
+        zoomedRT.pitch = rt.pitch;
+        zoomedRT.zoom_level = zoomLevel - 1;
 
         const auto spriteCoords = ScreenCoordsXY{ coords.x / 2, coords.y / 2 };
         GfxDrawSpritePaletteSetSoftware(
-            zoomed_dpi, imageId.WithIndex(imageId.GetIndex() - g1->zoomed_offset), spriteCoords, paletteMap);
+            zoomedRT, imageId.WithIndex(imageId.GetIndex() - g1->zoomed_offset), spriteCoords, paletteMap);
         return;
     }
 
@@ -920,15 +920,15 @@ void FASTCALL GfxDrawSpritePaletteSetSoftware(
     GfxSpriteToBuffer(rt, args);
 }
 
-void FASTCALL GfxSpriteToBuffer(RenderTarget& dpi, const DrawSpriteArgs& args)
+void FASTCALL GfxSpriteToBuffer(RenderTarget& rt, const DrawSpriteArgs& args)
 {
     if (args.SourceImage.flags & G1_FLAG_RLE_COMPRESSION)
     {
-        GfxRleSpriteToBuffer(dpi, args);
+        GfxRleSpriteToBuffer(rt, args);
     }
     else if (!(args.SourceImage.flags & G1_FLAG_1))
     {
-        GfxBmpSpriteToBuffer(dpi, args);
+        GfxBmpSpriteToBuffer(rt, args);
     }
 }
 

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -259,13 +259,13 @@ int32_t GfxWrapString(u8string_view text, int32_t width, FontStyle fontStyle, u8
  * Draws text that is left aligned and vertically centred.
  */
 void GfxDrawStringLeftCentred(
-    RenderTarget& dpi, StringId format, void* args, ColourWithFlags colour, const ScreenCoordsXY& coords)
+    RenderTarget& rt, StringId format, void* args, ColourWithFlags colour, const ScreenCoordsXY& coords)
 {
     char buffer[512];
     auto bufferPtr = buffer;
     FormatStringLegacy(bufferPtr, sizeof(buffer), format, args);
     int32_t height = StringGetHeightRaw(bufferPtr, FontStyle::Medium);
-    DrawText(dpi, coords - ScreenCoordsXY{ 0, (height / 2) }, { colour }, bufferPtr);
+    DrawText(rt, coords - ScreenCoordsXY{ 0, (height / 2) }, { colour }, bufferPtr);
 }
 
 /**
@@ -323,16 +323,16 @@ static void ColourCharacterWindow(colour_t colour, const uint16_t* current_font_
  * dpi      : edi
  */
 void DrawStringCentredRaw(
-    RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t numLines, const utf8* text, FontStyle fontStyle)
+    RenderTarget& rt, const ScreenCoordsXY& coords, int32_t numLines, const utf8* text, FontStyle fontStyle)
 {
-    ScreenCoordsXY screenCoords(dpi.x, dpi.y);
-    DrawText(dpi, screenCoords, { COLOUR_BLACK, fontStyle }, "");
+    ScreenCoordsXY screenCoords(rt.x, rt.y);
+    DrawText(rt, screenCoords, { COLOUR_BLACK, fontStyle }, "");
     screenCoords = coords;
 
     for (int32_t i = 0; i <= numLines; i++)
     {
         int32_t width = GfxGetStringWidth(text, fontStyle);
-        DrawText(dpi, screenCoords - ScreenCoordsXY{ width / 2, 0 }, { kTextColour254, fontStyle }, text);
+        DrawText(rt, screenCoords - ScreenCoordsXY{ width / 2, 0 }, { kTextColour254, fontStyle }, text);
 
         const utf8* ch = text;
         const utf8* nextCh = nullptr;
@@ -418,13 +418,13 @@ int32_t StringGetHeightRaw(std::string_view text, FontStyle fontStyle)
  * ticks    : ebp >> 16
  */
 void DrawNewsTicker(
-    RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, colour_t colour, StringId format, u8string_view args,
+    RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, colour_t colour, StringId format, u8string_view args,
     int32_t ticks)
 {
     int32_t numLines, lineHeight, lineY;
-    ScreenCoordsXY screenCoords(dpi.x, dpi.y);
+    ScreenCoordsXY screenCoords(rt.x, rt.y);
 
-    DrawText(dpi, screenCoords, { colour }, "");
+    DrawText(rt, screenCoords, { colour }, "");
 
     u8string wrappedString;
     GfxWrapString(FormatStringID(format, args), width, FontStyle::Small, &wrappedString, &numLines);
@@ -463,7 +463,7 @@ void DrawNewsTicker(
         }
 
         screenCoords = { coords.x - halfWidth, lineY };
-        DrawText(dpi, screenCoords, { kTextColour254, FontStyle::Small }, buffer);
+        DrawText(rt, screenCoords, { kTextColour254, FontStyle::Small }, buffer);
 
         if (numCharactersDrawn > numCharactersToDraw)
         {
@@ -475,7 +475,7 @@ void DrawNewsTicker(
     }
 }
 
-static void TTFDrawCharacterSprite(RenderTarget& dpi, int32_t codepoint, TextDrawInfo* info)
+static void TTFDrawCharacterSprite(RenderTarget& rt, int32_t codepoint, TextDrawInfo* info)
 {
     int32_t characterWidth = FontSpriteGetCodepointWidth(info->FontStyle, codepoint);
     auto sprite = FontSpriteGetCodepointSprite(info->FontStyle, codepoint);
@@ -489,24 +489,24 @@ static void TTFDrawCharacterSprite(RenderTarget& dpi, int32_t codepoint, TextDra
         }
 
         PaletteMap paletteMap(info->palette);
-        GfxDrawGlyph(dpi, sprite, screenCoords, paletteMap);
+        GfxDrawGlyph(rt, sprite, screenCoords, paletteMap);
     }
 
     info->x += characterWidth;
 }
 
-static void TTFDrawStringRawSprite(RenderTarget& dpi, std::string_view text, TextDrawInfo* info)
+static void TTFDrawStringRawSprite(RenderTarget& rt, std::string_view text, TextDrawInfo* info)
 {
     CodepointView codepoints(text);
     for (auto codepoint : codepoints)
     {
-        TTFDrawCharacterSprite(dpi, codepoint, info);
+        TTFDrawCharacterSprite(rt, codepoint, info);
     }
 }
 
 #ifndef DISABLE_TTF
 
-static void TTFDrawStringRawTTF(RenderTarget& dpi, std::string_view text, TextDrawInfo* info)
+static void TTFDrawStringRawTTF(RenderTarget& rt, std::string_view text, TextDrawInfo* info)
 {
     if (!TTFInitialise())
         return;
@@ -514,7 +514,7 @@ static void TTFDrawStringRawTTF(RenderTarget& dpi, std::string_view text, TextDr
     TTFFontDescriptor* fontDesc = TTFGetFontFromSpriteBase(info->FontStyle);
     if (fontDesc->font == nullptr)
     {
-        TTFDrawStringRawSprite(dpi, text, info);
+        TTFDrawStringRawSprite(rt, text, info);
         return;
     }
 
@@ -528,21 +528,21 @@ static void TTFDrawStringRawTTF(RenderTarget& dpi, std::string_view text, TextDr
     if (surface == nullptr)
         return;
 
-    auto drawingEngine = dpi.DrawingEngine;
+    auto drawingEngine = rt.DrawingEngine;
     if (drawingEngine != nullptr)
     {
         int32_t drawX = info->x + fontDesc->offset_x;
         int32_t drawY = info->y + fontDesc->offset_y;
         uint8_t hintThresh = Config::Get().fonts.EnableHinting ? fontDesc->hinting_threshold : 0;
         OpenRCT2::Drawing::IDrawingContext* dc = drawingEngine->GetDrawingContext();
-        dc->DrawTTFBitmap(dpi, info, surface, drawX, drawY, hintThresh);
+        dc->DrawTTFBitmap(rt, info, surface, drawX, drawY, hintThresh);
     }
     info->x += surface->w;
 }
 
 #endif // DISABLE_TTF
 
-static void TTFProcessFormatCode(RenderTarget& dpi, const FmtString::Token& token, TextDrawInfo* info)
+static void TTFProcessFormatCode(RenderTarget& rt, const FmtString::Token& token, TextDrawInfo* info)
 {
     switch (token.kind)
     {
@@ -598,7 +598,7 @@ static void TTFProcessFormatCode(RenderTarget& dpi, const FmtString::Token& toke
             {
                 if (!(info->flags & TEXT_DRAW_FLAG_NO_DRAW))
                 {
-                    GfxDrawSprite(dpi, imageId, { info->x, info->y });
+                    GfxDrawSprite(rt, imageId, { info->x, info->y });
                 }
                 info->x += g1->width;
             }
@@ -646,7 +646,7 @@ static bool ShouldUseSpriteForCodepoint(char32_t codepoint)
 }
 #endif // DISABLE_TTF
 
-static void TTFProcessStringLiteral(RenderTarget& dpi, std::string_view text, TextDrawInfo* info)
+static void TTFProcessStringLiteral(RenderTarget& rt, std::string_view text, TextDrawInfo* info)
 {
 #ifndef DISABLE_TTF
     bool isTTF = info->flags & TEXT_DRAW_FLAG_TTF;
@@ -656,7 +656,7 @@ static void TTFProcessStringLiteral(RenderTarget& dpi, std::string_view text, Te
 
     if (!isTTF)
     {
-        TTFDrawStringRawSprite(dpi, text, info);
+        TTFDrawStringRawSprite(rt, text, info);
     }
 #ifndef DISABLE_TTF
     else
@@ -679,7 +679,7 @@ static void TTFProcessStringLiteral(RenderTarget& dpi, std::string_view text, Te
         #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
     #endif
                     auto len = it.GetIndex() - ttfRunIndex.value();
-                    TTFDrawStringRawTTF(dpi, text.substr(ttfRunIndex.value(), len), info);
+                    TTFDrawStringRawTTF(rt, text.substr(ttfRunIndex.value(), len), info);
     #if defined(__GNUC__) && !defined(__clang__)
         #pragma GCC diagnostic pop
     #endif
@@ -687,7 +687,7 @@ static void TTFProcessStringLiteral(RenderTarget& dpi, std::string_view text, Te
                 }
 
                 // Draw the sprite font glyph
-                TTFDrawCharacterSprite(dpi, codepoint, info);
+                TTFDrawCharacterSprite(rt, codepoint, info);
             }
             else
             {
@@ -702,24 +702,24 @@ static void TTFProcessStringLiteral(RenderTarget& dpi, std::string_view text, Te
         {
             // Final TTF run
             auto len = text.size() - *ttfRunIndex;
-            TTFDrawStringRawTTF(dpi, text.substr(ttfRunIndex.value(), len), info);
+            TTFDrawStringRawTTF(rt, text.substr(ttfRunIndex.value(), len), info);
         }
     }
 #endif // DISABLE_TTF
 }
 
-static void TTFProcessStringCodepoint(RenderTarget& dpi, codepoint_t codepoint, TextDrawInfo* info)
+static void TTFProcessStringCodepoint(RenderTarget& rt, codepoint_t codepoint, TextDrawInfo* info)
 {
     char buffer[8]{};
     UTF8WriteCodepoint(buffer, codepoint);
-    TTFProcessStringLiteral(dpi, buffer, info);
+    TTFProcessStringLiteral(rt, buffer, info);
 }
 
-static void TTFProcessString(RenderTarget& dpi, std::string_view text, TextDrawInfo* info)
+static void TTFProcessString(RenderTarget& rt, std::string_view text, TextDrawInfo* info)
 {
     if (info->flags & TEXT_DRAW_FLAG_NO_FORMATTING)
     {
-        TTFProcessStringLiteral(dpi, text, info);
+        TTFProcessStringLiteral(rt, text, info);
         info->maxX = std::max(info->maxX, info->x);
         info->maxY = std::max(info->maxY, info->y);
     }
@@ -730,16 +730,16 @@ static void TTFProcessString(RenderTarget& dpi, std::string_view text, TextDrawI
         {
             if (token.IsLiteral())
             {
-                TTFProcessStringLiteral(dpi, token.text, info);
+                TTFProcessStringLiteral(rt, token.text, info);
             }
             else if (token.IsCodepoint())
             {
                 auto codepoint = token.GetCodepoint();
-                TTFProcessStringCodepoint(dpi, codepoint, info);
+                TTFProcessStringCodepoint(rt, codepoint, info);
             }
             else
             {
-                TTFProcessFormatCode(dpi, token, info);
+                TTFProcessFormatCode(rt, token, info);
             }
             info->maxX = std::max(info->maxX, info->x);
             info->maxY = std::max(info->maxY, info->y);
@@ -801,7 +801,7 @@ static void TTFProcessInitialColour(ColourWithFlags colour, TextDrawInfo* info)
 }
 
 void TTFDrawString(
-    RenderTarget& dpi, const_utf8string text, ColourWithFlags colour, const ScreenCoordsXY& coords, bool noFormatting,
+    RenderTarget& rt, const_utf8string text, ColourWithFlags colour, const ScreenCoordsXY& coords, bool noFormatting,
     FontStyle fontStyle, TextDarkness darkness)
 {
     if (text == nullptr)
@@ -836,10 +836,10 @@ void TTFDrawString(
 
     std::memcpy(info.palette, gTextPalette, sizeof(info.palette));
     TTFProcessInitialColour(colour, &info);
-    TTFProcessString(dpi, text, &info);
+    TTFProcessString(rt, text, &info);
     std::memcpy(gTextPalette, info.palette, sizeof(info.palette));
 
-    dpi.lastStringPos = { info.x, info.y };
+    rt.lastStringPos = { info.x, info.y };
 }
 
 static int32_t TTFGetStringWidth(std::string_view text, FontStyle fontStyle, bool noFormatting)
@@ -876,7 +876,7 @@ static int32_t TTFGetStringWidth(std::string_view text, FontStyle fontStyle, boo
  *  rct2: 0x00682F28
  */
 void GfxDrawStringWithYOffsets(
-    RenderTarget& dpi, const utf8* text, ColourWithFlags colour, const ScreenCoordsXY& coords, const int8_t* yOffsets,
+    RenderTarget& rt, const utf8* text, ColourWithFlags colour, const ScreenCoordsXY& coords, const int8_t* yOffsets,
     bool forceSpriteFont, FontStyle fontStyle)
 {
     TextDrawInfo info;
@@ -897,10 +897,10 @@ void GfxDrawStringWithYOffsets(
 
     std::memcpy(info.palette, gTextPalette, sizeof(info.palette));
     TTFProcessInitialColour(colour, &info);
-    TTFProcessString(dpi, text, &info);
+    TTFProcessString(rt, text, &info);
     std::memcpy(gTextPalette, info.palette, sizeof(info.palette));
 
-    dpi.lastStringPos = { info.x, info.y };
+    rt.lastStringPos = { info.x, info.y };
 }
 
 u8string ShortenPath(const u8string& path, int32_t availableWidth, FontStyle fontStyle)

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -259,7 +259,7 @@ int32_t GfxWrapString(u8string_view text, int32_t width, FontStyle fontStyle, u8
  * Draws text that is left aligned and vertically centred.
  */
 void GfxDrawStringLeftCentred(
-    DrawPixelInfo& dpi, StringId format, void* args, ColourWithFlags colour, const ScreenCoordsXY& coords)
+    RenderTarget& dpi, StringId format, void* args, ColourWithFlags colour, const ScreenCoordsXY& coords)
 {
     char buffer[512];
     auto bufferPtr = buffer;
@@ -323,7 +323,7 @@ static void ColourCharacterWindow(colour_t colour, const uint16_t* current_font_
  * dpi      : edi
  */
 void DrawStringCentredRaw(
-    DrawPixelInfo& dpi, const ScreenCoordsXY& coords, int32_t numLines, const utf8* text, FontStyle fontStyle)
+    RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t numLines, const utf8* text, FontStyle fontStyle)
 {
     ScreenCoordsXY screenCoords(dpi.x, dpi.y);
     DrawText(dpi, screenCoords, { COLOUR_BLACK, fontStyle }, "");
@@ -418,7 +418,7 @@ int32_t StringGetHeightRaw(std::string_view text, FontStyle fontStyle)
  * ticks    : ebp >> 16
  */
 void DrawNewsTicker(
-    DrawPixelInfo& dpi, const ScreenCoordsXY& coords, int32_t width, colour_t colour, StringId format, u8string_view args,
+    RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, colour_t colour, StringId format, u8string_view args,
     int32_t ticks)
 {
     int32_t numLines, lineHeight, lineY;
@@ -475,7 +475,7 @@ void DrawNewsTicker(
     }
 }
 
-static void TTFDrawCharacterSprite(DrawPixelInfo& dpi, int32_t codepoint, TextDrawInfo* info)
+static void TTFDrawCharacterSprite(RenderTarget& dpi, int32_t codepoint, TextDrawInfo* info)
 {
     int32_t characterWidth = FontSpriteGetCodepointWidth(info->FontStyle, codepoint);
     auto sprite = FontSpriteGetCodepointSprite(info->FontStyle, codepoint);
@@ -495,7 +495,7 @@ static void TTFDrawCharacterSprite(DrawPixelInfo& dpi, int32_t codepoint, TextDr
     info->x += characterWidth;
 }
 
-static void TTFDrawStringRawSprite(DrawPixelInfo& dpi, std::string_view text, TextDrawInfo* info)
+static void TTFDrawStringRawSprite(RenderTarget& dpi, std::string_view text, TextDrawInfo* info)
 {
     CodepointView codepoints(text);
     for (auto codepoint : codepoints)
@@ -506,7 +506,7 @@ static void TTFDrawStringRawSprite(DrawPixelInfo& dpi, std::string_view text, Te
 
 #ifndef DISABLE_TTF
 
-static void TTFDrawStringRawTTF(DrawPixelInfo& dpi, std::string_view text, TextDrawInfo* info)
+static void TTFDrawStringRawTTF(RenderTarget& dpi, std::string_view text, TextDrawInfo* info)
 {
     if (!TTFInitialise())
         return;
@@ -542,7 +542,7 @@ static void TTFDrawStringRawTTF(DrawPixelInfo& dpi, std::string_view text, TextD
 
 #endif // DISABLE_TTF
 
-static void TTFProcessFormatCode(DrawPixelInfo& dpi, const FmtString::Token& token, TextDrawInfo* info)
+static void TTFProcessFormatCode(RenderTarget& dpi, const FmtString::Token& token, TextDrawInfo* info)
 {
     switch (token.kind)
     {
@@ -646,7 +646,7 @@ static bool ShouldUseSpriteForCodepoint(char32_t codepoint)
 }
 #endif // DISABLE_TTF
 
-static void TTFProcessStringLiteral(DrawPixelInfo& dpi, std::string_view text, TextDrawInfo* info)
+static void TTFProcessStringLiteral(RenderTarget& dpi, std::string_view text, TextDrawInfo* info)
 {
 #ifndef DISABLE_TTF
     bool isTTF = info->flags & TEXT_DRAW_FLAG_TTF;
@@ -708,14 +708,14 @@ static void TTFProcessStringLiteral(DrawPixelInfo& dpi, std::string_view text, T
 #endif // DISABLE_TTF
 }
 
-static void TTFProcessStringCodepoint(DrawPixelInfo& dpi, codepoint_t codepoint, TextDrawInfo* info)
+static void TTFProcessStringCodepoint(RenderTarget& dpi, codepoint_t codepoint, TextDrawInfo* info)
 {
     char buffer[8]{};
     UTF8WriteCodepoint(buffer, codepoint);
     TTFProcessStringLiteral(dpi, buffer, info);
 }
 
-static void TTFProcessString(DrawPixelInfo& dpi, std::string_view text, TextDrawInfo* info)
+static void TTFProcessString(RenderTarget& dpi, std::string_view text, TextDrawInfo* info)
 {
     if (info->flags & TEXT_DRAW_FLAG_NO_FORMATTING)
     {
@@ -801,7 +801,7 @@ static void TTFProcessInitialColour(ColourWithFlags colour, TextDrawInfo* info)
 }
 
 void TTFDrawString(
-    DrawPixelInfo& dpi, const_utf8string text, ColourWithFlags colour, const ScreenCoordsXY& coords, bool noFormatting,
+    RenderTarget& dpi, const_utf8string text, ColourWithFlags colour, const ScreenCoordsXY& coords, bool noFormatting,
     FontStyle fontStyle, TextDarkness darkness)
 {
     if (text == nullptr)
@@ -865,7 +865,7 @@ static int32_t TTFGetStringWidth(std::string_view text, FontStyle fontStyle, boo
         info.flags |= TEXT_DRAW_FLAG_NO_FORMATTING;
     }
 
-    DrawPixelInfo dummy{};
+    RenderTarget dummy{};
     TTFProcessString(dummy, text, &info);
 
     return info.maxX;
@@ -876,7 +876,7 @@ static int32_t TTFGetStringWidth(std::string_view text, FontStyle fontStyle, boo
  *  rct2: 0x00682F28
  */
 void GfxDrawStringWithYOffsets(
-    DrawPixelInfo& dpi, const utf8* text, ColourWithFlags colour, const ScreenCoordsXY& coords, const int8_t* yOffsets,
+    RenderTarget& dpi, const utf8* text, ColourWithFlags colour, const ScreenCoordsXY& coords, const int8_t* yOffsets,
     bool forceSpriteFont, FontStyle fontStyle)
 {
     TextDrawInfo info;

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -678,7 +678,7 @@ void MaskFn(
     MaskFunc(width, height, maskSrc, colourSrc, dst, maskWrap, colourWrap, dstWrap);
 }
 
-void GfxFilterPixel(DrawPixelInfo& dpi, const ScreenCoordsXY& coords, FilterPaletteID palette)
+void GfxFilterPixel(RenderTarget& dpi, const ScreenCoordsXY& coords, FilterPaletteID palette)
 {
     GfxFilterRect(dpi, { coords, coords }, palette);
 }
@@ -770,7 +770,7 @@ void GfxInvalidateScreen()
  * height (dx)
  * drawpixelinfo (edi)
  */
-bool ClipDrawPixelInfo(DrawPixelInfo& dst, DrawPixelInfo& src, const ScreenCoordsXY& coords, int32_t width, int32_t height)
+bool ClipDrawPixelInfo(RenderTarget& dst, RenderTarget& src, const ScreenCoordsXY& coords, int32_t width, int32_t height)
 {
     assert(src.zoom_level == ZoomLevel{ 0 });
     int32_t right = coords.x + width;
@@ -837,7 +837,7 @@ void GfxInvalidatePickedUpPeep()
     }
 }
 
-void GfxDrawPickedUpPeep(DrawPixelInfo& dpi)
+void GfxDrawPickedUpPeep(RenderTarget& dpi)
 {
     if (gPickupPeepImage.HasValue())
     {
@@ -868,14 +868,14 @@ std::optional<PaletteMap> GetPaletteMapForColour(colour_t paletteId)
     return std::nullopt;
 }
 
-uint8_t* DrawPixelInfo::GetBitsOffset(const ScreenCoordsXY& pos) const
+uint8_t* RenderTarget::GetBitsOffset(const ScreenCoordsXY& pos) const
 {
     return bits + pos.x + pos.y * LineStride();
 }
 
-DrawPixelInfo DrawPixelInfo::Crop(const ScreenCoordsXY& pos, const ScreenSize& size) const
+RenderTarget RenderTarget::Crop(const ScreenCoordsXY& pos, const ScreenSize& size) const
 {
-    DrawPixelInfo result = *this;
+    RenderTarget result = *this;
     result.bits = GetBitsOffset(pos);
     result.x = pos.x;
     result.y = pos.y;
@@ -1117,7 +1117,7 @@ void ToggleWindowedMode()
     Config::Save();
 }
 
-void DebugDPI(DrawPixelInfo& dpi)
+void DebugDPI(RenderTarget& dpi)
 {
     ScreenCoordsXY topLeft = { dpi.x, dpi.y };
     ScreenCoordsXY bottomRight = { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 };

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -678,9 +678,9 @@ void MaskFn(
     MaskFunc(width, height, maskSrc, colourSrc, dst, maskWrap, colourWrap, dstWrap);
 }
 
-void GfxFilterPixel(RenderTarget& dpi, const ScreenCoordsXY& coords, FilterPaletteID palette)
+void GfxFilterPixel(RenderTarget& rt, const ScreenCoordsXY& coords, FilterPaletteID palette)
 {
-    GfxFilterRect(dpi, { coords, coords }, palette);
+    GfxFilterRect(rt, { coords, coords }, palette);
 }
 
 /**
@@ -837,11 +837,11 @@ void GfxInvalidatePickedUpPeep()
     }
 }
 
-void GfxDrawPickedUpPeep(RenderTarget& dpi)
+void GfxDrawPickedUpPeep(RenderTarget& rt)
 {
     if (gPickupPeepImage.HasValue())
     {
-        GfxDrawSprite(dpi, gPickupPeepImage, { gPickupPeepX, gPickupPeepY });
+        GfxDrawSprite(rt, gPickupPeepImage, { gPickupPeepX, gPickupPeepY });
     }
 }
 
@@ -1111,31 +1111,31 @@ void RefreshVideo()
 
 void ToggleWindowedMode()
 {
-    int32_t targetMode = Config::Get().general.FullscreenMode == 0 ? 2 : 0;
-    ContextSetFullscreenMode(targetMode);
-    Config::Get().general.FullscreenMode = targetMode;
+    int32_t rt = Config::Get().general.FullscreenMode == 0 ? 2 : 0;
+    ContextSetFullscreenMode(rt);
+    Config::Get().general.FullscreenMode = rt;
     Config::Save();
 }
 
-void DebugDPI(RenderTarget& dpi)
+void DebugDPI(RenderTarget& rt)
 {
-    ScreenCoordsXY topLeft = { dpi.x, dpi.y };
-    ScreenCoordsXY bottomRight = { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 };
-    ScreenCoordsXY topRight = { dpi.x + dpi.width - 1, dpi.y };
-    ScreenCoordsXY bottomLeft = { dpi.x, dpi.y + dpi.height - 1 };
+    ScreenCoordsXY topLeft = { rt.x, rt.y };
+    ScreenCoordsXY bottomRight = { rt.x + rt.width - 1, rt.y + rt.height - 1 };
+    ScreenCoordsXY topRight = { rt.x + rt.width - 1, rt.y };
+    ScreenCoordsXY bottomLeft = { rt.x, rt.y + rt.height - 1 };
 
-    GfxDrawLine(dpi, { topLeft, bottomRight }, PaletteIndex::pi136);
-    GfxDrawLine(dpi, { bottomLeft, topRight }, PaletteIndex::pi136);
-    GfxDrawLine(dpi, { topLeft, topRight }, PaletteIndex::pi129);
-    GfxDrawLine(dpi, { topRight, bottomRight }, PaletteIndex::pi129);
-    GfxDrawLine(dpi, { bottomLeft, bottomRight }, PaletteIndex::pi129);
-    GfxDrawLine(dpi, { topLeft, bottomLeft }, PaletteIndex::pi129);
+    GfxDrawLine(rt, { topLeft, bottomRight }, PaletteIndex::pi136);
+    GfxDrawLine(rt, { bottomLeft, topRight }, PaletteIndex::pi136);
+    GfxDrawLine(rt, { topLeft, topRight }, PaletteIndex::pi129);
+    GfxDrawLine(rt, { topRight, bottomRight }, PaletteIndex::pi129);
+    GfxDrawLine(rt, { bottomLeft, bottomRight }, PaletteIndex::pi129);
+    GfxDrawLine(rt, { topLeft, bottomLeft }, PaletteIndex::pi129);
 
-    GfxDrawLine(dpi, { topLeft, topLeft + ScreenCoordsXY{ 4, 0 } }, PaletteIndex::pi136);
+    GfxDrawLine(rt, { topLeft, topLeft + ScreenCoordsXY{ 4, 0 } }, PaletteIndex::pi136);
 
-    const auto str = std::to_string(dpi.x);
-    DrawText(dpi, ScreenCoordsXY{ dpi.x, dpi.y }, { COLOUR_WHITE, FontStyle::Tiny }, str.c_str());
+    const auto str = std::to_string(rt.x);
+    DrawText(rt, ScreenCoordsXY{ rt.x, rt.y }, { COLOUR_WHITE, FontStyle::Tiny }, str.c_str());
 
-    const auto str2 = std::to_string(dpi.y);
-    DrawText(dpi, ScreenCoordsXY{ dpi.x, dpi.y + 6 }, { COLOUR_WHITE, FontStyle::Tiny }, str2.c_str());
+    const auto str2 = std::to_string(rt.y);
+    DrawText(rt, ScreenCoordsXY{ rt.x, rt.y + 6 }, { COLOUR_WHITE, FontStyle::Tiny }, str2.c_str());
 }

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -517,21 +517,21 @@ void GfxTransposePalette(int32_t pal, uint8_t product);
 void LoadPalette();
 
 // other
-void GfxClear(RenderTarget& dpi, uint8_t paletteIndex);
-void GfxFilterPixel(RenderTarget& dpi, const ScreenCoordsXY& coords, FilterPaletteID palette);
+void GfxClear(RenderTarget& rt, uint8_t paletteIndex);
+void GfxFilterPixel(RenderTarget& rt, const ScreenCoordsXY& coords, FilterPaletteID palette);
 void GfxInvalidatePickedUpPeep();
-void GfxDrawPickedUpPeep(RenderTarget& dpi);
+void GfxDrawPickedUpPeep(RenderTarget& rt);
 
 // line
-void GfxDrawLine(RenderTarget& dpi, const ScreenLine& line, int32_t colour);
-void GfxDrawLineSoftware(RenderTarget& dpi, const ScreenLine& line, int32_t colour);
+void GfxDrawLine(RenderTarget& rt, const ScreenLine& line, int32_t colour);
+void GfxDrawLineSoftware(RenderTarget& rt, const ScreenLine& line, int32_t colour);
 void GfxDrawDashedLine(
-    RenderTarget& dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color);
+    RenderTarget& rt, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color);
 
 // rect
-void GfxFillRect(RenderTarget& dpi, const ScreenRect& rect, int32_t colour);
-void GfxFillRectInset(RenderTarget& dpi, const ScreenRect& rect, ColourWithFlags colour, uint8_t flags);
-void GfxFilterRect(RenderTarget& dpi, const ScreenRect& rect, FilterPaletteID palette);
+void GfxFillRect(RenderTarget& rt, const ScreenRect& rect, int32_t colour);
+void GfxFillRectInset(RenderTarget& rt, const ScreenRect& rect, ColourWithFlags colour, uint8_t flags);
+void GfxFilterRect(RenderTarget& rt, const ScreenRect& rect, FilterPaletteID palette);
 
 // sprite
 bool GfxLoadG1(const OpenRCT2::IPlatformEnvironment& env);
@@ -545,30 +545,30 @@ const G1Element* GfxGetG1Element(ImageIndex image_id);
 void GfxSetG1Element(ImageIndex imageId, const G1Element* g1);
 std::optional<Gx> GfxLoadGx(const std::vector<uint8_t>& buffer);
 bool IsCsgLoaded();
-void FASTCALL GfxSpriteToBuffer(RenderTarget& dpi, const DrawSpriteArgs& args);
-void FASTCALL GfxBmpSpriteToBuffer(RenderTarget& dpi, const DrawSpriteArgs& args);
-void FASTCALL GfxRleSpriteToBuffer(RenderTarget& dpi, const DrawSpriteArgs& args);
-void FASTCALL GfxDrawSprite(RenderTarget& dpi, const ImageId image_id, const ScreenCoordsXY& coords);
-void FASTCALL GfxDrawGlyph(RenderTarget& dpi, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
-void FASTCALL GfxDrawSpriteSolid(RenderTarget& dpi, const ImageId image, const ScreenCoordsXY& coords, uint8_t colour);
-void FASTCALL GfxDrawSpriteRawMasked(
-    RenderTarget& dpi, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage);
-void FASTCALL GfxDrawSpriteSoftware(RenderTarget& dpi, const ImageId imageId, const ScreenCoordsXY& spriteCoords);
+void FASTCALL GfxSpriteToBuffer(RenderTarget& rt, const DrawSpriteArgs& args);
+void FASTCALL GfxBmpSpriteToBuffer(RenderTarget& rt, const DrawSpriteArgs& args);
+void FASTCALL GfxRleSpriteToBuffer(RenderTarget& rt, const DrawSpriteArgs& args);
+void FASTCALL GfxDrawSprite(RenderTarget& rt, const ImageId image_id, const ScreenCoordsXY& coords);
+void FASTCALL GfxDrawGlyph(RenderTarget& rt, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
+void FASTCALL GfxDrawSpriteSolid(RenderTarget& rt, const ImageId image, const ScreenCoordsXY& coords, uint8_t colour);
+void FASTCALL
+    GfxDrawSpriteRawMasked(RenderTarget& rt, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage);
+void FASTCALL GfxDrawSpriteSoftware(RenderTarget& rt, const ImageId imageId, const ScreenCoordsXY& spriteCoords);
 void FASTCALL GfxDrawSpritePaletteSetSoftware(
-    RenderTarget& dpi, const ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
+    RenderTarget& rt, const ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
 void FASTCALL GfxDrawSpriteRawMaskedSoftware(
-    RenderTarget& dpi, const ScreenCoordsXY& scrCoords, const ImageId maskImage, const ImageId colourImage);
+    RenderTarget& rt, const ScreenCoordsXY& scrCoords, const ImageId maskImage, const ImageId colourImage);
 
 // string
 void GfxDrawStringLeftCentred(
-    RenderTarget& dpi, StringId format, void* args, ColourWithFlags colour, const ScreenCoordsXY& coords);
+    RenderTarget& rt, StringId format, void* args, ColourWithFlags colour, const ScreenCoordsXY& coords);
 void DrawStringCentredRaw(
-    RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t numLines, const utf8* text, FontStyle fontStyle);
+    RenderTarget& rt, const ScreenCoordsXY& coords, int32_t numLines, const utf8* text, FontStyle fontStyle);
 void DrawNewsTicker(
-    RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, colour_t colour, StringId format, u8string_view args,
+    RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, colour_t colour, StringId format, u8string_view args,
     int32_t ticks);
 void GfxDrawStringWithYOffsets(
-    RenderTarget& dpi, const utf8* text, ColourWithFlags colour, const ScreenCoordsXY& coords, const int8_t* yOffsets,
+    RenderTarget& rt, const utf8* text, ColourWithFlags colour, const ScreenCoordsXY& coords, const int8_t* yOffsets,
     bool forceSpriteFont, FontStyle fontStyle);
 
 int32_t GfxWrapString(u8string_view text, int32_t width, FontStyle fontStyle, u8string* outWrappedText, int32_t* outNumLines);
@@ -579,7 +579,7 @@ int32_t StringGetHeightRaw(std::string_view text, FontStyle fontStyle);
 int32_t GfxClipString(char* buffer, int32_t width, FontStyle fontStyle);
 u8string ShortenPath(const u8string& path, int32_t availableWidth, FontStyle fontStyle);
 void TTFDrawString(
-    RenderTarget& dpi, const_utf8string text, ColourWithFlags colour, const ScreenCoordsXY& coords, bool noFormatting,
+    RenderTarget& rt, const_utf8string text, ColourWithFlags colour, const ScreenCoordsXY& coords, bool noFormatting,
     FontStyle fontStyle, TextDarkness darkness);
 
 // scrolling text
@@ -615,6 +615,6 @@ void UpdatePaletteEffects();
 void RefreshVideo();
 void ToggleWindowedMode();
 
-void DebugDPI(RenderTarget& dpi);
+void DebugDPI(RenderTarget& rt);
 
 #include "NewDrawing.h"

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -68,7 +68,7 @@ struct Gx
     std::unique_ptr<uint8_t[]> data;
 };
 
-struct DrawPixelInfo
+struct RenderTarget
 {
     uint8_t* bits{};
     int32_t x{};
@@ -88,7 +88,7 @@ struct DrawPixelInfo
     OpenRCT2::Drawing::IDrawingEngine* DrawingEngine{};
 
     uint8_t* GetBitsOffset(const ScreenCoordsXY& pos) const;
-    DrawPixelInfo Crop(const ScreenCoordsXY& pos, const ScreenSize& size) const;
+    RenderTarget Crop(const ScreenCoordsXY& pos, const ScreenSize& size) const;
 
     [[nodiscard]] constexpr int32_t WorldX() const
     {
@@ -508,7 +508,7 @@ extern int32_t gPickupPeepY;
 
 extern bool gTinyFontAntiAliased;
 
-bool ClipDrawPixelInfo(DrawPixelInfo& dst, DrawPixelInfo& src, const ScreenCoordsXY& coords, int32_t width, int32_t height);
+bool ClipDrawPixelInfo(RenderTarget& dst, RenderTarget& src, const ScreenCoordsXY& coords, int32_t width, int32_t height);
 void GfxSetDirtyBlocks(const ScreenRect& rect);
 void GfxInvalidateScreen();
 
@@ -517,21 +517,21 @@ void GfxTransposePalette(int32_t pal, uint8_t product);
 void LoadPalette();
 
 // other
-void GfxClear(DrawPixelInfo& dpi, uint8_t paletteIndex);
-void GfxFilterPixel(DrawPixelInfo& dpi, const ScreenCoordsXY& coords, FilterPaletteID palette);
+void GfxClear(RenderTarget& dpi, uint8_t paletteIndex);
+void GfxFilterPixel(RenderTarget& dpi, const ScreenCoordsXY& coords, FilterPaletteID palette);
 void GfxInvalidatePickedUpPeep();
-void GfxDrawPickedUpPeep(DrawPixelInfo& dpi);
+void GfxDrawPickedUpPeep(RenderTarget& dpi);
 
 // line
-void GfxDrawLine(DrawPixelInfo& dpi, const ScreenLine& line, int32_t colour);
-void GfxDrawLineSoftware(DrawPixelInfo& dpi, const ScreenLine& line, int32_t colour);
+void GfxDrawLine(RenderTarget& dpi, const ScreenLine& line, int32_t colour);
+void GfxDrawLineSoftware(RenderTarget& dpi, const ScreenLine& line, int32_t colour);
 void GfxDrawDashedLine(
-    DrawPixelInfo& dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color);
+    RenderTarget& dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color);
 
 // rect
-void GfxFillRect(DrawPixelInfo& dpi, const ScreenRect& rect, int32_t colour);
-void GfxFillRectInset(DrawPixelInfo& dpi, const ScreenRect& rect, ColourWithFlags colour, uint8_t flags);
-void GfxFilterRect(DrawPixelInfo& dpi, const ScreenRect& rect, FilterPaletteID palette);
+void GfxFillRect(RenderTarget& dpi, const ScreenRect& rect, int32_t colour);
+void GfxFillRectInset(RenderTarget& dpi, const ScreenRect& rect, ColourWithFlags colour, uint8_t flags);
+void GfxFilterRect(RenderTarget& dpi, const ScreenRect& rect, FilterPaletteID palette);
 
 // sprite
 bool GfxLoadG1(const OpenRCT2::IPlatformEnvironment& env);
@@ -545,30 +545,30 @@ const G1Element* GfxGetG1Element(ImageIndex image_id);
 void GfxSetG1Element(ImageIndex imageId, const G1Element* g1);
 std::optional<Gx> GfxLoadGx(const std::vector<uint8_t>& buffer);
 bool IsCsgLoaded();
-void FASTCALL GfxSpriteToBuffer(DrawPixelInfo& dpi, const DrawSpriteArgs& args);
-void FASTCALL GfxBmpSpriteToBuffer(DrawPixelInfo& dpi, const DrawSpriteArgs& args);
-void FASTCALL GfxRleSpriteToBuffer(DrawPixelInfo& dpi, const DrawSpriteArgs& args);
-void FASTCALL GfxDrawSprite(DrawPixelInfo& dpi, const ImageId image_id, const ScreenCoordsXY& coords);
-void FASTCALL GfxDrawGlyph(DrawPixelInfo& dpi, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
-void FASTCALL GfxDrawSpriteSolid(DrawPixelInfo& dpi, const ImageId image, const ScreenCoordsXY& coords, uint8_t colour);
+void FASTCALL GfxSpriteToBuffer(RenderTarget& dpi, const DrawSpriteArgs& args);
+void FASTCALL GfxBmpSpriteToBuffer(RenderTarget& dpi, const DrawSpriteArgs& args);
+void FASTCALL GfxRleSpriteToBuffer(RenderTarget& dpi, const DrawSpriteArgs& args);
+void FASTCALL GfxDrawSprite(RenderTarget& dpi, const ImageId image_id, const ScreenCoordsXY& coords);
+void FASTCALL GfxDrawGlyph(RenderTarget& dpi, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
+void FASTCALL GfxDrawSpriteSolid(RenderTarget& dpi, const ImageId image, const ScreenCoordsXY& coords, uint8_t colour);
 void FASTCALL GfxDrawSpriteRawMasked(
-    DrawPixelInfo& dpi, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage);
-void FASTCALL GfxDrawSpriteSoftware(DrawPixelInfo& dpi, const ImageId imageId, const ScreenCoordsXY& spriteCoords);
+    RenderTarget& dpi, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage);
+void FASTCALL GfxDrawSpriteSoftware(RenderTarget& dpi, const ImageId imageId, const ScreenCoordsXY& spriteCoords);
 void FASTCALL GfxDrawSpritePaletteSetSoftware(
-    DrawPixelInfo& dpi, const ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
+    RenderTarget& dpi, const ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
 void FASTCALL GfxDrawSpriteRawMaskedSoftware(
-    DrawPixelInfo& dpi, const ScreenCoordsXY& scrCoords, const ImageId maskImage, const ImageId colourImage);
+    RenderTarget& dpi, const ScreenCoordsXY& scrCoords, const ImageId maskImage, const ImageId colourImage);
 
 // string
 void GfxDrawStringLeftCentred(
-    DrawPixelInfo& dpi, StringId format, void* args, ColourWithFlags colour, const ScreenCoordsXY& coords);
+    RenderTarget& dpi, StringId format, void* args, ColourWithFlags colour, const ScreenCoordsXY& coords);
 void DrawStringCentredRaw(
-    DrawPixelInfo& dpi, const ScreenCoordsXY& coords, int32_t numLines, const utf8* text, FontStyle fontStyle);
+    RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t numLines, const utf8* text, FontStyle fontStyle);
 void DrawNewsTicker(
-    DrawPixelInfo& dpi, const ScreenCoordsXY& coords, int32_t width, colour_t colour, StringId format, u8string_view args,
+    RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, colour_t colour, StringId format, u8string_view args,
     int32_t ticks);
 void GfxDrawStringWithYOffsets(
-    DrawPixelInfo& dpi, const utf8* text, ColourWithFlags colour, const ScreenCoordsXY& coords, const int8_t* yOffsets,
+    RenderTarget& dpi, const utf8* text, ColourWithFlags colour, const ScreenCoordsXY& coords, const int8_t* yOffsets,
     bool forceSpriteFont, FontStyle fontStyle);
 
 int32_t GfxWrapString(u8string_view text, int32_t width, FontStyle fontStyle, u8string* outWrappedText, int32_t* outNumLines);
@@ -579,7 +579,7 @@ int32_t StringGetHeightRaw(std::string_view text, FontStyle fontStyle);
 int32_t GfxClipString(char* buffer, int32_t width, FontStyle fontStyle);
 u8string ShortenPath(const u8string& path, int32_t availableWidth, FontStyle fontStyle);
 void TTFDrawString(
-    DrawPixelInfo& dpi, const_utf8string text, ColourWithFlags colour, const ScreenCoordsXY& coords, bool noFormatting,
+    RenderTarget& dpi, const_utf8string text, ColourWithFlags colour, const ScreenCoordsXY& coords, bool noFormatting,
     FontStyle fontStyle, TextDarkness darkness);
 
 // scrolling text
@@ -615,6 +615,6 @@ void UpdatePaletteEffects();
 void RefreshVideo();
 void ToggleWindowedMode();
 
-void DebugDPI(DrawPixelInfo& dpi);
+void DebugDPI(RenderTarget& dpi);
 
 #include "NewDrawing.h"

--- a/src/openrct2/drawing/IDrawingContext.h
+++ b/src/openrct2/drawing/IDrawingContext.h
@@ -20,21 +20,21 @@ namespace OpenRCT2::Drawing
     {
         virtual ~IDrawingContext() = default;
 
-        virtual void Clear(RenderTarget& dpi, uint8_t paletteIndex) = 0;
-        virtual void FillRect(RenderTarget& dpi, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom)
+        virtual void Clear(RenderTarget& rt, uint8_t paletteIndex) = 0;
+        virtual void FillRect(RenderTarget& rt, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom)
             = 0;
         virtual void FilterRect(
-            RenderTarget& dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom)
+            RenderTarget& rt, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom)
             = 0;
-        virtual void DrawLine(RenderTarget& dpi, uint32_t colour, const ScreenLine& line) = 0;
-        virtual void DrawSprite(RenderTarget& dpi, const ImageId image, int32_t x, int32_t y) = 0;
+        virtual void DrawLine(RenderTarget& rt, uint32_t colour, const ScreenLine& line) = 0;
+        virtual void DrawSprite(RenderTarget& rt, const ImageId image, int32_t x, int32_t y) = 0;
         virtual void DrawSpriteRawMasked(
-            RenderTarget& dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage)
+            RenderTarget& rt, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage)
             = 0;
-        virtual void DrawSpriteSolid(RenderTarget& dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) = 0;
-        virtual void DrawGlyph(RenderTarget& dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette) = 0;
+        virtual void DrawSpriteSolid(RenderTarget& rt, const ImageId image, int32_t x, int32_t y, uint8_t colour) = 0;
+        virtual void DrawGlyph(RenderTarget& rt, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette) = 0;
         virtual void DrawTTFBitmap(
-            RenderTarget& dpi, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y, uint8_t hintingThreshold)
+            RenderTarget& rt, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y, uint8_t hintingThreshold)
             = 0;
     };
 

--- a/src/openrct2/drawing/IDrawingContext.h
+++ b/src/openrct2/drawing/IDrawingContext.h
@@ -20,21 +20,21 @@ namespace OpenRCT2::Drawing
     {
         virtual ~IDrawingContext() = default;
 
-        virtual void Clear(DrawPixelInfo& dpi, uint8_t paletteIndex) = 0;
-        virtual void FillRect(DrawPixelInfo& dpi, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom)
+        virtual void Clear(RenderTarget& dpi, uint8_t paletteIndex) = 0;
+        virtual void FillRect(RenderTarget& dpi, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom)
             = 0;
         virtual void FilterRect(
-            DrawPixelInfo& dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom)
+            RenderTarget& dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom)
             = 0;
-        virtual void DrawLine(DrawPixelInfo& dpi, uint32_t colour, const ScreenLine& line) = 0;
-        virtual void DrawSprite(DrawPixelInfo& dpi, const ImageId image, int32_t x, int32_t y) = 0;
+        virtual void DrawLine(RenderTarget& dpi, uint32_t colour, const ScreenLine& line) = 0;
+        virtual void DrawSprite(RenderTarget& dpi, const ImageId image, int32_t x, int32_t y) = 0;
         virtual void DrawSpriteRawMasked(
-            DrawPixelInfo& dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage)
+            RenderTarget& dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage)
             = 0;
-        virtual void DrawSpriteSolid(DrawPixelInfo& dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) = 0;
-        virtual void DrawGlyph(DrawPixelInfo& dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette) = 0;
+        virtual void DrawSpriteSolid(RenderTarget& dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) = 0;
+        virtual void DrawGlyph(RenderTarget& dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette) = 0;
         virtual void DrawTTFBitmap(
-            DrawPixelInfo& dpi, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y, uint8_t hintingThreshold)
+            RenderTarget& dpi, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y, uint8_t hintingThreshold)
             = 0;
     };
 

--- a/src/openrct2/drawing/IDrawingContext.h
+++ b/src/openrct2/drawing/IDrawingContext.h
@@ -21,8 +21,7 @@ namespace OpenRCT2::Drawing
         virtual ~IDrawingContext() = default;
 
         virtual void Clear(RenderTarget& rt, uint8_t paletteIndex) = 0;
-        virtual void FillRect(RenderTarget& rt, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom)
-            = 0;
+        virtual void FillRect(RenderTarget& rt, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom) = 0;
         virtual void FilterRect(
             RenderTarget& rt, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom)
             = 0;

--- a/src/openrct2/drawing/IDrawingEngine.h
+++ b/src/openrct2/drawing/IDrawingEngine.h
@@ -90,7 +90,7 @@ namespace OpenRCT2::Drawing
     {
         virtual ~IWeatherDrawer() = default;
         virtual void Draw(
-            RenderTarget& dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
+            RenderTarget& rt, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
             const uint8_t* weatherpattern)
             = 0;
     };

--- a/src/openrct2/drawing/IDrawingEngine.h
+++ b/src/openrct2/drawing/IDrawingEngine.h
@@ -38,7 +38,7 @@ enum DrawingEngineFlag
 };
 using DrawingEngineFlags = FlagHolder<uint8_t, DrawingEngineFlag>;
 
-struct DrawPixelInfo;
+struct RenderTarget;
 
 namespace OpenRCT2::Ui
 {
@@ -70,7 +70,7 @@ namespace OpenRCT2::Drawing
         virtual std::string Screenshot() = 0;
 
         virtual IDrawingContext* GetDrawingContext() = 0;
-        virtual DrawPixelInfo* GetDrawingPixelInfo() = 0;
+        virtual RenderTarget* GetDrawingPixelInfo() = 0;
 
         virtual DrawingEngineFlags GetFlags() = 0;
 
@@ -90,7 +90,7 @@ namespace OpenRCT2::Drawing
     {
         virtual ~IWeatherDrawer() = default;
         virtual void Draw(
-            DrawPixelInfo& dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
+            RenderTarget& dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
             const uint8_t* weatherpattern)
             = 0;
     };

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -39,7 +39,7 @@ namespace OpenRCT2::Drawing::LightFx
     static uint8_t _bakedLightTexture_spot_1[64 * 64];
     static uint8_t _bakedLightTexture_spot_2[128 * 128];
     static uint8_t _bakedLightTexture_spot_3[256 * 256];
-    static DrawPixelInfo _pixelInfo;
+    static RenderTarget _pixelInfo;
     static bool _lightfxAvailable = false;
 
     static void* _light_rendered_buffer_back = nullptr;
@@ -182,7 +182,7 @@ namespace OpenRCT2::Drawing::LightFx
         CalcRescaleLightHalf(_bakedLightTexture_spot_0, _bakedLightTexture_spot_1, 32, 32);
     }
 
-    void UpdateBuffers(DrawPixelInfo& info)
+    void UpdateBuffers(RenderTarget& info)
     {
         _light_rendered_buffer_front = realloc(_light_rendered_buffer_front, info.width * info.height);
         _light_rendered_buffer_back = realloc(_light_rendered_buffer_back, info.width * info.height);
@@ -298,7 +298,7 @@ namespace OpenRCT2::Drawing::LightFx
                     if (w != nullptr)
                     {
                         // based on GetMapCoordinatesFromPosWindow
-                        DrawPixelInfo dpi;
+                        RenderTarget dpi;
                         dpi.zoom_level = _current_view_zoom_front;
                         dpi.x = _current_view_zoom_front.ApplyInversedTo(entry.viewCoords.x + offsetPattern[0 + pat * 2]);
                         dpi.y = _current_view_zoom_front.ApplyInversedTo(entry.viewCoords.y + offsetPattern[1 + pat * 2]);

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -298,26 +298,26 @@ namespace OpenRCT2::Drawing::LightFx
                     if (w != nullptr)
                     {
                         // based on GetMapCoordinatesFromPosWindow
-                        RenderTarget dpi;
-                        dpi.zoom_level = _current_view_zoom_front;
-                        dpi.x = _current_view_zoom_front.ApplyInversedTo(entry.viewCoords.x + offsetPattern[0 + pat * 2]);
-                        dpi.y = _current_view_zoom_front.ApplyInversedTo(entry.viewCoords.y + offsetPattern[1 + pat * 2]);
-                        dpi.height = 1;
-                        dpi.width = 1;
+                        RenderTarget rt;
+                        rt.zoom_level = _current_view_zoom_front;
+                        rt.x = _current_view_zoom_front.ApplyInversedTo(entry.viewCoords.x + offsetPattern[0 + pat * 2]);
+                        rt.y = _current_view_zoom_front.ApplyInversedTo(entry.viewCoords.y + offsetPattern[1 + pat * 2]);
+                        rt.height = 1;
+                        rt.width = 1;
 
-                        dpi.cullingX = dpi.x;
-                        dpi.cullingY = dpi.y;
-                        dpi.cullingWidth = dpi.width;
-                        dpi.cullingHeight = dpi.height;
+                        rt.cullingX = rt.x;
+                        rt.cullingY = rt.y;
+                        rt.cullingWidth = rt.width;
+                        rt.cullingHeight = rt.height;
 
-                        PaintSession* session = PaintSessionAlloc(dpi, w->viewport->flags, w->viewport->rotation);
+                        PaintSession* session = PaintSessionAlloc(rt, w->viewport->flags, w->viewport->rotation);
                         PaintSessionGenerate(*session);
                         PaintSessionArrange(*session);
                         auto info = SetInteractionInfoFromPaintSession(
                             session, w->viewport->flags, kViewportInteractionItemAll);
                         PaintSessionFree(session);
 
-                        //  LOG_WARNING("[%i, %i]", dpi->x, dpi->y);
+                        //  LOG_WARNING("[%i, %i]", rt.x, rt.y);
 
                         mapCoord = info.Loc;
                         mapCoord.x += tileOffsetX;

--- a/src/openrct2/drawing/LightFX.h
+++ b/src/openrct2/drawing/LightFX.h
@@ -15,7 +15,7 @@
 
 struct CoordsXY;
 struct Vehicle;
-struct DrawPixelInfo;
+struct RenderTarget;
 struct CoordsXYZ;
 struct EntityBase;
 
@@ -51,7 +51,7 @@ namespace OpenRCT2::Drawing::LightFx
 
     void Init();
 
-    void UpdateBuffers(DrawPixelInfo&);
+    void UpdateBuffers(RenderTarget&);
 
     void PrepareLightList();
     void SwapBuffers();

--- a/src/openrct2/drawing/Line.cpp
+++ b/src/openrct2/drawing/Line.cpp
@@ -16,7 +16,7 @@
  * Draws a horizontal line of specified colour to a buffer.
  *  rct2: 0x0068474C
  */
-static void GfxDrawLineOnBuffer(DrawPixelInfo& dpi, char colour, const ScreenCoordsXY& coords, int32_t no_pixels)
+static void GfxDrawLineOnBuffer(RenderTarget& dpi, char colour, const ScreenCoordsXY& coords, int32_t no_pixels)
 {
     ScreenCoordsXY offset{ coords.x - dpi.x, coords.y - dpi.y };
 
@@ -74,7 +74,7 @@ static void GfxDrawLineOnBuffer(DrawPixelInfo& dpi, char colour, const ScreenCoo
  * colour (ebp)
  */
 
-void GfxDrawLineSoftware(DrawPixelInfo& dpi, const ScreenLine& line, int32_t colour)
+void GfxDrawLineSoftware(RenderTarget& dpi, const ScreenLine& line, int32_t colour)
 {
     const ZoomLevel zoom = dpi.zoom_level;
     int32_t x1 = zoom.ApplyInversedTo(line.GetX1());

--- a/src/openrct2/drawing/Line.cpp
+++ b/src/openrct2/drawing/Line.cpp
@@ -16,12 +16,12 @@
  * Draws a horizontal line of specified colour to a buffer.
  *  rct2: 0x0068474C
  */
-static void GfxDrawLineOnBuffer(RenderTarget& dpi, char colour, const ScreenCoordsXY& coords, int32_t no_pixels)
+static void GfxDrawLineOnBuffer(RenderTarget& rt, char colour, const ScreenCoordsXY& coords, int32_t no_pixels)
 {
-    ScreenCoordsXY offset{ coords.x - dpi.x, coords.y - dpi.y };
+    ScreenCoordsXY offset{ coords.x - rt.x, coords.y - rt.y };
 
-    const int32_t width = dpi.width;
-    const int32_t height = dpi.height;
+    const int32_t width = rt.width;
+    const int32_t height = rt.height;
 
     // Check to make sure point is in the y range
     if (offset.y < 0)
@@ -54,7 +54,7 @@ static void GfxDrawLineOnBuffer(RenderTarget& dpi, char colour, const ScreenCoor
     }
 
     // Get the buffer we are drawing to and move to the first coordinate.
-    uint8_t* bits_pointer = dpi.bits + offset.y * dpi.LineStride() + offset.x;
+    uint8_t* bits_pointer = rt.bits + offset.y * rt.LineStride() + offset.x;
 
     // Draw the line to the specified colour
     for (; no_pixels > 0; --no_pixels, ++bits_pointer)
@@ -74,30 +74,30 @@ static void GfxDrawLineOnBuffer(RenderTarget& dpi, char colour, const ScreenCoor
  * colour (ebp)
  */
 
-void GfxDrawLineSoftware(RenderTarget& dpi, const ScreenLine& line, int32_t colour)
+void GfxDrawLineSoftware(RenderTarget& rt, const ScreenLine& line, int32_t colour)
 {
-    const ZoomLevel zoom = dpi.zoom_level;
+    const ZoomLevel zoom = rt.zoom_level;
     int32_t x1 = zoom.ApplyInversedTo(line.GetX1());
     int32_t x2 = zoom.ApplyInversedTo(line.GetX2());
     int32_t y1 = zoom.ApplyInversedTo(line.GetY1());
     int32_t y2 = zoom.ApplyInversedTo(line.GetY2());
     // Check to make sure the line is within the drawing area
-    if ((x1 < dpi.x) && (x2 < dpi.x))
+    if ((x1 < rt.x) && (x2 < rt.x))
     {
         return;
     }
 
-    if ((y1 < dpi.y) && (y2 < dpi.y))
+    if ((y1 < rt.y) && (y2 < rt.y))
     {
         return;
     }
 
-    if ((x1 > (dpi.x + dpi.width)) && (x2 > (dpi.x + dpi.width)))
+    if ((x1 > (rt.x + rt.width)) && (x2 > (rt.x + rt.width)))
     {
         return;
     }
 
-    if ((y1 > (dpi.y + dpi.height)) && (y2 > (dpi.y + dpi.height)))
+    if ((y1 > (rt.y + rt.height)) && (y2 > (rt.y + rt.height)))
     {
         return;
     }
@@ -143,14 +143,14 @@ void GfxDrawLineSoftware(RenderTarget& dpi, const ScreenLine& line, int32_t colo
     {
         // Vertical lines are drawn 1 pixel at a time
         if (steep)
-            GfxDrawLineOnBuffer(dpi, colour, { y, x }, 1);
+            GfxDrawLineOnBuffer(rt, colour, { y, x }, 1);
 
         error -= delta_y;
         if (error < 0)
         {
             // Non vertical lines are drawn with as many pixels in a horizontal line as possible
             if (!steep)
-                GfxDrawLineOnBuffer(dpi, colour, { x_start, y }, length);
+                GfxDrawLineOnBuffer(rt, colour, { x_start, y }, length);
 
             // Reset non vertical line vars
             x_start = x + 1;
@@ -162,7 +162,7 @@ void GfxDrawLineSoftware(RenderTarget& dpi, const ScreenLine& line, int32_t colo
         // Catch the case of the last line
         if (x + 1 == x2 && !steep)
         {
-            GfxDrawLineOnBuffer(dpi, colour, { x_start, y }, length);
+            GfxDrawLineOnBuffer(rt, colour, { x_start, y }, length);
         }
     }
 }

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -109,7 +109,7 @@ void DrawingEngineDispose()
     }
 }
 
-DrawPixelInfo& DrawingEngineGetDpi()
+RenderTarget& DrawingEngineGetDpi()
 {
     auto context = GetContext();
     auto drawingEngine = context->GetDrawingEngine();
@@ -154,7 +154,7 @@ void GfxSetDirtyBlocks(const ScreenRect& rect)
     }
 }
 
-void GfxClear(DrawPixelInfo& dpi, uint8_t paletteIndex)
+void GfxClear(RenderTarget& dpi, uint8_t paletteIndex)
 {
     auto drawingEngine = dpi.DrawingEngine;
     if (drawingEngine != nullptr)
@@ -164,7 +164,7 @@ void GfxClear(DrawPixelInfo& dpi, uint8_t paletteIndex)
     }
 }
 
-void GfxFillRect(DrawPixelInfo& dpi, const ScreenRect& rect, int32_t colour)
+void GfxFillRect(RenderTarget& dpi, const ScreenRect& rect, int32_t colour)
 {
     auto drawingEngine = dpi.DrawingEngine;
     if (drawingEngine != nullptr)
@@ -174,7 +174,7 @@ void GfxFillRect(DrawPixelInfo& dpi, const ScreenRect& rect, int32_t colour)
     }
 }
 
-void GfxFilterRect(DrawPixelInfo& dpi, const ScreenRect& rect, FilterPaletteID palette)
+void GfxFilterRect(RenderTarget& dpi, const ScreenRect& rect, FilterPaletteID palette)
 {
     auto drawingEngine = dpi.DrawingEngine;
     if (drawingEngine != nullptr)
@@ -184,7 +184,7 @@ void GfxFilterRect(DrawPixelInfo& dpi, const ScreenRect& rect, FilterPaletteID p
     }
 }
 
-void GfxDrawLine(DrawPixelInfo& dpi, const ScreenLine& line, int32_t colour)
+void GfxDrawLine(RenderTarget& dpi, const ScreenLine& line, int32_t colour)
 {
     auto drawingEngine = dpi.DrawingEngine;
     if (drawingEngine != nullptr)
@@ -195,7 +195,7 @@ void GfxDrawLine(DrawPixelInfo& dpi, const ScreenLine& line, int32_t colour)
 }
 
 void GfxDrawDashedLine(
-    DrawPixelInfo& dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color)
+    RenderTarget& dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color)
 {
     assert(dashedLineSegmentLength > 0);
 
@@ -227,7 +227,7 @@ void GfxDrawDashedLine(
     }
 }
 
-void FASTCALL GfxDrawSprite(DrawPixelInfo& dpi, const ImageId imageId, const ScreenCoordsXY& coords)
+void FASTCALL GfxDrawSprite(RenderTarget& dpi, const ImageId imageId, const ScreenCoordsXY& coords)
 {
     auto drawingEngine = dpi.DrawingEngine;
     if (drawingEngine != nullptr)
@@ -237,7 +237,7 @@ void FASTCALL GfxDrawSprite(DrawPixelInfo& dpi, const ImageId imageId, const Scr
     }
 }
 
-void FASTCALL GfxDrawGlyph(DrawPixelInfo& dpi, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
+void FASTCALL GfxDrawGlyph(RenderTarget& dpi, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
 {
     auto drawingEngine = dpi.DrawingEngine;
     if (drawingEngine != nullptr)
@@ -248,7 +248,7 @@ void FASTCALL GfxDrawGlyph(DrawPixelInfo& dpi, const ImageId image, const Screen
 }
 
 void FASTCALL
-    GfxDrawSpriteRawMasked(DrawPixelInfo& dpi, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage)
+    GfxDrawSpriteRawMasked(RenderTarget& dpi, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage)
 {
     auto drawingEngine = dpi.DrawingEngine;
     if (drawingEngine != nullptr)
@@ -258,7 +258,7 @@ void FASTCALL
     }
 }
 
-void FASTCALL GfxDrawSpriteSolid(DrawPixelInfo& dpi, const ImageId image, const ScreenCoordsXY& coords, uint8_t colour)
+void FASTCALL GfxDrawSpriteSolid(RenderTarget& dpi, const ImageId image, const ScreenCoordsXY& coords, uint8_t colour)
 {
     auto drawingEngine = dpi.DrawingEngine;
     if (drawingEngine != nullptr)

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -154,52 +154,52 @@ void GfxSetDirtyBlocks(const ScreenRect& rect)
     }
 }
 
-void GfxClear(RenderTarget& dpi, uint8_t paletteIndex)
+void GfxClear(RenderTarget& rt, uint8_t paletteIndex)
 {
-    auto drawingEngine = dpi.DrawingEngine;
+    auto drawingEngine = rt.DrawingEngine;
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext();
-        dc->Clear(dpi, paletteIndex);
+        dc->Clear(rt, paletteIndex);
     }
 }
 
-void GfxFillRect(RenderTarget& dpi, const ScreenRect& rect, int32_t colour)
+void GfxFillRect(RenderTarget& rt, const ScreenRect& rect, int32_t colour)
 {
-    auto drawingEngine = dpi.DrawingEngine;
+    auto drawingEngine = rt.DrawingEngine;
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext();
-        dc->FillRect(dpi, colour, rect.GetLeft(), rect.GetTop(), rect.GetRight(), rect.GetBottom());
+        dc->FillRect(rt, colour, rect.GetLeft(), rect.GetTop(), rect.GetRight(), rect.GetBottom());
     }
 }
 
-void GfxFilterRect(RenderTarget& dpi, const ScreenRect& rect, FilterPaletteID palette)
+void GfxFilterRect(RenderTarget& rt, const ScreenRect& rect, FilterPaletteID palette)
 {
-    auto drawingEngine = dpi.DrawingEngine;
+    auto drawingEngine = rt.DrawingEngine;
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext();
-        dc->FilterRect(dpi, palette, rect.GetLeft(), rect.GetTop(), rect.GetRight(), rect.GetBottom());
+        dc->FilterRect(rt, palette, rect.GetLeft(), rect.GetTop(), rect.GetRight(), rect.GetBottom());
     }
 }
 
-void GfxDrawLine(RenderTarget& dpi, const ScreenLine& line, int32_t colour)
+void GfxDrawLine(RenderTarget& rt, const ScreenLine& line, int32_t colour)
 {
-    auto drawingEngine = dpi.DrawingEngine;
+    auto drawingEngine = rt.DrawingEngine;
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext();
-        dc->DrawLine(dpi, colour, line);
+        dc->DrawLine(rt, colour, line);
     }
 }
 
 void GfxDrawDashedLine(
-    RenderTarget& dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color)
+    RenderTarget& rt, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color)
 {
     assert(dashedLineSegmentLength > 0);
 
-    const auto drawingEngine = dpi.DrawingEngine;
+    const auto drawingEngine = rt.DrawingEngine;
     if (drawingEngine != nullptr)
     {
         constexpr int32_t kPrecisionFactor = 1000;
@@ -222,49 +222,49 @@ void GfxDrawDashedLine(
         {
             x = screenLine.GetX1() + dxPrecise * i * 2 / kPrecisionFactor;
             y = screenLine.GetY1() + dyPrecise * i * 2 / kPrecisionFactor;
-            dc->DrawLine(dpi, color, { { x, y }, { x + dxPrecise / kPrecisionFactor, y + dyPrecise / kPrecisionFactor } });
+            dc->DrawLine(rt, color, { { x, y }, { x + dxPrecise / kPrecisionFactor, y + dyPrecise / kPrecisionFactor } });
         }
     }
 }
 
-void FASTCALL GfxDrawSprite(RenderTarget& dpi, const ImageId imageId, const ScreenCoordsXY& coords)
+void FASTCALL GfxDrawSprite(RenderTarget& rt, const ImageId imageId, const ScreenCoordsXY& coords)
 {
-    auto drawingEngine = dpi.DrawingEngine;
+    auto drawingEngine = rt.DrawingEngine;
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext();
-        dc->DrawSprite(dpi, imageId, coords.x, coords.y);
+        dc->DrawSprite(rt, imageId, coords.x, coords.y);
     }
 }
 
-void FASTCALL GfxDrawGlyph(RenderTarget& dpi, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
+void FASTCALL GfxDrawGlyph(RenderTarget& rt, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
 {
-    auto drawingEngine = dpi.DrawingEngine;
+    auto drawingEngine = rt.DrawingEngine;
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext();
-        dc->DrawGlyph(dpi, image, coords.x, coords.y, paletteMap);
+        dc->DrawGlyph(rt, image, coords.x, coords.y, paletteMap);
     }
 }
 
 void FASTCALL
-    GfxDrawSpriteRawMasked(RenderTarget& dpi, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage)
+    GfxDrawSpriteRawMasked(RenderTarget& rt, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage)
 {
-    auto drawingEngine = dpi.DrawingEngine;
+    auto drawingEngine = rt.DrawingEngine;
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext();
-        dc->DrawSpriteRawMasked(dpi, coords.x, coords.y, maskImage, colourImage);
+        dc->DrawSpriteRawMasked(rt, coords.x, coords.y, maskImage, colourImage);
     }
 }
 
-void FASTCALL GfxDrawSpriteSolid(RenderTarget& dpi, const ImageId image, const ScreenCoordsXY& coords, uint8_t colour)
+void FASTCALL GfxDrawSpriteSolid(RenderTarget& rt, const ImageId image, const ScreenCoordsXY& coords, uint8_t colour)
 {
-    auto drawingEngine = dpi.DrawingEngine;
+    auto drawingEngine = rt.DrawingEngine;
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext();
-        dc->DrawSpriteSolid(dpi, image, coords.x, coords.y, colour);
+        dc->DrawSpriteSolid(rt, image, coords.x, coords.y, colour);
     }
 }
 

--- a/src/openrct2/drawing/NewDrawing.h
+++ b/src/openrct2/drawing/NewDrawing.h
@@ -12,7 +12,7 @@
 #include "../localisation/StringIdType.h"
 #include "ColourPalette.h"
 
-struct DrawPixelInfo;
+struct RenderTarget;
 
 enum class DrawingEngine : int32_t;
 
@@ -24,7 +24,7 @@ void DrawingEngineSetPalette(const OpenRCT2::Drawing::GamePalette& colours);
 void DrawingEngineCopyRect(int32_t x, int32_t y, int32_t width, int32_t height, int32_t dx, int32_t dy);
 void DrawingEngineDispose();
 
-DrawPixelInfo& DrawingEngineGetDpi();
+RenderTarget& DrawingEngineGetDpi();
 bool DrawingEngineHasDirtyOptimisations();
 void DrawingEngineInvalidateImage(uint32_t image);
 void DrawingEngineSetVSync(bool vsync);

--- a/src/openrct2/drawing/Rect.cpp
+++ b/src/openrct2/drawing/Rect.cpp
@@ -23,7 +23,7 @@
  * colour (ebp)
  * flags (si)
  */
-void GfxFillRectInset(DrawPixelInfo& dpi, const ScreenRect& rect, ColourWithFlags colour, uint8_t flags)
+void GfxFillRectInset(RenderTarget& dpi, const ScreenRect& rect, ColourWithFlags colour, uint8_t flags)
 {
     const auto leftTop = ScreenCoordsXY{ rect.GetLeft(), rect.GetTop() };
     const auto leftBottom = ScreenCoordsXY{ rect.GetLeft(), rect.GetBottom() };

--- a/src/openrct2/drawing/Rect.cpp
+++ b/src/openrct2/drawing/Rect.cpp
@@ -23,7 +23,7 @@
  * colour (ebp)
  * flags (si)
  */
-void GfxFillRectInset(RenderTarget& dpi, const ScreenRect& rect, ColourWithFlags colour, uint8_t flags)
+void GfxFillRectInset(RenderTarget& rt, const ScreenRect& rect, ColourWithFlags colour, uint8_t flags)
 {
     const auto leftTop = ScreenCoordsXY{ rect.GetLeft(), rect.GetTop() };
     const auto leftBottom = ScreenCoordsXY{ rect.GetLeft(), rect.GetBottom() };
@@ -35,33 +35,33 @@ void GfxFillRectInset(RenderTarget& dpi, const ScreenRect& rect, ColourWithFlags
 
         if (flags & INSET_RECT_FLAG_BORDER_NONE)
         {
-            GfxFilterRect(dpi, rect, palette.base);
+            GfxFilterRect(rt, rect, palette.base);
         }
         else if (flags & INSET_RECT_FLAG_BORDER_INSET)
         {
             // Draw outline of box
-            GfxFilterRect(dpi, { leftTop, leftBottom }, palette.highlight);
-            GfxFilterRect(dpi, { leftTop, rightTop }, palette.highlight);
-            GfxFilterRect(dpi, { rightTop, rightBottom }, palette.shadow);
-            GfxFilterRect(dpi, { leftBottom, rightBottom }, palette.shadow);
+            GfxFilterRect(rt, { leftTop, leftBottom }, palette.highlight);
+            GfxFilterRect(rt, { leftTop, rightTop }, palette.highlight);
+            GfxFilterRect(rt, { rightTop, rightBottom }, palette.shadow);
+            GfxFilterRect(rt, { leftBottom, rightBottom }, palette.shadow);
 
             if (!(flags & INSET_RECT_FLAG_FILL_NONE))
             {
-                GfxFilterRect(dpi, { leftTop + ScreenCoordsXY{ 1, 1 }, rightBottom - ScreenCoordsXY{ 1, 1 } }, palette.base);
+                GfxFilterRect(rt, { leftTop + ScreenCoordsXY{ 1, 1 }, rightBottom - ScreenCoordsXY{ 1, 1 } }, palette.base);
             }
         }
         else
         {
             // Draw outline of box
-            GfxFilterRect(dpi, { leftTop, leftBottom }, palette.shadow);
-            GfxFilterRect(dpi, { leftTop, rightTop }, palette.shadow);
-            GfxFilterRect(dpi, { rightTop, rightBottom }, palette.highlight);
-            GfxFilterRect(dpi, { leftBottom, rightBottom }, palette.highlight);
+            GfxFilterRect(rt, { leftTop, leftBottom }, palette.shadow);
+            GfxFilterRect(rt, { leftTop, rightTop }, palette.shadow);
+            GfxFilterRect(rt, { rightTop, rightBottom }, palette.highlight);
+            GfxFilterRect(rt, { leftBottom, rightBottom }, palette.highlight);
 
             if (!(flags & INSET_RECT_FLAG_FILL_NONE))
             {
                 GfxFilterRect(
-                    dpi, { leftTop + ScreenCoordsXY{ 1, 1 }, { rightBottom - ScreenCoordsXY{ 1, 1 } } }, palette.base);
+                    rt, { leftTop + ScreenCoordsXY{ 1, 1 }, { rightBottom - ScreenCoordsXY{ 1, 1 } } }, palette.base);
             }
         }
     }
@@ -83,15 +83,15 @@ void GfxFillRectInset(RenderTarget& dpi, const ScreenRect& rect, ColourWithFlags
 
         if (flags & INSET_RECT_FLAG_BORDER_NONE)
         {
-            GfxFillRect(dpi, rect, fill);
+            GfxFillRect(rt, rect, fill);
         }
         else if (flags & INSET_RECT_FLAG_BORDER_INSET)
         {
             // Draw outline of box
-            GfxFillRect(dpi, { leftTop, leftBottom }, shadow);
-            GfxFillRect(dpi, { leftTop + ScreenCoordsXY{ 1, 0 }, rightTop }, shadow);
-            GfxFillRect(dpi, { rightTop + ScreenCoordsXY{ 0, 1 }, rightBottom - ScreenCoordsXY{ 0, 1 } }, hilight);
-            GfxFillRect(dpi, { leftBottom + ScreenCoordsXY{ 1, 0 }, rightBottom }, hilight);
+            GfxFillRect(rt, { leftTop, leftBottom }, shadow);
+            GfxFillRect(rt, { leftTop + ScreenCoordsXY{ 1, 0 }, rightTop }, shadow);
+            GfxFillRect(rt, { rightTop + ScreenCoordsXY{ 0, 1 }, rightBottom - ScreenCoordsXY{ 0, 1 } }, hilight);
+            GfxFillRect(rt, { leftBottom + ScreenCoordsXY{ 1, 0 }, rightBottom }, hilight);
 
             if (!(flags & INSET_RECT_FLAG_FILL_NONE))
             {
@@ -106,16 +106,16 @@ void GfxFillRectInset(RenderTarget& dpi, const ScreenRect& rect, ColourWithFlags
                         fill = ColourMapA[colour.colour].lighter;
                     }
                 }
-                GfxFillRect(dpi, { leftTop + ScreenCoordsXY{ 1, 1 }, rightBottom - ScreenCoordsXY{ 1, 1 } }, fill);
+                GfxFillRect(rt, { leftTop + ScreenCoordsXY{ 1, 1 }, rightBottom - ScreenCoordsXY{ 1, 1 } }, fill);
             }
         }
         else
         {
             // Draw outline of box
-            GfxFillRect(dpi, { leftTop, leftBottom - ScreenCoordsXY{ 0, 1 } }, hilight);
-            GfxFillRect(dpi, { leftTop + ScreenCoordsXY{ 1, 0 }, rightTop - ScreenCoordsXY{ 1, 0 } }, hilight);
-            GfxFillRect(dpi, { rightTop, rightBottom - ScreenCoordsXY{ 0, 1 } }, shadow);
-            GfxFillRect(dpi, { leftBottom, rightBottom }, shadow);
+            GfxFillRect(rt, { leftTop, leftBottom - ScreenCoordsXY{ 0, 1 } }, hilight);
+            GfxFillRect(rt, { leftTop + ScreenCoordsXY{ 1, 0 }, rightTop - ScreenCoordsXY{ 1, 0 } }, hilight);
+            GfxFillRect(rt, { rightTop, rightBottom - ScreenCoordsXY{ 0, 1 } }, shadow);
+            GfxFillRect(rt, { leftBottom, rightBottom }, shadow);
 
             if (!(flags & INSET_RECT_FLAG_FILL_NONE))
             {
@@ -123,7 +123,7 @@ void GfxFillRectInset(RenderTarget& dpi, const ScreenRect& rect, ColourWithFlags
                 {
                     fill = ColourMapA[COLOUR_BLACK].light;
                 }
-                GfxFillRect(dpi, { leftTop + ScreenCoordsXY{ 1, 1 }, rightBottom - ScreenCoordsXY{ 1, 1 } }, fill);
+                GfxFillRect(rt, { leftTop + ScreenCoordsXY{ 1, 1 }, rightBottom - ScreenCoordsXY{ 1, 1 } }, fill);
             }
         }
     }

--- a/src/openrct2/drawing/Rect.cpp
+++ b/src/openrct2/drawing/Rect.cpp
@@ -60,8 +60,7 @@ void GfxFillRectInset(RenderTarget& rt, const ScreenRect& rect, ColourWithFlags 
 
             if (!(flags & INSET_RECT_FLAG_FILL_NONE))
             {
-                GfxFilterRect(
-                    rt, { leftTop + ScreenCoordsXY{ 1, 1 }, { rightBottom - ScreenCoordsXY{ 1, 1 } } }, palette.base);
+                GfxFilterRect(rt, { leftTop + ScreenCoordsXY{ 1, 1 }, { rightBottom - ScreenCoordsXY{ 1, 1 } } }, palette.base);
             }
         }
     }

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -51,7 +51,7 @@ static void ScrollingTextSetBitmapForTTF(
 static void ScrollingTextInitialiseCharacterBitmaps(uint32_t glyphStart, uint16_t offset, uint16_t count, bool isAntiAliased)
 {
     uint8_t drawingSurface[64];
-    DrawPixelInfo dpi;
+    RenderTarget dpi;
     dpi.bits = reinterpret_cast<uint8_t*>(&drawingSurface);
     dpi.width = 8;
     dpi.height = 8;

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -51,15 +51,15 @@ static void ScrollingTextSetBitmapForTTF(
 static void ScrollingTextInitialiseCharacterBitmaps(uint32_t glyphStart, uint16_t offset, uint16_t count, bool isAntiAliased)
 {
     uint8_t drawingSurface[64];
-    RenderTarget dpi;
-    dpi.bits = reinterpret_cast<uint8_t*>(&drawingSurface);
-    dpi.width = 8;
-    dpi.height = 8;
+    RenderTarget rt;
+    rt.bits = reinterpret_cast<uint8_t*>(&drawingSurface);
+    rt.width = 8;
+    rt.height = 8;
 
     for (int32_t i = 0; i < count; i++)
     {
         std::fill_n(drawingSurface, sizeof(drawingSurface), 0x00);
-        GfxDrawSpriteSoftware(dpi, ImageId(glyphStart + (EnumValue(FontStyle::Tiny) * count) + i), { -1, 0 });
+        GfxDrawSpriteSoftware(rt, ImageId(glyphStart + (EnumValue(FontStyle::Tiny) * count) + i), { -1, 0 });
 
         for (int32_t x = 0; x < 8; x++)
         {
@@ -67,7 +67,7 @@ static void ScrollingTextInitialiseCharacterBitmaps(uint32_t glyphStart, uint16_
             for (int32_t y = 0; y < 8; y++)
             {
                 val >>= 1;
-                uint8_t pixel = dpi.bits[x + y * 8];
+                uint8_t pixel = rt.bits[x + y * 8];
                 if (pixel == 1 || (isAntiAliased && pixel == 2))
                 {
                     val |= 0x80;

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -32,7 +32,7 @@ public:
         LineHeight = FontGetLineHeight(paint.FontStyle);
     }
 
-    void Draw(DrawPixelInfo& dpi, const ScreenCoordsXY& coords)
+    void Draw(RenderTarget& dpi, const ScreenCoordsXY& coords)
     {
         TextPaint tempPaint = Paint;
 
@@ -75,7 +75,7 @@ public:
 };
 
 void DrawText(
-    DrawPixelInfo& dpi, const ScreenCoordsXY& coords, const TextPaint& paint, const_utf8string text, bool noFormatting)
+    RenderTarget& dpi, const ScreenCoordsXY& coords, const TextPaint& paint, const_utf8string text, bool noFormatting)
 {
     int32_t width = noFormatting ? GfxGetStringWidthNoFormatting(text, paint.FontStyle)
                                  : GfxGetStringWidth(text, paint.FontStyle);
@@ -109,21 +109,21 @@ void DrawText(
     }
 }
 
-void DrawTextBasic(DrawPixelInfo& dpi, const ScreenCoordsXY& coords, StringId format)
+void DrawTextBasic(RenderTarget& dpi, const ScreenCoordsXY& coords, StringId format)
 {
     Formatter ft{};
     TextPaint textPaint{};
     DrawTextBasic(dpi, coords, format, ft, textPaint);
 }
 
-void DrawTextBasic(DrawPixelInfo& dpi, const ScreenCoordsXY& coords, StringId format, const Formatter& ft, TextPaint textPaint)
+void DrawTextBasic(RenderTarget& dpi, const ScreenCoordsXY& coords, StringId format, const Formatter& ft, TextPaint textPaint)
 {
     utf8 buffer[512];
     OpenRCT2::FormatStringLegacy(buffer, sizeof(buffer), format, ft.Data());
     DrawText(dpi, coords, textPaint, buffer);
 }
 
-void DrawTextEllipsised(DrawPixelInfo& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format)
+void DrawTextEllipsised(RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format)
 {
     Formatter ft{};
     TextPaint textPaint{};
@@ -131,7 +131,7 @@ void DrawTextEllipsised(DrawPixelInfo& dpi, const ScreenCoordsXY& coords, int32_
 }
 
 void DrawTextEllipsised(
-    DrawPixelInfo& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft, TextPaint textPaint)
+    RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft, TextPaint textPaint)
 {
     utf8 buffer[512];
     OpenRCT2::FormatStringLegacy(buffer, sizeof(buffer), format, ft.Data());
@@ -140,7 +140,7 @@ void DrawTextEllipsised(
     DrawText(dpi, coords, textPaint, buffer);
 }
 
-int32_t DrawTextWrapped(DrawPixelInfo& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format)
+int32_t DrawTextWrapped(RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format)
 {
     Formatter ft{};
     TextPaint textPaint{};
@@ -148,7 +148,7 @@ int32_t DrawTextWrapped(DrawPixelInfo& dpi, const ScreenCoordsXY& coords, int32_
 }
 
 int32_t DrawTextWrapped(
-    DrawPixelInfo& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft, TextPaint textPaint)
+    RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft, TextPaint textPaint)
 {
     const void* args = ft.Data();
 

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -32,7 +32,7 @@ public:
         LineHeight = FontGetLineHeight(paint.FontStyle);
     }
 
-    void Draw(RenderTarget& dpi, const ScreenCoordsXY& coords)
+    void Draw(RenderTarget& rt, const ScreenCoordsXY& coords)
     {
         TextPaint tempPaint = Paint;
 
@@ -51,7 +51,7 @@ public:
         const utf8* buffer = Buffer.data();
         for (int32_t line = 0; line < LineCount; ++line)
         {
-            DrawText(dpi, lineCoords, tempPaint, buffer);
+            DrawText(rt, lineCoords, tempPaint, buffer);
             tempPaint.Colour = kTextColour254;
             buffer = GetStringEnd(buffer) + 1;
             lineCoords.y += LineHeight;
@@ -74,8 +74,7 @@ public:
     }
 };
 
-void DrawText(
-    RenderTarget& dpi, const ScreenCoordsXY& coords, const TextPaint& paint, const_utf8string text, bool noFormatting)
+void DrawText(RenderTarget& rt, const ScreenCoordsXY& coords, const TextPaint& paint, const_utf8string text, bool noFormatting)
 {
     int32_t width = noFormatting ? GfxGetStringWidthNoFormatting(text, paint.FontStyle)
                                  : GfxGetStringWidth(text, paint.FontStyle);
@@ -93,62 +92,62 @@ void DrawText(
             break;
     }
 
-    TTFDrawString(dpi, text, paint.Colour, alignedCoords, noFormatting, paint.FontStyle, paint.Darkness);
+    TTFDrawString(rt, text, paint.Colour, alignedCoords, noFormatting, paint.FontStyle, paint.Darkness);
 
     if (paint.UnderlineText == TextUnderline::On)
     {
         GfxFillRect(
-            dpi, { { alignedCoords + ScreenCoordsXY{ 0, 11 } }, { alignedCoords + ScreenCoordsXY{ width, 11 } } },
+            rt, { { alignedCoords + ScreenCoordsXY{ 0, 11 } }, { alignedCoords + ScreenCoordsXY{ width, 11 } } },
             gTextPalette[1]);
         if (gTextPalette[2] != 0)
         {
             GfxFillRect(
-                dpi, { { alignedCoords + ScreenCoordsXY{ 1, 12 } }, { alignedCoords + ScreenCoordsXY{ width + 1, 12 } } },
+                rt, { { alignedCoords + ScreenCoordsXY{ 1, 12 } }, { alignedCoords + ScreenCoordsXY{ width + 1, 12 } } },
                 gTextPalette[2]);
         }
     }
 }
 
-void DrawTextBasic(RenderTarget& dpi, const ScreenCoordsXY& coords, StringId format)
+void DrawTextBasic(RenderTarget& rt, const ScreenCoordsXY& coords, StringId format)
 {
     Formatter ft{};
     TextPaint textPaint{};
-    DrawTextBasic(dpi, coords, format, ft, textPaint);
+    DrawTextBasic(rt, coords, format, ft, textPaint);
 }
 
-void DrawTextBasic(RenderTarget& dpi, const ScreenCoordsXY& coords, StringId format, const Formatter& ft, TextPaint textPaint)
+void DrawTextBasic(RenderTarget& rt, const ScreenCoordsXY& coords, StringId format, const Formatter& ft, TextPaint textPaint)
 {
     utf8 buffer[512];
     OpenRCT2::FormatStringLegacy(buffer, sizeof(buffer), format, ft.Data());
-    DrawText(dpi, coords, textPaint, buffer);
+    DrawText(rt, coords, textPaint, buffer);
 }
 
-void DrawTextEllipsised(RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format)
+void DrawTextEllipsised(RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format)
 {
     Formatter ft{};
     TextPaint textPaint{};
-    DrawTextEllipsised(dpi, coords, width, format, ft, textPaint);
+    DrawTextEllipsised(rt, coords, width, format, ft, textPaint);
 }
 
 void DrawTextEllipsised(
-    RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft, TextPaint textPaint)
+    RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft, TextPaint textPaint)
 {
     utf8 buffer[512];
     OpenRCT2::FormatStringLegacy(buffer, sizeof(buffer), format, ft.Data());
     GfxClipString(buffer, width, textPaint.FontStyle);
 
-    DrawText(dpi, coords, textPaint, buffer);
+    DrawText(rt, coords, textPaint, buffer);
 }
 
-int32_t DrawTextWrapped(RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format)
+int32_t DrawTextWrapped(RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format)
 {
     Formatter ft{};
     TextPaint textPaint{};
-    return DrawTextWrapped(dpi, coords, width, format, ft, textPaint);
+    return DrawTextWrapped(rt, coords, width, format, ft, textPaint);
 }
 
 int32_t DrawTextWrapped(
-    RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft, TextPaint textPaint)
+    RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft, TextPaint textPaint)
 {
     const void* args = ft.Data();
 
@@ -161,11 +160,11 @@ int32_t DrawTextWrapped(
         int32_t lineHeight = layout.GetHeight() / lineCount;
         int32_t yOffset = (lineCount - 1) * lineHeight / 2;
 
-        layout.Draw(dpi, coords - ScreenCoordsXY{ layout.GetWidth() / 2, yOffset });
+        layout.Draw(rt, coords - ScreenCoordsXY{ layout.GetWidth() / 2, yOffset });
     }
     else
     {
-        layout.Draw(dpi, coords);
+        layout.Draw(rt, coords);
     }
 
     return layout.GetHeight();

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -199,17 +199,17 @@ struct TextPaint
     }
 };
 
-void DrawTextBasic(RenderTarget& dpi, const ScreenCoordsXY& coords, StringId format);
+void DrawTextBasic(RenderTarget& rt, const ScreenCoordsXY& coords, StringId format);
 void DrawTextEllipsised(RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format);
-int32_t DrawTextWrapped(RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format);
+int32_t DrawTextWrapped(RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format);
 
 void DrawText(
     RenderTarget& dpi, const ScreenCoordsXY& coords, const TextPaint& paint, const_utf8string text, bool noFormatting = false);
 void DrawTextBasic(
-    RenderTarget& dpi, const ScreenCoordsXY& coords, StringId format, const Formatter& ft, TextPaint textPaint = {});
+    RenderTarget& rt, const ScreenCoordsXY& coords, StringId format, const Formatter& ft, TextPaint textPaint = {});
 void DrawTextEllipsised(
     RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft,
     TextPaint textPaint = {});
 int32_t DrawTextWrapped(
-    RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft,
+    RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft,
     TextPaint textPaint = {});

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -14,7 +14,7 @@
 #include "Font.h"
 
 struct ScreenCoordsXY;
-struct DrawPixelInfo;
+struct RenderTarget;
 class Formatter;
 
 enum class TextAlignment
@@ -199,17 +199,17 @@ struct TextPaint
     }
 };
 
-void DrawTextBasic(DrawPixelInfo& dpi, const ScreenCoordsXY& coords, StringId format);
-void DrawTextEllipsised(DrawPixelInfo& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format);
-int32_t DrawTextWrapped(DrawPixelInfo& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format);
+void DrawTextBasic(RenderTarget& dpi, const ScreenCoordsXY& coords, StringId format);
+void DrawTextEllipsised(RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format);
+int32_t DrawTextWrapped(RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format);
 
 void DrawText(
-    DrawPixelInfo& dpi, const ScreenCoordsXY& coords, const TextPaint& paint, const_utf8string text, bool noFormatting = false);
+    RenderTarget& dpi, const ScreenCoordsXY& coords, const TextPaint& paint, const_utf8string text, bool noFormatting = false);
 void DrawTextBasic(
-    DrawPixelInfo& dpi, const ScreenCoordsXY& coords, StringId format, const Formatter& ft, TextPaint textPaint = {});
+    RenderTarget& dpi, const ScreenCoordsXY& coords, StringId format, const Formatter& ft, TextPaint textPaint = {});
 void DrawTextEllipsised(
-    DrawPixelInfo& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft,
+    RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft,
     TextPaint textPaint = {});
 int32_t DrawTextWrapped(
-    DrawPixelInfo& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft,
+    RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft,
     TextPaint textPaint = {});

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -200,7 +200,7 @@ struct TextPaint
 };
 
 void DrawTextBasic(RenderTarget& dpi, const ScreenCoordsXY& coords, StringId format);
-void DrawTextEllipsised(RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format);
+void DrawTextEllipsised(RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format);
 int32_t DrawTextWrapped(RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format);
 
 void DrawText(
@@ -208,7 +208,7 @@ void DrawText(
 void DrawTextBasic(
     RenderTarget& dpi, const ScreenCoordsXY& coords, StringId format, const Formatter& ft, TextPaint textPaint = {});
 void DrawTextEllipsised(
-    RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft,
+    RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft,
     TextPaint textPaint = {});
 int32_t DrawTextWrapped(
     RenderTarget& dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft,

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -204,7 +204,7 @@ void DrawTextEllipsised(RenderTarget& rt, const ScreenCoordsXY& coords, int32_t 
 int32_t DrawTextWrapped(RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format);
 
 void DrawText(
-    RenderTarget& dpi, const ScreenCoordsXY& coords, const TextPaint& paint, const_utf8string text, bool noFormatting = false);
+    RenderTarget& rt, const ScreenCoordsXY& coords, const TextPaint& paint, const_utf8string text, bool noFormatting = false);
 void DrawTextBasic(
     RenderTarget& rt, const ScreenCoordsXY& coords, StringId format, const Formatter& ft, TextPaint textPaint = {});
 void DrawTextEllipsised(

--- a/src/openrct2/drawing/Weather.cpp
+++ b/src/openrct2/drawing/Weather.cpp
@@ -23,13 +23,13 @@ using namespace OpenRCT2;
 using namespace OpenRCT2::Drawing;
 
 static void DrawLightRain(
-    RenderTarget& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
+    RenderTarget& rt, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
 static void DrawHeavyRain(
-    RenderTarget& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
+    RenderTarget& rt, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
 static void DrawLightSnow(
-    RenderTarget& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
+    RenderTarget& rt, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
 static void DrawHeavySnow(
-    RenderTarget& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
+    RenderTarget& rt, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
 
 /**
  *
@@ -51,7 +51,7 @@ const DrawWeatherFunc DrawSnowFunctions[] = {
  *
  *  rct2: 0x00684218
  */
-void DrawWeather(RenderTarget& dpi, IWeatherDrawer* weatherDrawer)
+void DrawWeather(RenderTarget& rt, IWeatherDrawer* weatherDrawer)
 {
     if (!Config::Get().general.RenderWeatherEffects)
         return;
@@ -74,7 +74,7 @@ void DrawWeather(RenderTarget& dpi, IWeatherDrawer* weatherDrawer)
     }
 
     auto uiContext = GetContext()->GetUiContext();
-    uiContext->DrawWeatherAnimation(weatherDrawer, dpi, drawFunc);
+    uiContext->DrawWeatherAnimation(weatherDrawer, rt, drawFunc);
 }
 
 /**
@@ -82,7 +82,7 @@ void DrawWeather(RenderTarget& dpi, IWeatherDrawer* weatherDrawer)
  *  rct2: 0x00684114
  */
 static void DrawLightRain(
-    RenderTarget& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
+    RenderTarget& rt, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
 {
     const auto currentTicks = getGameState().currentTicks;
 
@@ -91,14 +91,14 @@ static void DrawLightRain(
     y_start = -y_start;
     x_start += left;
     y_start += top;
-    weatherDrawer->Draw(dpi, left, top, width, height, x_start, y_start, kRainPattern);
+    weatherDrawer->Draw(rt, left, top, width, height, x_start, y_start, kRainPattern);
 
     x_start = -static_cast<int32_t>(currentTicks) + 0x18;
     y_start = (currentTicks * 4) + 0x0D;
     y_start = -y_start;
     x_start += left;
     y_start += top;
-    weatherDrawer->Draw(dpi, left, top, width, height, x_start, y_start, kRainPattern);
+    weatherDrawer->Draw(rt, left, top, width, height, x_start, y_start, kRainPattern);
 }
 
 /**
@@ -106,7 +106,7 @@ static void DrawLightRain(
  *  rct2: 0x0068416D
  */
 static void DrawHeavyRain(
-    RenderTarget& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
+    RenderTarget& rt, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
 {
     const auto currentTicks = getGameState().currentTicks;
 
@@ -115,32 +115,32 @@ static void DrawHeavyRain(
     y_start = -y_start;
     x_start += left;
     y_start += top;
-    weatherDrawer->Draw(dpi, left, top, width, height, x_start, y_start, kRainPattern);
+    weatherDrawer->Draw(rt, left, top, width, height, x_start, y_start, kRainPattern);
 
     x_start = -static_cast<int32_t>(currentTicks) + 0x10;
     y_start = (currentTicks * 6) + 5;
     y_start = -y_start;
     x_start += left;
     y_start += top;
-    weatherDrawer->Draw(dpi, left, top, width, height, x_start, y_start, kRainPattern);
+    weatherDrawer->Draw(rt, left, top, width, height, x_start, y_start, kRainPattern);
 
     x_start = -static_cast<int32_t>(currentTicks) + 8;
     y_start = (currentTicks * 3) + 7;
     y_start = -y_start;
     x_start += left;
     y_start += top;
-    weatherDrawer->Draw(dpi, left, top, width, height, x_start, y_start, kRainPattern);
+    weatherDrawer->Draw(rt, left, top, width, height, x_start, y_start, kRainPattern);
 
     x_start = -static_cast<int32_t>(currentTicks) + 0x18;
     y_start = (currentTicks * 4) + 0x0D;
     y_start = -y_start;
     x_start += left;
     y_start += top;
-    weatherDrawer->Draw(dpi, left, top, width, height, x_start, y_start, kRainPattern);
+    weatherDrawer->Draw(rt, left, top, width, height, x_start, y_start, kRainPattern);
 }
 
 static void DrawLightSnow(
-    RenderTarget& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
+    RenderTarget& rt, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
 {
     const auto currentTicks = getGameState().currentTicks;
 
@@ -153,18 +153,18 @@ static void DrawLightSnow(
     y_start = -y_start;
     x_start += left;
     y_start += top;
-    weatherDrawer->Draw(dpi, left, top, width, height, x_start, y_start, kSnowPattern);
+    weatherDrawer->Draw(rt, left, top, width, height, x_start, y_start, kSnowPattern);
 
     x_start = negT + 16 + (cos(cosTick) * 6);
     y_start = t + 16;
     y_start = -y_start;
     x_start += left;
     y_start += top;
-    weatherDrawer->Draw(dpi, left, top, width, height, x_start, y_start, kSnowPattern);
+    weatherDrawer->Draw(rt, left, top, width, height, x_start, y_start, kSnowPattern);
 }
 
 static void DrawHeavySnow(
-    RenderTarget& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
+    RenderTarget& rt, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
 {
     const auto currentTicks = getGameState().currentTicks;
 
@@ -173,26 +173,26 @@ static void DrawHeavySnow(
     y_start = -y_start;
     x_start += left;
     y_start += top;
-    weatherDrawer->Draw(dpi, left, top, width, height, x_start, y_start, kSnowPattern);
+    weatherDrawer->Draw(rt, left, top, width, height, x_start, y_start, kSnowPattern);
 
     x_start = -static_cast<int32_t>(currentTicks * 4) + 6;
     y_start = currentTicks + 5;
     y_start = -y_start;
     x_start += left;
     y_start += top;
-    weatherDrawer->Draw(dpi, left, top, width, height, x_start, y_start, kSnowPattern);
+    weatherDrawer->Draw(rt, left, top, width, height, x_start, y_start, kSnowPattern);
 
     x_start = -static_cast<int32_t>(currentTicks * 2) + 11;
     y_start = currentTicks + 18;
     y_start = -y_start;
     x_start += left;
     y_start += top;
-    weatherDrawer->Draw(dpi, left, top, width, height, x_start, y_start, kSnowPattern);
+    weatherDrawer->Draw(rt, left, top, width, height, x_start, y_start, kSnowPattern);
 
     x_start = -static_cast<int32_t>(currentTicks * 3) + 17;
     y_start = currentTicks + 11;
     y_start = -y_start;
     x_start += left;
     y_start += top;
-    weatherDrawer->Draw(dpi, left, top, width, height, x_start, y_start, kSnowPattern);
+    weatherDrawer->Draw(rt, left, top, width, height, x_start, y_start, kSnowPattern);
 }

--- a/src/openrct2/drawing/Weather.cpp
+++ b/src/openrct2/drawing/Weather.cpp
@@ -23,13 +23,13 @@ using namespace OpenRCT2;
 using namespace OpenRCT2::Drawing;
 
 static void DrawLightRain(
-    DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
+    RenderTarget& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
 static void DrawHeavyRain(
-    DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
+    RenderTarget& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
 static void DrawLightSnow(
-    DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
+    RenderTarget& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
 static void DrawHeavySnow(
-    DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
+    RenderTarget& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
 
 /**
  *
@@ -51,7 +51,7 @@ const DrawWeatherFunc DrawSnowFunctions[] = {
  *
  *  rct2: 0x00684218
  */
-void DrawWeather(DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer)
+void DrawWeather(RenderTarget& dpi, IWeatherDrawer* weatherDrawer)
 {
     if (!Config::Get().general.RenderWeatherEffects)
         return;
@@ -82,7 +82,7 @@ void DrawWeather(DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer)
  *  rct2: 0x00684114
  */
 static void DrawLightRain(
-    DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
+    RenderTarget& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
 {
     const auto currentTicks = getGameState().currentTicks;
 
@@ -106,7 +106,7 @@ static void DrawLightRain(
  *  rct2: 0x0068416D
  */
 static void DrawHeavyRain(
-    DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
+    RenderTarget& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
 {
     const auto currentTicks = getGameState().currentTicks;
 
@@ -140,7 +140,7 @@ static void DrawHeavyRain(
 }
 
 static void DrawLightSnow(
-    DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
+    RenderTarget& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
 {
     const auto currentTicks = getGameState().currentTicks;
 
@@ -164,7 +164,7 @@ static void DrawLightSnow(
 }
 
 static void DrawHeavySnow(
-    DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
+    RenderTarget& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
 {
     const auto currentTicks = getGameState().currentTicks;
 

--- a/src/openrct2/drawing/Weather.h
+++ b/src/openrct2/drawing/Weather.h
@@ -37,4 +37,4 @@ static constexpr uint8_t kSnowPattern[] =
 
 // clang-format on
 
-void DrawWeather(RenderTarget& dpi, OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer);
+void DrawWeather(RenderTarget& rt, OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer);

--- a/src/openrct2/drawing/Weather.h
+++ b/src/openrct2/drawing/Weather.h
@@ -11,7 +11,7 @@
 
 #include <cstdint>
 
-struct DrawPixelInfo;
+struct RenderTarget;
 
 namespace OpenRCT2::Drawing
 {
@@ -37,4 +37,4 @@ static constexpr uint8_t kSnowPattern[] =
 
 // clang-format on
 
-void DrawWeather(DrawPixelInfo& dpi, OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer);
+void DrawWeather(RenderTarget& dpi, OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer);

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -44,7 +44,7 @@ X8WeatherDrawer::~X8WeatherDrawer()
 }
 
 void X8WeatherDrawer::Draw(
-    DrawPixelInfo& dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
+    RenderTarget& dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
     const uint8_t* weatherpattern)
 {
     const uint8_t* pattern = weatherpattern;
@@ -92,7 +92,7 @@ void X8WeatherDrawer::Draw(
     }
 }
 
-void X8WeatherDrawer::Restore(DrawPixelInfo& dpi)
+void X8WeatherDrawer::Restore(RenderTarget& dpi)
 {
     if (_weatherPixelsCount > 0)
     {
@@ -253,7 +253,7 @@ IDrawingContext* X8DrawingEngine::GetDrawingContext()
     return _drawingContext;
 }
 
-DrawPixelInfo* X8DrawingEngine::GetDrawingPixelInfo()
+RenderTarget* X8DrawingEngine::GetDrawingPixelInfo()
 {
     return &_bitsDPI;
 }
@@ -268,7 +268,7 @@ void X8DrawingEngine::InvalidateImage([[maybe_unused]] uint32_t image)
     // Not applicable for this engine
 }
 
-DrawPixelInfo* X8DrawingEngine::GetDPI()
+RenderTarget* X8DrawingEngine::GetDPI()
 {
     return &_bitsDPI;
 }
@@ -314,7 +314,7 @@ void X8DrawingEngine::ConfigureBits(uint32_t width, uint32_t height, uint32_t pi
     _height = height;
     _pitch = pitch;
 
-    DrawPixelInfo* dpi = &_bitsDPI;
+    RenderTarget* dpi = &_bitsDPI;
     dpi->bits = _bits;
     dpi->x = 0;
     dpi->y = 0;
@@ -366,7 +366,7 @@ X8DrawingContext::X8DrawingContext(X8DrawingEngine* engine)
     _engine = engine;
 }
 
-void X8DrawingContext::Clear(DrawPixelInfo& dpi, uint8_t paletteIndex)
+void X8DrawingContext::Clear(RenderTarget& dpi, uint8_t paletteIndex)
 {
     Guard::Assert(_isDrawing == true);
 
@@ -429,7 +429,7 @@ static constexpr const uint16_t* kPatterns[] = {
 };
 // clang-format on
 
-void X8DrawingContext::FillRect(DrawPixelInfo& dpi, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom)
+void X8DrawingContext::FillRect(RenderTarget& dpi, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
     Guard::Assert(_isDrawing == true);
 
@@ -552,7 +552,7 @@ void X8DrawingContext::FillRect(DrawPixelInfo& dpi, uint32_t colour, int32_t lef
 }
 
 void X8DrawingContext::FilterRect(
-    DrawPixelInfo& dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom)
+    RenderTarget& dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
     Guard::Assert(_isDrawing == true);
 
@@ -620,14 +620,14 @@ void X8DrawingContext::FilterRect(
     }
 }
 
-void X8DrawingContext::DrawLine(DrawPixelInfo& dpi, uint32_t colour, const ScreenLine& line)
+void X8DrawingContext::DrawLine(RenderTarget& dpi, uint32_t colour, const ScreenLine& line)
 {
     Guard::Assert(_isDrawing == true);
 
     GfxDrawLineSoftware(dpi, line, colour);
 }
 
-void X8DrawingContext::DrawSprite(DrawPixelInfo& dpi, const ImageId imageId, int32_t x, int32_t y)
+void X8DrawingContext::DrawSprite(RenderTarget& dpi, const ImageId imageId, int32_t x, int32_t y)
 {
     Guard::Assert(_isDrawing == true);
 
@@ -635,14 +635,14 @@ void X8DrawingContext::DrawSprite(DrawPixelInfo& dpi, const ImageId imageId, int
 }
 
 void X8DrawingContext::DrawSpriteRawMasked(
-    DrawPixelInfo& dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage)
+    RenderTarget& dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage)
 {
     Guard::Assert(_isDrawing == true);
 
     GfxDrawSpriteRawMaskedSoftware(dpi, { x, y }, maskImage, colourImage);
 }
 
-void X8DrawingContext::DrawSpriteSolid(DrawPixelInfo& dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour)
+void X8DrawingContext::DrawSpriteSolid(RenderTarget& dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour)
 {
     Guard::Assert(_isDrawing == true);
 
@@ -654,7 +654,7 @@ void X8DrawingContext::DrawSpriteSolid(DrawPixelInfo& dpi, const ImageId image, 
     GfxDrawSpritePaletteSetSoftware(dpi, ImageId(image.GetIndex(), 0), spriteCoords, PaletteMap(palette));
 }
 
-void X8DrawingContext::DrawGlyph(DrawPixelInfo& dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap)
+void X8DrawingContext::DrawGlyph(RenderTarget& dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap)
 {
     Guard::Assert(_isDrawing == true);
 
@@ -664,7 +664,7 @@ void X8DrawingContext::DrawGlyph(DrawPixelInfo& dpi, const ImageId image, int32_
 #ifndef DISABLE_TTF
 template<bool TUseHinting>
 static void DrawTTFBitmapInternal(
-    DrawPixelInfo& dpi, uint8_t colour, TTFSurface* surface, int32_t x, int32_t y, uint8_t hintingThreshold)
+    RenderTarget& dpi, uint8_t colour, TTFSurface* surface, int32_t x, int32_t y, uint8_t hintingThreshold)
 {
     assert(dpi.zoom_level == ZoomLevel{ 0 });
     const int32_t surfaceWidth = surface->w;
@@ -734,7 +734,7 @@ static void DrawTTFBitmapInternal(
 #endif // DISABLE_TTF
 
 void X8DrawingContext::DrawTTFBitmap(
-    DrawPixelInfo& dpi, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y, uint8_t hintingThreshold)
+    RenderTarget& dpi, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y, uint8_t hintingThreshold)
 {
 #ifndef DISABLE_TTF
     const uint8_t fgColor = info->palette[1];

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -44,7 +44,7 @@ X8WeatherDrawer::~X8WeatherDrawer()
 }
 
 void X8WeatherDrawer::Draw(
-    RenderTarget& dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
+    RenderTarget& rt, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
     const uint8_t* weatherpattern)
 {
     const uint8_t* pattern = weatherpattern;
@@ -54,10 +54,10 @@ void X8WeatherDrawer::Draw(
     uint8_t patternStartXOffset = xStart % patternXSpace;
     uint8_t patternStartYOffset = yStart % patternYSpace;
 
-    uint32_t pixelOffset = dpi.LineStride() * y + x;
+    uint32_t pixelOffset = rt.LineStride() * y + x;
     uint8_t patternYPos = patternStartYOffset % patternYSpace;
 
-    uint8_t* screenBits = dpi.bits;
+    uint8_t* screenBits = rt.bits;
 
     // Stores the colours of changed pixels
     WeatherPixel* newPixels = &_weatherPixels[_weatherPixelsCount];
@@ -86,18 +86,18 @@ void X8WeatherDrawer::Draw(
             }
         }
 
-        pixelOffset += dpi.LineStride();
+        pixelOffset += rt.LineStride();
         patternYPos++;
         patternYPos %= patternYSpace;
     }
 }
 
-void X8WeatherDrawer::Restore(RenderTarget& dpi)
+void X8WeatherDrawer::Restore(RenderTarget& rt)
 {
     if (_weatherPixelsCount > 0)
     {
-        uint32_t numPixels = dpi.LineStride() * dpi.height;
-        uint8_t* bits = dpi.bits;
+        uint32_t numPixels = rt.LineStride() * rt.height;
+        uint8_t* bits = rt.bits;
         for (uint32_t i = 0; i < _weatherPixelsCount; i++)
         {
             WeatherPixel weatherPixel = _weatherPixels[i];
@@ -121,7 +121,7 @@ void X8WeatherDrawer::Restore(RenderTarget& dpi)
 X8DrawingEngine::X8DrawingEngine([[maybe_unused]] const std::shared_ptr<Ui::IUiContext>& uiContext)
 {
     _drawingContext = new X8DrawingContext(this);
-    _bitsDPI.DrawingEngine = this;
+    _mainRT.DrawingEngine = this;
     LightFx::SetAvailable(true);
     _lastLightFXenabled = Config::Get().general.EnableLightFx;
 }
@@ -142,7 +142,7 @@ void X8DrawingEngine::Resize(uint32_t width, uint32_t height)
     ConfigureBits(width, height, pitch);
 
     _drawingContext->BeginDraw();
-    _drawingContext->Clear(_bitsDPI, PaletteIndex::pi10);
+    _drawingContext->Clear(_mainRT, PaletteIndex::pi10);
     _drawingContext->EndDraw();
 }
 
@@ -171,7 +171,7 @@ void X8DrawingEngine::BeginDraw()
             GfxInvalidateScreen();
             _lastLightFXenabled = Config::Get().general.EnableLightFx;
         }
-        _weatherDrawer.Restore(_bitsDPI);
+        _weatherDrawer.Restore(_mainRT);
     }
 
     _drawingContext->BeginDraw();
@@ -195,7 +195,7 @@ void X8DrawingEngine::PaintWindows()
 
 void X8DrawingEngine::PaintWeather()
 {
-    DrawWeather(_bitsDPI, &_weatherDrawer);
+    DrawWeather(_mainRT, &_weatherDrawer);
 }
 
 void X8DrawingEngine::CopyRect(int32_t x, int32_t y, int32_t width, int32_t height, int32_t dx, int32_t dy)
@@ -217,9 +217,9 @@ void X8DrawingEngine::CopyRect(int32_t x, int32_t y, int32_t width, int32_t heig
     width += lmargin + rmargin;
     height += tmargin + bmargin;
 
-    int32_t stride = _bitsDPI.LineStride();
-    uint8_t* to = _bitsDPI.bits + y * stride + x;
-    uint8_t* from = _bitsDPI.bits + (y - dy) * stride + x - dx;
+    int32_t stride = _mainRT.LineStride();
+    uint8_t* to = _mainRT.bits + y * stride + x;
+    uint8_t* from = _mainRT.bits + (y - dy) * stride + x - dx;
 
     if (dy > 0)
     {
@@ -240,7 +240,7 @@ void X8DrawingEngine::CopyRect(int32_t x, int32_t y, int32_t width, int32_t heig
 
 std::string X8DrawingEngine::Screenshot()
 {
-    return ScreenshotDumpPNG(_bitsDPI);
+    return ScreenshotDumpPNG(_mainRT);
 }
 
 IDrawingContext* X8DrawingEngine::GetDrawingContext()
@@ -255,7 +255,7 @@ IDrawingContext* X8DrawingEngine::GetDrawingContext()
 
 RenderTarget* X8DrawingEngine::GetDrawingPixelInfo()
 {
-    return &_bitsDPI;
+    return &_mainRT;
 }
 
 DrawingEngineFlags X8DrawingEngine::GetFlags()
@@ -270,7 +270,7 @@ void X8DrawingEngine::InvalidateImage([[maybe_unused]] uint32_t image)
 
 RenderTarget* X8DrawingEngine::GetDPI()
 {
-    return &_bitsDPI;
+    return &_mainRT;
 }
 
 void X8DrawingEngine::ConfigureBits(uint32_t width, uint32_t height, uint32_t pitch)
@@ -314,19 +314,19 @@ void X8DrawingEngine::ConfigureBits(uint32_t width, uint32_t height, uint32_t pi
     _height = height;
     _pitch = pitch;
 
-    RenderTarget* dpi = &_bitsDPI;
-    dpi->bits = _bits;
-    dpi->x = 0;
-    dpi->y = 0;
-    dpi->width = width;
-    dpi->height = height;
-    dpi->pitch = _pitch - width;
+    RenderTarget* rt = &_mainRT;
+    rt->bits = _bits;
+    rt->x = 0;
+    rt->y = 0;
+    rt->width = width;
+    rt->height = height;
+    rt->pitch = _pitch - width;
 
     ConfigureDirtyGrid();
 
     if (LightFx::IsAvailable())
     {
-        LightFx::UpdateBuffers(*dpi);
+        LightFx::UpdateBuffers(*rt);
     }
 }
 
@@ -354,7 +354,7 @@ void X8DrawingEngine::DrawDirtyBlocks(int32_t left, int32_t top, int32_t right, 
 {
     // Draw region
     OnDrawDirtyBlock(left, top, right, bottom);
-    WindowDrawAll(_bitsDPI, left, top, right, bottom);
+    WindowDrawAll(_mainRT, left, top, right, bottom);
 }
 
 #ifdef __WARN_SUGGEST_FINAL_METHODS__
@@ -366,18 +366,18 @@ X8DrawingContext::X8DrawingContext(X8DrawingEngine* engine)
     _engine = engine;
 }
 
-void X8DrawingContext::Clear(RenderTarget& dpi, uint8_t paletteIndex)
+void X8DrawingContext::Clear(RenderTarget& rt, uint8_t paletteIndex)
 {
     Guard::Assert(_isDrawing == true);
 
-    int32_t w = dpi.width;
-    int32_t h = dpi.height;
-    uint8_t* ptr = dpi.bits;
+    int32_t w = rt.width;
+    int32_t h = rt.height;
+    uint8_t* ptr = rt.bits;
 
     for (int32_t y = 0; y < h; y++)
     {
         std::fill_n(ptr, w, paletteIndex);
-        ptr += w + dpi.pitch;
+        ptr += w + rt.pitch;
     }
 }
 
@@ -429,50 +429,50 @@ static constexpr const uint16_t* kPatterns[] = {
 };
 // clang-format on
 
-void X8DrawingContext::FillRect(RenderTarget& dpi, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom)
+void X8DrawingContext::FillRect(RenderTarget& rt, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
     Guard::Assert(_isDrawing == true);
 
-    assert(dpi.zoom_level == ZoomLevel{ 0 });
+    assert(rt.zoom_level == ZoomLevel{ 0 });
     if (left > right)
         return;
     if (top > bottom)
         return;
-    if (dpi.x > right)
+    if (rt.x > right)
         return;
-    if (left >= dpi.x + dpi.width)
+    if (left >= rt.x + rt.width)
         return;
-    if (bottom < dpi.y)
+    if (bottom < rt.y)
         return;
-    if (top >= dpi.y + dpi.height)
+    if (top >= rt.y + rt.height)
         return;
 
     uint16_t crosskPattern = 0;
 
-    int32_t startX = left - dpi.x;
+    int32_t startX = left - rt.x;
     if (startX < 0)
     {
         crosskPattern ^= startX;
         startX = 0;
     }
 
-    int32_t endX = right - dpi.x + 1;
-    if (endX > dpi.width)
+    int32_t endX = right - rt.x + 1;
+    if (endX > rt.width)
     {
-        endX = dpi.width;
+        endX = rt.width;
     }
 
-    int32_t startY = top - dpi.y;
+    int32_t startY = top - rt.y;
     if (startY < 0)
     {
         crosskPattern ^= startY;
         startY = 0;
     }
 
-    int32_t endY = bottom - dpi.y + 1;
-    if (endY > dpi.height)
+    int32_t endY = bottom - rt.y + 1;
+    if (endY > rt.height)
     {
-        endY = dpi.height;
+        endY = rt.height;
     }
 
     int32_t width = endX - startX;
@@ -481,10 +481,10 @@ void X8DrawingContext::FillRect(RenderTarget& dpi, uint32_t colour, int32_t left
     if (colour & 0x1000000)
     {
         // Cross hatching
-        uint8_t* dst = startY * dpi.LineStride() + startX + dpi.bits;
+        uint8_t* dst = startY * rt.LineStride() + startX + rt.bits;
         for (int32_t i = 0; i < height; i++)
         {
-            uint8_t* nextdst = dst + dpi.LineStride();
+            uint8_t* nextdst = dst + rt.LineStride();
             uint32_t p = Numerics::ror32(crosskPattern, 1);
             p = (p & 0xFFFF0000) | width;
 
@@ -508,22 +508,22 @@ void X8DrawingContext::FillRect(RenderTarget& dpi, uint32_t colour, int32_t left
     }
     else if (colour & 0x4000000)
     {
-        uint8_t* dst = startY * dpi.LineStride() + startX + dpi.bits;
+        uint8_t* dst = startY * rt.LineStride() + startX + rt.bits;
 
         // The pattern loops every 15 lines this is which
         // part the pattern is on.
-        int32_t patternY = (startY + dpi.y) % 16;
+        int32_t patternY = (startY + rt.y) % 16;
 
         // The pattern loops every 15 pixels this is which
         // part the pattern is on.
-        int32_t startkPatternX = (startX + dpi.x) % 16;
+        int32_t startkPatternX = (startX + rt.x) % 16;
         int32_t patternX = startkPatternX;
 
         const uint16_t* patternsrc = kPatterns[colour >> 28]; // or possibly uint8_t)[esi*4] ?
 
         for (int32_t numLines = height; numLines > 0; numLines--)
         {
-            uint8_t* nextdst = dst + dpi.LineStride();
+            uint8_t* nextdst = dst + rt.LineStride();
             uint16_t pattern = patternsrc[patternY];
 
             for (int32_t numPixels = width; numPixels > 0; numPixels--)
@@ -542,17 +542,17 @@ void X8DrawingContext::FillRect(RenderTarget& dpi, uint32_t colour, int32_t left
     }
     else
     {
-        uint8_t* dst = startY * dpi.LineStride() + startX + dpi.bits;
+        uint8_t* dst = startY * rt.LineStride() + startX + rt.bits;
         for (int32_t i = 0; i < height; i++)
         {
             std::fill_n(dst, width, colour & 0xFF);
-            dst += dpi.LineStride();
+            dst += rt.LineStride();
         }
     }
 }
 
 void X8DrawingContext::FilterRect(
-    RenderTarget& dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom)
+    RenderTarget& rt, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
     Guard::Assert(_isDrawing == true);
 
@@ -560,43 +560,43 @@ void X8DrawingContext::FilterRect(
         return;
     if (top > bottom)
         return;
-    if (dpi.x > right)
+    if (rt.x > right)
         return;
-    if (left >= dpi.x + dpi.width)
+    if (left >= rt.x + rt.width)
         return;
-    if (bottom < dpi.y)
+    if (bottom < rt.y)
         return;
-    if (top >= dpi.y + dpi.height)
+    if (top >= rt.y + rt.height)
         return;
 
-    int32_t startX = left - dpi.x;
+    int32_t startX = left - rt.x;
     if (startX < 0)
     {
         startX = 0;
     }
 
-    int32_t endX = right - dpi.x + 1;
-    if (endX > dpi.width)
+    int32_t endX = right - rt.x + 1;
+    if (endX > rt.width)
     {
-        endX = dpi.width;
+        endX = rt.width;
     }
 
-    int32_t startY = top - dpi.y;
+    int32_t startY = top - rt.y;
     if (startY < 0)
     {
         startY = 0;
     }
 
-    int32_t endY = bottom - dpi.y + 1;
-    if (endY > dpi.height)
+    int32_t endY = bottom - rt.y + 1;
+    if (endY > rt.height)
     {
-        endY = dpi.height;
+        endY = rt.height;
     }
 
     int32_t width = endX - startX;
     int32_t height = endY - startY;
 
-    uint8_t* dst = dpi.bits + (startY * dpi.LineStride() + startX);
+    uint8_t* dst = rt.bits + (startY * rt.LineStride() + startX);
 
     // Find colour in colour table?
     auto paletteMap = GetPaletteMapForColour(EnumValue(palette));
@@ -604,7 +604,7 @@ void X8DrawingContext::FilterRect(
     {
         const auto& paletteEntries = paletteMap.value();
         const int32_t scaled_width = width;
-        const int32_t step = dpi.LineStride();
+        const int32_t step = rt.LineStride();
 
         // Fill the rectangle with the colours from the colour table
         auto c = height;
@@ -620,29 +620,29 @@ void X8DrawingContext::FilterRect(
     }
 }
 
-void X8DrawingContext::DrawLine(RenderTarget& dpi, uint32_t colour, const ScreenLine& line)
+void X8DrawingContext::DrawLine(RenderTarget& rt, uint32_t colour, const ScreenLine& line)
 {
     Guard::Assert(_isDrawing == true);
 
-    GfxDrawLineSoftware(dpi, line, colour);
+    GfxDrawLineSoftware(rt, line, colour);
 }
 
-void X8DrawingContext::DrawSprite(RenderTarget& dpi, const ImageId imageId, int32_t x, int32_t y)
+void X8DrawingContext::DrawSprite(RenderTarget& rt, const ImageId imageId, int32_t x, int32_t y)
 {
     Guard::Assert(_isDrawing == true);
 
-    GfxDrawSpriteSoftware(dpi, imageId, { x, y });
+    GfxDrawSpriteSoftware(rt, imageId, { x, y });
 }
 
 void X8DrawingContext::DrawSpriteRawMasked(
-    RenderTarget& dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage)
+    RenderTarget& rt, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage)
 {
     Guard::Assert(_isDrawing == true);
 
-    GfxDrawSpriteRawMaskedSoftware(dpi, { x, y }, maskImage, colourImage);
+    GfxDrawSpriteRawMaskedSoftware(rt, { x, y }, maskImage, colourImage);
 }
 
-void X8DrawingContext::DrawSpriteSolid(RenderTarget& dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour)
+void X8DrawingContext::DrawSpriteSolid(RenderTarget& rt, const ImageId image, int32_t x, int32_t y, uint8_t colour)
 {
     Guard::Assert(_isDrawing == true);
 
@@ -651,37 +651,37 @@ void X8DrawingContext::DrawSpriteSolid(RenderTarget& dpi, const ImageId image, i
     palette[0] = 0;
 
     const auto spriteCoords = ScreenCoordsXY{ x, y };
-    GfxDrawSpritePaletteSetSoftware(dpi, ImageId(image.GetIndex(), 0), spriteCoords, PaletteMap(palette));
+    GfxDrawSpritePaletteSetSoftware(rt, ImageId(image.GetIndex(), 0), spriteCoords, PaletteMap(palette));
 }
 
-void X8DrawingContext::DrawGlyph(RenderTarget& dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap)
+void X8DrawingContext::DrawGlyph(RenderTarget& rt, const ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap)
 {
     Guard::Assert(_isDrawing == true);
 
-    GfxDrawSpritePaletteSetSoftware(dpi, image, { x, y }, paletteMap);
+    GfxDrawSpritePaletteSetSoftware(rt, image, { x, y }, paletteMap);
 }
 
 #ifndef DISABLE_TTF
 template<bool TUseHinting>
 static void DrawTTFBitmapInternal(
-    RenderTarget& dpi, uint8_t colour, TTFSurface* surface, int32_t x, int32_t y, uint8_t hintingThreshold)
+    RenderTarget& rt, uint8_t colour, TTFSurface* surface, int32_t x, int32_t y, uint8_t hintingThreshold)
 {
-    assert(dpi.zoom_level == ZoomLevel{ 0 });
+    assert(rt.zoom_level == ZoomLevel{ 0 });
     const int32_t surfaceWidth = surface->w;
     int32_t width = surfaceWidth;
     int32_t height = surface->h;
 
-    const int32_t overflowX = (dpi.x + dpi.width) - (x + width);
-    const int32_t overflowY = (dpi.y + dpi.height) - (y + height);
+    const int32_t overflowX = (rt.x + rt.width) - (x + width);
+    const int32_t overflowY = (rt.y + rt.height) - (y + height);
     if (overflowX < 0)
         width += overflowX;
     if (overflowY < 0)
         height += overflowY;
-    int32_t skipX = x - dpi.x;
-    int32_t skipY = y - dpi.y;
+    int32_t skipX = x - rt.x;
+    int32_t skipY = y - rt.y;
 
     auto src = static_cast<const uint8_t*>(surface->pixels);
-    uint8_t* dst = dpi.bits;
+    uint8_t* dst = rt.bits;
 
     if (skipX < 0)
     {
@@ -697,10 +697,10 @@ static void DrawTTFBitmapInternal(
     }
 
     dst += skipX;
-    dst += skipY * dpi.LineStride();
+    dst += skipY * rt.LineStride();
 
     const int32_t srcScanSkip = surfaceWidth - width;
-    const int32_t dstScanSkip = dpi.LineStride() - width;
+    const int32_t dstScanSkip = rt.LineStride() - width;
     for (int32_t yy = 0; yy < height; yy++)
     {
         for (int32_t xx = 0; xx < width; xx++)
@@ -734,7 +734,7 @@ static void DrawTTFBitmapInternal(
 #endif // DISABLE_TTF
 
 void X8DrawingContext::DrawTTFBitmap(
-    RenderTarget& dpi, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y, uint8_t hintingThreshold)
+    RenderTarget& rt, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y, uint8_t hintingThreshold)
 {
 #ifndef DISABLE_TTF
     const uint8_t fgColor = info->palette[1];
@@ -742,20 +742,20 @@ void X8DrawingContext::DrawTTFBitmap(
 
     if (info->flags & TEXT_DRAW_FLAG_OUTLINE)
     {
-        DrawTTFBitmapInternal<false>(dpi, bgColor, surface, x + 1, y, 0);
-        DrawTTFBitmapInternal<false>(dpi, bgColor, surface, x - 1, y, 0);
-        DrawTTFBitmapInternal<false>(dpi, bgColor, surface, x, y + 1, 0);
-        DrawTTFBitmapInternal<false>(dpi, bgColor, surface, x, y - 1, 0);
+        DrawTTFBitmapInternal<false>(rt, bgColor, surface, x + 1, y, 0);
+        DrawTTFBitmapInternal<false>(rt, bgColor, surface, x - 1, y, 0);
+        DrawTTFBitmapInternal<false>(rt, bgColor, surface, x, y + 1, 0);
+        DrawTTFBitmapInternal<false>(rt, bgColor, surface, x, y - 1, 0);
     }
     if (info->flags & TEXT_DRAW_FLAG_INSET)
     {
-        DrawTTFBitmapInternal<false>(dpi, bgColor, surface, x + 1, y + 1, 0);
+        DrawTTFBitmapInternal<false>(rt, bgColor, surface, x + 1, y + 1, 0);
     }
 
     if (hintingThreshold > 0)
-        DrawTTFBitmapInternal<true>(dpi, fgColor, surface, x, y, hintingThreshold);
+        DrawTTFBitmapInternal<true>(rt, fgColor, surface, x, y, hintingThreshold);
     else
-        DrawTTFBitmapInternal<false>(dpi, fgColor, surface, x, y, 0);
+        DrawTTFBitmapInternal<false>(rt, fgColor, surface, x, y, 0);
 #endif // DISABLE_TTF
 }
 

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -47,7 +47,7 @@ namespace OpenRCT2
             void Draw(
                 RenderTarget& rt, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
                 const uint8_t* weatherpattern) override;
-            void Restore(RenderTarget& dpi);
+            void Restore(RenderTarget& rt);
         };
 
 #ifdef __WARN_SUGGEST_FINAL_TYPES__

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -45,9 +45,9 @@ namespace OpenRCT2
             X8WeatherDrawer();
             ~X8WeatherDrawer();
             void Draw(
-                DrawPixelInfo& dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
+                RenderTarget& dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
                 const uint8_t* weatherpattern) override;
-            void Restore(DrawPixelInfo& dpi);
+            void Restore(RenderTarget& dpi);
         };
 
 #ifdef __WARN_SUGGEST_FINAL_TYPES__
@@ -63,7 +63,7 @@ namespace OpenRCT2
             size_t _bitsSize = 0;
             uint8_t* _bits = nullptr;
 
-            DrawPixelInfo _bitsDPI = {};
+            RenderTarget _bitsDPI = {};
 
             bool _lastLightFXenabled = false;
 
@@ -104,11 +104,11 @@ namespace OpenRCT2
             void CopyRect(int32_t x, int32_t y, int32_t width, int32_t height, int32_t dx, int32_t dy) override;
             std::string Screenshot() override;
             IDrawingContext* GetDrawingContext() override;
-            DrawPixelInfo* GetDrawingPixelInfo() override;
+            RenderTarget* GetDrawingPixelInfo() override;
             DrawingEngineFlags GetFlags() override;
             void InvalidateImage(uint32_t image) override;
 
-            DrawPixelInfo* GetDPI();
+            RenderTarget* GetDPI();
 
         protected:
             void ConfigureBits(uint32_t width, uint32_t height, uint32_t pitch);
@@ -134,19 +134,19 @@ namespace OpenRCT2
 
             void BeginDraw();
             void EndDraw();
-            void Clear(DrawPixelInfo& dpi, uint8_t paletteIndex) override;
-            void FillRect(DrawPixelInfo& dpi, uint32_t colour, int32_t x, int32_t y, int32_t w, int32_t h) override;
+            void Clear(RenderTarget& dpi, uint8_t paletteIndex) override;
+            void FillRect(RenderTarget& dpi, uint32_t colour, int32_t x, int32_t y, int32_t w, int32_t h) override;
             void FilterRect(
-                DrawPixelInfo& dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) override;
-            void DrawLine(DrawPixelInfo& dpi, uint32_t colour, const ScreenLine& line) override;
-            void DrawSprite(DrawPixelInfo& dpi, const ImageId imageId, int32_t x, int32_t y) override;
+                RenderTarget& dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) override;
+            void DrawLine(RenderTarget& dpi, uint32_t colour, const ScreenLine& line) override;
+            void DrawSprite(RenderTarget& dpi, const ImageId imageId, int32_t x, int32_t y) override;
             void DrawSpriteRawMasked(
-                DrawPixelInfo& dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) override;
-            void DrawSpriteSolid(DrawPixelInfo& dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) override;
+                RenderTarget& dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) override;
+            void DrawSpriteSolid(RenderTarget& dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) override;
             void DrawGlyph(
-                DrawPixelInfo& dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap) override;
+                RenderTarget& dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap) override;
             void DrawTTFBitmap(
-                DrawPixelInfo& dpi, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y,
+                RenderTarget& dpi, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y,
                 uint8_t hintingThreshold) override;
 
             bool IsActive() const noexcept

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -45,7 +45,7 @@ namespace OpenRCT2
             X8WeatherDrawer();
             ~X8WeatherDrawer();
             void Draw(
-                RenderTarget& dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
+                RenderTarget& rt, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
                 const uint8_t* weatherpattern) override;
             void Restore(RenderTarget& dpi);
         };
@@ -63,7 +63,7 @@ namespace OpenRCT2
             size_t _bitsSize = 0;
             uint8_t* _bits = nullptr;
 
-            RenderTarget _bitsDPI = {};
+            RenderTarget _mainRT = {};
 
             bool _lastLightFXenabled = false;
 
@@ -134,19 +134,18 @@ namespace OpenRCT2
 
             void BeginDraw();
             void EndDraw();
-            void Clear(RenderTarget& dpi, uint8_t paletteIndex) override;
-            void FillRect(RenderTarget& dpi, uint32_t colour, int32_t x, int32_t y, int32_t w, int32_t h) override;
+            void Clear(RenderTarget& rt, uint8_t paletteIndex) override;
+            void FillRect(RenderTarget& rt, uint32_t colour, int32_t x, int32_t y, int32_t w, int32_t h) override;
             void FilterRect(
-                RenderTarget& dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) override;
-            void DrawLine(RenderTarget& dpi, uint32_t colour, const ScreenLine& line) override;
-            void DrawSprite(RenderTarget& dpi, const ImageId imageId, int32_t x, int32_t y) override;
+                RenderTarget& rt, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) override;
+            void DrawLine(RenderTarget& rt, uint32_t colour, const ScreenLine& line) override;
+            void DrawSprite(RenderTarget& rt, const ImageId imageId, int32_t x, int32_t y) override;
             void DrawSpriteRawMasked(
-                RenderTarget& dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) override;
-            void DrawSpriteSolid(RenderTarget& dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) override;
-            void DrawGlyph(
-                RenderTarget& dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap) override;
+                RenderTarget& rt, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) override;
+            void DrawSpriteSolid(RenderTarget& rt, const ImageId image, int32_t x, int32_t y, uint8_t colour) override;
+            void DrawGlyph(RenderTarget& rt, const ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap) override;
             void DrawTTFBitmap(
-                RenderTarget& dpi, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y,
+                RenderTarget& rt, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y,
                 uint8_t hintingThreshold) override;
 
             bool IsActive() const noexcept

--- a/src/openrct2/entity/Duck.cpp
+++ b/src/openrct2/entity/Duck.cpp
@@ -374,8 +374,8 @@ void Duck::Paint(PaintSession& session, int32_t imageDirection) const
 {
     PROFILED_FUNCTION();
 
-    RenderTarget& dpi = session.DPI;
-    if (dpi.zoom_level > ZoomLevel{ 1 })
+    RenderTarget& rt = session.DPI;
+    if (rt.zoom_level > ZoomLevel{ 1 })
         return;
 
     uint32_t imageId = GetFrameImage(imageDirection);

--- a/src/openrct2/entity/Duck.cpp
+++ b/src/openrct2/entity/Duck.cpp
@@ -374,7 +374,7 @@ void Duck::Paint(PaintSession& session, int32_t imageDirection) const
 {
     PROFILED_FUNCTION();
 
-    DrawPixelInfo& dpi = session.DPI;
+    RenderTarget& dpi = session.DPI;
     if (dpi.zoom_level > ZoomLevel{ 1 })
         return;
 

--- a/src/openrct2/entity/Fountain.cpp
+++ b/src/openrct2/entity/Fountain.cpp
@@ -410,8 +410,8 @@ void JumpingFountain::Paint(PaintSession& session, int32_t imageDirection) const
     constexpr uint32_t kJumpingFountainSnowBaseImage = 23037;
     constexpr uint32_t kJumpingFountainWaterBaseImage = 22973;
 
-    RenderTarget& dpi = session.DPI;
-    if (dpi.zoom_level > ZoomLevel{ 0 })
+    RenderTarget& rt = session.DPI;
+    if (rt.zoom_level > ZoomLevel{ 0 })
     {
         return;
     }

--- a/src/openrct2/entity/Fountain.cpp
+++ b/src/openrct2/entity/Fountain.cpp
@@ -410,7 +410,7 @@ void JumpingFountain::Paint(PaintSession& session, int32_t imageDirection) const
     constexpr uint32_t kJumpingFountainSnowBaseImage = 23037;
     constexpr uint32_t kJumpingFountainWaterBaseImage = 22973;
 
-    DrawPixelInfo& dpi = session.DPI;
+    RenderTarget& dpi = session.DPI;
     if (dpi.zoom_level > ZoomLevel{ 0 })
     {
         return;

--- a/src/openrct2/entity/Litter.cpp
+++ b/src/openrct2/entity/Litter.cpp
@@ -184,7 +184,7 @@ void Litter::Paint(PaintSession& session, int32_t imageDirection) const
 {
     PROFILED_FUNCTION();
 
-    DrawPixelInfo& dpi = session.DPI;
+    RenderTarget& dpi = session.DPI;
     if (dpi.zoom_level > ZoomLevel{ 0 })
         return; // If zoomed at all no litter drawn
 

--- a/src/openrct2/entity/Litter.cpp
+++ b/src/openrct2/entity/Litter.cpp
@@ -184,8 +184,8 @@ void Litter::Paint(PaintSession& session, int32_t imageDirection) const
 {
     PROFILED_FUNCTION();
 
-    RenderTarget& dpi = session.DPI;
-    if (dpi.zoom_level > ZoomLevel{ 0 })
+    RenderTarget& rt = session.DPI;
+    if (rt.zoom_level > ZoomLevel{ 0 })
         return; // If zoomed at all no litter drawn
 
     // litter has no sprite direction so remove that

--- a/src/openrct2/entity/MoneyEffect.cpp
+++ b/src/openrct2/entity/MoneyEffect.cpp
@@ -197,8 +197,8 @@ void MoneyEffect::Paint(PaintSession& session, int32_t imageDirection) const
         return;
     }
 
-    RenderTarget& dpi = session.DPI;
-    if (dpi.zoom_level > ZoomLevel{ 0 })
+    RenderTarget& rt = session.DPI;
+    if (rt.zoom_level > ZoomLevel{ 0 })
     {
         return;
     }

--- a/src/openrct2/entity/MoneyEffect.cpp
+++ b/src/openrct2/entity/MoneyEffect.cpp
@@ -197,7 +197,7 @@ void MoneyEffect::Paint(PaintSession& session, int32_t imageDirection) const
         return;
     }
 
-    DrawPixelInfo& dpi = session.DPI;
+    RenderTarget& dpi = session.DPI;
     if (dpi.zoom_level > ZoomLevel{ 0 })
     {
         return;

--- a/src/openrct2/entity/Particle.cpp
+++ b/src/openrct2/entity/Particle.cpp
@@ -171,7 +171,7 @@ void VehicleCrashParticle::Paint(PaintSession& session, int32_t imageDirection) 
 {
     PROFILED_FUNCTION();
 
-    DrawPixelInfo& dpi = session.DPI;
+    RenderTarget& dpi = session.DPI;
     if (dpi.zoom_level > ZoomLevel{ 0 })
     {
         return;

--- a/src/openrct2/entity/Particle.cpp
+++ b/src/openrct2/entity/Particle.cpp
@@ -171,8 +171,8 @@ void VehicleCrashParticle::Paint(PaintSession& session, int32_t imageDirection) 
 {
     PROFILED_FUNCTION();
 
-    RenderTarget& dpi = session.DPI;
-    if (dpi.zoom_level > ZoomLevel{ 0 })
+    RenderTarget& rt = session.DPI;
+    if (rt.zoom_level > ZoomLevel{ 0 })
     {
         return;
     }

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -40,7 +40,7 @@ static TextInputSession* _chatTextInputSession;
 static const u8string& ChatGetHistory(size_t index);
 static uint32_t ChatHistoryGetTime(size_t index);
 static void ChatClearInput();
-static int32_t ChatHistoryDrawString(RenderTarget& dpi, const char* text, const ScreenCoordsXY& screenCoords, int32_t width);
+static int32_t ChatHistoryDrawString(RenderTarget& rt, const char* text, const ScreenCoordsXY& screenCoords, int32_t width);
 
 bool ChatAvailable()
 {
@@ -84,7 +84,7 @@ void ChatUpdate()
     _chatCaretTicks = (_chatCaretTicks + 1) % 30;
 }
 
-void ChatDraw(RenderTarget& dpi, ColourWithFlags chatBackgroundColor)
+void ChatDraw(RenderTarget& rt, ColourWithFlags chatBackgroundColor)
 {
     thread_local std::string lineBuffer;
 
@@ -138,16 +138,16 @@ void ChatDraw(RenderTarget& dpi, ColourWithFlags chatBackgroundColor)
         GfxSetDirtyBlocks(
             { topLeft - ScreenCoordsXY{ 0, 5 }, bottomRight + ScreenCoordsXY{ 0, 5 } }); // Background area + Textbox
         GfxFilterRect(
-            dpi, { topLeft - ScreenCoordsXY{ 0, 5 }, bottomRight + ScreenCoordsXY{ 0, 5 } },
+            rt, { topLeft - ScreenCoordsXY{ 0, 5 }, bottomRight + ScreenCoordsXY{ 0, 5 } },
             FilterPaletteID::Palette51); // Opaque grey background
         GfxFillRectInset(
-            dpi, { topLeft - ScreenCoordsXY{ 0, 5 }, bottomRight + ScreenCoordsXY{ 0, 5 } }, chatBackgroundColor,
+            rt, { topLeft - ScreenCoordsXY{ 0, 5 }, bottomRight + ScreenCoordsXY{ 0, 5 } }, chatBackgroundColor,
             INSET_RECT_FLAG_FILL_NONE);
         GfxFillRectInset(
-            dpi, { topLeft + ScreenCoordsXY{ 1, -4 }, bottomRight - ScreenCoordsXY{ 1, inputLineHeight + 6 } },
+            rt, { topLeft + ScreenCoordsXY{ 1, -4 }, bottomRight - ScreenCoordsXY{ 1, inputLineHeight + 6 } },
             chatBackgroundColor, INSET_RECT_FLAG_BORDER_INSET);
         GfxFillRectInset(
-            dpi, { bottomLeft + ScreenCoordsXY{ 1, -inputLineHeight - 5 }, bottomRight + ScreenCoordsXY{ -1, 4 } },
+            rt, { bottomLeft + ScreenCoordsXY{ 1, -inputLineHeight - 5 }, bottomRight + ScreenCoordsXY{ -1, 4 } },
             chatBackgroundColor,
             INSET_RECT_FLAG_BORDER_INSET); // Textbox
     }
@@ -169,7 +169,7 @@ void ChatDraw(RenderTarget& dpi, ColourWithFlags chatBackgroundColor)
 
         lineBuffer = ChatGetHistory(i);
         auto lineCh = lineBuffer.c_str();
-        stringHeight = ChatHistoryDrawString(dpi, lineCh, screenCoords, _chatWidth - 10) + 5;
+        stringHeight = ChatHistoryDrawString(rt, lineCh, screenCoords, _chatWidth - 10) + 5;
         GfxSetDirtyBlocks(
             { { screenCoords - ScreenCoordsXY{ 0, stringHeight } }, { screenCoords + ScreenCoordsXY{ _chatWidth, 20 } } });
 
@@ -191,7 +191,7 @@ void ChatDraw(RenderTarget& dpi, ColourWithFlags chatBackgroundColor)
         auto ft = Formatter();
         ft.Add<const char*>(lineCh);
         inputLineHeight = DrawTextWrapped(
-            dpi, screenCoords + ScreenCoordsXY{ 0, 3 }, _chatWidth - 10, STR_STRING, ft, { kTextColour255 });
+            rt, screenCoords + ScreenCoordsXY{ 0, 3 }, _chatWidth - 10, STR_STRING, ft, { kTextColour255 });
         GfxSetDirtyBlocks({ screenCoords, { screenCoords + ScreenCoordsXY{ _chatWidth, inputLineHeight + 15 } } });
 
         // TODO: Show caret if the input text has multiple lines
@@ -201,7 +201,7 @@ void ChatDraw(RenderTarget& dpi, ColourWithFlags chatBackgroundColor)
             int32_t caretX = screenCoords.x + GfxGetStringWidth(lineBuffer, FontStyle::Medium);
             int32_t caretY = screenCoords.y + 14;
 
-            GfxFillRect(dpi, { { caretX, caretY }, { caretX + 6, caretY + 1 } }, PaletteIndex::pi56);
+            GfxFillRect(rt, { { caretX, caretY }, { caretX + 6, caretY + 1 } }, PaletteIndex::pi56);
         }
     }
 }
@@ -285,7 +285,7 @@ static void ChatClearInput()
 
 // This method is the same as gfx_draw_string_left_wrapped.
 // But this adjusts the initial Y coordinate depending of the number of lines.
-static int32_t ChatHistoryDrawString(RenderTarget& dpi, const char* text, const ScreenCoordsXY& screenCoords, int32_t width)
+static int32_t ChatHistoryDrawString(RenderTarget& rt, const char* text, const ScreenCoordsXY& screenCoords, int32_t width)
 {
     int32_t numLines;
     u8string wrappedString;
@@ -302,7 +302,7 @@ static int32_t ChatHistoryDrawString(RenderTarget& dpi, const char* text, const 
     int32_t lineY = screenCoords.y;
     for (int32_t line = 0; line <= numLines; ++line)
     {
-        DrawText(dpi, { screenCoords.x, lineY - (numLines * lineHeight) }, { kTextColour254 }, bufferPtr);
+        DrawText(rt, { screenCoords.x, lineY - (numLines * lineHeight) }, { kTextColour254 }, bufferPtr);
         bufferPtr = GetStringEnd(bufferPtr) + 1;
         lineY += lineHeight;
     }

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -40,7 +40,7 @@ static TextInputSession* _chatTextInputSession;
 static const u8string& ChatGetHistory(size_t index);
 static uint32_t ChatHistoryGetTime(size_t index);
 static void ChatClearInput();
-static int32_t ChatHistoryDrawString(DrawPixelInfo& dpi, const char* text, const ScreenCoordsXY& screenCoords, int32_t width);
+static int32_t ChatHistoryDrawString(RenderTarget& dpi, const char* text, const ScreenCoordsXY& screenCoords, int32_t width);
 
 bool ChatAvailable()
 {
@@ -84,7 +84,7 @@ void ChatUpdate()
     _chatCaretTicks = (_chatCaretTicks + 1) % 30;
 }
 
-void ChatDraw(DrawPixelInfo& dpi, ColourWithFlags chatBackgroundColor)
+void ChatDraw(RenderTarget& dpi, ColourWithFlags chatBackgroundColor)
 {
     thread_local std::string lineBuffer;
 
@@ -285,7 +285,7 @@ static void ChatClearInput()
 
 // This method is the same as gfx_draw_string_left_wrapped.
 // But this adjusts the initial Y coordinate depending of the number of lines.
-static int32_t ChatHistoryDrawString(DrawPixelInfo& dpi, const char* text, const ScreenCoordsXY& screenCoords, int32_t width)
+static int32_t ChatHistoryDrawString(RenderTarget& dpi, const char* text, const ScreenCoordsXY& screenCoords, int32_t width)
 {
     int32_t numLines;
     u8string wrappedString;

--- a/src/openrct2/interface/Chat.h
+++ b/src/openrct2/interface/Chat.h
@@ -19,7 +19,7 @@ constexpr int16_t kChatInputSize = 1024;
 constexpr uint8_t kChatMaxMessageLength = 200;
 constexpr int16_t kChatMaxWindowWidth = 600;
 
-struct DrawPixelInfo;
+struct RenderTarget;
 struct ScreenCoordsXY;
 
 enum class ChatInput : uint8_t
@@ -38,7 +38,7 @@ void ChatToggle();
 
 void ChatInit();
 void ChatUpdate();
-void ChatDraw(DrawPixelInfo& dpi, ColourWithFlags chatBackgroundColour);
+void ChatDraw(RenderTarget& dpi, ColourWithFlags chatBackgroundColour);
 
 void ChatAddHistory(std::string_view s);
 void ChatInput(ChatInput input);

--- a/src/openrct2/interface/Chat.h
+++ b/src/openrct2/interface/Chat.h
@@ -38,7 +38,7 @@ void ChatToggle();
 
 void ChatInit();
 void ChatUpdate();
-void ChatDraw(RenderTarget& dpi, ColourWithFlags chatBackgroundColour);
+void ChatDraw(RenderTarget& rt, ColourWithFlags chatBackgroundColour);
 
 void ChatAddHistory(std::string_view s);
 void ChatInput(ChatInput input);

--- a/src/openrct2/interface/InteractiveConsole.h
+++ b/src/openrct2/interface/InteractiveConsole.h
@@ -13,7 +13,7 @@
 #include <cstdint>
 #include <string>
 
-struct DrawPixelInfo;
+struct RenderTarget;
 struct TextInputSession;
 
 enum class FormatToken : uint8_t;

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -52,7 +52,7 @@ extern uint8_t gClipHeight;
 
 uint8_t gScreenshotCountdown = 0;
 
-static bool WriteDpiToFile(std::string_view path, const DrawPixelInfo& dpi, const GamePalette& palette)
+static bool WriteDpiToFile(std::string_view path, const RenderTarget& dpi, const GamePalette& palette)
 {
     auto const pixels8 = dpi.bits;
     auto const pixelsLen = dpi.LineStride() * dpi.height;
@@ -172,7 +172,7 @@ static std::optional<std::string> ScreenshotGetNextPath()
     return std::nullopt;
 };
 
-std::string ScreenshotDumpPNG(DrawPixelInfo& dpi)
+std::string ScreenshotDumpPNG(RenderTarget& dpi)
 {
     // Get a free screenshot path
     auto path = ScreenshotGetNextPath();
@@ -227,9 +227,9 @@ static int32_t GetTallestVisibleTileTop(
     return minViewY - 64;
 }
 
-static DrawPixelInfo CreateDPI(const Viewport& viewport)
+static RenderTarget CreateDPI(const Viewport& viewport)
 {
-    DrawPixelInfo dpi;
+    RenderTarget dpi;
     dpi.width = viewport.width;
     dpi.height = viewport.height;
     dpi.bits = new (std::nothrow) uint8_t[dpi.width * dpi.height];
@@ -246,7 +246,7 @@ static DrawPixelInfo CreateDPI(const Viewport& viewport)
     return dpi;
 }
 
-static void ReleaseDPI(DrawPixelInfo& dpi)
+static void ReleaseDPI(RenderTarget& dpi)
 {
     if (dpi.bits != nullptr)
         delete[] dpi.bits;
@@ -305,7 +305,7 @@ static Viewport GetGiantViewport(int32_t rotation, ZoomLevel zoom)
     return viewport;
 }
 
-static void RenderViewport(IDrawingEngine* drawingEngine, const Viewport& viewport, DrawPixelInfo& dpi)
+static void RenderViewport(IDrawingEngine* drawingEngine, const Viewport& viewport, RenderTarget& dpi)
 {
     // Ensure sprites appear regardless of rotation
     ResetAllSpriteQuadrantPlacements();
@@ -327,7 +327,7 @@ static void RenderViewport(IDrawingEngine* drawingEngine, const Viewport& viewpo
 
 void ScreenshotGiant()
 {
-    DrawPixelInfo dpi{};
+    RenderTarget dpi{};
     try
     {
         auto path = ScreenshotGetNextPath();
@@ -446,7 +446,7 @@ int32_t CommandLineForScreenshot(const char** argv, int32_t argc, ScreenshotOpti
     }
 
     int32_t exitCode = 1;
-    DrawPixelInfo dpi;
+    RenderTarget dpi;
     try
     {
         bool customLocation = false;

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -172,7 +172,7 @@ static std::optional<std::string> ScreenshotGetNextPath()
     return std::nullopt;
 };
 
-std::string ScreenshotDumpPNG(RenderTarget& dpi)
+std::string ScreenshotDumpPNG(RenderTarget& rt)
 {
     // Get a free screenshot path
     auto path = ScreenshotGetNextPath();
@@ -182,7 +182,7 @@ std::string ScreenshotDumpPNG(RenderTarget& dpi)
         return "";
     }
 
-    if (WriteDpiToFile(path.value(), dpi, gPalette))
+    if (WriteDpiToFile(path.value(), rt, gPalette))
     {
         return path.value();
     }
@@ -229,30 +229,30 @@ static int32_t GetTallestVisibleTileTop(
 
 static RenderTarget CreateDPI(const Viewport& viewport)
 {
-    RenderTarget dpi;
-    dpi.width = viewport.width;
-    dpi.height = viewport.height;
-    dpi.bits = new (std::nothrow) uint8_t[dpi.width * dpi.height];
-    if (dpi.bits == nullptr)
+    RenderTarget rt;
+    rt.width = viewport.width;
+    rt.height = viewport.height;
+    rt.bits = new (std::nothrow) uint8_t[rt.width * rt.height];
+    if (rt.bits == nullptr)
     {
         throw std::runtime_error("Giant screenshot failed, unable to allocate memory for image.");
     }
 
     if (viewport.flags & VIEWPORT_FLAG_TRANSPARENT_BACKGROUND)
     {
-        std::memset(dpi.bits, PaletteIndex::pi0, static_cast<size_t>(dpi.width) * dpi.height);
+        std::memset(rt.bits, PaletteIndex::pi0, static_cast<size_t>(rt.width) * rt.height);
     }
 
-    return dpi;
+    return rt;
 }
 
-static void ReleaseDPI(RenderTarget& dpi)
+static void ReleaseDPI(RenderTarget& rt)
 {
-    if (dpi.bits != nullptr)
-        delete[] dpi.bits;
-    dpi.bits = nullptr;
-    dpi.width = 0;
-    dpi.height = 0;
+    if (rt.bits != nullptr)
+        delete[] rt.bits;
+    rt.bits = nullptr;
+    rt.width = 0;
+    rt.height = 0;
 }
 
 static Viewport GetGiantViewport(int32_t rotation, ZoomLevel zoom)
@@ -305,7 +305,7 @@ static Viewport GetGiantViewport(int32_t rotation, ZoomLevel zoom)
     return viewport;
 }
 
-static void RenderViewport(IDrawingEngine* drawingEngine, const Viewport& viewport, RenderTarget& dpi)
+static void RenderViewport(IDrawingEngine* drawingEngine, const Viewport& viewport, RenderTarget& rt)
 {
     // Ensure sprites appear regardless of rotation
     ResetAllSpriteQuadrantPlacements();
@@ -319,15 +319,15 @@ static void RenderViewport(IDrawingEngine* drawingEngine, const Viewport& viewpo
 
     tempDrawingEngine->BeginDraw();
 
-    dpi.DrawingEngine = drawingEngine;
-    ViewportRender(dpi, &viewport);
+    rt.DrawingEngine = drawingEngine;
+    ViewportRender(rt, &viewport);
 
     tempDrawingEngine->EndDraw();
 }
 
 void ScreenshotGiant()
 {
-    RenderTarget dpi{};
+    RenderTarget rt{};
     try
     {
         auto path = ScreenshotGetNextPath();
@@ -355,10 +355,10 @@ void ScreenshotGiant()
             viewport.flags |= VIEWPORT_FLAG_TRANSPARENT_BACKGROUND;
         }
 
-        dpi = CreateDPI(viewport);
+        rt = CreateDPI(viewport);
 
-        RenderViewport(nullptr, viewport, dpi);
-        WriteDpiToFile(path.value(), dpi, gPalette);
+        RenderViewport(nullptr, viewport, rt);
+        WriteDpiToFile(path.value(), rt, gPalette);
 
         // Show user that screenshot saved successfully
         const auto filename = Path::GetFileName(path.value());
@@ -373,7 +373,7 @@ void ScreenshotGiant()
         ContextShowError(STR_SCREENSHOT_FAILED, kStringIdNone, {}, true);
     }
 
-    ReleaseDPI(dpi);
+    ReleaseDPI(rt);
 }
 
 static void ApplyOptions(const ScreenshotOptions* options, Viewport& viewport)
@@ -446,7 +446,7 @@ int32_t CommandLineForScreenshot(const char** argv, int32_t argc, ScreenshotOpti
     }
 
     int32_t exitCode = 1;
-    RenderTarget dpi;
+    RenderTarget rt;
     try
     {
         bool customLocation = false;
@@ -546,17 +546,17 @@ int32_t CommandLineForScreenshot(const char** argv, int32_t argc, ScreenshotOpti
 
         ApplyOptions(options, viewport);
 
-        dpi = CreateDPI(viewport);
+        rt = CreateDPI(viewport);
 
-        RenderViewport(nullptr, viewport, dpi);
-        WriteDpiToFile(outputPath, dpi, gPalette);
+        RenderViewport(nullptr, viewport, rt);
+        WriteDpiToFile(outputPath, rt, gPalette);
     }
     catch (const std::exception& e)
     {
         std::printf("%s\n", e.what());
         exitCode = -1;
     }
-    ReleaseDPI(dpi);
+    ReleaseDPI(rt);
 
     DrawingEngineDispose();
 
@@ -639,8 +639,8 @@ void CaptureImage(const CaptureOptions& options)
     }
 
     auto outputPath = ResolveFilenameForCapture(options.Filename);
-    auto dpi = CreateDPI(viewport);
-    RenderViewport(nullptr, viewport, dpi);
-    WriteDpiToFile(outputPath, dpi, gPalette);
-    ReleaseDPI(dpi);
+    auto rt = CreateDPI(viewport);
+    RenderViewport(nullptr, viewport, rt);
+    WriteDpiToFile(outputPath, rt, gPalette);
+    ReleaseDPI(rt);
 }

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -52,17 +52,17 @@ extern uint8_t gClipHeight;
 
 uint8_t gScreenshotCountdown = 0;
 
-static bool WriteDpiToFile(std::string_view path, const RenderTarget& dpi, const GamePalette& palette)
+static bool WriteDpiToFile(std::string_view path, const RenderTarget& rt, const GamePalette& palette)
 {
-    auto const pixels8 = dpi.bits;
-    auto const pixelsLen = dpi.LineStride() * dpi.height;
+    auto const pixels8 = rt.bits;
+    auto const pixelsLen = rt.LineStride() * rt.height;
     try
     {
         Image image;
-        image.Width = dpi.width;
-        image.Height = dpi.height;
+        image.Width = rt.width;
+        image.Height = rt.height;
         image.Depth = 8;
-        image.Stride = dpi.LineStride();
+        image.Stride = rt.LineStride();
         image.Palette = palette;
         image.Pixels = std::vector<uint8_t>(pixels8, pixels8 + pixelsLen);
         Imaging::WriteToFile(path, image, ImageFormat::png);

--- a/src/openrct2/interface/Screenshot.h
+++ b/src/openrct2/interface/Screenshot.h
@@ -17,7 +17,7 @@
 #include <optional>
 #include <string>
 
-struct DrawPixelInfo;
+struct RenderTarget;
 
 extern uint8_t gScreenshotCountdown;
 
@@ -53,7 +53,7 @@ struct CaptureOptions
 
 void ScreenshotCheck();
 std::string ScreenshotDump();
-std::string ScreenshotDumpPNG(DrawPixelInfo& dpi);
+std::string ScreenshotDumpPNG(RenderTarget& dpi);
 
 void ScreenshotGiant();
 int32_t CommandLineForScreenshot(const char** argv, int32_t argc, ScreenshotOptions* options);

--- a/src/openrct2/interface/Screenshot.h
+++ b/src/openrct2/interface/Screenshot.h
@@ -53,7 +53,7 @@ struct CaptureOptions
 
 void ScreenshotCheck();
 std::string ScreenshotDump();
-std::string ScreenshotDumpPNG(RenderTarget& dpi);
+std::string ScreenshotDumpPNG(RenderTarget& rt);
 
 void ScreenshotGiant();
 int32_t CommandLineForScreenshot(const char** argv, int32_t argc, ScreenshotOptions* options);

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -79,8 +79,8 @@ namespace OpenRCT2
     {
     }
 
-    static void ViewportPaintWeatherGloom(RenderTarget& dpi);
-    static void ViewportPaint(const Viewport* viewport, RenderTarget& dpi);
+    static void ViewportPaintWeatherGloom(RenderTarget& rt);
+    static void ViewportPaint(const Viewport* viewport, RenderTarget& rt);
     static void ViewportUpdateFollowSprite(WindowBase* window);
     static void ViewportUpdateSmartFollowEntity(WindowBase* window);
     static void ViewportUpdateSmartFollowStaff(WindowBase* window, const Staff& peep);
@@ -333,7 +333,7 @@ namespace OpenRCT2
      *  rct2: 0x006E7FF3
      */
     static void ViewportRedrawAfterShift(
-        RenderTarget& dpi, WindowBase* window, const WindowBase* originalWindow, const ScreenCoordsXY shift,
+        RenderTarget& rt, WindowBase* window, const WindowBase* originalWindow, const ScreenCoordsXY shift,
         const ScreenRect& drawRect)
     {
         // sub-divide by intersecting windows
@@ -355,41 +355,41 @@ namespace OpenRCT2
                     return itNext;
                 }();
                 ViewportRedrawAfterShift(
-                    dpi, itNextWindow == g_window_list.end() ? nullptr : itNextWindow->get(), originalWindow, shift, drawRect);
+                    rt, itNextWindow == g_window_list.end() ? nullptr : itNextWindow->get(), originalWindow, shift, drawRect);
                 return;
             }
 
             if (drawRect.GetLeft() < window->windowPos.x)
             {
                 ScreenRect leftRect = { drawRect.Point1, { window->windowPos.x, drawRect.GetBottom() } };
-                ViewportRedrawAfterShift(dpi, window, originalWindow, shift, leftRect);
+                ViewportRedrawAfterShift(rt, window, originalWindow, shift, leftRect);
 
                 ScreenRect rightRect = { { window->windowPos.x, drawRect.GetTop() }, drawRect.Point2 };
-                ViewportRedrawAfterShift(dpi, window, originalWindow, shift, rightRect);
+                ViewportRedrawAfterShift(rt, window, originalWindow, shift, rightRect);
             }
             else if (drawRect.GetRight() > window->windowPos.x + window->width)
             {
                 ScreenRect leftRect = { drawRect.Point1, { window->windowPos.x + window->width, drawRect.GetBottom() } };
-                ViewportRedrawAfterShift(dpi, window, originalWindow, shift, leftRect);
+                ViewportRedrawAfterShift(rt, window, originalWindow, shift, leftRect);
 
                 ScreenRect rightRect = { { window->windowPos.x + window->width, drawRect.GetTop() }, drawRect.Point2 };
-                ViewportRedrawAfterShift(dpi, window, originalWindow, shift, rightRect);
+                ViewportRedrawAfterShift(rt, window, originalWindow, shift, rightRect);
             }
             else if (drawRect.GetTop() < window->windowPos.y)
             {
                 ScreenRect topRect = { drawRect.Point1, { drawRect.GetRight(), window->windowPos.y } };
-                ViewportRedrawAfterShift(dpi, window, originalWindow, shift, topRect);
+                ViewportRedrawAfterShift(rt, window, originalWindow, shift, topRect);
 
                 ScreenRect bottomRect = { { drawRect.GetLeft(), window->windowPos.y }, drawRect.Point2 };
-                ViewportRedrawAfterShift(dpi, window, originalWindow, shift, bottomRect);
+                ViewportRedrawAfterShift(rt, window, originalWindow, shift, bottomRect);
             }
             else if (drawRect.GetBottom() > window->windowPos.y + window->height)
             {
                 ScreenRect topRect = { drawRect.Point1, { drawRect.GetRight(), window->windowPos.y + window->height } };
-                ViewportRedrawAfterShift(dpi, window, originalWindow, shift, topRect);
+                ViewportRedrawAfterShift(rt, window, originalWindow, shift, topRect);
 
                 ScreenRect bottomRect = { { drawRect.GetLeft(), window->windowPos.y + window->height }, drawRect.Point2 };
-                ViewportRedrawAfterShift(dpi, window, originalWindow, shift, bottomRect);
+                ViewportRedrawAfterShift(rt, window, originalWindow, shift, bottomRect);
             }
         }
         else
@@ -410,14 +410,14 @@ namespace OpenRCT2
                 {
                     // draw left
                     auto _right = left + shift.x;
-                    WindowDrawAll(dpi, left, top, _right, bottom);
+                    WindowDrawAll(rt, left, top, _right, bottom);
                     left += shift.x;
                 }
                 else if (shift.x < 0)
                 {
                     // draw right
                     auto _left = right + shift.x;
-                    WindowDrawAll(dpi, _left, top, right, bottom);
+                    WindowDrawAll(rt, _left, top, right, bottom);
                     right += shift.x;
                 }
 
@@ -425,24 +425,24 @@ namespace OpenRCT2
                 {
                     // draw top
                     bottom = top + shift.y;
-                    WindowDrawAll(dpi, left, top, right, bottom);
+                    WindowDrawAll(rt, left, top, right, bottom);
                 }
                 else if (shift.y < 0)
                 {
                     // draw bottom
                     top = bottom + shift.y;
-                    WindowDrawAll(dpi, left, top, right, bottom);
+                    WindowDrawAll(rt, left, top, right, bottom);
                 }
             }
             else
             {
                 // redraw whole draw rectangle
-                WindowDrawAll(dpi, left, top, right, bottom);
+                WindowDrawAll(rt, left, top, right, bottom);
             }
         }
     }
 
-    static void ViewportShiftPixels(RenderTarget& dpi, WindowBase* window, Viewport* viewport, int32_t x_diff, int32_t y_diff)
+    static void ViewportShiftPixels(RenderTarget& rt, WindowBase* window, Viewport* viewport, int32_t x_diff, int32_t y_diff)
     {
         // This loop redraws all parts covered by transparent windows.
         auto it = WindowGetIterator(window);
@@ -484,11 +484,11 @@ namespace OpenRCT2
             if (top >= bottom)
                 continue;
 
-            WindowDrawAll(dpi, left, top, right, bottom);
+            WindowDrawAll(rt, left, top, right, bottom);
         }
 
         ViewportRedrawAfterShift(
-            dpi, window, window, { x_diff, y_diff },
+            rt, window, window, { x_diff, y_diff },
             { viewport->pos, { viewport->pos.x + viewport->width, viewport->pos.y + viewport->height } });
     }
 
@@ -522,8 +522,8 @@ namespace OpenRCT2
 
             if (DrawingEngineHasDirtyOptimisations())
             {
-                RenderTarget& dpi = DrawingEngineGetDpi();
-                WindowDrawAll(dpi, left, top, right, bottom);
+                RenderTarget& rt = DrawingEngineGetDpi();
+                WindowDrawAll(rt, left, top, right, bottom);
                 return;
             }
             else
@@ -574,8 +574,8 @@ namespace OpenRCT2
 
         if (DrawingEngineHasDirtyOptimisations())
         {
-            RenderTarget& dpi = DrawingEngineGetDpi();
-            ViewportShiftPixels(dpi, w, viewport, x_diff, y_diff);
+            RenderTarget& rt = DrawingEngineGetDpi();
+            ViewportShiftPixels(rt, w, viewport, x_diff, y_diff);
         }
         else
         {
@@ -928,21 +928,21 @@ namespace OpenRCT2
      *  edi: dpi
      *  ebp: bottom
      */
-    void ViewportRender(RenderTarget& dpi, const Viewport* viewport)
+    void ViewportRender(RenderTarget& rt, const Viewport* viewport)
     {
         if (viewport->flags & VIEWPORT_FLAG_RENDERING_INHIBITED)
             return;
 
-        if (dpi.x + dpi.width <= viewport->pos.x)
+        if (rt.x + rt.width <= viewport->pos.x)
             return;
-        if (dpi.y + dpi.height <= viewport->pos.y)
+        if (rt.y + rt.height <= viewport->pos.y)
             return;
-        if (dpi.x >= viewport->pos.x + viewport->width)
+        if (rt.x >= viewport->pos.x + viewport->width)
             return;
-        if (dpi.y >= viewport->pos.y + viewport->height)
+        if (rt.y >= viewport->pos.y + viewport->height)
             return;
 
-        ViewportPaint(viewport, dpi);
+        ViewportPaint(viewport, rt);
     }
 
     static void ViewportFillColumn(PaintSession& session)
@@ -994,27 +994,27 @@ namespace OpenRCT2
      *  edi: dpi
      *  ebp: bottom
      */
-    static void ViewportPaint(const Viewport* viewport, RenderTarget& dpi)
+    static void ViewportPaint(const Viewport* viewport, RenderTarget& rt)
     {
         PROFILED_FUNCTION();
 
-        const int32_t offsetX = dpi.x - viewport->pos.x;
-        const int32_t offsetY = dpi.y - viewport->pos.y;
+        const int32_t offsetX = rt.x - viewport->pos.x;
+        const int32_t offsetY = rt.y - viewport->pos.y;
         const int32_t worldX = viewport->zoom.ApplyInversedTo(viewport->viewPos.x) + std::max(0, offsetX);
         const int32_t worldY = viewport->zoom.ApplyInversedTo(viewport->viewPos.y) + std::max(0, offsetY);
-        const int32_t width = std::min(viewport->pos.x + viewport->width, dpi.x + dpi.width) - std::max(viewport->pos.x, dpi.x);
-        const int32_t height = std::min(viewport->pos.y + viewport->height, dpi.y + dpi.height)
-            - std::max(viewport->pos.y, dpi.y);
+        const int32_t width = std::min(viewport->pos.x + viewport->width, rt.x + rt.width) - std::max(viewport->pos.x, rt.x);
+        const int32_t height = std::min(viewport->pos.y + viewport->height, rt.y + rt.height)
+            - std::max(viewport->pos.y, rt.y);
 
-        RenderTarget worldDpi;
-        worldDpi.DrawingEngine = dpi.DrawingEngine;
-        worldDpi.bits = dpi.bits + std::max(0, -offsetX) + std::max(0, -offsetY) * dpi.LineStride();
-        worldDpi.x = worldX;
-        worldDpi.y = worldY;
-        worldDpi.width = width;
-        worldDpi.height = height;
-        worldDpi.pitch = dpi.LineStride() - worldDpi.width;
-        worldDpi.zoom_level = viewport->zoom;
+        RenderTarget worldRT;
+        worldRT.DrawingEngine = rt.DrawingEngine;
+        worldRT.bits = rt.bits + std::max(0, -offsetX) + std::max(0, -offsetY) * rt.LineStride();
+        worldRT.x = worldX;
+        worldRT.y = worldY;
+        worldRT.width = width;
+        worldRT.height = height;
+        worldRT.pitch = rt.LineStride() - worldRT.width;
+        worldRT.zoom_level = viewport->zoom;
 
         _paintColumns.clear();
 
@@ -1029,48 +1029,48 @@ namespace OpenRCT2
         }
 
         bool useParallelDrawing = false;
-        if (useMultithreading && dpi.DrawingEngine->GetFlags().has(DrawingEngineFlag::parallelDrawing))
+        if (useMultithreading && rt.DrawingEngine->GetFlags().has(DrawingEngineFlag::parallelDrawing))
         {
             useParallelDrawing = true;
         }
 
-        const int32_t columnWidth = worldDpi.zoom_level.ApplyInversedTo(kCoordsXYStep);
-        const int32_t rightBorder = worldDpi.x + worldDpi.width;
-        const int32_t alignedX = floor2(worldDpi.x, columnWidth);
+        const int32_t columnWidth = worldRT.zoom_level.ApplyInversedTo(kCoordsXYStep);
+        const int32_t rightBorder = worldRT.x + worldRT.width;
+        const int32_t alignedX = floor2(worldRT.x, columnWidth);
 
         // Generate and sort columns.
         for (int32_t x = alignedX; x < rightBorder; x += columnWidth)
         {
-            PaintSession* session = PaintSessionAlloc(worldDpi, viewport->flags, viewport->rotation);
+            PaintSession* session = PaintSessionAlloc(worldRT, viewport->flags, viewport->rotation);
             _paintColumns.push_back(session);
 
-            RenderTarget& columnDpi = session->DPI;
-            if (x >= columnDpi.x)
+            RenderTarget& columnRT = session->DPI;
+            if (x >= columnRT.x)
             {
-                const int32_t leftPitch = x - columnDpi.x;
-                columnDpi.width = columnDpi.width - leftPitch;
-                columnDpi.bits += leftPitch;
-                columnDpi.pitch += leftPitch;
-                columnDpi.x = x;
+                const int32_t leftPitch = x - columnRT.x;
+                columnRT.width = columnRT.width - leftPitch;
+                columnRT.bits += leftPitch;
+                columnRT.pitch += leftPitch;
+                columnRT.x = x;
             }
 
-            int32_t paintRight = columnDpi.x + columnDpi.width;
+            int32_t paintRight = columnRT.x + columnRT.width;
             if (paintRight >= x + columnWidth)
             {
                 const int32_t rightPitch = paintRight - x - columnWidth;
                 paintRight -= rightPitch;
-                columnDpi.pitch += rightPitch;
+                columnRT.pitch += rightPitch;
             }
-            columnDpi.width = paintRight - columnDpi.x;
+            columnRT.width = paintRight - columnRT.x;
 
             // culling sprites outside the clipped column causes sorting differences between invalidation blocks
             // not culling sprites outside the full column width also causes a different kind of glitching
             constexpr int32_t cullingY = ZoomLevel::max().ApplyInversedTo(std::numeric_limits<int32_t>::max()) / 2;
 
-            columnDpi.cullingX = floor2(columnDpi.x, columnWidth);
-            columnDpi.cullingY = -cullingY;
-            columnDpi.cullingWidth = columnWidth;
-            columnDpi.cullingHeight = cullingY * 2;
+            columnRT.cullingX = floor2(columnRT.x, columnWidth);
+            columnRT.cullingY = -cullingY;
+            columnRT.cullingWidth = columnWidth;
+            columnRT.cullingHeight = cullingY * 2;
 
             if (useMultithreading)
             {
@@ -1111,16 +1111,16 @@ namespace OpenRCT2
         }
     }
 
-    static void ViewportPaintWeatherGloom(RenderTarget& dpi)
+    static void ViewportPaintWeatherGloom(RenderTarget& rt)
     {
         auto paletteId = ClimateGetWeatherGloomPaletteId(getGameState().weatherCurrent);
         if (paletteId != FilterPaletteID::PaletteNull)
         {
-            auto x = dpi.x;
-            auto y = dpi.y;
-            auto w = dpi.width;
-            auto h = dpi.height;
-            GfxFilterRect(dpi, ScreenRect(x, y, x + w, y + h), paletteId);
+            auto x = rt.x;
+            auto y = rt.y;
+            auto w = rt.width;
+            auto h = rt.height;
+            GfxFilterRect(rt, ScreenRect(x, y, x + w, y + h), paletteId);
         }
     }
 
@@ -1628,7 +1628,7 @@ namespace OpenRCT2
      * rct2: 0x00679074
      */
     static bool IsSpriteInteractedWithPaletteSet(
-        RenderTarget& dpi, ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap,
+        RenderTarget& rt, ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap,
         const uint8_t imageType)
     {
         PROFILED_FUNCTION();
@@ -1639,11 +1639,11 @@ namespace OpenRCT2
             return false;
         }
 
-        ZoomLevel zoomLevel = dpi.zoom_level;
-        ScreenCoordsXY interactionPoint{ dpi.WorldX(), dpi.WorldY() };
+        ZoomLevel zoomLevel = rt.zoom_level;
+        ScreenCoordsXY interactionPoint{ rt.WorldX(), rt.WorldY() };
         ScreenCoordsXY origin = coords;
 
-        if (dpi.zoom_level > ZoomLevel{ 0 })
+        if (rt.zoom_level > ZoomLevel{ 0 })
         {
             if (g1->flags & G1_FLAG_NO_ZOOM_DRAW)
             {
@@ -1695,7 +1695,7 @@ namespace OpenRCT2
      *  rct2: 0x00679023
      */
 
-    static bool IsSpriteInteractedWith(RenderTarget& dpi, ImageId imageId, const ScreenCoordsXY& coords)
+    static bool IsSpriteInteractedWith(RenderTarget& rt, ImageId imageId, const ScreenCoordsXY& coords)
     {
         PROFILED_FUNCTION();
 
@@ -1722,7 +1722,7 @@ namespace OpenRCT2
         {
             imageType = IMAGE_TYPE_DEFAULT;
         }
-        return IsSpriteInteractedWithPaletteSet(dpi, imageId, coords, paletteMap, imageType);
+        return IsSpriteInteractedWithPaletteSet(rt, imageId, coords, paletteMap, imageType);
     }
 
     /**
@@ -1815,19 +1815,19 @@ namespace OpenRCT2
                 viewLoc.x &= viewport->zoom.ApplyTo(0xFFFFFFFF) & 0xFFFFFFFF;
                 viewLoc.y &= viewport->zoom.ApplyTo(0xFFFFFFFF) & 0xFFFFFFFF;
             }
-            RenderTarget dpi;
-            dpi.zoom_level = viewport->zoom;
-            dpi.x = viewport->zoom.ApplyInversedTo(viewLoc.x);
-            dpi.y = viewport->zoom.ApplyInversedTo(viewLoc.y);
-            dpi.height = 1;
-            dpi.width = 1;
+            RenderTarget rt;
+            rt.zoom_level = viewport->zoom;
+            rt.x = viewport->zoom.ApplyInversedTo(viewLoc.x);
+            rt.y = viewport->zoom.ApplyInversedTo(viewLoc.y);
+            rt.height = 1;
+            rt.width = 1;
 
-            dpi.cullingX = dpi.x;
-            dpi.cullingY = dpi.y;
-            dpi.cullingWidth = dpi.width;
-            dpi.cullingHeight = dpi.height;
+            rt.cullingX = rt.x;
+            rt.cullingY = rt.y;
+            rt.cullingWidth = rt.width;
+            rt.cullingHeight = rt.height;
 
-            PaintSession* session = PaintSessionAlloc(dpi, viewport->flags, viewport->rotation);
+            PaintSession* session = PaintSessionAlloc(rt, viewport->flags, viewport->rotation);
             PaintSessionGenerate(*session);
             PaintSessionArrange(*session);
             info = SetInteractionInfoFromPaintSession(session, viewport->flags, flags & 0xFFFF);

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1003,8 +1003,7 @@ namespace OpenRCT2
         const int32_t worldX = viewport->zoom.ApplyInversedTo(viewport->viewPos.x) + std::max(0, offsetX);
         const int32_t worldY = viewport->zoom.ApplyInversedTo(viewport->viewPos.y) + std::max(0, offsetY);
         const int32_t width = std::min(viewport->pos.x + viewport->width, rt.x + rt.width) - std::max(viewport->pos.x, rt.x);
-        const int32_t height = std::min(viewport->pos.y + viewport->height, rt.y + rt.height)
-            - std::max(viewport->pos.y, rt.y);
+        const int32_t height = std::min(viewport->pos.y + viewport->height, rt.y + rt.height) - std::max(viewport->pos.y, rt.y);
 
         RenderTarget worldRT;
         worldRT.DrawingEngine = rt.DrawingEngine;
@@ -1628,8 +1627,7 @@ namespace OpenRCT2
      * rct2: 0x00679074
      */
     static bool IsSpriteInteractedWithPaletteSet(
-        RenderTarget& rt, ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap,
-        const uint8_t imageType)
+        RenderTarget& rt, ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap, const uint8_t imageType)
     {
         PROFILED_FUNCTION();
 

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -79,8 +79,8 @@ namespace OpenRCT2
     {
     }
 
-    static void ViewportPaintWeatherGloom(DrawPixelInfo& dpi);
-    static void ViewportPaint(const Viewport* viewport, DrawPixelInfo& dpi);
+    static void ViewportPaintWeatherGloom(RenderTarget& dpi);
+    static void ViewportPaint(const Viewport* viewport, RenderTarget& dpi);
     static void ViewportUpdateFollowSprite(WindowBase* window);
     static void ViewportUpdateSmartFollowEntity(WindowBase* window);
     static void ViewportUpdateSmartFollowStaff(WindowBase* window, const Staff& peep);
@@ -333,7 +333,7 @@ namespace OpenRCT2
      *  rct2: 0x006E7FF3
      */
     static void ViewportRedrawAfterShift(
-        DrawPixelInfo& dpi, WindowBase* window, const WindowBase* originalWindow, const ScreenCoordsXY shift,
+        RenderTarget& dpi, WindowBase* window, const WindowBase* originalWindow, const ScreenCoordsXY shift,
         const ScreenRect& drawRect)
     {
         // sub-divide by intersecting windows
@@ -442,7 +442,7 @@ namespace OpenRCT2
         }
     }
 
-    static void ViewportShiftPixels(DrawPixelInfo& dpi, WindowBase* window, Viewport* viewport, int32_t x_diff, int32_t y_diff)
+    static void ViewportShiftPixels(RenderTarget& dpi, WindowBase* window, Viewport* viewport, int32_t x_diff, int32_t y_diff)
     {
         // This loop redraws all parts covered by transparent windows.
         auto it = WindowGetIterator(window);
@@ -522,7 +522,7 @@ namespace OpenRCT2
 
             if (DrawingEngineHasDirtyOptimisations())
             {
-                DrawPixelInfo& dpi = DrawingEngineGetDpi();
+                RenderTarget& dpi = DrawingEngineGetDpi();
                 WindowDrawAll(dpi, left, top, right, bottom);
                 return;
             }
@@ -574,7 +574,7 @@ namespace OpenRCT2
 
         if (DrawingEngineHasDirtyOptimisations())
         {
-            DrawPixelInfo& dpi = DrawingEngineGetDpi();
+            RenderTarget& dpi = DrawingEngineGetDpi();
             ViewportShiftPixels(dpi, w, viewport, x_diff, y_diff);
         }
         else
@@ -928,7 +928,7 @@ namespace OpenRCT2
      *  edi: dpi
      *  ebp: bottom
      */
-    void ViewportRender(DrawPixelInfo& dpi, const Viewport* viewport)
+    void ViewportRender(RenderTarget& dpi, const Viewport* viewport)
     {
         if (viewport->flags & VIEWPORT_FLAG_RENDERING_INHIBITED)
             return;
@@ -994,7 +994,7 @@ namespace OpenRCT2
      *  edi: dpi
      *  ebp: bottom
      */
-    static void ViewportPaint(const Viewport* viewport, DrawPixelInfo& dpi)
+    static void ViewportPaint(const Viewport* viewport, RenderTarget& dpi)
     {
         PROFILED_FUNCTION();
 
@@ -1006,7 +1006,7 @@ namespace OpenRCT2
         const int32_t height = std::min(viewport->pos.y + viewport->height, dpi.y + dpi.height)
             - std::max(viewport->pos.y, dpi.y);
 
-        DrawPixelInfo worldDpi;
+        RenderTarget worldDpi;
         worldDpi.DrawingEngine = dpi.DrawingEngine;
         worldDpi.bits = dpi.bits + std::max(0, -offsetX) + std::max(0, -offsetY) * dpi.LineStride();
         worldDpi.x = worldX;
@@ -1044,7 +1044,7 @@ namespace OpenRCT2
             PaintSession* session = PaintSessionAlloc(worldDpi, viewport->flags, viewport->rotation);
             _paintColumns.push_back(session);
 
-            DrawPixelInfo& columnDpi = session->DPI;
+            RenderTarget& columnDpi = session->DPI;
             if (x >= columnDpi.x)
             {
                 const int32_t leftPitch = x - columnDpi.x;
@@ -1111,7 +1111,7 @@ namespace OpenRCT2
         }
     }
 
-    static void ViewportPaintWeatherGloom(DrawPixelInfo& dpi)
+    static void ViewportPaintWeatherGloom(RenderTarget& dpi)
     {
         auto paletteId = ClimateGetWeatherGloomPaletteId(getGameState().weatherCurrent);
         if (paletteId != FilterPaletteID::PaletteNull)
@@ -1628,7 +1628,7 @@ namespace OpenRCT2
      * rct2: 0x00679074
      */
     static bool IsSpriteInteractedWithPaletteSet(
-        DrawPixelInfo& dpi, ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap,
+        RenderTarget& dpi, ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap,
         const uint8_t imageType)
     {
         PROFILED_FUNCTION();
@@ -1695,7 +1695,7 @@ namespace OpenRCT2
      *  rct2: 0x00679023
      */
 
-    static bool IsSpriteInteractedWith(DrawPixelInfo& dpi, ImageId imageId, const ScreenCoordsXY& coords)
+    static bool IsSpriteInteractedWith(RenderTarget& dpi, ImageId imageId, const ScreenCoordsXY& coords)
     {
         PROFILED_FUNCTION();
 
@@ -1815,7 +1815,7 @@ namespace OpenRCT2
                 viewLoc.x &= viewport->zoom.ApplyTo(0xFFFFFFFF) & 0xFFFFFFFF;
                 viewLoc.y &= viewport->zoom.ApplyTo(0xFFFFFFFF) & 0xFFFFFFFF;
             }
-            DrawPixelInfo dpi;
+            RenderTarget dpi;
             dpi.zoom_level = viewport->zoom;
             dpi.x = viewport->zoom.ApplyInversedTo(viewLoc.x);
             dpi.y = viewport->zoom.ApplyInversedTo(viewLoc.y);

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -190,7 +190,7 @@ namespace OpenRCT2
     void ViewportUpdateSmartFollowGuest(WindowBase* window, const Guest& peep);
     void ViewportRotateSingle(WindowBase* window, int32_t direction);
     void ViewportRotateAll(int32_t direction);
-    void ViewportRender(RenderTarget& dpi, const Viewport* viewport);
+    void ViewportRender(RenderTarget& rt, const Viewport* viewport);
 
     CoordsXYZ ViewportAdjustForMapHeight(const ScreenCoordsXY& startCoords, uint8_t rotation);
 

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -18,7 +18,7 @@
 
 struct PaintSession;
 struct PaintStruct;
-struct DrawPixelInfo;
+struct RenderTarget;
 struct TileElement;
 struct EntityBase;
 struct Guest;
@@ -190,7 +190,7 @@ namespace OpenRCT2
     void ViewportUpdateSmartFollowGuest(WindowBase* window, const Guest& peep);
     void ViewportRotateSingle(WindowBase* window, int32_t direction);
     void ViewportRotateAll(int32_t direction);
-    void ViewportRender(DrawPixelInfo& dpi, const Viewport* viewport);
+    void ViewportRender(RenderTarget& dpi, const Viewport* viewport);
 
     CoordsXYZ ViewportAdjustForMapHeight(const ScreenCoordsXY& startCoords, uint8_t rotation);
 

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -579,7 +579,7 @@ static constexpr float kWindowScrollLocations[][2] = {
     static void WindowDrawSingle(RenderTarget& rt, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
     {
         assert(rt.zoom_level == ZoomLevel{ 0 });
-        // Copy dpi so we can crop it
+        // Copy render target so we can crop it
         RenderTarget copy = rt;
 
         // Clamp left to 0

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -71,8 +71,8 @@ static constexpr float kWindowScrollLocations[][2] = {
 };
     // clang-format on
 
-    static void WindowDrawCore(DrawPixelInfo& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
-    static void WindowDrawSingle(DrawPixelInfo& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
+    static void WindowDrawCore(RenderTarget& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
+    static void WindowDrawSingle(RenderTarget& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
 
     std::list<std::shared_ptr<WindowBase>>::iterator WindowGetIterator(const WindowBase* w)
     {
@@ -494,7 +494,7 @@ static constexpr float kWindowScrollLocations[][2] = {
      * Splits a drawing of a window into regions that can be seen and are not hidden
      * by other opaque overlapping windows.
      */
-    void WindowDraw(DrawPixelInfo& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
+    void WindowDraw(RenderTarget& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
     {
         if (!WindowIsVisible(w))
             return;
@@ -551,7 +551,7 @@ static constexpr float kWindowScrollLocations[][2] = {
     /**
      * Draws the given window and any other overlapping transparent windows.
      */
-    static void WindowDrawCore(DrawPixelInfo& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
+    static void WindowDrawCore(RenderTarget& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
     {
         // Clamp region
         left = std::max<int32_t>(left, w.windowPos.x);
@@ -576,11 +576,11 @@ static constexpr float kWindowScrollLocations[][2] = {
         }
     }
 
-    static void WindowDrawSingle(DrawPixelInfo& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
+    static void WindowDrawSingle(RenderTarget& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
     {
         assert(dpi.zoom_level == ZoomLevel{ 0 });
         // Copy dpi so we can crop it
-        DrawPixelInfo copy = dpi;
+        RenderTarget copy = dpi;
 
         // Clamp left to 0
         int32_t overflow = left - copy.x;
@@ -905,7 +905,7 @@ static constexpr float kWindowScrollLocations[][2] = {
      * right (dx)
      * bottom (bp)
      */
-    void WindowDrawAll(DrawPixelInfo& dpi, int32_t left, int32_t top, int32_t right, int32_t bottom)
+    void WindowDrawAll(RenderTarget& dpi, int32_t left, int32_t top, int32_t right, int32_t bottom)
     {
         auto windowDPI = dpi.Crop({ left, top }, { right - left, bottom - top });
         WindowVisitEach([&windowDPI, left, top, right, bottom](WindowBase* w) {

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -71,8 +71,8 @@ static constexpr float kWindowScrollLocations[][2] = {
 };
     // clang-format on
 
-    static void WindowDrawCore(RenderTarget& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
-    static void WindowDrawSingle(RenderTarget& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
+    static void WindowDrawCore(RenderTarget& rt, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
+    static void WindowDrawSingle(RenderTarget& rt, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
 
     std::list<std::shared_ptr<WindowBase>>::iterator WindowGetIterator(const WindowBase* w)
     {
@@ -494,7 +494,7 @@ static constexpr float kWindowScrollLocations[][2] = {
      * Splits a drawing of a window into regions that can be seen and are not hidden
      * by other opaque overlapping windows.
      */
-    void WindowDraw(RenderTarget& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
+    void WindowDraw(RenderTarget& rt, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
     {
         if (!WindowIsVisible(w))
             return;
@@ -518,26 +518,26 @@ static constexpr float kWindowScrollLocations[][2] = {
             if (topwindow->windowPos.x > left)
             {
                 // Split draw at topwindow.left
-                WindowDrawCore(dpi, w, left, top, topwindow->windowPos.x, bottom);
-                WindowDrawCore(dpi, w, topwindow->windowPos.x, top, right, bottom);
+                WindowDrawCore(rt, w, left, top, topwindow->windowPos.x, bottom);
+                WindowDrawCore(rt, w, topwindow->windowPos.x, top, right, bottom);
             }
             else if (topwindow->windowPos.x + topwindow->width < right)
             {
                 // Split draw at topwindow.right
-                WindowDrawCore(dpi, w, left, top, topwindow->windowPos.x + topwindow->width, bottom);
-                WindowDrawCore(dpi, w, topwindow->windowPos.x + topwindow->width, top, right, bottom);
+                WindowDrawCore(rt, w, left, top, topwindow->windowPos.x + topwindow->width, bottom);
+                WindowDrawCore(rt, w, topwindow->windowPos.x + topwindow->width, top, right, bottom);
             }
             else if (topwindow->windowPos.y > top)
             {
                 // Split draw at topwindow.top
-                WindowDrawCore(dpi, w, left, top, right, topwindow->windowPos.y);
-                WindowDrawCore(dpi, w, left, topwindow->windowPos.y, right, bottom);
+                WindowDrawCore(rt, w, left, top, right, topwindow->windowPos.y);
+                WindowDrawCore(rt, w, left, topwindow->windowPos.y, right, bottom);
             }
             else if (topwindow->windowPos.y + topwindow->height < bottom)
             {
                 // Split draw at topwindow.bottom
-                WindowDrawCore(dpi, w, left, top, right, topwindow->windowPos.y + topwindow->height);
-                WindowDrawCore(dpi, w, left, topwindow->windowPos.y + topwindow->height, right, bottom);
+                WindowDrawCore(rt, w, left, top, right, topwindow->windowPos.y + topwindow->height);
+                WindowDrawCore(rt, w, left, topwindow->windowPos.y + topwindow->height, right, bottom);
             }
 
             // Drawing for this region should be done now, exit
@@ -545,13 +545,13 @@ static constexpr float kWindowScrollLocations[][2] = {
         }
 
         // No windows overlap
-        WindowDrawCore(dpi, w, left, top, right, bottom);
+        WindowDrawCore(rt, w, left, top, right, bottom);
     }
 
     /**
      * Draws the given window and any other overlapping transparent windows.
      */
-    static void WindowDrawCore(RenderTarget& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
+    static void WindowDrawCore(RenderTarget& rt, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
     {
         // Clamp region
         left = std::max<int32_t>(left, w.windowPos.x);
@@ -571,16 +571,16 @@ static constexpr float kWindowScrollLocations[][2] = {
                 continue;
             if ((&w == v || (v->flags & WF_TRANSPARENT)) && WindowIsVisible(*v))
             {
-                WindowDrawSingle(dpi, *v, left, top, right, bottom);
+                WindowDrawSingle(rt, *v, left, top, right, bottom);
             }
         }
     }
 
-    static void WindowDrawSingle(RenderTarget& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
+    static void WindowDrawSingle(RenderTarget& rt, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
     {
-        assert(dpi.zoom_level == ZoomLevel{ 0 });
+        assert(rt.zoom_level == ZoomLevel{ 0 });
         // Copy dpi so we can crop it
-        RenderTarget copy = dpi;
+        RenderTarget copy = rt;
 
         // Clamp left to 0
         int32_t overflow = left - copy.x;
@@ -905,17 +905,17 @@ static constexpr float kWindowScrollLocations[][2] = {
      * right (dx)
      * bottom (bp)
      */
-    void WindowDrawAll(RenderTarget& dpi, int32_t left, int32_t top, int32_t right, int32_t bottom)
+    void WindowDrawAll(RenderTarget& rt, int32_t left, int32_t top, int32_t right, int32_t bottom)
     {
-        auto windowDPI = dpi.Crop({ left, top }, { right - left, bottom - top });
-        WindowVisitEach([&windowDPI, left, top, right, bottom](WindowBase* w) {
+        auto windowRT = rt.Crop({ left, top }, { right - left, bottom - top });
+        WindowVisitEach([&windowRT, left, top, right, bottom](WindowBase* w) {
             if (w->flags & WF_TRANSPARENT)
                 return;
             if (right <= w->windowPos.x || bottom <= w->windowPos.y)
                 return;
             if (left >= w->windowPos.x + w->width || top >= w->windowPos.y + w->height)
                 return;
-            WindowDraw(windowDPI, *w, left, top, right, bottom);
+            WindowDraw(windowRT, *w, left, top, right, bottom);
         });
     }
 

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -22,7 +22,7 @@
 #include <list>
 #include <memory>
 
-struct DrawPixelInfo;
+struct RenderTarget;
 struct TrackDesignFileRef;
 struct ScenarioIndexEntry;
 
@@ -320,8 +320,8 @@ namespace OpenRCT2
     void WindowCheckAllValidZoom();
     void WindowZoomSet(WindowBase& w, ZoomLevel zoomLevel, bool atCursor);
 
-    void WindowDrawAll(DrawPixelInfo& dpi, int32_t left, int32_t top, int32_t right, int32_t bottom);
-    void WindowDraw(DrawPixelInfo& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
+    void WindowDrawAll(RenderTarget& dpi, int32_t left, int32_t top, int32_t right, int32_t bottom);
+    void WindowDraw(RenderTarget& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
 
     bool isToolActive(WindowClass cls);
     bool isToolActive(WindowClass cls, rct_windownumber number);

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -320,8 +320,8 @@ namespace OpenRCT2
     void WindowCheckAllValidZoom();
     void WindowZoomSet(WindowBase& w, ZoomLevel zoomLevel, bool atCursor);
 
-    void WindowDrawAll(RenderTarget& dpi, int32_t left, int32_t top, int32_t right, int32_t bottom);
-    void WindowDraw(RenderTarget& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
+    void WindowDrawAll(RenderTarget& rt, int32_t left, int32_t top, int32_t right, int32_t bottom);
+    void WindowDraw(RenderTarget& rt, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
 
     bool isToolActive(WindowClass cls);
     bool isToolActive(WindowClass cls, rct_windownumber number);

--- a/src/openrct2/interface/WindowBase.h
+++ b/src/openrct2/interface/WindowBase.h
@@ -154,10 +154,10 @@ namespace OpenRCT2
         virtual void OnPrepareDraw()
         {
         }
-        virtual void OnDraw(DrawPixelInfo& dpi)
+        virtual void OnDraw(RenderTarget& dpi)
         {
         }
-        virtual void OnDrawWidget(WidgetIndex widgetIndex, DrawPixelInfo& dpi)
+        virtual void OnDrawWidget(WidgetIndex widgetIndex, RenderTarget& dpi)
         {
         }
         virtual OpenRCT2String OnTooltip(WidgetIndex widgetIndex, StringId fallback)
@@ -192,7 +192,7 @@ namespace OpenRCT2
         virtual void OnScrollMouseDown(int32_t scrollIndex, const ScreenCoordsXY& screenCoords)
         {
         }
-        virtual void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi)
+        virtual void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi)
         {
         }
         virtual void OnToolUpdate(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords)

--- a/src/openrct2/interface/WindowBase.h
+++ b/src/openrct2/interface/WindowBase.h
@@ -154,10 +154,10 @@ namespace OpenRCT2
         virtual void OnPrepareDraw()
         {
         }
-        virtual void OnDraw(RenderTarget& dpi)
+        virtual void OnDraw(RenderTarget& rt)
         {
         }
-        virtual void OnDrawWidget(WidgetIndex widgetIndex, RenderTarget& dpi)
+        virtual void OnDrawWidget(WidgetIndex widgetIndex, RenderTarget& rt)
         {
         }
         virtual OpenRCT2String OnTooltip(WidgetIndex widgetIndex, StringId fallback)
@@ -192,7 +192,7 @@ namespace OpenRCT2
         virtual void OnScrollMouseDown(int32_t scrollIndex, const ScreenCoordsXY& screenCoords)
         {
         }
-        virtual void OnScrollDraw(int32_t scrollIndex, RenderTarget& dpi)
+        virtual void OnScrollDraw(int32_t scrollIndex, RenderTarget& rt)
         {
         }
         virtual void OnToolUpdate(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords)

--- a/src/openrct2/object/BannerObject.cpp
+++ b/src/openrct2/object/BannerObject.cpp
@@ -75,7 +75,7 @@ void BannerObject::Unload()
     _legacyType.image = 0;
 }
 
-void BannerObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const
+void BannerObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
 

--- a/src/openrct2/object/BannerObject.cpp
+++ b/src/openrct2/object/BannerObject.cpp
@@ -75,15 +75,15 @@ void BannerObject::Unload()
     _legacyType.image = 0;
 }
 
-void BannerObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
+void BannerObject::DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
 
     auto image0 = ImageId(_legacyType.image, COLOUR_BORDEAUX_RED);
     auto image1 = ImageId(_legacyType.image + 1, COLOUR_BORDEAUX_RED);
 
-    GfxDrawSprite(dpi, image0, screenCoords + ScreenCoordsXY{ -12, 8 });
-    GfxDrawSprite(dpi, image1, screenCoords + ScreenCoordsXY{ -12, 8 });
+    GfxDrawSprite(rt, image0, screenCoords + ScreenCoordsXY{ -12, 8 });
+    GfxDrawSprite(rt, image1, screenCoords + ScreenCoordsXY{ -12, 8 });
 }
 
 void BannerObject::ReadJson(IReadObjectContext* context, json_t& root)

--- a/src/openrct2/object/BannerObject.h
+++ b/src/openrct2/object/BannerObject.h
@@ -31,5 +31,5 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const override;
 };

--- a/src/openrct2/object/BannerObject.h
+++ b/src/openrct2/object/BannerObject.h
@@ -31,5 +31,5 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
 };

--- a/src/openrct2/object/ClimateObject.cpp
+++ b/src/openrct2/object/ClimateObject.cpp
@@ -52,7 +52,7 @@ void ClimateObject::Unload()
 static RawClimate readWeatherTable(json_t& weather);
 static Climate convertRawClimate(const RawClimate& rawClimate);
 
-void ClimateObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
+void ClimateObject::DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const
 {
     const auto dist = getYearlyDistribution();
     const auto totalSize = kNumClimateMonths * kWeatherDistSize;
@@ -62,12 +62,12 @@ void ClimateObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height
         auto type = WeatherType(i);
         auto imageId = ImageId(ClimateGetWeatherSpriteId(type));
         auto coords = ScreenCoordsXY(8 + (i % 3) * 35, 3 + (i / 3) * 37);
-        GfxDrawSprite(dpi, imageId, coords);
+        GfxDrawSprite(rt, imageId, coords);
 
         auto ft = Formatter();
         ft.Add<uint16_t>(dist[i] * 100 / totalSize);
         DrawTextEllipsised(
-            dpi, coords + ScreenCoordsXY{ 12, 22 }, 35, STR_CLIMATE_WEATHER_PERCENT, ft,
+            rt, coords + ScreenCoordsXY{ 12, 22 }, 35, STR_CLIMATE_WEATHER_PERCENT, ft,
             { FontStyle::Small, TextAlignment::CENTRE });
     }
 }

--- a/src/openrct2/object/ClimateObject.cpp
+++ b/src/openrct2/object/ClimateObject.cpp
@@ -52,7 +52,7 @@ void ClimateObject::Unload()
 static RawClimate readWeatherTable(json_t& weather);
 static Climate convertRawClimate(const RawClimate& rawClimate);
 
-void ClimateObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const
+void ClimateObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
 {
     const auto dist = getYearlyDistribution();
     const auto totalSize = kNumClimateMonths * kWeatherDistSize;

--- a/src/openrct2/object/ClimateObject.h
+++ b/src/openrct2/object/ClimateObject.h
@@ -29,7 +29,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
 
     const TemperatureThresholds& getItemThresholds() const;
     const WeatherPattern& getPatternForMonth(uint8_t month) const;

--- a/src/openrct2/object/ClimateObject.h
+++ b/src/openrct2/object/ClimateObject.h
@@ -29,7 +29,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const override;
 
     const TemperatureThresholds& getItemThresholds() const;
     const WeatherPattern& getPatternForMonth(uint8_t month) const;

--- a/src/openrct2/object/EntranceObject.cpp
+++ b/src/openrct2/object/EntranceObject.cpp
@@ -45,12 +45,12 @@ void EntranceObject::Unload()
     _legacyType.image_id = 0;
 }
 
-void EntranceObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
+void EntranceObject::DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
-    GfxDrawSprite(dpi, ImageId(_legacyType.image_id + 1), screenCoords + ScreenCoordsXY{ -32, 14 });
-    GfxDrawSprite(dpi, ImageId(_legacyType.image_id + 0), screenCoords + ScreenCoordsXY{ 0, 28 });
-    GfxDrawSprite(dpi, ImageId(_legacyType.image_id + 2), screenCoords + ScreenCoordsXY{ 32, 44 });
+    GfxDrawSprite(rt, ImageId(_legacyType.image_id + 1), screenCoords + ScreenCoordsXY{ -32, 14 });
+    GfxDrawSprite(rt, ImageId(_legacyType.image_id + 0), screenCoords + ScreenCoordsXY{ 0, 28 });
+    GfxDrawSprite(rt, ImageId(_legacyType.image_id + 2), screenCoords + ScreenCoordsXY{ 32, 44 });
 }
 
 void EntranceObject::ReadJson(IReadObjectContext* context, json_t& root)

--- a/src/openrct2/object/EntranceObject.cpp
+++ b/src/openrct2/object/EntranceObject.cpp
@@ -45,7 +45,7 @@ void EntranceObject::Unload()
     _legacyType.image_id = 0;
 }
 
-void EntranceObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const
+void EntranceObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
     GfxDrawSprite(dpi, ImageId(_legacyType.image_id + 1), screenCoords + ScreenCoordsXY{ -32, 14 });

--- a/src/openrct2/object/EntranceObject.h
+++ b/src/openrct2/object/EntranceObject.h
@@ -32,7 +32,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
 
     ImageIndex GetImage(uint8_t sequence, Direction direction) const;
     uint8_t GetScrollingMode() const;

--- a/src/openrct2/object/EntranceObject.h
+++ b/src/openrct2/object/EntranceObject.h
@@ -32,7 +32,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const override;
 
     ImageIndex GetImage(uint8_t sequence, Direction direction) const;
     uint8_t GetScrollingMode() const;

--- a/src/openrct2/object/FootpathObject.cpp
+++ b/src/openrct2/object/FootpathObject.cpp
@@ -68,7 +68,7 @@ void FootpathObject::Unload()
     _legacyType.image = 0;
 }
 
-void FootpathObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const
+void FootpathObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
     GfxDrawSprite(dpi, ImageId(_pathSurfaceDescriptor.PreviewImage), screenCoords - ScreenCoordsXY{ 49, 17 });

--- a/src/openrct2/object/FootpathObject.cpp
+++ b/src/openrct2/object/FootpathObject.cpp
@@ -68,11 +68,11 @@ void FootpathObject::Unload()
     _legacyType.image = 0;
 }
 
-void FootpathObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
+void FootpathObject::DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
-    GfxDrawSprite(dpi, ImageId(_pathSurfaceDescriptor.PreviewImage), screenCoords - ScreenCoordsXY{ 49, 17 });
-    GfxDrawSprite(dpi, ImageId(_queueSurfaceDescriptor.PreviewImage), screenCoords + ScreenCoordsXY{ 4, -17 });
+    GfxDrawSprite(rt, ImageId(_pathSurfaceDescriptor.PreviewImage), screenCoords - ScreenCoordsXY{ 49, 17 });
+    GfxDrawSprite(rt, ImageId(_queueSurfaceDescriptor.PreviewImage), screenCoords + ScreenCoordsXY{ 4, -17 });
 }
 
 void FootpathObject::ReadJson(IReadObjectContext* context, json_t& root)

--- a/src/openrct2/object/FootpathObject.h
+++ b/src/openrct2/object/FootpathObject.h
@@ -54,5 +54,5 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const override;
 };

--- a/src/openrct2/object/FootpathObject.h
+++ b/src/openrct2/object/FootpathObject.h
@@ -54,5 +54,5 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
 };

--- a/src/openrct2/object/FootpathRailingsObject.cpp
+++ b/src/openrct2/object/FootpathRailingsObject.cpp
@@ -49,7 +49,7 @@ void FootpathRailingsObject::Unload()
     RailingsImageId = 0;
 }
 
-void FootpathRailingsObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
+void FootpathRailingsObject::DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const
 {
     auto x = width / 2;
     auto y = height / 2;
@@ -63,20 +63,20 @@ void FootpathRailingsObject::DrawPreview(RenderTarget& dpi, int32_t width, int32
         for (int i = 0; i < 2; i++)
         {
             auto h = i * 16;
-            GfxDrawSprite(dpi, img, { x - 8, y + 8 + h });
-            GfxDrawSprite(dpi, img, { x + 8, y + 16 + h });
+            GfxDrawSprite(rt, img, { x - 8, y + 8 + h });
+            GfxDrawSprite(rt, img, { x + 8, y + 16 + h });
         }
 
-        GfxDrawSprite(dpi, helper.WithIndex(BridgeImageId + 5), { x, y - 17 });
-        GfxDrawSprite(dpi, ImageId(RailingsImageId + 1), { x + 4, y - 14 });
-        GfxDrawSprite(dpi, ImageId(RailingsImageId + 1), { x + 27, y - 2 });
+        GfxDrawSprite(rt, helper.WithIndex(BridgeImageId + 5), { x, y - 17 });
+        GfxDrawSprite(rt, ImageId(RailingsImageId + 1), { x + 4, y - 14 });
+        GfxDrawSprite(rt, ImageId(RailingsImageId + 1), { x + 27, y - 2 });
     }
     else
     {
-        GfxDrawSprite(dpi, helper.WithIndex(BridgeImageId + 22), { x + 0, y + 16 });
-        GfxDrawSprite(dpi, helper.WithIndex(BridgeImageId + 49), { x, y - 17 });
-        GfxDrawSprite(dpi, ImageId(RailingsImageId + 1), { x + 4, y - 14 });
-        GfxDrawSprite(dpi, ImageId(RailingsImageId + 1), { x + 27, y - 3 });
+        GfxDrawSprite(rt, helper.WithIndex(BridgeImageId + 22), { x + 0, y + 16 });
+        GfxDrawSprite(rt, helper.WithIndex(BridgeImageId + 49), { x, y - 17 });
+        GfxDrawSprite(rt, ImageId(RailingsImageId + 1), { x + 4, y - 14 });
+        GfxDrawSprite(rt, ImageId(RailingsImageId + 1), { x + 27, y - 3 });
     }
 }
 

--- a/src/openrct2/object/FootpathRailingsObject.cpp
+++ b/src/openrct2/object/FootpathRailingsObject.cpp
@@ -49,7 +49,7 @@ void FootpathRailingsObject::Unload()
     RailingsImageId = 0;
 }
 
-void FootpathRailingsObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const
+void FootpathRailingsObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
 {
     auto x = width / 2;
     auto y = height / 2;

--- a/src/openrct2/object/FootpathRailingsObject.h
+++ b/src/openrct2/object/FootpathRailingsObject.h
@@ -32,7 +32,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const override;
 
     const PathRailingsDescriptor& GetDescriptor() const
     {

--- a/src/openrct2/object/FootpathRailingsObject.h
+++ b/src/openrct2/object/FootpathRailingsObject.h
@@ -32,7 +32,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
 
     const PathRailingsDescriptor& GetDescriptor() const
     {

--- a/src/openrct2/object/FootpathSurfaceObject.cpp
+++ b/src/openrct2/object/FootpathSurfaceObject.cpp
@@ -46,12 +46,12 @@ void FootpathSurfaceObject::Unload()
     BaseImageId = 0;
 }
 
-void FootpathSurfaceObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
+void FootpathSurfaceObject::DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2 - 16, height / 2 };
-    GfxDrawSprite(dpi, ImageId(BaseImageId + 3), screenCoords);
-    GfxDrawSprite(dpi, ImageId(BaseImageId + 16), { screenCoords.x + 32, screenCoords.y - 16 });
-    GfxDrawSprite(dpi, ImageId(BaseImageId + 8), { screenCoords.x + 32, screenCoords.y + 16 });
+    GfxDrawSprite(rt, ImageId(BaseImageId + 3), screenCoords);
+    GfxDrawSprite(rt, ImageId(BaseImageId + 16), { screenCoords.x + 32, screenCoords.y - 16 });
+    GfxDrawSprite(rt, ImageId(BaseImageId + 8), { screenCoords.x + 32, screenCoords.y + 16 });
 }
 
 void FootpathSurfaceObject::ReadJson(IReadObjectContext* context, json_t& root)

--- a/src/openrct2/object/FootpathSurfaceObject.cpp
+++ b/src/openrct2/object/FootpathSurfaceObject.cpp
@@ -46,7 +46,7 @@ void FootpathSurfaceObject::Unload()
     BaseImageId = 0;
 }
 
-void FootpathSurfaceObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const
+void FootpathSurfaceObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2 - 16, height / 2 };
     GfxDrawSprite(dpi, ImageId(BaseImageId + 3), screenCoords);

--- a/src/openrct2/object/FootpathSurfaceObject.h
+++ b/src/openrct2/object/FootpathSurfaceObject.h
@@ -28,7 +28,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
 
     void SetRepositoryItem(ObjectRepositoryItem* item) const override;
 

--- a/src/openrct2/object/FootpathSurfaceObject.h
+++ b/src/openrct2/object/FootpathSurfaceObject.h
@@ -28,7 +28,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const override;
 
     void SetRepositoryItem(ObjectRepositoryItem* item) const override;
 

--- a/src/openrct2/object/LargeSceneryObject.cpp
+++ b/src/openrct2/object/LargeSceneryObject.cpp
@@ -143,7 +143,7 @@ void LargeSceneryObject::Unload()
     _baseImageId = _legacyType.image = 0;
 }
 
-void LargeSceneryObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const
+void LargeSceneryObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, (height / 2) - 39 };
 

--- a/src/openrct2/object/LargeSceneryObject.cpp
+++ b/src/openrct2/object/LargeSceneryObject.cpp
@@ -143,7 +143,7 @@ void LargeSceneryObject::Unload()
     _baseImageId = _legacyType.image = 0;
 }
 
-void LargeSceneryObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
+void LargeSceneryObject::DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, (height / 2) - 39 };
 
@@ -155,7 +155,7 @@ void LargeSceneryObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t h
     if (_legacyType.flags & LARGE_SCENERY_FLAG_HAS_TERTIARY_COLOUR)
         image = image.WithTertiary(COLOUR_DARK_BROWN);
 
-    GfxDrawSprite(dpi, image, screenCoords);
+    GfxDrawSprite(rt, image, screenCoords);
 }
 
 enum

--- a/src/openrct2/object/LargeSceneryObject.h
+++ b/src/openrct2/object/LargeSceneryObject.h
@@ -36,7 +36,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const override;
 
 private:
     [[nodiscard]] static std::vector<LargeSceneryTile> ReadTiles(OpenRCT2::IStream* stream);

--- a/src/openrct2/object/LargeSceneryObject.h
+++ b/src/openrct2/object/LargeSceneryObject.h
@@ -36,7 +36,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
 
 private:
     [[nodiscard]] static std::vector<LargeSceneryTile> ReadTiles(OpenRCT2::IStream* stream);

--- a/src/openrct2/object/MusicObject.cpp
+++ b/src/openrct2/object/MusicObject.cpp
@@ -87,15 +87,15 @@ void MusicObject::Unload()
     NameStringId = 0;
 }
 
-void MusicObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
+void MusicObject::DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const
 {
     // Write (no image)
     int32_t x = width / 2;
     int32_t y = height / 2;
     if (_hasPreview)
-        GfxDrawSprite(dpi, ImageId(_previewImageId), { 0, 0 });
+        GfxDrawSprite(rt, ImageId(_previewImageId), { 0, 0 });
     else
-        DrawTextBasic(dpi, { x, y }, STR_WINDOW_NO_IMAGE, {}, { TextAlignment::CENTRE });
+        DrawTextBasic(rt, { x, y }, STR_WINDOW_NO_IMAGE, {}, { TextAlignment::CENTRE });
 }
 
 bool MusicObject::HasPreview() const

--- a/src/openrct2/object/MusicObject.cpp
+++ b/src/openrct2/object/MusicObject.cpp
@@ -87,7 +87,7 @@ void MusicObject::Unload()
     NameStringId = 0;
 }
 
-void MusicObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const
+void MusicObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
 {
     // Write (no image)
     int32_t x = width / 2;

--- a/src/openrct2/object/MusicObject.h
+++ b/src/openrct2/object/MusicObject.h
@@ -61,7 +61,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
     bool HasPreview() const;
 
     std::optional<uint8_t> GetOriginalStyleId() const;

--- a/src/openrct2/object/MusicObject.h
+++ b/src/openrct2/object/MusicObject.h
@@ -61,7 +61,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const override;
     bool HasPreview() const;
 
     std::optional<uint8_t> GetOriginalStyleId() const;

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -150,7 +150,7 @@ namespace OpenRCT2
     struct IStream;
 }
 struct ObjectRepositoryItem;
-struct DrawPixelInfo;
+struct RenderTarget;
 
 enum class ObjectError : uint32_t
 {
@@ -287,7 +287,7 @@ public:
     virtual void Load() = 0;
     virtual void Unload() = 0;
 
-    virtual void DrawPreview(DrawPixelInfo& /*dpi*/, int32_t /*width*/, int32_t /*height*/) const
+    virtual void DrawPreview(RenderTarget& /*dpi*/, int32_t /*width*/, int32_t /*height*/) const
     {
     }
 

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -287,7 +287,7 @@ public:
     virtual void Load() = 0;
     virtual void Unload() = 0;
 
-    virtual void DrawPreview(RenderTarget& /*dpi*/, int32_t /*width*/, int32_t /*height*/) const
+    virtual void DrawPreview(RenderTarget& /*rt*/, int32_t /*width*/, int32_t /*height*/) const
     {
     }
 

--- a/src/openrct2/object/ObjectRepository.h
+++ b/src/openrct2/object/ObjectRepository.h
@@ -29,7 +29,7 @@ namespace OpenRCT2::Localisation
     class LocalisationService;
 }
 
-struct DrawPixelInfo;
+struct RenderTarget;
 
 enum ObjectItemFlags : uint8_t
 {

--- a/src/openrct2/object/PathAdditionObject.cpp
+++ b/src/openrct2/object/PathAdditionObject.cpp
@@ -80,7 +80,7 @@ void PathAdditionObject::Unload()
     _legacyType.image = 0;
 }
 
-void PathAdditionObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const
+void PathAdditionObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
     GfxDrawSprite(dpi, ImageId(_legacyType.image), screenCoords - ScreenCoordsXY{ 22, 24 });

--- a/src/openrct2/object/PathAdditionObject.cpp
+++ b/src/openrct2/object/PathAdditionObject.cpp
@@ -80,10 +80,10 @@ void PathAdditionObject::Unload()
     _legacyType.image = 0;
 }
 
-void PathAdditionObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
+void PathAdditionObject::DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
-    GfxDrawSprite(dpi, ImageId(_legacyType.image), screenCoords - ScreenCoordsXY{ 22, 24 });
+    GfxDrawSprite(rt, ImageId(_legacyType.image), screenCoords - ScreenCoordsXY{ 22, 24 });
 }
 
 static PathAdditionDrawType ParseDrawType(const std::string& s)

--- a/src/openrct2/object/PathAdditionObject.h
+++ b/src/openrct2/object/PathAdditionObject.h
@@ -30,5 +30,5 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const override;
 };

--- a/src/openrct2/object/PathAdditionObject.h
+++ b/src/openrct2/object/PathAdditionObject.h
@@ -30,5 +30,5 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
 };

--- a/src/openrct2/object/PeepAnimationsObject.cpp
+++ b/src/openrct2/object/PeepAnimationsObject.cpp
@@ -201,18 +201,18 @@ bool PeepAnimationsObject::IsSlowWalking(PeepAnimationGroup animGroup) const
     return _animationGroups[EnumValue(animGroup)].isSlowWalking;
 }
 
-void PeepAnimationsObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
+void PeepAnimationsObject::DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const
 {
     auto centre = ScreenCoordsXY{ width / 2, height / 2 };
 
     // Draw inline sprite in the centre
-    GfxDrawSprite(dpi, ImageId(_imageOffsetId + 0), centre + ScreenCoordsXY{ -8, -8 });
+    GfxDrawSprite(rt, ImageId(_imageOffsetId + 0), centre + ScreenCoordsXY{ -8, -8 });
 
     // Draw four cardinal directions around the inline sprite
-    GfxDrawSprite(dpi, ImageId(_imageOffsetId + 4, COLOUR_BRIGHT_RED, COLOUR_TEAL), centre + ScreenCoordsXY{ -32, -24 });
-    GfxDrawSprite(dpi, ImageId(_imageOffsetId + 2, COLOUR_BRIGHT_RED, COLOUR_TEAL), centre + ScreenCoordsXY{ +32, +32 });
-    GfxDrawSprite(dpi, ImageId(_imageOffsetId + 1, COLOUR_BRIGHT_RED, COLOUR_TEAL), centre + ScreenCoordsXY{ +32, -24 });
-    GfxDrawSprite(dpi, ImageId(_imageOffsetId + 3, COLOUR_BRIGHT_RED, COLOUR_TEAL), centre + ScreenCoordsXY{ -32, +32 });
+    GfxDrawSprite(rt, ImageId(_imageOffsetId + 4, COLOUR_BRIGHT_RED, COLOUR_TEAL), centre + ScreenCoordsXY{ -32, -24 });
+    GfxDrawSprite(rt, ImageId(_imageOffsetId + 2, COLOUR_BRIGHT_RED, COLOUR_TEAL), centre + ScreenCoordsXY{ +32, +32 });
+    GfxDrawSprite(rt, ImageId(_imageOffsetId + 1, COLOUR_BRIGHT_RED, COLOUR_TEAL), centre + ScreenCoordsXY{ +32, -24 });
+    GfxDrawSprite(rt, ImageId(_imageOffsetId + 3, COLOUR_BRIGHT_RED, COLOUR_TEAL), centre + ScreenCoordsXY{ -32, +32 });
 }
 
 void PeepAnimationsObject::SetRepositoryItem(ObjectRepositoryItem* item) const

--- a/src/openrct2/object/PeepAnimationsObject.cpp
+++ b/src/openrct2/object/PeepAnimationsObject.cpp
@@ -201,7 +201,7 @@ bool PeepAnimationsObject::IsSlowWalking(PeepAnimationGroup animGroup) const
     return _animationGroups[EnumValue(animGroup)].isSlowWalking;
 }
 
-void PeepAnimationsObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const
+void PeepAnimationsObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
 {
     auto centre = ScreenCoordsXY{ width / 2, height / 2 };
 

--- a/src/openrct2/object/PeepAnimationsObject.h
+++ b/src/openrct2/object/PeepAnimationsObject.h
@@ -55,6 +55,6 @@ public:
         return _noRandomPlacement;
     }
 
-    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const override;
     void SetRepositoryItem(ObjectRepositoryItem* item) const override;
 };

--- a/src/openrct2/object/PeepAnimationsObject.h
+++ b/src/openrct2/object/PeepAnimationsObject.h
@@ -55,6 +55,6 @@ public:
         return _noRandomPlacement;
     }
 
-    void DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
     void SetRepositoryItem(ObjectRepositoryItem* item) const override;
 };

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -348,7 +348,7 @@ void RideObject::Unload()
     _legacyType.images_offset = 0;
 }
 
-void RideObject::DrawPreview(DrawPixelInfo& dpi, [[maybe_unused]] int32_t width, [[maybe_unused]] int32_t height) const
+void RideObject::DrawPreview(RenderTarget& dpi, [[maybe_unused]] int32_t width, [[maybe_unused]] int32_t height) const
 {
     uint32_t imageId = _legacyType.images_offset;
 

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -348,7 +348,7 @@ void RideObject::Unload()
     _legacyType.images_offset = 0;
 }
 
-void RideObject::DrawPreview(RenderTarget& dpi, [[maybe_unused]] int32_t width, [[maybe_unused]] int32_t height) const
+void RideObject::DrawPreview(RenderTarget& rt, [[maybe_unused]] int32_t width, [[maybe_unused]] int32_t height) const
 {
     uint32_t imageId = _legacyType.images_offset;
 
@@ -360,7 +360,7 @@ void RideObject::DrawPreview(RenderTarget& dpi, [[maybe_unused]] int32_t width, 
         imageId++;
     }
 
-    GfxDrawSprite(dpi, ImageId(imageId), { 0, 0 });
+    GfxDrawSprite(rt, ImageId(imageId), { 0, 0 });
 }
 
 std::string RideObject::GetDescription() const

--- a/src/openrct2/object/RideObject.h
+++ b/src/openrct2/object/RideObject.h
@@ -44,7 +44,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
 
     std::string GetDescription() const;
     std::string GetCapacity() const;

--- a/src/openrct2/object/RideObject.h
+++ b/src/openrct2/object/RideObject.h
@@ -44,7 +44,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const override;
 
     std::string GetDescription() const;
     std::string GetCapacity() const;

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -70,12 +70,12 @@ void SceneryGroupObject::Unload()
     _legacyType.image = 0;
 }
 
-void SceneryGroupObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
+void SceneryGroupObject::DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
 
     const auto imageId = ImageId(_legacyType.image + 1, COLOUR_DARK_GREEN);
-    GfxDrawSprite(dpi, imageId, screenCoords - ScreenCoordsXY{ 15, 14 });
+    GfxDrawSprite(rt, imageId, screenCoords - ScreenCoordsXY{ 15, 14 });
 }
 
 static std::optional<uint8_t> GetSceneryType(const ObjectType type)

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -70,7 +70,7 @@ void SceneryGroupObject::Unload()
     _legacyType.image = 0;
 }
 
-void SceneryGroupObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const
+void SceneryGroupObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
 

--- a/src/openrct2/object/SceneryGroupObject.h
+++ b/src/openrct2/object/SceneryGroupObject.h
@@ -36,7 +36,7 @@ public:
     void Unload() override;
     void UpdateEntryIndexes();
 
-    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const override;
 
     void SetRepositoryItem(ObjectRepositoryItem* item) const override;
 

--- a/src/openrct2/object/SceneryGroupObject.h
+++ b/src/openrct2/object/SceneryGroupObject.h
@@ -36,7 +36,7 @@ public:
     void Unload() override;
     void UpdateEntryIndexes();
 
-    void DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
 
     void SetRepositoryItem(ObjectRepositoryItem* item) const override;
 

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -96,7 +96,7 @@ void SmallSceneryObject::Unload()
     _legacyType.image = 0;
 }
 
-void SmallSceneryObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
+void SmallSceneryObject::DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const
 {
     auto imageId = ImageId(_legacyType.image);
     if (_legacyType.HasFlag(SMALL_SCENERY_FLAG_HAS_PRIMARY_COLOUR))
@@ -120,12 +120,12 @@ void SmallSceneryObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t h
         screenCoords.y -= 12;
     }
 
-    GfxDrawSprite(dpi, imageId, screenCoords);
+    GfxDrawSprite(rt, imageId, screenCoords);
 
     if (_legacyType.HasFlag(SMALL_SCENERY_FLAG_HAS_GLASS))
     {
         imageId = ImageId(_legacyType.image + 4).WithTransparency(COLOUR_BORDEAUX_RED);
-        GfxDrawSprite(dpi, imageId, screenCoords);
+        GfxDrawSprite(rt, imageId, screenCoords);
     }
 
     if (_legacyType.HasFlag(SMALL_SCENERY_FLAG_ANIMATED_FG))
@@ -135,7 +135,7 @@ void SmallSceneryObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t h
         {
             imageId = imageId.WithSecondary(COLOUR_YELLOW);
         }
-        GfxDrawSprite(dpi, imageId, screenCoords);
+        GfxDrawSprite(rt, imageId, screenCoords);
     }
 }
 

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -96,7 +96,7 @@ void SmallSceneryObject::Unload()
     _legacyType.image = 0;
 }
 
-void SmallSceneryObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const
+void SmallSceneryObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
 {
     auto imageId = ImageId(_legacyType.image);
     if (_legacyType.HasFlag(SMALL_SCENERY_FLAG_HAS_PRIMARY_COLOUR))

--- a/src/openrct2/object/SmallSceneryObject.h
+++ b/src/openrct2/object/SmallSceneryObject.h
@@ -34,7 +34,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
 
 private:
     static std::vector<uint8_t> ReadFrameOffsets(OpenRCT2::IStream* stream);

--- a/src/openrct2/object/SmallSceneryObject.h
+++ b/src/openrct2/object/SmallSceneryObject.h
@@ -34,7 +34,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const override;
 
 private:
     static std::vector<uint8_t> ReadFrameOffsets(OpenRCT2::IStream* stream);

--- a/src/openrct2/object/StationObject.cpp
+++ b/src/openrct2/object/StationObject.cpp
@@ -46,7 +46,7 @@ void StationObject::Unload()
     ShelterImageId = kImageIndexUndefined;
 }
 
-void StationObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const
+void StationObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, (height / 2) + 16 };
 

--- a/src/openrct2/object/StationObject.cpp
+++ b/src/openrct2/object/StationObject.cpp
@@ -46,7 +46,7 @@ void StationObject::Unload()
     ShelterImageId = kImageIndexUndefined;
 }
 
-void StationObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
+void StationObject::DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, (height / 2) + 16 };
 
@@ -65,16 +65,16 @@ void StationObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height
         imageId = imageId.WithSecondary(colour1);
     }
 
-    GfxDrawSprite(dpi, imageId, screenCoords);
+    GfxDrawSprite(rt, imageId, screenCoords);
     if (Flags & StationObjectFlags::isTransparent)
     {
-        GfxDrawSprite(dpi, tImageId, screenCoords);
+        GfxDrawSprite(rt, tImageId, screenCoords);
     }
 
-    GfxDrawSprite(dpi, imageId.WithIndexOffset(4), screenCoords);
+    GfxDrawSprite(rt, imageId.WithIndexOffset(4), screenCoords);
     if (Flags & StationObjectFlags::isTransparent)
     {
-        GfxDrawSprite(dpi, tImageId.WithIndexOffset(4), screenCoords);
+        GfxDrawSprite(rt, tImageId.WithIndexOffset(4), screenCoords);
     }
 }
 

--- a/src/openrct2/object/StationObject.h
+++ b/src/openrct2/object/StationObject.h
@@ -37,5 +37,5 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const override;
 };

--- a/src/openrct2/object/StationObject.h
+++ b/src/openrct2/object/StationObject.h
@@ -37,5 +37,5 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
 };

--- a/src/openrct2/object/TerrainEdgeObject.cpp
+++ b/src/openrct2/object/TerrainEdgeObject.cpp
@@ -39,7 +39,7 @@ void TerrainEdgeObject::Unload()
     BaseImageId = 0;
 }
 
-void TerrainEdgeObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const
+void TerrainEdgeObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
 

--- a/src/openrct2/object/TerrainEdgeObject.cpp
+++ b/src/openrct2/object/TerrainEdgeObject.cpp
@@ -39,13 +39,13 @@ void TerrainEdgeObject::Unload()
     BaseImageId = 0;
 }
 
-void TerrainEdgeObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
+void TerrainEdgeObject::DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
 
     auto imageId = ImageId(BaseImageId + 5);
-    GfxDrawSprite(dpi, imageId, screenCoords + ScreenCoordsXY{ 8, -8 });
-    GfxDrawSprite(dpi, imageId, screenCoords + ScreenCoordsXY{ 8, 8 });
+    GfxDrawSprite(rt, imageId, screenCoords + ScreenCoordsXY{ 8, -8 });
+    GfxDrawSprite(rt, imageId, screenCoords + ScreenCoordsXY{ 8, 8 });
 }
 
 void TerrainEdgeObject::ReadJson(IReadObjectContext* context, json_t& root)

--- a/src/openrct2/object/TerrainEdgeObject.h
+++ b/src/openrct2/object/TerrainEdgeObject.h
@@ -26,7 +26,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
 
     static TerrainEdgeObject* GetById(ObjectEntryIndex entryIndex);
 };

--- a/src/openrct2/object/TerrainEdgeObject.h
+++ b/src/openrct2/object/TerrainEdgeObject.h
@@ -26,7 +26,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const override;
 
     static TerrainEdgeObject* GetById(ObjectEntryIndex entryIndex);
 };

--- a/src/openrct2/object/TerrainSurfaceObject.cpp
+++ b/src/openrct2/object/TerrainSurfaceObject.cpp
@@ -49,7 +49,7 @@ void TerrainSurfaceObject::Unload()
     NumEntries = 0;
 }
 
-void TerrainSurfaceObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const
+void TerrainSurfaceObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
 {
     auto imageId = ImageId(GetImageId({}, 1, 0, 0, false, false));
     if (Colour != kNoValue)

--- a/src/openrct2/object/TerrainSurfaceObject.cpp
+++ b/src/openrct2/object/TerrainSurfaceObject.cpp
@@ -49,7 +49,7 @@ void TerrainSurfaceObject::Unload()
     NumEntries = 0;
 }
 
-void TerrainSurfaceObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
+void TerrainSurfaceObject::DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const
 {
     auto imageId = ImageId(GetImageId({}, 1, 0, 0, false, false));
     if (Colour != kNoValue)
@@ -69,7 +69,7 @@ void TerrainSurfaceObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t
         }
         for (int32_t j = 0; j < 4; j++)
         {
-            GfxDrawSprite(dpi, imageId, screenCoords);
+            GfxDrawSprite(rt, imageId, screenCoords);
             screenCoords.x += 64;
         }
         screenCoords.y += 16;

--- a/src/openrct2/object/TerrainSurfaceObject.h
+++ b/src/openrct2/object/TerrainSurfaceObject.h
@@ -61,7 +61,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const override;
 
     ImageId GetImageId(
         const CoordsXY& position, uint8_t length, uint8_t rotation, uint8_t offset, bool grid, bool underground) const;

--- a/src/openrct2/object/TerrainSurfaceObject.h
+++ b/src/openrct2/object/TerrainSurfaceObject.h
@@ -61,7 +61,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
 
     ImageId GetImageId(
         const CoordsXY& position, uint8_t length, uint8_t rotation, uint8_t offset, bool grid, bool underground) const;

--- a/src/openrct2/object/WallObject.cpp
+++ b/src/openrct2/object/WallObject.cpp
@@ -70,7 +70,7 @@ void WallObject::Unload()
     _legacyType.image = 0;
 }
 
-void WallObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const
+void WallObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
 

--- a/src/openrct2/object/WallObject.cpp
+++ b/src/openrct2/object/WallObject.cpp
@@ -70,7 +70,7 @@ void WallObject::Unload()
     _legacyType.image = 0;
 }
 
-void WallObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
+void WallObject::DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
 
@@ -83,16 +83,16 @@ void WallObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) c
         imageId = imageId.WithSecondary(COLOUR_YELLOW);
     }
 
-    GfxDrawSprite(dpi, imageId, screenCoords);
+    GfxDrawSprite(rt, imageId, screenCoords);
 
     if (_legacyType.flags & WALL_SCENERY_HAS_GLASS)
     {
         auto glassImageId = imageId.WithTransparency(COLOUR_BORDEAUX_RED).WithIndexOffset(6);
-        GfxDrawSprite(dpi, glassImageId, screenCoords);
+        GfxDrawSprite(rt, glassImageId, screenCoords);
     }
     else if (_legacyType.flags & WALL_SCENERY_IS_DOOR)
     {
-        GfxDrawSprite(dpi, imageId.WithIndexOffset(1), screenCoords);
+        GfxDrawSprite(rt, imageId.WithIndexOffset(1), screenCoords);
     }
 }
 

--- a/src/openrct2/object/WallObject.h
+++ b/src/openrct2/object/WallObject.h
@@ -30,5 +30,5 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const override;
 };

--- a/src/openrct2/object/WallObject.h
+++ b/src/openrct2/object/WallObject.h
@@ -30,5 +30,5 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
 };

--- a/src/openrct2/object/WaterObject.cpp
+++ b/src/openrct2/object/WaterObject.cpp
@@ -56,11 +56,11 @@ void WaterObject::Unload()
     _legacyType.palette_index_2 = 0;
 }
 
-void WaterObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
+void WaterObject::DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const
 {
     // Write (no image)
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
-    DrawTextBasic(dpi, screenCoords, STR_WINDOW_NO_IMAGE, {}, { TextAlignment::CENTRE });
+    DrawTextBasic(rt, screenCoords, STR_WINDOW_NO_IMAGE, {}, { TextAlignment::CENTRE });
 }
 
 void WaterObject::ReadJson([[maybe_unused]] IReadObjectContext* context, json_t& root)

--- a/src/openrct2/object/WaterObject.cpp
+++ b/src/openrct2/object/WaterObject.cpp
@@ -56,7 +56,7 @@ void WaterObject::Unload()
     _legacyType.palette_index_2 = 0;
 }
 
-void WaterObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const
+void WaterObject::DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const
 {
     // Write (no image)
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };

--- a/src/openrct2/object/WaterObject.h
+++ b/src/openrct2/object/WaterObject.h
@@ -32,7 +32,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
 
 private:
     void ReadJsonPalette(json_t& jPalette);

--- a/src/openrct2/object/WaterObject.h
+++ b/src/openrct2/object/WaterObject.h
@@ -32,7 +32,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(RenderTarget& dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(RenderTarget& rt, int32_t width, int32_t height) const override;
 
 private:
     void ReadJsonPalette(json_t& jPalette);

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -103,7 +103,7 @@ static void PaintSessionAddPSToQuadrant(PaintSession& session, PaintStruct* ps)
     session.QuadrantFrontIndex = std::max(session.QuadrantFrontIndex, paintQuadrantIndex);
 }
 
-static constexpr bool imageWithinDPI(const ScreenCoordsXY& imagePos, const G1Element& g1, const DrawPixelInfo& dpi)
+static constexpr bool imageWithinDPI(const ScreenCoordsXY& imagePos, const G1Element& g1, const RenderTarget& dpi)
 {
     const int32_t left = imagePos.x + g1.x_offset;
     const int32_t bottom = imagePos.y + g1.y_offset;
@@ -683,7 +683,7 @@ void PaintSessionArrange(PaintSessionCore& session)
     return _paintArrangeFuncsLegacy[session.CurrentRotation](session);
 }
 
-static inline void PaintAttachedPS(DrawPixelInfo& dpi, PaintStruct* ps, uint32_t viewFlags)
+static inline void PaintAttachedPS(RenderTarget& dpi, PaintStruct* ps, uint32_t viewFlags)
 {
     AttachedPaintStruct* attached_ps = ps->Attached;
     for (; attached_ps != nullptr; attached_ps = attached_ps->NextEntry)
@@ -854,7 +854,7 @@ static ImageId PaintPSColourifyImage(const PaintStruct* ps, ImageId imageId, uin
     }
 }
 
-PaintSession* PaintSessionAlloc(DrawPixelInfo& dpi, uint32_t viewFlags, uint8_t rotation)
+PaintSession* PaintSessionAlloc(RenderTarget& dpi, uint32_t viewFlags, uint8_t rotation)
 {
     return GetContext()->GetPainter()->CreateSession(dpi, viewFlags, rotation);
 }
@@ -1081,7 +1081,7 @@ void PaintFloatingMoneyEffect(
  *
  *  rct2: 0x006860C3
  */
-void PaintDrawMoneyStructs(DrawPixelInfo& dpi, PaintStringStruct* ps)
+void PaintDrawMoneyStructs(RenderTarget& dpi, PaintStringStruct* ps)
 {
     do
     {

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -103,7 +103,7 @@ static void PaintSessionAddPSToQuadrant(PaintSession& session, PaintStruct* ps)
     session.QuadrantFrontIndex = std::max(session.QuadrantFrontIndex, paintQuadrantIndex);
 }
 
-static constexpr bool imageWithinDPI(const ScreenCoordsXY& imagePos, const G1Element& g1, const RenderTarget& dpi)
+static constexpr bool imageWithinDPI(const ScreenCoordsXY& imagePos, const G1Element& g1, const RenderTarget& rt)
 {
     const int32_t left = imagePos.x + g1.x_offset;
     const int32_t bottom = imagePos.y + g1.y_offset;
@@ -114,29 +114,29 @@ static constexpr bool imageWithinDPI(const ScreenCoordsXY& imagePos, const G1Ele
     // mber: It is possible to use only the bottom else block here if you change <= and >= to simply < and >.
     // However, since this is used to cull paint structs, I'd prefer to keep the condition strict and calculate
     // the culling differently for minifying and magnifying.
-    const auto zoom = dpi.zoom_level;
+    const auto zoom = rt.zoom_level;
     if (zoom > ZoomLevel{ 0 })
     {
-        const int32_t x = zoom.ApplyTo(dpi.cullingX);
-        const int32_t y = zoom.ApplyTo(dpi.cullingY);
+        const int32_t x = zoom.ApplyTo(rt.cullingX);
+        const int32_t y = zoom.ApplyTo(rt.cullingY);
         if (right <= x)
             return false;
         if (top <= y)
             return false;
-        if (left >= x + zoom.ApplyTo(dpi.cullingWidth))
+        if (left >= x + zoom.ApplyTo(rt.cullingWidth))
             return false;
-        if (bottom >= y + zoom.ApplyTo(dpi.cullingHeight))
+        if (bottom >= y + zoom.ApplyTo(rt.cullingHeight))
             return false;
     }
     else
     {
-        if (zoom.ApplyInversedTo(right) <= dpi.cullingX)
+        if (zoom.ApplyInversedTo(right) <= rt.cullingX)
             return false;
-        if (zoom.ApplyInversedTo(top) <= dpi.cullingY)
+        if (zoom.ApplyInversedTo(top) <= rt.cullingY)
             return false;
-        if (zoom.ApplyInversedTo(left) >= dpi.cullingX + dpi.cullingWidth)
+        if (zoom.ApplyInversedTo(left) >= rt.cullingX + rt.cullingWidth)
             return false;
-        if (zoom.ApplyInversedTo(bottom) >= dpi.cullingY + dpi.cullingHeight)
+        if (zoom.ApplyInversedTo(bottom) >= rt.cullingY + rt.cullingHeight)
             return false;
     }
     return true;

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -683,7 +683,7 @@ void PaintSessionArrange(PaintSessionCore& session)
     return _paintArrangeFuncsLegacy[session.CurrentRotation](session);
 }
 
-static inline void PaintAttachedPS(RenderTarget& dpi, PaintStruct* ps, uint32_t viewFlags)
+static inline void PaintAttachedPS(RenderTarget& rt, PaintStruct* ps, uint32_t viewFlags)
 {
     AttachedPaintStruct* attached_ps = ps->Attached;
     for (; attached_ps != nullptr; attached_ps = attached_ps->NextEntry)
@@ -693,11 +693,11 @@ static inline void PaintAttachedPS(RenderTarget& dpi, PaintStruct* ps, uint32_t 
         auto imageId = PaintPSColourifyImage(ps, attached_ps->image_id, viewFlags);
         if (attached_ps->IsMasked)
         {
-            GfxDrawSpriteRawMasked(dpi, screenCoords, imageId, attached_ps->ColourImageId);
+            GfxDrawSpriteRawMasked(rt, screenCoords, imageId, attached_ps->ColourImageId);
         }
         else
         {
-            GfxDrawSprite(dpi, imageId, screenCoords);
+            GfxDrawSprite(rt, imageId, screenCoords);
         }
     }
 }
@@ -754,7 +754,7 @@ void PaintDrawStructs(PaintSession& session)
 
 static void PaintPSImageWithBoundingBoxes(PaintSession& session, PaintStruct* ps, ImageId imageId, int32_t x, int32_t y)
 {
-    auto& dpi = session.DPI;
+    auto& rt = session.DPI;
 
     const uint8_t colour = BoundBoxDebugColours[EnumValue(ps->InteractionItem)];
     const uint8_t rotation = session.CurrentRotation;
@@ -816,28 +816,28 @@ static void PaintPSImageWithBoundingBoxes(PaintSession& session, PaintStruct* ps
     const auto screenCoordBackBottom = Translate3DTo2DWithZ(rotation, backBottom);
 
     // bottom square
-    GfxDrawLine(dpi, { screenCoordFrontBottom, screenCoordLeftBottom }, colour);
-    GfxDrawLine(dpi, { screenCoordBackBottom, screenCoordLeftBottom }, colour);
-    GfxDrawLine(dpi, { screenCoordBackBottom, screenCoordRightBottom }, colour);
-    GfxDrawLine(dpi, { screenCoordFrontBottom, screenCoordRightBottom }, colour);
+    GfxDrawLine(rt, { screenCoordFrontBottom, screenCoordLeftBottom }, colour);
+    GfxDrawLine(rt, { screenCoordBackBottom, screenCoordLeftBottom }, colour);
+    GfxDrawLine(rt, { screenCoordBackBottom, screenCoordRightBottom }, colour);
+    GfxDrawLine(rt, { screenCoordFrontBottom, screenCoordRightBottom }, colour);
 
     // vertical back + sides
-    GfxDrawLine(dpi, { screenCoordBackTop, screenCoordBackBottom }, colour);
-    GfxDrawLine(dpi, { screenCoordLeftTop, screenCoordLeftBottom }, colour);
-    GfxDrawLine(dpi, { screenCoordRightTop, screenCoordRightBottom }, colour);
+    GfxDrawLine(rt, { screenCoordBackTop, screenCoordBackBottom }, colour);
+    GfxDrawLine(rt, { screenCoordLeftTop, screenCoordLeftBottom }, colour);
+    GfxDrawLine(rt, { screenCoordRightTop, screenCoordRightBottom }, colour);
 
     // top square back
-    GfxDrawLine(dpi, { screenCoordBackTop, screenCoordLeftTop }, colour);
-    GfxDrawLine(dpi, { screenCoordBackTop, screenCoordRightTop }, colour);
+    GfxDrawLine(rt, { screenCoordBackTop, screenCoordLeftTop }, colour);
+    GfxDrawLine(rt, { screenCoordBackTop, screenCoordRightTop }, colour);
 
-    GfxDrawSprite(dpi, imageId, { x, y });
+    GfxDrawSprite(rt, imageId, { x, y });
 
     // vertical front
-    GfxDrawLine(dpi, { screenCoordFrontTop, screenCoordFrontBottom }, colour);
+    GfxDrawLine(rt, { screenCoordFrontTop, screenCoordFrontBottom }, colour);
 
     // top square
-    GfxDrawLine(dpi, { screenCoordFrontTop, screenCoordLeftTop }, colour);
-    GfxDrawLine(dpi, { screenCoordFrontTop, screenCoordRightTop }, colour);
+    GfxDrawLine(rt, { screenCoordFrontTop, screenCoordLeftTop }, colour);
+    GfxDrawLine(rt, { screenCoordFrontTop, screenCoordRightTop }, colour);
 }
 
 static ImageId PaintPSColourifyImage(const PaintStruct* ps, ImageId imageId, uint32_t viewFlags)
@@ -854,9 +854,9 @@ static ImageId PaintPSColourifyImage(const PaintStruct* ps, ImageId imageId, uin
     }
 }
 
-PaintSession* PaintSessionAlloc(RenderTarget& dpi, uint32_t viewFlags, uint8_t rotation)
+PaintSession* PaintSessionAlloc(RenderTarget& rt, uint32_t viewFlags, uint8_t rotation)
 {
-    return GetContext()->GetPainter()->CreateSession(dpi, viewFlags, rotation);
+    return GetContext()->GetPainter()->CreateSession(rt, viewFlags, rotation);
 }
 
 void PaintSessionFree(PaintSession* session)
@@ -1081,7 +1081,7 @@ void PaintFloatingMoneyEffect(
  *
  *  rct2: 0x006860C3
  */
-void PaintDrawMoneyStructs(RenderTarget& dpi, PaintStringStruct* ps)
+void PaintDrawMoneyStructs(RenderTarget& rt, PaintStringStruct* ps)
 {
     do
     {
@@ -1097,7 +1097,7 @@ void PaintDrawMoneyStructs(RenderTarget& dpi, PaintStringStruct* ps)
         }
 
         GfxDrawStringWithYOffsets(
-            dpi, buffer, { COLOUR_BLACK }, ps->ScreenPos, reinterpret_cast<int8_t*>(ps->y_offsets), forceSpriteFont,
+            rt, buffer, { COLOUR_BLACK }, ps->ScreenPos, reinterpret_cast<int8_t*>(ps->y_offsets), forceSpriteFont,
             FontStyle::Medium);
     } while ((ps = ps->NextEntry) != nullptr);
 }

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -307,9 +307,9 @@ void PaintFloatingMoneyEffect(
     PaintSession& session, money64 amount, StringId string_id, int32_t y, int32_t z, int8_t y_offsets[], int32_t offset_x,
     uint32_t rotation);
 
-PaintSession* PaintSessionAlloc(RenderTarget& dpi, uint32_t viewFlags, uint8_t rotation);
+PaintSession* PaintSessionAlloc(RenderTarget& rt, uint32_t viewFlags, uint8_t rotation);
 void PaintSessionFree(PaintSession* session);
 void PaintSessionGenerate(PaintSession& session);
 void PaintSessionArrange(PaintSessionCore& session);
 void PaintDrawStructs(PaintSession& session);
-void PaintDrawMoneyStructs(RenderTarget& dpi, PaintStringStruct* ps);
+void PaintDrawMoneyStructs(RenderTarget& rt, PaintStringStruct* ps);

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -191,7 +191,7 @@ struct PaintNodeStorage
 
 struct PaintSession : public PaintSessionCore
 {
-    DrawPixelInfo DPI;
+    RenderTarget DPI;
     PaintNodeStorage paintEntries;
 
     PaintStruct* AllocateNormalPaintEntry() noexcept
@@ -307,9 +307,9 @@ void PaintFloatingMoneyEffect(
     PaintSession& session, money64 amount, StringId string_id, int32_t y, int32_t z, int8_t y_offsets[], int32_t offset_x,
     uint32_t rotation);
 
-PaintSession* PaintSessionAlloc(DrawPixelInfo& dpi, uint32_t viewFlags, uint8_t rotation);
+PaintSession* PaintSessionAlloc(RenderTarget& dpi, uint32_t viewFlags, uint8_t rotation);
 void PaintSessionFree(PaintSession* session);
 void PaintSessionGenerate(PaintSession& session);
 void PaintSessionArrange(PaintSessionCore& session);
 void PaintDrawStructs(PaintSession& session);
-void PaintDrawMoneyStructs(DrawPixelInfo& dpi, PaintStringStruct* ps);
+void PaintDrawMoneyStructs(RenderTarget& dpi, PaintStringStruct* ps);

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -77,7 +77,7 @@ void Painter::Paint(IDrawingEngine& de)
     gCurrentDrawCount++;
 }
 
-void Painter::PaintReplayNotice(DrawPixelInfo& dpi, const char* text)
+void Painter::PaintReplayNotice(RenderTarget& dpi, const char* text)
 {
     ScreenCoordsXY screenCoords(_uiContext->GetWidth() / 2, _uiContext->GetHeight() - 44);
 
@@ -103,7 +103,7 @@ static bool ShouldShowFPS()
     return windowMgr->FindByClass(WindowClass::TopToolbar);
 }
 
-void Painter::PaintFPS(DrawPixelInfo& dpi)
+void Painter::PaintFPS(RenderTarget& dpi)
 {
     if (!ShouldShowFPS())
         return;
@@ -144,7 +144,7 @@ void Painter::MeasureFPS()
     _lastSecond = currentTime;
 }
 
-PaintSession* Painter::CreateSession(DrawPixelInfo& dpi, uint32_t viewFlags, uint8_t rotation)
+PaintSession* Painter::CreateSession(RenderTarget& dpi, uint32_t viewFlags, uint8_t rotation)
 {
     PROFILED_FUNCTION();
 

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -38,20 +38,20 @@ void Painter::Paint(IDrawingEngine& de)
 {
     PROFILED_FUNCTION();
 
-    auto dpi = de.GetDrawingPixelInfo();
+    auto rt = de.GetDrawingPixelInfo();
 
     if (IntroIsPlaying())
     {
-        IntroDraw(*dpi);
+        IntroDraw(*rt);
     }
     else
     {
         de.PaintWindows();
 
         UpdatePaletteEffects();
-        _uiContext->Draw(*dpi);
+        _uiContext->Draw(*rt);
 
-        GfxDrawPickedUpPeep(*dpi);
+        GfxDrawPickedUpPeep(*rt);
         GfxInvalidatePickedUpPeep();
 
         de.PaintWeather();
@@ -68,16 +68,16 @@ void Painter::Paint(IDrawingEngine& de)
         text = "Normalising...";
 
     if (text != nullptr)
-        PaintReplayNotice(*dpi, text);
+        PaintReplayNotice(*rt, text);
 
     if (Config::Get().general.ShowFPS)
     {
-        PaintFPS(*dpi);
+        PaintFPS(*rt);
     }
     gCurrentDrawCount++;
 }
 
-void Painter::PaintReplayNotice(RenderTarget& dpi, const char* text)
+void Painter::PaintReplayNotice(RenderTarget& rt, const char* text)
 {
     ScreenCoordsXY screenCoords(_uiContext->GetWidth() / 2, _uiContext->GetHeight() - 44);
 
@@ -88,7 +88,7 @@ void Painter::PaintReplayNotice(RenderTarget& dpi, const char* text)
     screenCoords.x = screenCoords.x - stringWidth;
 
     if (((getGameState().currentTicks >> 1) & 0xF) > 4)
-        DrawText(dpi, screenCoords, { COLOUR_SATURATED_RED }, buffer);
+        DrawText(rt, screenCoords, { COLOUR_SATURATED_RED }, buffer);
 
     // Make area dirty so the text doesn't get drawn over the last
     GfxSetDirtyBlocks({ screenCoords, screenCoords + ScreenCoordsXY{ stringWidth, 16 } });
@@ -103,7 +103,7 @@ static bool ShouldShowFPS()
     return windowMgr->FindByClass(WindowClass::TopToolbar);
 }
 
-void Painter::PaintFPS(RenderTarget& dpi)
+void Painter::PaintFPS(RenderTarget& rt)
 {
     if (!ShouldShowFPS())
         return;
@@ -125,10 +125,10 @@ void Painter::PaintFPS(RenderTarget& dpi)
         screenCoords.y = kTopToolbarHeight + 3;
     }
 
-    DrawText(dpi, screenCoords, { COLOUR_WHITE }, buffer);
+    DrawText(rt, screenCoords, { COLOUR_WHITE }, buffer);
 
     // Make area dirty so the text doesn't get drawn over the last
-    GfxSetDirtyBlocks({ { screenCoords - ScreenCoordsXY{ 16, 4 } }, { dpi.lastStringPos.x + 16, screenCoords.y + 16 } });
+    GfxSetDirtyBlocks({ { screenCoords - ScreenCoordsXY{ 16, 4 } }, { rt.lastStringPos.x + 16, screenCoords.y + 16 } });
 }
 
 void Painter::MeasureFPS()
@@ -144,7 +144,7 @@ void Painter::MeasureFPS()
     _lastSecond = currentTime;
 }
 
-PaintSession* Painter::CreateSession(RenderTarget& dpi, uint32_t viewFlags, uint8_t rotation)
+PaintSession* Painter::CreateSession(RenderTarget& rt, uint32_t viewFlags, uint8_t rotation)
 {
     PROFILED_FUNCTION();
 
@@ -164,7 +164,7 @@ PaintSession* Painter::CreateSession(RenderTarget& dpi, uint32_t viewFlags, uint
         session = &_paintSessionPool.emplace_back();
     }
 
-    session->DPI = dpi;
+    session->DPI = rt;
     session->ViewFlags = viewFlags;
     session->QuadrantBackIndex = std::numeric_limits<uint32_t>::max();
     session->QuadrantFrontIndex = 0;

--- a/src/openrct2/paint/Painter.h
+++ b/src/openrct2/paint/Painter.h
@@ -46,13 +46,13 @@ namespace OpenRCT2
             explicit Painter(const std::shared_ptr<Ui::IUiContext>& uiContext);
             void Paint(Drawing::IDrawingEngine& de);
 
-            PaintSession* CreateSession(RenderTarget& dpi, uint32_t viewFlags, uint8_t rotation);
+            PaintSession* CreateSession(RenderTarget& rt, uint32_t viewFlags, uint8_t rotation);
             void ReleaseSession(PaintSession* session);
             ~Painter();
 
         private:
-            void PaintReplayNotice(RenderTarget& dpi, const char* text);
-            void PaintFPS(RenderTarget& dpi);
+            void PaintReplayNotice(RenderTarget& rt, const char* text);
+            void PaintFPS(RenderTarget& rt);
             void MeasureFPS();
         };
     } // namespace Paint

--- a/src/openrct2/paint/Painter.h
+++ b/src/openrct2/paint/Painter.h
@@ -16,7 +16,7 @@
 #include <sfl/segmented_vector.hpp>
 #include <vector>
 
-struct DrawPixelInfo;
+struct RenderTarget;
 
 namespace OpenRCT2
 {
@@ -46,13 +46,13 @@ namespace OpenRCT2
             explicit Painter(const std::shared_ptr<Ui::IUiContext>& uiContext);
             void Paint(Drawing::IDrawingEngine& de);
 
-            PaintSession* CreateSession(DrawPixelInfo& dpi, uint32_t viewFlags, uint8_t rotation);
+            PaintSession* CreateSession(RenderTarget& dpi, uint32_t viewFlags, uint8_t rotation);
             void ReleaseSession(PaintSession* session);
             ~Painter();
 
         private:
-            void PaintReplayNotice(DrawPixelInfo& dpi, const char* text);
-            void PaintFPS(DrawPixelInfo& dpi);
+            void PaintReplayNotice(RenderTarget& dpi, const char* text);
+            void PaintFPS(RenderTarget& dpi);
             void MeasureFPS();
         };
     } // namespace Paint

--- a/src/openrct2/paint/tile_element/Paint.PathAddition.cpp
+++ b/src/openrct2/paint/tile_element/Paint.PathAddition.cpp
@@ -199,7 +199,7 @@ static void PathAdditionBenchesPaint(
 /* rct2: 0x006A6008 */
 static void PathAdditionJumpingFountainsPaint(
     PaintSession& session, const PathAdditionEntry& pathAdditionEntry, int32_t height, ImageId imageTemplate,
-    DrawPixelInfo& dpi)
+    RenderTarget& dpi)
 {
     if (dpi.zoom_level > ZoomLevel{ 0 })
         return;

--- a/src/openrct2/paint/tile_element/Paint.PathAddition.cpp
+++ b/src/openrct2/paint/tile_element/Paint.PathAddition.cpp
@@ -199,9 +199,9 @@ static void PathAdditionBenchesPaint(
 /* rct2: 0x006A6008 */
 static void PathAdditionJumpingFountainsPaint(
     PaintSession& session, const PathAdditionEntry& pathAdditionEntry, int32_t height, ImageId imageTemplate,
-    RenderTarget& dpi)
+    RenderTarget& rt)
 {
-    if (dpi.zoom_level > ZoomLevel{ 0 })
+    if (rt.zoom_level > ZoomLevel{ 0 })
         return;
 
     auto imageId = imageTemplate.WithIndex(pathAdditionEntry.image);

--- a/src/openrct2/paint/tile_element/Paint.PathAddition.cpp
+++ b/src/openrct2/paint/tile_element/Paint.PathAddition.cpp
@@ -198,8 +198,7 @@ static void PathAdditionBenchesPaint(
 
 /* rct2: 0x006A6008 */
 static void PathAdditionJumpingFountainsPaint(
-    PaintSession& session, const PathAdditionEntry& pathAdditionEntry, int32_t height, ImageId imageTemplate,
-    RenderTarget& rt)
+    PaintSession& session, const PathAdditionEntry& pathAdditionEntry, int32_t height, ImageId imageTemplate, RenderTarget& rt)
 {
     if (rt.zoom_level > ZoomLevel{ 0 })
         return;

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -392,6 +392,6 @@ uint16_t PaintUtilRotateSegments(uint16_t segments, uint8_t rotation)
 
 bool PaintShouldShowHeightMarkers(const PaintSession& session, const uint32_t viewportFlag)
 {
-    auto dpi = &session.DPI;
-    return (session.ViewFlags & viewportFlag) && (dpi->zoom_level <= ZoomLevel{ 0 });
+    auto rt = &session.DPI;
+    return (session.ViewFlags & viewportFlag) && (rt->zoom_level <= ZoomLevel{ 0 });
 }

--- a/src/openrct2/paint/vehicle/VehiclePaint.cpp
+++ b/src/openrct2/paint/vehicle/VehiclePaint.cpp
@@ -1018,8 +1018,8 @@ static void vehicle_sprite_paint(
         session, imageId, { 0, 0, z },
         { { bb.offset_x, bb.offset_y, bb.offset_z + z }, { bb.length_x, bb.length_y, bb.length_z } });
 
-    auto* dpi = &session.DPI;
-    if (dpi->zoom_level < ZoomLevel{ 2 } && vehicle->num_peeps > 0 && carEntry->no_seating_rows > 0)
+    auto& rt = session.DPI;
+    if (rt.zoom_level < ZoomLevel{ 2 } && vehicle->num_peeps > 0 && carEntry->no_seating_rows > 0)
     {
         PaintVehicleRiders(session, vehicle, carEntry, baseImageId, z, bb);
     }

--- a/src/openrct2/park/ParkPreview.cpp
+++ b/src/openrct2/park/ParkPreview.cpp
@@ -224,7 +224,7 @@ namespace OpenRCT2
 
         drawingEngine->BeginDraw();
 
-        DrawPixelInfo dpi{
+        RenderTarget dpi{
             .bits = static_cast<uint8_t*>(image.pixels),
             .x = 0,
             .y = 0,
@@ -242,7 +242,7 @@ namespace OpenRCT2
         return image;
     }
 
-    void drawPreviewImage(const PreviewImage& image, DrawPixelInfo& dpi, ScreenCoordsXY screenPos)
+    void drawPreviewImage(const PreviewImage& image, RenderTarget& dpi, ScreenCoordsXY screenPos)
     {
         auto* drawingEngine = GetContext()->GetDrawingEngine();
         if (drawingEngine == nullptr)

--- a/src/openrct2/park/ParkPreview.cpp
+++ b/src/openrct2/park/ParkPreview.cpp
@@ -224,7 +224,7 @@ namespace OpenRCT2
 
         drawingEngine->BeginDraw();
 
-        RenderTarget dpi{
+        RenderTarget rt{
             .bits = static_cast<uint8_t*>(image.pixels),
             .x = 0,
             .y = 0,
@@ -235,7 +235,7 @@ namespace OpenRCT2
             .DrawingEngine = drawingEngine.get(),
         };
 
-        ViewportRender(dpi, &saveVp);
+        ViewportRender(rt, &saveVp);
 
         drawingEngine->EndDraw();
 

--- a/src/openrct2/park/ParkPreview.cpp
+++ b/src/openrct2/park/ParkPreview.cpp
@@ -242,7 +242,7 @@ namespace OpenRCT2
         return image;
     }
 
-    void drawPreviewImage(const PreviewImage& image, RenderTarget& dpi, ScreenCoordsXY screenPos)
+    void drawPreviewImage(const PreviewImage& image, RenderTarget& rt, ScreenCoordsXY screenPos)
     {
         auto* drawingEngine = GetContext()->GetDrawingEngine();
         if (drawingEngine == nullptr)
@@ -261,7 +261,7 @@ namespace OpenRCT2
             drawingEngine->InvalidateImage(imageId.GetIndex());
 
             // Draw preview image and restore original G1 image
-            GfxDrawSprite(dpi, imageId, screenPos);
+            GfxDrawSprite(rt, imageId, screenPos);
             *g1 = backupG1;
             drawingEngine->InvalidateImage(imageId.GetIndex());
         }

--- a/src/openrct2/park/ParkPreview.h
+++ b/src/openrct2/park/ParkPreview.h
@@ -16,7 +16,7 @@
 #include <string>
 #include <vector>
 
-struct DrawPixelInfo;
+struct RenderTarget;
 
 namespace OpenRCT2
 {
@@ -54,5 +54,5 @@ namespace OpenRCT2
     struct GameState_t;
 
     ParkPreview generatePreviewFromGameState(const GameState_t& gameState);
-    void drawPreviewImage(const PreviewImage& image, DrawPixelInfo& dpi, ScreenCoordsXY screenPos);
+    void drawPreviewImage(const PreviewImage& image, RenderTarget& dpi, ScreenCoordsXY screenPos);
 } // namespace OpenRCT2

--- a/src/openrct2/park/ParkPreview.h
+++ b/src/openrct2/park/ParkPreview.h
@@ -54,5 +54,5 @@ namespace OpenRCT2
     struct GameState_t;
 
     ParkPreview generatePreviewFromGameState(const GameState_t& gameState);
-    void drawPreviewImage(const PreviewImage& image, RenderTarget& dpi, ScreenCoordsXY screenPos);
+    void drawPreviewImage(const PreviewImage& image, RenderTarget& rt, ScreenCoordsXY screenPos);
 } // namespace OpenRCT2

--- a/src/openrct2/peep/PeepAnimations.cpp
+++ b/src/openrct2/peep/PeepAnimations.cpp
@@ -279,7 +279,7 @@ namespace OpenRCT2
 
         uint8_t bitmap[kHeight][kWidth] = { 0 };
 
-        RenderTarget dpi = {
+        RenderTarget rt = {
             .bits = reinterpret_cast<uint8_t*>(bitmap),
             .x = -(kWidth / 2),
             .y = -(kHeight / 2),
@@ -292,7 +292,7 @@ namespace OpenRCT2
         const auto numImages = *(std::max_element(anim.frame_offsets.begin(), anim.frame_offsets.end())) + 1;
         for (int32_t i = 0; i < numImages; ++i)
         {
-            GfxDrawSpriteSoftware(dpi, ImageId(anim.base_image + i), { 0, 0 });
+            GfxDrawSpriteSoftware(rt, ImageId(anim.base_image + i), { 0, 0 });
         }
 
         int32_t spriteWidth = -1;

--- a/src/openrct2/peep/PeepAnimations.cpp
+++ b/src/openrct2/peep/PeepAnimations.cpp
@@ -279,7 +279,7 @@ namespace OpenRCT2
 
         uint8_t bitmap[kHeight][kWidth] = { 0 };
 
-        DrawPixelInfo dpi = {
+        RenderTarget dpi = {
             .bits = reinterpret_cast<uint8_t*>(bitmap),
             .x = -(kWidth / 2),
             .y = -(kHeight / 2),

--- a/src/openrct2/ride/CarEntry.cpp
+++ b/src/openrct2/ride/CarEntry.cpp
@@ -53,7 +53,7 @@ void CarEntrySetImageMaxSizes(CarEntry& carEntry, int32_t numImages)
 
     uint8_t bitmap[kHeight][kWidth] = { 0 };
 
-    RenderTarget dpi = {
+    RenderTarget rt = {
         .bits = reinterpret_cast<uint8_t*>(bitmap),
         .x = -(kWidth / 2),
         .y = -(kHeight / 2),
@@ -65,7 +65,7 @@ void CarEntrySetImageMaxSizes(CarEntry& carEntry, int32_t numImages)
 
     for (int32_t i = 0; i < numImages; ++i)
     {
-        GfxDrawSpriteSoftware(dpi, ImageId(carEntry.base_image_id + i), { 0, 0 });
+        GfxDrawSpriteSoftware(rt, ImageId(carEntry.base_image_id + i), { 0, 0 });
     }
 
     int32_t spriteWidth = -1;

--- a/src/openrct2/ride/CarEntry.cpp
+++ b/src/openrct2/ride/CarEntry.cpp
@@ -53,7 +53,7 @@ void CarEntrySetImageMaxSizes(CarEntry& carEntry, int32_t numImages)
 
     uint8_t bitmap[kHeight][kWidth] = { 0 };
 
-    DrawPixelInfo dpi = {
+    RenderTarget dpi = {
         .bits = reinterpret_cast<uint8_t*>(bitmap),
         .x = -(kWidth / 2),
         .y = -(kHeight / 2),

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -2120,7 +2120,7 @@ void TrackDesignDrawPreview(TrackDesign& td, uint8_t* pixels)
     view.zoom = zoom_level;
     view.flags = VIEWPORT_FLAG_HIDE_BASE | VIEWPORT_FLAG_HIDE_ENTITIES;
 
-    DrawPixelInfo dpi;
+    RenderTarget dpi;
     dpi.x = 0;
     dpi.y = 0;
     dpi.width = 370;

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -2120,16 +2120,16 @@ void TrackDesignDrawPreview(TrackDesign& td, uint8_t* pixels)
     view.zoom = zoom_level;
     view.flags = VIEWPORT_FLAG_HIDE_BASE | VIEWPORT_FLAG_HIDE_ENTITIES;
 
-    RenderTarget dpi;
-    dpi.x = 0;
-    dpi.y = 0;
-    dpi.width = 370;
-    dpi.height = 217;
-    dpi.pitch = 0;
-    dpi.bits = pixels;
+    RenderTarget rt;
+    rt.x = 0;
+    rt.y = 0;
+    rt.width = 370;
+    rt.height = 217;
+    rt.pitch = 0;
+    rt.bits = pixels;
 
     auto drawingEngine = std::make_unique<X8DrawingEngine>(GetContext()->GetUiContext());
-    dpi.DrawingEngine = drawingEngine.get();
+    rt.DrawingEngine = drawingEngine.get();
 
     drawingEngine->BeginDraw();
 
@@ -2138,9 +2138,9 @@ void TrackDesignDrawPreview(TrackDesign& td, uint8_t* pixels)
     {
         view.viewPos = Translate3DTo2DWithZ(i, centre) - offset;
         view.rotation = i;
-        ViewportRender(dpi, &view);
+        ViewportRender(rt, &view);
 
-        dpi.bits += kTrackPreviewImageSize;
+        rt.bits += kTrackPreviewImageSize;
     }
 
     drawingEngine->EndDraw();

--- a/src/openrct2/scenes/intro/IntroScene.cpp
+++ b/src/openrct2/scenes/intro/IntroScene.cpp
@@ -211,10 +211,8 @@ namespace OpenRCT2
 
                 // Draw Infogrames logo
                 GfxDrawSprite(rt, ImageId(SPR_INTRO_INFOGRAMES_00), { (screenWidth / 2) - 320 + 69, _introStateCounter + 69 });
-                GfxDrawSprite(
-                    rt, ImageId(SPR_INTRO_INFOGRAMES_10), { (screenWidth / 2) - 320 + 319, _introStateCounter + 69 });
-                GfxDrawSprite(
-                    rt, ImageId(SPR_INTRO_INFOGRAMES_01), { (screenWidth / 2) - 320 + 69, _introStateCounter + 319 });
+                GfxDrawSprite(rt, ImageId(SPR_INTRO_INFOGRAMES_10), { (screenWidth / 2) - 320 + 319, _introStateCounter + 69 });
+                GfxDrawSprite(rt, ImageId(SPR_INTRO_INFOGRAMES_01), { (screenWidth / 2) - 320 + 69, _introStateCounter + 319 });
                 GfxDrawSprite(
                     rt, ImageId(SPR_INTRO_INFOGRAMES_11), { (screenWidth / 2) - 320 + 319, _introStateCounter + 319 });
                 break;

--- a/src/openrct2/scenes/intro/IntroScene.cpp
+++ b/src/openrct2/scenes/intro/IntroScene.cpp
@@ -56,7 +56,7 @@ namespace OpenRCT2
     static void ScreenIntroProcessMouseInput();
     static void ScreenIntroProcessKeyboardInput();
     static void ScreenIntroSkipPart();
-    static void ScreenIntroDrawLogo(DrawPixelInfo& dpi);
+    static void ScreenIntroDrawLogo(RenderTarget& dpi);
 
     // rct2: 0x0068E966
     void IntroScene::Tick()
@@ -187,7 +187,7 @@ namespace OpenRCT2
         }
     }
 
-    void IntroDraw(DrawPixelInfo& dpi)
+    void IntroDraw(RenderTarget& dpi)
     {
         int32_t screenWidth = ContextGetWidth();
 
@@ -302,7 +302,7 @@ namespace OpenRCT2
         }
     }
 
-    static void ScreenIntroDrawLogo(DrawPixelInfo& dpi)
+    static void ScreenIntroDrawLogo(RenderTarget& dpi)
     {
         int32_t screenWidth = ContextGetWidth();
         int32_t imageWidth = 640;

--- a/src/openrct2/scenes/intro/IntroScene.cpp
+++ b/src/openrct2/scenes/intro/IntroScene.cpp
@@ -56,7 +56,7 @@ namespace OpenRCT2
     static void ScreenIntroProcessMouseInput();
     static void ScreenIntroProcessKeyboardInput();
     static void ScreenIntroSkipPart();
-    static void ScreenIntroDrawLogo(RenderTarget& dpi);
+    static void ScreenIntroDrawLogo(RenderTarget& rt);
 
     // rct2: 0x0068E966
     void IntroScene::Tick()
@@ -187,7 +187,7 @@ namespace OpenRCT2
         }
     }
 
-    void IntroDraw(RenderTarget& dpi)
+    void IntroDraw(RenderTarget& rt)
     {
         int32_t screenWidth = ContextGetWidth();
 
@@ -197,37 +197,37 @@ namespace OpenRCT2
             case IntroState::Disclaimer2:
                 break;
             case IntroState::PublisherBegin:
-                GfxClear(dpi, kBackgroundColourDark);
+                GfxClear(rt, kBackgroundColourDark);
                 break;
             case IntroState::PublisherScroll:
-                GfxClear(dpi, kBackgroundColourDark);
+                GfxClear(rt, kBackgroundColourDark);
 
                 // Draw a white rectangle for the logo background (gives a bit of white margin)
                 GfxFillRect(
-                    dpi,
+                    rt,
                     { { (screenWidth / 2) - 320 + 50, _introStateCounter + 50 },
                       { (screenWidth / 2) - 320 + 50 + 540, _introStateCounter + 50 + 425 } },
                     kBorderColourPublisher);
 
                 // Draw Infogrames logo
-                GfxDrawSprite(dpi, ImageId(SPR_INTRO_INFOGRAMES_00), { (screenWidth / 2) - 320 + 69, _introStateCounter + 69 });
+                GfxDrawSprite(rt, ImageId(SPR_INTRO_INFOGRAMES_00), { (screenWidth / 2) - 320 + 69, _introStateCounter + 69 });
                 GfxDrawSprite(
-                    dpi, ImageId(SPR_INTRO_INFOGRAMES_10), { (screenWidth / 2) - 320 + 319, _introStateCounter + 69 });
+                    rt, ImageId(SPR_INTRO_INFOGRAMES_10), { (screenWidth / 2) - 320 + 319, _introStateCounter + 69 });
                 GfxDrawSprite(
-                    dpi, ImageId(SPR_INTRO_INFOGRAMES_01), { (screenWidth / 2) - 320 + 69, _introStateCounter + 319 });
+                    rt, ImageId(SPR_INTRO_INFOGRAMES_01), { (screenWidth / 2) - 320 + 69, _introStateCounter + 319 });
                 GfxDrawSprite(
-                    dpi, ImageId(SPR_INTRO_INFOGRAMES_11), { (screenWidth / 2) - 320 + 319, _introStateCounter + 319 });
+                    rt, ImageId(SPR_INTRO_INFOGRAMES_11), { (screenWidth / 2) - 320 + 319, _introStateCounter + 319 });
                 break;
             case IntroState::DeveloperBegin:
-                GfxClear(dpi, kBackgroundColourDark);
+                GfxClear(rt, kBackgroundColourDark);
                 GfxTransposePalette(PALETTE_G1_IDX_DEVELOPER, 255);
                 break;
             case IntroState::DeveloperScroll:
-                GfxClear(dpi, kBackgroundColourDark);
+                GfxClear(rt, kBackgroundColourDark);
 
                 // Draw Chris Sawyer logo
-                GfxDrawSprite(dpi, ImageId(SPR_INTRO_CHRIS_SAWYER_00), { (screenWidth / 2) - 320 + 70, _introStateCounter });
-                GfxDrawSprite(dpi, ImageId(SPR_INTRO_CHRIS_SAWYER_10), { (screenWidth / 2) - 320 + 320, _introStateCounter });
+                GfxDrawSprite(rt, ImageId(SPR_INTRO_CHRIS_SAWYER_00), { (screenWidth / 2) - 320 + 70, _introStateCounter });
+                GfxDrawSprite(rt, ImageId(SPR_INTRO_CHRIS_SAWYER_10), { (screenWidth / 2) - 320 + 320, _introStateCounter });
                 break;
             case IntroState::LogoFadeIn:
                 if (_introStateCounter <= 0xFF00)
@@ -238,10 +238,10 @@ namespace OpenRCT2
                 {
                     GfxTransposePalette(PALETTE_G1_IDX_LOGO, 255);
                 }
-                ScreenIntroDrawLogo(dpi);
+                ScreenIntroDrawLogo(rt);
                 break;
             case IntroState::LogoWait:
-                ScreenIntroDrawLogo(dpi);
+                ScreenIntroDrawLogo(rt);
                 break;
             case IntroState::LogoFadeOut:
                 if (_introStateCounter >= 0)
@@ -252,10 +252,10 @@ namespace OpenRCT2
                 {
                     GfxTransposePalette(PALETTE_G1_IDX_LOGO, 0);
                 }
-                ScreenIntroDrawLogo(dpi);
+                ScreenIntroDrawLogo(rt);
                 break;
             case IntroState::Clear:
-                GfxClear(dpi, kBackgroundColourDark);
+                GfxClear(rt, kBackgroundColourDark);
                 break;
             default:
                 break;
@@ -302,7 +302,7 @@ namespace OpenRCT2
         }
     }
 
-    static void ScreenIntroDrawLogo(RenderTarget& dpi)
+    static void ScreenIntroDrawLogo(RenderTarget& rt)
     {
         int32_t screenWidth = ContextGetWidth();
         int32_t imageWidth = 640;
@@ -315,12 +315,12 @@ namespace OpenRCT2
         DrawingEngineInvalidateImage(SPR_INTRO_LOGO_11);
         DrawingEngineInvalidateImage(SPR_INTRO_LOGO_21);
 
-        GfxClear(dpi, kBackgroundColourLogo);
-        GfxDrawSprite(dpi, ImageId(SPR_INTRO_LOGO_00), { imageX + 0, 0 });
-        GfxDrawSprite(dpi, ImageId(SPR_INTRO_LOGO_10), { imageX + 220, 0 });
-        GfxDrawSprite(dpi, ImageId(SPR_INTRO_LOGO_20), { imageX + 440, 0 });
-        GfxDrawSprite(dpi, ImageId(SPR_INTRO_LOGO_01), { imageX + 0, 240 });
-        GfxDrawSprite(dpi, ImageId(SPR_INTRO_LOGO_11), { imageX + 220, 240 });
-        GfxDrawSprite(dpi, ImageId(SPR_INTRO_LOGO_21), { imageX + 440, 240 });
+        GfxClear(rt, kBackgroundColourLogo);
+        GfxDrawSprite(rt, ImageId(SPR_INTRO_LOGO_00), { imageX + 0, 0 });
+        GfxDrawSprite(rt, ImageId(SPR_INTRO_LOGO_10), { imageX + 220, 0 });
+        GfxDrawSprite(rt, ImageId(SPR_INTRO_LOGO_20), { imageX + 440, 0 });
+        GfxDrawSprite(rt, ImageId(SPR_INTRO_LOGO_01), { imageX + 0, 240 });
+        GfxDrawSprite(rt, ImageId(SPR_INTRO_LOGO_11), { imageX + 220, 240 });
+        GfxDrawSprite(rt, ImageId(SPR_INTRO_LOGO_21), { imageX + 440, 240 });
     }
 } // namespace OpenRCT2

--- a/src/openrct2/scenes/intro/IntroScene.h
+++ b/src/openrct2/scenes/intro/IntroScene.h
@@ -45,5 +45,5 @@ namespace OpenRCT2
 
     bool IntroIsPlaying();
     void IntroUpdate();
-    void IntroDraw(RenderTarget& dpi);
+    void IntroDraw(RenderTarget& rt);
 } // namespace OpenRCT2

--- a/src/openrct2/scenes/intro/IntroScene.h
+++ b/src/openrct2/scenes/intro/IntroScene.h
@@ -13,7 +13,7 @@
 
 #include <cstdint>
 
-struct DrawPixelInfo;
+struct RenderTarget;
 
 namespace OpenRCT2
 {
@@ -45,5 +45,5 @@ namespace OpenRCT2
 
     bool IntroIsPlaying();
     void IntroUpdate();
-    void IntroDraw(DrawPixelInfo& dpi);
+    void IntroDraw(RenderTarget& dpi);
 } // namespace OpenRCT2

--- a/src/openrct2/ui/DummyUiContext.cpp
+++ b/src/openrct2/ui/DummyUiContext.cpp
@@ -30,7 +30,7 @@ namespace OpenRCT2::Ui
         void Tick() override
         {
         }
-        void Draw(DrawPixelInfo& /*dpi*/) override
+        void Draw(RenderTarget& /*dpi*/) override
         {
         }
 
@@ -172,7 +172,7 @@ namespace OpenRCT2::Ui
         {
             return std::make_shared<X8DrawingEngineFactory>();
         }
-        void DrawWeatherAnimation(IWeatherDrawer* weatherDrawer, DrawPixelInfo& dpi, DrawWeatherFunc drawFunc) override
+        void DrawWeatherAnimation(IWeatherDrawer* weatherDrawer, RenderTarget& dpi, DrawWeatherFunc drawFunc) override
         {
         }
 

--- a/src/openrct2/ui/DummyUiContext.cpp
+++ b/src/openrct2/ui/DummyUiContext.cpp
@@ -30,7 +30,7 @@ namespace OpenRCT2::Ui
         void Tick() override
         {
         }
-        void Draw(RenderTarget& /*dpi*/) override
+        void Draw(RenderTarget& /*rt*/) override
         {
         }
 

--- a/src/openrct2/ui/DummyUiContext.cpp
+++ b/src/openrct2/ui/DummyUiContext.cpp
@@ -172,7 +172,7 @@ namespace OpenRCT2::Ui
         {
             return std::make_shared<X8DrawingEngineFactory>();
         }
-        void DrawWeatherAnimation(IWeatherDrawer* weatherDrawer, RenderTarget& dpi, DrawWeatherFunc drawFunc) override
+        void DrawWeatherAnimation(IWeatherDrawer* weatherDrawer, RenderTarget& rt, DrawWeatherFunc drawFunc) override
         {
         }
 

--- a/src/openrct2/ui/UiContext.h
+++ b/src/openrct2/ui/UiContext.h
@@ -28,7 +28,7 @@ namespace OpenRCT2
         struct IDrawingEngineFactory;
         struct IWeatherDrawer;
         using DrawWeatherFunc = void (*)(
-            RenderTarget& dpi, OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width,
+            RenderTarget& rt, OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width,
             int32_t height);
     } // namespace Drawing
 
@@ -100,7 +100,7 @@ namespace OpenRCT2
 
             virtual void InitialiseScriptExtensions() = 0;
             virtual void Tick() = 0;
-            virtual void Draw(RenderTarget& dpi) = 0;
+            virtual void Draw(RenderTarget& rt) = 0;
 
             // Window
             virtual void CreateWindow() = 0;
@@ -150,7 +150,7 @@ namespace OpenRCT2
             // Drawing
             [[nodiscard]] virtual std::shared_ptr<Drawing::IDrawingEngineFactory> GetDrawingEngineFactory() = 0;
             virtual void DrawWeatherAnimation(
-                OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer, RenderTarget& dpi,
+                OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer, RenderTarget& rt,
                 OpenRCT2::Drawing::DrawWeatherFunc drawFunc)
                 = 0;
 

--- a/src/openrct2/ui/UiContext.h
+++ b/src/openrct2/ui/UiContext.h
@@ -150,8 +150,7 @@ namespace OpenRCT2
             // Drawing
             [[nodiscard]] virtual std::shared_ptr<Drawing::IDrawingEngineFactory> GetDrawingEngineFactory() = 0;
             virtual void DrawWeatherAnimation(
-                OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer, RenderTarget& rt,
-                OpenRCT2::Drawing::DrawWeatherFunc drawFunc)
+                OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer, RenderTarget& rt, OpenRCT2::Drawing::DrawWeatherFunc drawFunc)
                 = 0;
 
             // Text input

--- a/src/openrct2/ui/UiContext.h
+++ b/src/openrct2/ui/UiContext.h
@@ -18,7 +18,7 @@
 #include <vector>
 
 struct ScreenCoordsXY;
-struct DrawPixelInfo;
+struct RenderTarget;
 struct ITitleSequencePlayer;
 
 namespace OpenRCT2
@@ -28,7 +28,7 @@ namespace OpenRCT2
         struct IDrawingEngineFactory;
         struct IWeatherDrawer;
         using DrawWeatherFunc = void (*)(
-            DrawPixelInfo& dpi, OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width,
+            RenderTarget& dpi, OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width,
             int32_t height);
     } // namespace Drawing
 
@@ -100,7 +100,7 @@ namespace OpenRCT2
 
             virtual void InitialiseScriptExtensions() = 0;
             virtual void Tick() = 0;
-            virtual void Draw(DrawPixelInfo& dpi) = 0;
+            virtual void Draw(RenderTarget& dpi) = 0;
 
             // Window
             virtual void CreateWindow() = 0;
@@ -150,7 +150,7 @@ namespace OpenRCT2
             // Drawing
             [[nodiscard]] virtual std::shared_ptr<Drawing::IDrawingEngineFactory> GetDrawingEngineFactory() = 0;
             virtual void DrawWeatherAnimation(
-                OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer, DrawPixelInfo& dpi,
+                OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer, RenderTarget& dpi,
                 OpenRCT2::Drawing::DrawWeatherFunc drawFunc)
                 = 0;
 


### PR DESCRIPTION
I've delayed this one for too long, also with this we move a step closer to OpenLoco.

I've renamed them all using VAX so most of them are by hand and not with magic regex rules which has the chance of doing it wrong, so there should be no breakage. There are some missing but doing this the safe way is quite exhausting.