### PR TITLE
Fix park fences drawing underneath and through opaque water

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#24353] ‘Show dirty visuals’ is off by one pixel and does not work correctly with higher framerates.
 - Fix: [#24362] When upgrading from an older version on Windows, old versions of official objects are not always removed.  
 - Fix: [#24371] Fix divide by zero in the scenery window when there is no scenery.
+- Fix: [#24403] Park fences draw underneath and through opaque water.
 
 0.4.22 (2025-05-04)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -1298,6 +1298,8 @@ void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, con
 
     const uint16_t waterHeight = tileElement.GetWaterHeight();
     const bool waterGetsClipped = (session.ViewFlags & VIEWPORT_FLAG_CLIP_VIEW) && (waterHeight > gClipHeight * kCoordsZStep);
+    const bool waterIsTransparent = Config::Get().general.TransparentWater
+        || (session.ViewFlags & VIEWPORT_FLAG_UNDERGROUND_INSIDE);
 
     if (waterHeight > 0 && !gTrackDesignSaveMode && !waterGetsClipped)
     {
@@ -1317,9 +1319,8 @@ void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, con
         const auto image_id = ImageId(SPR_WATER_MASK + image_offset, FilterPaletteID::PaletteWater).WithBlended(true);
         PaintAddImageAsParent(session, image_id, { 0, 0, waterHeight }, { 32, 32, -1 });
 
-        const bool transparent = Config::Get().general.TransparentWater
-            || (session.ViewFlags & VIEWPORT_FLAG_UNDERGROUND_INSIDE);
-        const uint32_t overlayStart = transparent ? EnumValue(SPR_WATER_OVERLAY) : EnumValue(SPR_G2_OPAQUE_WATER_OVERLAY);
+        const uint32_t overlayStart = waterIsTransparent ? EnumValue(SPR_WATER_OVERLAY)
+                                                         : EnumValue(SPR_G2_OPAQUE_WATER_OVERLAY);
         PaintAttachToPreviousPS(session, ImageId(overlayStart + image_offset), 0, 0);
 
         if (!(session.ViewFlags & VIEWPORT_FLAG_HIDE_VERTICAL))
@@ -1350,7 +1351,7 @@ void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, con
             if (edgeHasFence == 0)
                 continue;
 
-            int32_t local_height = height;
+            int32_t fenceHeight = height;
             int32_t image_id = 0;
 
             if (!(surfaceShape & fenceData.bit_1))
@@ -1370,7 +1371,7 @@ void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, con
             }
             else
             {
-                local_height += 16;
+                fenceHeight += 16;
 
                 if (!(surfaceShape & 0x10))
                 { // Loc6619B5 (first)
@@ -1390,9 +1391,14 @@ void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, con
                 }
             }
 
+            if (!waterIsTransparent && fenceHeight < waterHeight)
+            {
+                continue;
+            }
+
             PaintAddImageAsParent(
-                session, ImageId(image_id), { fenceData.offset, local_height },
-                { { fenceData.Boundbox.offset, local_height + 1 }, { fenceData.Boundbox.length, 9 } });
+                session, ImageId(image_id), { fenceData.offset, fenceHeight },
+                { { fenceData.Boundbox.offset, fenceHeight + 1 }, { fenceData.Boundbox.length, 9 } });
         }
     }
 


### PR DESCRIPTION
This fixes park fences drawing underneath and through opaque water.
This should be equivalent to how they are drawn in RCT1.

Here's a little test park. You can also check the islands on Barony Bridge, and any other park where the park fence goes through water.

[Urban Park.zip](https://github.com/user-attachments/files/20214684/Urban.Park.zip)

Here it is in RCT1:
![RCT1](https://github.com/user-attachments/assets/987cff74-6ce5-4504-b6bc-a8573ea8dc61)
Current ORCT2:
![ORCT2](https://github.com/user-attachments/assets/5974d7d3-2e20-4866-af0c-95b467bd0ed8)
This fix:
![ORCT2Fix](https://github.com/user-attachments/assets/1fce0563-24cb-40b3-b5a4-ab3d6167c115)
