### PR TITLE
Remove const_cast in GetWidgetByIndex

### DIFF
--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -1043,15 +1043,14 @@ namespace OpenRCT2::Ui
         }
     }
 
-    Widget* GetWidgetByIndex(const WindowBase& w, WidgetIndex widgetIndex)
+    Widget* GetWidgetByIndex(WindowBase& w, WidgetIndex widgetIndex)
     {
         if (widgetIndex >= w.widgets.size())
         {
             LOG_ERROR("Widget index %i out of bounds for window class %u", widgetIndex, w.classification);
         }
 
-        // FIXME: This const_cast is bad.
-        return const_cast<Widget*>(w.widgets.data() + widgetIndex);
+        return &w.widgets[widgetIndex];
     }
 
     static void SafeSetWidgetFlag(WindowBase& w, WidgetIndex widgetIndex, WidgetFlags mask, bool value)

--- a/src/openrct2-ui/interface/Widget.h
+++ b/src/openrct2-ui/interface/Widget.h
@@ -32,7 +32,7 @@
 namespace OpenRCT2::Ui
 {
     ImageId GetColourButtonImage(colour_t colour);
-    Widget* GetWidgetByIndex(const WindowBase& w, WidgetIndex widgetIndex);
+    Widget* GetWidgetByIndex(WindowBase& w, WidgetIndex widgetIndex);
 
     constexpr uint32_t kWidgetContentEmpty = 0xFFFFFFFF;
     constexpr auto kBarBlink = (1u << 31);


### PR DESCRIPTION
The function `GetWidgetByIndex` is used in const context in `WidgetDraw`, but write access is needed by its other user, `SafeSetWidgetFlag`.

Dropping `const` from the window argument removes the need for the ugly `const_cast`.