### PR TITLE
Fix #24544: RCT1 Maze designs with wooden walls are not imported correctly

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -40,6 +40,7 @@
 - Fix: [#24448] Shortcuts involving the Caps Lock key are wrongly localised to NumPad Dot.
 - Fix: [#24464] Window and viewport visibility is not calculated correctly causing minor performance issues.
 - Fix: [#24488] Objects are not always redrawn immediately when they are reloaded from the Object Selection window.
+- Fix: [#24544] RCT1 Maze designs with wooden walls are not imported correctly.
 
 0.4.22 (2025-05-04)
 ------------------------------------------------------------------------

--- a/src/openrct2/rct1/T4Importer.cpp
+++ b/src/openrct2/rct1/T4Importer.cpp
@@ -100,6 +100,12 @@ namespace OpenRCT2::RCT1
                 td->appearance.trackColours[i].additional = RCT1::GetColour(td4aa.TrackRailColour[i]);
                 td->appearance.trackColours[i].supports = RCT1::GetColour(td4aa.TrackSupportColour[i]);
             }
+            // The maze style is saved in the support colour, but taking it through the conversion function
+            // will mess up style 3 (wooden fences).
+            if (td4aa.Type == RideType::HedgeMaze)
+            {
+                td->appearance.trackColours[0].supports = td4aa.TrackSupportColour[0];
+            }
 
             return ImportTD4Base(std::move(td), td4aa);
         }


### PR DESCRIPTION
Error caused by RCT1<->RCT2 colour mapping being erroneously applied to maze track designs too.