### PR TITLE
Update hendrikmuhs/ccache-action to v1.2.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.13
+        uses: hendrikmuhs/ccache-action@v1.2.18
         with:
           key: ${{ matrix.cache_key }}
       - name: Install GCC problem matcher
@@ -366,13 +366,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.13
+        uses: hendrikmuhs/ccache-action@v1.2.18
         with:
           key: ${{ matrix.cache_key }}
-      - name: Configure ccache
-        run: |
-          # See https://github.com/hendrikmuhs/ccache-action/issues/146
-          ccache --set-config=compiler_check=content
       - name: Install GCC problem matcher
         uses: ammaraskar/gcc-problem-matcher@master
       - name: Build OpenRCT2
@@ -464,7 +460,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.13
+        uses: hendrikmuhs/ccache-action@v1.2.18
         with:
           key: linux-${{ matrix.platform }}-${{ matrix.distro }}
       - name: Get pre-reqs
@@ -494,7 +490,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.13
+        uses: hendrikmuhs/ccache-action@v1.2.18
         with:
           key: linux-appimage
       - name: Install Clang 15
@@ -553,7 +549,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.13
+        uses: hendrikmuhs/ccache-action@v1.2.18
         with:
           key: linux-clang
       - name: Install GCC problem matcher
@@ -569,7 +565,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.13
+        uses: hendrikmuhs/ccache-action@v1.2.18
         with:
           key: linux-clang
       - name: Install GCC problem matcher
@@ -610,7 +606,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.13
+        uses: hendrikmuhs/ccache-action@v1.2.18
         with:
           key: android
       - name: Install GCC problem matcher
@@ -638,7 +634,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.13
+        uses: hendrikmuhs/ccache-action@v1.2.18
         with:
           key: emscripten
       - name: Install GCC problem matcher


### PR DESCRIPTION
v1.2.17 or higher is needed to use the new GitHub cache service - the old one was decommissioned on the 15th of April: https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts

As the fix for https://github.com/hendrikmuhs/ccache-action/issues/146 was merged in v1.2.17, I also removed that section.