### PR TITLE
Fix #24422: More than one viewport is causing issues

### DIFF
--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -47,7 +47,7 @@
 #include "WindowBase.h"
 
 #include <cstring>
-#include <sfl/segmented_vector.hpp>
+#include <list>
 #include <unordered_map>
 
 namespace OpenRCT2
@@ -65,7 +65,7 @@ namespace OpenRCT2
     uint8_t gShowLandRightsRefCount;
     uint8_t gShowConstructionRightsRefCount;
 
-    static sfl::segmented_vector<Viewport, 32> _viewports;
+    static std::list<Viewport> _viewports;
     Viewport* g_music_tracking_viewport;
 
     static std::unique_ptr<JobPool> _paintJobs;


### PR DESCRIPTION
I'm not really sure what is going on here so for the time being let's just revert it back, some of the windows seem to have issues with viewports in general, they keep recreating them each frame which is pretty bad.

Close #24422