### PR TITLE
Refactor window visibility cache and fix viewport visibility

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -23,6 +23,7 @@
 - Fix: [#24406] The network status window uses an undefined string for its title.
 - Fix: [#24444] In the object load error window, the guide text overlaps when the title bar is enlarged.
 - Fix: [#24448] Shortcuts involving the Caps Lock key are wrongly localised to NumPad Dot.
+- Fix: [#24464] Window and viewport visibility is not calculated correctly causing minor performance issues.
 
 0.4.22 (2025-05-04)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -366,8 +366,6 @@ public:
 
     void PaintWindows() override
     {
-        WindowResetVisibilities();
-
         if (ClimateHasWeatherEffect())
         {
             WindowUpdateAllViewports();

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -184,8 +184,6 @@ void X8DrawingEngine::EndDraw()
 
 void X8DrawingEngine::PaintWindows()
 {
-    WindowResetVisibilities();
-
     // Redraw dirty regions before updating the viewports, otherwise
     // when viewports get panned, they copy dirty pixels
     DrawAllDirtyBlocks();

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -203,6 +203,7 @@ namespace OpenRCT2
         if (Config::Get().general.AlwaysShowGridlines)
             viewport->flags |= VIEWPORT_FLAG_GRIDLINES;
         w->viewport = viewport;
+        viewport->isVisible = w->IsVisible();
 
         CoordsXYZ centrePos = focus.GetPos();
         w->viewport_target_sprite = std::visit(
@@ -250,7 +251,7 @@ namespace OpenRCT2
     {
         for (auto& vp : _viewports)
         {
-            if (maxZoom == ZoomLevel{ -1 } || vp.zoom <= ZoomLevel{ maxZoom })
+            if (vp.isVisible && (maxZoom == ZoomLevel{ -1 } || vp.zoom <= ZoomLevel{ maxZoom }))
             {
                 int32_t x1, y1, x2, y2;
 
@@ -272,7 +273,7 @@ namespace OpenRCT2
     {
         for (auto& vp : _viewports)
         {
-            if (maxZoom == ZoomLevel{ -1 } || vp.zoom <= ZoomLevel{ maxZoom })
+            if (vp.isVisible && (maxZoom == ZoomLevel{ -1 } || vp.zoom <= ZoomLevel{ maxZoom }))
             {
                 auto screenCoords = Translate3DTo2DWithZ(vp.rotation, pos);
                 auto screenPos = ScreenRect(
@@ -287,7 +288,7 @@ namespace OpenRCT2
     {
         for (auto& vp : _viewports)
         {
-            if (maxZoom == ZoomLevel{ -1 } || vp.zoom <= ZoomLevel{ maxZoom })
+            if (vp.isVisible && (maxZoom == ZoomLevel{ -1 } || vp.zoom <= ZoomLevel{ maxZoom }))
             {
                 ViewportInvalidate(&vp, screenRect);
             }
@@ -1840,24 +1841,6 @@ namespace OpenRCT2
     void ViewportInvalidate(const Viewport* viewport, const ScreenRect& screenRect)
     {
         PROFILED_FUNCTION();
-
-        // if unknown viewport visibility, use the containing window to discover the status
-        if (viewport->visibility == VisibilityCache::unknown)
-        {
-            auto windowManager = Ui::GetWindowManager();
-            auto owner = windowManager->GetOwner(viewport);
-            if (owner != nullptr && owner->classification != WindowClass::MainWindow)
-            {
-                // note, window_is_visible will update viewport->visibility, so this should have a low hit count
-                if (!WindowIsVisible(*owner))
-                {
-                    return;
-                }
-            }
-        }
-
-        if (viewport->visibility == VisibilityCache::covered)
-            return;
 
         auto zoom = viewport->zoom;
         auto viewPos = viewport->viewPos;

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -203,7 +203,7 @@ namespace OpenRCT2
         if (Config::Get().general.AlwaysShowGridlines)
             viewport->flags |= VIEWPORT_FLAG_GRIDLINES;
         w->viewport = viewport;
-        viewport->isVisible = w->IsVisible();
+        viewport->isVisible = w->isVisible;
 
         CoordsXYZ centrePos = focus.GetPos();
         w->viewport_target_sprite = std::visit(

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -38,7 +38,7 @@ namespace OpenRCT2
         uint32_t flags{};
         ZoomLevel zoom{};
         uint8_t rotation{};
-        VisibilityCache visibility{};
+        bool isVisible = false;
 
         [[nodiscard]] constexpr int32_t ViewWidth() const
         {

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -115,7 +115,7 @@ static constexpr float kWindowScrollLocations[][2] = {
     void WindowUpdateAllViewports()
     {
         WindowVisitEach([&](WindowBase* w) {
-            if (w->viewport != nullptr && WindowIsVisible(*w))
+            if (w->viewport != nullptr && w->IsVisible())
             {
                 ViewportUpdatePosition(w);
             }
@@ -155,6 +155,8 @@ static constexpr float kWindowScrollLocations[][2] = {
 
         auto windowManager = Ui::GetWindowManager();
         windowManager->UpdateMouseWheel();
+
+        WindowVisitEach([](WindowBase* const w) { w->UpdateVisibility(); });
     }
 
     void WindowNotifyLanguageChange()
@@ -496,7 +498,7 @@ static constexpr float kWindowScrollLocations[][2] = {
      */
     void WindowDraw(RenderTarget& rt, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
     {
-        if (!WindowIsVisible(w))
+        if (!w.IsVisible())
             return;
 
         // Divide the draws up for only the visible regions of the window recursively
@@ -569,7 +571,7 @@ static constexpr float kWindowScrollLocations[][2] = {
             auto* v = (*it).get();
             if (v->flags & WF_DEAD)
                 continue;
-            if ((&w == v || (v->flags & WF_TRANSPARENT)) && WindowIsVisible(*v))
+            if ((&w == v || (v->flags & WF_TRANSPARENT)) && v->IsVisible())
             {
                 WindowDrawSingle(rt, *v, left, top, right, bottom);
             }
@@ -855,48 +857,6 @@ static constexpr float kWindowScrollLocations[][2] = {
         windowMgr->CloseByClass(WindowClass::Textinput);
     }
 
-    bool WindowIsVisible(WindowBase& w)
-    {
-        // w->visibility is used to prevent repeat calculations within an iteration by caching the result
-
-        if (w.visibility == VisibilityCache::visible)
-            return true;
-        if (w.visibility == VisibilityCache::covered)
-            return false;
-
-        // only consider viewports, consider the main window always visible
-        if (w.viewport == nullptr || w.classification == WindowClass::MainWindow)
-        {
-            // default to previous behaviour
-            w.visibility = VisibilityCache::visible;
-            return true;
-        }
-
-        // start from the window above the current
-        auto itPos = WindowGetIterator(&w);
-        for (auto it = std::next(itPos); it != g_window_list.end(); it++)
-        {
-            auto& w_other = *(*it);
-            if (w_other.flags & WF_DEAD)
-                continue;
-
-            // if covered by a higher window, no rendering needed
-            if (w_other.windowPos.x <= w.windowPos.x && w_other.windowPos.y <= w.windowPos.y
-                && w_other.windowPos.x + w_other.width >= w.windowPos.x + w.width
-                && w_other.windowPos.y + w_other.height >= w.windowPos.y + w.height)
-            {
-                w.visibility = VisibilityCache::covered;
-                w.viewport->visibility = VisibilityCache::covered;
-                return false;
-            }
-        }
-
-        // default to previous behaviour
-        w.visibility = VisibilityCache::visible;
-        w.viewport->visibility = VisibilityCache::visible;
-        return true;
-    }
-
     /**
      *
      *  rct2: 0x006E7499
@@ -940,18 +900,6 @@ static constexpr float kWindowScrollLocations[][2] = {
             }
         }
         return nullptr;
-    }
-
-    void WindowResetVisibilities()
-    {
-        // reset window visibility status to unknown
-        WindowVisitEach([](WindowBase* w) {
-            w->visibility = VisibilityCache::unknown;
-            if (w->viewport != nullptr)
-            {
-                w->viewport->visibility = VisibilityCache::unknown;
-            }
-        });
     }
 
     void WindowInitAll()

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -26,7 +26,6 @@ struct RenderTarget;
 struct TrackDesignFileRef;
 struct ScenarioIndexEntry;
 
-enum class VisibilityCache : uint8_t;
 enum class CursorID : uint8_t;
 enum class CloseWindowModifier : uint8_t;
 
@@ -232,13 +231,6 @@ enum class ModalResult : int8_t
     ok,
 };
 
-enum class VisibilityCache : uint8_t
-{
-    unknown,
-    visible,
-    covered
-};
-
 enum class CloseWindowModifier : uint8_t
 {
     none,
@@ -341,10 +333,7 @@ namespace OpenRCT2
 
     void TextinputCancel();
 
-    bool WindowIsVisible(WindowBase& w);
-
     Viewport* WindowGetPreviousViewport(Viewport* current);
-    void WindowResetVisibilities();
     void WindowInitAll();
 
     void WindowFollowSprite(WindowBase& w, EntityId spriteIndex);

--- a/src/openrct2/interface/WindowBase.cpp
+++ b/src/openrct2/interface/WindowBase.cpp
@@ -166,45 +166,4 @@ namespace OpenRCT2
     {
         return getTitleBarCurrentHeight() - kTitleHeightNormal;
     }
-
-    bool WindowBase::IsVisible() const
-    {
-        return isVisible;
-    }
-
-    void WindowBase::UpdateVisibility()
-    {
-        if (viewport == nullptr)
-        {
-            isVisible = true;
-            return;
-        }
-        if (classification == WindowClass::MainWindow)
-        {
-            isVisible = true;
-            viewport->isVisible = true;
-            return;
-        }
-
-        // start from the window above the current
-        auto itPos = WindowGetIterator(this);
-        for (auto it = std::next(itPos); it != g_window_list.end(); it++)
-        {
-            const auto& other = *(*it);
-            if (other.flags & WF_DEAD)
-                continue;
-
-            if (other.windowPos.x <= windowPos.x && other.windowPos.y <= windowPos.y
-                && other.windowPos.x + other.width >= windowPos.x + width
-                && other.windowPos.y + other.height >= windowPos.y + height)
-            {
-                isVisible = false;
-                viewport->isVisible = false;
-                return;
-            }
-        }
-
-        isVisible = true;
-        viewport->isVisible = true;
-    }
 } // namespace OpenRCT2

--- a/src/openrct2/interface/WindowBase.cpp
+++ b/src/openrct2/interface/WindowBase.cpp
@@ -166,4 +166,45 @@ namespace OpenRCT2
     {
         return getTitleBarCurrentHeight() - kTitleHeightNormal;
     }
+
+    bool WindowBase::IsVisible() const
+    {
+        return isVisible;
+    }
+
+    void WindowBase::UpdateVisibility()
+    {
+        if (viewport == nullptr)
+        {
+            isVisible = true;
+            return;
+        }
+        if (classification == WindowClass::MainWindow)
+        {
+            isVisible = true;
+            viewport->isVisible = true;
+            return;
+        }
+
+        // start from the window above the current
+        auto itPos = WindowGetIterator(this);
+        for (auto it = std::next(itPos); it != g_window_list.end(); it++)
+        {
+            const auto& other = *(*it);
+            if (other.flags & WF_DEAD)
+                continue;
+
+            if (other.windowPos.x <= windowPos.x && other.windowPos.y <= windowPos.y
+                && other.windowPos.x + other.width >= windowPos.x + width
+                && other.windowPos.y + other.height >= windowPos.y + height)
+            {
+                isVisible = false;
+                viewport->isVisible = false;
+                return;
+            }
+        }
+
+        isVisible = true;
+        viewport->isVisible = true;
+    }
 } // namespace OpenRCT2

--- a/src/openrct2/interface/WindowBase.h
+++ b/src/openrct2/interface/WindowBase.h
@@ -106,11 +106,7 @@ namespace OpenRCT2
         ScreenCoordsXY savedViewPos{};
         WindowClass classification{};
         ColourWithFlags colours[6]{};
-
-    private:
         bool isVisible = true;
-
-    public:
         EntityId viewport_smart_follow_sprite{ EntityId::GetNull() }; // Handles setting viewport target sprite etc
 
         void SetViewportLocation(const CoordsXYZ& coords);
@@ -129,9 +125,6 @@ namespace OpenRCT2
         virtual ~WindowBase() = default;
 
         WindowBase& operator=(const WindowBase&) = delete;
-
-        bool IsVisible() const;
-        void UpdateVisibility();
 
         constexpr bool canBeResized() const
         {

--- a/src/openrct2/interface/WindowBase.h
+++ b/src/openrct2/interface/WindowBase.h
@@ -106,7 +106,11 @@ namespace OpenRCT2
         ScreenCoordsXY savedViewPos{};
         WindowClass classification{};
         ColourWithFlags colours[6]{};
-        VisibilityCache visibility{};
+
+    private:
+        bool isVisible = true;
+
+    public:
         EntityId viewport_smart_follow_sprite{ EntityId::GetNull() }; // Handles setting viewport target sprite etc
 
         void SetViewportLocation(const CoordsXYZ& coords);
@@ -125,6 +129,9 @@ namespace OpenRCT2
         virtual ~WindowBase() = default;
 
         WindowBase& operator=(const WindowBase&) = delete;
+
+        bool IsVisible() const;
+        void UpdateVisibility();
 
         constexpr bool canBeResized() const
         {


### PR DESCRIPTION
This refactors window visibility and fixes a couple of bugs related to viewports.

- `WindowIsVisible` was a getter that was also updating the visibility if it was not already set. It makes much more sense to update it once in `WindowUpdateAll` and then just return that result.
- Viewport visibility was generally not getting set due to a couple of bugs. The main viewport was not setting its viewport visibility at all. Several windows with viewports were recreating their viewports every frame (see #24433), causing the visibility to get out of sync with the window. It now sets it to the windows visibility on creation.
- Because the viewport visibility was rarely set, `ViewportInvalidate` was having to go to the window manager and get the window visibility every time, which causes major slowdown when invalidating hundreds of thousands of times a frame. It now only has to check a bool. I've also moved up that check to the parent functions to prevent some unnecessary calculations.

This should improve performance a small amount. It usually takes significantly more invalidations than most normal parks have to really see a big difference. I came across this issue when I was testing invalidating 500,000+ map animations.

You might notice that windows are always set to visible if they don't have a viewport. That is the current behavior and there is some more complications with that about window translucency as well. Another time maybe.