### PR TITLE
Use the intended bounding box for vehicle sprite fallbacks

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#22476] “Time since last inspection” statistic is available in the rides window.
 - Feature: [#24313] [Plugin] Add API for setting a ride vehicle’s sprite to a smoke plume.
+- Improved: [#24345] Vehicle fallback sprites are less likely to glitch with the track.
 - Improved: [#24362, #24491] The Windows installer is now translated as well.
 - Improved: [#24364] Improve the fallback vehicle sprites for Zero G Rolls, and allow small ones to be built without cheats if the fallbacks are available.
 - Improved: [#24368] Clicking the in-game update notication now leads to a more user-friendly download page.

--- a/src/openrct2/paint/vehicle/VehiclePaint.cpp
+++ b/src/openrct2/paint/vehicle/VehiclePaint.cpp
@@ -2143,13 +2143,14 @@ static void VehiclePitchUp42BankedLeft135(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
+    constexpr uint32_t corkscrewFrame = 13;
     const int32_t modifiedImageDirection = (imageDirection + 8) % 32;
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
         ? boundingBoxIndex
-        : YawTo4(modifiedImageDirection) + 13 * 4 + kBoundBoxIndexCorkscrew;
+        : YawTo4(modifiedImageDirection) + corkscrewFrame * kNumOrthogonalDirections + kBoundBoxIndexCorkscrew;
     if (carEntry->GroupEnabled(SpriteGroupType::Corkscrews))
     {
-        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, modifiedImageDirection, 13);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, modifiedImageDirection, corkscrewFrame);
         VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
@@ -2162,11 +2163,13 @@ static void VehiclePitchUp42BankedRight135(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo4(imageDirection) + 3 * 4 + kBoundBoxIndexCorkscrew;
+    constexpr uint32_t corkscrewFrame = 3;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : YawTo4(imageDirection) + corkscrewFrame * kNumOrthogonalDirections + kBoundBoxIndexCorkscrew;
     if (carEntry->GroupEnabled(SpriteGroupType::Corkscrews))
     {
-        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, imageDirection, 3);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, imageDirection, corkscrewFrame);
         VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
@@ -2973,11 +2976,13 @@ static void VehiclePitchDown42BankedLeft135(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo4(imageDirection) + 8 * 4 + kBoundBoxIndexCorkscrew;
+    constexpr uint32_t corkscrewFrame = 8;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : YawTo4(imageDirection) + corkscrewFrame * kNumOrthogonalDirections + kBoundBoxIndexCorkscrew;
     if (carEntry->GroupEnabled(SpriteGroupType::Corkscrews))
     {
-        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, imageDirection, 8);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, imageDirection, corkscrewFrame);
         VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
@@ -2990,13 +2995,14 @@ static void VehiclePitchDown42BankedRight135(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
+    constexpr uint32_t corkscrewFrame = 18;
     const int32_t modifiedImageDirection = (imageDirection + 8) % 32;
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
         ? boundingBoxIndex
-        : YawTo4(modifiedImageDirection) + 18 * 4 + kBoundBoxIndexCorkscrew;
+        : YawTo4(modifiedImageDirection) + corkscrewFrame * kNumOrthogonalDirections + kBoundBoxIndexCorkscrew;
     if (carEntry->GroupEnabled(SpriteGroupType::Corkscrews))
     {
-        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, modifiedImageDirection, 18);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, modifiedImageDirection, corkscrewFrame);
         VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
@@ -3463,7 +3469,7 @@ void VehiclePitchCorkscrew(
     }
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
         ? boundingBoxIndex
-        : (YawTo4(imageDirection)) + corkscrewFrame * 4 + kBoundBoxIndexCorkscrew;
+        : (YawTo4(imageDirection)) + corkscrewFrame * kNumOrthogonalDirections + kBoundBoxIndexCorkscrew;
     if (carEntry->GroupEnabled(SpriteGroupType::Corkscrews))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, imageDirection, corkscrewFrame);

--- a/src/openrct2/paint/vehicle/VehiclePaint.cpp
+++ b/src/openrct2/paint/vehicle/VehiclePaint.cpp
@@ -993,7 +993,7 @@ static void PaintVehicleRiders(
 
 // 6D5214
 static void vehicle_sprite_paint(
-    PaintSession& session, const Vehicle* vehicle, int32_t spriteNum, const VehicleBoundBox& bb, int32_t z,
+    PaintSession& session, const Vehicle* vehicle, int32_t spriteIndex, const VehicleBoundBox& bb, int32_t z,
     const CarEntry* carEntry)
 {
     if (carEntry->draw_order >= std::size(VehicleBoundboxes))
@@ -1001,7 +1001,7 @@ static void vehicle_sprite_paint(
         return;
     }
 
-    auto baseImageId = static_cast<uint32_t>(spriteNum);
+    auto baseImageId = static_cast<uint32_t>(spriteIndex);
     if (carEntry->flags & CAR_ENTRY_FLAG_SPINNING_ADDITIONAL_FRAMES)
     {
         baseImageId += (vehicle->spin_sprite / 8) & 31;
@@ -1030,11 +1030,11 @@ static void vehicle_sprite_paint(
 
 // 6D520E
 static void VehicleSpritePaintWithSwinging(
-    PaintSession& session, const Vehicle* vehicle, int32_t spriteNum, int32_t boundingBoxIndex, int32_t z,
+    PaintSession& session, const Vehicle* vehicle, int32_t spriteIndex, int32_t boundingBoxIndex, int32_t z,
     const CarEntry* carEntry)
 {
     vehicle_sprite_paint(
-        session, vehicle, spriteNum + vehicle->SwingSprite, VehicleBoundboxes[carEntry->draw_order][boundingBoxIndex], z,
+        session, vehicle, spriteIndex + vehicle->SwingSprite, VehicleBoundboxes[carEntry->draw_order][boundingBoxIndex], z,
         carEntry);
 }
 
@@ -1044,8 +1044,8 @@ static void VehicleSpritePaintRestraints(
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     auto restraintFrame = ((vehicle->restraints_position - 64) / 64);
-    auto spriteNum = carEntry->SpriteOffset(SpriteGroupType::RestraintAnimation, imageDirection, restraintFrame);
-    vehicle_sprite_paint(session, vehicle, spriteNum, VehicleBoundboxes[carEntry->draw_order][boundingBoxIndex], z, carEntry);
+    const auto spriteIndex = carEntry->SpriteOffset(SpriteGroupType::RestraintAnimation, imageDirection, restraintFrame);
+    vehicle_sprite_paint(session, vehicle, spriteIndex, VehicleBoundboxes[carEntry->draw_order][boundingBoxIndex], z, carEntry);
 }
 
 // Returns the opposite of the bank angle for reversed cars, normal bank angle otherwise
@@ -1071,8 +1071,8 @@ static void VehiclePitchFlatUnbanked(
         return;
     }
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
-    auto spriteNum = carEntry->SpriteOffset(SpriteGroupType::SlopeFlat, imageDirection, 0);
-    VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+    const auto spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopeFlat, imageDirection, 0);
+    VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
 }
 
 // 6D4EE7
@@ -1083,8 +1083,8 @@ static void VehiclePitchFlatBankedLeft22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::FlatBanked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::FlatBanked22, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::FlatBanked22, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1100,8 +1100,8 @@ static void VehiclePitchFlatBankedLeft45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection) + 108;
     if (carEntry->GroupEnabled(SpriteGroupType::FlatBanked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::FlatBanked45, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::FlatBanked45, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1117,8 +1117,8 @@ static void VehiclePitchFlatBankedRight22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::FlatBanked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::FlatBanked22, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::FlatBanked22, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1134,8 +1134,8 @@ static void VehiclePitchFlatBankedRight45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection) ^ 8) + 108;
     if (carEntry->GroupEnabled(SpriteGroupType::FlatBanked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::FlatBanked45, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::FlatBanked45, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1155,8 +1155,8 @@ static void VehiclePitchFlatBankedLeft67(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 124;
     if (carEntry->GroupEnabled(SpriteGroupType::FlatBanked67))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::FlatBanked67, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::FlatBanked67, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1176,8 +1176,8 @@ static void VehiclePitchFlatBankedLeft90(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 128;
     if (carEntry->GroupEnabled(SpriteGroupType::FlatBanked90))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::FlatBanked90, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::FlatBanked90, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1197,8 +1197,8 @@ static void VehiclePitchFlatBankedLeft112(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 132;
     if (carEntry->GroupEnabled(SpriteGroupType::InlineTwists))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::InlineTwists, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::InlineTwists, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1218,8 +1218,8 @@ static void VehiclePitchFlatBankedLeft135(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 136;
     if (carEntry->GroupEnabled(SpriteGroupType::InlineTwists))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::InlineTwists, imageDirection, 2);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::InlineTwists, imageDirection, 2);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1239,8 +1239,8 @@ static void VehiclePitchFlatBankedLeft157(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 140;
     if (carEntry->GroupEnabled(SpriteGroupType::InlineTwists))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::InlineTwists, imageDirection, 4);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::InlineTwists, imageDirection, 4);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1260,8 +1260,8 @@ static void VehiclePitchFlatBankedRight67(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 124;
     if (carEntry->GroupEnabled(SpriteGroupType::FlatBanked67))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::FlatBanked67, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::FlatBanked67, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1281,8 +1281,8 @@ static void VehiclePitchFlatBankedRight90(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 128;
     if (carEntry->GroupEnabled(SpriteGroupType::FlatBanked90))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::FlatBanked90, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::FlatBanked90, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1302,8 +1302,8 @@ static void VehiclePitchFlatBankedRight112(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 132;
     if (carEntry->GroupEnabled(SpriteGroupType::InlineTwists))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::InlineTwists, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::InlineTwists, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1323,8 +1323,8 @@ static void VehiclePitchFlatBankedRight135(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 136;
     if (carEntry->GroupEnabled(SpriteGroupType::InlineTwists))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::InlineTwists, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::InlineTwists, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1344,8 +1344,8 @@ static void VehiclePitchFlatBankedRight157(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 140;
     if (carEntry->GroupEnabled(SpriteGroupType::InlineTwists))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::InlineTwists, imageDirection, 5);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::InlineTwists, imageDirection, 5);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1475,8 +1475,8 @@ static void VehiclePitchUp12Unbanked(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes12, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes12, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1492,8 +1492,8 @@ static void VehiclePitchUp12BankedLeft22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked22, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked22, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1509,8 +1509,8 @@ static void VehiclePitchUp12BankedLeft45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked45, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked45, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1526,8 +1526,8 @@ static void VehiclePitchUp12BankedRight22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked22, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked22, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1543,8 +1543,8 @@ static void VehiclePitchUp12BankedRight45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked45, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked45, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1604,8 +1604,8 @@ static void VehiclePitchUp25Unbanked(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 16;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1621,8 +1621,8 @@ static void VehiclePitchUp25BankedLeft22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection) + 16;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked22, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked22, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1645,8 +1645,8 @@ static void VehiclePitchUp25BankedLeft45(
     }
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked45, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked45, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1662,8 +1662,8 @@ static void VehiclePitchUp25BankedRight22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection) + 16;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked22, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked22, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1686,8 +1686,8 @@ static void VehiclePitchUp25BankedRight45(
     }
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked45, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked45, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1702,8 +1702,8 @@ static void VehiclePitchUp25BankedLeft67(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 124;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked67))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked67, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked67, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1718,8 +1718,8 @@ static void VehiclePitchUp25BankedLeft90(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 128;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked90))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked90, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked90, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1734,8 +1734,8 @@ static void VehiclePitchUp25BankedLeft112(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 132;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1750,8 +1750,8 @@ static void VehiclePitchUp25BankedLeft135(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 136;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 4);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 4);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1766,8 +1766,8 @@ static void VehiclePitchUp25BankedLeft157(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 140;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 8);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 8);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1782,8 +1782,8 @@ static void VehiclePitchUp25BankedRight67(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 124;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked67))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked67, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked67, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1798,8 +1798,8 @@ static void VehiclePitchUp25BankedRight90(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 128;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked90))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked90, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked90, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1814,8 +1814,8 @@ static void VehiclePitchUp25BankedRight112(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 132;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1830,8 +1830,8 @@ static void VehiclePitchUp25BankedRight135(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 136;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 5);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 5);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1846,8 +1846,8 @@ static void VehiclePitchUp25BankedRight157(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 140;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 9);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 9);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1940,8 +1940,8 @@ static void VehiclePitchUp42Unbanked(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes42, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1956,8 +1956,8 @@ static void VehiclePitchUp42BankedLeft22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked22, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked22, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1972,8 +1972,8 @@ static void VehiclePitchUp42BankedLeft45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked45, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked45, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -1988,8 +1988,8 @@ static void VehiclePitchUp42BankedRight22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked22, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked22, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2004,8 +2004,8 @@ static void VehiclePitchUp42BankedRight45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked45, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked45, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2020,8 +2020,8 @@ static void VehiclePitchUp42BankedLeft67(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked67))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked67, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked67, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2036,8 +2036,8 @@ static void VehiclePitchUp42BankedLeft90(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked90))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked90, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked90, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2052,8 +2052,8 @@ static void VehiclePitchUp42BankedRight67(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked67))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked67, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked67, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2068,8 +2068,8 @@ static void VehiclePitchUp42BankedRight90(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked90))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked90, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked90, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2086,8 +2086,8 @@ static void VehiclePitchUp42BankedLeft135(
                                                                       : YawTo4(modifiedImageDirection) + 13 * 4 + 144;
     if (carEntry->GroupEnabled(SpriteGroupType::Corkscrews))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, modifiedImageDirection, 13);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, modifiedImageDirection, 13);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2102,8 +2102,8 @@ static void VehiclePitchUp42BankedRight135(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 3 * 4 + 144;
     if (carEntry->GroupEnabled(SpriteGroupType::Corkscrews))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2164,8 +2164,8 @@ static void VehiclePitchUp60Unbanked(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes60))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes60, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes60, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2180,8 +2180,8 @@ static void VehiclePitchUp60BankedLeft22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes60Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes60Banked22, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes60Banked22, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2196,8 +2196,8 @@ static void VehiclePitchUp60BankedRight22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes60Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes60Banked22, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes60Banked22, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2239,8 +2239,8 @@ static void VehiclePitchDown12Unbanked(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes12, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes12, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2256,8 +2256,8 @@ static void VehiclePitchDown12BankedLeft22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked22, imageDirection, 2);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked22, imageDirection, 2);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2273,8 +2273,8 @@ static void VehiclePitchDown12BankedLeft45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked45, imageDirection, 2);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked45, imageDirection, 2);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2290,8 +2290,8 @@ static void VehiclePitchDown12BankedRight22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked22, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked22, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2307,8 +2307,8 @@ static void VehiclePitchDown12BankedRight45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked45, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked45, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2402,8 +2402,8 @@ static void VehiclePitchDown25Unbanked(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo16(imageDirection)) ^ 8) + 16;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2419,8 +2419,8 @@ static void VehiclePitchDown25BankedLeft22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo16(imageDirection)) ^ 8) + 16;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked22, imageDirection, 2);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked22, imageDirection, 2);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2443,8 +2443,8 @@ static void VehiclePitchDown25BankedLeft45(
     }
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked45, imageDirection, 2);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked45, imageDirection, 2);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2460,8 +2460,8 @@ static void VehiclePitchDown25BankedRight22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo16(imageDirection)) ^ 8) + 16;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked22, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked22, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2484,8 +2484,8 @@ static void VehiclePitchDown25BankedRight45(
     }
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked45, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked45, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2500,8 +2500,8 @@ static void VehiclePitchDown25BankedLeft67(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 124;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked67))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked67, imageDirection, 2);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked67, imageDirection, 2);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2516,8 +2516,8 @@ static void VehiclePitchDown25BankedLeft90(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 128;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked90))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked90, imageDirection, 2);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked90, imageDirection, 2);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2532,8 +2532,8 @@ static void VehiclePitchDown25BankedLeft112(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 132;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 2);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 2);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2548,8 +2548,8 @@ static void VehiclePitchDown25BankedLeft135(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 136;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 6);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 6);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2564,8 +2564,8 @@ static void VehiclePitchDown25BankedLeft157(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 140;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 10);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 10);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2580,8 +2580,8 @@ static void VehiclePitchDown25BankedRight67(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 124;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked67))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked67, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked67, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2596,8 +2596,8 @@ static void VehiclePitchDown25BankedRight90(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 128;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked90))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked90, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked90, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2612,8 +2612,8 @@ static void VehiclePitchDown25BankedRight112(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 132;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2628,8 +2628,8 @@ static void VehiclePitchDown25BankedRight135(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 136;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 7);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 7);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2644,8 +2644,8 @@ static void VehiclePitchDown25BankedRight157(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 140;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 11);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 11);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2738,8 +2738,8 @@ static void VehiclePitchDown42Unbanked(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo8(imageDirection)) ^ 4) + 32;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes42, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2754,8 +2754,8 @@ static void VehiclePitchDown42BankedLeft22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked22, imageDirection, 2);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked22, imageDirection, 2);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2770,8 +2770,8 @@ static void VehiclePitchDown42BankedLeft45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked45, imageDirection, 2);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked45, imageDirection, 2);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2786,8 +2786,8 @@ static void VehiclePitchDown42BankedRight22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked22, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked22, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2802,8 +2802,8 @@ static void VehiclePitchDown42BankedRight45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked45, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked45, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2818,8 +2818,8 @@ static void VehiclePitchDown42BankedLeft67(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked67))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked67, imageDirection, 2);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked67, imageDirection, 2);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2834,8 +2834,8 @@ static void VehiclePitchDown42BankedLeft90(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked90))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked90, imageDirection, 2);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked90, imageDirection, 2);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2850,8 +2850,8 @@ static void VehiclePitchDown42BankedRight67(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked67))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked67, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked67, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2866,8 +2866,8 @@ static void VehiclePitchDown42BankedRight90(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked90))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked90, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked90, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2882,8 +2882,8 @@ static void VehiclePitchDown42BankedLeft135(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 8 * 4 + 144;
     if (carEntry->GroupEnabled(SpriteGroupType::Corkscrews))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, imageDirection, 8);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, imageDirection, 8);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2900,8 +2900,8 @@ static void VehiclePitchDown42BankedRight135(
                                                                       : YawTo4(modifiedImageDirection) + 18 * 4 + 144;
     if (carEntry->GroupEnabled(SpriteGroupType::Corkscrews))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, modifiedImageDirection, 18);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, modifiedImageDirection, 18);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2961,8 +2961,8 @@ static void VehiclePitchDown60Unbanked(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo16(imageDirection)) ^ 8) + 40;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes60))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes60, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes60, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2977,8 +2977,8 @@ static void VehiclePitchDown60BankedLeft22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes60Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes60Banked22, imageDirection, 2);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes60Banked22, imageDirection, 2);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -2993,8 +2993,8 @@ static void VehiclePitchDown60BankedRight22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes60Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes60Banked22, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes60Banked22, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3034,8 +3034,8 @@ static void VehiclePitchUp75(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection)) + 56;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes75))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes75, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes75, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3051,8 +3051,8 @@ static void VehiclePitchUp90(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 60;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes90))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes90, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes90, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3072,8 +3072,8 @@ static void VehiclePitchUp105(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection)) + 76;
     if (carEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3089,8 +3089,8 @@ static void VehiclePitchUp120(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection)) + 80;
     if (carEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 2);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 2);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3106,8 +3106,8 @@ static void VehiclePitchUp135(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection)) + 84;
     if (carEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 4);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 4);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3123,8 +3123,8 @@ static void VehiclePitchUp150(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection)) + 88;
     if (carEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 6);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 6);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3140,8 +3140,8 @@ static void VehiclePitchUp165(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection)) + 92;
     if (carEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 8);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 8);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3161,8 +3161,8 @@ static void VehiclePitchInverted(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection)) + 96;
     if (carEntry->GroupEnabled(SpriteGroupType::SlopeInverted))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::SlopeInverted, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopeInverted, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3190,8 +3190,8 @@ static void VehiclePitchDown75(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo4(imageDirection)) ^ 2) + 56;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes75))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes75, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes75, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3215,8 +3215,8 @@ static void VehiclePitchDown90(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo16(imageDirection)) ^ 8) + 60;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes90))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes90, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes90, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3240,8 +3240,8 @@ static void VehiclePitchDown105(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo4(imageDirection)) ^ 2) + 76;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes90))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3261,8 +3261,8 @@ static void VehiclePitchDown120(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo4(imageDirection)) ^ 2) + 80;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes90))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3282,8 +3282,8 @@ static void VehiclePitchDown135(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo4(imageDirection)) ^ 2) + 84;
     if (carEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 5);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 5);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3303,8 +3303,8 @@ static void VehiclePitchDown150(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo4(imageDirection)) ^ 2) + 88;
     if (carEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 7);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 7);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3324,8 +3324,8 @@ static void VehiclePitchDown165(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo4(imageDirection)) ^ 2) + 92;
     if (carEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 9);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 9);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3351,8 +3351,8 @@ void VehiclePitchCorkscrew(
                                                                       : (YawTo4(imageDirection)) + corkscrewFrame * 4 + 144;
     if (carEntry->GroupEnabled(SpriteGroupType::Corkscrews))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, imageDirection, corkscrewFrame);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, imageDirection, corkscrewFrame);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3374,8 +3374,8 @@ static void VehiclePitchUp8Unbanked(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes8, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3391,8 +3391,8 @@ static void VehiclePitchUp8BankedLeft22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked22, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked22, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3408,8 +3408,8 @@ static void VehiclePitchUp8BankedRight22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked22, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked22, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3424,8 +3424,8 @@ static void VehiclePitchUp8BankedLeft45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked45, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked45, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3440,8 +3440,8 @@ static void VehiclePitchUp8BankedRight45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked45, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked45, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3492,8 +3492,8 @@ static void VehiclePitchUp16Unbanked(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes16, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3508,8 +3508,8 @@ static void VehiclePitchUp16BankedLeft22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked22, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked22, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3524,8 +3524,8 @@ static void VehiclePitchUp16BankedRight22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked22, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked22, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3540,8 +3540,8 @@ static void VehiclePitchUp16BankedLeft45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked45, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked45, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3556,8 +3556,8 @@ static void VehiclePitchUp16BankedRight45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked45, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked45, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3604,8 +3604,8 @@ static void VehiclePitchUp50Unbanked(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes50, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3620,8 +3620,8 @@ static void VehiclePitchUp50BankedLeft45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked45, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked45, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3636,8 +3636,8 @@ static void VehiclePitchUp50BankedRight45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked45, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked45, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3652,8 +3652,8 @@ static void VehiclePitchUp50BankedLeft67(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked67))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked67, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked67, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3668,8 +3668,8 @@ static void VehiclePitchUp50BankedRight67(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked67))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked67, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked67, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3684,8 +3684,8 @@ static void VehiclePitchUp50BankedLeft90(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked90))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked90, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked90, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3700,8 +3700,8 @@ static void VehiclePitchUp50BankedRight90(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked90))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked90, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked90, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3757,8 +3757,8 @@ static void VehiclePitchDown8Unbanked(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes8, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3774,8 +3774,8 @@ static void VehiclePitchDown8BankedLeft22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked22, imageDirection, 2);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked22, imageDirection, 2);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3791,8 +3791,8 @@ static void VehiclePitchDown8BankedRight22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked22, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked22, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3807,8 +3807,8 @@ static void VehiclePitchDown8BankedLeft45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked45, imageDirection, 2);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked45, imageDirection, 2);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3823,8 +3823,8 @@ static void VehiclePitchDown8BankedRight45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked45, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked45, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3875,8 +3875,8 @@ static void VehiclePitchDown16Unbanked(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes16, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3891,8 +3891,8 @@ static void VehiclePitchDown16BankedLeft22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked22, imageDirection, 2);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked22, imageDirection, 2);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3907,8 +3907,8 @@ static void VehiclePitchDown16BankedRight22(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16Banked22))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked22, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked22, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3923,8 +3923,8 @@ static void VehiclePitchDown16BankedLeft45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked45, imageDirection, 2);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked45, imageDirection, 2);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3939,8 +3939,8 @@ static void VehiclePitchDown16BankedRight45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked45, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked45, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -3987,8 +3987,8 @@ static void VehiclePitchDown50Unbanked(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes50, imageDirection, 1);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50, imageDirection, 1);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -4003,8 +4003,8 @@ static void VehiclePitchDown50BankedLeft45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked45, imageDirection, 2);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked45, imageDirection, 2);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -4019,8 +4019,8 @@ static void VehiclePitchDown50BankedRight45(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked45))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked45, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked45, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -4035,8 +4035,8 @@ static void VehiclePitchDown50BankedLeft67(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked67))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked67, imageDirection, 2);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked67, imageDirection, 2);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -4051,8 +4051,8 @@ static void VehiclePitchDown50BankedRight67(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked67))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked67, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked67, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -4067,8 +4067,8 @@ static void VehiclePitchDown50BankedLeft90(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked90))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked90, imageDirection, 2);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked90, imageDirection, 2);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -4083,8 +4083,8 @@ static void VehiclePitchDown50BankedRight90(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked90))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked90, imageDirection, 3);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked90, imageDirection, 3);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -4169,8 +4169,8 @@ static void VehiclePitchSpiralLiftUp(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::CurvedLiftHillUp))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::CurvedLiftHillUp, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::CurvedLiftHillUp, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {
@@ -4185,8 +4185,8 @@ static void VehiclePitchSpiralLiftDown(
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
     if (carEntry->GroupEnabled(SpriteGroupType::CurvedLiftHillDown))
     {
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::CurvedLiftHillDown, imageDirection, 0);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxIndex, z, carEntry);
+        const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::CurvedLiftHillDown, imageDirection, 0);
+        VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
     }
     else
     {

--- a/src/openrct2/paint/vehicle/VehiclePaint.cpp
+++ b/src/openrct2/paint/vehicle/VehiclePaint.cpp
@@ -961,7 +961,7 @@ constexpr uint32_t kBoundingBoxIndexUndefined = std::numeric_limits<uint32_t>::m
 #pragma region VehiclePaintUtil
 
 static void PaintVehicleRiders(
-    PaintSession& session, const Vehicle* vehicle, const CarEntry* carEntry, uint32_t baseImageId, int32_t z,
+    PaintSession& session, const Vehicle* vehicle, const CarEntry* carEntry, uint32_t baseImageId, const int32_t z,
     const VehicleBoundBox& bb)
 {
     baseImageId += carEntry->NumCarImages;
@@ -993,7 +993,7 @@ static void PaintVehicleRiders(
 
 // 6D5214
 static void vehicle_sprite_paint(
-    PaintSession& session, const Vehicle* vehicle, int32_t spriteIndex, const VehicleBoundBox& bb, int32_t z,
+    PaintSession& session, const Vehicle* vehicle, int32_t spriteIndex, const VehicleBoundBox& bb, const int32_t z,
     const CarEntry* carEntry)
 {
     if (carEntry->draw_order >= std::size(VehicleBoundboxes))
@@ -1030,7 +1030,7 @@ static void vehicle_sprite_paint(
 
 // 6D520E
 static void VehicleSpritePaintWithSwinging(
-    PaintSession& session, const Vehicle* vehicle, int32_t spriteIndex, int32_t boundingBoxIndex, int32_t z,
+    PaintSession& session, const Vehicle* vehicle, int32_t spriteIndex, int32_t boundingBoxIndex, const int32_t z,
     const CarEntry* carEntry)
 {
     vehicle_sprite_paint(
@@ -1039,7 +1039,7 @@ static void VehicleSpritePaintWithSwinging(
 }
 
 static void VehicleSpritePaintRestraints(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -1060,7 +1060,7 @@ static uint8_t GetPaintBankRotation(const Vehicle* vehicle)
 
 // 6D51DE
 static void VehiclePitchFlatUnbanked(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     // Restraint animations are only drawn for vehicles that are in a cardinal direction (north, east, south, west)
@@ -1077,7 +1077,7 @@ static void VehiclePitchFlatUnbanked(
 
 // 6D4EE7
 static void VehiclePitchFlatBankedLeft22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -1094,7 +1094,7 @@ static void VehiclePitchFlatBankedLeft22(
 
 // 6D4F34
 static void VehiclePitchFlatBankedLeft45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection) + 108;
@@ -1111,7 +1111,7 @@ static void VehiclePitchFlatBankedLeft45(
 
 // 6D4F0C
 static void VehiclePitchFlatBankedRight22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -1128,7 +1128,7 @@ static void VehiclePitchFlatBankedRight22(
 
 // 6D4F5C
 static void VehiclePitchFlatBankedRight45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection) ^ 8) + 108;
@@ -1145,7 +1145,7 @@ static void VehiclePitchFlatBankedRight45(
 
 // 6D4F84
 static void VehiclePitchFlatBankedLeft67(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (vehicle->HasFlag(VehicleFlags::CarIsInverted))
@@ -1166,7 +1166,7 @@ static void VehiclePitchFlatBankedLeft67(
 
 // 6D4FE4
 static void VehiclePitchFlatBankedLeft90(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (vehicle->HasFlag(VehicleFlags::CarIsInverted))
@@ -1187,7 +1187,7 @@ static void VehiclePitchFlatBankedLeft90(
 
 // 6D5055
 static void VehiclePitchFlatBankedLeft112(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (vehicle->HasFlag(VehicleFlags::CarIsInverted))
@@ -1208,7 +1208,7 @@ static void VehiclePitchFlatBankedLeft112(
 
 // 6D50C6
 static void VehiclePitchFlatBankedLeft135(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (vehicle->HasFlag(VehicleFlags::CarIsInverted))
@@ -1229,7 +1229,7 @@ static void VehiclePitchFlatBankedLeft135(
 
 // 6D5137
 static void VehiclePitchFlatBankedLeft157(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (vehicle->HasFlag(VehicleFlags::CarIsInverted))
@@ -1250,7 +1250,7 @@ static void VehiclePitchFlatBankedLeft157(
 
 // 6D4FB1
 static void VehiclePitchFlatBankedRight67(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (vehicle->HasFlag(VehicleFlags::CarIsInverted))
@@ -1271,7 +1271,7 @@ static void VehiclePitchFlatBankedRight67(
 
 // 6D501B
 static void VehiclePitchFlatBankedRight90(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (vehicle->HasFlag(VehicleFlags::CarIsInverted))
@@ -1292,7 +1292,7 @@ static void VehiclePitchFlatBankedRight90(
 
 // 6D508C
 static void VehiclePitchFlatBankedRight112(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (vehicle->HasFlag(VehicleFlags::CarIsInverted))
@@ -1313,7 +1313,7 @@ static void VehiclePitchFlatBankedRight112(
 
 // 6D50FD
 static void VehiclePitchFlatBankedRight135(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (vehicle->HasFlag(VehicleFlags::CarIsInverted))
@@ -1334,7 +1334,7 @@ static void VehiclePitchFlatBankedRight135(
 
 // 6D516E
 static void VehiclePitchFlatBankedRight157(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (vehicle->HasFlag(VehicleFlags::CarIsInverted))
@@ -1355,7 +1355,7 @@ static void VehiclePitchFlatBankedRight157(
 
 // 6D4EE4
 static void VehiclePitchUninvertedFlatBankedLeft22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     carEntry--;
@@ -1364,7 +1364,7 @@ static void VehiclePitchUninvertedFlatBankedLeft22(
 
 // 6D4F31
 static void VehiclePitchUninvertedFlatBankedLeft45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     carEntry--;
@@ -1373,7 +1373,7 @@ static void VehiclePitchUninvertedFlatBankedLeft45(
 
 // 6D4F09
 static void VehiclePitchUninvertedFlatBankedRight22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     carEntry--;
@@ -1382,7 +1382,7 @@ static void VehiclePitchUninvertedFlatBankedRight22(
 
 // 6D4F59
 static void VehiclePitchUninvertedFlatBankedRight45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     carEntry--;
@@ -1391,7 +1391,7 @@ static void VehiclePitchUninvertedFlatBankedRight45(
 
 // 6D51D7
 static void VehiclePitchFlat(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     // 0x009A3DE4:
@@ -1469,7 +1469,7 @@ static void VehiclePitchFlat(
 
 // 6D4614
 static void VehiclePitchUp12Unbanked(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -1486,7 +1486,7 @@ static void VehiclePitchUp12Unbanked(
 
 // 6D4662
 static void VehiclePitchUp12BankedLeft22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -1503,7 +1503,7 @@ static void VehiclePitchUp12BankedLeft22(
 
 // 6D46DB
 static void VehiclePitchUp12BankedLeft45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -1520,7 +1520,7 @@ static void VehiclePitchUp12BankedLeft45(
 
 // 6D467D
 static void VehiclePitchUp12BankedRight22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -1537,7 +1537,7 @@ static void VehiclePitchUp12BankedRight22(
 
 // 6D46FD
 static void VehiclePitchUp12BankedRight45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -1554,7 +1554,7 @@ static void VehiclePitchUp12BankedRight45(
 
 // 6D460D
 static void VehiclePitchUp12(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     // 0x009A3C04:
@@ -1598,7 +1598,7 @@ static void VehiclePitchUp12(
 
 // 6D4791
 static void VehiclePitchUp25Unbanked(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 16;
@@ -1615,7 +1615,7 @@ static void VehiclePitchUp25Unbanked(
 
 // 6D4833
 static void VehiclePitchUp25BankedLeft22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection) + 16;
@@ -1632,7 +1632,7 @@ static void VehiclePitchUp25BankedLeft22(
 
 // 6D48D6
 static void VehiclePitchUp25BankedLeft45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (boundingBoxIndex == kBoundingBoxIndexUndefined)
@@ -1656,7 +1656,7 @@ static void VehiclePitchUp25BankedLeft45(
 
 // 6D4858
 static void VehiclePitchUp25BankedRight22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection) + 16;
@@ -1673,7 +1673,7 @@ static void VehiclePitchUp25BankedRight22(
 
 // 6D4910
 static void VehiclePitchUp25BankedRight45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (boundingBoxIndex == kBoundingBoxIndexUndefined)
@@ -1696,7 +1696,7 @@ static void VehiclePitchUp25BankedRight45(
 }
 
 static void VehiclePitchUp25BankedLeft67(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 124;
@@ -1712,7 +1712,7 @@ static void VehiclePitchUp25BankedLeft67(
 }
 
 static void VehiclePitchUp25BankedLeft90(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 128;
@@ -1728,7 +1728,7 @@ static void VehiclePitchUp25BankedLeft90(
 }
 
 static void VehiclePitchUp25BankedLeft112(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 132;
@@ -1744,7 +1744,7 @@ static void VehiclePitchUp25BankedLeft112(
 }
 
 static void VehiclePitchUp25BankedLeft135(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 136;
@@ -1760,7 +1760,7 @@ static void VehiclePitchUp25BankedLeft135(
 }
 
 static void VehiclePitchUp25BankedLeft157(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 140;
@@ -1776,7 +1776,7 @@ static void VehiclePitchUp25BankedLeft157(
 }
 
 static void VehiclePitchUp25BankedRight67(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 124;
@@ -1792,7 +1792,7 @@ static void VehiclePitchUp25BankedRight67(
 }
 
 static void VehiclePitchUp25BankedRight90(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 128;
@@ -1808,7 +1808,7 @@ static void VehiclePitchUp25BankedRight90(
 }
 
 static void VehiclePitchUp25BankedRight112(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 132;
@@ -1824,7 +1824,7 @@ static void VehiclePitchUp25BankedRight112(
 }
 
 static void VehiclePitchUp25BankedRight135(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 136;
@@ -1840,7 +1840,7 @@ static void VehiclePitchUp25BankedRight135(
 }
 
 static void VehiclePitchUp25BankedRight157(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 140;
@@ -1857,7 +1857,7 @@ static void VehiclePitchUp25BankedRight157(
 
 // 6D476C
 static void VehiclePitchUp25(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     // 0x009A3CA4:
@@ -1934,7 +1934,7 @@ static void VehiclePitchUp25(
 
 // 6D49DC
 static void VehiclePitchUp42Unbanked(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
@@ -1950,7 +1950,7 @@ static void VehiclePitchUp42Unbanked(
 }
 
 static void VehiclePitchUp42BankedLeft22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
@@ -1966,7 +1966,7 @@ static void VehiclePitchUp42BankedLeft22(
 }
 
 static void VehiclePitchUp42BankedLeft45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
@@ -1982,7 +1982,7 @@ static void VehiclePitchUp42BankedLeft45(
 }
 
 static void VehiclePitchUp42BankedRight22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
@@ -1998,7 +1998,7 @@ static void VehiclePitchUp42BankedRight22(
 }
 
 static void VehiclePitchUp42BankedRight45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
@@ -2014,7 +2014,7 @@ static void VehiclePitchUp42BankedRight45(
 }
 
 static void VehiclePitchUp42BankedLeft67(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
@@ -2030,7 +2030,7 @@ static void VehiclePitchUp42BankedLeft67(
 }
 
 static void VehiclePitchUp42BankedLeft90(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
@@ -2046,7 +2046,7 @@ static void VehiclePitchUp42BankedLeft90(
 }
 
 static void VehiclePitchUp42BankedRight67(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
@@ -2062,7 +2062,7 @@ static void VehiclePitchUp42BankedRight67(
 }
 
 static void VehiclePitchUp42BankedRight90(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
@@ -2078,7 +2078,7 @@ static void VehiclePitchUp42BankedRight90(
 }
 
 static void VehiclePitchUp42BankedLeft135(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     const int32_t modifiedImageDirection = (imageDirection + 8) % 32;
@@ -2096,7 +2096,7 @@ static void VehiclePitchUp42BankedLeft135(
 }
 
 static void VehiclePitchUp42BankedRight135(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 3 * 4 + 144;
@@ -2113,7 +2113,7 @@ static void VehiclePitchUp42BankedRight135(
 
 // 6D49DC
 static void VehiclePitchUp42(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     switch (GetPaintBankRotation(vehicle))
@@ -2158,7 +2158,7 @@ static void VehiclePitchUp42(
 
 // 6D4A31
 static void VehiclePitchUp60Unbanked(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
@@ -2174,7 +2174,7 @@ static void VehiclePitchUp60Unbanked(
 }
 
 static void VehiclePitchUp60BankedLeft22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
@@ -2190,7 +2190,7 @@ static void VehiclePitchUp60BankedLeft22(
 }
 
 static void VehiclePitchUp60BankedRight22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
@@ -2206,7 +2206,7 @@ static void VehiclePitchUp60BankedRight22(
 }
 
 static void VehiclePitchUp60(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     switch (GetPaintBankRotation(vehicle))
@@ -2233,7 +2233,7 @@ static void VehiclePitchUp60(
 
 // 6D463D
 static void VehiclePitchDown12Unbanked(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -2250,7 +2250,7 @@ static void VehiclePitchDown12Unbanked(
 
 // 6D469B
 static void VehiclePitchDown12BankedLeft22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -2267,7 +2267,7 @@ static void VehiclePitchDown12BankedLeft22(
 
 // 6D4722
 static void VehiclePitchDown12BankedLeft45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -2284,7 +2284,7 @@ static void VehiclePitchDown12BankedLeft45(
 
 // 6D46B9
 static void VehiclePitchDown12BankedRight22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -2301,7 +2301,7 @@ static void VehiclePitchDown12BankedRight22(
 
 // 6D4747
 static void VehiclePitchDown12BankedRight45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -2318,7 +2318,7 @@ static void VehiclePitchDown12BankedRight45(
 
 // 6D4636
 static void VehiclePitchDown12(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     // 0x009A3C54:
@@ -2396,7 +2396,7 @@ static void VehiclePitchDown12(
 
 // 6D47E4
 static void VehiclePitchDown25Unbanked(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo16(imageDirection)) ^ 8) + 16;
@@ -2413,7 +2413,7 @@ static void VehiclePitchDown25Unbanked(
 
 // 6D4880
 static void VehiclePitchDown25BankedLeft22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo16(imageDirection)) ^ 8) + 16;
@@ -2430,7 +2430,7 @@ static void VehiclePitchDown25BankedLeft22(
 
 // 6D4953
 static void VehiclePitchDown25BankedLeft45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (boundingBoxIndex == kBoundingBoxIndexUndefined)
@@ -2454,7 +2454,7 @@ static void VehiclePitchDown25BankedLeft45(
 
 // 6D48AB
 static void VehiclePitchDown25BankedRight22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo16(imageDirection)) ^ 8) + 16;
@@ -2471,7 +2471,7 @@ static void VehiclePitchDown25BankedRight22(
 
 // 6D4996
 static void VehiclePitchDown25BankedRight45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (boundingBoxIndex == kBoundingBoxIndexUndefined)
@@ -2494,7 +2494,7 @@ static void VehiclePitchDown25BankedRight45(
 }
 
 static void VehiclePitchDown25BankedLeft67(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 124;
@@ -2510,7 +2510,7 @@ static void VehiclePitchDown25BankedLeft67(
 }
 
 static void VehiclePitchDown25BankedLeft90(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 128;
@@ -2526,7 +2526,7 @@ static void VehiclePitchDown25BankedLeft90(
 }
 
 static void VehiclePitchDown25BankedLeft112(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 132;
@@ -2542,7 +2542,7 @@ static void VehiclePitchDown25BankedLeft112(
 }
 
 static void VehiclePitchDown25BankedLeft135(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 136;
@@ -2558,7 +2558,7 @@ static void VehiclePitchDown25BankedLeft135(
 }
 
 static void VehiclePitchDown25BankedLeft157(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 140;
@@ -2574,7 +2574,7 @@ static void VehiclePitchDown25BankedLeft157(
 }
 
 static void VehiclePitchDown25BankedRight67(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 124;
@@ -2590,7 +2590,7 @@ static void VehiclePitchDown25BankedRight67(
 }
 
 static void VehiclePitchDown25BankedRight90(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 128;
@@ -2606,7 +2606,7 @@ static void VehiclePitchDown25BankedRight90(
 }
 
 static void VehiclePitchDown25BankedRight112(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 132;
@@ -2622,7 +2622,7 @@ static void VehiclePitchDown25BankedRight112(
 }
 
 static void VehiclePitchDown25BankedRight135(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 136;
@@ -2638,7 +2638,7 @@ static void VehiclePitchDown25BankedRight135(
 }
 
 static void VehiclePitchDown25BankedRight157(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 140;
@@ -2655,7 +2655,7 @@ static void VehiclePitchDown25BankedRight157(
 
 // 6D47DD
 static void VehiclePitchDown25(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     // 0x009A3CF4:
@@ -2732,7 +2732,7 @@ static void VehiclePitchDown25(
 
 // 6D4A05
 static void VehiclePitchDown42Unbanked(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo8(imageDirection)) ^ 4) + 32;
@@ -2748,7 +2748,7 @@ static void VehiclePitchDown42Unbanked(
 }
 
 static void VehiclePitchDown42BankedLeft22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
@@ -2764,7 +2764,7 @@ static void VehiclePitchDown42BankedLeft22(
 }
 
 static void VehiclePitchDown42BankedLeft45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
@@ -2780,7 +2780,7 @@ static void VehiclePitchDown42BankedLeft45(
 }
 
 static void VehiclePitchDown42BankedRight22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
@@ -2796,7 +2796,7 @@ static void VehiclePitchDown42BankedRight22(
 }
 
 static void VehiclePitchDown42BankedRight45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
@@ -2812,7 +2812,7 @@ static void VehiclePitchDown42BankedRight45(
 }
 
 static void VehiclePitchDown42BankedLeft67(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
@@ -2828,7 +2828,7 @@ static void VehiclePitchDown42BankedLeft67(
 }
 
 static void VehiclePitchDown42BankedLeft90(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
@@ -2844,7 +2844,7 @@ static void VehiclePitchDown42BankedLeft90(
 }
 
 static void VehiclePitchDown42BankedRight67(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
@@ -2860,7 +2860,7 @@ static void VehiclePitchDown42BankedRight67(
 }
 
 static void VehiclePitchDown42BankedRight90(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
@@ -2876,7 +2876,7 @@ static void VehiclePitchDown42BankedRight90(
 }
 
 static void VehiclePitchDown42BankedLeft135(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 8 * 4 + 144;
@@ -2892,7 +2892,7 @@ static void VehiclePitchDown42BankedLeft135(
 }
 
 static void VehiclePitchDown42BankedRight135(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     const int32_t modifiedImageDirection = (imageDirection + 8) % 32;
@@ -2910,7 +2910,7 @@ static void VehiclePitchDown42BankedRight135(
 }
 
 static void VehiclePitchDown42(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     switch (GetPaintBankRotation(vehicle))
@@ -2955,7 +2955,7 @@ static void VehiclePitchDown42(
 
 // 6D4A59
 static void VehiclePitchDown60Unbanked(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo16(imageDirection)) ^ 8) + 40;
@@ -2971,7 +2971,7 @@ static void VehiclePitchDown60Unbanked(
 }
 
 static void VehiclePitchDown60BankedLeft22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
@@ -2987,7 +2987,7 @@ static void VehiclePitchDown60BankedLeft22(
 }
 
 static void VehiclePitchDown60BankedRight22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
@@ -3003,7 +3003,7 @@ static void VehiclePitchDown60BankedRight22(
 }
 
 static void VehiclePitchDown60(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     switch (GetPaintBankRotation(vehicle))
@@ -3028,7 +3028,7 @@ static void VehiclePitchDown60(
 
 // 6D4A81
 static void VehiclePitchUp75(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection)) + 56;
@@ -3045,7 +3045,7 @@ static void VehiclePitchUp75(
 
 // 6D4AE8
 static void VehiclePitchUp90(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 60;
@@ -3066,7 +3066,7 @@ static void VehiclePitchUp90(
 
 // 6D4B57
 static void VehiclePitchUp105(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection)) + 76;
@@ -3083,7 +3083,7 @@ static void VehiclePitchUp105(
 
 // 6D4BB7
 static void VehiclePitchUp120(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection)) + 80;
@@ -3100,7 +3100,7 @@ static void VehiclePitchUp120(
 
 // 6D4C17
 static void VehiclePitchUp135(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection)) + 84;
@@ -3117,7 +3117,7 @@ static void VehiclePitchUp135(
 
 // 6D4C77
 static void VehiclePitchUp150(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection)) + 88;
@@ -3134,7 +3134,7 @@ static void VehiclePitchUp150(
 
 // 6D4CD7
 static void VehiclePitchUp165(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection)) + 92;
@@ -3155,7 +3155,7 @@ static void VehiclePitchUp165(
 
 // 6D4D37
 static void VehiclePitchInverted(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection)) + 96;
@@ -3176,7 +3176,7 @@ static void VehiclePitchInverted(
 
 // 6D4AA3
 static void VehiclePitchDown75(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (vehicle->HasFlag(VehicleFlags::CarIsInverted))
@@ -3201,7 +3201,7 @@ static void VehiclePitchDown75(
 
 // 6D4B0D
 static void VehiclePitchDown90(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (vehicle->HasFlag(VehicleFlags::CarIsInverted))
@@ -3230,7 +3230,7 @@ static void VehiclePitchDown90(
 
 // 6D4B80
 static void VehiclePitchDown105(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (vehicle->HasFlag(VehicleFlags::CarIsInverted))
@@ -3251,7 +3251,7 @@ static void VehiclePitchDown105(
 
 // 6D4BE0
 static void VehiclePitchDown120(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (vehicle->HasFlag(VehicleFlags::CarIsInverted))
@@ -3272,7 +3272,7 @@ static void VehiclePitchDown120(
 
 // 6D4C40
 static void VehiclePitchDown135(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (vehicle->HasFlag(VehicleFlags::CarIsInverted))
@@ -3293,7 +3293,7 @@ static void VehiclePitchDown135(
 
 // 6D4CA0
 static void VehiclePitchDown150(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (vehicle->HasFlag(VehicleFlags::CarIsInverted))
@@ -3314,7 +3314,7 @@ static void VehiclePitchDown150(
 
 // 6D4D00
 static void VehiclePitchDown165(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (vehicle->HasFlag(VehicleFlags::CarIsInverted))
@@ -3340,7 +3340,7 @@ static void VehiclePitchDown165(
 // 6D51A5
 template<int32_t corkscrewFrame>
 void VehiclePitchCorkscrew(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     if (vehicle->HasFlag(VehicleFlags::CarIsInverted))
@@ -3368,7 +3368,7 @@ void VehiclePitchCorkscrew(
 
 // 6D4D67
 static void VehiclePitchUp8Unbanked(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3385,7 +3385,7 @@ static void VehiclePitchUp8Unbanked(
 
 // 6D4DB5
 static void VehiclePitchUp8BankedLeft22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3402,7 +3402,7 @@ static void VehiclePitchUp8BankedLeft22(
 
 // 6D4DD3
 static void VehiclePitchUp8BankedRight22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3418,7 +3418,7 @@ static void VehiclePitchUp8BankedRight22(
 }
 
 static void VehiclePitchUp8BankedLeft45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3434,7 +3434,7 @@ static void VehiclePitchUp8BankedLeft45(
 }
 
 static void VehiclePitchUp8BankedRight45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3451,7 +3451,7 @@ static void VehiclePitchUp8BankedRight45(
 
 // 6D4D60
 static void VehiclePitchUp8(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     // 0x009A3D44:
@@ -3486,7 +3486,7 @@ static void VehiclePitchUp8(
 
 // 6D4E3A
 static void VehiclePitchUp16Unbanked(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3502,7 +3502,7 @@ static void VehiclePitchUp16Unbanked(
 }
 
 static void VehiclePitchUp16BankedLeft22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3518,7 +3518,7 @@ static void VehiclePitchUp16BankedLeft22(
 }
 
 static void VehiclePitchUp16BankedRight22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3534,7 +3534,7 @@ static void VehiclePitchUp16BankedRight22(
 }
 
 static void VehiclePitchUp16BankedLeft45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3550,7 +3550,7 @@ static void VehiclePitchUp16BankedLeft45(
 }
 
 static void VehiclePitchUp16BankedRight45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3566,7 +3566,7 @@ static void VehiclePitchUp16BankedRight45(
 }
 
 static void VehiclePitchUp16(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     switch (GetPaintBankRotation(vehicle))
@@ -3598,7 +3598,7 @@ static void VehiclePitchUp16(
 
 // 6D4E8F
 static void VehiclePitchUp50Unbanked(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3614,7 +3614,7 @@ static void VehiclePitchUp50Unbanked(
 }
 
 static void VehiclePitchUp50BankedLeft45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
@@ -3630,7 +3630,7 @@ static void VehiclePitchUp50BankedLeft45(
 }
 
 static void VehiclePitchUp50BankedRight45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
@@ -3646,7 +3646,7 @@ static void VehiclePitchUp50BankedRight45(
 }
 
 static void VehiclePitchUp50BankedLeft67(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
@@ -3662,7 +3662,7 @@ static void VehiclePitchUp50BankedLeft67(
 }
 
 static void VehiclePitchUp50BankedRight67(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
@@ -3678,7 +3678,7 @@ static void VehiclePitchUp50BankedRight67(
 }
 
 static void VehiclePitchUp50BankedLeft90(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
@@ -3694,7 +3694,7 @@ static void VehiclePitchUp50BankedLeft90(
 }
 
 static void VehiclePitchUp50BankedRight90(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
@@ -3710,7 +3710,7 @@ static void VehiclePitchUp50BankedRight90(
 }
 
 static void VehiclePitchUp50(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     switch (GetPaintBankRotation(vehicle))
@@ -3751,7 +3751,7 @@ static void VehiclePitchUp50(
 
 // 6D4D90
 static void VehiclePitchDown8Unbanked(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3768,7 +3768,7 @@ static void VehiclePitchDown8Unbanked(
 
 // 6D4DF4
 static void VehiclePitchDown8BankedLeft22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3785,7 +3785,7 @@ static void VehiclePitchDown8BankedLeft22(
 
 // 6D4E15
 static void VehiclePitchDown8BankedRight22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3801,7 +3801,7 @@ static void VehiclePitchDown8BankedRight22(
 }
 
 static void VehiclePitchDown8BankedLeft45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3817,7 +3817,7 @@ static void VehiclePitchDown8BankedLeft45(
 }
 
 static void VehiclePitchDown8BankedRight45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3834,7 +3834,7 @@ static void VehiclePitchDown8BankedRight45(
 
 // 6D4D89
 static void VehiclePitchDown8(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     // 0x009A3D94:
@@ -3869,7 +3869,7 @@ static void VehiclePitchDown8(
 
 // 6D4E63
 static void VehiclePitchDown16Unbanked(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3885,7 +3885,7 @@ static void VehiclePitchDown16Unbanked(
 }
 
 static void VehiclePitchDown16BankedLeft22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3901,7 +3901,7 @@ static void VehiclePitchDown16BankedLeft22(
 }
 
 static void VehiclePitchDown16BankedRight22(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3917,7 +3917,7 @@ static void VehiclePitchDown16BankedRight22(
 }
 
 static void VehiclePitchDown16BankedLeft45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3933,7 +3933,7 @@ static void VehiclePitchDown16BankedLeft45(
 }
 
 static void VehiclePitchDown16BankedRight45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3949,7 +3949,7 @@ static void VehiclePitchDown16BankedRight45(
 }
 
 static void VehiclePitchDown16(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     switch (GetPaintBankRotation(vehicle))
@@ -3981,7 +3981,7 @@ static void VehiclePitchDown16(
 
 // 6D4EB8
 static void VehiclePitchDown50Unbanked(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -3997,7 +3997,7 @@ static void VehiclePitchDown50Unbanked(
 }
 
 static void VehiclePitchDown50BankedLeft45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
@@ -4013,7 +4013,7 @@ static void VehiclePitchDown50BankedLeft45(
 }
 
 static void VehiclePitchDown50BankedRight45(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
@@ -4029,7 +4029,7 @@ static void VehiclePitchDown50BankedRight45(
 }
 
 static void VehiclePitchDown50BankedLeft67(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
@@ -4045,7 +4045,7 @@ static void VehiclePitchDown50BankedLeft67(
 }
 
 static void VehiclePitchDown50BankedRight67(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
@@ -4061,7 +4061,7 @@ static void VehiclePitchDown50BankedRight67(
 }
 
 static void VehiclePitchDown50BankedLeft90(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
@@ -4077,7 +4077,7 @@ static void VehiclePitchDown50BankedLeft90(
 }
 
 static void VehiclePitchDown50BankedRight90(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
@@ -4093,7 +4093,7 @@ static void VehiclePitchDown50BankedRight90(
 }
 
 static void VehiclePitchDown50(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     switch (GetPaintBankRotation(vehicle))
@@ -4132,7 +4132,7 @@ static void VehiclePitchDown50(
 
 // 6D47DA
 static void VehiclePitchInvertingDown25(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     carEntry--;
@@ -4141,7 +4141,7 @@ static void VehiclePitchInvertingDown25(
 
 // 6D4A02
 static void VehiclePitchInvertingDown42(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     carEntry--;
@@ -4150,7 +4150,7 @@ static void VehiclePitchInvertingDown42(
 
 // 6D4A56
 static void VehiclePitchInvertingDown60(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     carEntry--;
@@ -4163,7 +4163,7 @@ static void VehiclePitchInvertingDown60(
 
 // 6D4773
 static void VehiclePitchSpiralLiftUp(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -4179,7 +4179,7 @@ static void VehiclePitchSpiralLiftUp(
 }
 
 static void VehiclePitchSpiralLiftDown(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry,
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
@@ -4273,7 +4273,7 @@ static constexpr vehicle_sprite_func PaintFunctionsByPitch[] = {
  *
  *  rct2: 0x006D5600
  */
-static void vehicle_visual_splash1_effect(PaintSession& session, int32_t z, const Vehicle* vehicle)
+static void vehicle_visual_splash1_effect(PaintSession& session, const int32_t z, const Vehicle* vehicle)
 {
     if (vehicle->GetTrackType() != TrackElemType::Watersplash)
     {
@@ -4300,7 +4300,7 @@ static void vehicle_visual_splash1_effect(PaintSession& session, int32_t z, cons
  *
  *  rct2: 0x006D5696
  */
-static void vehicle_visual_splash2_effect(PaintSession& session, int32_t z, const Vehicle* vehicle)
+static void vehicle_visual_splash2_effect(PaintSession& session, const int32_t z, const Vehicle* vehicle)
 {
     if (vehicle->Orientation & 7)
     {
@@ -4323,7 +4323,7 @@ static void vehicle_visual_splash2_effect(PaintSession& session, int32_t z, cons
  *
  *  rct2: 0x006D57EE
  */
-static void vehicle_visual_splash3_effect(PaintSession& session, int32_t z, const Vehicle* vehicle)
+static void vehicle_visual_splash3_effect(PaintSession& session, const int32_t z, const Vehicle* vehicle)
 {
     if (vehicle->Orientation & 7)
     {
@@ -4346,7 +4346,7 @@ static void vehicle_visual_splash3_effect(PaintSession& session, int32_t z, cons
  *
  *  rct2: 0x006D5783
  */
-static void vehicle_visual_splash4_effect(PaintSession& session, int32_t z, const Vehicle* vehicle)
+static void vehicle_visual_splash4_effect(PaintSession& session, const int32_t z, const Vehicle* vehicle)
 {
     Vehicle* vehicle2 = GetEntity<Vehicle>(vehicle->prev_vehicle_on_ride);
     if (vehicle2 == nullptr)
@@ -4374,7 +4374,7 @@ static void vehicle_visual_splash4_effect(PaintSession& session, int32_t z, cons
  *
  *  rct2: 0x006D5701
  */
-static void vehicle_visual_splash5_effect(PaintSession& session, int32_t z, const Vehicle* vehicle)
+static void vehicle_visual_splash5_effect(PaintSession& session, const int32_t z, const Vehicle* vehicle)
 {
     Vehicle* vehicle2 = GetEntity<Vehicle>(vehicle->prev_vehicle_on_ride);
     if (vehicle2 == nullptr)
@@ -4402,7 +4402,7 @@ static void vehicle_visual_splash5_effect(PaintSession& session, int32_t z, cons
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { { 0, 0, z }, { 1, 1, 0 } });
 }
 
-void VehicleVisualSplashEffect(PaintSession& session, int32_t z, const Vehicle* vehicle, const CarEntry* carEntry)
+void VehicleVisualSplashEffect(PaintSession& session, const int32_t z, const Vehicle* vehicle, const CarEntry* carEntry)
 {
     switch (carEntry->effect_visual)
     {
@@ -4431,7 +4431,7 @@ void VehicleVisualSplashEffect(PaintSession& session, int32_t z, const Vehicle* 
  *  rct2: 0x006D45F8
  */
 void VehicleVisualDefault(
-    PaintSession& session, int32_t imageDirection, int32_t z, const Vehicle* vehicle, const CarEntry* carEntry)
+    PaintSession& session, int32_t imageDirection, const int32_t z, const Vehicle* vehicle, const CarEntry* carEntry)
 {
     if (vehicle->Pitch < std::size(PaintFunctionsByPitch))
     {

--- a/src/openrct2/paint/vehicle/VehiclePaint.cpp
+++ b/src/openrct2/paint/vehicle/VehiclePaint.cpp
@@ -954,7 +954,26 @@ const uint8_t PitchInvertTable[] = {
 // Opposite Bank values for reversed cars
 const uint8_t BankInvertTable[] = { 0, 3, 4, 1, 2, 10, 11, 12, 13, 14, 5, 6, 7, 8, 9, 15, 18, 19, 16, 17 };
 
-constexpr uint32_t kBoundingBoxIndexUndefined = std::numeric_limits<uint32_t>::max();
+constexpr uint32_t kBoundBoxIndexUndefined = std::numeric_limits<uint32_t>::max();
+constexpr uint32_t kBoundBoxIndexFlat = 0;
+constexpr uint32_t kBoundBoxIndex25 = 16;
+constexpr uint32_t kBoundBoxIndex42 = 32;
+constexpr uint32_t kBoundBoxIndex60 = 40;
+constexpr uint32_t kBoundBoxIndex75 = 56;
+constexpr uint32_t kBoundBoxIndex90 = 60;
+constexpr uint32_t kBoundBoxIndex105 = 76;
+constexpr uint32_t kBoundBoxIndex120 = 80;
+constexpr uint32_t kBoundBoxIndex135 = 84;
+constexpr uint32_t kBoundBoxIndex150 = 88;
+constexpr uint32_t kBoundBoxIndex165 = 92;
+constexpr uint32_t kBoundBoxIndexInverted = 96; // 100-107 unused??
+constexpr uint32_t kBoundBoxIndexFlatBanked45 = 108;
+constexpr uint32_t kBoundBoxIndexFlatBanked67 = 124;
+constexpr uint32_t kBoundBoxIndexFlatBanked90 = 128;
+constexpr uint32_t kBoundBoxIndexFlatBanked112 = 132;
+constexpr uint32_t kBoundBoxIndexFlatBanked135 = 136;
+constexpr uint32_t kBoundBoxIndexFlatBanked157 = 140;
+constexpr uint32_t kBoundBoxIndexCorkscrew = 144;
 
 #pragma endregion
 
@@ -1042,7 +1061,8 @@ static void VehicleSpritePaintRestraints(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     auto restraintFrame = ((vehicle->restraints_position - 64) / 64);
     const auto spriteIndex = carEntry->SpriteOffset(SpriteGroupType::RestraintAnimation, imageDirection, restraintFrame);
     vehicle_sprite_paint(session, vehicle, spriteIndex, VehicleBoundboxes[carEntry->draw_order][boundingBoxIndex], z, carEntry);
@@ -1070,7 +1090,8 @@ static void VehiclePitchFlatUnbanked(
         VehicleSpritePaintRestraints(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
         return;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     const auto spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopeFlat, imageDirection, 0);
     VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
 }
@@ -1080,7 +1101,8 @@ static void VehiclePitchFlatBankedLeft22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::FlatBanked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::FlatBanked22, imageDirection, 0);
@@ -1097,7 +1119,8 @@ static void VehiclePitchFlatBankedLeft45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection) + 108;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlatBanked45;
     if (carEntry->GroupEnabled(SpriteGroupType::FlatBanked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::FlatBanked45, imageDirection, 0);
@@ -1114,7 +1137,8 @@ static void VehiclePitchFlatBankedRight22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::FlatBanked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::FlatBanked22, imageDirection, 1);
@@ -1131,7 +1155,8 @@ static void VehiclePitchFlatBankedRight45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection) ^ 8) + 108;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo16(imageDirection) ^ 8) + kBoundBoxIndexFlatBanked45;
     if (carEntry->GroupEnabled(SpriteGroupType::FlatBanked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::FlatBanked45, imageDirection, 1);
@@ -1152,7 +1177,8 @@ static void VehiclePitchFlatBankedLeft67(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 124;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked67;
     if (carEntry->GroupEnabled(SpriteGroupType::FlatBanked67))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::FlatBanked67, imageDirection, 0);
@@ -1173,7 +1199,8 @@ static void VehiclePitchFlatBankedLeft90(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 128;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked90;
     if (carEntry->GroupEnabled(SpriteGroupType::FlatBanked90))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::FlatBanked90, imageDirection, 0);
@@ -1194,7 +1221,8 @@ static void VehiclePitchFlatBankedLeft112(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 132;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked112;
     if (carEntry->GroupEnabled(SpriteGroupType::InlineTwists))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::InlineTwists, imageDirection, 0);
@@ -1215,7 +1243,8 @@ static void VehiclePitchFlatBankedLeft135(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 136;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked135;
     if (carEntry->GroupEnabled(SpriteGroupType::InlineTwists))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::InlineTwists, imageDirection, 2);
@@ -1236,7 +1265,8 @@ static void VehiclePitchFlatBankedLeft157(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 140;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked157;
     if (carEntry->GroupEnabled(SpriteGroupType::InlineTwists))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::InlineTwists, imageDirection, 4);
@@ -1257,7 +1287,8 @@ static void VehiclePitchFlatBankedRight67(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 124;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked67;
     if (carEntry->GroupEnabled(SpriteGroupType::FlatBanked67))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::FlatBanked67, imageDirection, 1);
@@ -1278,7 +1309,8 @@ static void VehiclePitchFlatBankedRight90(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 128;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked90;
     if (carEntry->GroupEnabled(SpriteGroupType::FlatBanked90))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::FlatBanked90, imageDirection, 1);
@@ -1299,7 +1331,8 @@ static void VehiclePitchFlatBankedRight112(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 132;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked112;
     if (carEntry->GroupEnabled(SpriteGroupType::InlineTwists))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::InlineTwists, imageDirection, 1);
@@ -1320,7 +1353,8 @@ static void VehiclePitchFlatBankedRight135(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 136;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked135;
     if (carEntry->GroupEnabled(SpriteGroupType::InlineTwists))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::InlineTwists, imageDirection, 3);
@@ -1341,7 +1375,8 @@ static void VehiclePitchFlatBankedRight157(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 140;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked157;
     if (carEntry->GroupEnabled(SpriteGroupType::InlineTwists))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::InlineTwists, imageDirection, 5);
@@ -1472,7 +1507,8 @@ static void VehiclePitchUp12Unbanked(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes12, imageDirection, 0);
@@ -1489,7 +1525,8 @@ static void VehiclePitchUp12BankedLeft22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked22, imageDirection, 0);
@@ -1506,7 +1543,8 @@ static void VehiclePitchUp12BankedLeft45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked45, imageDirection, 0);
@@ -1523,7 +1561,8 @@ static void VehiclePitchUp12BankedRight22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked22, imageDirection, 1);
@@ -1540,7 +1579,8 @@ static void VehiclePitchUp12BankedRight45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked45, imageDirection, 1);
@@ -1601,7 +1641,8 @@ static void VehiclePitchUp25Unbanked(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 16;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex25;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25, imageDirection, 0);
@@ -1618,7 +1659,8 @@ static void VehiclePitchUp25BankedLeft22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection) + 16;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndex25;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked22, imageDirection, 0);
@@ -1635,13 +1677,13 @@ static void VehiclePitchUp25BankedLeft45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    if (boundingBoxIndex == kBoundingBoxIndexUndefined)
+    if (boundingBoxIndex == kBoundBoxIndexUndefined)
     {
         boundingBoxIndex = YawTo16(imageDirection);
         if (carEntry->draw_order < 5)
-            boundingBoxIndex += 108;
+            boundingBoxIndex += kBoundBoxIndexFlatBanked45;
         else
-            boundingBoxIndex += 16;
+            boundingBoxIndex += kBoundBoxIndex25;
     }
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked45))
     {
@@ -1659,7 +1701,8 @@ static void VehiclePitchUp25BankedRight22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection) + 16;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndex25;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked22, imageDirection, 1);
@@ -1676,13 +1719,13 @@ static void VehiclePitchUp25BankedRight45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    if (boundingBoxIndex == kBoundingBoxIndexUndefined)
+    if (boundingBoxIndex == kBoundBoxIndexUndefined)
     {
         boundingBoxIndex = YawTo16(imageDirection);
         if (carEntry->draw_order < 5)
-            boundingBoxIndex = (boundingBoxIndex ^ 8) + 108;
+            boundingBoxIndex = (boundingBoxIndex ^ 8) + kBoundBoxIndexFlatBanked45;
         else
-            boundingBoxIndex += 16;
+            boundingBoxIndex += kBoundBoxIndex25;
     }
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked45))
     {
@@ -1699,7 +1742,8 @@ static void VehiclePitchUp25BankedLeft67(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 124;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked67;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked67))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked67, imageDirection, 0);
@@ -1715,7 +1759,8 @@ static void VehiclePitchUp25BankedLeft90(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 128;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked90;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked90))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked90, imageDirection, 0);
@@ -1731,7 +1776,8 @@ static void VehiclePitchUp25BankedLeft112(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 132;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked112;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 0);
@@ -1747,7 +1793,8 @@ static void VehiclePitchUp25BankedLeft135(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 136;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked135;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 4);
@@ -1763,7 +1810,8 @@ static void VehiclePitchUp25BankedLeft157(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 140;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked157;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 8);
@@ -1779,7 +1827,8 @@ static void VehiclePitchUp25BankedRight67(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 124;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked67;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked67))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked67, imageDirection, 1);
@@ -1795,7 +1844,8 @@ static void VehiclePitchUp25BankedRight90(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 128;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked90;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked90))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked90, imageDirection, 1);
@@ -1811,7 +1861,8 @@ static void VehiclePitchUp25BankedRight112(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 132;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked112;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 1);
@@ -1827,7 +1878,8 @@ static void VehiclePitchUp25BankedRight135(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 136;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked135;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 5);
@@ -1843,7 +1895,8 @@ static void VehiclePitchUp25BankedRight157(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 140;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked157;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 9);
@@ -1937,7 +1990,8 @@ static void VehiclePitchUp42Unbanked(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42, imageDirection, 0);
@@ -1953,7 +2007,8 @@ static void VehiclePitchUp42BankedLeft22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked22, imageDirection, 0);
@@ -1969,7 +2024,8 @@ static void VehiclePitchUp42BankedLeft45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked45, imageDirection, 0);
@@ -1985,7 +2041,8 @@ static void VehiclePitchUp42BankedRight22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked22, imageDirection, 1);
@@ -2001,7 +2058,8 @@ static void VehiclePitchUp42BankedRight45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked45, imageDirection, 1);
@@ -2017,7 +2075,8 @@ static void VehiclePitchUp42BankedLeft67(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked67))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked67, imageDirection, 0);
@@ -2033,7 +2092,8 @@ static void VehiclePitchUp42BankedLeft90(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked90))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked90, imageDirection, 0);
@@ -2049,7 +2109,8 @@ static void VehiclePitchUp42BankedRight67(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked67))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked67, imageDirection, 1);
@@ -2065,7 +2126,8 @@ static void VehiclePitchUp42BankedRight90(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked90))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked90, imageDirection, 1);
@@ -2082,8 +2144,9 @@ static void VehiclePitchUp42BankedLeft135(
     uint32_t boundingBoxIndex)
 {
     const int32_t modifiedImageDirection = (imageDirection + 8) % 32;
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex
-                                                                      : YawTo4(modifiedImageDirection) + 13 * 4 + 144;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : YawTo4(modifiedImageDirection) + 13 * 4 + kBoundBoxIndexCorkscrew;
     if (carEntry->GroupEnabled(SpriteGroupType::Corkscrews))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, modifiedImageDirection, 13);
@@ -2099,7 +2162,8 @@ static void VehiclePitchUp42BankedRight135(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 3 * 4 + 144;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo4(imageDirection) + 3 * 4 + kBoundBoxIndexCorkscrew;
     if (carEntry->GroupEnabled(SpriteGroupType::Corkscrews))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, imageDirection, 3);
@@ -2161,7 +2225,8 @@ static void VehiclePitchUp60Unbanked(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes60))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes60, imageDirection, 0);
@@ -2177,7 +2242,8 @@ static void VehiclePitchUp60BankedLeft22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes60Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes60Banked22, imageDirection, 0);
@@ -2193,7 +2259,8 @@ static void VehiclePitchUp60BankedRight22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes60Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes60Banked22, imageDirection, 1);
@@ -2236,7 +2303,8 @@ static void VehiclePitchDown12Unbanked(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes12, imageDirection, 1);
@@ -2253,7 +2321,8 @@ static void VehiclePitchDown12BankedLeft22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked22, imageDirection, 2);
@@ -2270,7 +2339,8 @@ static void VehiclePitchDown12BankedLeft45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked45, imageDirection, 2);
@@ -2287,7 +2357,8 @@ static void VehiclePitchDown12BankedRight22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked22, imageDirection, 3);
@@ -2304,7 +2375,8 @@ static void VehiclePitchDown12BankedRight45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes12Banked45, imageDirection, 3);
@@ -2399,7 +2471,8 @@ static void VehiclePitchDown25Unbanked(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo16(imageDirection)) ^ 8) + 16;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : ((YawTo16(imageDirection)) ^ 8) + kBoundBoxIndex25;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25, imageDirection, 1);
@@ -2416,7 +2489,8 @@ static void VehiclePitchDown25BankedLeft22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo16(imageDirection)) ^ 8) + 16;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : ((YawTo16(imageDirection)) ^ 8) + kBoundBoxIndex25;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked22, imageDirection, 2);
@@ -2433,13 +2507,13 @@ static void VehiclePitchDown25BankedLeft45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    if (boundingBoxIndex == kBoundingBoxIndexUndefined)
+    if (boundingBoxIndex == kBoundBoxIndexUndefined)
     {
         boundingBoxIndex = YawTo16(imageDirection);
         if (carEntry->draw_order < 5)
-            boundingBoxIndex += 108;
+            boundingBoxIndex += kBoundBoxIndexFlatBanked45;
         else
-            boundingBoxIndex = (boundingBoxIndex ^ 8) + 16;
+            boundingBoxIndex = (boundingBoxIndex ^ 8) + kBoundBoxIndex25;
     }
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked45))
     {
@@ -2457,7 +2531,8 @@ static void VehiclePitchDown25BankedRight22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo16(imageDirection)) ^ 8) + 16;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : ((YawTo16(imageDirection)) ^ 8) + kBoundBoxIndex25;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked22, imageDirection, 3);
@@ -2474,13 +2549,13 @@ static void VehiclePitchDown25BankedRight45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    if (boundingBoxIndex == kBoundingBoxIndexUndefined)
+    if (boundingBoxIndex == kBoundBoxIndexUndefined)
     {
         boundingBoxIndex = YawTo16(imageDirection);
         if (carEntry->draw_order < 5)
-            boundingBoxIndex = (boundingBoxIndex ^ 8) + 108;
+            boundingBoxIndex = (boundingBoxIndex ^ 8) + kBoundBoxIndexFlatBanked45;
         else
-            boundingBoxIndex = (boundingBoxIndex ^ 8) + 16;
+            boundingBoxIndex = (boundingBoxIndex ^ 8) + kBoundBoxIndex25;
     }
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked45))
     {
@@ -2497,7 +2572,8 @@ static void VehiclePitchDown25BankedLeft67(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 124;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked67;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked67))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked67, imageDirection, 2);
@@ -2513,7 +2589,8 @@ static void VehiclePitchDown25BankedLeft90(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 128;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked90;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked90))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked90, imageDirection, 2);
@@ -2529,7 +2606,8 @@ static void VehiclePitchDown25BankedLeft112(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 132;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked112;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 2);
@@ -2545,7 +2623,8 @@ static void VehiclePitchDown25BankedLeft135(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 136;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked135;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 6);
@@ -2561,7 +2640,8 @@ static void VehiclePitchDown25BankedLeft157(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 140;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked157;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 10);
@@ -2577,7 +2657,8 @@ static void VehiclePitchDown25BankedRight67(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 124;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked67;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked67))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked67, imageDirection, 3);
@@ -2593,7 +2674,8 @@ static void VehiclePitchDown25BankedRight90(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 128;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked90;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked90))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25Banked90, imageDirection, 3);
@@ -2609,7 +2691,8 @@ static void VehiclePitchDown25BankedRight112(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 132;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked112;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 3);
@@ -2625,7 +2708,8 @@ static void VehiclePitchDown25BankedRight135(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 136;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked135;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 7);
@@ -2641,7 +2725,8 @@ static void VehiclePitchDown25BankedRight157(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection) ^ 2) + 140;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked157;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes25InlineTwists, imageDirection, 11);
@@ -2735,7 +2820,8 @@ static void VehiclePitchDown42Unbanked(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo8(imageDirection)) ^ 4) + 32;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : ((YawTo8(imageDirection)) ^ 4) + kBoundBoxIndex42;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42, imageDirection, 1);
@@ -2751,7 +2837,8 @@ static void VehiclePitchDown42BankedLeft22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked22, imageDirection, 2);
@@ -2767,7 +2854,8 @@ static void VehiclePitchDown42BankedLeft45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked45, imageDirection, 2);
@@ -2783,7 +2871,8 @@ static void VehiclePitchDown42BankedRight22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked22, imageDirection, 3);
@@ -2799,7 +2888,8 @@ static void VehiclePitchDown42BankedRight45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked45, imageDirection, 3);
@@ -2815,7 +2905,8 @@ static void VehiclePitchDown42BankedLeft67(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked67))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked67, imageDirection, 2);
@@ -2831,7 +2922,8 @@ static void VehiclePitchDown42BankedLeft90(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked90))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked90, imageDirection, 2);
@@ -2847,7 +2939,8 @@ static void VehiclePitchDown42BankedRight67(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked67))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked67, imageDirection, 3);
@@ -2863,7 +2956,8 @@ static void VehiclePitchDown42BankedRight90(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo8(imageDirection)) + 32;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked90))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes42Banked90, imageDirection, 3);
@@ -2879,7 +2973,8 @@ static void VehiclePitchDown42BankedLeft135(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo4(imageDirection) + 8 * 4 + 144;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo4(imageDirection) + 8 * 4 + kBoundBoxIndexCorkscrew;
     if (carEntry->GroupEnabled(SpriteGroupType::Corkscrews))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, imageDirection, 8);
@@ -2896,8 +2991,9 @@ static void VehiclePitchDown42BankedRight135(
     uint32_t boundingBoxIndex)
 {
     const int32_t modifiedImageDirection = (imageDirection + 8) % 32;
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex
-                                                                      : YawTo4(modifiedImageDirection) + 18 * 4 + 144;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : YawTo4(modifiedImageDirection) + 18 * 4 + kBoundBoxIndexCorkscrew;
     if (carEntry->GroupEnabled(SpriteGroupType::Corkscrews))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, modifiedImageDirection, 18);
@@ -2958,7 +3054,8 @@ static void VehiclePitchDown60Unbanked(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo16(imageDirection)) ^ 8) + 40;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : ((YawTo16(imageDirection)) ^ 8) + kBoundBoxIndex60;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes60))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes60, imageDirection, 1);
@@ -2974,7 +3071,8 @@ static void VehiclePitchDown60BankedLeft22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes60Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes60Banked22, imageDirection, 2);
@@ -2990,7 +3088,8 @@ static void VehiclePitchDown60BankedRight22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes60Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes60Banked22, imageDirection, 3);
@@ -3031,7 +3130,8 @@ static void VehiclePitchUp75(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection)) + 56;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection)) + kBoundBoxIndex75;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes75))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes75, imageDirection, 0);
@@ -3048,7 +3148,8 @@ static void VehiclePitchUp90(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 60;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex90;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes90))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes90, imageDirection, 0);
@@ -3069,7 +3170,8 @@ static void VehiclePitchUp105(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection)) + 76;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection)) + kBoundBoxIndex105;
     if (carEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 0);
@@ -3086,7 +3188,8 @@ static void VehiclePitchUp120(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection)) + 80;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection)) + kBoundBoxIndex120;
     if (carEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 2);
@@ -3103,7 +3206,8 @@ static void VehiclePitchUp135(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection)) + 84;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection)) + kBoundBoxIndex135;
     if (carEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 4);
@@ -3120,7 +3224,8 @@ static void VehiclePitchUp150(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection)) + 88;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection)) + kBoundBoxIndex150;
     if (carEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 6);
@@ -3137,7 +3242,8 @@ static void VehiclePitchUp165(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection)) + 92;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection)) + kBoundBoxIndex165;
     if (carEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 8);
@@ -3158,7 +3264,8 @@ static void VehiclePitchInverted(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo4(imageDirection)) + 96;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo4(imageDirection)) + kBoundBoxIndexInverted;
     if (carEntry->GroupEnabled(SpriteGroupType::SlopeInverted))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopeInverted, imageDirection, 0);
@@ -3187,7 +3294,8 @@ static void VehiclePitchDown75(
             carEntry--;
         }
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo4(imageDirection)) ^ 2) + 56;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : ((YawTo4(imageDirection)) ^ 2) + kBoundBoxIndex75;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes75))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes75, imageDirection, 1);
@@ -3212,7 +3320,8 @@ static void VehiclePitchDown90(
             carEntry--;
         }
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo16(imageDirection)) ^ 8) + 60;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : ((YawTo16(imageDirection)) ^ 8) + kBoundBoxIndex90;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes90))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes90, imageDirection, 1);
@@ -3237,7 +3346,8 @@ static void VehiclePitchDown105(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo4(imageDirection)) ^ 2) + 76;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : ((YawTo4(imageDirection)) ^ 2) + kBoundBoxIndex105;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes90))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 1);
@@ -3258,7 +3368,8 @@ static void VehiclePitchDown120(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo4(imageDirection)) ^ 2) + 80;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : ((YawTo4(imageDirection)) ^ 2) + kBoundBoxIndex120;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes90))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 3);
@@ -3279,7 +3390,8 @@ static void VehiclePitchDown135(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo4(imageDirection)) ^ 2) + 84;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : ((YawTo4(imageDirection)) ^ 2) + kBoundBoxIndex135;
     if (carEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 5);
@@ -3300,7 +3412,8 @@ static void VehiclePitchDown150(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo4(imageDirection)) ^ 2) + 88;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : ((YawTo4(imageDirection)) ^ 2) + kBoundBoxIndex150;
     if (carEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 7);
@@ -3321,7 +3434,8 @@ static void VehiclePitchDown165(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : ((YawTo4(imageDirection)) ^ 2) + 92;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : ((YawTo4(imageDirection)) ^ 2) + kBoundBoxIndex165;
     if (carEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::SlopesLoop, imageDirection, 9);
@@ -3347,8 +3461,9 @@ void VehiclePitchCorkscrew(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex
-                                                                      : (YawTo4(imageDirection)) + corkscrewFrame * 4 + 144;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : (YawTo4(imageDirection)) + corkscrewFrame * 4 + kBoundBoxIndexCorkscrew;
     if (carEntry->GroupEnabled(SpriteGroupType::Corkscrews))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, imageDirection, corkscrewFrame);
@@ -3371,7 +3486,8 @@ static void VehiclePitchUp8Unbanked(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8, imageDirection, 0);
@@ -3388,7 +3504,8 @@ static void VehiclePitchUp8BankedLeft22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked22, imageDirection, 0);
@@ -3405,7 +3522,8 @@ static void VehiclePitchUp8BankedRight22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked22, imageDirection, 1);
@@ -3421,7 +3539,8 @@ static void VehiclePitchUp8BankedLeft45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked45, imageDirection, 0);
@@ -3437,7 +3556,8 @@ static void VehiclePitchUp8BankedRight45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked45, imageDirection, 1);
@@ -3489,7 +3609,8 @@ static void VehiclePitchUp16Unbanked(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16, imageDirection, 0);
@@ -3505,7 +3626,8 @@ static void VehiclePitchUp16BankedLeft22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked22, imageDirection, 0);
@@ -3521,7 +3643,8 @@ static void VehiclePitchUp16BankedRight22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked22, imageDirection, 1);
@@ -3537,7 +3660,8 @@ static void VehiclePitchUp16BankedLeft45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked45, imageDirection, 0);
@@ -3553,7 +3677,8 @@ static void VehiclePitchUp16BankedRight45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked45, imageDirection, 1);
@@ -3601,7 +3726,8 @@ static void VehiclePitchUp50Unbanked(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50, imageDirection, 0);
@@ -3617,7 +3743,8 @@ static void VehiclePitchUp50BankedLeft45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked45, imageDirection, 0);
@@ -3633,7 +3760,8 @@ static void VehiclePitchUp50BankedRight45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked45, imageDirection, 1);
@@ -3649,7 +3777,8 @@ static void VehiclePitchUp50BankedLeft67(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked67))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked67, imageDirection, 0);
@@ -3665,7 +3794,8 @@ static void VehiclePitchUp50BankedRight67(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked67))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked67, imageDirection, 1);
@@ -3681,7 +3811,8 @@ static void VehiclePitchUp50BankedLeft90(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked90))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked90, imageDirection, 0);
@@ -3697,7 +3828,8 @@ static void VehiclePitchUp50BankedRight90(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked90))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked90, imageDirection, 1);
@@ -3754,7 +3886,8 @@ static void VehiclePitchDown8Unbanked(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8, imageDirection, 1);
@@ -3771,7 +3904,8 @@ static void VehiclePitchDown8BankedLeft22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked22, imageDirection, 2);
@@ -3788,7 +3922,8 @@ static void VehiclePitchDown8BankedRight22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked22, imageDirection, 3);
@@ -3804,7 +3939,8 @@ static void VehiclePitchDown8BankedLeft45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked45, imageDirection, 2);
@@ -3820,7 +3956,8 @@ static void VehiclePitchDown8BankedRight45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked45, imageDirection, 3);
@@ -3872,7 +4009,8 @@ static void VehiclePitchDown16Unbanked(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16, imageDirection, 1);
@@ -3888,7 +4026,8 @@ static void VehiclePitchDown16BankedLeft22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked22, imageDirection, 2);
@@ -3904,7 +4043,8 @@ static void VehiclePitchDown16BankedRight22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16Banked22))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked22, imageDirection, 3);
@@ -3920,7 +4060,8 @@ static void VehiclePitchDown16BankedLeft45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked45, imageDirection, 2);
@@ -3936,7 +4077,8 @@ static void VehiclePitchDown16BankedRight45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked45, imageDirection, 3);
@@ -3984,7 +4126,8 @@ static void VehiclePitchDown50Unbanked(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50, imageDirection, 1);
@@ -4000,7 +4143,8 @@ static void VehiclePitchDown50BankedLeft45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked45, imageDirection, 2);
@@ -4016,7 +4160,8 @@ static void VehiclePitchDown50BankedRight45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked45, imageDirection, 3);
@@ -4032,7 +4177,8 @@ static void VehiclePitchDown50BankedLeft67(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked67))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked67, imageDirection, 2);
@@ -4048,7 +4194,8 @@ static void VehiclePitchDown50BankedRight67(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked67))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked67, imageDirection, 3);
@@ -4064,7 +4211,8 @@ static void VehiclePitchDown50BankedLeft90(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked90))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked90, imageDirection, 2);
@@ -4080,7 +4228,8 @@ static void VehiclePitchDown50BankedRight90(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : (YawTo16(imageDirection)) + 40;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50Banked90))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes50Banked90, imageDirection, 3);
@@ -4166,7 +4315,8 @@ static void VehiclePitchSpiralLiftUp(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::CurvedLiftHillUp))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::CurvedLiftHillUp, imageDirection, 0);
@@ -4182,7 +4332,8 @@ static void VehiclePitchSpiralLiftDown(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundingBoxIndexUndefined ? boundingBoxIndex : YawTo16(imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
     if (carEntry->GroupEnabled(SpriteGroupType::CurvedLiftHillDown))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::CurvedLiftHillDown, imageDirection, 0);
@@ -4440,11 +4591,11 @@ void VehicleVisualDefault(
             auto imagePitch = PitchInvertTable[vehicle->Pitch];
             auto imageYaw = (imageDirection + (OpenRCT2::Entity::Yaw::kBaseRotation / 2))
                 & (OpenRCT2::Entity::Yaw::kBaseRotation - 1);
-            PaintFunctionsByPitch[imagePitch](session, vehicle, imageYaw, z, carEntry, kBoundingBoxIndexUndefined);
+            PaintFunctionsByPitch[imagePitch](session, vehicle, imageYaw, z, carEntry, kBoundBoxIndexUndefined);
         }
         else
         {
-            PaintFunctionsByPitch[vehicle->Pitch](session, vehicle, imageDirection, z, carEntry, kBoundingBoxIndexUndefined);
+            PaintFunctionsByPitch[vehicle->Pitch](session, vehicle, imageDirection, z, carEntry, kBoundBoxIndexUndefined);
         }
     }
 }


### PR DESCRIPTION
This changes the vehicle paint functions to use the original intended bounding box for the vehicle sprite even when a fallback sprite is used. Currently it will use the bounding box for the sprite that gets used, so for example if a vehicle that has only flat sprites is on a steep slope, it will use the flat bounding box. This changes it so that it will use the steep bounding box instead, etc.

The reason why you would want to do this is because vehicle bounding boxes are often a certain way to make sure it works together with the track properly, and to prevent them from colliding with each other. To be honest this has a very minor affect on helping fallback sprites look better, if any change at all, but it will be necessary to prevent glitching with my fix for steep wooden supports #23908 when using vehicles without steep or gentle sprites. This PR is spun off from that one, and implements it properly across all functions. I'm not super happy with how that requires changes to vehicle bbs, but I have messed around with it yet again and found no other way that works. Let me know if it's acceptable or not.

I also did a minor bit of cleanup to the vehicle paint functions. I added some consts to make it a bit easier to see what is going on. This code and vehicle bounding boxes in general could really do with a major refactor, but whilst many functions look uniform there is more things hiding in there and I don't really know what can be done with it at the moment.

I have diffed several parks to make sure that no non fallback vehicle bounding box has changed.