### PR TITLE
Fix #24447: Refresh the shortcut window when changing language

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,6 +24,7 @@
 - Fix: [#24403] Park fences draw underneath and through opaque water.
 - Fix: [#24406] The network status window uses an undefined string for its title.
 - Fix: [#24444] In the object load error window, the guide text overlaps when the title bar is enlarged.
+- Fix: [#24447] Shortcut list is not refreshed when changing language.
 - Fix: [#24448] Shortcuts involving the Caps Lock key are wrongly localised to NumPad Dot.
 - Fix: [#24464] Window and viewport visibility is not calculated correctly causing minor performance issues.
 

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -335,6 +335,11 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
+        void OnLanguageChange() override
+        {
+            InitialiseList();
+        }
+
         void RefreshBindings()
         {
             InitialiseList();


### PR DESCRIPTION
Fix for #24447 by reinitialising the shortcut window list when a language change has been detected.