### PR TITLE
Linux: add .desktop hint to request discrete GPU

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Improved: [#24467] Apply tweening only to on-screen entities when not zoomed out for better performance with uncapped FPS.
 - Improved: [#24474] More efficiently search viewports when playing Audio.
 - Improved: [#24479] More descriptive error messages for `set` commands in the in-game console.
+- Improved: [#24563] The Linux .desktop file will now request the more powerful dedicated GPU on hybrid graphics systems.
 - Change: [#24342, #24484] g2.dat is now split into g2.dat, fonts.dat and tracks.dat.
 - Change: [#24362] The Windows installer now prevents installing to the same folder as RollerCoaster Tycoon 2 or Classic.
 - Change: [#24418] Small & Large Zero G Rolls can now be built on the LIM Launched RC without cheats if vehicle sprites are available.

--- a/distribution/linux/openrct2.desktop
+++ b/distribution/linux/openrct2.desktop
@@ -39,3 +39,4 @@ Comment[zh_CN]=过山车大亨2(RollerCoaster Tycoon 2)的开源重新开发版�
 Comment[zh_TW]=重新開發並開放源碼的模擬樂園2 (RollerCoaster Tycoon 2)。
 Categories=Game;Simulation;
 Keywords=openrct2;rct2;rct;roller;coaster;tycoon;simulation;
+PrefersNonDefaultGPU=true


### PR DESCRIPTION
This hint was added in v1.4 of the spec and supported by GNOME (since 2020) and KDE (since 2021) and is intended for systems with hybrid graphics. It tells the system to launch the application on the more powerful discrete GPU as opposed to the more energy efficient integrated graphics.

Systems like this (e.g. the Optimus laptops) are the spawn of Satan, but this makes the experience much more enjoyable for the poor users with a system like this.

Reference: https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html