### PR TITLE
Disable scenario options rather than hiding them

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -2242,14 +2242,14 @@ STR_3235    :Show financial options
 STR_3236    :Show guest options
 STR_3238    :No Money
 STR_3239    :Make this park a ‘no money’ park with no financial restrictions
-STR_3240    :{WINDOW_COLOUR_2}Initial cash:
-STR_3241    :{WINDOW_COLOUR_2}Initial loan:
-STR_3242    :{WINDOW_COLOUR_2}Maximum loan size:
-STR_3243    :{WINDOW_COLOUR_2}Annual interest rate:
+STR_3240    :Initial cash:
+STR_3241    :Initial loan:
+STR_3242    :Maximum loan size:
+STR_3243    :Annual interest rate:
 STR_3244    :Forbid marketing campaigns
 STR_3245    :Forbid advertising, promotional schemes, and other marketing campaigns
-STR_3246    :{WINDOW_COLOUR_2}{CURRENCY}
-STR_3247    :{WINDOW_COLOUR_2}{COMMA16}%
+STR_3246    :{CURRENCY}
+STR_3247    :{COMMA16}%
 STR_3248    :Can’t increase initial cash any further!
 STR_3249    :Can’t reduce initial cash any further!
 STR_3250    :Can’t increase initial loan any further!
@@ -2258,10 +2258,10 @@ STR_3252    :Can’t increase maximum loan size any further!
 STR_3253    :Can’t reduce maximum loan size any further!
 STR_3254    :Can’t increase interest rate any further!
 STR_3255    :Can’t reduce interest rate any further!
-STR_3260    :{WINDOW_COLOUR_2}Cash per guest (average):
-STR_3261    :{WINDOW_COLOUR_2}Guests’ initial happiness:
-STR_3262    :{WINDOW_COLOUR_2}Guests’ initial hunger:
-STR_3263    :{WINDOW_COLOUR_2}Guests’ initial thirst:
+STR_3260    :Cash per guest (average):
+STR_3261    :Guests’ initial happiness:
+STR_3262    :Guests’ initial hunger:
+STR_3263    :Guests’ initial thirst:
 STR_3264    :Can’t increase this any further!
 STR_3265    :Can’t reduce this any further!
 STR_3266    :Select how this park charges for entrance and rides
@@ -2275,11 +2275,11 @@ STR_3273    :Park rating is harder to increase and maintain
 STR_3274    :Make the park rating value more challenging
 STR_3275    :Guests are more difficult to attract
 STR_3276    :Make it more difficult to attract guests to the park
-STR_3277    :{WINDOW_COLOUR_2}Cost to buy land:
-STR_3278    :{WINDOW_COLOUR_2}Cost to buy construction rights:
+STR_3277    :Cost to buy land:
+STR_3278    :Cost to buy construction rights:
 STR_3279    :Free park entry / Pay per ride
 STR_3280    :Pay to enter park / Free rides
