### PR TITLE
Allow AddClamp to deduce return type from the first argument

### DIFF
--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -614,7 +614,7 @@ void CheatSetAction::SetMoney(money64 amount) const
 void CheatSetAction::AddMoney(money64 amount) const
 {
     auto& gameState = getGameState();
-    gameState.cash = AddClamp<money64>(gameState.cash, amount);
+    AddClamp(&gameState.cash, amount);
 
     auto* windowMgr = Ui::GetWindowManager();
     windowMgr->InvalidateByClass(WindowClass::Finances);

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -614,7 +614,7 @@ void CheatSetAction::SetMoney(money64 amount) const
 void CheatSetAction::AddMoney(money64 amount) const
 {
     auto& gameState = getGameState();
-    AddClamp(&gameState.cash, amount);
+    gameState.cash = AddClamp(gameState.cash, amount);
 
     auto* windowMgr = Ui::GetWindowManager();
     windowMgr->InvalidateByClass(WindowClass::Finances);

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -3891,7 +3891,7 @@ void Guest::UpdateRideFreeVehicleEnterRide(Ride& ride)
         }
         else
         {
-            ride.totalProfit = AddClamp<money64>(ride.totalProfit, ridePrice);
+            AddClamp(&ride.totalProfit, ridePrice);
             ride.windowInvalidateFlags |= RIDE_INVALIDATE_RIDE_INCOME;
             SpendMoney(PaidOnRides, ridePrice, ExpenditureType::ParkRideTickets);
         }
@@ -6280,7 +6280,7 @@ static void PeepUpdateWalkingBreakScenery(Guest* peep)
 
         if (std::max(xDist, yDist) < 224)
         {
-            innerPeep->StaffVandalsStopped = AddClamp(innerPeep->StaffVandalsStopped, 1u);
+            AddClamp(&innerPeep->StaffVandalsStopped, 1);
             return;
         }
     }

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -3891,7 +3891,7 @@ void Guest::UpdateRideFreeVehicleEnterRide(Ride& ride)
         }
         else
         {
-            AddClamp(&ride.totalProfit, ridePrice);
+            ride.totalProfit = AddClamp(ride.totalProfit, ridePrice);
             ride.windowInvalidateFlags |= RIDE_INVALIDATE_RIDE_INCOME;
             SpendMoney(PaidOnRides, ridePrice, ExpenditureType::ParkRideTickets);
         }
@@ -6280,7 +6280,7 @@ static void PeepUpdateWalkingBreakScenery(Guest* peep)
 
         if (std::max(xDist, yDist) < 224)
         {
-            AddClamp(&innerPeep->StaffVandalsStopped, 1);
+            innerPeep->StaffVandalsStopped = AddClamp(innerPeep->StaffVandalsStopped, 1);
             return;
         }
     }

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -1055,7 +1055,7 @@ void Staff::UpdateMowing()
             surfaceElement->SetGrassLength(GRASS_LENGTH_MOWED);
             MapInvalidateTileZoom0({ NextLoc, surfaceElement->GetBaseZ(), surfaceElement->GetBaseZ() + 16 });
         }
-        StaffLawnsMown = AddClamp(StaffLawnsMown, 1u);
+        AddClamp(&StaffLawnsMown, 1);
         WindowInvalidateFlags |= PEEP_INVALIDATE_STAFF_STATS;
     }
 }
@@ -1114,7 +1114,7 @@ void Staff::UpdateWatering()
 
             tile_element->AsSmallScenery()->SetAge(0);
             MapInvalidateTileZoom0({ actionLoc, tile_element->GetBaseZ(), tile_element->GetClearanceZ() });
-            StaffGardensWatered = AddClamp(StaffGardensWatered, 1u);
+            AddClamp(&StaffGardensWatered, 1);
             WindowInvalidateFlags |= PEEP_INVALIDATE_STAFF_STATS;
         } while (!(tile_element++)->IsLastForTile());
 
@@ -1197,7 +1197,7 @@ void Staff::UpdateEmptyingBin()
         tile_element->AsPath()->SetAdditionStatus(additionStatus);
 
         MapInvalidateTileZoom0({ NextLoc, tile_element->GetBaseZ(), tile_element->GetClearanceZ() });
-        StaffBinsEmptied = AddClamp(StaffBinsEmptied, 1u);
+        AddClamp(&StaffBinsEmptied, 1);
         WindowInvalidateFlags |= PEEP_INVALIDATE_STAFF_STATS;
     }
 }
@@ -1216,7 +1216,7 @@ void Staff::UpdateSweeping()
     {
         // Remove sick at this location
         Litter::RemoveAt(GetLocation());
-        StaffLitterSwept = AddClamp(StaffLitterSwept, 1u);
+        AddClamp(&StaffLitterSwept, 1);
         WindowInvalidateFlags |= PEEP_INVALIDATE_STAFF_STATS;
     }
     if (auto loc = UpdateAction(); loc.has_value())
