### PR TITLE
Improve Dive Loop vehicle fallback sprites

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Improved: [#24364] Improve the fallback vehicle sprites for Zero G Rolls, and allow small ones to be built without cheats if the fallbacks are available.
 - Improved: [#24368] Clicking the in-game update notication now leads to a more user-friendly download page.
 - Improved: [#24409] Steam installs of RCT Classic are now detected automatically.
+- Improved: [#24417] Improve the fallback vehicle sprites for Dive Loops.
 - Change: [#24342] g2.dat is now split into g2.dat and fonts.dat.
 - Change: [#24362] The Windows installer now prevents installing to the same folder as RollerCoaster Tycoon 2 or Classic.
 - Change: [#24418] Small & Large Zero G Rolls can now be built on the LIM Launched RC without cheats if vehicle sprites are available.

--- a/src/openrct2/paint/vehicle/VehiclePaint.cpp
+++ b/src/openrct2/paint/vehicle/VehiclePaint.cpp
@@ -3926,36 +3926,6 @@ static void VehiclePitchDown50BankedRight90(
     }
 }
 
-static void VehiclePitchDown50BankedLeft135(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
-{
-    if (carEntry->GroupEnabled(SpriteGroupType::Corkscrews))
-    {
-        int32_t boundingBoxNum = (YawTo4(imageDirection)) + 4 * 4 + 144;
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, imageDirection, 4);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxNum, z, carEntry);
-    }
-    else
-    {
-        VehiclePitchDown60Unbanked(session, vehicle, imageDirection, z, carEntry);
-    }
-}
-
-static void VehiclePitchDown50BankedRight135(
-    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
-{
-    if (carEntry->GroupEnabled(SpriteGroupType::Corkscrews))
-    {
-        int32_t boundingBoxNum = (YawTo4(imageDirection)) + 4 * 4 + 144;
-        int32_t spriteNum = carEntry->SpriteOffset(SpriteGroupType::Corkscrews, imageDirection, 4);
-        VehicleSpritePaintWithSwinging(session, vehicle, spriteNum, boundingBoxNum, z, carEntry);
-    }
-    else
-    {
-        VehiclePitchDown60Unbanked(session, vehicle, imageDirection, z, carEntry);
-    }
-}
-
 static void VehiclePitchDown50(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
@@ -3976,17 +3946,11 @@ static void VehiclePitchDown50(
         case 6:
             VehiclePitchDown50BankedLeft90(session, vehicle, imageDirection, z, carEntry);
             break;
-        case 8:
-            VehiclePitchDown50BankedLeft135(session, vehicle, imageDirection, z, carEntry);
-            break;
         case 10:
             VehiclePitchDown50BankedRight67(session, vehicle, imageDirection, z, carEntry);
             break;
         case 11:
             VehiclePitchDown50BankedRight90(session, vehicle, imageDirection, z, carEntry);
-            break;
-        case 13:
-            VehiclePitchDown50BankedRight135(session, vehicle, imageDirection, z, carEntry);
             break;
         default:
             VehiclePitchDown60Unbanked(session, vehicle, imageDirection, z, carEntry);

--- a/src/openrct2/paint/vehicle/VehiclePaint.cpp
+++ b/src/openrct2/paint/vehicle/VehiclePaint.cpp
@@ -3484,7 +3484,7 @@ static void VehiclePitchUp50BankedLeft45(
     }
     else
     {
-        VehiclePitchUp60Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchUp50Unbanked(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -3499,7 +3499,7 @@ static void VehiclePitchUp50BankedRight45(
     }
     else
     {
-        VehiclePitchUp60Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchUp50Unbanked(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -3514,7 +3514,7 @@ static void VehiclePitchUp50BankedLeft67(
     }
     else
     {
-        VehiclePitchUp60Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchUp25BankedLeft45(session, vehicle, (imageDirection + 2) % 32, z, carEntry);
     }
 }
 
@@ -3529,7 +3529,7 @@ static void VehiclePitchUp50BankedRight67(
     }
     else
     {
-        VehiclePitchUp60Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchUp25BankedRight45(session, vehicle, (imageDirection - 2) % 32, z, carEntry);
     }
 }
 
@@ -3544,7 +3544,7 @@ static void VehiclePitchUp50BankedLeft90(
     }
     else
     {
-        VehiclePitchUp60Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchCorkscrew<12>(session, vehicle, (imageDirection + 8) % 32, z, carEntry);
     }
 }
 
@@ -3559,7 +3559,7 @@ static void VehiclePitchUp50BankedRight90(
     }
     else
     {
-        VehiclePitchUp60Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchCorkscrew<2>(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -3877,7 +3877,7 @@ static void VehiclePitchDown50BankedLeft67(
     }
     else
     {
-        VehiclePitchDown50Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchDown25BankedLeft45(session, vehicle, (imageDirection - 2) % 32, z, carEntry);
     }
 }
 
@@ -3892,7 +3892,7 @@ static void VehiclePitchDown50BankedRight67(
     }
     else
     {
-        VehiclePitchDown50Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchDown25BankedRight45(session, vehicle, (imageDirection + 2) % 32, z, carEntry);
     }
 }
 
@@ -3907,7 +3907,7 @@ static void VehiclePitchDown50BankedLeft90(
     }
     else
     {
-        VehiclePitchDown50Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchCorkscrew<7>(session, vehicle, imageDirection, z, carEntry);
     }
 }
 
@@ -3922,7 +3922,7 @@ static void VehiclePitchDown50BankedRight90(
     }
     else
     {
-        VehiclePitchDown50Unbanked(session, vehicle, imageDirection, z, carEntry);
+        VehiclePitchCorkscrew<17>(session, vehicle, (imageDirection + 8) % 32, z, carEntry);
     }
 }
 


### PR DESCRIPTION
This improves the vehicle fallback sprites for Dive Loops. I have used gentle banked sprites and some corkscrew sprites. The gentle banked sprite does cause a slightly noticeable angle change on longer cars, but I was not able to find any other suitable sprite, and not having an inbetween sprite makes some trains look quite bad, including the twister trains which I think a lot of people will be using with dive loops.


https://github.com/user-attachments/assets/f336db4a-7fcd-4caa-ab8f-b589f6d15922

(Park is [Ramses by Sulakke](https://www.nedesigns.com/park/6132/nedc6-ramses/))


https://github.com/user-attachments/assets/762c230d-22dd-463a-b93d-78893843c32a


https://github.com/user-attachments/assets/98eaf0e4-b99a-4de7-a60e-1784da77a993


https://github.com/user-attachments/assets/6ee4da4e-d2f7-40d2-8dc9-c9f4d249c120


https://github.com/user-attachments/assets/0e9b8230-af71-4232-b65b-0d8834b51262

This is what they currently look like:


https://github.com/user-attachments/assets/34d7586f-596e-4493-9894-748e78fef3d4


This also deletes 2 vehicle paint functions which are unused and probably incorrect. No subposition data uses either of them, they both have the same implementation which is probably wrong for at least one of them, and there is no up equivalent of either.

There is a use case here for #24345. Without it, the cars glitch through the back side of the dive loop:
![novehiclefallbackbbs](https://github.com/user-attachments/assets/16bec1be-1a96-4eb2-a6c9-73fdda8baa2a)
With the vehicle boundbox fallbacks, it uses the intended bounding box and so it doesn't glitch:
![vehiclefallbackbbs](https://github.com/user-attachments/assets/a8bad661-0e29-44a9-94f7-bef6b95d083a)
