### PR TITLE
Fix guest window viewport on pick up and thoughts not invalidating

### DIFF
--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -933,6 +933,22 @@ namespace OpenRCT2::Ui::Windows
                     }
                 }
             }
+
+            const std::optional<Focus> currentFocus = peep->State != PeepState::Picked ? std::optional(Focus(peep->Id))
+                                                                                       : std::nullopt;
+            if (focus != currentFocus)
+            {
+                OnViewportRotate();
+            }
+
+            for (const auto& thought : peep->Thoughts)
+            {
+                if (thought.freshness == 1 || thought.freshness == 2)
+                {
+                    InvalidateWidget(WIDX_MARQUEE);
+                    break;
+                }
+            }
         }
 
         void OnTextInputOverview(WidgetIndex widgetIndex, std::string_view text)


### PR DESCRIPTION
Another regression from #24433.
Fixes the viewport not disappearing when a guest is picked up, and the thoughts marquee not invalidating.