### PR TITLE
Close #24368: 'Update available' button should lead to openrct2.io

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.23 (in development)
 ------------------------------------------------------------------------
+- Improved: [#24368] Clicking the in-game update notication now leads to a more user-friendly download page.
 
 0.4.22 (2025-05-04)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,9 @@
 0.4.23 (in development)
 ------------------------------------------------------------------------
 - Improved: [#24368] Clicking the in-game update notication now leads to a more user-friendly download page.
+- Change: [#24342] g2.dat is now split into g2.dat and fonts.dat. 
+- Fix: [#24346] Possible crash during line drawing in OpenGL mode.
+- Fix: [#24353] ‘Show dirty visuals’ is off by one pixel and does not work correctly with higher framerates.  
 
 0.4.22 (2025-05-04)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -165,7 +165,7 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_OPEN_URL:
                     if (_newVersionInfo != nullptr)
                     {
-                        GetContext()->GetUiContext()->OpenURL(_newVersionInfo->url);
+                        GetContext()->GetUiContext()->OpenURL("https://openrct2.io/download/release");
                     }
                     else
                     {

--- a/src/openrct2/Version.cpp
+++ b/src/openrct2/Version.cpp
@@ -70,7 +70,7 @@ NewVersionInfo GetLatestVersion()
     // If the check doesn't succeed, provide current version so we don't bother user
     // with invalid data.
     std::string tag = gVersionInfoTag;
-    NewVersionInfo verinfo{ tag, "", "", "" };
+    NewVersionInfo verinfo{ tag, "", "" };
 #if !defined(DISABLE_HTTP) && !defined(DISABLE_VERSION_CHECKER)
     auto now = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
     auto then = Config::Get().general.LastVersionCheckTime;
@@ -100,7 +100,6 @@ NewVersionInfo GetLatestVersion()
         verinfo.tag = Json::GetString(root["tag_name"]);
         verinfo.name = Json::GetString(root["name"]);
         verinfo.changelog = Json::GetString(root["body"]);
-        verinfo.url = Json::GetString(root["html_url"]);
 
         Config::Get().general.LastVersionCheckTime = now;
         Config::Save();

--- a/src/openrct2/Version.h
+++ b/src/openrct2/Version.h
@@ -83,7 +83,6 @@ struct NewVersionInfo
     std::string tag;
     std::string name;
     std::string changelog;
-    std::string url;
 };
 
 NewVersionInfo GetLatestVersion();


### PR DESCRIPTION
Do not squash merge. Included a commit to add some missing issues to the changelog.