-STR_3281    :{WINDOW_COLOUR_2}Entry price:
+STR_3281    :Entry price:
 STR_3283    :Select rides to be preserved
 STR_3285    :Scenario options - Preserved Rides
 STR_3286    :Select objective for this scenario

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.24 (in development)
 ------------------------------------------------------------------------
 - Feature: [#24411] Vanilla scenarios now also have previews in the scenario selection window.
+- Change: [#24559] Scenario options are now disabled rather than hidden when disabling money makes them non-applicable.
 - Change: [objects#383] Disable all base colours on non-remappable WWTT vehicles, change black to light_blue.
 - Change: [objects#384] Remove erroneously enabled WWTT third remaps.
 - Fix: [#15846] Rightclicking on track piece when there is construction below does not work.

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -112,11 +112,14 @@ namespace OpenRCT2::Ui::Windows
         WIDX_PAGE_START,
 
         // Objective tab
-        WIDX_OBJECTIVE = WIDX_PAGE_START,
+        WIDX_OBJECTIVE_LABEL = WIDX_PAGE_START,
+        WIDX_OBJECTIVE,
         WIDX_OBJECTIVE_DROPDOWN,
+        WIDX_OBJECTIVE_ARG_1_LABEL,
         WIDX_OBJECTIVE_ARG_1,
         WIDX_OBJECTIVE_ARG_1_INCREASE,
         WIDX_OBJECTIVE_ARG_1_DECREASE,
+        WIDX_OBJECTIVE_ARG_2_LABEL,
         WIDX_OBJECTIVE_ARG_2,
         WIDX_OBJECTIVE_ARG_2_INCREASE,
         WIDX_OBJECTIVE_ARG_2_DECREASE,
@@ -211,9 +214,12 @@ namespace OpenRCT2::Ui::Windows
 
     static constexpr auto window_editor_scenario_options_objective_widgets = makeWidgets(
         makeOptionsWidgets(STR_SCENARIO_OPTIONS_OBJECTIVE, kSizeObjective),
+        makeWidget        ({  8,  48}, {344,  12}, WidgetType::label,    WindowColour::secondary, STR_OBJECTIVE_DROPDOWN_LABEL                                       ),
         makeWidget        ({ 98,  48}, {344,  12}, WidgetType::dropdownMenu, WindowColour::secondary, kStringIdNone,           STR_SELECT_OBJECTIVE_FOR_THIS_SCENARIO_TIP     ),
         makeWidget        ({430,  49}, { 11,  10}, WidgetType::button,   WindowColour::secondary, STR_DROPDOWN_GLYPH, STR_SELECT_OBJECTIVE_FOR_THIS_SCENARIO_TIP     ),
+        makeWidget        ({ 28,  65}, {140,  12}, WidgetType::label,    WindowColour::secondary, kStringIdEmpty                                                     ),
         makeSpinnerWidgets({158,  65}, {120,  12}, WidgetType::button,   WindowColour::secondary                                                                     ), // NB: 3 widgets
+        makeWidget        ({ 28,  82}, {140,  12}, WidgetType::label,    WindowColour::secondary, STR_WINDOW_OBJECTIVE_DATE                                          ),
         makeSpinnerWidgets({158,  82}, {120,  12}, WidgetType::button,   WindowColour::secondary                                                                     ), // NB: 3 widgets
         makeWidget        ({ 14,  99}, {340,  12}, WidgetType::checkbox, WindowColour::secondary, STR_HARD_PARK_RATING,   STR_HARD_PARK_RATING_TIP                   )
     );
@@ -1050,9 +1056,11 @@ namespace OpenRCT2::Ui::Windows
             {
                 case OBJECTIVE_GUESTS_BY:
                 case OBJECTIVE_PARK_VALUE_BY:
+                    widgets[WIDX_OBJECTIVE_ARG_1_LABEL].type = WidgetType::label;
                     widgets[WIDX_OBJECTIVE_ARG_1].type = WidgetType::spinner;
                     widgets[WIDX_OBJECTIVE_ARG_1_INCREASE].type = WidgetType::button;
                     widgets[WIDX_OBJECTIVE_ARG_1_DECREASE].type = WidgetType::button;
+                    widgets[WIDX_OBJECTIVE_ARG_2_LABEL].type = WidgetType::label;
                     widgets[WIDX_OBJECTIVE_ARG_2].type = WidgetType::spinner;
                     widgets[WIDX_OBJECTIVE_ARG_2_INCREASE].type = WidgetType::button;
                     widgets[WIDX_OBJECTIVE_ARG_2_DECREASE].type = WidgetType::button;
@@ -1063,24 +1071,60 @@ namespace OpenRCT2::Ui::Windows
                 case OBJECTIVE_FINISH_5_ROLLERCOASTERS:
                 case OBJECTIVE_REPAY_LOAN_AND_PARK_VALUE:
                 case OBJECTIVE_MONTHLY_FOOD_INCOME:
+                    widgets[WIDX_OBJECTIVE_ARG_1_LABEL].type = WidgetType::label;
                     widgets[WIDX_OBJECTIVE_ARG_1].type = WidgetType::spinner;
                     widgets[WIDX_OBJECTIVE_ARG_1_INCREASE].type = WidgetType::button;
                     widgets[WIDX_OBJECTIVE_ARG_1_DECREASE].type = WidgetType::button;
+                    widgets[WIDX_OBJECTIVE_ARG_2_LABEL].type = WidgetType::empty;
                     widgets[WIDX_OBJECTIVE_ARG_2].type = WidgetType::empty;
                     widgets[WIDX_OBJECTIVE_ARG_2_INCREASE].type = WidgetType::empty;
                     widgets[WIDX_OBJECTIVE_ARG_2_DECREASE].type = WidgetType::empty;
                     break;
                 default:
+                    widgets[WIDX_OBJECTIVE_ARG_1_LABEL].type = WidgetType::empty;
                     widgets[WIDX_OBJECTIVE_ARG_1].type = WidgetType::empty;
                     widgets[WIDX_OBJECTIVE_ARG_1_INCREASE].type = WidgetType::empty;
                     widgets[WIDX_OBJECTIVE_ARG_1_DECREASE].type = WidgetType::empty;
+                    widgets[WIDX_OBJECTIVE_ARG_2_LABEL].type = WidgetType::empty;
                     widgets[WIDX_OBJECTIVE_ARG_2].type = WidgetType::empty;
                     widgets[WIDX_OBJECTIVE_ARG_2_INCREASE].type = WidgetType::empty;
                     widgets[WIDX_OBJECTIVE_ARG_2_DECREASE].type = WidgetType::empty;
                     break;
             }
 
-            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty : WidgetType::closeBox;
+            auto arg1StringId = kStringIdEmpty;
+            if (widgets[WIDX_OBJECTIVE_ARG_1_LABEL].type != WidgetType::empty)
+            {
+                // Objective argument 1 label
+                switch (gameState.scenarioObjective.Type)
+                {
+                    case OBJECTIVE_GUESTS_BY:
+                    case OBJECTIVE_GUESTS_AND_RATING:
+                        arg1StringId = STR_WINDOW_OBJECTIVE_GUEST_COUNT;
+                        break;
+                    case OBJECTIVE_PARK_VALUE_BY:
+                    case OBJECTIVE_REPAY_LOAN_AND_PARK_VALUE:
+                        arg1StringId = STR_WINDOW_OBJECTIVE_PARK_VALUE;
+                        break;
+                    case OBJECTIVE_MONTHLY_RIDE_INCOME:
+                        arg1StringId = STR_WINDOW_OBJECTIVE_MONTHLY_INCOME;
+                        break;
+                    case OBJECTIVE_MONTHLY_FOOD_INCOME:
+                        arg1StringId = STR_WINDOW_OBJECTIVE_MONTHLY_PROFIT;
+                        break;
+                    case OBJECTIVE_10_ROLLERCOASTERS_LENGTH:
+                        arg1StringId = STR_WINDOW_OBJECTIVE_MINIMUM_LENGTH;
+                        break;
+                    default:
+                        arg1StringId = STR_WINDOW_OBJECTIVE_EXCITEMENT_RATING;
+                        break;
+                }
+            }
+
+            widgets[WIDX_OBJECTIVE_ARG_1_LABEL].text = arg1StringId;
+
+            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty
+                                                                                   : WidgetType::closeBox;
 
             SetWidgetPressed(WIDX_HARD_PARK_RATING, gameState.park.Flags & PARK_FLAGS_DIFFICULT_PARK_RATING);
         }
@@ -1092,49 +1136,20 @@ namespace OpenRCT2::Ui::Windows
         void ObjectiveOnDraw(RenderTarget& rt)
         {
             const auto& gameState = getGameState();
-            StringId stringId;
 
             DrawWidgets(rt);
             DrawTabImages(rt);
 
-            // Objective label
-            auto screenCoords = windowPos + ScreenCoordsXY{ 8, widgets[WIDX_OBJECTIVE].top };
-            DrawTextBasic(rt, screenCoords, STR_OBJECTIVE_DROPDOWN_LABEL);
-
             // Objective value
-            screenCoords = windowPos + ScreenCoordsXY{ widgets[WIDX_OBJECTIVE].left + 1, widgets[WIDX_OBJECTIVE].top };
+            auto screenCoords = windowPos + ScreenCoordsXY{ widgets[WIDX_OBJECTIVE].left + 1, widgets[WIDX_OBJECTIVE].top };
             auto ft = Formatter();
             ft.Add<StringId>(ObjectiveDropdownOptionNames[gameState.scenarioObjective.Type]);
             DrawTextBasic(rt, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
 
             if (widgets[WIDX_OBJECTIVE_ARG_1].type != WidgetType::empty)
             {
-                // Objective argument 1 label
-                screenCoords = windowPos + ScreenCoordsXY{ 28, widgets[WIDX_OBJECTIVE_ARG_1].top };
-                switch (gameState.scenarioObjective.Type)
-                {
-                    case OBJECTIVE_GUESTS_BY:
-                    case OBJECTIVE_GUESTS_AND_RATING:
-                        stringId = STR_WINDOW_OBJECTIVE_GUEST_COUNT;
-                        break;
-                    case OBJECTIVE_PARK_VALUE_BY:
-                    case OBJECTIVE_REPAY_LOAN_AND_PARK_VALUE:
-                        stringId = STR_WINDOW_OBJECTIVE_PARK_VALUE;
-                        break;
-                    case OBJECTIVE_MONTHLY_RIDE_INCOME:
-                        stringId = STR_WINDOW_OBJECTIVE_MONTHLY_INCOME;
-                        break;
-                    case OBJECTIVE_MONTHLY_FOOD_INCOME:
-                        stringId = STR_WINDOW_OBJECTIVE_MONTHLY_PROFIT;
-                        break;
-                    case OBJECTIVE_10_ROLLERCOASTERS_LENGTH:
-                        stringId = STR_WINDOW_OBJECTIVE_MINIMUM_LENGTH;
-                        break;
-                    default:
-                        stringId = STR_WINDOW_OBJECTIVE_EXCITEMENT_RATING;
-                        break;
-                }
-                DrawTextBasic(rt, screenCoords, stringId);
+                const auto wColour2 = colours[1];
+                StringId stringId = kStringIdEmpty;
 
                 // Objective argument 1 value
                 screenCoords = windowPos
@@ -1167,15 +1182,11 @@ namespace OpenRCT2::Ui::Windows
                         ft.Add<money64>(gameState.scenarioObjective.Currency);
                         break;
                 }
-                DrawTextBasic(rt, screenCoords, stringId, ft, { COLOUR_BLACK });
+                DrawTextBasic(rt, screenCoords, stringId, ft, wColour2);
             }
 
             if (widgets[WIDX_OBJECTIVE_ARG_2].type != WidgetType::empty)
             {
-                // Objective argument 2 label
-                screenCoords = windowPos + ScreenCoordsXY{ 28, widgets[WIDX_OBJECTIVE_ARG_2].top };
-                DrawTextBasic(rt, screenCoords, STR_WINDOW_OBJECTIVE_DATE);
-
                 // Objective argument 2 value
                 screenCoords = windowPos
                     + ScreenCoordsXY{ widgets[WIDX_OBJECTIVE_ARG_2].left + 1, widgets[WIDX_OBJECTIVE_ARG_2].top };
@@ -1591,70 +1602,75 @@ namespace OpenRCT2::Ui::Windows
             SetPressedTab();
 
             auto& gameState = getGameState();
-            if (gameState.park.Flags & PARK_FLAGS_NO_MONEY)
+            bool noMoney = gameState.park.Flags & PARK_FLAGS_NO_MONEY;
+            SetWidgetPressed(WIDX_NO_MONEY, noMoney);
+
+            SetWidgetDisabled(WIDX_GROUP_LOAN, noMoney);
+            SetWidgetDisabled(WIDX_INITIAL_LOAN_LABEL, noMoney);
+            SetWidgetDisabled(WIDX_INITIAL_LOAN, noMoney);
+            SetWidgetDisabled(WIDX_INITIAL_LOAN_INCREASE, noMoney);
+            SetWidgetDisabled(WIDX_INITIAL_LOAN_DECREASE, noMoney);
+            SetWidgetDisabled(WIDX_MAXIMUM_LOAN_LABEL, noMoney);
+            SetWidgetDisabled(WIDX_MAXIMUM_LOAN, noMoney);
+            SetWidgetDisabled(WIDX_MAXIMUM_LOAN_INCREASE, noMoney);
+            SetWidgetDisabled(WIDX_MAXIMUM_LOAN_DECREASE, noMoney);
+
+            if (gameState.park.Flags & PARK_FLAGS_RCT1_INTEREST)
             {
-                SetWidgetPressed(WIDX_NO_MONEY, true);
-                for (int32_t i = WIDX_GROUP_LOAN; i <= WIDX_FORBID_MARKETING; i++)
-                    widgets[i].type = WidgetType::empty;
+                widgets[WIDX_INTEREST_RATE_LABEL].type = WidgetType::empty;
+                widgets[WIDX_INTEREST_RATE].type = WidgetType::empty;
+                widgets[WIDX_INTEREST_RATE_INCREASE].type = WidgetType::empty;
+                widgets[WIDX_INTEREST_RATE_DECREASE].type = WidgetType::empty;
+                widgets[WIDX_RCT1_INTEREST].type = WidgetType::checkbox;
+                SetWidgetPressed(WIDX_RCT1_INTEREST, true);
+                SetWidgetDisabled(WIDX_RCT1_INTEREST, noMoney);
             }
             else
             {
-                SetWidgetPressed(WIDX_NO_MONEY, false);
+                widgets[WIDX_INTEREST_RATE_LABEL].type = WidgetType::label;
+                widgets[WIDX_INTEREST_RATE].type = WidgetType::spinner;
+                widgets[WIDX_INTEREST_RATE_INCREASE].type = WidgetType::button;
+                widgets[WIDX_INTEREST_RATE_DECREASE].type = WidgetType::button;
+                widgets[WIDX_RCT1_INTEREST].type = WidgetType::empty;
+                SetWidgetDisabled(WIDX_INTEREST_RATE_LABEL, noMoney);
+                SetWidgetDisabled(WIDX_INTEREST_RATE, noMoney);
+                SetWidgetDisabled(WIDX_INTEREST_RATE_INCREASE, noMoney);
+                SetWidgetDisabled(WIDX_INTEREST_RATE_DECREASE, noMoney);
+            }
 
-                widgets[WIDX_GROUP_LOAN].type = WidgetType::groupbox;
-                widgets[WIDX_INITIAL_LOAN_LABEL].type = WidgetType::label;
-                widgets[WIDX_INITIAL_LOAN].type = WidgetType::spinner;
-                widgets[WIDX_INITIAL_LOAN_INCREASE].type = WidgetType::button;
-                widgets[WIDX_INITIAL_LOAN_DECREASE].type = WidgetType::button;
-                widgets[WIDX_MAXIMUM_LOAN_LABEL].type = WidgetType::label;
-                widgets[WIDX_MAXIMUM_LOAN].type = WidgetType::spinner;
-                widgets[WIDX_MAXIMUM_LOAN_INCREASE].type = WidgetType::button;
-                widgets[WIDX_MAXIMUM_LOAN_DECREASE].type = WidgetType::button;
+            SetWidgetDisabled(WIDX_GROUP_BUSINESS_MODEL, noMoney);
+            SetWidgetDisabled(WIDX_INITIAL_CASH_LABEL, noMoney);
+            SetWidgetDisabled(WIDX_INITIAL_CASH, noMoney);
+            SetWidgetDisabled(WIDX_INITIAL_CASH_INCREASE, noMoney);
+            SetWidgetDisabled(WIDX_INITIAL_CASH_DECREASE, noMoney);
+            SetWidgetDisabled(WIDX_PAY_FOR_PARK_OR_RIDES_LABEL, noMoney);
+            SetWidgetDisabled(WIDX_PAY_FOR_PARK_OR_RIDES, noMoney);
+            SetWidgetDisabled(WIDX_PAY_FOR_PARK_OR_RIDES_DROPDOWN, noMoney);
+            SetWidgetDisabled(WIDX_FORBID_MARKETING, noMoney);
 
-                if (gameState.park.Flags & PARK_FLAGS_RCT1_INTEREST)
-                {
-                    widgets[WIDX_INTEREST_RATE_LABEL].type = WidgetType::empty;
-                    widgets[WIDX_INTEREST_RATE].type = WidgetType::empty;
-                    widgets[WIDX_INTEREST_RATE_INCREASE].type = WidgetType::empty;
-                    widgets[WIDX_INTEREST_RATE_DECREASE].type = WidgetType::empty;
-                    widgets[WIDX_RCT1_INTEREST].type = WidgetType::checkbox;
-                    SetWidgetPressed(WIDX_RCT1_INTEREST, true);
-                }
-                else
-                {
-                    widgets[WIDX_INTEREST_RATE_LABEL].type = WidgetType::label;
-                    widgets[WIDX_INTEREST_RATE].type = WidgetType::spinner;
-                    widgets[WIDX_INTEREST_RATE_INCREASE].type = WidgetType::button;
-                    widgets[WIDX_INTEREST_RATE_DECREASE].type = WidgetType::button;
-                    widgets[WIDX_RCT1_INTEREST].type = WidgetType::empty;
-                }
-
-                widgets[WIDX_GROUP_BUSINESS_MODEL].type = WidgetType::groupbox;
-                widgets[WIDX_INITIAL_CASH_LABEL].type = WidgetType::label;
-                widgets[WIDX_INITIAL_CASH].type = WidgetType::spinner;
-                widgets[WIDX_INITIAL_CASH_INCREASE].type = WidgetType::button;
-                widgets[WIDX_INITIAL_CASH_DECREASE].type = WidgetType::button;
-                widgets[WIDX_PAY_FOR_PARK_OR_RIDES_LABEL].type = WidgetType::label;
-                widgets[WIDX_PAY_FOR_PARK_OR_RIDES].type = WidgetType::dropdownMenu;
-                widgets[WIDX_PAY_FOR_PARK_OR_RIDES_DROPDOWN].type = WidgetType::button;
+            if (!Park::EntranceFeeUnlocked())
+            {
+                widgets[WIDX_ENTRY_PRICE_LABEL].type = WidgetType::empty;
+                widgets[WIDX_ENTRY_PRICE].type = WidgetType::empty;
+                widgets[WIDX_ENTRY_PRICE_INCREASE].type = WidgetType::empty;
+                widgets[WIDX_ENTRY_PRICE_DECREASE].type = WidgetType::empty;
+            }
+            else
+            {
                 widgets[WIDX_ENTRY_PRICE_LABEL].type = WidgetType::label;
                 widgets[WIDX_ENTRY_PRICE].type = WidgetType::spinner;
                 widgets[WIDX_ENTRY_PRICE_INCREASE].type = WidgetType::button;
                 widgets[WIDX_ENTRY_PRICE_DECREASE].type = WidgetType::button;
-                widgets[WIDX_FORBID_MARKETING].type = WidgetType::checkbox;
-
-                if (!Park::EntranceFeeUnlocked())
-                {
-                    widgets[WIDX_ENTRY_PRICE_LABEL].type = WidgetType::empty;
-                    widgets[WIDX_ENTRY_PRICE].type = WidgetType::empty;
-                    widgets[WIDX_ENTRY_PRICE_INCREASE].type = WidgetType::empty;
-                    widgets[WIDX_ENTRY_PRICE_DECREASE].type = WidgetType::empty;
-                }
+                SetWidgetDisabled(WIDX_ENTRY_PRICE_LABEL, noMoney);
+                SetWidgetDisabled(WIDX_ENTRY_PRICE, noMoney);
+                SetWidgetDisabled(WIDX_ENTRY_PRICE_INCREASE, noMoney);
+                SetWidgetDisabled(WIDX_ENTRY_PRICE_DECREASE, noMoney);
             }
 
             SetWidgetPressed(WIDX_FORBID_MARKETING, gameState.park.Flags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN);
 
-            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty : WidgetType::closeBox;
+            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty
+                                                                                   : WidgetType::closeBox;
         }
 
         void FinancialDraw(RenderTarget& rt)
@@ -1664,7 +1680,8 @@ namespace OpenRCT2::Ui::Windows
             WindowDrawWidgets(*this, rt);
             DrawTabImages(rt);
 
-            auto& gameState = getGameState();
+            const auto& gameState = getGameState();
+            const auto wColour2 = colours[1];
 
             const auto& initialCashWidget = widgets[WIDX_INITIAL_CASH];
             if (initialCashWidget.type != WidgetType::empty)
@@ -1672,7 +1689,8 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords = windowPos + ScreenCoordsXY{ initialCashWidget.left + 1, initialCashWidget.top };
                 auto ft = Formatter();
                 ft.Add<money64>(getGameState().initialCash);
-                DrawTextBasic(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
+                auto colour = !IsWidgetDisabled(WIDX_INITIAL_CASH) ? wColour2 : wColour2.withFlag(ColourFlag::inset, true);
+                DrawTextBasic(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft, colour);
             }
 
             const auto& initialLoanWidget = widgets[WIDX_INITIAL_LOAN];
@@ -1681,7 +1699,8 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords = windowPos + ScreenCoordsXY{ initialLoanWidget.left + 1, initialLoanWidget.top };
                 auto ft = Formatter();
                 ft.Add<money64>(gameState.bankLoan);
-                DrawTextBasic(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
+                auto colour = !IsWidgetDisabled(WIDX_INITIAL_LOAN) ? wColour2 : wColour2.withFlag(ColourFlag::inset, true);
+                DrawTextBasic(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft, colour);
             }
 
             const auto& maximumLoanWidget = widgets[WIDX_MAXIMUM_LOAN];
@@ -1690,7 +1709,8 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords = windowPos + ScreenCoordsXY{ maximumLoanWidget.left + 1, maximumLoanWidget.top };
                 auto ft = Formatter();
                 ft.Add<money64>(getGameState().maxBankLoan);
-                DrawTextBasic(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
+                auto colour = !IsWidgetDisabled(WIDX_MAXIMUM_LOAN) ? wColour2 : wColour2.withFlag(ColourFlag::inset, true);
+                DrawTextBasic(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft, colour);
             }
 
             const auto& interestRateWidget = widgets[WIDX_INTEREST_RATE];
@@ -1701,7 +1721,8 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<int16_t>(
                     std::clamp<int16_t>(static_cast<int16_t>(gameState.bankLoanInterestRate), INT16_MIN, INT16_MAX));
-                DrawTextBasic(rt, screenCoords, STR_PERCENT_FORMAT_LABEL, ft);
+                auto colour = !IsWidgetDisabled(WIDX_INTEREST_RATE) ? wColour2 : wColour2.withFlag(ColourFlag::inset, true);
+                DrawTextBasic(rt, screenCoords, STR_PERCENT_FORMAT_LABEL, ft, colour);
             }
 
             const auto& payForParkOrRidesWidget = widgets[WIDX_PAY_FOR_PARK_OR_RIDES];
@@ -1719,7 +1740,9 @@ namespace OpenRCT2::Ui::Windows
                 else
                     ft.Add<StringId>(STR_PAY_PARK_ENTER);
 
-                DrawTextBasic(rt, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
+                auto colour = !IsWidgetDisabled(WIDX_PAY_FOR_PARK_OR_RIDES) ? wColour2
+                                                                            : wColour2.withFlag(ColourFlag::inset, true);
+                DrawTextBasic(rt, screenCoords, STR_STRINGID, ft, colour);
             }
 
             const auto& entryPriceWidget = widgets[WIDX_ENTRY_PRICE];
@@ -1729,7 +1752,8 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords = windowPos + ScreenCoordsXY{ entryPriceWidget.left + 1, entryPriceWidget.top };
                 auto ft = Formatter();
                 ft.Add<money64>(gameState.park.EntranceFee);
-                DrawTextBasic(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
+                auto colour = !IsWidgetDisabled(WIDX_INITIAL_CASH) ? wColour2 : wColour2.withFlag(ColourFlag::inset, true);
+                DrawTextBasic(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft, colour);
             }
         }
 
@@ -1925,20 +1949,15 @@ namespace OpenRCT2::Ui::Windows
             SetPressedTab();
 
             auto& gameState = getGameState();
-            if (gameState.park.Flags & PARK_FLAGS_NO_MONEY)
-            {
-                widgets[WIDX_CASH_PER_GUEST].type = WidgetType::empty;
-                widgets[WIDX_CASH_PER_GUEST_INCREASE].type = WidgetType::empty;
-                widgets[WIDX_CASH_PER_GUEST_DECREASE].type = WidgetType::empty;
-            }
-            else
-            {
-                widgets[WIDX_CASH_PER_GUEST].type = WidgetType::spinner;
-                widgets[WIDX_CASH_PER_GUEST_INCREASE].type = WidgetType::button;
-                widgets[WIDX_CASH_PER_GUEST_DECREASE].type = WidgetType::button;
-            }
+            bool noMoney = gameState.park.Flags & PARK_FLAGS_NO_MONEY;
 
-            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty : WidgetType::closeBox;
+            SetWidgetDisabled(WIDX_CASH_PER_GUEST_LABEL, noMoney);
+            SetWidgetDisabled(WIDX_CASH_PER_GUEST, noMoney);
+            SetWidgetDisabled(WIDX_CASH_PER_GUEST_INCREASE, noMoney);
+            SetWidgetDisabled(WIDX_CASH_PER_GUEST_DECREASE, noMoney);
+
+            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty
+                                                                                   : WidgetType::closeBox;
 
             SetWidgetPressed(WIDX_HARD_GUEST_GENERATION, gameState.park.Flags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION);
         }
@@ -1949,7 +1968,9 @@ namespace OpenRCT2::Ui::Windows
 
             WindowDrawWidgets(*this, rt);
             DrawTabImages(rt);
-            auto& gameState = getGameState();
+
+            const auto& gameState = getGameState();
+            const auto wColour2 = colours[1];
 
             const auto& cashPerGuestWidget = widgets[WIDX_CASH_PER_GUEST];
             if (cashPerGuestWidget.type != WidgetType::empty)
@@ -1958,29 +1979,32 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords = windowPos + ScreenCoordsXY{ cashPerGuestWidget.left + 1, cashPerGuestWidget.top };
                 auto ft = Formatter();
                 ft.Add<money64>(gameState.guestInitialCash);
-                DrawTextBasic(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
+                auto colour = !IsWidgetDisabled(WIDX_CASH_PER_GUEST) ? wColour2 : wColour2.withFlag(ColourFlag::inset, true);
+                DrawTextBasic(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft, colour);
             }
+
+            auto colour = wColour2;
 
             // Guest initial happiness value
             const auto& initialHappinessWidget = widgets[WIDX_GUEST_INITIAL_HAPPINESS];
             screenCoords = windowPos + ScreenCoordsXY{ initialHappinessWidget.left + 1, initialHappinessWidget.top };
             auto ft = Formatter();
             ft.Add<uint16_t>((gameState.guestInitialHappiness * 100) / 255);
-            DrawTextBasic(rt, screenCoords, STR_PERCENT_FORMAT_LABEL, ft);
+            DrawTextBasic(rt, screenCoords, STR_PERCENT_FORMAT_LABEL, ft, colour);
 
             // Guest initial hunger value
             const auto& initialHungerWidget = widgets[WIDX_GUEST_INITIAL_HUNGER];
             screenCoords = windowPos + ScreenCoordsXY{ initialHungerWidget.left + 1, initialHungerWidget.top };
             ft = Formatter();
             ft.Add<uint16_t>(((255 - gameState.guestInitialHunger) * 100) / 255);
-            DrawTextBasic(rt, screenCoords, STR_PERCENT_FORMAT_LABEL, ft);
+            DrawTextBasic(rt, screenCoords, STR_PERCENT_FORMAT_LABEL, ft, colour);
 
             // Guest initial thirst value
             const auto& initialThirstWidget = widgets[WIDX_GUEST_INITIAL_THIRST];
             screenCoords = windowPos + ScreenCoordsXY{ initialThirstWidget.left + 1, initialThirstWidget.top };
             ft = Formatter();
             ft.Add<uint16_t>(((255 - gameState.guestInitialThirst) * 100) / 255);
-            DrawTextBasic(rt, screenCoords, STR_PERCENT_FORMAT_LABEL, ft);
+            DrawTextBasic(rt, screenCoords, STR_PERCENT_FORMAT_LABEL, ft, colour);
 
             // Guests' intensity value
             {
@@ -2118,27 +2142,23 @@ namespace OpenRCT2::Ui::Windows
             SetPressedTab();
 
             auto& gameState = getGameState();
-            if (gameState.park.Flags & PARK_FLAGS_NO_MONEY)
-            {
-                for (int32_t i = WIDX_LAND_COST_LABEL; i <= WIDX_CONSTRUCTION_RIGHTS_COST_DECREASE; i++)
-                    widgets[i].type = WidgetType::empty;
-            }
-            else
-            {
-                widgets[WIDX_LAND_COST_LABEL].type = WidgetType::label;
-                widgets[WIDX_LAND_COST].type = WidgetType::spinner;
-                widgets[WIDX_LAND_COST_INCREASE].type = WidgetType::button;
-                widgets[WIDX_LAND_COST_DECREASE].type = WidgetType::button;
-                widgets[WIDX_CONSTRUCTION_RIGHTS_COST].type = WidgetType::spinner;
-                widgets[WIDX_CONSTRUCTION_RIGHTS_COST_INCREASE].type = WidgetType::button;
-                widgets[WIDX_CONSTRUCTION_RIGHTS_COST_DECREASE].type = WidgetType::button;
-            }
+            bool noMoney = gameState.park.Flags & PARK_FLAGS_NO_MONEY;
+
+            SetWidgetDisabled(WIDX_LAND_COST_LABEL, noMoney);
+            SetWidgetDisabled(WIDX_LAND_COST, noMoney);
+            SetWidgetDisabled(WIDX_LAND_COST_INCREASE, noMoney);
+            SetWidgetDisabled(WIDX_LAND_COST_DECREASE, noMoney);
+            SetWidgetDisabled(WIDX_CONSTRUCTION_RIGHTS_COST_LABEL, noMoney);
+            SetWidgetDisabled(WIDX_CONSTRUCTION_RIGHTS_COST, noMoney);
+            SetWidgetDisabled(WIDX_CONSTRUCTION_RIGHTS_COST_INCREASE, noMoney);
+            SetWidgetDisabled(WIDX_CONSTRUCTION_RIGHTS_COST_DECREASE, noMoney);
 
             SetWidgetPressed(WIDX_FORBID_TREE_REMOVAL, gameState.park.Flags & PARK_FLAGS_FORBID_TREE_REMOVAL);
             SetWidgetPressed(WIDX_FORBID_LANDSCAPE_CHANGES, gameState.park.Flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES);
             SetWidgetPressed(WIDX_FORBID_HIGH_CONSTRUCTION, gameState.park.Flags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION);
 
-            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty : WidgetType::closeBox;
+            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty
+                                                                                   : WidgetType::closeBox;
         }
 
         void LandDraw(RenderTarget& rt)
@@ -2149,6 +2169,8 @@ namespace OpenRCT2::Ui::Windows
             DrawTabImages(rt);
 
             const auto& gameState = getGameState();
+            const auto wColour2 = colours[1];
+
             const auto& landCostWidget = widgets[WIDX_LAND_COST];
             if (landCostWidget.type != WidgetType::empty)
             {
@@ -2156,7 +2178,8 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords = windowPos + ScreenCoordsXY{ landCostWidget.left + 1, landCostWidget.top };
                 auto ft = Formatter();
                 ft.Add<money64>(gameState.landPrice);
-                DrawTextBasic(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
+                auto colour = !IsWidgetDisabled(WIDX_LAND_COST) ? wColour2 : wColour2.withFlag(ColourFlag::inset, true);
+                DrawTextBasic(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft, colour);
             }
 
             const auto& constructionRightsCostWidget = widgets[WIDX_CONSTRUCTION_RIGHTS_COST];
@@ -2167,7 +2190,9 @@ namespace OpenRCT2::Ui::Windows
                     + ScreenCoordsXY{ constructionRightsCostWidget.left + 1, constructionRightsCostWidget.top };
                 auto ft = Formatter();
                 ft.Add<money64>(gameState.constructionRightsPrice);
-                DrawTextBasic(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
+                auto colour = !IsWidgetDisabled(WIDX_CONSTRUCTION_RIGHTS_COST) ? wColour2
+                                                                               : wColour2.withFlag(ColourFlag::inset, true);
+                DrawTextBasic(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft, colour);
             }
         }
 
@@ -2281,7 +2306,8 @@ namespace OpenRCT2::Ui::Windows
         {
             SetPressedTab();
 
-            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty : WidgetType::closeBox;
+            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty
+                                                                                   : WidgetType::closeBox;
         }
 
         /**

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -1123,8 +1123,7 @@ namespace OpenRCT2::Ui::Windows
 
             widgets[WIDX_OBJECTIVE_ARG_1_LABEL].text = arg1StringId;
 
-            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty
-                                                                                   : WidgetType::closeBox;
+            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty : WidgetType::closeBox;
 
             SetWidgetPressed(WIDX_HARD_PARK_RATING, gameState.park.Flags & PARK_FLAGS_DIFFICULT_PARK_RATING);
         }
@@ -1669,8 +1668,7 @@ namespace OpenRCT2::Ui::Windows
 
             SetWidgetPressed(WIDX_FORBID_MARKETING, gameState.park.Flags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN);
 
-            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty
-                                                                                   : WidgetType::closeBox;
+            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty : WidgetType::closeBox;
         }
 
         void FinancialDraw(RenderTarget& rt)
@@ -1956,8 +1954,7 @@ namespace OpenRCT2::Ui::Windows
             SetWidgetDisabled(WIDX_CASH_PER_GUEST_INCREASE, noMoney);
             SetWidgetDisabled(WIDX_CASH_PER_GUEST_DECREASE, noMoney);
 
-            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty
-                                                                                   : WidgetType::closeBox;
+            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty : WidgetType::closeBox;
 
             SetWidgetPressed(WIDX_HARD_GUEST_GENERATION, gameState.park.Flags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION);
         }
@@ -2157,8 +2154,7 @@ namespace OpenRCT2::Ui::Windows
             SetWidgetPressed(WIDX_FORBID_LANDSCAPE_CHANGES, gameState.park.Flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES);
             SetWidgetPressed(WIDX_FORBID_HIGH_CONSTRUCTION, gameState.park.Flags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION);
 
-            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty
-                                                                                   : WidgetType::closeBox;
+            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty : WidgetType::closeBox;
         }
 
         void LandDraw(RenderTarget& rt)
@@ -2306,8 +2302,7 @@ namespace OpenRCT2::Ui::Windows
         {
             SetPressedTab();
 
-            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty
-                                                                                   : WidgetType::closeBox;
+            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty : WidgetType::closeBox;
         }
 
         /**


### PR DESCRIPTION
When money is disabled for a scenario, the relevant options are hidden in the scenario options window. This causes some awkward gaps in three of the settings tabs. This PR slightly reworks the scenario options window, such that non-applicable financial options are now rendered as disabled instead of hidden altogether.

NB: this PR removes hardcoded format codes in English (UK) only. Other languages will have to be adjusted in the Localisation repository. Fortunately, the strings in question are only used by the scenario options window.

### Finance (before / after)
![Forest Frontiers 2025-06-02 21-48-08](https://github.com/user-attachments/assets/453ffeb7-7906-43c3-81cc-005232aaac07) ![Forest Frontiers 2025-06-02 21-45-41](https://github.com/user-attachments/assets/bfc4f054-deda-4804-855e-f9c0ed77652c)

### Guests (before / after)
![Forest Frontiers 2025-06-02 21-48-10](https://github.com/user-attachments/assets/8c3a2a9a-0481-49c3-8a01-267a9a41e6a6) ![Forest Frontiers 2025-06-02 21-45-44](https://github.com/user-attachments/assets/63555eb4-5ee2-43d6-b746-a76c51131de7)

### Land (before / after)
![Forest Frontiers 2025-06-02 21-48-12](https://github.com/user-attachments/assets/7f2ca5ec-9277-4a2b-b58c-143b9498f0b3) ![Forest Frontiers 2025-06-02 21-45-45](https://github.com/user-attachments/assets/06787bfa-0d99-4911-90e8-96dacc4b0df6)