### PR TITLE
Fix for Issue 24327 plugin window not resize correctly when switching tabs

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -251,6 +251,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * (QuestionableDeer)
 * David Sungaila (sungaila)
 * Garrett Leach (GarrettLeach)
+* Jater Xu (jaterx)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -900,7 +900,8 @@ namespace OpenRCT2::Ui::Windows
 
             // WindowBase::getTitleBarCurrentHeight() is not returning the right value when first time OnOpen()
             const int16_t titleOffset = WindowBase::getTitleBarTargetHeight() - kTitleHeightNormal;
-            // Since we changed the caption and close button's bottom, we will need to retrieve where the content starts at dynamically now
+            // Since we changed the caption and close button's bottom,
+            // we will need to retrieve where the content starts at dynamically now
             const int16_t tabTop = widgetList[WIDX_TITLE].bottom + 1;
             const int16_t tabBottom = tabTop + 26;
 
@@ -970,7 +971,7 @@ namespace OpenRCT2::Ui::Windows
             int16_t maxBottom = 0;
             for (const auto& widget : widgetList)
             {
-                //bitmask to only acquire the max bottom for the visible widgets
+                // Bitmask to only acquire the max bottom for the visible widgets
                 if (!(widget.flags & WIDGET_FLAGS::IS_HIDDEN))
                 {
                     maxBottom = std::max(maxBottom, widget.bottom);

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -977,7 +977,7 @@ namespace OpenRCT2::Ui::Windows
             // +5 just for extra padding at the bottom
             const int16_t newHeight = maxBottom + 5;
             height = newHeight;
-
+            
             SetWidgets(widgetList);
             WindowInitScrollWidgets(*this);
             UpdateViewport();

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -976,7 +976,6 @@ namespace OpenRCT2::Ui::Windows
 
             // +5 just for extra padding at the bottom
             const int16_t newHeight = maxBottom + 5;
-
             height = newHeight;
 
             SetWidgets(widgetList);

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -893,8 +893,18 @@ namespace OpenRCT2::Ui::Windows
                 _info.WidgetIndexMap.push_back(std::numeric_limits<size_t>::max());
             }
 
+            const int16_t titleHeight = Config::Get().interface.EnlargedUi ? kTitleHeightLarge : kTitleHeightNormal;
+            const int16_t titleOffset = titleHeight - kTitleHeightNormal;
+
+            if (widgetList.size() > WIDX_CLOSE)
+            {
+                widgetList[WIDX_TITLE].bottom = widgetList[WIDX_TITLE].top + titleHeight;
+                widgetList[WIDX_CLOSE].bottom = widgetList[WIDX_CLOSE].top + titleHeight;
+                widgetList[WIDX_CONTENT_PANEL].top = kTitleHeightNormal + titleOffset;
+            }
+
             // Add window tabs
-            const int16_t tabTop = 17;
+            const int16_t tabTop = 17 + titleOffset;
             const int16_t tabBottom = 43 + titleOffset;
             for (size_t tabDescIndex = 0; tabDescIndex < _info.Desc.Tabs.size(); tabDescIndex++)
             {
@@ -966,7 +976,6 @@ namespace OpenRCT2::Ui::Windows
 
             // +5 just for extra padding at the bottom
             const int16_t newHeight = maxBottom + 5;
-
             height = newHeight;
 
             SetWidgets(widgetList);

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -978,7 +978,7 @@ namespace OpenRCT2::Ui::Windows
             const int16_t newHeight = maxBottom + 5;
 
             height = newHeight;
-            
+
             SetWidgets(widgetList);
             WindowInitScrollWidgets(*this);
             UpdateViewport();

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -894,14 +894,13 @@ namespace OpenRCT2::Ui::Windows
             }
 
             /* Resize the caption and close button to match the title bar size in runtime.
-               We don't need to put it ResizeFrame since only when calling the RefreshWidget, 
-               the static UI shim got recreated, causing the stale value to be updated again. */
+               when the static UI shim got recreated, causing the stale value to be updated again. */
             widgetList[WIDX_TITLE].bottom = WindowBase::getTitleBarTargetHeight() + 1;
             widgetList[WIDX_CLOSE].bottom = WindowBase::getTitleBarTargetHeight();
 
             // WindowBase::getTitleBarCurrentHeight() is not returning the right value when first time OnOpen()
             const int16_t titleOffset = WindowBase::getTitleBarTargetHeight() - kTitleHeightNormal;
-            // Since we changed the caption and close button's bottom, we will need to retrieve where the content starts at dyanmically now
+            // Since we changed the caption and close button's bottom, we will need to retrieve where the content starts at dynamically now
             const int16_t tabTop = widgetList[WIDX_TITLE].bottom + 1;
             const int16_t tabBottom = tabTop + 26;
 

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -893,19 +893,11 @@ namespace OpenRCT2::Ui::Windows
                 _info.WidgetIndexMap.push_back(std::numeric_limits<size_t>::max());
             }
 
