### PR TITLE
News queue refactors, part 2

### DIFF
--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -244,12 +244,12 @@ namespace OpenRCT2::Ui::Windows
             auto screenCoords = windowPos + ScreenCoordsXY{ middleOutsetWidget.midX(), middleOutsetWidget.top + 11 };
             int32_t itemWidth = middleOutsetWidget.width() - 62;
             DrawNewsTicker(
-                rt, screenCoords, itemWidth, COLOUR_BRIGHT_GREEN, STR_BOTTOM_TOOLBAR_NEWS_TEXT, newsItem->Text,
-                newsItem->Ticks);
+                rt, screenCoords, itemWidth, COLOUR_BRIGHT_GREEN, STR_BOTTOM_TOOLBAR_NEWS_TEXT, newsItem->text,
+                newsItem->ticks);
 
             const auto& newsSubjectWidget = widgets[WIDX_NEWS_SUBJECT];
             screenCoords = windowPos + ScreenCoordsXY{ newsSubjectWidget.left, newsSubjectWidget.top };
-            switch (newsItem->Type)
+            switch (newsItem->type)
             {
                 case News::ItemType::Ride:
                     GfxDrawSprite(rt, ImageId(SPR_RIDE), screenCoords);
@@ -257,7 +257,7 @@ namespace OpenRCT2::Ui::Windows
                 case News::ItemType::PeepOnRide:
                 case News::ItemType::Peep:
                 {
-                    if (newsItem->HasButton())
+                    if (newsItem->hasButton())
                         break;
 
                     RenderTarget clippedRT;
@@ -266,7 +266,7 @@ namespace OpenRCT2::Ui::Windows
                         break;
                     }
 
-                    auto peep = TryGetEntity<Peep>(EntityId::FromUnderlying(newsItem->Assoc));
+                    auto peep = TryGetEntity<Peep>(EntityId::FromUnderlying(newsItem->assoc));
                     if (peep == nullptr)
                         return;
 
@@ -325,7 +325,7 @@ namespace OpenRCT2::Ui::Windows
                     GfxDrawSprite(rt, ImageId(SPR_FINANCE), screenCoords);
                     break;
                 case News::ItemType::Research:
-                    GfxDrawSprite(rt, ImageId(newsItem->Assoc < 0x10000 ? SPR_NEW_SCENERY : SPR_NEW_RIDE), screenCoords);
+                    GfxDrawSprite(rt, ImageId(newsItem->assoc < 0x10000 ? SPR_NEW_SCENERY : SPR_NEW_RIDE), screenCoords);
                     break;
                 case News::ItemType::Peeps:
                     GfxDrawSprite(rt, ImageId(SPR_GUESTS), screenCoords);
@@ -452,7 +452,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
                 case WIDX_NEWS_SUBJECT:
                     newsItem = News::GetItem(0);
-                    News::OpenSubject(newsItem->Type, newsItem->Assoc);
+                    News::OpenSubject(newsItem->type, newsItem->assoc);
                     break;
                 case WIDX_NEWS_LOCATE:
                     if (News::IsQueueEmpty())
@@ -461,7 +461,7 @@ namespace OpenRCT2::Ui::Windows
                     {
                         newsItem = News::GetItem(0);
 
-                        auto subjectLoc = News::GetSubjectLocation(newsItem->Type, newsItem->Assoc);
+                        auto subjectLoc = News::GetSubjectLocation(newsItem->type, newsItem->assoc);
 
                         if (!subjectLoc.has_value())
                             break;
@@ -591,18 +591,18 @@ namespace OpenRCT2::Ui::Windows
                 disabled_widgets &= ~(1uLL << WIDX_NEWS_LOCATE);
 
                 // Find out if the news item is no longer valid
-                auto subjectLoc = News::GetSubjectLocation(newsItem->Type, newsItem->Assoc);
+                auto subjectLoc = News::GetSubjectLocation(newsItem->type, newsItem->assoc);
 
                 if (!subjectLoc.has_value())
                     disabled_widgets |= (1uLL << WIDX_NEWS_LOCATE);
 
-                if (!(newsItem->TypeHasSubject()))
+                if (!(newsItem->typeHasSubject()))
                 {
                     disabled_widgets |= (1uLL << WIDX_NEWS_SUBJECT);
                     widgets[WIDX_NEWS_SUBJECT].type = WindowWidgetType::Empty;
                 }
 
-                if (newsItem->HasButton())
+                if (newsItem->hasButton())
                 {
                     disabled_widgets |= (1uLL << WIDX_NEWS_SUBJECT);
                     disabled_widgets |= (1uLL << WIDX_NEWS_LOCATE);

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -251,11 +251,11 @@ namespace OpenRCT2::Ui::Windows
             screenCoords = windowPos + ScreenCoordsXY{ newsSubjectWidget.left, newsSubjectWidget.top };
             switch (newsItem->type)
             {
-                case News::ItemType::Ride:
+                case News::ItemType::ride:
                     GfxDrawSprite(rt, ImageId(SPR_RIDE), screenCoords);
                     break;
-                case News::ItemType::PeepOnRide:
-                case News::ItemType::Peep:
+                case News::ItemType::peepOnRide:
+                case News::ItemType::peep:
                 {
                     if (newsItem->hasButton())
                         break;
@@ -320,25 +320,25 @@ namespace OpenRCT2::Ui::Windows
                     }
                     break;
                 }
-                case News::ItemType::Money:
-                case News::ItemType::Campaign:
+                case News::ItemType::money:
+                case News::ItemType::campaign:
                     GfxDrawSprite(rt, ImageId(SPR_FINANCE), screenCoords);
                     break;
-                case News::ItemType::Research:
+                case News::ItemType::research:
                     GfxDrawSprite(rt, ImageId(newsItem->assoc < 0x10000 ? SPR_NEW_SCENERY : SPR_NEW_RIDE), screenCoords);
                     break;
-                case News::ItemType::Peeps:
+                case News::ItemType::peeps:
                     GfxDrawSprite(rt, ImageId(SPR_GUESTS), screenCoords);
                     break;
-                case News::ItemType::Award:
+                case News::ItemType::award:
                     GfxDrawSprite(rt, ImageId(SPR_AWARD), screenCoords);
                     break;
-                case News::ItemType::Graph:
+                case News::ItemType::graph:
                     GfxDrawSprite(rt, ImageId(SPR_GRAPH), screenCoords);
                     break;
-                case News::ItemType::Null:
-                case News::ItemType::Blank:
-                case News::ItemType::Count:
+                case News::ItemType::null:
+                case News::ItemType::blank:
+                case News::ItemType::count:
                     break;
             }
         }

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -230,11 +230,11 @@ namespace OpenRCT2::Ui::Windows
 
                     switch (newsItem.type)
                     {
-                        case News::ItemType::Ride:
+                        case News::ItemType::ride:
                             GfxDrawSprite(rt, ImageId(SPR_RIDE), screenCoords);
                             break;
-                        case News::ItemType::Peep:
-                        case News::ItemType::PeepOnRide:
+                        case News::ItemType::peep:
+                        case News::ItemType::peepOnRide:
                         {
                             RenderTarget clippedRT;
                             if (!ClipDrawPixelInfo(clippedRT, rt, screenCoords + ScreenCoordsXY{ 1, 1 }, 22, 22))
@@ -271,25 +271,25 @@ namespace OpenRCT2::Ui::Windows
                             GfxDrawSprite(clippedRT, image, clipCoords);
                             break;
                         }
-                        case News::ItemType::Money:
-                        case News::ItemType::Campaign:
+                        case News::ItemType::money:
+                        case News::ItemType::campaign:
                             GfxDrawSprite(rt, ImageId(SPR_FINANCE), screenCoords);
                             break;
-                        case News::ItemType::Research:
+                        case News::ItemType::research:
                             GfxDrawSprite(rt, ImageId(newsItem.assoc < 0x10000 ? SPR_NEW_SCENERY : SPR_NEW_RIDE), screenCoords);
                             break;
-                        case News::ItemType::Peeps:
+                        case News::ItemType::peeps:
                             GfxDrawSprite(rt, ImageId(SPR_GUESTS), screenCoords);
                             break;
-                        case News::ItemType::Award:
+                        case News::ItemType::award:
                             GfxDrawSprite(rt, ImageId(SPR_AWARD), screenCoords);
                             break;
-                        case News::ItemType::Graph:
+                        case News::ItemType::graph:
                             GfxDrawSprite(rt, ImageId(SPR_GRAPH), screenCoords);
                             break;
-                        case News::ItemType::Null:
-                        case News::ItemType::Blank:
-                        case News::ItemType::Count:
+                        case News::ItemType::null:
+                        case News::ItemType::blank:
+                        case News::ItemType::count:
                             break;
                     }
                 }

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -102,19 +102,19 @@ namespace OpenRCT2::Ui::Windows
             }
 
             const auto& newsItem = gameState.newsItems.GetArchived()[j];
