### PR TITLE
Fix #23289: Dodgems and Flying Saucers can spawn on top of each other when opened

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -18,6 +18,7 @@
 - Fix: [#5269] Font bugs when using the Russian release of RCT2 as the base game.
 - Fix: [#11071, #22958] The virtual floor does not always draw correctly.
 - Fix: [#20158] Custom animated scenery .DATs with frame offsets draw a random sprite at the end of their animation.
+- Fix: [#23289] Dodgems and Flying Saucer cars can spawn on top of each other when the ride is opened.
 - Fix: [#24332] Banner font renders differently when using RCT Classic as the base game.
 - Fix: [#24346] Possible crash during line drawing in OpenGL mode.
 - Fix: [#24353] ‘Show dirty visuals’ is off by one pixel and does not work correctly with higher framerates.

--- a/src/openrct2/entity/EntityBase.h
+++ b/src/openrct2/entity/EntityBase.h
@@ -54,6 +54,8 @@ struct EntityBase
      */
     void MoveTo(const CoordsXYZ& newLocation);
 
+    void MoveToAndUpdateSpatialIndex(const CoordsXYZ& newLocation);
+
     /**
      * Sets the entity location without screen invalidation.
      */

--- a/src/openrct2/entity/EntityRegistry.cpp
+++ b/src/openrct2/entity/EntityRegistry.cpp
@@ -448,6 +448,18 @@ static void EntitySpatialRemove(EntityBase& entity)
     entity.SpatialIndex = kInvalidSpatialIndex;
 }
 
+static void UpdateEntitySpatialIndex(EntityBase& entity)
+{
+    if (entity.SpatialIndex & kSpatialIndexDirtyMask)
+    {
+        if (entity.SpatialIndex != kInvalidSpatialIndex)
+        {
+            EntitySpatialRemove(entity);
+        }
+        EntitySpatialInsert(entity, { entity.x, entity.y });
+    }
+}
+
 void UpdateEntitiesSpatialIndex()
 {
     for (auto& entityList : gEntityLists)
@@ -455,16 +467,9 @@ void UpdateEntitiesSpatialIndex()
         for (auto& entityId : entityList)
         {
             auto* entity = TryGetEntity(entityId);
-            if (entity == nullptr || entity->Type == EntityType::Null)
-                continue;
-
-            if (entity->SpatialIndex & kSpatialIndexDirtyMask)
+            if (entity != nullptr && entity->Type != EntityType::Null)
             {
-                if (entity->SpatialIndex != kInvalidSpatialIndex)
-                {
-                    EntitySpatialRemove(*entity);
-                }
-                EntitySpatialInsert(*entity, { entity->x, entity->y });
+                UpdateEntitySpatialIndex(*entity);
             }
         }
     }
@@ -536,6 +541,12 @@ void EntityBase::MoveTo(const CoordsXYZ& newLocation)
         EntitySetCoordinates(loc, this);
         Invalidate(); // Invalidate new position.
     }
+}
+
+void EntityBase::MoveToAndUpdateSpatialIndex(const CoordsXYZ& newLocation)
+{
+    MoveTo(newLocation);
+    UpdateEntitySpatialIndex(*this);
 }
 
 /**

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3308,7 +3308,7 @@ static Vehicle* VehicleCreateCar(
             chosenLoc.x = dodgemPos.x + (ScenarioRand() & 0xFF);
         } while (vehicle->DodgemsCarWouldCollideAt(chosenLoc).has_value());
 
-        vehicle->MoveTo({ chosenLoc, dodgemPos.z });
+        vehicle->MoveToAndUpdateSpatialIndex({ chosenLoc, dodgemPos.z });
     }
     else
     {


### PR DESCRIPTION
This fixes #23289 and fixes #24461: Dodgems and Flying Saucers spawning on top of each other when opened.

The issue here is that the entity spatial index needs to be updated when the cars are placed, so that they can be found when checking where to place the next car. This was broken when the spatial index update was changed.