### PR TITLE
Add scripting hooks for ride fixes

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -107,7 +107,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Keith Stellyes (keithstellyes) - Misc.
 * Bas Cantrijn (Basssiiie) - Various plugin additions, misc.
 * Adrian Zdanowicz (CookiePLMonster) - Misc.
-* Andrew Pratt (andrewpratt64) - Added api hook for vehicle crashes, api function to get entities on a tile
+* Andrew Pratt (andrewpratt0x40) - Added api hooks and functions
 * Karst van Galen Last (AuraSpecs) - Ride paint (bounding boxes, extra track pieces), soundtrack, sound effects, misc.
 * (8street) - Misc.
 * Umar Ahmed (umar-ahmed) - MacOS file watcher

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -515,6 +515,7 @@ declare global {
         subscribe(hook: "network.leave", callback: (e: NetworkEventArgs) => void): IDisposable;
         subscribe(hook: "park.guest.softcap.calculate", callback: (e: ParkCalculateGuestCapArgs) => void): IDisposable;
         subscribe(hook: "ride.ratings.calculate", callback: (e: RideRatingsCalculateArgs) => void): IDisposable;
+        subscribe(hook: "ride.fix", callback: (e: RideFixArgs) => void): IDisposable;
         subscribe(hook: "vehicle.crash", callback: (e: VehicleCrashArgs) => void): IDisposable;
 
         /**
@@ -645,6 +646,7 @@ declare global {
         "network.join" |
         "network.leave" |
         "park.guest.softcap.calculate" |
+        "ride.fix" |
         "ride.ratings.calculate" |
         "vehicle.crash";
 
@@ -1666,6 +1668,10 @@ declare global {
     interface VehicleCrashArgs {
         readonly id: number;
         readonly crashIntoType: VehicleCrashIntoType;
+    }
+
+    interface RideFixArgs {
+        readonly ride: number;
     }
 
     /**

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -3895,6 +3895,12 @@ namespace OpenRCT2::Ui::Windows
                     if (dropdownIndex == 0)
                     {
                         Vehicle* vehicle;
+
+#ifdef ENABLE_SCRIPTING
+                        if (ride->breakdownReasonPending != BREAKDOWN_NONE)
+                            InvokeRideFixHook(*ride);
+#endif
+
                         switch (ride->breakdownReasonPending)
                         {
                             case BREAKDOWN_SAFETY_CUT_OUT:

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -945,3 +945,7 @@ std::vector<RideId> GetTracklessRides();
 
 void CircusMusicUpdate(Ride& ride);
 void DefaultMusicUpdate(Ride& ride);
+
+#ifdef ENABLE_SCRIPTING
+void InvokeRideFixHook(const Ride& ride);
+#endif

--- a/src/openrct2/scripting/HookEngine.cpp
+++ b/src/openrct2/scripting/HookEngine.cpp
@@ -28,6 +28,7 @@ static const EnumMap<HookType> HooksLookupTable({
     { "network.join", HookType::networkJoin },
     { "network.leave", HookType::networkLeave },
     { "ride.ratings.calculate", HookType::rideRatingsCalculate },
+    { "ride.fix", HookType::rideFix },
     { "action.location", HookType::actionLocation },
     { "guest.generation", HookType::guestGeneration },
     { "vehicle.crash", HookType::vehicleCrash },

--- a/src/openrct2/scripting/HookEngine.h
+++ b/src/openrct2/scripting/HookEngine.h
@@ -36,6 +36,7 @@ namespace OpenRCT2::Scripting
         networkJoin,
         networkLeave,
         rideRatingsCalculate,
+        rideFix,
         actionLocation,
         guestGeneration,
         vehicleCrash,

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -46,7 +46,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t kPluginApiVersion = 108;
+    static constexpr int32_t kPluginApiVersion = 109;
 
     // Versions marking breaking changes.
     static constexpr int32_t kApiVersionPeepDeprecation = 33;


### PR DESCRIPTION
This adds the hook "ride.fix" to the scripting api. It is called whenever a ride is fixed. The hook includes the id of the ride that was fixed.