-            if (newsItem.HasButton())
+            if (newsItem.hasButton())
             {
                 return;
             }
 
             if (_pressedButtonIndex == 1)
             {
-                News::OpenSubject(newsItem.Type, newsItem.Assoc);
+                News::OpenSubject(newsItem.type, newsItem.assoc);
             }
             else if (_pressedButtonIndex > 1)
             {
                 static WindowBase* _mainWindow;
-                auto subjectLoc = News::GetSubjectLocation(newsItem.Type, newsItem.Assoc);
+                auto subjectLoc = News::GetSubjectLocation(newsItem.type, newsItem.assoc);
                 if (subjectLoc.has_value() && (_mainWindow = WindowGetMain()) != nullptr)
                 {
                     WindowScrollToLocation(*_mainWindow, subjectLoc.value());
@@ -138,18 +138,18 @@ namespace OpenRCT2::Ui::Windows
             {
                 if (mutableScreenCoords.y < itemHeight)
                 {
-                    if (newsItem.HasButton() || mutableScreenCoords.y < 14 || mutableScreenCoords.y >= 38
+                    if (newsItem.hasButton() || mutableScreenCoords.y < 14 || mutableScreenCoords.y >= 38
                         || mutableScreenCoords.x < 328)
                     {
                         buttonIndex = 0;
                         break;
                     }
-                    if (mutableScreenCoords.x < 351 && newsItem.TypeHasSubject())
+                    if (mutableScreenCoords.x < 351 && newsItem.typeHasSubject())
                     {
                         buttonIndex = 1;
                         break;
                     }
-                    if (mutableScreenCoords.x < 376 && newsItem.TypeHasLocation())
+                    if (mutableScreenCoords.x < 376 && newsItem.typeHasLocation())
                     {
                         buttonIndex = 2;
                         break;
@@ -200,20 +200,20 @@ namespace OpenRCT2::Ui::Windows
                 // Date text
                 {
                     auto ft = Formatter();
-                    ft.Add<StringId>(DateDayNames[newsItem.Day - 1]);
-                    ft.Add<StringId>(DateGameMonthNames[DateGetMonth(newsItem.MonthYear)]);
+                    ft.Add<StringId>(DateDayNames[newsItem.day - 1]);
+                    ft.Add<StringId>(DateGameMonthNames[DateGetMonth(newsItem.monthYear)]);
                     DrawTextBasic(rt, { 2, y }, STR_NEWS_DATE_FORMAT, ft, { COLOUR_WHITE, FontStyle::Small });
                 }
                 // Item text
                 {
                     auto ft = Formatter();
-                    ft.Add<const char*>(newsItem.Text.c_str());
+                    ft.Add<const char*>(newsItem.text.c_str());
                     DrawTextWrapped(
                         rt, { 2, y + lineHeight }, 325, STR_BOTTOM_TOOLBAR_NEWS_TEXT, ft,
                         { COLOUR_BRIGHT_GREEN, FontStyle::Small });
                 }
                 // Subject button
-                if ((newsItem.TypeHasSubject()) && !(newsItem.HasButton()))
+                if ((newsItem.typeHasSubject()) && !(newsItem.hasButton()))
                 {
                     auto screenCoords = ScreenCoordsXY{ 328, y + lineHeight + 4 };
 
@@ -228,7 +228,7 @@ namespace OpenRCT2::Ui::Windows
                     }
                     GfxFillRectInset(rt, { screenCoords, screenCoords + ScreenCoordsXY{ 23, 23 } }, colours[2], press);
 
-                    switch (newsItem.Type)
+                    switch (newsItem.type)
                     {
                         case News::ItemType::Ride:
                             GfxDrawSprite(rt, ImageId(SPR_RIDE), screenCoords);
@@ -242,7 +242,7 @@ namespace OpenRCT2::Ui::Windows
                                 break;
                             }
 
-                            auto peep = TryGetEntity<Peep>(EntityId::FromUnderlying(newsItem.Assoc));
+                            auto peep = TryGetEntity<Peep>(EntityId::FromUnderlying(newsItem.assoc));
                             if (peep == nullptr)
                             {
                                 break;
@@ -276,7 +276,7 @@ namespace OpenRCT2::Ui::Windows
                             GfxDrawSprite(rt, ImageId(SPR_FINANCE), screenCoords);
                             break;
                         case News::ItemType::Research:
-                            GfxDrawSprite(rt, ImageId(newsItem.Assoc < 0x10000 ? SPR_NEW_SCENERY : SPR_NEW_RIDE), screenCoords);
+                            GfxDrawSprite(rt, ImageId(newsItem.assoc < 0x10000 ? SPR_NEW_SCENERY : SPR_NEW_RIDE), screenCoords);
                             break;
                         case News::ItemType::Peeps:
                             GfxDrawSprite(rt, ImageId(SPR_GUESTS), screenCoords);
@@ -295,7 +295,7 @@ namespace OpenRCT2::Ui::Windows
                 }
 
                 // Location button
-                if ((newsItem.TypeHasLocation()) && !(newsItem.HasButton()))
+                if ((newsItem.typeHasLocation()) && !(newsItem.hasButton()))
                 {
                     auto screenCoords = ScreenCoordsXY{ 352, y + lineHeight + 4 };
 

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -320,7 +320,7 @@ namespace OpenRCT2::Ui::Windows
 
         if (widgetIndex == (WIDX_LAST_DEVELOPMENT_BUTTON + widgetOffset))
         {
-            News::OpenSubject(News::ItemType::Research, gameState.researchLastItem->rawValue);
+            News::OpenSubject(News::ItemType::research, gameState.researchLastItem->rawValue);
         }
     }
 

--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -354,7 +354,7 @@ namespace OpenRCT2
             _currentRecording.reset();
 
             News::Item* news = News::AddItemToQueue(News::ItemType::Blank, "Replay recording stopped", 0);
-            news->SetFlags(News::ItemFlags::HasButton); // Has no subject.
+            news->setFlags(News::ItemFlags::HasButton); // Has no subject.
 
             return result;
         }
@@ -480,7 +480,7 @@ namespace OpenRCT2
             if (_mode == ReplayMode::PLAYING)
             {
                 News::Item* news = News::AddItemToQueue(News::ItemType::Blank, "Replay playback complete", 0);
-                news->SetFlags(News::ItemFlags::HasButton); // Has no subject.
+                news->setFlags(News::ItemFlags::HasButton); // Has no subject.
             }
 
             // When normalizing the output we don't touch the mode.

--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -353,8 +353,8 @@ namespace OpenRCT2
 
             _currentRecording.reset();
 
-            News::Item* news = News::AddItemToQueue(News::ItemType::Blank, "Replay recording stopped", 0);
-            news->setFlags(News::ItemFlags::HasButton); // Has no subject.
+            News::Item* news = News::AddItemToQueue(News::ItemType::blank, "Replay recording stopped", 0);
+            news->setFlags(News::ItemFlags::hasButton); // Has no subject.
 
             return result;
         }
@@ -479,8 +479,8 @@ namespace OpenRCT2
             // During normal playback we pause the game if stopped.
             if (_mode == ReplayMode::PLAYING)
             {
-                News::Item* news = News::AddItemToQueue(News::ItemType::Blank, "Replay playback complete", 0);
-                news->setFlags(News::ItemFlags::HasButton); // Has no subject.
+                News::Item* news = News::AddItemToQueue(News::ItemType::blank, "Replay playback complete", 0);
+                news->setFlags(News::ItemFlags::hasButton); // Has no subject.
             }
 
             // When normalizing the output we don't touch the mode.

--- a/src/openrct2/actions/RideDemolishAction.cpp
+++ b/src/openrct2/actions/RideDemolishAction.cpp
@@ -131,7 +131,7 @@ GameActions::Result RideDemolishAction::DemolishRide(Ride& ride) const
     RideClearLeftoverEntrances(ride);
 
     const auto rideId = ride.id;
-    News::DisableNewsItems(News::ItemType::Ride, rideId.ToUnderlying());
+    News::DisableNewsItems(News::ItemType::ride, rideId.ToUnderlying());
 
     UnlinkAllBannersForRide(ride.id);
 

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -1702,7 +1702,7 @@ static bool GuestDecideAndBuyItem(Guest& guest, Ride& ride, const ShopItem shopI
         ft.Add<StringId>(shopItemDescriptor.Naming.Indefinite);
         if (Config::Get().notifications.GuestBoughtItem)
         {
-            News::AddItemToQueue(News::ItemType::PeepOnRide, STR_PEEP_TRACKING_NOTIFICATION_BOUGHT_X, guest.Id, ft);
+            News::AddItemToQueue(News::ItemType::peepOnRide, STR_PEEP_TRACKING_NOTIFICATION_BOUGHT_X, guest.Id, ft);
         }
     }
 
@@ -3627,7 +3627,7 @@ void PeepUpdateRideLeaveEntranceDefault(Guest& guest, Ride& ride, CoordsXYZD& en
         ride.formatNameTo(ft);
         if (Config::Get().notifications.RideWarnings)
         {
-            News::AddItemToQueue(News::ItemType::Ride, STR_GUESTS_GETTING_STUCK_ON_RIDE, guest.CurrentRide.ToUnderlying(), ft);
+            News::AddItemToQueue(News::ItemType::ride, STR_GUESTS_GETTING_STUCK_ON_RIDE, guest.CurrentRide.ToUnderlying(), ft);
         }
     }
 }
@@ -3932,7 +3932,7 @@ void Guest::UpdateRideFreeVehicleEnterRide(Ride& ride)
 
         if (Config::Get().notifications.GuestOnRide)
         {
-            News::AddItemToQueue(News::ItemType::PeepOnRide, msg_string, Id, ft);
+            News::AddItemToQueue(News::ItemType::peepOnRide, msg_string, Id, ft);
         }
     }
 
@@ -5086,7 +5086,7 @@ void Guest::UpdateRideLeaveExit()
 
             if (Config::Get().notifications.GuestLeftRide)
             {
-                News::AddItemToQueue(News::ItemType::PeepOnRide, STR_PEEP_TRACKING_LEFT_RIDE_X, Id, ft);
+                News::AddItemToQueue(News::ItemType::peepOnRide, STR_PEEP_TRACKING_LEFT_RIDE_X, Id, ft);
             }
         }
     }

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -728,14 +728,14 @@ void PeepEntityRemove(Peep* peep)
     bool wasGuest = staff == nullptr;
     if (wasGuest)
     {
-        News::DisableNewsItems(News::ItemType::PeepOnRide, peep->Id.ToUnderlying());
+        News::DisableNewsItems(News::ItemType::peepOnRide, peep->Id.ToUnderlying());
     }
     else
     {
         staff->ClearPatrolArea();
         UpdateConsolidatedPatrolAreas();
 
-        News::DisableNewsItems(News::ItemType::Peep, staff->Id.ToUnderlying());
+        News::DisableNewsItems(News::ItemType::peep, staff->Id.ToUnderlying());
     }
     EntityRemove(peep);
 
