### PR TITLE
Refactor how map animations are created and stored, eliminate limit

### DIFF
--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -321,7 +321,7 @@ namespace OpenRCT2
         RideMeasurementsUpdate();
         News::UpdateCurrentItem();
 
-        MapAnimationInvalidateAll();
+        MapAnimationUpdateAll();
         VehicleSoundsUpdate();
         PeepUpdateCrowdNoise();
         ClimateUpdateSound();

--- a/src/openrct2/actions/BannerPlaceAction.cpp
+++ b/src/openrct2/actions/BannerPlaceAction.cpp
@@ -161,7 +161,7 @@ GameActions::Result BannerPlaceAction::Execute() const
     bannerElement->SetGhost(GetFlags() & GAME_COMMAND_FLAG_GHOST);
 
     MapInvalidateTileFull(_loc);
-    MapAnimationCreate(MAP_ANIMATION_TYPE_BANNER, CoordsXYZ{ _loc, bannerElement->GetBaseZ() });
+    MapAnimationCreate(_loc, bannerElement);
 
     res.Cost = bannerEntry->price;
     return res;

--- a/src/openrct2/actions/LargeSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/LargeSceneryPlaceAction.cpp
@@ -314,7 +314,7 @@ GameActions::Result LargeSceneryPlaceAction::Execute() const
             newSceneryElement->SetBannerIndex(banner->id);
         }
 
-        MapAnimationCreate(MAP_ANIMATION_TYPE_LARGE_SCENERY, { curTile, zLow });
+        MapAnimationCreate(curTile, newSceneryElement);
         MapInvalidateTileFull(curTile);
 
         if (tile.index == 0)

--- a/src/openrct2/actions/ParkEntrancePlaceAction.cpp
+++ b/src/openrct2/actions/ParkEntrancePlaceAction.cpp
@@ -186,7 +186,7 @@ GameActions::Result ParkEntrancePlaceAction::Execute() const
 
         if (index == 0)
         {
-            MapAnimationCreate(MAP_ANIMATION_TYPE_PARK_ENTRANCE, { entranceLoc, zLow });
+            MapAnimationCreate(entranceLoc, entranceElement);
         }
     }
 

--- a/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
+++ b/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
@@ -213,7 +213,7 @@ GameActions::Result RideEntranceExitPlaceAction::Execute() const
         station.LastPeepInQueue = EntityId::GetNull();
         station.QueueLength = 0;
 
-        MapAnimationCreate(MAP_ANIMATION_TYPE_RIDE_ENTRANCE, { _loc, z });
+        MapAnimationCreate(_loc, entranceElement);
     }
 
     FootpathQueueChainReset();

