### PR TITLE
Fix new ride window not always redrawing properly when searching

### DIFF
--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -527,6 +527,7 @@ namespace OpenRCT2::Ui::Windows
             _filter.assign(text);
 
             scrolls->contentOffsetY = 0;
+            PopulateRideList();
             Invalidate();
         }
 


### PR DESCRIPTION
Regression from #24433. Fixes the new ride window not redrawing the ride list properly when searching.

It actually does invalidate already, but it doesn't update the ride list before it invalidates so it was previously relying on the next frame to update and invalidate it.

![newridebug](https://github.com/user-attachments/assets/4909035b-c1b5-4e1f-aadf-2cd5c63732b4)
