### PR TITLE
Fix #20158: Animated scenery DATs with frame offsets draw random sprite at end of their animation

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Change: [#24418] Small & Large Zero G Rolls can now be built on the LIM Launched RC without cheats if vehicle sprites are available.
 - Fix: [#5269] Font bugs when using the Russian release of RCT2 as the base game.
 - Fix: [#11071, #22958] The virtual floor does not always draw correctly.
+- Fix: [#20158] Custom animated scenery .DATs with frame offsets draw a random sprite at the end of their animation.
 - Fix: [#24332] Banner font renders differently when using RCT Classic as the base game.
 - Fix: [#24346] Possible crash during line drawing in OpenGL mode.
 - Fix: [#24353] ‘Show dirty visuals’ is off by one pixel and does not work correctly with higher framerates.

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -148,7 +148,6 @@ std::vector<uint8_t> SmallSceneryObject::ReadFrameOffsets(OpenRCT2::IStream* str
     {
         data.push_back(frameOffset);
     }
-    data.push_back(frameOffset);
     return data;
 }
 


### PR DESCRIPTION
This fixes #20158. Animated scenery .DATs with frame offsets draw a random sprite at end of their animation.


https://github.com/user-attachments/assets/4bee04f2-f64f-4af9-806e-47618d571610


https://github.com/user-attachments/assets/1f742a71-394f-47cf-b45b-aa91fd110f16


The issue here is that when loading the frame offsets it was adding the sentinel value of 255 in to the list. The way these delayed animations work is they count up to their max value, if it's under the amount of frame offsets, it looks up that frame, otherwise it draws the first frame. With 255 in there, it draws whatever random sprite is 255 * 4 ahead of it for a single frame.