### PR TITLE
Fix incorrect Zero G Roll vehicle yaw rotations

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Fix: [#24346] Possible crash during line drawing in OpenGL mode.
 - Fix: [#24353] ‘Show dirty visuals’ is off by one pixel and does not work correctly with higher framerates.
 - Fix: [#24362] When upgrading from an older version on Windows, old versions of official objects are not always removed.  
+- Fix: [#24366] Zero G Rolls have some incorrect vehicle yaw rotations.
 - Fix: [#24371] Fix divide by zero in the scenery window when there is no scenery.
 - Fix: [#24403] Park fences draw underneath and through opaque water.
 - Fix: [#24406] The network status window uses an undefined string for its title.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -49,7 +49,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kNetworkStreamVersion = 0;
+constexpr uint8_t kNetworkStreamVersion = 1;
 
 const std::string kNetworkStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kNetworkStreamVersion);
 


### PR DESCRIPTION
This fixes some incorrect yaw rotations in the Zero G Roll subposition data. I believe that yaw rotation does not affect physics, so it is safe to change these values, but please correct me if I am wrong. The left zero g roll up didn't have this issue. This may need a network version bump.

Here's what it currently looks like:

https://github.com/user-attachments/assets/63859e4b-0271-46e7-a9db-7b96edf2ba31

And here's what it looks like with this PR:

https://github.com/user-attachments/assets/626049ef-2aa1-45e6-ae6e-8e83ed385be8

There is still a very brief change in pitch angle that makes it not as smooth looking as it could be, but changing that will have an affect on the physics.

Here's another video where it is quite obvious that it rotates back and forth:

https://github.com/user-attachments/assets/e310e722-635b-4603-88df-d0a476f6304e

