### PR TITLE
Remove unnecessary ninja install on macOS CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,8 +387,7 @@ jobs:
         uses: ammaraskar/gcc-problem-matcher@master
       - name: Build OpenRCT2
         run: |
-          # NB: GitHub comes with `pkg-config` preinstalled on macOS images
-          HOMEBREW_NO_ANALYTICS=1 brew install ninja
+          # NB: GitHub comes with `pkg-config` and `ninja` preinstalled on macOS images
           . scripts/setenv -q && build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=on ${{ matrix.build_flags }}
       - name: Build artifacts
         run: |


### PR DESCRIPTION
Remove unnecessary ninja install on macOS CI as it comes preinstalled on macOS images, similiar to `pkg-config`