--- a/src/openrct2/actions/SmallSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/SmallSceneryPlaceAction.cpp
@@ -452,7 +452,7 @@ GameActions::Result SmallSceneryPlaceAction::Execute() const
     MapInvalidateTileFull(_loc);
     if (sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_ANIMATED))
     {
-        MapAnimationCreate(MAP_ANIMATION_TYPE_SMALL_SCENERY, CoordsXYZ{ _loc, sceneryElement->GetBaseZ() });
+        MapAnimationCreate(_loc, sceneryElement);
     }
 
     return res;

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -594,18 +594,16 @@ GameActions::Result TrackPlaceAction::Execute() const
         switch (_trackType)
         {
             case TrackElemType::Waterfall:
-                MapAnimationCreate(MAP_ANIMATION_TYPE_TRACK_WATERFALL, CoordsXYZ{ mapLoc, trackElement->GetBaseZ() });
-                break;
+                [[fallthrough]];
             case TrackElemType::Rapids:
-                MapAnimationCreate(MAP_ANIMATION_TYPE_TRACK_RAPIDS, CoordsXYZ{ mapLoc, trackElement->GetBaseZ() });
-                break;
+                [[fallthrough]];
             case TrackElemType::Whirlpool:
-                MapAnimationCreate(MAP_ANIMATION_TYPE_TRACK_WHIRLPOOL, CoordsXYZ{ mapLoc, trackElement->GetBaseZ() });
-                break;
+                [[fallthrough]];
             case TrackElemType::SpinningTunnel:
-                MapAnimationCreate(MAP_ANIMATION_TYPE_TRACK_SPINNINGTUNNEL, CoordsXYZ{ mapLoc, trackElement->GetBaseZ() });
+                MapAnimationCreate(mapLoc, trackElement);
                 break;
             case TrackElemType::Brakes:
+                [[fallthrough]];
             case TrackElemType::DiagBrakes:
                 trackElement->SetBrakeClosed(true);
                 break;

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -599,6 +599,8 @@ GameActions::Result TrackPlaceAction::Execute() const
                 [[fallthrough]];
             case TrackElemType::Whirlpool:
                 [[fallthrough]];
+            case TrackElemType::OnRidePhoto:
+                [[fallthrough]];
             case TrackElemType::SpinningTunnel:
                 MapAnimationCreate(mapLoc, trackElement);
                 break;

--- a/src/openrct2/actions/WallPlaceAction.cpp
+++ b/src/openrct2/actions/WallPlaceAction.cpp
@@ -399,7 +399,7 @@ GameActions::Result WallPlaceAction::Execute() const
 
     wallElement->SetGhost(GetFlags() & GAME_COMMAND_FLAG_GHOST);
 
-    MapAnimationCreate(MAP_ANIMATION_TYPE_WALL, targetLoc);
+    MapAnimationCreate(targetLoc, wallElement);
     MapInvalidateTileZoom1({ _loc, wallElement->GetBaseZ(), wallElement->GetBaseZ() + 72 });
 
     res.Cost = wallEntry->price;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -6411,18 +6411,6 @@ void Vehicle::UpdateGoKartAttemptSwitchLanes()
 
 /**
  *
- *  rct2: 0x006DB545
- */
-static void trigger_on_ride_photo(const CoordsXYZ& loc, TileElement* tileElement)
-{
-    tileElement->AsTrack()->SetPhotoTimeout();
-
-    // NOTE: Might also not be required here.
-    MapAnimationCreate(loc, tileElement);
-}
-
-/**
- *
  *  rct2: 0x006DEDE8
  */
 void Vehicle::UpdateSceneryDoorBackwards() const
@@ -7106,7 +7094,8 @@ bool Vehicle::UpdateTrackMotionForwardsGetNewTrack(
     }
     if (trackType == TrackElemType::OnRidePhoto)
     {
-        trigger_on_ride_photo(TrackLocation, tileElement);
+        tileElement->AsTrack()->SetPhotoTimeout();
+        MapInvalidateElement(TrackLocation, tileElement);
     }
     if (trackType == TrackElemType::RotationControlToggle)
     {

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -6310,7 +6310,8 @@ static void AnimateSceneryDoor(const CoordsXYZD& doorLocation, const CoordsXYZ& 
     {
         door->SetAnimationIsBackwards(isBackwards);
         door->SetAnimationFrame(1);
-        MapAnimationCreate(MAP_ANIMATION_TYPE_WALL_DOOR, doorLocation);
+        // NOTE: What is this doing here? This is probably not required.
+        MapAnimationCreate(doorLocation, door);
         play_scenery_door_open_sound(trackLocation, door);
     }
 
@@ -6414,7 +6415,8 @@ static void trigger_on_ride_photo(const CoordsXYZ& loc, TileElement* tileElement
 {
     tileElement->AsTrack()->SetPhotoTimeout();
 
-    MapAnimationCreate(MAP_ANIMATION_TYPE_TRACK_ONRIDEPHOTO, { loc, tileElement->GetBaseZ() });
+    // NOTE: Might also not be required here.
+    MapAnimationCreate(loc, tileElement);
 }
 
 /**

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -6312,7 +6312,7 @@ static void AnimateSceneryDoor(const CoordsXYZD& doorLocation, const CoordsXYZ& 
         door->SetAnimationFrame(1);
         play_scenery_door_open_sound(trackLocation, door);
 
-        MapInvalidateElement(doorLocation, door->as<TileElement>());
+        MapAnimationCreate(doorLocation, door);
     }
 
     if (isLastVehicle)
@@ -6321,7 +6321,7 @@ static void AnimateSceneryDoor(const CoordsXYZD& doorLocation, const CoordsXYZ& 
         door->SetAnimationFrame(6);
         play_scenery_door_close_sound(trackLocation, door);
 
-        MapInvalidateElement(doorLocation, door->as<TileElement>());
+        MapAnimationCreate(doorLocation, door);
     }
 }
 
@@ -7095,7 +7095,7 @@ bool Vehicle::UpdateTrackMotionForwardsGetNewTrack(
     if (trackType == TrackElemType::OnRidePhoto)
     {
         tileElement->AsTrack()->SetPhotoTimeout();
-        MapInvalidateElement(TrackLocation, tileElement);
+        MapAnimationCreate(TrackLocation, tileElement);
     }
     if (trackType == TrackElemType::RotationControlToggle)
     {

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -6310,9 +6310,9 @@ static void AnimateSceneryDoor(const CoordsXYZD& doorLocation, const CoordsXYZ& 
     {
         door->SetAnimationIsBackwards(isBackwards);
         door->SetAnimationFrame(1);
-        // NOTE: What is this doing here? This is probably not required.
-        MapAnimationCreate(doorLocation, door);
         play_scenery_door_open_sound(trackLocation, door);
+
+        MapInvalidateElement(doorLocation, door->as<TileElement>());
     }
 
     if (isLastVehicle)
@@ -6320,6 +6320,8 @@ static void AnimateSceneryDoor(const CoordsXYZD& doorLocation, const CoordsXYZ& 
         door->SetAnimationIsBackwards(isBackwards);
         door->SetAnimationFrame(6);
         play_scenery_door_close_sound(trackLocation, door);
+
+        MapInvalidateElement(doorLocation, door->as<TileElement>());
     }
 }
 

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -914,7 +914,7 @@ void FootpathChainRideQueue(
             lastPathElement->AsPath()->SetHasQueueBanner(true);
             lastPathElement->AsPath()->SetQueueBannerDirection(lastPathDirection); // set the ride sign direction
 
-            MapAnimationCreate(MAP_ANIMATION_TYPE_QUEUE_BANNER, { lastPath, lastPathElement->GetBaseZ() });
+            MapAnimationCreate(lastPath, lastPathElement);
         }
     }
 }

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -40,7 +40,7 @@
 
 using namespace OpenRCT2;
 
-// Set to track tiles that contain animated elements
+// A list of tile coordinates which contains animated tile elements.
 static std::vector<TileCoordsXY> _mapAnimations;
 
 static void InvalidateTile(const CoordsXYZ& loc, int32_t zMin, int32_t zMax)
@@ -221,13 +221,13 @@ static bool UpdateBannerAnimation([[maybe_unused]] BannerElement* banner, Coords
 
 static bool UpdateTileAnimations(const TileCoordsXY& coords)
 {
-    bool wasUpdated = false;
     auto tileElement = MapGetFirstElementAt(coords);
     if (tileElement == nullptr)
     {
         return false;
     }
 
+    bool hasAnimations = false;
     do
     {
         auto baseZ = tileElement->GetBaseZ();
@@ -236,32 +236,32 @@ static bool UpdateTileAnimations(const TileCoordsXY& coords)
         switch (tileElement->GetType())
         {
             case TileElementType::Entrance:
-                wasUpdated |= UpdateEntranceAnimation(tileElement->AsEntrance(), loc, baseZ);
+                hasAnimations |= UpdateEntranceAnimation(tileElement->AsEntrance(), loc, baseZ);
                 break;
             case TileElementType::Path:
-                wasUpdated |= UpdatePathAnimation(tileElement->AsPath(), loc, baseZ);
+                hasAnimations |= UpdatePathAnimation(tileElement->AsPath(), loc, baseZ);
                 break;
             case TileElementType::SmallScenery:
-                wasUpdated |= UpdateSmallSceneryAnimation(tileElement->AsSmallScenery(), loc, baseZ);
+                hasAnimations |= UpdateSmallSceneryAnimation(tileElement->AsSmallScenery(), loc, baseZ);
                 break;
             case TileElementType::Track:
-                wasUpdated |= UpdateTrackAnimation(tileElement->AsTrack(), loc, baseZ);
+                hasAnimations |= UpdateTrackAnimation(tileElement->AsTrack(), loc, baseZ);
                 break;
             case TileElementType::Banner:
-                wasUpdated |= UpdateBannerAnimation(tileElement->AsBanner(), loc, baseZ);
+                hasAnimations |= UpdateBannerAnimation(tileElement->AsBanner(), loc, baseZ);
                 break;
             case TileElementType::LargeScenery:
-                wasUpdated |= UpdateLargeSceneryAnimation(tileElement->AsLargeScenery(), loc, baseZ);
+                hasAnimations |= UpdateLargeSceneryAnimation(tileElement->AsLargeScenery(), loc, baseZ);
                 break;
             case TileElementType::Wall:
-                wasUpdated |= UpdateWallAnimation(tileElement->AsWall(), loc, baseZ);
+                hasAnimations |= UpdateWallAnimation(tileElement->AsWall(), loc, baseZ);
                 break;
             default:
                 break;
         }
     } while (!(tileElement++)->IsLastForTile());
 
-    return wasUpdated;
+    return hasAnimations;
 }
 
 static void MarkTileAnimated(const CoordsXY& loc)

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -149,6 +149,8 @@ static bool UpdateTrackAnimation(TrackElement* track, CoordsXYZ& loc, int32_t ba
                 return true;
             }
             break;
+        default:
+            break;
     }
 
     return false;
@@ -372,7 +374,6 @@ static bool IsElementAnimated(const TileElementBase* el)
                 case TrackElemType::SpinningTunnel:
                 case TrackElemType::OnRidePhoto:
                     return true;
-                    break;
                 default:
                     break;
             }

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -180,24 +180,35 @@ static bool UpdateWallAnimation(WallElement* wall, CoordsXYZ& loc, int32_t baseZ
     {
         if (!(getGameState().currentTicks & 1) && !GameIsPaused())
         {
-            uint8_t currentFrame = wall->GetAnimationFrame();
+            const auto currentFrame = wall->GetAnimationFrame();
             if (currentFrame != 0)
             {
+                auto newFrame = currentFrame;
                 if (currentFrame == 15)
                 {
-                    wall->SetAnimationFrame(0);
+                    newFrame = 0;
                 }
                 else if (currentFrame != 5)
                 {
-                    currentFrame++;
-                    if (currentFrame == 13 && !(entry->flags & WALL_SCENERY_LONG_DOOR_ANIMATION))
-                        currentFrame = 15;
-                    wall->SetAnimationFrame(currentFrame);
+                    newFrame++;
+                    if (newFrame == 13 && !(entry->flags & WALL_SCENERY_LONG_DOOR_ANIMATION))
+                        newFrame = 15;
+                }
+
+                if (currentFrame != newFrame)
+                {
+                    wall->SetAnimationFrame(newFrame);
                     InvalidateTile(loc, baseZ, baseZ + 32);
-                    return true;
                 }
             }
+            else
+            {
+                // Animation completed.
+                return false;
+            }
         }
+
+        return true;
     }
     else if ((entry->flags2 & WALL_SCENERY_2_ANIMATED) || entry->scrolling_mode != SCROLLING_MODE_NONE)
     {

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -201,11 +201,6 @@ static bool UpdateWallAnimation(WallElement* wall, CoordsXYZ& loc, int32_t baseZ
                     InvalidateTile(loc, baseZ, baseZ + 32);
                 }
             }
-            else
-            {
-                // Animation completed.
-                return false;
-            }
         }
 
         return true;

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -146,9 +146,8 @@ static bool UpdateTrackAnimation(TrackElement* track, CoordsXYZ& loc, int32_t ba
             {
                 InvalidateTile(loc, baseZ, clearZ);
                 track->DecrementPhotoTimeout();
-                return true;
             }
-            break;
+            return true;
         default:
             break;
     }

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -319,9 +319,7 @@ static bool IsElementAnimated(const TileElementBase* el)
         {
             auto wall = el->AsWall();
             auto entry = wall->GetEntry();
-            if (entry != nullptr
-                && ((entry->flags2 & WALL_SCENERY_2_ANIMATED) || entry->scrolling_mode != SCROLLING_MODE_NONE
-                    || (entry->flags & WALL_SCENERY_IS_DOOR)))
+            if (entry != nullptr && ((entry->flags2 & WALL_SCENERY_2_ANIMATED) || entry->scrolling_mode != SCROLLING_MODE_NONE))
             {
                 return true;
             }

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -269,7 +269,8 @@ static void MarkTileAnimated(const CoordsXY& loc)
     auto coords = TileCoordsXY{ loc };
 
     auto it = std::lower_bound(_mapAnimations.begin(), _mapAnimations.end(), coords, [](auto& a, auto& b) {
-        return std::tie(a.x, a.y) < std::tie(b.x, b.y);
+        // NOTE: Ordering should match GetFirstElementAt which is x + (y * size)
+        return std::tie(a.y, a.x) < std::tie(b.y, a.x);
     });
 
     if (it != _mapAnimations.end() && *it == coords)

--- a/src/openrct2/world/MapAnimation.h
+++ b/src/openrct2/world/MapAnimation.h
@@ -12,39 +12,12 @@
 #include "Location.hpp"
 
 #include <cstdint>
-#include <vector>
 
-struct TileElement;
+struct TileElementBase;
 
-struct MapAnimation
-{
-    uint8_t type{};
-    CoordsXYZ location{};
-};
-
-enum
-{
-    MAP_ANIMATION_TYPE_RIDE_ENTRANCE,
-    MAP_ANIMATION_TYPE_QUEUE_BANNER,
-    MAP_ANIMATION_TYPE_SMALL_SCENERY,
-    MAP_ANIMATION_TYPE_PARK_ENTRANCE,
-    MAP_ANIMATION_TYPE_TRACK_WATERFALL,
-    MAP_ANIMATION_TYPE_TRACK_RAPIDS,
-    MAP_ANIMATION_TYPE_TRACK_ONRIDEPHOTO,
-    MAP_ANIMATION_TYPE_TRACK_WHIRLPOOL,
-    MAP_ANIMATION_TYPE_TRACK_SPINNINGTUNNEL,
-    MAP_ANIMATION_TYPE_REMOVE,
-    MAP_ANIMATION_TYPE_BANNER,
-    MAP_ANIMATION_TYPE_LARGE_SCENERY,
-    MAP_ANIMATION_TYPE_WALL_DOOR,
-    MAP_ANIMATION_TYPE_WALL,
-    MAP_ANIMATION_TYPE_COUNT
-};
-
-void MapAnimationCreate(int32_t type, const CoordsXYZ& loc);
-void MapAnimationInvalidateAll();
-const std::vector<MapAnimation>& GetMapAnimations();
+void MapAnimationCreate(const CoordsXY& coords, const TileElementBase* tileElement);
+void MapAnimationCreate(const CoordsXY& coords);
+void MapAnimationUpdateAll();
 void ClearMapAnimations();
 void MapAnimationAutoCreate();
-void MapAnimationAutoCreateAtTileElement(TileCoordsXY coords, TileElement* el);
 void ShiftAllMapAnimations(CoordsXY amount);

--- a/src/openrct2/world/MapAnimation.h
+++ b/src/openrct2/world/MapAnimation.h
@@ -16,7 +16,6 @@
 struct TileElementBase;
 
 void MapAnimationCreate(const CoordsXY& coords, const TileElementBase* tileElement);
-void MapAnimationCreate(const CoordsXY& coords);
 void MapAnimationUpdateAll();
 void ClearMapAnimations();
 void MapAnimationAutoCreate();

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -349,7 +349,7 @@ namespace OpenRCT2::TileInspector
             *pastedElement = element;
             pastedElement->SetLastForTile(lastForTile);
 
-            MapAnimationAutoCreateAtTileElement(tileLoc, pastedElement);
+            MapAnimationCreate(tileLoc.ToCoordsXY(), pastedElement);
 
             if (IsTileSelected(loc))
             {


### PR DESCRIPTION
The way it worked was a little funky, each stored animation would query all tile elements just to find the right thing, in this PR I changed it to just storing the tile coordinates to let the system know it holds animated elements and we will now only ever traverse a tile once and just update all elements that need it. Also this removes the limit of 2000 animations, this needs a bit of testing on how it may impacts the performance on parks full of animated stuff.

Close #18450, Close #23113, Close #22684, Close #16176