@@ -2422,13 +2422,13 @@ bool Staff::UpdateFixingFinishFixOrInspect(bool firstRun, int32_t steps, Ride& r
         {
             UpdateRideInspected(CurrentRide);
 
-            StaffRidesInspected = AddClamp(StaffRidesInspected, 1u);
+            AddClamp(&StaffRidesInspected, 1);
             WindowInvalidateFlags |= RIDE_INVALIDATE_RIDE_INCOME | RIDE_INVALIDATE_RIDE_LIST;
             ride.mechanicStatus = RIDE_MECHANIC_STATUS_UNDEFINED;
             return true;
         }
 
-        StaffRidesFixed = AddClamp(StaffRidesFixed, 1u);
+        AddClamp(&StaffRidesFixed, 1);
         WindowInvalidateFlags |= RIDE_INVALIDATE_RIDE_INCOME | RIDE_INVALIDATE_RIDE_LIST;
 
         Orientation = PeepDirection << 3;

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -1055,7 +1055,7 @@ void Staff::UpdateMowing()
             surfaceElement->SetGrassLength(GRASS_LENGTH_MOWED);
             MapInvalidateTileZoom0({ NextLoc, surfaceElement->GetBaseZ(), surfaceElement->GetBaseZ() + 16 });
         }
-        AddClamp(&StaffLawnsMown, 1);
+        StaffLawnsMown = AddClamp(StaffLawnsMown, 1);
         WindowInvalidateFlags |= PEEP_INVALIDATE_STAFF_STATS;
     }
 }
@@ -1114,7 +1114,7 @@ void Staff::UpdateWatering()
 
             tile_element->AsSmallScenery()->SetAge(0);
             MapInvalidateTileZoom0({ actionLoc, tile_element->GetBaseZ(), tile_element->GetClearanceZ() });
-            AddClamp(&StaffGardensWatered, 1);
+            StaffGardensWatered = AddClamp(StaffGardensWatered, 1);
             WindowInvalidateFlags |= PEEP_INVALIDATE_STAFF_STATS;
         } while (!(tile_element++)->IsLastForTile());
 
@@ -1197,7 +1197,7 @@ void Staff::UpdateEmptyingBin()
         tile_element->AsPath()->SetAdditionStatus(additionStatus);
 
         MapInvalidateTileZoom0({ NextLoc, tile_element->GetBaseZ(), tile_element->GetClearanceZ() });
-        AddClamp(&StaffBinsEmptied, 1);
+        StaffBinsEmptied = AddClamp(StaffBinsEmptied, 1);
         WindowInvalidateFlags |= PEEP_INVALIDATE_STAFF_STATS;
     }
 }
@@ -1216,7 +1216,7 @@ void Staff::UpdateSweeping()
     {
         // Remove sick at this location
         Litter::RemoveAt(GetLocation());
-        AddClamp(&StaffLitterSwept, 1);
+        StaffLitterSwept = AddClamp(StaffLitterSwept, 1);
         WindowInvalidateFlags |= PEEP_INVALIDATE_STAFF_STATS;
     }
     if (auto loc = UpdateAction(); loc.has_value())