@@ -783,7 +783,7 @@ void Peep::UpdateFalling()
         {
             auto ft = Formatter();
             FormatNameTo(ft);
-            News::AddItemToQueue(News::ItemType::Blank, STR_NEWS_ITEM_GUEST_DROWNED, x | (y << 16), ft);
+            News::AddItemToQueue(News::ItemType::blank, STR_NEWS_ITEM_GUEST_DROWNED, x | (y << 16), ft);
         }
 
         auto& gameState = getGameState();
@@ -1046,7 +1046,7 @@ void PeepProblemWarningsUpdate()
         if (Config::Get().notifications.GuestWarnings)
         {
             constexpr auto thoughtId = static_cast<uint32_t>(PeepThoughtType::Hungry);
-            News::AddItemToQueue(News::ItemType::Peeps, STR_PEEPS_ARE_HUNGRY, thoughtId, {});
+            News::AddItemToQueue(News::ItemType::peeps, STR_PEEPS_ARE_HUNGRY, thoughtId, {});
         }
     }
 
@@ -1058,7 +1058,7 @@ void PeepProblemWarningsUpdate()
         if (Config::Get().notifications.GuestWarnings)
         {
             constexpr auto thoughtId = static_cast<uint32_t>(PeepThoughtType::Thirsty);
-            News::AddItemToQueue(News::ItemType::Peeps, STR_PEEPS_ARE_THIRSTY, thoughtId, {});
+            News::AddItemToQueue(News::ItemType::peeps, STR_PEEPS_ARE_THIRSTY, thoughtId, {});
         }
     }
 
@@ -1070,7 +1070,7 @@ void PeepProblemWarningsUpdate()
         if (Config::Get().notifications.GuestWarnings)
         {
             constexpr auto thoughtId = static_cast<uint32_t>(PeepThoughtType::Toilet);
-            News::AddItemToQueue(News::ItemType::Peeps, STR_PEEPS_CANT_FIND_TOILET, thoughtId, {});
+            News::AddItemToQueue(News::ItemType::peeps, STR_PEEPS_CANT_FIND_TOILET, thoughtId, {});
         }
     }
 
@@ -1082,7 +1082,7 @@ void PeepProblemWarningsUpdate()
         if (Config::Get().notifications.GuestWarnings)
         {
             constexpr auto thoughtId = static_cast<uint32_t>(PeepThoughtType::BadLitter);
-            News::AddItemToQueue(News::ItemType::Peeps, STR_PEEPS_DISLIKE_LITTER, thoughtId, {});
+            News::AddItemToQueue(News::ItemType::peeps, STR_PEEPS_DISLIKE_LITTER, thoughtId, {});
         }
     }
 
@@ -1094,7 +1094,7 @@ void PeepProblemWarningsUpdate()
         if (Config::Get().notifications.GuestWarnings)
         {
             constexpr auto thoughtId = static_cast<uint32_t>(PeepThoughtType::PathDisgusting);
-            News::AddItemToQueue(News::ItemType::Peeps, STR_PEEPS_DISGUSTED_BY_PATHS, thoughtId, {});
+            News::AddItemToQueue(News::ItemType::peeps, STR_PEEPS_DISGUSTED_BY_PATHS, thoughtId, {});
         }
     }
 
@@ -1106,7 +1106,7 @@ void PeepProblemWarningsUpdate()
         if (Config::Get().notifications.GuestWarnings)
         {
             constexpr auto thoughtId = static_cast<uint32_t>(PeepThoughtType::Vandalism);
-            News::AddItemToQueue(News::ItemType::Peeps, STR_PEEPS_DISLIKE_VANDALISM, thoughtId, {});
+            News::AddItemToQueue(News::ItemType::peeps, STR_PEEPS_DISLIKE_VANDALISM, thoughtId, {});
         }
     }
 
@@ -1118,7 +1118,7 @@ void PeepProblemWarningsUpdate()
         if (Config::Get().notifications.GuestWarnings)
         {
             constexpr auto thoughtId = static_cast<uint32_t>(PeepThoughtType::CantFindExit);
-            News::AddItemToQueue(News::ItemType::Peeps, STR_PEEPS_GETTING_LOST_OR_STUCK, thoughtId, {});
+            News::AddItemToQueue(News::ItemType::peeps, STR_PEEPS_GETTING_LOST_OR_STUCK, thoughtId, {});
         }
     }
     else if (lostCounter >= kPeepLostWarningThreshold)
@@ -1127,7 +1127,7 @@ void PeepProblemWarningsUpdate()
         if (Config::Get().notifications.GuestWarnings)
         {
             constexpr auto thoughtId = static_cast<uint32_t>(PeepThoughtType::Lost);
-            News::AddItemToQueue(News::ItemType::Peeps, STR_PEEPS_GETTING_LOST_OR_STUCK, thoughtId, {});
+            News::AddItemToQueue(News::ItemType::peeps, STR_PEEPS_GETTING_LOST_OR_STUCK, thoughtId, {});
         }
     }
 
@@ -1143,7 +1143,7 @@ void PeepProblemWarningsUpdate()
                 queueComplainingGuestsMap.begin(), queueComplainingGuestsMap.end(),
                 [](auto& lhs, auto& rhs) { return lhs.second < rhs.second; });
             auto rideId = rideWithMostQueueComplaints->first.ToUnderlying();
-            News::AddItemToQueue(News::ItemType::Ride, STR_PEEPS_COMPLAINING_ABOUT_QUEUE_LENGTH_WARNING, rideId, {});
+            News::AddItemToQueue(News::ItemType::ride, STR_PEEPS_COMPLAINING_ABOUT_QUEUE_LENGTH_WARNING, rideId, {});
         }
     }
 }
@@ -1727,7 +1727,7 @@ static bool PeepInteractWithEntrance(Peep* peep, const CoordsXYE& coords, uint8_
             ride->formatNameTo(ft);
             if (Config::Get().notifications.GuestQueuingForRide)
             {
-                News::AddItemToQueue(News::ItemType::PeepOnRide, STR_PEEP_TRACKING_PEEP_JOINED_QUEUE_FOR_X, guest->Id, ft);
+                News::AddItemToQueue(News::ItemType::peepOnRide, STR_PEEP_TRACKING_PEEP_JOINED_QUEUE_FOR_X, guest->Id, ft);
             }
         }
     }
@@ -1788,7 +1788,7 @@ static bool PeepInteractWithEntrance(Peep* peep, const CoordsXYE& coords, uint8_
                 guest->FormatNameTo(ft);
                 if (Config::Get().notifications.GuestLeftPark)
                 {
-                    News::AddItemToQueue(News::ItemType::PeepOnRide, STR_PEEP_TRACKING_LEFT_PARK, guest->Id, ft);
+                    News::AddItemToQueue(News::ItemType::peepOnRide, STR_PEEP_TRACKING_LEFT_PARK, guest->Id, ft);
                 }
             }
             return true;
@@ -2180,7 +2180,7 @@ static void PeepInteractWithPath(Peep* peep, const CoordsXYE& coords)
                         if (Config::Get().notifications.GuestQueuingForRide)
                         {
                             News::AddItemToQueue(
-                                News::ItemType::PeepOnRide, STR_PEEP_TRACKING_PEEP_JOINED_QUEUE_FOR_X, guest->Id, ft);
+                                News::ItemType::peepOnRide, STR_PEEP_TRACKING_PEEP_JOINED_QUEUE_FOR_X, guest->Id, ft);
                         }
                     }
 
