### PR TITLE
Add scripting hooks for ride fixes

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -107,7 +107,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Keith Stellyes (keithstellyes) - Misc.
 * Bas Cantrijn (Basssiiie) - Various plugin additions, misc.
 * Adrian Zdanowicz (CookiePLMonster) - Misc.
-* Andrew Pratt (andrewpratt64) - Added api hook for vehicle crashes, api function to get entities on a tile
+* Andrew Pratt (andrewpratt0x40) - Added api hooks, api function to get entities on a tile
 * Karst van Galen Last (AuraSpecs) - Ride paint (bounding boxes, extra track pieces), soundtrack, sound effects, misc.
 * (8street) - Misc.
 * Umar Ahmed (umar-ahmed) - MacOS file watcher

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -516,6 +516,8 @@ declare global {
         subscribe(hook: "park.guest.softcap.calculate", callback: (e: ParkCalculateGuestCapArgs) => void): IDisposable;
         subscribe(hook: "ride.ratings.calculate", callback: (e: RideRatingsCalculateArgs) => void): IDisposable;
         subscribe(hook: "vehicle.crash", callback: (e: VehicleCrashArgs) => void): IDisposable;
+        subscribe(hook: "ride.breakdown", callback: (e: RideBreakdownArgs) => void): IDisposable;
+        subscribe(hook: "ride.fix", callback: (e: RideFixArgs) => void): IDisposable;
 
         /**
          * Can only be used in intransient plugins.
@@ -645,6 +647,7 @@ declare global {
         "network.join" |
         "network.leave" |
         "park.guest.softcap.calculate" |
+        "ride.breakdown" |
         "ride.ratings.calculate" |
         "vehicle.crash";
 
@@ -1667,6 +1670,18 @@ declare global {
         readonly id: number;
         readonly crashIntoType: VehicleCrashIntoType;
     }
+    
+    interface RideBreakdownArgs {
+        readonly ride: number;
+        readonly reason: BreakdownType;
+        readonly vehicle: number | null;
+    }
+
+    interface RideFixArgs
+    {
+        readonly ride: number;
+        readonly fixedBy: number;
+    }
 
     /**
      * The 'suggestedGuestMaximum' field in this interface can be used to override
@@ -1750,7 +1765,7 @@ declare global {
          * @param elementIndex The index of the track element on the tile.
          */
         getTrackIterator(location: CoordsXY, elementIndex: number): TrackIterator | null;
-		
+        
     }
 
     type TileElementType =
@@ -2501,30 +2516,30 @@ declare global {
          * Highest drop height in height units. Use `context.formatString()` to convert into metres/feet. Ex: `formatString('{HEIGHT}', ride.highestDropHeight)`.
          */
         readonly highestDropHeight: number;
-		
-		 /**
+        
+         /**
          * The current breakdown of the ride.
          */
         readonly breakdown: BreakdownType;
-		 
-		/**
+         
+        /**
          * Set a breakdown on a ride.
          * @param breakdown The type of breakdown to set.
          */
         setBreakdown(breakdown: BreakdownType): void;
-		
-		/**
+        
+        /**
          * Fix a ride / clear the breakdown.
          */
         fixBreakdown(): void;
-		
+        
     }
 
     type RideClassification = "ride" | "stall" | "facility";
 
     type RideStatus = "closed" | "open" | "testing" | "simulating";
-	
-	type BreakdownType =  "brakes_failure" | "control_failure" | "doors_stuck_closed" | "doors_stuck_open" | "restraints_stuck_closed" | "restraints_stuck_open"  | "safety_cut_out" | "vehicle_malfunction";
+    
+    type BreakdownType =  "brakes_failure" | "control_failure" | "doors_stuck_closed" | "doors_stuck_open" | "restraints_stuck_closed" | "restraints_stuck_open"  | "safety_cut_out" | "vehicle_malfunction";
 
     interface TrackColour {
         main: number;
@@ -3869,7 +3884,7 @@ declare global {
         "empty_juice_cup" |
         "empty_bowl_blue";
 
-	/**
+    /**
      * Represents balloon entity.
      */
     interface Balloon extends Entity {
@@ -3877,9 +3892,9 @@ declare global {
          * The colour of the balloon.
          */
         colour: number;      
-	}
-	
-	/**
+    }
+    
+    /**
      * Represents money_effect entity.
      */
     interface MoneyEffect extends Entity {
@@ -3887,8 +3902,8 @@ declare global {
          * The value of the money effect.
          */
         value: number;  
-	}
-	
+    }
+    
     /**
      * Network APIs
      * Use `network.mode` to determine whether the current game is a client, server or in single player mode.

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -3893,6 +3893,9 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_FORCE_BREAKDOWN:
                     if (dropdownIndex == 0)
                     {
+#ifdef ENABLE_SCRIPTING
+                        InvokeRideFixHook(*ride);
+#endif
                         Vehicle* vehicle;
                         switch (ride->breakdownReasonPending)
                         {

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -944,3 +944,7 @@ std::vector<RideId> GetTracklessRides();
 
 void CircusMusicUpdate(Ride& ride);
 void DefaultMusicUpdate(Ride& ride);
+
+#ifdef ENABLE_SCRIPTING
+void InvokeRideFixHook(const Ride& ride);
+#endif

--- a/src/openrct2/scripting/HookEngine.cpp
+++ b/src/openrct2/scripting/HookEngine.cpp
@@ -35,6 +35,8 @@ static const EnumMap<HookType> HooksLookupTable({
     { "map.changed", HookType::mapChanged },
     { "map.save", HookType::mapSave },
     { "park.guest.softcap.calculate", HookType::parkCalculateGuestCap },
+    { "ride.breakdown", HookType::rideBreakdown },
+    { "ride.fix", HookType::rideFix }
 });
 
 HookType OpenRCT2::Scripting::GetHookType(const std::string& name)

--- a/src/openrct2/scripting/HookEngine.h
+++ b/src/openrct2/scripting/HookEngine.h
@@ -43,6 +43,8 @@ namespace OpenRCT2::Scripting
         mapChanged,
         mapSave,
         parkCalculateGuestCap,
+        rideBreakdown,
+        rideFix,
         count,
         notDefined = -1,
     };

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -46,7 +46,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t kPluginApiVersion = 107;
+    static constexpr int32_t kPluginApiVersion = 108;
 
     // Versions marking breaking changes.
     static constexpr int32_t kApiVersionPeepDeprecation = 33;


### PR DESCRIPTION
**EDIT:** I just noticed PR 24243. Oops :/
This PR does however include information for the car
that broke down, and also includes a hook for when
rides are fixed.

This adds the hook "ride.breakdown" to the scripting api. It is called whenever a ride breaks down. The hook includes the id of the ride that broke down, the type of breakdown, and what car broke down, if applicable.

This also adds the hook "ride.fix" to the scripting api. It is called whenever a ride is fixed. The hook includes the id of the ride that was fixed.

I left some TODO comments in the code for things I wasn't sure about, particularly when the "ride.breakdown" hook is invoked. It is currently invoked within the "RidePrepareBreakdown" function in openrct2/ride/Ride.cpp, which is called before the breakdown notification is shown to the player. I could change it so that the hook is fired at the same time that the notification is sent if that is preferred. Note that the notification does not fire immediately when forcing a breakdown via the drop-down menu in the maintenance tab for a ride.

Lastly, I changed my username under contributors.md to reflect my new account.

An example plugin that uses the new hooks may be found here: https://pastebin.com/GmhYwGsb