### PR TITLE
Change FindVehicleToEnter to account for pair-loading vehicles in rare cases

### DIFF
--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -2585,7 +2585,7 @@ static bool FindVehicleToEnter(
             if (vehicle == nullptr)
                 continue;
 
-            if (vehicle->next_free_seat >= vehicle->num_seats)
+            if (vehicle->next_free_seat >= (vehicle->num_seats & kVehicleSeatNumMask))
                 continue;
 
             if (vehicle->status != Vehicle::Status::WaitingForPassengers)


### PR DESCRIPTION
Handles the case where a ride in dodgems or race mode cannot load more guests if it has a custom vehicle which loads in pairs.

Likely needs a network version bump.

Fixes #24510