@@ -2297,7 +2297,7 @@ static bool PeepInteractWithShop(Peep* peep, const CoordsXYE& coords)
                 : STR_PEEP_TRACKING_PEEP_IS_ON_X;
             if (Config::Get().notifications.GuestUsedFacility)
             {
-                News::AddItemToQueue(News::ItemType::PeepOnRide, string_id, guest->Id, ft);
+                News::AddItemToQueue(News::ItemType::peepOnRide, string_id, guest->Id, ft);
             }
         }
     }

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1603,20 +1603,20 @@ static void ConsoleCommandAddNewsItem([[maybe_unused]] InteractiveConsole& conso
     if (argv.size() < 2)
     {
         console.WriteLineWarning("Too few arguments");
-        static_assert(News::ItemTypeCount == 11, "News::ItemType::Count changed, update console command!");
+        static_assert(News::ItemTypeCount == 11, "News::ItemType::count changed, update console command!");
         console.WriteLine("add_news_item <type> <message> [assoc]");
         console.WriteLine("type is one of:");
-        console.WriteLine("    0 (News::ItemType::Null)");
-        console.WriteLine("    1 (News::ItemType::Ride)");
-        console.WriteLine("    2 (News::ItemType::PeepOnRide)");
-        console.WriteLine("    3 (News::ItemType::Peep)");
-        console.WriteLine("    4 (News::ItemType::Money)");
-        console.WriteLine("    5 (News::ItemType::Blank)");
-        console.WriteLine("    6 (News::ItemType::Research)");
-        console.WriteLine("    7 (News::ItemType::Peeps)");
-        console.WriteLine("    8 (News::ItemType::Award)");
-        console.WriteLine("    9 (News::ItemType::Graph)");
-        console.WriteLine("   10 (News::ItemType::Campaign)");
+        console.WriteLine("    0 (News::ItemType::null)");
+        console.WriteLine("    1 (News::ItemType::ride)");
+        console.WriteLine("    2 (News::ItemType::peepOnRide)");
+        console.WriteLine("    3 (News::ItemType::peep)");
+        console.WriteLine("    4 (News::ItemType::money)");
+        console.WriteLine("    5 (News::ItemType::blank)");
+        console.WriteLine("    6 (News::ItemType::research)");
+        console.WriteLine("    7 (News::ItemType::peeps)");
+        console.WriteLine("    8 (News::ItemType::award)");
+        console.WriteLine("    9 (News::ItemType::graph)");
+        console.WriteLine("   10 (News::ItemType::campaign)");
         console.WriteLine("message is the message to display, wrapped in quotes for multiple words");
         console.WriteLine("assoc is the associated id of ride/peep/tile/etc. If the selected ItemType doesn't need an assoc "
                           "(Null, Money, Award, Graph), you can leave this field blank");

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -650,7 +650,7 @@ void AwardUpdateAll()
                 currentAwards.push_back(Award{ 5u, awardType });
                 if (Config::Get().notifications.ParkAward)
                 {
-                    News::AddItemToQueue(News::ItemType::Award, AwardNewsStrings[EnumValue(awardType)], 0, {});
+                    News::AddItemToQueue(News::ItemType::award, AwardNewsStrings[EnumValue(awardType)], 0, {});
                 }
                 windowMgr->InvalidateByClass(WindowClass::ParkInformation);
             }

--- a/src/openrct2/management/Marketing.cpp
+++ b/src/openrct2/management/Marketing.cpp
@@ -100,7 +100,7 @@ static void MarketingRaiseFinishedNotification(const MarketingCampaign& campaign
             ft.Add<StringId>(GetShopItemDescriptor(campaign.ShopItemType).Naming.Plural);
         }
 
-        News::AddItemToQueue(News::ItemType::Campaign, kMarketingCampaignNames[campaign.Type][2], 0, ft);
+        News::AddItemToQueue(News::ItemType::campaign, kMarketingCampaignNames[campaign.Type][2], 0, ft);
     }
 }
 

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -121,7 +121,7 @@ void News::InitQueue(GameState_t& gameState)
 
 uint16_t News::ItemQueues::IncrementTicks()
 {
-    return ++Current().Ticks;
+    return ++Current().ticks;
 }
 
 static void TickCurrent()
