### PR TITLE
Add required sprites to unbanked and banked large gentle turns

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -25,6 +25,7 @@
 - Fix: [#22628] Potential crash while rebuilding the scenario index.
 - Fix: [#23289] Dodgems and Flying Saucer cars can spawn on top of each other when the ride is opened.
 - Fix: [#24332] Banner font renders differently when using RCT Classic as the base game.
+- Fix: [#24343] Large gentle turns are buildable without cheats when the vehicles do not have sprites for them.
 - Fix: [#24346] Possible crash during line drawing in OpenGL mode.
 - Fix: [#24353] ‘Show dirty visuals’ is off by one pixel and does not work correctly with higher framerates.
 - Fix: [#24362] When upgrading from an older version on Windows, old versions of official objects are not always removed.  

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -25,7 +25,7 @@
 - Fix: [#22628] Potential crash while rebuilding the scenario index.
 - Fix: [#23289] Dodgems and Flying Saucer cars can spawn on top of each other when the ride is opened.
 - Fix: [#24332] Banner font renders differently when using RCT Classic as the base game.
-- Fix: [#24343] Large gentle turns are buildable without cheats when the vehicles do not have sprites for them.
+- Fix: [#24343] Large gently sloped turns are buildable without cheats when the vehicles do not have sprites for them.
 - Fix: [#24346] Possible crash during line drawing in OpenGL mode.
 - Fix: [#24353] ‘Show dirty visuals’ is off by one pixel and does not work correctly with higher framerates.
 - Fix: [#24362] When upgrading from an older version on Windows, old versions of official objects are not always removed.  

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4914,13 +4914,13 @@ OpenRCT2::BitSet<EnumValue(TrackGroup::count)> RideEntryGetSupportedTrackPieces(
           SpritePrecision::Sprites4 }, // TrackGroup::flyingHalfLoopInvertedUp
         { SpriteGroupType::Slopes25, SpritePrecision::Sprites4, SpriteGroupType::Slopes60, SpritePrecision::Sprites4,
           SpriteGroupType::Slopes75, SpritePrecision::Sprites4, SpriteGroupType::Slopes90,
-          SpritePrecision::Sprites4 },                             // TrackGroup::flyingHalfLoopUninvertedDown
-        {},                                                        // TrackGroup::slopeCurveLarge
-        {},                                                        // TrackGroup::slopeCurveLargeBanked
-        { SpriteGroupType::SlopeFlat, SpritePrecision::Sprites8 }, // TrackGroup::diagBrakes
-        { SpriteGroupType::SlopeFlat, SpritePrecision::Sprites8 }, // TrackGroup::diagBlockBrakes
-        { SpriteGroupType::Slopes25, SpritePrecision::Sprites8 },  // TrackGroup::inclinedBrakes
-        { SpriteGroupType::SlopeFlat, SpritePrecision::Sprites8 }, // TrackGroup::diagBooster
+          SpritePrecision::Sprites4 },                                     // TrackGroup::flyingHalfLoopUninvertedDown
+        { SpriteGroupType::Slopes25, SpritePrecision::Sprites16 },         // TrackGroup::slopeCurveLarge
+        { SpriteGroupType::Slopes25Banked45, SpritePrecision::Sprites16 }, // TrackGroup::slopeCurveLargeBanked
+        { SpriteGroupType::SlopeFlat, SpritePrecision::Sprites8 },         // TrackGroup::diagBrakes
+        { SpriteGroupType::SlopeFlat, SpritePrecision::Sprites8 },         // TrackGroup::diagBlockBrakes
+        { SpriteGroupType::Slopes25, SpritePrecision::Sprites8 },          // TrackGroup::inclinedBrakes
+        { SpriteGroupType::SlopeFlat, SpritePrecision::Sprites8 },         // TrackGroup::diagBooster
         { SpriteGroupType::Slopes8, SpritePrecision::Sprites4, SpriteGroupType::Slopes16, SpritePrecision::Sprites4,
           SpriteGroupType::Slopes25, SpritePrecision::Sprites8, SpriteGroupType::Slopes42, SpritePrecision::Sprites8,
           SpriteGroupType::Slopes50, SpritePrecision::Sprites4 }, // TrackGroup::slopeSteepLong


### PR DESCRIPTION
This adds entries to the sprites required for track groups for the large gentle turns. This means that they can't be built without cheats for the RCT1 go karts. The required sprites is based on the pitch and bank values used in the track subposition data. I'm not sure if this needs a changelog entry for the go kart issue or not.

![rct1 go kart bug](https://github.com/user-attachments/assets/decbf53e-f7ca-47e0-b12b-b669fc9ff29b)
