### PR TITLE
Eliminate more shared_ptr usage

### DIFF
--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -1321,14 +1321,22 @@ public:
                 for (auto it = g_window_list.rbegin(); it != g_window_list.rend(); it++)
                 {
                     auto& w2 = *it;
+                    if (w2->flags & WF_DEAD)
+                    {
+                        continue;
+                    }
                     if (!(w2->flags & WF_STICK_TO_FRONT))
                     {
-                        itDestPos = it.base();
+                        // base() returns the next element in the list, so we need to decrement it.
+                        itDestPos = std::prev(it.base());
                         break;
                     }
                 }
 
-                std::iter_swap(itSourcePos, itDestPos);
+                if (itSourcePos != itDestPos)
+                {
+                    std::iter_swap(itSourcePos, itDestPos);
+                }
                 w.Invalidate();
 
                 if (w.windowPos.x + w.width < 20)

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -1328,7 +1328,7 @@ public:
                     }
                 }
 
-                g_window_list.splice(itDestPos, g_window_list, itSourcePos);
+                std::iter_swap(itSourcePos, itDestPos);
                 w.Invalidate();
 
                 if (w.windowPos.x + w.width < 20)

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -1481,7 +1481,7 @@ namespace OpenRCT2::Ui::Windows
     void CloseWindowsOwnedByPlugin(std::shared_ptr<Plugin> plugin)
     {
         // Get all the windows that need closing
-        std::vector<std::shared_ptr<WindowBase>> customWindows;
+        std::vector<WindowBase*> customWindows;
         for (const auto& window : g_window_list)
         {
             if (window->classification == WindowClass::Custom)
@@ -1490,7 +1490,7 @@ namespace OpenRCT2::Ui::Windows
                 auto& customInfo = GetInfo(customWindow);
                 if (customInfo.Owner == plugin)
                 {
-                    customWindows.push_back(window);
+                    customWindows.push_back(window.get());
                 }
             }
         }
@@ -1498,7 +1498,7 @@ namespace OpenRCT2::Ui::Windows
         for (auto& window : customWindows)
         {
             auto* windowMgr = Ui::GetWindowManager();
-            windowMgr->Close(*window.get());
+            windowMgr->Close(*window);
         }
     }
 

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -47,7 +47,7 @@
 #include "WindowBase.h"
 
 #include <cstring>
-#include <list>
+#include <sfl/segmented_vector.hpp>
 #include <unordered_map>
 
 namespace OpenRCT2
@@ -65,7 +65,7 @@ namespace OpenRCT2
     uint8_t gShowLandRightsRefCount;
     uint8_t gShowConstructionRightsRefCount;
 
-    static std::list<Viewport> _viewports;
+    static sfl::segmented_vector<Viewport, 32> _viewports;
     Viewport* g_music_tracking_viewport;
 
     static std::unique_ptr<JobPool> _paintJobs;

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -294,7 +294,7 @@ namespace OpenRCT2
 
     extern colour_t gCurrentWindowColours[3];
 
-    std::list<std::shared_ptr<WindowBase>>::iterator WindowGetIterator(const WindowBase* w);
+    std::vector<std::unique_ptr<WindowBase>>::iterator WindowGetIterator(const WindowBase* w);
     void WindowVisitEach(std::function<void(WindowBase*)> func);
 
     void WindowSetFlagForAllViewports(uint32_t viewportFlag, bool enabled);

--- a/src/openrct2/interface/WindowBase.h
+++ b/src/openrct2/interface/WindowBase.h
@@ -227,5 +227,5 @@ namespace OpenRCT2
 #endif
 
     // rct2: 0x01420078
-    extern std::list<std::shared_ptr<WindowBase>> g_window_list;
+    extern std::vector<std::unique_ptr<WindowBase>> g_window_list;
 } // namespace OpenRCT2


### PR DESCRIPTION
Since the windows are unfortunately polymorphic it is still fragmented but this beats shared_ptr + list which add a good amount of overhead. Also turned viewport storage to segmented_vector, it's like a vector but allocates in blocks so we get pointer stability which is probably why std::list was used.

Adds an additional 2 to 4 FPS in complex parks.