@@ -137,7 +137,7 @@ static void TickCurrent()
 
 int32_t News::ItemQueues::RemoveTime() const
 {
-    if (!Recent[5].IsEmpty() && !Recent[4].IsEmpty() && !Recent[3].IsEmpty() && !Recent[2].IsEmpty())
+    if (!Recent[5].isEmpty() && !Recent[4].isEmpty() && !Recent[3].isEmpty() && !Recent[2].isEmpty())
     {
         return 256;
     }
@@ -146,7 +146,7 @@ int32_t News::ItemQueues::RemoveTime() const
 
 bool News::ItemQueues::CurrentShouldBeArchived() const
 {
-    return Current().Ticks >= RemoveTime();
+    return Current().ticks >= RemoveTime();
 }
 
 /**
@@ -299,7 +299,7 @@ News::Item* News::ItemQueues::FirstOpenOrNewSlot()
     // The for loop above guarantees there is always an extra element to use
     assert(Recent.capacity() - Recent.size() >= 2);
     auto newsItem = res + 1;
-    newsItem->Type = News::ItemType::Null;
+    newsItem->type = News::ItemType::Null;
 
     return &*res;
 }
@@ -327,13 +327,13 @@ News::Item* News::AddItemToQueue(News::ItemType type, const utf8* text, uint32_t
 {
     auto& date = GetDate();
     News::Item* newsItem = getGameState().newsItems.FirstOpenOrNewSlot();
-    newsItem->Type = type;
-    newsItem->Flags = 0;
-    newsItem->Assoc = assoc; // Make optional for Award, Money, Graph and Null
-    newsItem->Ticks = 0;
-    newsItem->MonthYear = static_cast<uint16_t>(date.GetMonthsElapsed());
-    newsItem->Day = date.GetDay() + 1;
-    newsItem->Text = text;
+    newsItem->type = type;
+    newsItem->flags = 0;
+    newsItem->assoc = assoc; // Make optional for Award, Money, Graph and Null
+    newsItem->ticks = 0;
+    newsItem->monthYear = static_cast<uint16_t>(date.GetMonthsElapsed());
+    newsItem->day = date.GetDay() + 1;
+    newsItem->text = text;
 
     return newsItem;
 }
@@ -439,9 +439,9 @@ void News::DisableNewsItems(News::ItemType type, uint32_t assoc)
     auto& gameState = getGameState();
     // TODO: write test invalidating windows
     gameState.newsItems.ForeachRecentNews([type, assoc, &gameState](auto& newsItem) {
-        if (type == newsItem.Type && assoc == newsItem.Assoc)
+        if (type == newsItem.type && assoc == newsItem.assoc)
         {
-            newsItem.SetFlags(News::ItemFlags::HasButton);
+            newsItem.setFlags(News::ItemFlags::HasButton);
             if (&newsItem == &gameState.newsItems.Current())
             {
                 auto intent = Intent(INTENT_ACTION_INVALIDATE_TICKER_NEWS);
@@ -451,9 +451,9 @@ void News::DisableNewsItems(News::ItemType type, uint32_t assoc)
     });
 
     gameState.newsItems.ForeachArchivedNews([type, assoc](auto& newsItem) {
-        if (type == newsItem.Type && assoc == newsItem.Assoc)
+        if (type == newsItem.type && assoc == newsItem.assoc)
         {
-            newsItem.SetFlags(News::ItemFlags::HasButton);
+            newsItem.setFlags(News::ItemFlags::HasButton);
             auto* windowMgr = Ui::GetWindowManager();
             windowMgr->InvalidateByClass(WindowClass::RecentNews);
         }
@@ -473,7 +473,7 @@ void News::RemoveItem(int32_t index)
 
     auto& gameState = getGameState();
     // News item is already null, no need to remove it
-    if (gameState.newsItems[index].Type == News::ItemType::Null)
+    if (gameState.newsItems[index].type == News::ItemType::Null)
         return;
 
     size_t newsBoundary = index < News::ItemHistoryStart ? News::ItemHistoryStart : News::MaxItems;
@@ -481,7 +481,7 @@ void News::RemoveItem(int32_t index)
     {
         gameState.newsItems[i] = gameState.newsItems[i + 1];
     }
-    gameState.newsItems[newsBoundary - 1].Type = News::ItemType::Null;
+    gameState.newsItems[newsBoundary - 1].type = News::ItemType::Null;
 }
 
 void News::importNewsItems(

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -214,7 +214,7 @@ std::optional<CoordsXYZ> News::GetSubjectLocation(News::ItemType type, int32_t s
 
     switch (type)
     {
-        case News::ItemType::Ride:
+        case News::ItemType::ride:
         {
             Ride* ride = GetRide(RideId::FromUnderlying(subject));
             if (ride == nullptr || ride->overallView.IsNull())
@@ -225,7 +225,7 @@ std::optional<CoordsXYZ> News::GetSubjectLocation(News::ItemType type, int32_t s
             subjectLoc = CoordsXYZ{ rideViewCentre, TileElementHeight(rideViewCentre) };
             break;
         }
-        case News::ItemType::PeepOnRide:
+        case News::ItemType::peepOnRide:
         {
             auto peep = TryGetEntity<Peep>(EntityId::FromUnderlying(subject));
             if (peep == nullptr)
@@ -262,7 +262,7 @@ std::optional<CoordsXYZ> News::GetSubjectLocation(News::ItemType type, int32_t s
             }
             break;
         }
-        case News::ItemType::Peep:
+        case News::ItemType::peep:
         {
             auto peep = TryGetEntity<Peep>(EntityId::FromUnderlying(subject));
             if (peep != nullptr)
@@ -271,7 +271,7 @@ std::optional<CoordsXYZ> News::GetSubjectLocation(News::ItemType type, int32_t s
             }
             break;
         }
-        case News::ItemType::Blank:
+        case News::ItemType::blank:
         {
             auto subjectUnsigned = static_cast<uint32_t>(subject);
             auto subjectXY = CoordsXY{ static_cast<int16_t>(subjectUnsigned & 0xFFFF),
@@ -299,7 +299,7 @@ News::Item* News::ItemQueues::FirstOpenOrNewSlot()
     // The for loop above guarantees there is always an extra element to use
     assert(Recent.capacity() - Recent.size() >= 2);
     auto newsItem = res + 1;
-    newsItem->type = News::ItemType::Null;
+    newsItem->type = News::ItemType::null;
 
     return &*res;
 }
@@ -347,10 +347,10 @@ bool News::CheckIfItemRequiresAssoc(News::ItemType type)
 {
     switch (type)
     {
-        case News::ItemType::Null:
-        case News::ItemType::Award:
-        case News::ItemType::Money:
-        case News::ItemType::Graph:
+        case News::ItemType::null:
+        case News::ItemType::award:
+        case News::ItemType::money:
+        case News::ItemType::graph:
             return false;
         default:
             return true; // Everything else requires assoc
@@ -367,15 +367,15 @@ void News::OpenSubject(News::ItemType type, int32_t subject)
 {
     switch (type)
     {
-        case News::ItemType::Ride:
+        case News::ItemType::ride:
         {
             auto intent = Intent(WindowClass::Ride);
             intent.PutExtra(INTENT_EXTRA_RIDE_ID, subject);
             ContextOpenIntent(&intent);
             break;
         }
-        case News::ItemType::PeepOnRide:
-        case News::ItemType::Peep:
+        case News::ItemType::peepOnRide:
+        case News::ItemType::peep:
         {
             auto peep = TryGetEntity<Peep>(EntityId::FromUnderlying(subject));
             if (peep != nullptr)
@@ -386,13 +386,13 @@ void News::OpenSubject(News::ItemType type, int32_t subject)
             }
             break;
         }
-        case News::ItemType::Money:
+        case News::ItemType::money:
             ContextOpenWindow(WindowClass::Finances);
             break;
-        case News::ItemType::Campaign:
+        case News::ItemType::campaign:
             ContextOpenWindowView(WV_FINANCE_MARKETING);
             break;
-        case News::ItemType::Research:
+        case News::ItemType::research:
         {
             auto item = ResearchItem(subject, ResearchCategory::Transport, 0);
             if (item.type == Research::EntryType::Ride)
@@ -409,7 +409,7 @@ void News::OpenSubject(News::ItemType type, int32_t subject)
             ContextOpenIntent(&intent);
             break;
         }
-        case News::ItemType::Peeps:
+        case News::ItemType::peeps:
         {
             auto intent = Intent(WindowClass::GuestList);
             intent.PutExtra(INTENT_EXTRA_GUEST_LIST_FILTER, static_cast<int32_t>(GuestListFilterType::guestsThinkingX));
@@ -417,15 +417,15 @@ void News::OpenSubject(News::ItemType type, int32_t subject)
             ContextOpenIntent(&intent);
             break;
         }
-        case News::ItemType::Award:
+        case News::ItemType::award:
             ContextOpenWindowView(WV_PARK_AWARDS);
             break;
-        case News::ItemType::Graph:
+        case News::ItemType::graph:
             ContextOpenWindowView(WV_PARK_RATING);
             break;
-        case News::ItemType::Null:
-        case News::ItemType::Blank:
-        case News::ItemType::Count:
+        case News::ItemType::null:
+        case News::ItemType::blank:
+        case News::ItemType::count:
             break;
     }
 }
@@ -441,7 +441,7 @@ void News::DisableNewsItems(News::ItemType type, uint32_t assoc)
     gameState.newsItems.ForeachRecentNews([type, assoc, &gameState](auto& newsItem) {
         if (type == newsItem.type && assoc == newsItem.assoc)
         {
-            newsItem.setFlags(News::ItemFlags::HasButton);
+            newsItem.setFlags(News::ItemFlags::hasButton);
             if (&newsItem == &gameState.newsItems.Current())
             {
                 auto intent = Intent(INTENT_ACTION_INVALIDATE_TICKER_NEWS);
@@ -453,7 +453,7 @@ void News::DisableNewsItems(News::ItemType type, uint32_t assoc)
     gameState.newsItems.ForeachArchivedNews([type, assoc](auto& newsItem) {
         if (type == newsItem.type && assoc == newsItem.assoc)
         {
-            newsItem.setFlags(News::ItemFlags::HasButton);
+            newsItem.setFlags(News::ItemFlags::hasButton);
             auto* windowMgr = Ui::GetWindowManager();
             windowMgr->InvalidateByClass(WindowClass::RecentNews);
         }
@@ -473,7 +473,7 @@ void News::RemoveItem(int32_t index)
 
     auto& gameState = getGameState();
     // News item is already null, no need to remove it
-    if (gameState.newsItems[index].type == News::ItemType::Null)
+    if (gameState.newsItems[index].type == News::ItemType::null)
         return;
 
     size_t newsBoundary = index < News::ItemHistoryStart ? News::ItemHistoryStart : News::MaxItems;
@@ -481,7 +481,7 @@ void News::RemoveItem(int32_t index)
     {
         gameState.newsItems[i] = gameState.newsItems[i + 1];
     }
-    gameState.newsItems[newsBoundary - 1].type = News::ItemType::Null;
+    gameState.newsItems[newsBoundary - 1].type = News::ItemType::null;
 }
 
 void News::importNewsItems(

--- a/src/openrct2/management/NewsItem.h
+++ b/src/openrct2/management/NewsItem.h
@@ -32,31 +32,31 @@ namespace OpenRCT2::News
 {
     enum class ItemType : uint8_t
     {
-        Null,
-        Ride,
-        PeepOnRide,
-        Peep,
-        Money,
-        Blank,
-        Research,
-        Peeps,
-        Award,
-        Graph,
-        Campaign,
-        Count
+        null,
+        ride,
+        peepOnRide,
+        peep,
+        money,
+        blank,
+        research,
+        peeps,
+        award,
+        graph,
+        campaign,
+        count
     };
 
-    constexpr size_t ItemTypeCount = static_cast<size_t>(News::ItemType::Count);
+    constexpr size_t ItemTypeCount = static_cast<size_t>(News::ItemType::count);
 
     enum ItemTypeProperty : uint8_t
     {
-        HasLocation = 1,
-        HasSubject = 2,
+        hasLocation = 1,
+        hasSubject = 2,
     };
 
     enum ItemFlags : uint8_t
     {
-        HasButton = 1 << 0,
+        hasButton = 1 << 0,
     };
 
     /**
@@ -64,7 +64,7 @@ namespace OpenRCT2::News
      */
     struct Item
     {
-        News::ItemType type = News::ItemType::Null;
+        News::ItemType type = News::ItemType::null;
         uint8_t flags{};
         uint32_t assoc{};
         uint16_t ticks{};
@@ -74,28 +74,28 @@ namespace OpenRCT2::News
 
         constexpr bool isEmpty() const noexcept
         {
-            return type == News::ItemType::Null;
+            return type == News::ItemType::null;
         }
 
         constexpr uint8_t getTypeProperties() const
         {
             switch (type)
             {
-                case News::ItemType::Blank:
-                    return News::ItemTypeProperty::HasLocation;
-                case News::ItemType::Money:
-                case News::ItemType::Research:
-                case News::ItemType::Peeps:
-                case News::ItemType::Award:
-                case News::ItemType::Graph:
-                case News::ItemType::Campaign:
-                    return News::ItemTypeProperty::HasSubject;
-                case News::ItemType::Ride:
-                case News::ItemType::PeepOnRide:
-                case News::ItemType::Peep:
-                    return News::ItemTypeProperty::HasLocation | News::ItemTypeProperty::HasSubject;
-                case News::ItemType::Null:
-                case News::ItemType::Count:
+                case News::ItemType::blank:
+                    return News::ItemTypeProperty::hasLocation;
+                case News::ItemType::money:
+                case News::ItemType::research:
+                case News::ItemType::peeps:
+                case News::ItemType::award:
+                case News::ItemType::graph:
+                case News::ItemType::campaign:
+                    return News::ItemTypeProperty::hasSubject;
+                case News::ItemType::ride:
+                case News::ItemType::peepOnRide:
+                case News::ItemType::peep:
+                    return News::ItemTypeProperty::hasLocation | News::ItemTypeProperty::hasSubject;
+                case News::ItemType::null:
+                case News::ItemType::count:
                 default:
                     return 0;
             }
@@ -108,17 +108,17 @@ namespace OpenRCT2::News
 
         constexpr bool typeHasSubject() const
         {
-            return this->getTypeProperties() & News::ItemTypeProperty::HasSubject;
+            return this->getTypeProperties() & News::ItemTypeProperty::hasSubject;
         }
 
         constexpr bool typeHasLocation() const
         {
-            return this->getTypeProperties() & News::ItemTypeProperty::HasLocation;
+            return this->getTypeProperties() & News::ItemTypeProperty::hasLocation;
         }
 
         constexpr bool hasButton() const noexcept
         {
-            return flags & News::ItemFlags::HasButton;
+            return flags & News::ItemFlags::hasButton;
         }
     };
 
@@ -146,7 +146,7 @@ namespace OpenRCT2::News
 
         ItemQueue()
         {
-            std::get<0>(Queue).type = News::ItemType::Null;
+            std::get<0>(Queue).type = News::ItemType::null;
         }
 
         constexpr iterator begin() noexcept
@@ -204,7 +204,7 @@ namespace OpenRCT2::News
         void pop_front()
         {
             std::move(std::begin(Queue) + 1, std::end(Queue), std::begin(Queue));
-            Queue[N - 1].type = News::ItemType::Null;
+            Queue[N - 1].type = News::ItemType::null;
         }
 
         void push_back(const_reference item)
@@ -221,7 +221,7 @@ namespace OpenRCT2::News
                 *it = item;
                 ++it;
                 if (std::distance(it, std::end(Queue)))
-                    it->type = News::ItemType::Null;
+                    it->type = News::ItemType::null;
             }
         }
 

