### PR TITLE
Improve Zero G Roll fallback vehicle sprites

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.23 (in development)
 ------------------------------------------------------------------------
 - Feature: [#24313] [Plugin] Add API for setting a ride vehicle’s sprite to a smoke plume. 
+- Improved: [#24364] Vehicles without all the sprites for Zero G Rolls now use better fallbacks.
 - Improved: [#24368] Clicking the in-game update notication now leads to a more user-friendly download page.
 - Change: [#24342] g2.dat is now split into g2.dat and fonts.dat.
 - Change: [#24362] The Windows installer now prevents installing to the same folder as RollerCoaster Tycoon 2 or Classic.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,7 +1,7 @@
 0.4.23 (in development)
 ------------------------------------------------------------------------
 - Feature: [#24313] [Plugin] Add API for setting a ride vehicle’s sprite to a smoke plume. 
-- Improved: [#24364] Vehicles without all the sprites for Zero G Rolls now use better fallbacks.
+- Improved: [#24364] Improve the fallback vehicle sprites for Zero G Rolls, and allow small ones to be built without cheats if the fallbacks are available.
 - Improved: [#24368] Clicking the in-game update notication now leads to a more user-friendly download page.
 - Change: [#24342] g2.dat is now split into g2.dat and fonts.dat.
 - Change: [#24362] The Windows installer now prevents installing to the same folder as RollerCoaster Tycoon 2 or Classic.

--- a/src/openrct2/paint/vehicle/VehiclePaint.cpp
+++ b/src/openrct2/paint/vehicle/VehiclePaint.cpp
@@ -1969,7 +1969,7 @@ static void VehiclePitchUp42BankedLeft67(
     }
     else
     {
-        VehiclePitchUp42Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchUp25BankedLeft45(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -1984,7 +1984,7 @@ static void VehiclePitchUp42BankedLeft90(
     }
     else
     {
-        VehiclePitchUp42Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedLeft90(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -1999,7 +1999,7 @@ static void VehiclePitchUp42BankedRight67(
     }
     else
     {
-        VehiclePitchUp42Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchUp25BankedRight45(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -2014,7 +2014,7 @@ static void VehiclePitchUp42BankedRight90(
     }
     else
     {
-        VehiclePitchUp42Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedRight90(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -2724,7 +2724,7 @@ static void VehiclePitchDown42BankedLeft67(
     }
     else
     {
-        VehiclePitchDown42Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchDown25BankedLeft45(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -2739,7 +2739,7 @@ static void VehiclePitchDown42BankedLeft90(
     }
     else
     {
-        VehiclePitchDown42Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedLeft90(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -2754,7 +2754,7 @@ static void VehiclePitchDown42BankedRight67(
     }
     else
     {
-        VehiclePitchDown42Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchDown25BankedRight45(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -2769,7 +2769,7 @@ static void VehiclePitchDown42BankedRight90(
     }
     else
     {
-        VehiclePitchDown42Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedRight90(session, vehicle, imageDirection, z, carEntry);
     }
 }
 

--- a/src/openrct2/paint/vehicle/VehiclePaint.cpp
+++ b/src/openrct2/paint/vehicle/VehiclePaint.cpp
@@ -2441,7 +2441,7 @@ static void VehiclePitchDown25BankedLeft90(
     }
 }
 
-static void VehiclePitchDown25BankedLeft11BankedLeft45(
+static void VehiclePitchDown25BankedLeft112(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
@@ -2516,7 +2516,7 @@ static void VehiclePitchDown25BankedRight90(
     }
 }
 
-static void VehiclePitchDown25BankedRight11BankedLeft45(
+static void VehiclePitchDown25BankedRight112(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
@@ -2590,7 +2590,7 @@ static void VehiclePitchDown25(
             VehiclePitchDown25BankedLeft90(session, vehicle, imageDirection, z, carEntry);
             break;
         case 7:
-            VehiclePitchDown25BankedLeft11BankedLeft45(session, vehicle, imageDirection, z, carEntry);
+            VehiclePitchDown25BankedLeft112(session, vehicle, imageDirection, z, carEntry);
             break;
         case 8:
             VehiclePitchDown25BankedLeft135(session, vehicle, imageDirection, z, carEntry);
@@ -2605,7 +2605,7 @@ static void VehiclePitchDown25(
             VehiclePitchDown25BankedRight90(session, vehicle, imageDirection, z, carEntry);
             break;
         case 12:
-            VehiclePitchDown25BankedRight11BankedLeft45(session, vehicle, imageDirection, z, carEntry);
+            VehiclePitchDown25BankedRight112(session, vehicle, imageDirection, z, carEntry);
             break;
         case 13:
             VehiclePitchDown25BankedRight135(session, vehicle, imageDirection, z, carEntry);

--- a/src/openrct2/paint/vehicle/VehiclePaint.cpp
+++ b/src/openrct2/paint/vehicle/VehiclePaint.cpp
@@ -1682,7 +1682,7 @@ static void VehiclePitchUp25BankedLeft90(
     }
     else
     {
-        VehiclePitchUp25BankedLeft45(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedLeft90(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -1697,7 +1697,7 @@ static void VehiclePitchUp25BankedLeft112(
     }
     else
     {
-        VehiclePitchUp25BankedLeft45(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedLeft112(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -1712,7 +1712,7 @@ static void VehiclePitchUp25BankedLeft135(
     }
     else
     {
-        VehiclePitchUp25BankedLeft45(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedLeft135(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -1727,7 +1727,7 @@ static void VehiclePitchUp25BankedLeft157(
     }
     else
     {
-        VehiclePitchUp25BankedLeft45(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedLeft157(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -1757,7 +1757,7 @@ static void VehiclePitchUp25BankedRight90(
     }
     else
     {
-        VehiclePitchUp25BankedRight45(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedRight90(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -1772,7 +1772,7 @@ static void VehiclePitchUp25BankedRight112(
     }
     else
     {
-        VehiclePitchUp25BankedRight45(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedRight112(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -1787,7 +1787,7 @@ static void VehiclePitchUp25BankedRight135(
     }
     else
     {
-        VehiclePitchUp25BankedRight45(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedRight135(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -1802,7 +1802,7 @@ static void VehiclePitchUp25BankedRight157(
     }
     else
     {
-        VehiclePitchUp25BankedLeft45(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedRight157(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -2437,7 +2437,7 @@ static void VehiclePitchDown25BankedLeft90(
     }
     else
     {
-        VehiclePitchDown25BankedLeft45(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedLeft90(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -2452,7 +2452,7 @@ static void VehiclePitchDown25BankedLeft11BankedLeft45(
     }
     else
     {
-        VehiclePitchDown25BankedLeft45(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedLeft112(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -2467,7 +2467,7 @@ static void VehiclePitchDown25BankedLeft135(
     }
     else
     {
-        VehiclePitchDown25BankedLeft45(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedLeft135(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -2482,7 +2482,7 @@ static void VehiclePitchDown25BankedLeft157(
     }
     else
     {
-        VehiclePitchDown25BankedLeft45(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedLeft157(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -2512,7 +2512,7 @@ static void VehiclePitchDown25BankedRight90(
     }
     else
     {
-        VehiclePitchDown25BankedRight45(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedRight90(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -2527,7 +2527,7 @@ static void VehiclePitchDown25BankedRight11BankedLeft45(
     }
     else
     {
-        VehiclePitchDown25BankedRight45(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedRight112(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -2542,7 +2542,7 @@ static void VehiclePitchDown25BankedRight135(
     }
     else
     {
-        VehiclePitchDown25BankedRight45(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedRight135(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -2557,7 +2557,7 @@ static void VehiclePitchDown25BankedRight157(
     }
     else
     {
-        VehiclePitchDown25BankedRight45(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchFlatBankedRight157(session, vehicle, imageDirection, z, carEntry);
     }
 }
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4888,8 +4888,9 @@ OpenRCT2::BitSet<EnumValue(TrackGroup::count)> RideEntryGetSupportedTrackPieces(
         { SpriteGroupType::Slopes60, SpritePrecision::Sprites4, SpriteGroupType::Slopes75, SpritePrecision::Sprites4,
           SpriteGroupType::Slopes90, SpritePrecision::Sprites4, SpriteGroupType::SlopesLoop, SpritePrecision::Sprites4,
           SpriteGroupType::SlopeInverted, SpritePrecision::Sprites4 }, // TrackGroup::halfLoopMedium
-        { SpriteGroupType::Slopes25Banked67, SpritePrecision::Sprites4, SpriteGroupType::Slopes25Banked90,
-          SpritePrecision::Sprites4, SpriteGroupType::Slopes25InlineTwists,
+        { SpriteGroupType::Slopes25, SpritePrecision::Sprites4, SpriteGroupType::Slopes12Banked22, SpritePrecision::Sprites4,
+          SpriteGroupType::Slopes25Banked22, SpritePrecision::Sprites4, SpriteGroupType::Slopes25Banked45,
+          SpritePrecision::Sprites4, SpriteGroupType::InlineTwists, SpritePrecision::Sprites4, SpriteGroupType::SlopeInverted,
           SpritePrecision::Sprites4 }, // TrackGroup::zeroGRoll
         { SpriteGroupType::Slopes42Banked22, SpritePrecision::Sprites4, SpriteGroupType::Slopes42Banked45,
           SpritePrecision::Sprites4, SpriteGroupType::Slopes42Banked67, SpritePrecision::Sprites4,


### PR DESCRIPTION
This improves the fallback vehicle sprites for Zero G Rolls. Apart from one pitch/bank angle, they have been changed to fallback to the inline roll sprites. I tried to see if any of the corkscrew sprites could be used, but I didn't think any were suitable, and in my opinion having a smoother animation overall looks better than it changing angles several times. I also renamed a vehicle paint function that seems to have an incorrect name.


https://github.com/user-attachments/assets/a7bbcead-c0fe-4dba-867c-7dcc838ece1e


https://github.com/user-attachments/assets/433de4b5-db16-45fb-bb17-4b9c117abe57


https://github.com/user-attachments/assets/fc7a3101-cced-48a9-be50-12e6d62f73e1


https://github.com/user-attachments/assets/a0e7b8e0-0e3a-4860-a045-a49c7c1ff143

This is what they currently look like:


https://github.com/user-attachments/assets/89bd16c6-aaa3-4ab5-8554-a8eaf33d5395


https://github.com/user-attachments/assets/0325f2ef-1ebd-4c18-8a17-303159de1660

