### PR TITLE
NSIS installer: clear old objects, add all OpenRCT2 languages

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,7 +2,7 @@
 ------------------------------------------------------------------------
 - Improved: [#24368] Clicking the in-game update notication now leads to a more user-friendly download page.
 - Change: [#24342] g2.dat is now split into g2.dat and fonts.dat. 
-- Change: [#24362] The Windows installer now prevents installing to the same folder as RollerCoaster Tycoon 2.
+- Change: [#24362] The Windows installer now prevents installing to the same folder as RollerCoaster Tycoon 2 or Classic.
 - Fix: [#24346] Possible crash during line drawing in OpenGL mode.
 - Fix: [#24353] ‘Show dirty visuals’ is off by one pixel and does not work correctly with higher framerates.
 - Fix: [#24362] When upgrading from an older version on Windows, old versions of official objects are not always removed.  

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,8 +2,10 @@
 ------------------------------------------------------------------------
 - Improved: [#24368] Clicking the in-game update notication now leads to a more user-friendly download page.
 - Change: [#24342] g2.dat is now split into g2.dat and fonts.dat. 
+- Change: [#24362] The Windows installer now prevents installing to the same folder as RollerCoaster Tycoon 2.
 - Fix: [#24346] Possible crash during line drawing in OpenGL mode.
-- Fix: [#24353] ‘Show dirty visuals’ is off by one pixel and does not work correctly with higher framerates.  
+- Fix: [#24353] ‘Show dirty visuals’ is off by one pixel and does not work correctly with higher framerates.
+- Fix: [#24362] When upgrading from an older version on Windows, old versions of official objects are not always removed.  
 
 0.4.22 (2025-05-04)
 ------------------------------------------------------------------------

--- a/distribution/windows/install.nsi
+++ b/distribution/windows/install.nsi
@@ -2,7 +2,7 @@
 !define APPVERSION          "${APPV_MAIN}${APPV_EXTRA}"
 !define APPVERSIONINTERNAL  "${APPV_MAIN}.0"
 !define APPNAMEANDVERSION   "${APPNAME} ${APPVERSION}"
-!define APPURLLINK          "https://github.com/OpenRCT2/OpenRCT2"
+!define APPURLLINK          "https://openrct2.io"
 !define OPENRCT2_EXE        "openrct2.exe"
 !define OPENRCT2_COM        "openrct2.com"
 

--- a/distribution/windows/install.nsi
+++ b/distribution/windows/install.nsi
@@ -150,7 +150,8 @@ Section "!OpenRCT2" Section1
 
     SetShellVarContext all
 
-    ; Copy data files
+    ; Copy data files. Clear out the old dir first, to ensure upgrades do not result in old objects sticking around.
+    RMDir /r "$INSTDIR\data"
     SetOutPath "$INSTDIR\data\"
     File /r ${PATH_ROOT}bin\data\*
 

--- a/distribution/windows/install.nsi
+++ b/distribution/windows/install.nsi
@@ -555,10 +555,15 @@ Function un.onInit
 FunctionEnd
 
 Function DoNotInstallInRCT2Folder
-    IfFileExists "$INSTDIR\Data\g1.dat" exists notexists
-    exists:
+    IfFileExists "$INSTDIR\Data\g1.dat" datag1exists datag1notexists
+    datag1exists:
     MessageBox MB_OK|MB_ICONSTOP `You cannot install OpenRCT2 to the same directory as RollerCoaster Tycoon 2.`
     Abort
-    notexists:
+    datag1notexists:
+    IfFileExists "$INSTDIR\Assets\g1.dat" assetsg1exists assetsg1notexists
+    assetsg1exists:
+    MessageBox MB_OK|MB_ICONSTOP `You cannot install OpenRCT2 to the same directory as RollerCoaster Classic.`
+    Abort
+    assetsg1notexists:
 FunctionEnd
 ; eof

--- a/distribution/windows/install.nsi
+++ b/distribution/windows/install.nsi
@@ -106,8 +106,33 @@ ManifestDPIAware true
 !insertmacro MUI_UNPAGE_CONFIRM
 !insertmacro MUI_UNPAGE_INSTFILES
 
-; Set languages (first is default language)
+; Set languages (first is default language). Other languages are sorted by ISO code.
 !insertmacro MUI_LANGUAGE "English"
+!insertmacro MUI_LANGUAGE "Arabic"
+!insertmacro MUI_LANGUAGE "Catalan"
+!insertmacro MUI_LANGUAGE "Czech"
+!insertmacro MUI_LANGUAGE "Danish"
+!insertmacro MUI_LANGUAGE "German"
+!insertmacro MUI_LANGUAGE "Esperanto"
+!insertmacro MUI_LANGUAGE "Spanish"
+!insertmacro MUI_LANGUAGE "Finnish"
+!insertmacro MUI_LANGUAGE "French"
+!insertmacro MUI_LANGUAGE "Galician"
+!insertmacro MUI_LANGUAGE "Hungarian"
+!insertmacro MUI_LANGUAGE "Italian"
+!insertmacro MUI_LANGUAGE "Japanese"
+!insertmacro MUI_LANGUAGE "Korean"
+!insertmacro MUI_LANGUAGE "Norwegian"
+!insertmacro MUI_LANGUAGE "Dutch"
+!insertmacro MUI_LANGUAGE "Polish"
+!insertmacro MUI_LANGUAGE "PortugueseBR"
+!insertmacro MUI_LANGUAGE "Russian"
+!insertmacro MUI_LANGUAGE "Swedish"
+!insertmacro MUI_LANGUAGE "Turkish"
+!insertmacro MUI_LANGUAGE "Ukrainian"
+!insertmacro MUI_LANGUAGE "Vietnamese"
+!insertmacro MUI_LANGUAGE "SimpChinese"
+!insertmacro MUI_LANGUAGE "TradChinese"
 !insertmacro MUI_RESERVEFILE_LANGDLL
 
 !macro Init thing
@@ -220,7 +245,7 @@ SectionEnd
 
 ; Modern install component descriptions
 !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
-    !insertmacro MUI_DESCRIPTION_TEXT ${Section1} "Minimal OpenRCT2 installation in English. You must have RollerCoaster Tycoon 2 installed."
+    !insertmacro MUI_DESCRIPTION_TEXT ${Section1} "Minimal OpenRCT2 installation. You must have RollerCoaster Tycoon 2 installed."
 !insertmacro MUI_FUNCTION_DESCRIPTION_END
 
 ;-----------------------------------------------

--- a/distribution/windows/install.nsi
+++ b/distribution/windows/install.nsi
@@ -76,6 +76,7 @@ Var SHORTCUTS
 !define MUI_COMPONENTSPAGE_SMALLDESC
 !insertmacro MUI_PAGE_COMPONENTS
 
+!define MUI_PAGE_CUSTOMFUNCTION_LEAVE DoNotInstallInRCT2Folder
 !insertmacro MUI_PAGE_DIRECTORY
 
 ManifestDPIAware true
@@ -551,5 +552,13 @@ FunctionEnd
 
 Function un.onInit
 !insertmacro Init "uninstaller"
+FunctionEnd
+
+Function DoNotInstallInRCT2Folder
+    IfFileExists "$INSTDIR\Data\g1.dat" exists notexists
+    exists:
+    MessageBox MB_OK|MB_ICONSTOP `You cannot install OpenRCT2 to the same directory as RollerCoaster Tycoon 2.`
+    Abort
+    notexists:
 FunctionEnd
 ; eof

--- a/distribution/windows/install.nsi
+++ b/distribution/windows/install.nsi
@@ -562,7 +562,7 @@ Function DoNotInstallInRCT2Folder
     datag1notexists:
     IfFileExists "$INSTDIR\Assets\g1.dat" assetsg1exists assetsg1notexists
     assetsg1exists:
-    MessageBox MB_OK|MB_ICONSTOP `You cannot install OpenRCT2 to the same directory as RollerCoaster Classic.`
+    MessageBox MB_OK|MB_ICONSTOP `You cannot install OpenRCT2 to the same directory as RollerCoaster Tycoon Classic.`
     Abort
     assetsg1notexists:
 FunctionEnd


### PR DESCRIPTION
When installing, the $INSTDIR/data directory is now removed first, ensuring no old objects stick around to cause a nuisance.

I have also enabled all other languages that OpenRCT2 supports in the installer. NSIS autodetects the system language. Some bits of text will still need to be translated (e.g. "OpenRCT2 for Windows 7") -- I’ll create an issue on Localisation for that and include the results in another PR.

I have tested this PR using Wine, trying to upgrade from v0.3.5.1 and verifying it removed the old data, unlike the release installer for v0.4.22. Also verified the installer was in Dutch.

## Testing

This PR contains two components to test:
1. If the user tries to install in the RCT2 directory, it will now block. (It checks for the presence of Data\g1.dat, just like the game itself.)
2. The installer will now clear the `data` directory to avoid old objects lingering around.

Point 1 is easy to test. For point 2, you can use this as a test:
1. Install an old version of OpenRCT2, e.g. v0.3.5.1
2. Install the latest release of OpenRCT2 (v0.4.22). Observe that the `data` directory now contains objects from both version (e.g. `data/object/rct2/footpath`, which are split in v0.4.22)
3. Install a build from this PR. Observe that the `data` directory is cleared out during install and the aforementioned objects are no longer present.