--- a/src/openrct2/management/NewsItem.h
+++ b/src/openrct2/management/NewsItem.h
@@ -64,22 +64,22 @@ namespace OpenRCT2::News
      */
     struct Item
     {
-        News::ItemType Type = News::ItemType::Null;
-        uint8_t Flags{};
-        uint32_t Assoc{};
-        uint16_t Ticks{};
-        uint16_t MonthYear{};
-        uint8_t Day{};
-        std::string Text{};
+        News::ItemType type = News::ItemType::Null;
+        uint8_t flags{};
+        uint32_t assoc{};
+        uint16_t ticks{};
+        uint16_t monthYear{};
+        uint8_t day{};
+        std::string text{};
 
-        constexpr bool IsEmpty() const noexcept
+        constexpr bool isEmpty() const noexcept
         {
-            return Type == News::ItemType::Null;
+            return type == News::ItemType::Null;
         }
 
-        constexpr uint8_t GetTypeProperties() const
+        constexpr uint8_t getTypeProperties() const
         {
-            switch (Type)
+            switch (type)
             {
                 case News::ItemType::Blank:
                     return News::ItemTypeProperty::HasLocation;
@@ -101,24 +101,24 @@ namespace OpenRCT2::News
             }
         }
 
-        void SetFlags(uint8_t flag)
+        void setFlags(uint8_t flag)
         {
-            Flags |= flag;
+            flags |= flag;
         }
 
-        constexpr bool TypeHasSubject() const
+        constexpr bool typeHasSubject() const
         {
-            return this->GetTypeProperties() & News::ItemTypeProperty::HasSubject;
+            return this->getTypeProperties() & News::ItemTypeProperty::HasSubject;
         }
 
-        constexpr bool TypeHasLocation() const
+        constexpr bool typeHasLocation() const
         {
-            return this->GetTypeProperties() & News::ItemTypeProperty::HasLocation;
+            return this->getTypeProperties() & News::ItemTypeProperty::HasLocation;
         }
 
-        constexpr bool HasButton() const noexcept
+        constexpr bool hasButton() const noexcept
         {
-            return Flags & News::ItemFlags::HasButton;
+            return flags & News::ItemFlags::HasButton;
         }
     };
 
@@ -146,7 +146,7 @@ namespace OpenRCT2::News
 
         ItemQueue()
         {
-            std::get<0>(Queue).Type = News::ItemType::Null;
+            std::get<0>(Queue).type = News::ItemType::Null;
         }
 
         constexpr iterator begin() noexcept
@@ -163,7 +163,7 @@ namespace OpenRCT2::News
         }
         iterator end() noexcept
         {
-            return std::find_if(std::begin(Queue), std::end(Queue), [](const_reference item) { return item.IsEmpty(); });
+            return std::find_if(std::begin(Queue), std::end(Queue), [](const_reference item) { return item.isEmpty(); });
         }
         const_iterator end() const noexcept
         {
@@ -171,12 +171,12 @@ namespace OpenRCT2::News
         }
         const_iterator cend() const noexcept
         {
-            return std::find_if(std::cbegin(Queue), std::cend(Queue), [](const_reference item) { return item.IsEmpty(); });
+            return std::find_if(std::cbegin(Queue), std::cend(Queue), [](const_reference item) { return item.isEmpty(); });
         }
 
         constexpr bool empty() const noexcept
         {
-            return std::get<0>(Queue).IsEmpty();
+            return std::get<0>(Queue).isEmpty();
         }
 
         size_type size() const noexcept
@@ -204,7 +204,7 @@ namespace OpenRCT2::News
         void pop_front()
         {
             std::move(std::begin(Queue) + 1, std::end(Queue), std::begin(Queue));
-            Queue[N - 1].Type = News::ItemType::Null;
+            Queue[N - 1].type = News::ItemType::Null;
         }
 
         void push_back(const_reference item)
@@ -221,7 +221,7 @@ namespace OpenRCT2::News
                 *it = item;
                 ++it;
                 if (std::distance(it, std::end(Queue)))
-                    it->Type = News::ItemType::Null;
+                    it->type = News::ItemType::Null;
             }
         }
 

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -270,7 +270,7 @@ void ResearchFinishItem(const ResearchItem& researchItem)
             {
                 if (Config::Get().notifications.RideResearched)
                 {
-                    News::AddItemToQueue(News::ItemType::Research, availabilityString, researchItem.rawValue, ft);
+                    News::AddItemToQueue(News::ItemType::research, availabilityString, researchItem.rawValue, ft);
                 }
             }
 
@@ -293,7 +293,7 @@ void ResearchFinishItem(const ResearchItem& researchItem)
                 if (Config::Get().notifications.RideResearched)
                 {
                     News::AddItemToQueue(
-                        News::ItemType::Research, STR_NEWS_ITEM_RESEARCH_NEW_SCENERY_SET_AVAILABLE, researchItem.rawValue, ft);
+                        News::ItemType::research, STR_NEWS_ITEM_RESEARCH_NEW_SCENERY_SET_AVAILABLE, researchItem.rawValue, ft);
                 }
             }
 

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1155,20 +1155,20 @@ namespace OpenRCT2
 
         static void ReadWriteNewsItem(OrcaStream::ChunkStream& cs, News::Item& item)
         {
-            cs.ReadWrite(item.Type);
-            cs.ReadWrite(item.Flags);
-            cs.ReadWrite(item.Assoc);
-            cs.ReadWrite(item.Ticks);
-            cs.ReadWrite(item.MonthYear);
-            cs.ReadWrite(item.Day);
+            cs.ReadWrite(item.type);
+            cs.ReadWrite(item.flags);
+            cs.ReadWrite(item.assoc);
+            cs.ReadWrite(item.ticks);
+            cs.ReadWrite(item.monthYear);
+            cs.ReadWrite(item.day);
             if (cs.GetMode() == OrcaStream::Mode::READING)
             {
                 auto s = cs.Read<std::string>();
-                item.Text = s;
+                item.text = s;
             }
             else
             {
-                cs.Write(std::string_view(item.Text));
+                cs.Write(std::string_view(item.text));
             }
         }
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2198,29 +2198,28 @@ namespace OpenRCT2::RCT1
             park.Name = std::move(parkName);
         }
 
-        std::vector<OpenRCT2::News::Item> convertNewsQueue(const RCT12NewsItem* queue, size_t size)
+        std::vector<OpenRCT2::News::Item> convertNewsQueue(std::span<const RCT12NewsItem> queue)
         {
             std::vector<OpenRCT2::News::Item> output{};
-            const RCT12NewsItem* src = queue;
 
-            for (uint8_t i = 0; i < size; i++)
+            for (const auto& src : queue)
             {
                 News::Item dst{};
 
-                if (src->Type == 0)
+                if (src.Type == 0)
                     break;
 
-                dst.Type = static_cast<News::ItemType>(src->Type);
-                dst.Flags = src->Flags;
-                dst.Ticks = src->Ticks;
-                dst.MonthYear = src->MonthYear;
-                dst.Day = src->Day;
-                dst.Text = ConvertFormattedStringToOpenRCT2(std::string_view(src->Text, sizeof(src->Text)));
+                dst.Type = static_cast<News::ItemType>(src.Type);
+                dst.Flags = src.Flags;
+                dst.Ticks = src.Ticks;
+                dst.MonthYear = src.MonthYear;
+                dst.Day = src.Day;
+                dst.Text = ConvertFormattedStringToOpenRCT2(std::string_view(src.Text, sizeof(src.Text)));
 
                 if (dst.Type == News::ItemType::Research)
                 {
-                    uint8_t researchItem = src->Assoc & 0x000000FF;
-                    uint8_t researchType = (src->Assoc & 0x00FF0000) >> 16;
+                    uint8_t researchItem = src.Assoc & 0x000000FF;
+                    uint8_t researchType = (src.Assoc & 0x00FF0000) >> 16;
 
                     ::ResearchItem tmpResearchItem = {};
                     ConvertResearchEntry(&tmpResearchItem, researchItem, researchType);
@@ -2228,11 +2227,10 @@ namespace OpenRCT2::RCT1
                 }
                 else
                 {
-                    dst.Assoc = src->Assoc;
+                    dst.Assoc = src.Assoc;
                 }
 
                 output.emplace_back(dst);
-                src++;
             }
 
             return output;
@@ -2287,8 +2285,8 @@ namespace OpenRCT2::RCT1
             }
 
             // News items
-            auto recentMessages = convertNewsQueue(_s4.recentMessages, std::size(_s4.recentMessages));
-            auto archivedMessages = convertNewsQueue(_s4.archivedMessages, std::size(_s4.archivedMessages));
+            auto recentMessages = convertNewsQueue(_s4.recentMessages);
+            auto archivedMessages = convertNewsQueue(_s4.archivedMessages);
             News::importNewsItems(gameState, recentMessages, archivedMessages);
 
             // Initial guest status

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2216,7 +2216,7 @@ namespace OpenRCT2::RCT1
                 dst.day = src.Day;
                 dst.text = ConvertFormattedStringToOpenRCT2(std::string_view(src.Text, sizeof(src.Text)));
 
