### PR TITLE
Implement OnLanguageChange event for ScenarioSelect window

### DIFF
--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -145,6 +145,11 @@ namespace OpenRCT2::Ui::Windows
             InitScrollWidgets();
         }
 
+        void OnLanguageChange() override
+        {
+            ScenarioRepositoryScan();
+        }
+
         void OnMouseUp(WidgetIndex widgetIndex) override
         {
             if (widgetIndex == WIDX_CLOSE)


### PR DESCRIPTION
When changing the in-game language while the scenario selection window is open, the index isn't automatically updated, leaving the titles for the previous language. This PR leverages the `OnLanguageChange` event to immediately trigger a rebuild.