@@ -2422,13 +2422,13 @@ bool Staff::UpdateFixingFinishFixOrInspect(bool firstRun, int32_t steps, Ride& r
         {
             UpdateRideInspected(CurrentRide);
 
-            AddClamp(&StaffRidesInspected, 1);
+            StaffRidesInspected = AddClamp(StaffRidesInspected, 1);
             WindowInvalidateFlags |= RIDE_INVALIDATE_RIDE_INCOME | RIDE_INVALIDATE_RIDE_LIST;
             ride.mechanicStatus = RIDE_MECHANIC_STATUS_UNDEFINED;
             return true;
         }
 
-        AddClamp(&StaffRidesFixed, 1);
+        StaffRidesFixed = AddClamp(StaffRidesFixed, 1);
         WindowInvalidateFlags |= RIDE_INVALIDATE_RIDE_INCOME | RIDE_INVALIDATE_RIDE_LIST;
 
         Orientation = PeepDirection << 3;

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -77,7 +77,7 @@ bool FinanceCheckAffordability(money64 cost, uint32_t flags)
 void FinancePayment(money64 amount, ExpenditureType type)
 {
     auto& gameState = getGameState();
-    AddClamp(&gameState.cash, -amount);
+    gameState.cash = AddClamp(gameState.cash, -amount);
 
     gameState.expenditureTable[0][EnumValue(type)] -= amount;
     if (dword_988E60[EnumValue(type)] & 1)

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -76,9 +76,8 @@ bool FinanceCheckAffordability(money64 cost, uint32_t flags)
  */
 void FinancePayment(money64 amount, ExpenditureType type)
 {
-    // overflow check
     auto& gameState = getGameState();
-    gameState.cash = AddClamp<money64>(gameState.cash, -amount);
+    AddClamp(&gameState.cash, -amount);
 
     gameState.expenditureTable[0][EnumValue(type)] -= amount;
     if (dword_988E60[EnumValue(type)] & 1)

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -455,7 +455,7 @@ int32_t Vehicle::CableLiftUpdateTrackMotion()
         vehicleCount++;
 
         massTotal += vehicle->mass;
-        accelerationTotal = AddClamp<int32_t>(accelerationTotal, vehicle->acceleration);
+        AddClamp(&accelerationTotal, vehicle->acceleration);
     }
 
     int32_t newAcceleration = (accelerationTotal / vehicleCount) >> 9;

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -455,7 +455,7 @@ int32_t Vehicle::CableLiftUpdateTrackMotion()
         vehicleCount++;
 
         massTotal += vehicle->mass;
-        AddClamp(&accelerationTotal, vehicle->acceleration);
+        accelerationTotal = AddClamp(accelerationTotal, vehicle->acceleration);
     }
 
     int32_t newAcceleration = (accelerationTotal / vehicleCount) >> 9;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -876,14 +876,14 @@ void Vehicle::UpdateMeasurements()
 
         if (curRide->averageSpeedTestTimeout == 0 && absVelocity > 0)
         {
-            curRide->averageSpeed = AddClamp<int32_t>(curRide->averageSpeed, absVelocity);
+            AddClamp(&curRide->averageSpeed, absVelocity);
             stationForTestSegment.SegmentTime++;
         }
 
         int32_t distance = abs(((velocity + acceleration) >> 10) * 42);
         if (NumLaps == 0)
         {
-            stationForTestSegment.SegmentLength = AddClamp<int32_t>(stationForTestSegment.SegmentLength, distance);
+            AddClamp(&stationForTestSegment.SegmentLength, distance);
         }
 
         if (curRide->getRideTypeDescriptor().HasFlag(RtdFlag::hasGForces))
@@ -1187,7 +1187,7 @@ void Vehicle::UpdateMeasurements()
     if (distance < 0)
         return;
 
-    curRide->shelteredLength = AddClamp<int32_t>(curRide->shelteredLength, distance);
+    AddClamp(&curRide->shelteredLength, distance);
 }
 
 struct SoundIdVolume

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -876,14 +876,14 @@ void Vehicle::UpdateMeasurements()
 
         if (curRide->averageSpeedTestTimeout == 0 && absVelocity > 0)
         {
-            AddClamp(&curRide->averageSpeed, absVelocity);
+            curRide->averageSpeed = AddClamp(curRide->averageSpeed, absVelocity);
             stationForTestSegment.SegmentTime++;
         }
 
         int32_t distance = abs(((velocity + acceleration) >> 10) * 42);
         if (NumLaps == 0)
         {
-            AddClamp(&stationForTestSegment.SegmentLength, distance);
+            stationForTestSegment.SegmentLength = AddClamp(stationForTestSegment.SegmentLength, distance);
         }
 
         if (curRide->getRideTypeDescriptor().HasFlag(RtdFlag::hasGForces))
@@ -1187,7 +1187,7 @@ void Vehicle::UpdateMeasurements()
     if (distance < 0)
         return;
 