-                if (dst.type == News::ItemType::Research)
+                if (dst.type == News::ItemType::research)
                 {
                     uint8_t researchItem = src.Assoc & 0x000000FF;
                     uint8_t researchType = (src.Assoc & 0x00FF0000) >> 16;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2209,25 +2209,25 @@ namespace OpenRCT2::RCT1
                 if (src.Type == 0)
                     break;
 
-                dst.Type = static_cast<News::ItemType>(src.Type);
-                dst.Flags = src.Flags;
-                dst.Ticks = src.Ticks;
-                dst.MonthYear = src.MonthYear;
-                dst.Day = src.Day;
-                dst.Text = ConvertFormattedStringToOpenRCT2(std::string_view(src.Text, sizeof(src.Text)));
+                dst.type = static_cast<News::ItemType>(src.Type);
+                dst.flags = src.Flags;
+                dst.ticks = src.Ticks;
+                dst.monthYear = src.MonthYear;
+                dst.day = src.Day;
+                dst.text = ConvertFormattedStringToOpenRCT2(std::string_view(src.Text, sizeof(src.Text)));
 
-                if (dst.Type == News::ItemType::Research)
+                if (dst.type == News::ItemType::Research)
                 {
                     uint8_t researchItem = src.Assoc & 0x000000FF;
                     uint8_t researchType = (src.Assoc & 0x00FF0000) >> 16;
 
                     ::ResearchItem tmpResearchItem = {};
                     ConvertResearchEntry(&tmpResearchItem, researchItem, researchType);
-                    dst.Assoc = tmpResearchItem.rawValue;
+                    dst.assoc = tmpResearchItem.rawValue;
                 }
                 else
                 {
-                    dst.Assoc = src.Assoc;
+                    dst.assoc = src.Assoc;
                 }
 
                 output.emplace_back(dst);

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -322,33 +322,33 @@ namespace OpenRCT2::RCT2
             return {};
         }
 
-        std::vector<OpenRCT2::News::Item> convertNewsQueue(const RCT12NewsItem* queue, size_t size)
+        std::vector<OpenRCT2::News::Item> convertNewsQueue(std::span<const RCT12NewsItem> queue)
         {
             std::vector<OpenRCT2::News::Item> output{};
-            const RCT12NewsItem* src = queue;
 
-            for (uint8_t i = 0; i < size; i++)
+            auto index = 0;
+            for (const auto& src : queue)
             {
-                if (src->Type == 0)
+                if (src.Type == 0)
                     break;
 
-                if (src->Type >= News::ItemTypeCount)
+                if (src.Type >= News::ItemTypeCount)
                 {
-                    LOG_ERROR("Invalid news type 0x%x for news item %d, ignoring remaining news items", src->Type, i);
+                    LOG_ERROR("Invalid news type 0x%x for news item %d, ignoring remaining news items", src.Type, index);
                     break;
                 }
 
                 News::Item dst{};
-                dst.Type = static_cast<News::ItemType>(src->Type);
-                dst.Flags = src->Flags;
-                dst.Assoc = src->Assoc;
-                dst.Ticks = src->Ticks;
-                dst.MonthYear = src->MonthYear;
-                dst.Day = src->Day;
-                dst.Text = ConvertFormattedStringToOpenRCT2(std::string_view(src->Text, sizeof(src->Text)));
+                dst.Type = static_cast<News::ItemType>(src.Type);
+                dst.Flags = src.Flags;
+                dst.Assoc = src.Assoc;
+                dst.Ticks = src.Ticks;
+                dst.MonthYear = src.MonthYear;
+                dst.Day = src.Day;
+                dst.Text = ConvertFormattedStringToOpenRCT2(std::string_view(src.Text, sizeof(src.Text)));
 
                 output.emplace_back(dst);
-                src++;
+                index++;
             }
 
             return output;
@@ -607,8 +607,8 @@ namespace OpenRCT2::RCT2
             };
 
             // News items
-            auto recentMessages = convertNewsQueue(_s6.recentMessages, std::size(_s6.recentMessages));
-            auto archivedMessages = convertNewsQueue(_s6.archivedMessages, std::size(_s6.archivedMessages));
+            auto recentMessages = convertNewsQueue(_s6.recentMessages);
+            auto archivedMessages = convertNewsQueue(_s6.archivedMessages);
             News::importNewsItems(gameState, recentMessages, archivedMessages);
 
             // Pad13CE730

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -339,13 +339,13 @@ namespace OpenRCT2::RCT2
                 }
 
                 News::Item dst{};
-                dst.Type = static_cast<News::ItemType>(src.Type);
-                dst.Flags = src.Flags;
-                dst.Assoc = src.Assoc;
-                dst.Ticks = src.Ticks;
-                dst.MonthYear = src.MonthYear;
-                dst.Day = src.Day;
-                dst.Text = ConvertFormattedStringToOpenRCT2(std::string_view(src.Text, sizeof(src.Text)));
+                dst.type = static_cast<News::ItemType>(src.Type);
+                dst.flags = src.Flags;
+                dst.assoc = src.Assoc;
+                dst.ticks = src.Ticks;
+                dst.monthYear = src.MonthYear;
+                dst.day = src.Day;
+                dst.text = ConvertFormattedStringToOpenRCT2(std::string_view(src.Text, sizeof(src.Text)));
 
                 output.emplace_back(dst);
                 index++;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1602,7 +1602,7 @@ void RideBreakdownAddNewsItem(const Ride& ride)
     {
         Formatter ft;
         ride.formatNameTo(ft);
-        News::AddItemToQueue(News::ItemType::Ride, STR_RIDE_IS_BROKEN_DOWN, ride.id.ToUnderlying(), ft);
+        News::AddItemToQueue(News::ItemType::ride, STR_RIDE_IS_BROKEN_DOWN, ride.id.ToUnderlying(), ft);
     }
 }
 
@@ -1629,7 +1629,7 @@ static void RideBreakdownStatusUpdate(Ride& ride)
             {
                 Formatter ft;
                 ride.formatNameTo(ft);
-                News::AddItemToQueue(News::ItemType::Ride, STR_RIDE_IS_STILL_NOT_FIXED, ride.id.ToUnderlying(), ft);
+                News::AddItemToQueue(News::ItemType::ride, STR_RIDE_IS_STILL_NOT_FIXED, ride.id.ToUnderlying(), ft);
             }
         }
     }
@@ -2308,7 +2308,7 @@ static void RideEntranceExitConnected(Ride& ride)
             ride.formatNameTo(ft);
             if (Config::Get().notifications.RideWarnings)
             {
-                News::AddItemToQueue(News::ItemType::Ride, STR_ENTRANCE_NOT_CONNECTED, ride.id.ToUnderlying(), ft);
+                News::AddItemToQueue(News::ItemType::ride, STR_ENTRANCE_NOT_CONNECTED, ride.id.ToUnderlying(), ft);
             }
             ride.connectedMessageThrottle = 3;
         }
@@ -2320,7 +2320,7 @@ static void RideEntranceExitConnected(Ride& ride)
             ride.formatNameTo(ft);
             if (Config::Get().notifications.RideWarnings)
             {
-                News::AddItemToQueue(News::ItemType::Ride, STR_EXIT_NOT_CONNECTED, ride.id.ToUnderlying(), ft);
+                News::AddItemToQueue(News::ItemType::ride, STR_EXIT_NOT_CONNECTED, ride.id.ToUnderlying(), ft);
             }
             ride.connectedMessageThrottle = 3;
         }
@@ -2387,7 +2387,7 @@ static void RideShopConnected(const Ride& ride)
     {
         Formatter ft;
         ride2->formatNameTo(ft);
-        News::AddItemToQueue(News::ItemType::Ride, STR_ENTRANCE_NOT_CONNECTED, ride2->id.ToUnderlying(), ft);
+        News::AddItemToQueue(News::ItemType::ride, STR_ENTRANCE_NOT_CONNECTED, ride2->id.ToUnderlying(), ft);
     }
 
     ride2->connectedMessageThrottle = 3;
@@ -5278,7 +5278,7 @@ void Ride::crash(uint8_t vehicleIndex)
     {
         Formatter ft;
         formatNameTo(ft);
-        News::AddItemToQueue(News::ItemType::Ride, STR_RIDE_HAS_CRASHED, id.ToUnderlying(), ft);
+        News::AddItemToQueue(News::ItemType::ride, STR_RIDE_HAS_CRASHED, id.ToUnderlying(), ft);
     }
 }
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -2815,7 +2815,7 @@ void Vehicle::CheckIfMissing()
         curRide->formatNameTo(ft);
         ft.Add<StringId>(GetRideComponentName(GetRideTypeDescriptor(curRide->type).NameConvention.station).singular);
 
-        News::AddItemToQueue(News::ItemType::Ride, STR_NEWS_VEHICLE_HAS_STALLED, ride.ToUnderlying(), ft);
+        News::AddItemToQueue(News::ItemType::ride, STR_NEWS_VEHICLE_HAS_STALLED, ride.ToUnderlying(), ft);
     }
 }
 
@@ -4562,7 +4562,7 @@ static void ride_train_crash(Ride& ride, uint16_t numFatalities)
         {
             ride.formatNameTo(ft);
             News::AddItemToQueue(
-                News::ItemType::Ride, numFatalities == 1 ? STR_X_PERSON_DIED_ON_X : STR_X_PEOPLE_DIED_ON_X,
+                News::ItemType::ride, numFatalities == 1 ? STR_X_PERSON_DIED_ON_X : STR_X_PEOPLE_DIED_ON_X,
                 ride.id.ToUnderlying(), ft);
         }
 

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -240,7 +240,7 @@ static void ScenarioCheckEntranceFeeTooHigh()
             uint32_t packed_xy = (y << 16) | x;
             if (Config::Get().notifications.ParkWarnings)
             {
-                News::AddItemToQueue(News::ItemType::Blank, STR_ENTRANCE_FEE_TOO_HI, packed_xy, {});
+                News::AddItemToQueue(News::ItemType::blank, STR_ENTRANCE_FEE_TOO_HI, packed_xy, {});
             }
         }
     }
