### PR TITLE
Fix: undefined behaviour in string construction

### DIFF
--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -155,7 +155,7 @@ static std::optional<std::string> ScreenshotGetNextPath()
     // Generate a path with a `tries` number
     auto pathComposer = [&screenshotDirectory, &name](int tries) {
         auto composedFilename = Platform::SanitiseFilename(
-            name + ((tries > 0) ? " ("s + std::to_string(tries) + ")" : ""s) + ".png");
+            name + ((tries > 0) ? " ("s + std::to_string(tries) + ")"s : ""s) + ".png"s);
         return screenshotDirectory + PATH_SEPARATOR + composedFilename;
     };
 


### PR DESCRIPTION
Explicitly used `s` string literal suffix to ensure all concatenations are performed between `std::string` objects. This prevents unsafe implicit conversions and resolves a GCC warning about potential memory overlap caused by mixing raw string literals and `std::string` temporaries.

I ran into this issue when compiling OpenRCT2 for Raspberry Pi using GCC 12. The error it threw was:

```
In file included from /usr/include/c++/12/string:40,
                 from /usr/include/c++/12/stdexcept:39,
                 from /usr/include/c++/12/system_error:41,
                 from /usr/include/c++/12/bits/fs_fwd.h:35,
                 from /usr/include/c++/12/filesystem:44,
                 from OpenRCT2/src/openrct2/interface/../core/FileSystem.hpp:35,
                 from OpenRCT2/src/openrct2/interface/Screenshot.h:12,
                 from OpenRCT2/src/openrct2/interface/Screenshot.cpp:10:
In static member function ‘static constexpr std::char_traits<char>::char_type* std::char_traits<char>::copy(char_type*, const char_type*, std::size_t)’,
    inlined from ‘static constexpr void std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_S_copy(_CharT*, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12/bits/basic_string.h:423:21,
    inlined from ‘constexpr std::__cxx11::basic_string<_CharT, _Traits, _Allocator>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_M_replace(size_type, size_type, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12/bits/basic_string.tcc:532:22,
    inlined from ‘constexpr std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::replace(size_type, size_type, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12/bits/basic_string.h:2171:19,
    inlined from ‘constexpr std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::insert(size_type, const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12/bits/basic_string.h:1858:29,
    inlined from ‘constexpr std::__cxx11::basic_string<_CharT, _Traits, _Allocator> std::operator+(__cxx11::basic_string<_CharT, _Traits, _Allocator>&&, __cxx11::basic_string<_CharT, _Traits, _Allocator>&&) [with _CharT = char; _Traits = char_traits<char>; _Alloc = allocator<char>]’ at /usr/include/c++/12/bits/basic_string.h:3531:35,
    inlined from ‘ScreenshotGetNextPath()::<lambda(int)>’ at OpenRCT2/src/openrct2/interface/Screenshot.cpp:158:41,
    inlined from ‘std::optional<std::__cxx11::basic_string<char> > ScreenshotGetNextPath()’ at OpenRCT2/src/openrct2/interface/Screenshot.cpp:164:39:
/usr/include/c++/12/bits/char_traits.h:431:56: error: ‘void* __builtin_memcpy(void*, const void*, long unsigned int)’ accessing 9223372036854775811 or more bytes at offsets [3, 9223372036854775807] and 2 may overlap up to 9223372036854775815 bytes at offset -4 [-Werror=restrict]
  431 |         return static_cast<char_type*>(__builtin_memcpy(__s1, __s2, __n));
      |                                        ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [CMakeFiles/libopenrct2.dir/build.make:2736: CMakeFiles/libopenrct2.dir/src/openrct2/interface/Screenshot.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:89: CMakeFiles/libopenrct2.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```