### PR TITLE
Fix off-by-one when generating park minimaps

### DIFF
--- a/src/openrct2/park/ParkPreview.cpp
+++ b/src/openrct2/park/ParkPreview.cpp
@@ -155,7 +155,7 @@ namespace OpenRCT2
         for (auto y = 0u; y < image.height; y++)
         {
             int32_t mapY = 1 + (y * mapSkipFactor);
-            if (mapY >= drawableMapSize.y)
+            if (mapY > drawableMapSize.y)
                 break;
 
             _tileColourIndex = y % 2;


### PR DESCRIPTION
Discovered when dumping minimaps for #24411. Made it obvious that something went wrong, as the PNGs rendered the final lines solid white. (Unlike OpenRCT2, which rendered them transparent.)