@@ -692,33 +692,33 @@ ObjectiveStatus Objective::CheckGuestsAndRating() const
         {
             if (Config::Get().notifications.ParkRatingWarnings)
             {
-                News::AddItemToQueue(News::ItemType::Graph, STR_PARK_RATING_WARNING_4_WEEKS_REMAINING, 0, {});
+                News::AddItemToQueue(News::ItemType::graph, STR_PARK_RATING_WARNING_4_WEEKS_REMAINING, 0, {});
             }
         }
         else if (gameState.scenarioParkRatingWarningDays == 8)
         {
             if (Config::Get().notifications.ParkRatingWarnings)
             {
-                News::AddItemToQueue(News::ItemType::Graph, STR_PARK_RATING_WARNING_3_WEEKS_REMAINING, 0, {});
+                News::AddItemToQueue(News::ItemType::graph, STR_PARK_RATING_WARNING_3_WEEKS_REMAINING, 0, {});
             }
         }
         else if (gameState.scenarioParkRatingWarningDays == 15)
         {
             if (Config::Get().notifications.ParkRatingWarnings)
             {
-                News::AddItemToQueue(News::ItemType::Graph, STR_PARK_RATING_WARNING_2_WEEKS_REMAINING, 0, {});
+                News::AddItemToQueue(News::ItemType::graph, STR_PARK_RATING_WARNING_2_WEEKS_REMAINING, 0, {});
             }
         }
         else if (gameState.scenarioParkRatingWarningDays == 22)
         {
             if (Config::Get().notifications.ParkRatingWarnings)
             {
-                News::AddItemToQueue(News::ItemType::Graph, STR_PARK_RATING_WARNING_1_WEEK_REMAINING, 0, {});
+                News::AddItemToQueue(News::ItemType::graph, STR_PARK_RATING_WARNING_1_WEEK_REMAINING, 0, {});
             }
         }
         else if (gameState.scenarioParkRatingWarningDays == 29)
         {
-            News::AddItemToQueue(News::ItemType::Graph, STR_PARK_HAS_BEEN_CLOSED_DOWN, 0, {});
+            News::AddItemToQueue(News::ItemType::graph, STR_PARK_HAS_BEEN_CLOSED_DOWN, 0, {});
             gameState.park.Flags &= ~PARK_FLAGS_PARK_OPEN;
             gameState.guestInitialHappiness = 50;
             return ObjectiveStatus::Failure;

--- a/src/openrct2/scripting/bindings/world/ScPark.cpp
+++ b/src/openrct2/scripting/bindings/world/ScPark.cpp
@@ -370,11 +370,11 @@ namespace OpenRCT2::Scripting
         // End the lists by setting next item to null
         if (index < News::ItemHistoryStart)
         {
-            gameState.newsItems[index].type = News::ItemType::Null;
+            gameState.newsItems[index].type = News::ItemType::null;
         }
         if (archiveIndex < News::MaxItems)
         {
-            gameState.newsItems[archiveIndex].type = News::ItemType::Null;
+            gameState.newsItems[archiveIndex].type = News::ItemType::null;
         }
     }
 
@@ -384,7 +384,7 @@ namespace OpenRCT2::Scripting
         try
         {
             uint32_t assoc = std::numeric_limits<uint32_t>::max();
-            auto type = News::ItemType::Blank;
+            auto type = News::ItemType::blank;
             std::string text;
             if (message.type() == DukValue::Type::STRING)
             {
@@ -394,7 +394,7 @@ namespace OpenRCT2::Scripting
             {
                 type = GetParkMessageType(message["type"].as_string());
                 text = message["text"].as_string();
-                if (type == News::ItemType::Blank)
+                if (type == News::ItemType::blank)
                 {
                     assoc = static_cast<uint32_t>(((kCoordsNull & 0xFFFF) << 16) | (kCoordsNull & 0xFFFF));
                 }

--- a/src/openrct2/scripting/bindings/world/ScPark.cpp
+++ b/src/openrct2/scripting/bindings/world/ScPark.cpp
@@ -370,11 +370,11 @@ namespace OpenRCT2::Scripting
         // End the lists by setting next item to null
         if (index < News::ItemHistoryStart)
         {
-            gameState.newsItems[index].Type = News::ItemType::Null;
+            gameState.newsItems[index].type = News::ItemType::Null;
         }
         if (archiveIndex < News::MaxItems)
         {
-            gameState.newsItems[archiveIndex].Type = News::ItemType::Null;
+            gameState.newsItems[archiveIndex].type = News::ItemType::Null;
         }
     }
 

--- a/src/openrct2/scripting/bindings/world/ScParkMessage.cpp
+++ b/src/openrct2/scripting/bindings/world/ScParkMessage.cpp
@@ -56,7 +56,7 @@ namespace OpenRCT2::Scripting
         auto msg = GetMessage();
         if (msg != nullptr)
         {
-            return msg->MonthYear;
+            return msg->monthYear;
         }
         return 0;
     }
@@ -67,7 +67,7 @@ namespace OpenRCT2::Scripting
         auto msg = GetMessage();
         if (msg != nullptr)
         {
-            msg->MonthYear = value;
+            msg->monthYear = value;
         }
     }
 
@@ -76,7 +76,7 @@ namespace OpenRCT2::Scripting
         auto msg = GetMessage();
         if (msg != nullptr)
         {
-            return msg->Day;
+            return msg->day;
         }
         return 0;
     }
@@ -87,7 +87,7 @@ namespace OpenRCT2::Scripting
         auto msg = GetMessage();
         if (msg != nullptr)
         {
-            msg->Day = value;
+            msg->day = value;
         }
     }
 
@@ -96,7 +96,7 @@ namespace OpenRCT2::Scripting
         auto msg = GetMessage();
         if (msg != nullptr)
         {
-            return msg->Ticks;
+            return msg->ticks;
         }
         return 0;
     }
@@ -107,7 +107,7 @@ namespace OpenRCT2::Scripting
         auto msg = GetMessage();
         if (msg != nullptr)
         {
-            msg->Ticks = value;
+            msg->ticks = value;
         }
     }
 
@@ -116,7 +116,7 @@ namespace OpenRCT2::Scripting
         auto msg = GetMessage();
         if (msg != nullptr)
         {
-            return GetParkMessageType(msg->Type);
+            return GetParkMessageType(msg->type);
         }
         return {};
     }
@@ -127,7 +127,7 @@ namespace OpenRCT2::Scripting
         auto msg = GetMessage();
         if (msg != nullptr)
         {
-            msg->Type = GetParkMessageType(value);
+            msg->type = GetParkMessageType(value);
         }
     }
 
@@ -136,7 +136,7 @@ namespace OpenRCT2::Scripting
         auto msg = GetMessage();
         if (msg != nullptr)
         {
-            return msg->Assoc;
+            return msg->assoc;
         }
         return 0;
     }
@@ -147,7 +147,7 @@ namespace OpenRCT2::Scripting
         auto msg = GetMessage();
         if (msg != nullptr)
         {
-            msg->Assoc = value;
+            msg->assoc = value;
         }
     }
 
@@ -156,7 +156,7 @@ namespace OpenRCT2::Scripting
         auto msg = GetMessage();
         if (msg != nullptr)
         {
-            return msg->Text;
+            return msg->text;
         }
         return {};
     }
@@ -167,7 +167,7 @@ namespace OpenRCT2::Scripting
         auto msg = GetMessage();
         if (msg != nullptr)
         {
-            msg->Text = value;
+            msg->text = value;
         }
     }
 

--- a/src/openrct2/scripting/bindings/world/ScParkMessage.hpp
+++ b/src/openrct2/scripting/bindings/world/ScParkMessage.hpp
@@ -52,12 +52,12 @@ namespace OpenRCT2::Scripting
     inline News::Item FromDuk(const DukValue& value)
     {
         News::Item result{};
-        result.Type = GetParkMessageType(value["type"].as_string());
-        result.Assoc = value["subject"].as_uint();
-        result.Ticks = value["tickCount"].as_uint();
-        result.MonthYear = value["month"].as_uint();
-        result.Day = value["day"].as_uint();
-        result.Text = value["text"].as_string();
+        result.type = GetParkMessageType(value["type"].as_string());
+        result.assoc = value["subject"].as_uint();
+        result.ticks = value["tickCount"].as_uint();
+        result.monthYear = value["month"].as_uint();
+        result.day = value["day"].as_uint();
+        result.text = value["text"].as_string();
         return result;
     }
 

--- a/src/openrct2/scripting/bindings/world/ScParkMessage.hpp
+++ b/src/openrct2/scripting/bindings/world/ScParkMessage.hpp
@@ -27,13 +27,13 @@ namespace OpenRCT2::Scripting
     inline News::ItemType GetParkMessageType(const std::string& key)
     {
         // Get the first ItemType that appears in ParkMessageTypeStrings that isn't Null
-        auto firstType = static_cast<uint8_t>(News::ItemType::Ride);
+        auto firstType = static_cast<uint8_t>(News::ItemType::ride);
 
         auto begin = std::begin(ParkMessageTypeStrings);
         auto end = std::end(ParkMessageTypeStrings);
 
         auto it = std::find(begin, end, key);
-        return it != end ? static_cast<News::ItemType>(firstType + std::distance(begin, it)) : News::ItemType::Blank;
+        return it != end ? static_cast<News::ItemType>(firstType + std::distance(begin, it)) : News::ItemType::blank;
     }
 
     inline std::string GetParkMessageType(News::ItemType type)


### PR DESCRIPTION
Commit 1 passes std::span to convertNewsQueue, as requested by @ZehMatt in #24046.
Commits 2 and 3 just rename fields and methods.

The PR initially contained more, but since that caused some problems with older compilers, I decided to leave it for later.