### PR TITLE
Remove the use of shared_ptr for the Context

### DIFF
--- a/src/openrct2-ui/TextComposition.cpp
+++ b/src/openrct2-ui/TextComposition.cpp
@@ -150,7 +150,7 @@ void TextComposition::HandleMessage(const SDL_Event* e)
 
             auto [key, scancode] = ProcessKeyPress(rawKey, rawScancode);
 
-            GetContext()->GetUiContext()->SetKeysPressed(key, scancode);
+            GetContext()->GetUiContext().SetKeysPressed(key, scancode);
 
             // Text input
             if (_session.Buffer == nullptr)
@@ -218,7 +218,7 @@ void TextComposition::HandleMessage(const SDL_Event* e)
                 case SDLK_c:
                     if ((modifier & KB_PRIMARY_MODIFIER) && _session.Length)
                     {
-                        GetContext()->GetUiContext()->SetClipboardText(_session.Buffer->c_str());
+                        GetContext()->GetUiContext().SetClipboardText(_session.Buffer->c_str());
                         ContextShowError(STR_COPY_INPUT_TO_CLIPBOARD, kStringIdNone, {});
                     }
                     break;
@@ -234,7 +234,7 @@ void TextComposition::HandleMessage(const SDL_Event* e)
                 case SDLK_x:
                     if ((modifier & KB_PRIMARY_MODIFIER) && _session.Length)
                     {
-                        GetContext()->GetUiContext()->SetClipboardText(_session.Buffer->c_str());
+                        GetContext()->GetUiContext().SetClipboardText(_session.Buffer->c_str());
                         Clear();
                         Windows::WindowUpdateTextbox();
                         ContextShowError(STR_COPY_INPUT_TO_CLIPBOARD, kStringIdNone, {});

--- a/src/openrct2-ui/Ui.cpp
+++ b/src/openrct2-ui/Ui.cpp
@@ -67,19 +67,19 @@ int main(int argc, const char** argv)
         else
         {
             // Run OpenRCT2 with a UI context
-            auto env = ToShared(CreatePlatformEnvironment());
-            std::shared_ptr<IAudioContext> audioContext;
+            auto env = CreatePlatformEnvironment();
+            std::unique_ptr<IAudioContext> audioContext;
             try
             {
-                audioContext = ToShared(CreateAudioContext());
+                audioContext = CreateAudioContext();
             }
             catch (const SDLException& e)
             {
                 LOG_WARNING("Failed to create audio context. Using dummy audio context. Error message was: %s", e.what());
-                audioContext = ToShared(CreateDummyAudioContext());
+                audioContext = CreateDummyAudioContext();
             }
-            auto uiContext = ToShared(CreateUiContext(env));
-            context = CreateContext(env, audioContext, uiContext);
+            auto uiContext = CreateUiContext(*env);
+            context = CreateContext(std::move(env), std::move(audioContext), std::move(uiContext));
         }
         rc = context->RunOpenRCT2(argc, argv);
     }

--- a/src/openrct2-ui/UiContext.Linux.cpp
+++ b/src/openrct2-ui/UiContext.Linux.cpp
@@ -413,9 +413,9 @@ namespace OpenRCT2::Ui
 
         static void ThrowMissingDialogApp()
         {
-            auto uiContext = GetContext()->GetUiContext();
+            auto& uiContext = GetContext()->GetUiContext();
             std::string dialogMissingWarning = LanguageGetString(STR_MISSING_DIALOG_APPLICATION_ERROR);
-            uiContext->ShowMessageBox(dialogMissingWarning);
+            uiContext.ShowMessageBox(dialogMissingWarning);
             throw std::runtime_error(dialogMissingWarning);
         }
 

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -1054,8 +1054,8 @@ private:
 
     void SetAudioVolume(float value)
     {
-        auto audioContext = GetContext()->GetAudioContext();
-        auto mixer = audioContext->GetMixer();
+        auto& audioContext = GetContext()->GetAudioContext();
+        auto* mixer = audioContext.GetMixer();
         if (mixer != nullptr)
         {
             mixer->SetVolume(value);
@@ -1070,18 +1070,18 @@ std::unique_ptr<IUiContext> OpenRCT2::Ui::CreateUiContext(IPlatformEnvironment& 
 
 InGameConsole& OpenRCT2::Ui::GetInGameConsole()
 {
-    auto uiContext = std::static_pointer_cast<UiContext>(GetContext()->GetUiContext());
-    return uiContext->GetInGameConsole();
+    auto& uiContext = static_cast<UiContext&>(GetContext()->GetUiContext());
+    return uiContext.GetInGameConsole();
 }
 
 InputManager& OpenRCT2::Ui::GetInputManager()
 {
-    auto uiContext = std::static_pointer_cast<UiContext>(GetContext()->GetUiContext());
-    return uiContext->GetInputManager();
+    auto& uiContext = static_cast<UiContext&>(GetContext()->GetUiContext());
+    return uiContext.GetInputManager();
 }
 
 ShortcutManager& OpenRCT2::Ui::GetShortcutManager()
 {
-    auto uiContext = std::static_pointer_cast<UiContext>(GetContext()->GetUiContext());
-    return uiContext->GetShortcutManager();
+    auto& uiContext = static_cast<UiContext&>(GetContext()->GetUiContext());
+    return uiContext.GetShortcutManager();
 }

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -115,7 +115,7 @@ public:
         return _shortcutManager;
     }
 
-    explicit UiContext(const std::shared_ptr<IPlatformEnvironment>& env)
+    explicit UiContext(IPlatformEnvironment& env)
         : _platformUiContext(CreatePlatformUiContext())
         , _windowManager(CreateWindowManager())
         , _shortcutManager(env)
@@ -1063,7 +1063,7 @@ private:
     }
 };
 
-std::unique_ptr<IUiContext> OpenRCT2::Ui::CreateUiContext(const std::shared_ptr<IPlatformEnvironment>& env)
+std::unique_ptr<IUiContext> OpenRCT2::Ui::CreateUiContext(IPlatformEnvironment& env)
 {
     return std::make_unique<UiContext>(env);
 }

--- a/src/openrct2-ui/UiContext.h
+++ b/src/openrct2-ui/UiContext.h
@@ -50,7 +50,7 @@ namespace OpenRCT2::Ui
         virtual bool HasFilePicker() const = 0;
     };
 
-    [[nodiscard]] std::unique_ptr<IUiContext> CreateUiContext(const std::shared_ptr<IPlatformEnvironment>& env);
+    [[nodiscard]] std::unique_ptr<IUiContext> CreateUiContext(IPlatformEnvironment& env);
     [[nodiscard]] std::unique_ptr<IPlatformUiContext> CreatePlatformUiContext();
 
     [[nodiscard]] InGameConsole& GetInGameConsole();

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -737,9 +737,9 @@ public:
 
     static ScreenCoordsXY GetAutoPositionForNewWindow(int32_t width, int32_t height)
     {
-        auto uiContext = GetContext()->GetUiContext();
-        auto screenWidth = uiContext->GetWidth();
-        auto screenHeight = uiContext->GetHeight();
+        auto& uiContext = GetContext()->GetUiContext();
+        auto screenWidth = uiContext.GetWidth();
+        auto screenHeight = uiContext.GetHeight();
 
         // Place window in an empty corner of the screen
         const ScreenCoordsXY cornerPositions[] = {
@@ -827,9 +827,9 @@ public:
 
     static ScreenCoordsXY GetCentrePositionForNewWindow(int32_t width, int32_t height)
     {
-        auto uiContext = GetContext()->GetUiContext();
-        auto screenWidth = uiContext->GetWidth();
-        auto screenHeight = uiContext->GetHeight();
+        auto& uiContext = GetContext()->GetUiContext();
+        auto screenWidth = uiContext.GetWidth();
+        auto screenHeight = uiContext.GetHeight();
         return ScreenCoordsXY{ (screenWidth - width) / 2, std::max(kTopToolbarHeight + 1, (screenHeight - height) / 2) };
     }
 

--- a/src/openrct2-ui/audio/SDLAudioSource.cpp
+++ b/src/openrct2-ui/audio/SDLAudioSource.cpp
@@ -53,7 +53,7 @@ IAudioMixer* SDLAudioSource::GetMixer()
     if (ctx == nullptr)
         return nullptr;
 
-    auto audioContext = ctx->GetAudioContext();
+    auto& audioContext = ctx->GetAudioContext();
     return audioContext.GetMixer();
 }
 

--- a/src/openrct2-ui/audio/SDLAudioSource.cpp
+++ b/src/openrct2-ui/audio/SDLAudioSource.cpp
@@ -54,10 +54,7 @@ IAudioMixer* SDLAudioSource::GetMixer()
         return nullptr;
 
     auto audioContext = ctx->GetAudioContext();
-    if (audioContext == nullptr)
-        return nullptr;
-
-    return audioContext->GetMixer();
+    return audioContext.GetMixer();
 }
 
 int32_t SDLAudioSource::GetBytesPerSecond() const

