### PR TITLE
Invalidate screen on reload from object selection window

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -30,6 +30,7 @@
 - Fix: [#24447] Shortcut list is not refreshed when changing language.
 - Fix: [#24448] Shortcuts involving the Caps Lock key are wrongly localised to NumPad Dot.
 - Fix: [#24464] Window and viewport visibility is not calculated correctly causing minor performance issues.
+- Fix: [#24488] Objects are not always redrawn immediately when they are reloaded from the Object Selection window.
 
 0.4.22 (2025-05-04)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -478,6 +478,7 @@ namespace OpenRCT2::Ui::Windows
                         {
                             objectManager.UnloadObjects({ descriptor });
                             objectManager.LoadObject(descriptor, entryIndex);
+                            GfxInvalidateScreen();
                         }
                     }
                     break;


### PR DESCRIPTION
This invalidates the whole screen when an object is reloaded in the object selection window. Makes sure that it redraws immediately.