-    AddClamp(&curRide->shelteredLength, distance);
+    curRide->shelteredLength = AddClamp(curRide->shelteredLength, distance);
 }
 
 struct SoundIdVolume

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -227,7 +227,7 @@ void ScenarioSuccessSubmitName(GameState_t& gameState, const char* name)
 static void ScenarioCheckEntranceFeeTooHigh()
 {
     const auto& gameState = getGameState();
-    const auto max_fee = AddClamp<money64>(gameState.totalRideValueForMoney, gameState.totalRideValueForMoney / 2);
+    const auto max_fee = AddClamp(gameState.totalRideValueForMoney, gameState.totalRideValueForMoney / 2);
 
     if ((gameState.park.Flags & PARK_FLAGS_PARK_OPEN) && Park::GetEntranceFee() > max_fee)
     {

--- a/src/openrct2/util/Util.h
+++ b/src/openrct2/util/Util.h
@@ -17,27 +17,65 @@
 uint32_t UtilRand();
 float UtilRandNormalDistributed();
 
-template<typename T>
-constexpr T AddClamp(T value, T valueToAdd)
+template<typename T1, typename T2 = T1>
+constexpr T1 AddClamp(T1 value, T2 valueToAdd)
 {
-    if (std::is_same_v<decltype(value), money64>)
+    static_assert(std::is_arithmetic_v<T1> && std::is_arithmetic_v<T2>);
+    if (std::is_same_v<T1, money64>)
     {
         static_assert(sizeof(money64) == sizeof(int64_t));
     }
-    auto maxCap = std::numeric_limits<T>::max();
-    auto minCap = std::numeric_limits<T>::lowest();
-    if ((valueToAdd > 0) && (value > (maxCap - (valueToAdd))))
+
+    using CommonT = decltype(value + valueToAdd);
+    auto maxCap = static_cast<CommonT>(std::numeric_limits<T1>::max());
+    auto minCap = static_cast<CommonT>(std::numeric_limits<T1>::lowest());
+
+    CommonT result;
+    if ((valueToAdd > 0) && (static_cast<CommonT>(value) > (maxCap - valueToAdd)))
     {
-        return maxCap;
+        result = maxCap;
     }
-    else if ((valueToAdd < 0) && (value < (minCap - (valueToAdd))))
+    else if ((valueToAdd < 0) && (static_cast<CommonT>(value) < (minCap - valueToAdd)))
     {
-        return minCap;
+        result = minCap;
     }
     else
     {
-        return value + valueToAdd;
+        result = static_cast<CommonT>(value) + valueToAdd;
     }
+
+    return static_cast<T1>(result);
+}
+
+template<typename T1, typename T2 = T1>
+constexpr void AddClamp(T1* value, T2 valueToAdd)
+{
+    static_assert(std::is_arithmetic_v<T1> && std::is_arithmetic_v<T2>);
+    if (std::is_same_v<T1, money64>)
+    {
+        static_assert(sizeof(money64) == sizeof(int64_t));
+    }
+
+    using CommonT = decltype(*value + valueToAdd);
+    auto maxCap = static_cast<CommonT>(std::numeric_limits<T1>::max());
+    auto minCap = static_cast<CommonT>(std::numeric_limits<T1>::lowest());
+
+    CommonT v = static_cast<CommonT>(*value);
+    CommonT result;
+    if ((valueToAdd > 0) && (v > (maxCap - valueToAdd)))
+    {
+        result = maxCap;
+    }
+    else if ((valueToAdd < 0) && (v < (minCap - valueToAdd)))
+    {
+        result = minCap;
+    }
+    else
+    {
+        result = v + valueToAdd;
+    }
+
+    *value = static_cast<T1>(result);
 }
 
 uint8_t Lerp(uint8_t a, uint8_t b, float t);

--- a/src/openrct2/util/Util.h
+++ b/src/openrct2/util/Util.h
@@ -47,37 +47,6 @@ constexpr T1 AddClamp(T1 value, T2 valueToAdd)
     return static_cast<T1>(result);
 }
 
-template<typename T1, typename T2 = T1>
-constexpr void AddClamp(T1* value, T2 valueToAdd)
-{
-    static_assert(std::is_arithmetic_v<T1> && std::is_arithmetic_v<T2>);
-    if (std::is_same_v<T1, money64>)
-    {
-        static_assert(sizeof(money64) == sizeof(int64_t));
-    }
-
-    using CommonT = decltype(*value + valueToAdd);
-    auto maxCap = static_cast<CommonT>(std::numeric_limits<T1>::max());
-    auto minCap = static_cast<CommonT>(std::numeric_limits<T1>::lowest());
-
-    CommonT v = static_cast<CommonT>(*value);
-    CommonT result;
-    if ((valueToAdd > 0) && (v > (maxCap - valueToAdd)))
-    {
-        result = maxCap;
-    }
-    else if ((valueToAdd < 0) && (v < (minCap - valueToAdd)))
-    {
-        result = minCap;
-    }
-    else
-    {
-        result = v + valueToAdd;
-    }
-
-    *value = static_cast<T1>(result);
-}
-
 uint8_t Lerp(uint8_t a, uint8_t b, float t);
 float FLerp(float a, float b, float t);
 uint8_t SoftLight(uint8_t a, uint8_t b);

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -531,8 +531,7 @@ namespace OpenRCT2::Park
 
         auto result = gameState.park.Value - gameState.bankLoan;
 
-        // Clamp addition to prevent overflow
-        result = AddClamp<money64>(result, FinanceGetCurrentCash());
+        AddClamp(&result, FinanceGetCurrentCash());
 
         return result;
     }

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -531,7 +531,7 @@ namespace OpenRCT2::Park
 
         auto result = gameState.park.Value - gameState.bankLoan;
 
-        AddClamp(&result, FinanceGetCurrentCash());
+        result = AddClamp(result, FinanceGetCurrentCash());
 
         return result;
     }


### PR DESCRIPTION
This makes calls to AddClamp cleaner. The return type can still be made explicit (in the pure implementation) like before, but now it's entirely optional.