--- a/src/openrct2-ui/drawing/engines/DrawingEngineFactory.hpp
+++ b/src/openrct2-ui/drawing/engines/DrawingEngineFactory.hpp
@@ -17,18 +17,15 @@ namespace OpenRCT2::Ui
 {
     struct IUiContext;
 
-    [[nodiscard]] std::unique_ptr<Drawing::IDrawingEngine> CreateHardwareDisplayDrawingEngine(
-        const std::shared_ptr<IUiContext>& uiContext);
+    [[nodiscard]] std::unique_ptr<Drawing::IDrawingEngine> CreateHardwareDisplayDrawingEngine(IUiContext& uiContext);
 #ifndef DISABLE_OPENGL
-    [[nodiscard]] std::unique_ptr<Drawing::IDrawingEngine> CreateOpenGLDrawingEngine(
-        const std::shared_ptr<IUiContext>& uiContext);
+    [[nodiscard]] std::unique_ptr<Drawing::IDrawingEngine> CreateOpenGLDrawingEngine(IUiContext& uiContext);
 #endif
 
     class DrawingEngineFactory final : public Drawing::IDrawingEngineFactory
     {
     public:
-        [[nodiscard]] std::unique_ptr<Drawing::IDrawingEngine> Create(
-            DrawingEngine type, const std::shared_ptr<IUiContext>& uiContext) override
+        [[nodiscard]] std::unique_ptr<Drawing::IDrawingEngine> Create(DrawingEngine type, IUiContext& uiContext) override
         {
             switch (type)
             {

--- a/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
@@ -33,7 +33,7 @@ private:
     constexpr static uint32_t kDirtyVisualTime = 40;
     constexpr static uint32_t kDirtyRegionAlpha = 100;
 
-    std::shared_ptr<IUiContext> const _uiContext;
+    IUiContext& _uiContext;
     SDL_Window* _window = nullptr;
     SDL_Renderer* _sdlRenderer = nullptr;
     SDL_Texture* _screenTexture = nullptr;
@@ -54,11 +54,11 @@ private:
     bool smoothNN = false;
 
 public:
-    explicit HardwareDisplayDrawingEngine(const std::shared_ptr<IUiContext>& uiContext)
+    explicit HardwareDisplayDrawingEngine(IUiContext& uiContext)
         : X8DrawingEngine(uiContext)
         , _uiContext(uiContext)
     {
-        _window = static_cast<SDL_Window*>(_uiContext->GetWindow());
+        _window = static_cast<SDL_Window*>(_uiContext.GetWindow());
     }
 
     ~HardwareDisplayDrawingEngine() override
@@ -128,7 +128,7 @@ public:
             }
         }
 
-        ScaleQuality scaleQuality = GetContext()->GetUiContext()->GetScaleQuality();
+        ScaleQuality scaleQuality = GetContext()->GetUiContext().GetScaleQuality();
         if (scaleQuality == ScaleQuality::SmoothNearestNeighbour)
         {
             scaleQuality = ScaleQuality::Linear;
@@ -270,7 +270,7 @@ private:
             RenderDirtyVisuals();
         }
 
-        bool isSteamOverlayActive = GetContext()->GetUiContext()->IsSteamOverlayActive();
+        bool isSteamOverlayActive = GetContext()->GetUiContext().IsSteamOverlayActive();
         if (isSteamOverlayActive && Config::Get().general.SteamOverlayPause)
         {
             OverlayPreRenderCheck();
@@ -428,7 +428,7 @@ private:
     }
 };
 
-std::unique_ptr<IDrawingEngine> OpenRCT2::Ui::CreateHardwareDisplayDrawingEngine(const std::shared_ptr<IUiContext>& uiContext)
+std::unique_ptr<IDrawingEngine> OpenRCT2::Ui::CreateHardwareDisplayDrawingEngine(IUiContext& uiContext)
 {
     return std::make_unique<HardwareDisplayDrawingEngine>(uiContext);
 }

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -193,7 +193,7 @@ public:
 class OpenGLDrawingEngine final : public IDrawingEngine
 {
 private:
-    std::shared_ptr<IUiContext> const _uiContext;
+    IUiContext& _uiContext;
     SDL_Window* _window = nullptr;
     SDL_GLContext _context = nullptr;
 
@@ -218,12 +218,12 @@ public:
     SDL_Color Palette[256];
     vec4 GLPalette[256];
 
-    explicit OpenGLDrawingEngine(const std::shared_ptr<IUiContext>& uiContext)
+    explicit OpenGLDrawingEngine(IUiContext& uiContext)
         : _uiContext(uiContext)
         , _drawingContext(std::make_unique<OpenGLDrawingContext>(*this))
         , _weatherDrawer(_drawingContext.get())
     {
-        _window = static_cast<SDL_Window*>(_uiContext->GetWindow());
+        _window = static_cast<SDL_Window*>(_uiContext.GetWindow());
         _mainRT.DrawingEngine = this;
         LightFx::SetAvailable(false);
     }
@@ -555,11 +555,11 @@ private:
         _screenFramebuffer = std::make_unique<OpenGLFramebuffer>(_window);
         _smoothScaleFramebuffer.reset();
         _scaleFramebuffer.reset();
-        if (GetContext()->GetUiContext()->GetScaleQuality() != ScaleQuality::NearestNeighbour)
+        if (GetContext()->GetUiContext().GetScaleQuality() != ScaleQuality::NearestNeighbour)
         {
             _scaleFramebuffer = std::make_unique<OpenGLFramebuffer>(_width, _height, false, false);
         }
-        if (GetContext()->GetUiContext()->GetScaleQuality() == ScaleQuality::SmoothNearestNeighbour)
+        if (GetContext()->GetUiContext().GetScaleQuality() == ScaleQuality::SmoothNearestNeighbour)
         {
             uint32_t scale = std::ceil(Config::Get().general.WindowScale);
             _smoothScaleFramebuffer = std::make_unique<OpenGLFramebuffer>(_width * scale, _height * scale, false, false);
@@ -572,7 +572,7 @@ private:
     }
 };
 
-std::unique_ptr<IDrawingEngine> OpenRCT2::Ui::CreateOpenGLDrawingEngine(const std::shared_ptr<IUiContext>& uiContext)
+std::unique_ptr<IDrawingEngine> OpenRCT2::Ui::CreateOpenGLDrawingEngine(IUiContext& uiContext)
 {
     return std::make_unique<OpenGLDrawingEngine>(uiContext);
 }

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLShaderProgram.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLShaderProgram.cpp
@@ -58,8 +58,8 @@ GLuint OpenGLShader::GetShaderId()
 
 std::string OpenGLShader::GetPath(const std::string& name)
 {
-    auto env = GetContext()->GetPlatformEnvironment();
-    auto shadersPath = env->GetDirectoryPath(DirBase::openrct2, DirId::shaders);
+    auto& env = GetContext()->GetPlatformEnvironment();
+    auto shadersPath = env.GetDirectoryPath(DirBase::openrct2, DirId::shaders);
     auto path = Path::Combine(shadersPath, name);
     if (_type == GL_VERTEX_SHADER)
     {

--- a/src/openrct2-ui/input/ShortcutManager.cpp
+++ b/src/openrct2-ui/input/ShortcutManager.cpp
@@ -108,7 +108,7 @@ std::string RegisteredShortcut::GetDisplayString() const
     return result;
 }
 
-ShortcutManager::ShortcutManager(const std::shared_ptr<IPlatformEnvironment>& env)
+ShortcutManager::ShortcutManager(IPlatformEnvironment& env)
     : _env(env)
 {
     RegisterDefaultShortcuts();
@@ -196,7 +196,7 @@ void ShortcutManager::LoadUserBindings()
 {
     try
     {
-        auto path = fs::u8path(_env->GetFilePath(PathId::configShortcuts));
+        auto path = fs::u8path(_env.GetFilePath(PathId::configShortcuts));
         if (fs::exists(path))
         {
             LoadUserBindings(path);
@@ -206,7 +206,7 @@ void ShortcutManager::LoadUserBindings()
             try
             {
                 Console::WriteLine("Importing legacy shortcuts...");
-                auto legacyPath = fs::u8path(_env->GetFilePath(PathId::configShortcutsLegacy));
+                auto legacyPath = fs::u8path(_env.GetFilePath(PathId::configShortcutsLegacy));
                 if (fs::exists(legacyPath))
                 {
                     LoadLegacyBindings(legacyPath);
@@ -317,7 +317,7 @@ void ShortcutManager::SaveUserBindings()
 {
     try
     {
-        auto path = fs::u8path(_env->GetFilePath(PathId::configShortcuts));
+        auto path = fs::u8path(_env.GetFilePath(PathId::configShortcuts));
         SaveUserBindings(path);
     }
     catch (const std::exception& e)

--- a/src/openrct2-ui/input/ShortcutManager.h
+++ b/src/openrct2-ui/input/ShortcutManager.h
@@ -112,7 +112,7 @@ namespace OpenRCT2::Ui
     class ShortcutManager
     {
     private:
-        std::shared_ptr<IPlatformEnvironment> _env;
+        IPlatformEnvironment& _env;
         std::string _pendingShortcutChange;
 
         static std::optional<ShortcutInput> ConvertLegacyBinding(uint16_t binding);
@@ -126,7 +126,7 @@ namespace OpenRCT2::Ui
     public:
         std::unordered_map<std::string_view, RegisteredShortcut> Shortcuts;
 
-        ShortcutManager(const std::shared_ptr<IPlatformEnvironment>& env);
+        ShortcutManager(IPlatformEnvironment& env);
         ShortcutManager(const ShortcutManager&) = delete;
 
         void LoadUserBindings();

--- a/src/openrct2-ui/interface/FileBrowser.cpp
+++ b/src/openrct2-ui/interface/FileBrowser.cpp
@@ -37,7 +37,7 @@ namespace OpenRCT2::Ui::FileBrowser
     {
         RegisterCallback(callback);
 
-        auto hasFilePicker = OpenRCT2::GetContext()->GetUiContext()->HasFilePicker();
+        auto hasFilePicker = OpenRCT2::GetContext()->GetUiContext().HasFilePicker();
         auto& config = Config::Get().general;
 
         // Open system file picker?
@@ -144,11 +144,11 @@ namespace OpenRCT2::Ui::FileBrowser
                 break;
         }
 
-        auto env = GetContext()->GetPlatformEnvironment();
+        auto& env = GetContext()->GetPlatformEnvironment();
         if (subdir.has_value())
-            return env->GetDirectoryPath(DirBase::user, subdir.value());
+            return env.GetDirectoryPath(DirBase::user, subdir.value());
         else
-            return env->GetDirectoryPath(DirBase::user);
+            return env.GetDirectoryPath(DirBase::user);
     }
 
     const char* GetFilterPatternByType(const LoadSaveType type, const bool isSave)

--- a/src/openrct2-ui/interface/Theme.cpp
+++ b/src/openrct2-ui/interface/Theme.cpp
@@ -686,8 +686,8 @@ static constexpr UIThemeWindowEntry PredefinedThemeRCT1_Entries[] =
         std::string GetThemePath()
         {
             auto context = GetContext();
-            auto env = context->GetPlatformEnvironment();
-            return env->GetDirectoryPath(DirBase::user, DirId::themes);
+            auto& env = context->GetPlatformEnvironment();
+            return env.GetDirectoryPath(DirBase::user, DirId::themes);
         }
     } // namespace ThemeManager
 

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -132,7 +132,7 @@ namespace OpenRCT2::Ui::Windows
                     SetPage(widgetIndex - WIDX_TAB_ABOUT_OPENRCT2);
                     break;
                 case WIDX_JOIN_DISCORD:
-                    OpenRCT2::GetContext()->GetUiContext()->OpenURL("https://discord.gg/ZXZd8D8");
+                    OpenRCT2::GetContext()->GetUiContext().OpenURL("https://discord.gg/ZXZd8D8");
                     break;
                 case WIDX_CHANGELOG:
                     ContextOpenWindow(WindowClass::Changelog);
@@ -141,7 +141,7 @@ namespace OpenRCT2::Ui::Windows
                     ContextOpenWindowView(WV_NEW_VERSION_INFO);
                     break;
                 case WIDX_COPY_BUILD_INFO:
-                    OpenRCT2::GetContext()->GetUiContext()->SetClipboardText(gVersionInfoFull);
+                    OpenRCT2::GetContext()->GetUiContext().SetClipboardText(gVersionInfoFull);
                     break;
                 case WIDX_CONTRIBUTORS_BUTTON:
                     ContextOpenWindowView(WV_CONTRIBUTORS);

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -63,8 +63,8 @@ namespace OpenRCT2::Ui::Windows
          */
         const std::string GetText(PathId pathId)
         {
-            auto env = GetContext()->GetPlatformEnvironment();
-            auto path = env->GetFilePath(pathId);
+            auto& env = GetContext()->GetPlatformEnvironment();
+            auto path = env.GetFilePath(pathId);
             auto fs = std::ifstream(fs::u8path(path), std::ios::in);
             if (!fs.is_open())
             {
@@ -165,7 +165,7 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_OPEN_URL:
                     if (_newVersionInfo != nullptr)
                     {
-                        GetContext()->GetUiContext()->OpenURL("https://openrct2.io/download/release");
+                        GetContext()->GetUiContext().OpenURL("https://openrct2.io/download/release");
                     }
                     else
                     {

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -362,8 +362,8 @@ namespace OpenRCT2::Ui::Windows
 
         void InstallTrackDesign()
         {
-            auto env = OpenRCT2::GetContext()->GetPlatformEnvironment();
-            auto destPath = env->GetDirectoryPath(OpenRCT2::DirBase::user, OpenRCT2::DirId::trackDesigns);
+            auto& env = OpenRCT2::GetContext()->GetPlatformEnvironment();
+            auto destPath = env.GetDirectoryPath(OpenRCT2::DirBase::user, OpenRCT2::DirId::trackDesigns);
             if (!Path::CreateDirectory(destPath))
             {
                 LOG_ERROR("Unable to create directory '%s'", destPath.c_str());

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -365,7 +365,7 @@ namespace OpenRCT2::Ui::Windows
                     }
                 },
                 [](const ParkPreview preview) {
-                    auto* windowMgr = GetContext()->GetUiContext()->GetWindowManager();
+                    auto* windowMgr = GetContext()->GetUiContext().GetWindowManager();
                     auto* wnd = windowMgr->FindByClass(WindowClass::Loadsave);
                     if (wnd == nullptr)
                     {
@@ -497,8 +497,8 @@ namespace OpenRCT2::Ui::Windows
         {
             SetWidgets(window_loadsave_widgets);
 
-            const auto uiContext = OpenRCT2::GetContext()->GetUiContext();
-            if (!uiContext->HasFilePicker())
+            const auto& uiContext = OpenRCT2::GetContext()->GetUiContext();
+            if (!uiContext.HasFilePicker())
             {
                 disabled_widgets |= (1uLL << WIDX_SYSTEM_BROWSER);
                 widgets[WIDX_SYSTEM_BROWSER].type = WindowWidgetType::Empty;

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -377,7 +377,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             const auto clip = stream.str();
-            OpenRCT2::GetContext()->GetUiContext()->SetClipboardText(clip.c_str());
+            OpenRCT2::GetContext()->GetUiContext().SetClipboardText(clip.c_str());
         }
 
         void SelectObjectFromList(const int32_t index)
@@ -421,7 +421,7 @@ namespace OpenRCT2::Ui::Windows
                     if (selected_list_item > -1 && selected_list_item < no_list_items)
                     {
                         const auto name = std::string(_invalidEntries[selected_list_item].GetName());
-                        OpenRCT2::GetContext()->GetUiContext()->SetClipboardText(name.c_str());
+                        OpenRCT2::GetContext()->GetUiContext().SetClipboardText(name.c_str());
                     }
                     break;
                 case WIDX_COPY_ALL:

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -697,7 +697,7 @@ namespace OpenRCT2::Ui::Windows
             SetPressedTab();
 
             disabled_widgets = 0;
-            auto hasFilePicker = OpenRCT2::GetContext()->GetUiContext()->HasFilePicker();
+            auto hasFilePicker = OpenRCT2::GetContext()->GetUiContext().HasFilePicker();
             const bool advancedTabSelected = (WIDX_FIRST_TAB + page) == WIDX_TAB_ADVANCED;
             if (!hasFilePicker && advancedTabSelected)
             {
@@ -788,7 +788,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 case WIDX_RESOLUTION_DROPDOWN:
                 {
-                    const auto& resolutions = OpenRCT2::GetContext()->GetUiContext()->GetFullscreenResolutions();
+                    const auto& resolutions = OpenRCT2::GetContext()->GetUiContext().GetFullscreenResolutions();
 
                     int32_t selectedResolution = -1;
                     for (size_t i = 0; i < resolutions.size(); i++)
@@ -866,7 +866,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 case WIDX_RESOLUTION_DROPDOWN:
                 {
-                    const auto& resolutions = OpenRCT2::GetContext()->GetUiContext()->GetFullscreenResolutions();
+                    const auto& resolutions = OpenRCT2::GetContext()->GetUiContext().GetFullscreenResolutions();
 
                     const Resolution& resolution = resolutions[dropdownIndex];
                     if (resolution.Width != Config::Get().general.FullscreenWidth
@@ -1420,16 +1420,16 @@ namespace OpenRCT2::Ui::Windows
                     OpenRCT2::Audio::InitRideSounds(dropdownIndex);
                     if (dropdownIndex < OpenRCT2::Audio::GetDeviceCount())
                     {
-                        auto audioContext = GetContext()->GetAudioContext();
+                        auto& audioContext = GetContext()->GetAudioContext();
                         if (dropdownIndex == 0)
                         {
-                            audioContext->SetOutputDevice("");
+                            audioContext.SetOutputDevice("");
                             Config::Get().sound.Device = "";
                         }
                         else
                         {
                             const auto& deviceName = GetDeviceName(dropdownIndex);
-                            audioContext->SetOutputDevice(deviceName);
+                            audioContext.SetOutputDevice(deviceName);
                             Config::Get().sound.Device = deviceName;
                         }
                         Config::Save();
@@ -1981,7 +1981,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
                 case WIDX_PATH_TO_RCT1_BROWSE:
                 {
-                    auto rct1path = OpenRCT2::GetContext()->GetUiContext()->ShowDirectoryDialog(
+                    auto rct1path = OpenRCT2::GetContext()->GetUiContext().ShowDirectoryDialog(
                         LanguageGetString(STR_PATH_TO_RCT1_BROWSER));
                     if (!rct1path.empty())
                     {
@@ -2279,8 +2279,8 @@ namespace OpenRCT2::Ui::Windows
 
         static bool IsRCT1TitleMusicAvailable()
         {
-            auto env = GetContext()->GetPlatformEnvironment();
-            auto rct1path = env->GetDirectoryPath(DirBase::rct1);
+            auto& env = GetContext()->GetPlatformEnvironment();
+            auto rct1path = env.GetDirectoryPath(DirBase::rct1);
             return !rct1path.empty();
         }
 

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -244,9 +244,9 @@ namespace OpenRCT2::Ui::Windows
                     case DDIDX_OPEN_CONTENT_FOLDER:
                     {
                         auto context = OpenRCT2::GetContext();
-                        auto env = context->GetPlatformEnvironment();
-                        auto uiContext = context->GetUiContext();
-                        uiContext->OpenFolder(env->GetDirectoryPath(OpenRCT2::DirBase::user));
+                        auto& env = context->GetPlatformEnvironment();
+                        auto& uiContext = context->GetUiContext();
+                        uiContext.OpenFolder(env.GetDirectoryPath(OpenRCT2::DirBase::user));
                         break;
                     }
                     default:

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -493,7 +493,7 @@ namespace OpenRCT2::Ui::Windows
                             // Automatically fill the "OpenRCT2 build" input
                             auto versionStr = String::urlEncode(gVersionInfoFull);
                             url.append("&f299dd2a20432827d99b648f73eb4649b23f8ec98d158d6f82b81e43196ee36b=" + versionStr);
-                            OpenRCT2::GetContext()->GetUiContext()->OpenURL(url);
+                            OpenRCT2::GetContext()->GetUiContext().OpenURL(url);
                         }
                         break;
                         case DDIDX_UPDATE_AVAILABLE:

--- a/src/openrct2/AssetPackManager.cpp
+++ b/src/openrct2/AssetPackManager.cpp
@@ -68,12 +68,12 @@ void AssetPackManager::Scan()
     ClearAssetPacks();
 
     auto context = GetContext();
-    auto env = context->GetPlatformEnvironment();
+    auto& env = context->GetPlatformEnvironment();
 
-    auto openrct2Dir = fs::u8path(env->GetDirectoryPath(DirBase::openrct2, DirId::assetPacks));
+    auto openrct2Dir = fs::u8path(env.GetDirectoryPath(DirBase::openrct2, DirId::assetPacks));
     Scan(openrct2Dir);
 
-    auto userDirectory = fs::u8path(env->GetDirectoryPath(DirBase::user, DirId::assetPacks));
+    auto userDirectory = fs::u8path(env.GetDirectoryPath(DirBase::user, DirId::assetPacks));
     Path::CreateDirectory(userDirectory.u8string());
     Scan(userDirectory);
 }

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -105,9 +105,9 @@ namespace OpenRCT2
     {
     private:
         // Dependencies
-        std::shared_ptr<IPlatformEnvironment> const _env;
-        std::shared_ptr<IAudioContext> const _audioContext;
-        std::shared_ptr<IUiContext> const _uiContext;
+        std::unique_ptr<IPlatformEnvironment> const _env;
+        std::unique_ptr<IAudioContext> const _audioContext;
+        std::unique_ptr<IUiContext> const _uiContext;
 
         // Services
         std::unique_ptr<LocalisationService> _localisationService;
@@ -170,11 +170,11 @@ namespace OpenRCT2
 
     public:
         Context(
-            const std::shared_ptr<IPlatformEnvironment>& env, const std::shared_ptr<IAudioContext>& audioContext,
-            const std::shared_ptr<IUiContext>& uiContext)
-            : _env(env)
-            , _audioContext(audioContext)
-            , _uiContext(uiContext)
+            std::unique_ptr<IPlatformEnvironment>&& env, std::unique_ptr<IAudioContext>&& audioContext,
+            std::unique_ptr<IUiContext>& uiContext)
+            : _env(std::move(env))
+            , _audioContext(std::move(audioContext))
+            , _uiContext(std::move(uiContext))
             , _localisationService(std::make_unique<LocalisationService>(env))
             , _replayManager(CreateReplayManager())
             , _gameStateSnapshots(CreateGameStateSnapshots())
@@ -227,14 +227,14 @@ namespace OpenRCT2
             Instance = nullptr;
         }
 
-        std::shared_ptr<IAudioContext> GetAudioContext() override
+        IAudioContext& GetAudioContext() override
         {
-            return _audioContext;
+            return *_audioContext;
         }
 
-        std::shared_ptr<IUiContext> GetUiContext() override
+        IUiContext& GetUiContext() override
         {
-            return _uiContext;
+            return *_uiContext;
         }
 
 #ifdef ENABLE_SCRIPTING
@@ -244,9 +244,9 @@ namespace OpenRCT2
         }
 #endif
 
-        std::shared_ptr<IPlatformEnvironment> GetPlatformEnvironment() override
+        IPlatformEnvironment& GetPlatformEnvironment() override
         {
-            return _env;
+            return *_env;
         }
 
         Localisation::LocalisationService& GetLocalisationService() override
@@ -1581,10 +1581,10 @@ namespace OpenRCT2
     }
 
     std::unique_ptr<IContext> CreateContext(
-        const std::shared_ptr<IPlatformEnvironment>& env, const std::shared_ptr<Audio::IAudioContext>& audioContext,
-        const std::shared_ptr<IUiContext>& uiContext)
+        std::unique_ptr<IPlatformEnvironment>&& env, std::unique_ptr<Audio::IAudioContext>&& audioContext,
+        std::unique_ptr<IUiContext>&& uiContext)
     {
-        return std::make_unique<Context>(env, audioContext, uiContext);
+        return std::make_unique<Context>(std::move(env), std::move(audioContext), std::move(uiContext));
     }
 
     IContext* GetContext()

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -124,9 +124,9 @@ namespace OpenRCT2
     {
         virtual ~IContext() = default;
 
-        [[nodiscard]] virtual std::shared_ptr<Audio::IAudioContext> GetAudioContext() = 0;
-        [[nodiscard]] virtual std::shared_ptr<Ui::IUiContext> GetUiContext() = 0;
-        [[nodiscard]] virtual std::shared_ptr<IPlatformEnvironment> GetPlatformEnvironment() = 0;
+        [[nodiscard]] virtual Audio::IAudioContext& GetAudioContext() = 0;
+        [[nodiscard]] virtual Ui::IUiContext& GetUiContext() = 0;
+        [[nodiscard]] virtual IPlatformEnvironment& GetPlatformEnvironment() = 0;
         virtual Localisation::LocalisationService& GetLocalisationService() = 0;
         virtual IObjectManager& GetObjectManager() = 0;
         virtual IObjectRepository& GetObjectRepository() = 0;
@@ -184,8 +184,8 @@ namespace OpenRCT2
 
     [[nodiscard]] std::unique_ptr<IContext> CreateContext();
     [[nodiscard]] std::unique_ptr<IContext> CreateContext(
-        const std::shared_ptr<IPlatformEnvironment>& env, const std::shared_ptr<Audio::IAudioContext>& audioContext,
-        const std::shared_ptr<Ui::IUiContext>& uiContext);
+        std::unique_ptr<IPlatformEnvironment>&& env, std::unique_ptr<Audio::IAudioContext>&& audioContext,
+        std::unique_ptr<Ui::IUiContext>&& uiContext);
     [[nodiscard]] IContext* GetContext();
 } // namespace OpenRCT2
 

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -366,7 +366,7 @@ void GameLoadInit()
         WindowUnfollowSprite(*mainWindow);
     }
 
-    auto windowManager = context->GetUiContext()->GetWindowManager();
+    auto windowManager = context->GetUiContext().GetWindowManager();
     auto& gameState = getGameState();
     windowManager->SetMainView(gameState.savedView, gameState.savedViewZoom, gameState.savedViewRotation);
 
@@ -474,8 +474,8 @@ void SaveGameCmd(u8string_view name /* = {} */)
     }
     else
     {
-        auto env = GetContext()->GetPlatformEnvironment();
-        auto savePath = Path::Combine(env->GetDirectoryPath(DirBase::user, DirId::saves), u8string(name) + u8".park");
+        auto& env = GetContext()->GetPlatformEnvironment();
+        auto savePath = Path::Combine(env.GetDirectoryPath(DirBase::user, DirId::saves), u8string(name) + u8".park");
         SaveGameWithName(savePath);
     }
 }
@@ -517,12 +517,12 @@ static void LimitAutosaveCount(const size_t numberOfFilesToKeep, bool processLan
     size_t autosavesCount = 0;
     size_t numAutosavesToDelete = 0;
 
-    auto environment = GetContext()->GetPlatformEnvironment();
-    auto folderDirectory = environment->GetDirectoryPath(DirBase::user, DirId::saves);
+    auto& environment = GetContext()->GetPlatformEnvironment();
+    auto folderDirectory = environment.GetDirectoryPath(DirBase::user, DirId::saves);
     char const* fileFilter = "autosave_*.park";
     if (processLandscapeFolder)
     {
-        folderDirectory = environment->GetDirectoryPath(DirBase::user, DirId::landscapes);
+        folderDirectory = environment.GetDirectoryPath(DirBase::user, DirId::landscapes);
         fileFilter = "autosave_*.park";
     }
 
@@ -595,8 +595,8 @@ void GameAutosave()
     int32_t autosavesToKeep = Config::Get().general.AutosaveAmount;
     LimitAutosaveCount(autosavesToKeep - 1, isInEditorMode());
 
-    auto env = GetContext()->GetPlatformEnvironment();
-    auto autosaveDir = Path::Combine(env->GetDirectoryPath(DirBase::user, subDirectory), u8"autosave");
+    auto& env = GetContext()->GetPlatformEnvironment();
+    auto autosaveDir = Path::Combine(env.GetDirectoryPath(DirBase::user, subDirectory), u8"autosave");
     Path::CreateDirectory(autosaveDir);
 
     auto path = Path::Combine(autosaveDir, timeName);
@@ -711,7 +711,7 @@ void GameLoadOrQuitNoSavePrompt()
 void StartSilentRecord()
 {
     std::string name = Path::Combine(
-        OpenRCT2::GetContext()->GetPlatformEnvironment()->GetDirectoryPath(OpenRCT2::DirBase::user), u8"debug_replay.parkrep");
+        OpenRCT2::GetContext()->GetPlatformEnvironment().GetDirectoryPath(OpenRCT2::DirBase::user), u8"debug_replay.parkrep");
     auto* replayManager = OpenRCT2::GetContext()->GetReplayManager();
     if (replayManager->StartRecording(name, OpenRCT2::k_MaxReplayTicks, OpenRCT2::IReplayManager::RecordType::SILENT))
     {

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -111,7 +111,7 @@ namespace OpenRCT2
 
         if (GameIsNotPaused() && gPreviewingTitleSequenceInGame)
         {
-            auto player = GetContext()->GetUiContext()->GetTitleSequencePlayer();
+            auto player = GetContext()->GetUiContext().GetTitleSequencePlayer();
             if (player != nullptr)
             {
                 player->Update();

--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -413,7 +413,7 @@ namespace OpenRCT2
                 // If there are difference write a log to the desyncs folder
                 if (res != cmpData.spriteChanges.end())
                 {
-                    std::string outputPath = GetContext()->GetPlatformEnvironment()->GetDirectoryPath(
+                    std::string outputPath = GetContext()->GetPlatformEnvironment().GetDirectoryPath(
                         DirBase::user, DirId::desyncLogs);
                     char uniqueFileName[128] = {};
                     snprintf(uniqueFileName, sizeof(uniqueFileName), "replay_desync_%u.txt", currentTicks);
@@ -624,7 +624,7 @@ namespace OpenRCT2
                 fileName += ".parkrep";
             }
 
-            std::string outPath = GetContext()->GetPlatformEnvironment()->GetDirectoryPath(
+            std::string outPath = GetContext()->GetPlatformEnvironment().GetDirectoryPath(
                 DirBase::user, DirId::replayRecordings);
             std::string outFile = Path::Combine(outPath, fileName);
 

--- a/src/openrct2/actions/MapChangeSizeAction.cpp
+++ b/src/openrct2/actions/MapChangeSizeAction.cpp
@@ -83,8 +83,8 @@ GameActions::Result MapChangeSizeAction::Execute() const
     }
 
     auto* ctx = OpenRCT2::GetContext();
-    auto uiContext = ctx->GetUiContext();
-    auto* windowManager = uiContext->GetWindowManager();
+    auto& uiContext = ctx->GetUiContext();
+    auto* windowManager = uiContext.GetWindowManager();
     OpenRCT2::Park::UpdateSize(gameState);
 
     windowManager->BroadcastIntent(Intent(INTENT_ACTION_MAP));

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -76,15 +76,15 @@ namespace OpenRCT2::Audio
 
     void Init()
     {
-        auto audioContext = GetContext()->GetAudioContext();
+        auto& audioContext = GetContext()->GetAudioContext();
         if (Config::Get().sound.Device.empty())
         {
-            audioContext->SetOutputDevice("");
+            audioContext.SetOutputDevice("");
             _currentAudioDevice = 0;
         }
         else
         {
-            audioContext->SetOutputDevice(Config::Get().sound.Device);
+            audioContext.SetOutputDevice(Config::Get().sound.Device);
 
             PopulateDevices();
             for (int32_t i = 0; i < GetDeviceCount(); i++)
@@ -115,8 +115,8 @@ namespace OpenRCT2::Audio
 
     void PopulateDevices()
     {
-        auto audioContext = OpenRCT2::GetContext()->GetAudioContext();
-        std::vector<std::string> devices = audioContext->GetOutputDevices();
+        auto& audioContext = OpenRCT2::GetContext()->GetAudioContext();
+        std::vector<std::string> devices = audioContext.GetOutputDevices();
 
         // Replace blanks with localised unknown string
         for (auto& device : devices)
@@ -252,8 +252,8 @@ namespace OpenRCT2::Audio
 
     static bool IsRCT1TitleMusicAvailable()
     {
-        auto env = GetContext()->GetPlatformEnvironment();
-        auto rct1path = env->GetDirectoryPath(DirBase::rct1);
+        auto& env = GetContext()->GetPlatformEnvironment();
+        auto rct1path = env.GetDirectoryPath(DirBase::rct1);
         return !rct1path.empty();
     }
 
@@ -453,8 +453,8 @@ namespace OpenRCT2::Audio
 
     static IAudioMixer* GetMixer()
     {
-        auto audioContext = GetContext()->GetAudioContext();
-        return audioContext->GetMixer();
+        auto& audioContext = GetContext()->GetAudioContext();
+        return audioContext.GetMixer();
     }
 
     std::shared_ptr<IAudioChannel> CreateAudioChannel(

--- a/src/openrct2/command_line/RootCommands.cpp
+++ b/src/openrct2/command_line/RootCommands.cpp
@@ -401,7 +401,7 @@ static exitcode_t HandleCommandScanObjects([[maybe_unused]] CommandLineArgEnumer
     gOpenRCT2NoGraphics = true;
 
     auto context = OpenRCT2::CreateContext();
-    auto env = context->GetPlatformEnvironment();
+    auto& env = context->GetPlatformEnvironment();
     auto objectRepository = CreateObjectRepository(env);
     objectRepository->Construct(Config::Get().general.Language);
     return EXITCODE_OK;

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -817,8 +817,8 @@ namespace OpenRCT2::Config
 
     u8string GetDefaultPath()
     {
-        auto env = GetContext()->GetPlatformEnvironment();
-        return Path::Combine(env->GetDirectoryPath(DirBase::user), u8"config.ini");
+        auto& env = GetContext()->GetPlatformEnvironment();
+        return Path::Combine(env.GetDirectoryPath(DirBase::user), u8"config.ini");
     }
 
     bool SaveToPath(u8string_view path)
@@ -846,10 +846,10 @@ namespace OpenRCT2::Config
                 return false;
             }
 
-            auto uiContext = GetContext()->GetUiContext();
-            if (!uiContext->HasFilePicker())
+            auto& uiContext = GetContext()->GetUiContext();
+            if (!uiContext.HasFilePicker())
             {
-                uiContext->ShowMessageBox(LanguageGetString(STR_NEEDS_RCT2_FILES_MANUAL));
+                uiContext.ShowMessageBox(LanguageGetString(STR_NEEDS_RCT2_FILES_MANUAL));
                 return false;
             }
 
@@ -858,18 +858,18 @@ namespace OpenRCT2::Config
                 const char* g1DatPath = PATH_SEPARATOR "Data" PATH_SEPARATOR "g1.dat";
                 while (true)
                 {
-                    uiContext->ShowMessageBox(LanguageGetString(STR_NEEDS_RCT2_FILES));
+                    uiContext.ShowMessageBox(LanguageGetString(STR_NEEDS_RCT2_FILES));
                     std::string gog = LanguageGetString(STR_OWN_ON_GOG);
                     std::string hdd = LanguageGetString(STR_INSTALLED_ON_HDD);
 
                     std::vector<std::string> options;
                     std::string chosenOption;
 
-                    if (uiContext->HasMenuSupport())
+                    if (uiContext.HasMenuSupport())
                     {
                         options.push_back(hdd);
                         options.push_back(gog);
-                        int optionIndex = uiContext->ShowMenuDialog(
+                        int optionIndex = uiContext.ShowMenuDialog(
                             options, LanguageGetString(STR_OPENRCT2_SETUP), LanguageGetString(STR_WHICH_APPLIES_BEST));
                         if (optionIndex < 0 || static_cast<uint32_t>(optionIndex) >= options.size())
                         {
@@ -889,7 +889,7 @@ namespace OpenRCT2::Config
                     std::vector<std::string> possibleInstallPaths{};
                     if (chosenOption == hdd)
                     {
-                        possibleInstallPaths.emplace_back(uiContext->ShowDirectoryDialog(LanguageGetString(STR_PICK_RCT2_DIR)));
+                        possibleInstallPaths.emplace_back(uiContext.ShowDirectoryDialog(LanguageGetString(STR_PICK_RCT2_DIR)));
                     }
                     else if (chosenOption == gog)
                     {
@@ -897,16 +897,16 @@ namespace OpenRCT2::Config
                         std::string dummy;
                         if (!Platform::FindApp("innoextract", &dummy))
                         {
-                            uiContext->ShowMessageBox(LanguageGetString(STR_INSTALL_INNOEXTRACT));
+                            uiContext.ShowMessageBox(LanguageGetString(STR_INSTALL_INNOEXTRACT));
                             return false;
                         }
 
                         const std::string dest = Path::Combine(
-                            GetContext()->GetPlatformEnvironment()->GetDirectoryPath(DirBase::config), "rct2");
+                            GetContext()->GetPlatformEnvironment().GetDirectoryPath(DirBase::config), "rct2");
 
                         while (true)
                         {
-                            uiContext->ShowMessageBox(LanguageGetString(STR_PLEASE_SELECT_GOG_INSTALLER));
+                            uiContext.ShowMessageBox(LanguageGetString(STR_PLEASE_SELECT_GOG_INSTALLER));
                             auto gogPath = SelectGogInstaller();
                             if (gogPath.empty())
                             {
@@ -914,12 +914,12 @@ namespace OpenRCT2::Config
                                 return false;
                             }
 
-                            uiContext->ShowMessageBox(LanguageGetString(STR_THIS_WILL_TAKE_A_FEW_MINUTES));
+                            uiContext.ShowMessageBox(LanguageGetString(STR_THIS_WILL_TAKE_A_FEW_MINUTES));
 
                             if (ExtractGogInstaller(gogPath, dest))
                                 break;
 
-                            uiContext->ShowMessageBox(LanguageGetString(STR_NOT_THE_GOG_INSTALLER));
+                            uiContext.ShowMessageBox(LanguageGetString(STR_NOT_THE_GOG_INSTALLER));
                         }
 
                         // New installer extracts to ‘dest’, old installer installs in ‘dest/app’.
@@ -940,7 +940,7 @@ namespace OpenRCT2::Config
                         }
                     }
 
-                    uiContext->ShowMessageBox(FormatStringIDLegacy(STR_COULD_NOT_FIND_AT_PATH, &g1DatPath));
+                    uiContext.ShowMessageBox(FormatStringIDLegacy(STR_COULD_NOT_FIND_AT_PATH, &g1DatPath));
                 }
             }
             catch (const std::exception& ex)

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -495,8 +495,8 @@ bool GfxLoadG1(const IPlatformEnvironment& env)
         LOG_FATAL("Unable to load g1 graphics");
         if (!gOpenRCT2Headless)
         {
-            auto uiContext = GetContext()->GetUiContext();
-            uiContext->ShowMessageBox("Unable to load g1.dat. Your RollerCoaster Tycoon 2 path may be incorrectly set.");
+            auto& uiContext = GetContext()->GetUiContext();
+            uiContext.ShowMessageBox("Unable to load g1.dat. Your RollerCoaster Tycoon 2 path may be incorrectly set.");
         }
         return false;
     }
@@ -529,9 +529,9 @@ void GfxUnloadCsg()
 static bool GfxLoadOpenRCT2Gx(std::string filename, Gx& target, size_t expectedNumItems)
 {
     LOG_VERBOSE("GfxLoadOpenRCT2Gx(\"%s\")", filename.c_str());
-    auto env = GetContext()->GetPlatformEnvironment();
+    auto& env = GetContext()->GetPlatformEnvironment();
 
-    std::string path = Path::Combine(env->GetDirectoryPath(DirBase::openrct2), filename.c_str());
+    std::string path = Path::Combine(env.GetDirectoryPath(DirBase::openrct2), filename.c_str());
 
     try
     {
@@ -555,9 +555,9 @@ static bool GfxLoadOpenRCT2Gx(std::string filename, Gx& target, size_t expectedN
 
             if (!gOpenRCT2Headless)
             {
-                auto uiContext = GetContext()->GetUiContext();
-                uiContext->ShowMessageBox(errorMessage);
-                uiContext->ShowMessageBox(
+                auto& uiContext = GetContext()->GetUiContext();
+                uiContext.ShowMessageBox(errorMessage);
+                uiContext.ShowMessageBox(
                     "Warning: You may experience graphical glitches if you continue. It's recommended "
                     "that you update "
                     + filename + " if you're seeing this message");
@@ -586,8 +586,8 @@ static bool GfxLoadOpenRCT2Gx(std::string filename, Gx& target, size_t expectedN
         LOG_FATAL("Unable to load %s graphics", filename.c_str());
         if (!gOpenRCT2Headless)
         {
-            auto uiContext = GetContext()->GetUiContext();
-            uiContext->ShowMessageBox("Unable to load " + filename);
+            auto& uiContext = GetContext()->GetUiContext();
+            uiContext.ShowMessageBox("Unable to load " + filename);
         }
     }
     return false;

--- a/src/openrct2/drawing/IDrawingEngine.h
+++ b/src/openrct2/drawing/IDrawingEngine.h
@@ -83,7 +83,7 @@ namespace OpenRCT2::Drawing
         {
         }
         [[nodiscard]] virtual std::unique_ptr<IDrawingEngine>
-            Create(DrawingEngine type, const std::shared_ptr<OpenRCT2::Ui::IUiContext>& uiContext) = 0;
+            Create(DrawingEngine type, OpenRCT2::Ui::IUiContext& uiContext) = 0;
     };
 
     struct IWeatherDrawer

--- a/src/openrct2/drawing/IDrawingEngine.h
+++ b/src/openrct2/drawing/IDrawingEngine.h
@@ -82,8 +82,8 @@ namespace OpenRCT2::Drawing
         virtual ~IDrawingEngineFactory()
         {
         }
-        [[nodiscard]] virtual std::unique_ptr<IDrawingEngine>
-            Create(DrawingEngine type, OpenRCT2::Ui::IUiContext& uiContext) = 0;
+        [[nodiscard]] virtual std::unique_ptr<IDrawingEngine> Create(DrawingEngine type, OpenRCT2::Ui::IUiContext& uiContext)
+            = 0;
     };
 
     struct IWeatherDrawer

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -68,8 +68,8 @@ void DrawingEngineResize()
         auto drawingEngine = context->GetDrawingEngine();
         if (drawingEngine != nullptr)
         {
-            auto uiContext = context->GetUiContext();
-            drawingEngine->Resize(uiContext->GetWidth(), uiContext->GetHeight());
+            auto& uiContext = context->GetUiContext();
+            drawingEngine->Resize(uiContext.GetWidth(), uiContext.GetHeight());
         }
     }
 }

--- a/src/openrct2/drawing/Weather.cpp
+++ b/src/openrct2/drawing/Weather.cpp
@@ -73,8 +73,8 @@ void DrawWeather(RenderTarget& rt, IWeatherDrawer* weatherDrawer)
         drawFunc = DrawSnowFunctions[EnumValue(weatherLevel)];
     }
 
-    auto uiContext = GetContext()->GetUiContext();
-    uiContext->DrawWeatherAnimation(weatherDrawer, rt, drawFunc);
+    auto& uiContext = GetContext()->GetUiContext();
+    uiContext.DrawWeatherAnimation(weatherDrawer, rt, drawFunc);
 }
 
 /**

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -118,7 +118,7 @@ void X8WeatherDrawer::Restore(RenderTarget& rt)
     #pragma GCC diagnostic ignored "-Wsuggest-final-methods"
 #endif
 
-X8DrawingEngine::X8DrawingEngine([[maybe_unused]] const std::shared_ptr<Ui::IUiContext>& uiContext)
+X8DrawingEngine::X8DrawingEngine([[maybe_unused]] Ui::IUiContext& uiContext)
 {
     _drawingContext = new X8DrawingContext(this);
     _mainRT.DrawingEngine = this;

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -72,7 +72,7 @@ namespace OpenRCT2
             InvalidationGrid _invalidationGrid;
 
         public:
-            explicit X8DrawingEngine(const std::shared_ptr<Ui::IUiContext>& uiContext);
+            explicit X8DrawingEngine(Ui::IUiContext& uiContext);
 
 #ifdef __WARN_SUGGEST_FINAL_METHODS__
     #pragma GCC diagnostic push

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1305,8 +1305,8 @@ static void ConsoleCommandLoadPark([[maybe_unused]] InteractiveConsole& console,
     if (String::indexOf(argv[0].c_str(), '/') == SIZE_MAX && String::indexOf(argv[0].c_str(), '\\') == SIZE_MAX)
     {
         // no / or \ was included. File should be in save dir.
-        auto env = OpenRCT2::GetContext()->GetPlatformEnvironment();
-        auto directory = env->GetDirectoryPath(OpenRCT2::DirBase::user, OpenRCT2::DirId::saves);
+        auto& env = OpenRCT2::GetContext()->GetPlatformEnvironment();
+        auto directory = env.GetDirectoryPath(OpenRCT2::DirBase::user, OpenRCT2::DirId::saves);
         savePath = Path::Combine(directory, argv[0]);
     }
     else
@@ -1378,7 +1378,7 @@ static void ConsoleCommandReplayStartRecord(InteractiveConsole& console, const a
     {
         name += ".parkrep";
     }
-    std::string outPath = OpenRCT2::GetContext()->GetPlatformEnvironment()->GetDirectoryPath(
+    std::string outPath = OpenRCT2::GetContext()->GetPlatformEnvironment().GetDirectoryPath(
         OpenRCT2::DirBase::user, OpenRCT2::DirId::replayRecordings);
     name = Path::Combine(outPath, name);
 
@@ -1504,7 +1504,7 @@ static void ConsoleCommandReplayNormalise(InteractiveConsole& console, const arg
     {
         outputFile += ".parkrep";
     }
-    std::string outPath = OpenRCT2::GetContext()->GetPlatformEnvironment()->GetDirectoryPath(
+    std::string outPath = OpenRCT2::GetContext()->GetPlatformEnvironment().GetDirectoryPath(
         OpenRCT2::DirBase::user, OpenRCT2::DirId::replayRecordings);
     outputFile = Path::Combine(outPath, outputFile);
 

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -117,8 +117,8 @@ static std::string ScreenshotGetParkName()
 
 static std::string ScreenshotGetDirectory()
 {
-    auto env = GetContext()->GetPlatformEnvironment();
-    return env->GetDirectoryPath(DirBase::user, DirId::screenshots);
+    auto& env = GetContext()->GetPlatformEnvironment();
+    return env.GetDirectoryPath(DirBase::user, DirId::screenshots);
 }
 
 static std::pair<RealWorldDate, RealWorldTime> ScreenshotGetDateTime()

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -987,6 +987,6 @@ static constexpr float kWindowScrollLocations[][2] = {
     // TODO: declared in WindowManager.h; move when refactors continue
     Ui::IWindowManager* Ui::GetWindowManager()
     {
-        return GetContext()->GetUiContext()->GetWindowManager();
+        return GetContext()->GetUiContext().GetWindowManager();
     }
 } // namespace OpenRCT2

--- a/src/openrct2/localisation/LocalisationService.cpp
+++ b/src/openrct2/localisation/LocalisationService.cpp
@@ -24,7 +24,7 @@ using namespace OpenRCT2::Localisation;
 static constexpr uint16_t kBaseObjectStringID = 0x2000;
 static constexpr uint16_t kMaxObjectCachedStrings = 0x5000 - kBaseObjectStringID;
 
-LocalisationService::LocalisationService(const std::shared_ptr<IPlatformEnvironment>& env)
+LocalisationService::LocalisationService(IPlatformEnvironment& env)
     : _env(env)
 {
     for (StringId stringId = kBaseObjectStringID + kMaxObjectCachedStrings; stringId >= kBaseObjectStringID; stringId--)
@@ -70,7 +70,7 @@ const char* LocalisationService::GetString(StringId id) const
 std::string LocalisationService::GetLanguagePath(uint32_t languageId) const
 {
     auto locale = std::string(LanguagesDescriptors[languageId].locale);
-    auto languageDirectory = _env->GetDirectoryPath(DirBase::openrct2, DirId::languages);
+    auto languageDirectory = _env.GetDirectoryPath(DirBase::openrct2, DirId::languages);
     auto languagePath = Path::Combine(languageDirectory, locale + u8".txt");
     return languagePath;
 }

--- a/src/openrct2/localisation/LocalisationService.h
+++ b/src/openrct2/localisation/LocalisationService.h
@@ -30,7 +30,7 @@ namespace OpenRCT2::Localisation
     class LocalisationService
     {
     private:
-        const std::shared_ptr<IPlatformEnvironment> _env;
+        IPlatformEnvironment& _env;
         int32_t _currentLanguage{};
         bool _useTrueTypeFont{};
         std::vector<int32_t> _languageOrder;
@@ -53,7 +53,7 @@ namespace OpenRCT2::Localisation
             _useTrueTypeFont = value;
         }
 
-        LocalisationService(const std::shared_ptr<IPlatformEnvironment>& env);
+        LocalisationService(IPlatformEnvironment& env);
         ~LocalisationService();
 
         const char* GetString(StringId id) const;

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -1018,8 +1018,8 @@ void NetworkBase::SaveGroups()
 {
     if (GetMode() == NETWORK_MODE_SERVER)
     {
-        auto env = GetContext().GetPlatformEnvironment();
-        auto path = Path::Combine(env->GetDirectoryPath(DirBase::user), u8"groups.json");
+        auto& env = GetContext().GetPlatformEnvironment();
+        auto path = Path::Combine(env.GetDirectoryPath(DirBase::user), u8"groups.json");
 
         json_t jsonGroups = json_t::array();
         for (auto& group : group_list)
@@ -1078,8 +1078,8 @@ void NetworkBase::LoadGroups()
 {
     group_list.clear();
 
-    auto env = GetContext().GetPlatformEnvironment();
-    auto path = Path::Combine(env->GetDirectoryPath(DirBase::user), u8"groups.json");
+    auto& env = GetContext().GetPlatformEnvironment();
+    auto path = Path::Combine(env.GetDirectoryPath(DirBase::user), u8"groups.json");
 
     json_t jsonGroupConfig;
     if (File::Exists(path))
@@ -1165,8 +1165,8 @@ void NetworkBase::AppendLog(std::ostream& fs, std::string_view s)
 
 void NetworkBase::BeginChatLog()
 {
-    auto env = GetContext().GetPlatformEnvironment();
-    auto directory = env->GetDirectoryPath(DirBase::user, DirId::chatLogs);
+    auto& env = GetContext().GetPlatformEnvironment();
+    auto directory = env.GetDirectoryPath(DirBase::user, DirId::chatLogs);
     _chatLogPath = BeginLog(directory, "", _chatLogFilenameFormat);
     _chat_log_fs.open(fs::u8path(_chatLogPath), std::ios::out | std::ios::app);
 }
@@ -1186,8 +1186,8 @@ void NetworkBase::CloseChatLog()
 
 void NetworkBase::BeginServerLog()
 {
-    auto env = GetContext().GetPlatformEnvironment();
-    auto directory = env->GetDirectoryPath(DirBase::user, DirId::serverLogs);
+    auto& env = GetContext().GetPlatformEnvironment();
+    auto directory = env.GetDirectoryPath(DirBase::user, DirId::serverLogs);
     _serverLogPath = BeginLog(directory, ServerName, _serverLogFilenameFormat);
     _server_log_fs.open(fs::u8path(_serverLogPath), std::ios::out | std::ios::app | std::ios::binary);
 
@@ -2556,7 +2556,7 @@ void NetworkBase::Client_Handle_GAMESTATE(NetworkConnection& connection, Network
         {
             GameStateCompareData cmpData = snapshots->Compare(serverSnapshot, *desyncSnapshot);
 
-            std::string outputPath = GetContext().GetPlatformEnvironment()->GetDirectoryPath(DirBase::user, DirId::desyncLogs);
+            std::string outputPath = GetContext().GetPlatformEnvironment().GetDirectoryPath(DirBase::user, DirId::desyncLogs);
 
             Path::CreateDirectory(outputPath);
 
@@ -4010,8 +4010,8 @@ void NetworkAppendServerLog(const utf8* text)
 
 static u8string NetworkGetKeysDirectory()
 {
-    auto env = GetContext()->GetPlatformEnvironment();
-    return Path::Combine(env->GetDirectoryPath(DirBase::user), u8"keys");
+    auto& env = GetContext()->GetPlatformEnvironment();
+    return Path::Combine(env.GetDirectoryPath(DirBase::user), u8"keys");
 }
 
 static u8string NetworkGetPrivateKeyPath(u8string_view playerName)

--- a/src/openrct2/network/NetworkUser.cpp
+++ b/src/openrct2/network/NetworkUser.cpp
@@ -212,8 +212,8 @@ NetworkUser* NetworkUserManager::GetOrAddUser(const std::string& hash)
 
 u8string NetworkUserManager::GetStorePath()
 {
-    auto env = OpenRCT2::GetContext()->GetPlatformEnvironment();
-    return Path::Combine(env->GetDirectoryPath(OpenRCT2::DirBase::user), kUserStoreFilename);
+    auto& env = OpenRCT2::GetContext()->GetPlatformEnvironment();
+    return Path::Combine(env.GetDirectoryPath(OpenRCT2::DirBase::user), kUserStoreFilename);
 }
 
 #endif

--- a/src/openrct2/network/ServerList.cpp
+++ b/src/openrct2/network/ServerList.cpp
@@ -189,8 +189,8 @@ std::vector<ServerListEntry> ServerList::ReadFavourites() const
     std::vector<ServerListEntry> entries;
     try
     {
-        auto env = GetContext()->GetPlatformEnvironment();
-        auto path = env->GetFilePath(PathId::networkServers);
+        auto& env = GetContext()->GetPlatformEnvironment();
+        auto path = env.GetFilePath(PathId::networkServers);
         if (File::Exists(path))
         {
             auto fs = FileStream(path, FileMode::open);
@@ -242,8 +242,8 @@ bool ServerList::WriteFavourites(const std::vector<ServerListEntry>& entries) co
 {
     LOG_VERBOSE("server_list_write(%d, 0x%p)", entries.size(), entries.data());
 
-    auto env = GetContext()->GetPlatformEnvironment();
-    auto path = Path::Combine(env->GetDirectoryPath(DirBase::user), u8"servers.cfg");
+    auto& env = GetContext()->GetPlatformEnvironment();
+    auto path = Path::Combine(env.GetDirectoryPath(DirBase::user), u8"servers.cfg");
 
     try
     {

--- a/src/openrct2/object/AudioSampleTable.cpp
+++ b/src/openrct2/object/AudioSampleTable.cpp
@@ -110,7 +110,6 @@ void AudioSampleTable::LoadFrom(const AudioSampleTable& table, size_t sourceStar
 
 void AudioSampleTable::Load()
 {
-    auto audioContext = GetContext()->GetAudioContext();
     for (size_t i = 0; i < _entries.size(); i++)
     {
         auto& entry = _entries[i];
@@ -158,14 +157,14 @@ IAudioSource* AudioSampleTable::LoadSample(uint32_t index) const
             auto stream = entry.Asset->GetStream();
             if (stream != nullptr)
             {
-                auto audioContext = GetContext()->GetAudioContext();
+                auto& audioContext = GetContext()->GetAudioContext();
                 if (entry.PathIndex)
                 {
-                    result = audioContext->CreateStreamFromCSS(std::move(stream), *entry.PathIndex);
+                    result = audioContext.CreateStreamFromCSS(std::move(stream), *entry.PathIndex);
                 }
                 else
                 {
-                    result = audioContext->CreateStreamFromWAV(std::move(stream));
+                    result = audioContext.CreateStreamFromWAV(std::move(stream));
                 }
             }
         }

--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -379,8 +379,8 @@ std::vector<int32_t> ImageTable::ParseRange(std::string s)
 
 std::string ImageTable::FindLegacyObject(const std::string& name)
 {
-    const auto env = GetContext()->GetPlatformEnvironment();
-    auto objectsPath = env->GetDirectoryPath(DirBase::rct2, DirId::objects);
+    const auto& env = GetContext()->GetPlatformEnvironment();
+    auto objectsPath = env.GetDirectoryPath(DirBase::rct2, DirId::objects);
     auto objectPath = Path::Combine(objectsPath, name);
     if (File::Exists(objectPath))
     {

--- a/src/openrct2/object/MusicObject.cpp
+++ b/src/openrct2/object/MusicObject.cpp
@@ -47,13 +47,13 @@ void MusicObject::Load()
     }
 
     // Load metadata of samples
-    auto audioContext = GetContext()->GetAudioContext();
+    auto& audioContext = GetContext()->GetAudioContext();
     for (auto& track : _tracks)
     {
         auto stream = track.Asset.GetStream();
         if (stream != nullptr)
         {
-            auto source = audioContext->CreateStreamFromWAV(std::move(stream));
+            auto source = audioContext.CreateStreamFromWAV(std::move(stream));
             if (source != nullptr)
             {
                 track.BytesPerTick = source->GetBytesPerSecond() / 40;
@@ -226,8 +226,8 @@ ObjectAsset MusicObject::GetAsset(IReadObjectContext& context, std::string_view 
 {
     if (path.find("$RCT2:DATA/") == 0)
     {
-        auto env = GetContext()->GetPlatformEnvironment();
-        auto path2 = env->FindFile(DirBase::rct2, DirId::data, path.substr(11));
+        auto& env = GetContext()->GetPlatformEnvironment();
+        auto path2 = env.FindFile(DirBase::rct2, DirId::data, path.substr(11));
         return ObjectAsset(path2);
     }
 

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -508,8 +508,8 @@ namespace OpenRCT2::ObjectFactory
 
     static bool isUsingClassic()
     {
-        auto env = OpenRCT2::GetContext()->GetPlatformEnvironment();
-        return env->IsUsingClassic();
+        auto& env = OpenRCT2::GetContext()->GetPlatformEnvironment();
+        return env.IsUsingClassic();
     }
 
     std::unique_ptr<Object> CreateObjectFromJson(

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -177,16 +177,16 @@ private:
 
 class ObjectRepository final : public IObjectRepository
 {
-    std::shared_ptr<IPlatformEnvironment> const _env;
+    IPlatformEnvironment& _env;
     ObjectFileIndex const _fileIndex;
     std::vector<ObjectRepositoryItem> _items;
     ObjectIdentifierMap _newItemMap;
     ObjectEntryMap _itemMap;
 
 public:
-    explicit ObjectRepository(const std::shared_ptr<IPlatformEnvironment>& env)
+    explicit ObjectRepository(IPlatformEnvironment& env)
         : _env(env)
-        , _fileIndex(*this, *env)
+        , _fileIndex(*this, env)
     {
     }
 
@@ -586,7 +586,7 @@ private:
     std::string GetPathForNewObject(ObjectGeneration generation, std::string_view name)
     {
         // Get object directory and create it if it doesn't exist
-        auto userObjPath = _env->GetDirectoryPath(DirBase::user, DirId::objects);
+        auto userObjPath = _env.GetDirectoryPath(DirBase::user, DirId::objects);
         Path::CreateDirectory(userObjPath);
 
         // Find a unique file name
@@ -657,7 +657,7 @@ private:
     }
 };
 
-std::unique_ptr<IObjectRepository> CreateObjectRepository(const std::shared_ptr<IPlatformEnvironment>& env)
+std::unique_ptr<IObjectRepository> CreateObjectRepository(IPlatformEnvironment& env)
 {
     return std::make_unique<ObjectRepository>(env);
 }

--- a/src/openrct2/object/ObjectRepository.h
+++ b/src/openrct2/object/ObjectRepository.h
@@ -101,8 +101,7 @@ struct IObjectRepository
     virtual void ExportPackedObject(OpenRCT2::IStream* stream) = 0;
 };
 
-[[nodiscard]] std::unique_ptr<IObjectRepository> CreateObjectRepository(
-    const std::shared_ptr<OpenRCT2::IPlatformEnvironment>& env);
+[[nodiscard]] std::unique_ptr<IObjectRepository> CreateObjectRepository(OpenRCT2::IPlatformEnvironment& env);
 
 [[nodiscard]] bool IsObjectCustom(const ObjectRepositoryItem* object);
 

--- a/src/openrct2/object/ResourceTable.cpp
+++ b/src/openrct2/object/ResourceTable.cpp
@@ -71,6 +71,7 @@ ResourceTable::SourceInfo ResourceTable::ParseSource(std::string_view source)
         }
     }
 
+    auto& env = GetContext()->GetPlatformEnvironment();
     if (String::startsWith(base, "$LGX:"))
     {
         info.Kind = SourceKind::Gx;
@@ -78,35 +79,30 @@ ResourceTable::SourceInfo ResourceTable::ParseSource(std::string_view source)
     }
     else if (String::startsWith(base, "$G1"))
     {
-        auto env = GetContext()->GetPlatformEnvironment();
-        auto dataPath = env->GetDirectoryPath(DirBase::rct2, DirId::data);
+        auto dataPath = env.GetDirectoryPath(DirBase::rct2, DirId::data);
         info.Kind = SourceKind::G1;
         // info.Path = env->FindFile(DirBase::rct2, DirId::data, "g1.dat");
     }
     else if (String::startsWith(base, "$CSG"))
     {
-        auto env = GetContext()->GetPlatformEnvironment();
-        auto dataPath = env->GetDirectoryPath(DirBase::rct2, DirId::data);
+        auto dataPath = env.GetDirectoryPath(DirBase::rct2, DirId::data);
         info.Kind = SourceKind::Csg;
         // info.Path = env->FindFile(DirBase::rct2, DirId::data, "g1.dat");
     }
     else if (String::startsWith(base, "$RCT1:DATA/"))
     {
-        auto env = GetContext()->GetPlatformEnvironment();
         info.Kind = SourceKind::Data;
-        info.Path = env->FindFile(DirBase::rct1, DirId::data, fileName);
+        info.Path = env.FindFile(DirBase::rct1, DirId::data, fileName);
     }
     else if (String::startsWith(base, "$RCT2:DATA/"))
     {
-        auto env = GetContext()->GetPlatformEnvironment();
         info.Kind = SourceKind::Data;
-        info.Path = env->FindFile(DirBase::rct2, DirId::data, fileName);
+        info.Path = env.FindFile(DirBase::rct2, DirId::data, fileName);
     }
     else if (String::startsWith(base, "$RCT2:OBJDATA/"))
     {
-        auto env = GetContext()->GetPlatformEnvironment();
         info.Kind = SourceKind::ObjData;
-        info.Path = env->FindFile(DirBase::rct2, DirId::objects, fileName);
+        info.Path = env.FindFile(DirBase::rct2, DirId::objects, fileName);
     }
     else if (!String::startsWith(base, "$"))
     {

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -29,7 +29,7 @@ using namespace OpenRCT2::Drawing;
 using namespace OpenRCT2::Paint;
 using namespace OpenRCT2::Ui;
 
-Painter::Painter(const std::shared_ptr<IUiContext>& uiContext)
+Painter::Painter(IUiContext& uiContext)
     : _uiContext(uiContext)
 {
 }
@@ -49,7 +49,7 @@ void Painter::Paint(IDrawingEngine& de)
         de.PaintWindows();
 
         UpdatePaletteEffects();
-        _uiContext->Draw(*rt);
+        _uiContext.Draw(*rt);
 
         GfxDrawPickedUpPeep(*rt);
         GfxInvalidatePickedUpPeep();
@@ -79,7 +79,7 @@ void Painter::Paint(IDrawingEngine& de)
 
 void Painter::PaintReplayNotice(RenderTarget& rt, const char* text)
 {
-    ScreenCoordsXY screenCoords(_uiContext->GetWidth() / 2, _uiContext->GetHeight() - 44);
+    ScreenCoordsXY screenCoords(_uiContext.GetWidth() / 2, _uiContext.GetHeight() - 44);
 
     char buffer[64]{};
     FormatStringToBuffer(buffer, sizeof(buffer), "{OUTLINE}{RED}{STRING}", text);
@@ -115,7 +115,7 @@ void Painter::PaintFPS(RenderTarget& rt)
     const int32_t stringWidth = GfxGetStringWidth(buffer, FontStyle::Medium);
 
     // Figure out where counter should be rendered
-    ScreenCoordsXY screenCoords(_uiContext->GetWidth() / 2, 2);
+    ScreenCoordsXY screenCoords(_uiContext.GetWidth() / 2, 2);
     screenCoords.x = screenCoords.x - (stringWidth / 2);
 
     // Move counter below toolbar if buttons are centred

--- a/src/openrct2/paint/Painter.h
+++ b/src/openrct2/paint/Painter.h
@@ -35,7 +35,7 @@ namespace OpenRCT2
         struct Painter final
         {
         private:
-            std::shared_ptr<Ui::IUiContext> const _uiContext;
+            Ui::IUiContext& _uiContext;
             sfl::segmented_vector<PaintSession, 32> _paintSessionPool;
             std::vector<PaintSession*> _freePaintSessions;
             time_t _lastSecond = 0;
@@ -43,7 +43,7 @@ namespace OpenRCT2
             int32_t _frames = 0;
 
         public:
-            explicit Painter(const std::shared_ptr<Ui::IUiContext>& uiContext);
+            explicit Painter(Ui::IUiContext& uiContext);
             void Paint(Drawing::IDrawingEngine& de);
 
             PaintSession* CreateSession(RenderTarget& rt, uint32_t viewFlags, uint8_t rotation);

--- a/src/openrct2/platform/Crash.cpp
+++ b/src/openrct2/platform/Crash.cpp
@@ -316,8 +316,8 @@ static bool OnCrash(
 
 static std::wstring GetDumpDirectory()
 {
-    auto env = GetContext()->GetPlatformEnvironment();
-    auto crashPath = env->GetDirectoryPath(DirBase::user, DirId::crashDumps);
+    auto& env = GetContext()->GetPlatformEnvironment();
+    auto crashPath = env.GetDirectoryPath(DirBase::user, DirId::crashDumps);
 
     auto result = String::toWideChar(crashPath);
     return result;

--- a/src/openrct2/rct12/ScenarioPatcher.cpp
+++ b/src/openrct2/rct12/ScenarioPatcher.cpp
@@ -668,7 +668,6 @@ static void ApplyPathFixes(const json_t& scenarioPatch)
 
 static u8string getScenarioSHA256(u8string_view scenarioPath)
 {
-    auto env = OpenRCT2::GetContext()->GetPlatformEnvironment();
     auto scenarioData = OpenRCT2::File::ReadAllBytes(scenarioPath);
 #ifdef DISABLE_NETWORK
     auto scenarioStringHash = picosha2::hash256_hex_string(scenarioData);
@@ -682,8 +681,8 @@ static u8string getScenarioSHA256(u8string_view scenarioPath)
 
 static u8string GetPatchFileName(u8string_view scenarioHash)
 {
-    auto env = OpenRCT2::GetContext()->GetPlatformEnvironment();
-    auto scenarioPatches = env->GetDirectoryPath(OpenRCT2::DirBase::openrct2, OpenRCT2::DirId::scenarioPatches);
+    auto& env = OpenRCT2::GetContext()->GetPlatformEnvironment();
+    auto scenarioPatches = env.GetDirectoryPath(OpenRCT2::DirBase::openrct2, OpenRCT2::DirId::scenarioPatches);
     auto scenarioPatchFile = OpenRCT2::Path::WithExtension(scenarioHash.substr(0, 7), ".parkpatch");
     return OpenRCT2::Path::Combine(scenarioPatches, scenarioPatchFile);
 }

--- a/src/openrct2/ride/TrackDesignRepository.cpp
+++ b/src/openrct2/ride/TrackDesignRepository.cpp
@@ -112,16 +112,15 @@ private:
 class TrackDesignRepository final : public ITrackDesignRepository
 {
 private:
-    std::shared_ptr<IPlatformEnvironment> const _env;
+    IPlatformEnvironment& _env;
     TrackDesignFileIndex const _fileIndex;
     std::vector<TrackRepositoryItem> _items;
 
 public:
-    explicit TrackDesignRepository(const std::shared_ptr<IPlatformEnvironment>& env)
+    explicit TrackDesignRepository(IPlatformEnvironment& env)
         : _env(env)
-        , _fileIndex(*env)
+        , _fileIndex(env)
     {
-        Guard::ArgumentNotNull(env);
     }
 
     size_t GetCount() const override
@@ -258,7 +257,7 @@ public:
     std::string Install(const std::string& path, const std::string& name) override
     {
         std::string result;
-        std::string installDir = _env->GetDirectoryPath(DirBase::user, DirId::trackDesigns);
+        std::string installDir = _env.GetDirectoryPath(DirBase::user, DirId::trackDesigns);
 
         std::string newPath = Path::Combine(installDir, name + Path::GetExtension(path));
         if (File::Copy(path, newPath, false))
@@ -310,7 +309,7 @@ private:
     }
 };
 
-std::unique_ptr<ITrackDesignRepository> CreateTrackDesignRepository(const std::shared_ptr<IPlatformEnvironment>& env)
+std::unique_ptr<ITrackDesignRepository> CreateTrackDesignRepository(IPlatformEnvironment& env)
 {
     return std::make_unique<TrackDesignRepository>(env);
 }

--- a/src/openrct2/ride/TrackDesignRepository.h
+++ b/src/openrct2/ride/TrackDesignRepository.h
@@ -41,8 +41,7 @@ struct ITrackDesignRepository
     virtual std::string Install(const std::string& path, const std::string& name) = 0;
 };
 
-[[nodiscard]] std::unique_ptr<ITrackDesignRepository> CreateTrackDesignRepository(
-    const std::shared_ptr<OpenRCT2::IPlatformEnvironment>& env);
+[[nodiscard]] std::unique_ptr<ITrackDesignRepository> CreateTrackDesignRepository(OpenRCT2::IPlatformEnvironment& env);
 [[nodiscard]] std::string GetNameFromTrackPath(const std::string& path);
 
 void TrackRepositoryScan();

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -120,8 +120,8 @@ void ScenarioReset(GameState_t& gameState)
     }
 
     // Set the last saved game path
-    auto env = GetContext()->GetPlatformEnvironment();
-    auto savePath = env->GetDirectoryPath(DirBase::user, DirId::saves);
+    auto& env = GetContext()->GetPlatformEnvironment();
+    auto savePath = env.GetDirectoryPath(DirBase::user, DirId::saves);
     gScenarioSavePath = Path::Combine(savePath, gameState.park.Name + u8".park");
 
     gameState.currentExpenditure = 0;

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -251,15 +251,15 @@ class ScenarioRepository final : public IScenarioRepository
 private:
     static constexpr uint32_t HighscoreFileVersion = 2;
 
-    std::shared_ptr<IPlatformEnvironment> const _env;
+    IPlatformEnvironment& _env;
     ScenarioFileIndex const _fileIndex;
     std::vector<ScenarioIndexEntry> _scenarios;
     std::vector<ScenarioHighscoreEntry*> _highscores;
 
 public:
-    explicit ScenarioRepository(const std::shared_ptr<IPlatformEnvironment>& env)
+    explicit ScenarioRepository(IPlatformEnvironment& env)
         : _env(env)
-        , _fileIndex(*env)
+        , _fileIndex(env)
     {
     }
 
@@ -437,10 +437,10 @@ private:
      */
     void ImportMegaPark()
     {
-        auto mpdatPath = _env->FindFile(DirBase::rct1, DirId::data, "mp.dat");
+        auto mpdatPath = _env.FindFile(DirBase::rct1, DirId::data, "mp.dat");
         if (File::Exists(mpdatPath))
         {
-            auto scenarioDirectory = _env->GetDirectoryPath(DirBase::user, DirId::scenarios);
+            auto scenarioDirectory = _env.GetDirectoryPath(DirBase::user, DirId::scenarios);
             auto expectedSc21Path = Path::Combine(scenarioDirectory, "sc21.sc4");
             auto sc21Path = Path::ResolveCasing(expectedSc21Path);
             if (!File::Exists(sc21Path))
@@ -526,7 +526,7 @@ private:
 
     void LoadScores()
     {
-        std::string path = _env->GetFilePath(PathId::scores);
+        std::string path = _env.GetFilePath(PathId::scores);
         if (!File::Exists(path))
         {
             return;
@@ -566,8 +566,8 @@ private:
      */
     void LoadLegacyScores()
     {
-        std::string rct2Path = _env->GetFilePath(PathId::scoresRCT2);
-        std::string legacyPath = _env->GetFilePath(PathId::scoresLegacy);
+        std::string rct2Path = _env.GetFilePath(PathId::scoresRCT2);
+        std::string legacyPath = _env.GetFilePath(PathId::scoresLegacy);
         LoadLegacyScores(legacyPath);
         LoadLegacyScores(rct2Path);
     }
@@ -670,7 +670,7 @@ private:
 
     void SaveHighscores()
     {
-        std::string path = _env->GetFilePath(PathId::scores);
+        std::string path = _env.GetFilePath(PathId::scores);
         try
         {
             auto fs = FileStream(path, FileMode::write);
@@ -692,7 +692,7 @@ private:
     }
 };
 
-std::unique_ptr<IScenarioRepository> CreateScenarioRepository(const std::shared_ptr<IPlatformEnvironment>& env)
+std::unique_ptr<IScenarioRepository> CreateScenarioRepository(IPlatformEnvironment& env)
 {
     return std::make_unique<ScenarioRepository>(env);
 }

--- a/src/openrct2/scenario/ScenarioRepository.h
+++ b/src/openrct2/scenario/ScenarioRepository.h
@@ -89,8 +89,7 @@ struct IScenarioRepository
     virtual bool TryRecordHighscore(int32_t language, const utf8* scenarioFileName, money64 companyValue, const utf8* name) = 0;
 };
 
-[[nodiscard]] std::unique_ptr<IScenarioRepository> CreateScenarioRepository(
-    const std::shared_ptr<OpenRCT2::IPlatformEnvironment>& env);
+[[nodiscard]] std::unique_ptr<IScenarioRepository> CreateScenarioRepository(OpenRCT2::IPlatformEnvironment& env);
 [[nodiscard]] IScenarioRepository* GetScenarioRepository();
 
 void ScenarioRepositoryScan();

--- a/src/openrct2/scenes/title/TitleScene.cpp
+++ b/src/openrct2/scenes/title/TitleScene.cpp
@@ -206,7 +206,7 @@ void TitleScene::TitleInitialise()
 {
     if (_sequencePlayer == nullptr)
     {
-        _sequencePlayer = GetContext().GetUiContext()->GetTitleSequencePlayer();
+        _sequencePlayer = GetContext().GetUiContext().GetTitleSequencePlayer();
     }
     if (Config::Get().interface.RandomTitleSequence)
     {
@@ -288,7 +288,7 @@ bool TitleScene::TryLoadSequence(bool loadPreview)
     {
         if (_sequencePlayer == nullptr)
         {
-            _sequencePlayer = GetContext().GetUiContext()->GetTitleSequencePlayer();
+            _sequencePlayer = GetContext().GetUiContext().GetTitleSequencePlayer();
         }
 
         size_t numSequences = TitleSequenceManager::GetCount();

--- a/src/openrct2/scenes/title/TitleSequenceManager.cpp
+++ b/src/openrct2/scenes/title/TitleSequenceManager.cpp
@@ -254,14 +254,14 @@ namespace OpenRCT2::TitleSequenceManager
 
     static std::string GetDataSequencesPath()
     {
-        auto env = GetContext()->GetPlatformEnvironment();
-        return env->GetDirectoryPath(DirBase::openrct2, DirId::sequences);
+        auto& env = GetContext()->GetPlatformEnvironment();
+        return env.GetDirectoryPath(DirBase::openrct2, DirId::sequences);
     }
 
     static std::string GetUserSequencesPath()
     {
-        auto env = GetContext()->GetPlatformEnvironment();
-        return env->GetDirectoryPath(DirBase::user, DirId::sequences);
+        auto& env = GetContext()->GetPlatformEnvironment();
+        return env.GetDirectoryPath(DirBase::user, DirId::sequences);
     }
 
     static bool IsNameReserved(const std::string& name)

--- a/src/openrct2/ui/DummyUiContext.cpp
+++ b/src/openrct2/ui/DummyUiContext.cpp
@@ -160,8 +160,7 @@ namespace OpenRCT2::Ui
 
         class X8DrawingEngineFactory final : public IDrawingEngineFactory
         {
-            std::unique_ptr<IDrawingEngine> Create(
-                [[maybe_unused]] DrawingEngine type, const std::shared_ptr<IUiContext>& uiContext) override
+            std::unique_ptr<IDrawingEngine> Create([[maybe_unused]] DrawingEngine type, IUiContext& uiContext) override
             {
                 return std::make_unique<X8DrawingEngine>(uiContext);
             }
@@ -213,7 +212,7 @@ namespace OpenRCT2::Ui
         }
     };
 
-    std::shared_ptr<IUiContext> CreateDummyUiContext()
+    std::unique_ptr<IUiContext> CreateDummyUiContext()
     {
         return std::make_unique<DummyUiContext>();
     }

--- a/src/openrct2/ui/UiContext.h
+++ b/src/openrct2/ui/UiContext.h
@@ -168,6 +168,6 @@ namespace OpenRCT2
             virtual ITitleSequencePlayer* GetTitleSequencePlayer() = 0;
         };
 
-        [[nodiscard]] std::shared_ptr<IUiContext> CreateDummyUiContext();
+        [[nodiscard]] std::unique_ptr<IUiContext> CreateDummyUiContext();
     } // namespace Ui
 } // namespace OpenRCT2

--- a/test/tests/ScenarioPatcherTests.cpp
+++ b/test/tests/ScenarioPatcherTests.cpp
@@ -31,8 +31,8 @@ TEST(FetchAndApplyScenarioPatch, expected_json_format)
     bool initialised = context->Initialise();
     ASSERT_TRUE(initialised);
 
-    auto env = context->GetPlatformEnvironment();
-    auto scenarioPatches = env->GetDirectoryPath(OpenRCT2::DirBase::openrct2, OpenRCT2::DirId::scenarioPatches);
+    auto& env = context->GetPlatformEnvironment();
+    auto scenarioPatches = env.GetDirectoryPath(OpenRCT2::DirBase::openrct2, OpenRCT2::DirId::scenarioPatches);
 
     std::error_code ec;
     OpenRCT2::RCT12::SetDryRun(true);


### PR DESCRIPTION
@mixiate was profiling the code and turns out that calling GetUiContext is expensive, why should a simple sounding function be expensive? Because of shared_ptr, this is by no means a lightweight object to hold and manage a pointer. This eliminates the use of it and rather store references and also return references given we know the lifetime that is that of Context so there is no point in even using shared_ptrs.

Also we no longer have to now worry if ui context or audio context might be null, they are never null and its now reflected by getting a reference as we use dummies for headless instances.

I think the sudden overhead stems from a recent refactor that moved things into WindowManager and to obtain that it needs to go over the UiContext, with OpenGL now using invalidation it contributed a good chunk as it has to access the window manager to invalidate.

Depending on the scene the improvement varies, I observed 3 to 5 FPS more with this build.