-            const int16_t titleHeight = Config::Get().interface.EnlargedUi ? kTitleHeightLarge : kTitleHeightNormal;
-            const int16_t titleOffset = titleHeight - kTitleHeightNormal;
-
-            if (widgetList.size() > WIDX_CLOSE)
-            {
-                widgetList[WIDX_TITLE].bottom = widgetList[WIDX_TITLE].top + titleHeight;
-                widgetList[WIDX_CLOSE].bottom = widgetList[WIDX_CLOSE].top + titleHeight;
-                widgetList[WIDX_CONTENT_PANEL].top = kTitleHeightNormal + titleOffset;
-            }
-
             // Add window tabs
-            const int16_t tabTop = 17 + titleOffset;
-            const int16_t tabBottom = 43 + titleOffset;
+            if (_info.Desc.Tabs.size() != 0)
+            {
+                widgetList[WIDX_CONTENT_PANEL].top = 43;
+            }
             for (size_t tabDescIndex = 0; tabDescIndex < _info.Desc.Tabs.size(); tabDescIndex++)
             {
                 Widget widget{};
@@ -913,8 +905,8 @@ namespace OpenRCT2::Ui::Windows
                 widget.colour = 1;
                 widget.left = static_cast<int16_t>(3 + (tabDescIndex * 31));
                 widget.right = widget.left + 30;
-                widget.top = tabTop;
-                widget.bottom = tabBottom;
+                widget.top = 17;
+                widget.bottom = 43;
                 widget.image = ImageId(SPR_TAB, FilterPaletteID::PaletteNull);
                 widget.tooltip = kStringIdNone;
                 widgetList.push_back(widget);
@@ -922,28 +914,22 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Add custom widgets
-            size_t totalWidgets = _info.Desc.Widgets.size();
-            size_t tabWidgetsOffset = totalWidgets;
+            auto totalWidgets = _info.Desc.Widgets.size();
+            auto tabWidgetsOffset = totalWidgets;
             if (_info.Desc.Tabs.size() != 0)
             {
                 totalWidgets += _info.Desc.Tabs[page].Widgets.size();
             }
-
             for (size_t widgetDescIndex = 0; widgetDescIndex < totalWidgets; widgetDescIndex++)
             {
                 const auto& widgetDesc = widgetDescIndex < _info.Desc.Widgets.size()
                     ? _info.Desc.Widgets[widgetDescIndex]
                     : _info.Desc.Tabs[page].Widgets[widgetDescIndex - tabWidgetsOffset];
-
                 auto preWidgetSize = widgetList.size();
                 CreateWidget(widgetList, widgetDesc);
                 auto numWidgetsAdded = widgetList.size() - preWidgetSize;
-
                 for (size_t i = 0; i < numWidgetsAdded; i++)
                 {
-                    Widget& widget = widgetList[preWidgetSize + i];
-                    widget.top += titleOffset;
-                    widget.bottom += titleOffset;
                     _info.WidgetIndexMap.push_back(widgetDescIndex);
                 }
 
@@ -964,6 +950,7 @@ namespace OpenRCT2::Ui::Windows
                 }
             }
 
+<<<<<<< HEAD
             // Fix for plugin windows not resize correctly when switching tabs
             int16_t maxBottom = 0;
             for (const auto& widget : widgetList)
@@ -978,7 +965,10 @@ namespace OpenRCT2::Ui::Windows
             const int16_t newHeight = maxBottom + 5;
             height = newHeight;
             
+=======
+>>>>>>> parent of d02dff3f37 (Fix for Issue 24327 plugin window not resize correctly when switching tabs)
             SetWidgets(widgetList);
+
             WindowInitScrollWidgets(*this);
             UpdateViewport();
         }

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -893,18 +893,8 @@ namespace OpenRCT2::Ui::Windows
                 _info.WidgetIndexMap.push_back(std::numeric_limits<size_t>::max());
             }
 
-            const int16_t titleHeight = Config::Get().interface.EnlargedUi ? kTitleHeightLarge : kTitleHeightNormal;
-            const int16_t titleOffset = titleHeight - kTitleHeightNormal;
-
-            if (widgetList.size() > WIDX_CLOSE)
-            {
-                widgetList[WIDX_TITLE].bottom = widgetList[WIDX_TITLE].top + titleHeight;
-                widgetList[WIDX_CLOSE].bottom = widgetList[WIDX_CLOSE].top + titleHeight;
-                widgetList[WIDX_CONTENT_PANEL].top = kTitleHeightNormal + titleOffset;
-            }
-
             // Add window tabs
-            const int16_t tabTop = 17 + titleOffset;
+            const int16_t tabTop = 17;
             const int16_t tabBottom = 43 + titleOffset;
             for (size_t tabDescIndex = 0; tabDescIndex < _info.Desc.Tabs.size(); tabDescIndex++)
             {
@@ -976,6 +966,7 @@ namespace OpenRCT2::Ui::Windows
 
             // +5 just for extra padding at the bottom
             const int16_t newHeight = maxBottom + 5;
+
             height = newHeight;
 
             SetWidgets(widgetList);


### PR DESCRIPTION

Here is a fix for the plugin window resize issue! Thanks for your time and review!

https://github.com/OpenRCT2/OpenRCT2/issues/24327