### PR TITLE
Remove unused vClip in line shader

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/DrawLineShader.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/DrawLineShader.cpp
@@ -63,7 +63,6 @@ DrawLineShader::DrawLineShader()
     glEnableVertexAttribArray(vVertMat + 2);
     glEnableVertexAttribArray(vVertMat + 3);
 
-    glEnableVertexAttribArray(vClip);
     glEnableVertexAttribArray(vBounds);
     glEnableVertexAttribArray(vColour);
     glEnableVertexAttribArray(vDepth);

--- a/src/openrct2-ui/drawing/engines/opengl/DrawLineShader.h
+++ b/src/openrct2-ui/drawing/engines/opengl/DrawLineShader.h
@@ -19,7 +19,6 @@ namespace OpenRCT2::Ui
     private:
         GLuint uScreenSize;
 
-        GLuint vClip;
         GLuint vBounds;
         GLuint vColour;
         GLuint vDepth;


### PR DESCRIPTION
The vertex *line* shader does not have a `vClip` attribute. This is probably why `GetAttributeLocation` is never called in `DrawLineShader::GetLocations` to populate the member variable. Using the uninitialized value by passing it to `glEnableVertexAttribArray` will sometimes trigger an error when the value is absurd enough.