### PR TITLE
Fix virtual floor not invalidating correctly

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Change: [#24342] g2.dat is now split into g2.dat and fonts.dat.
 - Change: [#24362] The Windows installer now prevents installing to the same folder as RollerCoaster Tycoon 2 or Classic.
 - Change: [#24418] Small & Large Zero G Rolls can now be built on the LIM Launched RC without cheats if vehicle sprites are available.
+- Fix: [#11071, #22958] The virtual floor does not always draw correctly.
 - Fix: [#24346] Possible crash during line drawing in OpenGL mode.
 - Fix: [#24353] ‘Show dirty visuals’ is off by one pixel and does not work correctly with higher framerates.
 - Fix: [#24362] When upgrading from an older version on Windows, old versions of official objects are not always removed.  

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -1778,9 +1778,6 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        // Invalidate previous footpath piece.
-        VirtualFloorInvalidate();
-
         if (!isToolActive(WindowClass::Scenery))
         {
             if (res.Error != GameActions::Status::Ok)

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1075,13 +1075,11 @@ namespace OpenRCT2::Ui::Windows
                     MouseUpDemolish();
                     break;
                 case WIDX_NEXT_SECTION:
-                    VirtualFloorInvalidate();
                     RideSelectNextSection();
                     if (!(gMapSelectFlags & MAP_SELECT_FLAG_ENABLE))
                         VirtualFloorSetHeight(_currentTrackBegin.z);
                     break;
                 case WIDX_PREVIOUS_SECTION:
-                    VirtualFloorInvalidate();
                     RideSelectPreviousSection();
                     if (!(gMapSelectFlags & MAP_SELECT_FLAG_ENABLE))
                         VirtualFloorSetHeight(_currentTrackBegin.z);
@@ -3197,9 +3195,6 @@ namespace OpenRCT2::Ui::Windows
                             rideIndex, type, direction, liftHillAndAlternativeState, trackPos);
                         WindowRideConstructionUpdateActiveElements();
 
-                        // Invalidate previous track piece (we may not be changing height!)
-                        VirtualFloorInvalidate();
-
                         if (!(gMapSelectFlags & MAP_SELECT_FLAG_ENABLE))
                         {
                             // Set height to where the next track piece would begin
@@ -3544,6 +3539,7 @@ namespace OpenRCT2::Ui::Windows
                     *ride, entranceOrExitCoords, entranceOrExitCoords.direction, gRideEntranceExitPlaceType, stationNum);
             }
             WindowRideConstructionUpdateActiveElements();
+            VirtualFloorSetHeight(entranceOrExitCoords.z);
         }
     }
 
@@ -4787,9 +4783,6 @@ namespace OpenRCT2::Ui::Windows
         ViewportSetVisibility(visiblity);
         if (_currentTrackPitchEnd != TrackPitch::None)
             ViewportSetVisibility(ViewportVisibility::TrackHeights);
-
-        // Invalidate previous track piece (we may not be changing height!)
-        VirtualFloorInvalidate();
 
         if (!(gMapSelectFlags & MAP_SELECT_FLAG_ENABLE))
         {

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -1767,11 +1767,6 @@ namespace OpenRCT2::Ui::Windows
             MapInvalidateSelectionRect();
             MapInvalidateMapSelectionTiles();
 
-            if (Config::Get().general.VirtualFloorStyle != VirtualFloorStyles::Off)
-            {
-                VirtualFloorInvalidate();
-            }
-
             gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE;
             gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_CONSTRUCT;
 

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -18,6 +18,7 @@
 #include "../drawing/Text.h"
 #include "../localisation/Formatting.h"
 #include "../paint/Paint.h"
+#include "../paint/VirtualFloor.h"
 #include "../profiling/Profiling.h"
 #include "../scenes/intro/IntroScene.h"
 #include "../ui/UiContext.h"
@@ -46,6 +47,8 @@ void Painter::Paint(IDrawingEngine& de)
     }
     else
     {
+        VirtualFloorInvalidate(false);
+
         de.PaintWindows();
 
         UpdatePaletteEffects();

--- a/src/openrct2/paint/VirtualFloor.h
+++ b/src/openrct2/paint/VirtualFloor.h
@@ -29,7 +29,7 @@ void VirtualFloorSetHeight(int16_t height);
 
 void VirtualFloorEnable();
 void VirtualFloorDisable();
-void VirtualFloorInvalidate();
+void VirtualFloorInvalidate(const bool alwaysInvalidate);
 
 bool VirtualFloorTileIsFloor(const CoordsXY& loc);
 


### PR DESCRIPTION
This fixes the virtual floor not invalidating correctly.
Fixes #11071
Fixes #22958

https://github.com/user-attachments/assets/9e709c7f-7fe7-44ac-a9bd-54db50dc3670


https://github.com/user-attachments/assets/34c1b782-c35f-45c9-ab82-d9bc636f35db


https://github.com/user-attachments/assets/e08c335a-2b0d-4183-8e8e-949fa592a02e


https://github.com/user-attachments/assets/a2ba3a90-3291-4a52-8f3f-8ac7e5dfbbe1


It removes individual calls to `VirtualFloorInvalidate` and calls it once per frame instead. The function already handles invalidating the previous and current position only if they changed, and since it's global and there's only one floor, all it really needs to do is invalidate the previous frame position, and the current frame position once.
There's a little bit of cleanup to the virtual floor code too.