### PR TITLE
Land edge door animations

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#24411] Vanilla scenarios now also have previews in the scenario selection window.
 - Improved: [#22684] The limit of 2000 animated tile elements has been removed.
+- Improved: [#23228] Landscape edge doors now animate opening and closing and play a sound.
 - Improved: [#24026] Notification settings have been made into a tab of the Recent Messages window.
 - Change: [#24559] Scenario options are now disabled rather than hidden when disabling money makes them non-applicable.
 - Change: [objects#383] Disable all base colours on non-remappable WWTT vehicles, change black to light_blue.

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -613,8 +613,8 @@ GameActions::Result TrackPlaceAction::Execute() const
 
         if (rtd.HasFlag(RtdFlag::hasLandscapeDoors))
         {
-            trackElement->SetDoorAState(LANDSCAPE_DOOR_CLOSED);
-            trackElement->SetDoorBState(LANDSCAPE_DOOR_CLOSED);
+            trackElement->SetDoorAState(kLandEdgeDoorFrameClosed);
+            trackElement->SetDoorBState(kLandEdgeDoorFrameClosed);
         }
         else
         {

--- a/src/openrct2/audio/Audio.h
+++ b/src/openrct2/audio/Audio.h
@@ -154,6 +154,14 @@ namespace OpenRCT2::Audio
 
     extern VehicleSound gVehicleSoundList[kMaxVehicleSounds];
 
+    enum class DoorSoundType : uint8_t
+    {
+        none,
+        door,
+        portcullis,
+    };
+    constexpr uint8_t kDoorSoundTypeCount = 3;
+
     /**
      * Returns false when no audio device is available or when audio is turned off, otherwise true.
      */

--- a/src/openrct2/object/TerrainEdgeObject.cpp
+++ b/src/openrct2/object/TerrainEdgeObject.cpp
@@ -57,6 +57,11 @@ void TerrainEdgeObject::ReadJson(IReadObjectContext* context, json_t& root)
     if (properties.is_object())
     {
         HasDoors = Json::GetBoolean(properties["hasDoors"]);
+        const uint32_t doorSoundNumber = Json::GetNumber<uint32_t>(properties["doorSound"]);
+        if (doorSoundNumber < OpenRCT2::Audio::kDoorSoundTypeCount)
+        {
+            doorSound = static_cast<OpenRCT2::Audio::DoorSoundType>(doorSoundNumber);
+        }
     }
 
     PopulateTablesFromJson(context, root);

--- a/src/openrct2/object/TerrainEdgeObject.h
+++ b/src/openrct2/object/TerrainEdgeObject.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "../audio/Audio.h"
 #include "Object.h"
 
 class TerrainEdgeObject final : public Object
@@ -21,6 +22,7 @@ public:
     uint32_t IconImageId{};
     uint32_t BaseImageId{};
     bool HasDoors{};
+    OpenRCT2::Audio::DoorSoundType doorSound{};
 
     void ReadJson(IReadObjectContext* context, json_t& root) override;
     void Load() override;

--- a/src/openrct2/object/WallSceneryEntry.cpp
+++ b/src/openrct2/object/WallSceneryEntry.cpp
@@ -9,7 +9,8 @@
 
 #include "WallSceneryEntry.h"
 
-DoorSoundType WallSceneryEntry::getDoorSoundType() const
+OpenRCT2::Audio::DoorSoundType WallSceneryEntry::getDoorSoundType() const
 {
-    return static_cast<DoorSoundType>((flags2 & WALL_SCENERY_2_DOOR_SOUND_MASK) >> WALL_SCENERY_2_DOOR_SOUND_SHIFT);
+    return static_cast<OpenRCT2::Audio::DoorSoundType>(
+        (flags2 & WALL_SCENERY_2_DOOR_SOUND_MASK) >> WALL_SCENERY_2_DOOR_SOUND_SHIFT);
 }

--- a/src/openrct2/object/WallSceneryEntry.h
+++ b/src/openrct2/object/WallSceneryEntry.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "../audio/Audio.h"
 #include "../core/Money.hpp"
 #include "../localisation/StringIdType.h"
 #include "ObjectTypes.h"
@@ -36,13 +37,6 @@ enum WALL_SCENERY_2_FLAGS
     WALL_SCENERY_2_ANIMATED = (1 << 4),  // 0x10
 };
 
-enum class DoorSoundType : uint8_t
-{
-    none,
-    door,
-    portcullis,
-};
-
 struct WallSceneryEntry
 {
     static constexpr auto kObjectType = ObjectType::walls;
@@ -57,5 +51,5 @@ struct WallSceneryEntry
     ObjectEntryIndex scenery_tab_id;
     uint8_t scrolling_mode;
 
-    DoorSoundType getDoorSoundType() const;
+    OpenRCT2::Audio::DoorSoundType getDoorSoundType() const;
 };

--- a/src/openrct2/paint/track/gentle/GhostTrain.cpp
+++ b/src/openrct2/paint/track/gentle/GhostTrain.cpp
@@ -153,24 +153,26 @@ static constexpr uint32_t kGhostTrainTrackPiecesBrakes[4] = {
     SprGhostTrainTrackBrakesNwSe,
 };
 
-static constexpr TunnelType kDoorOpeningOutwardsToImage[] = {
-    TunnelType::Doors2, // Closed
-    TunnelType::Doors2, // Unused?
-    TunnelType::Doors3, // Half open
-    TunnelType::Doors4, // Fully open
-    TunnelType::Doors2, // Unused?
-    TunnelType::Doors2, // Unused?
-    TunnelType::Doors2, // Unused?
+static constexpr std::array<TunnelType, kLandEdgeDoorFrameCount> kDoorOpeningOutwardsToImage = {
+    TunnelType::Doors2, // closed
+    TunnelType::Doors3, // opening
+    TunnelType::Doors3, // opening
+    TunnelType::Doors4, // open
+    TunnelType::Doors3, // closing
+    TunnelType::Doors3, // closing
+    TunnelType::Doors2, // closed
+    TunnelType::Doors2, // unused
 };
 
-static constexpr TunnelType kDoorOpeningInwardsToImage[] = {
-    TunnelType::Doors2, // Closed
-    TunnelType::Doors2, // Unused?
-    TunnelType::Doors5, // Half open
-    TunnelType::Doors6, // Fully open
-    TunnelType::Doors2, // Unused?
-    TunnelType::Doors2, // Unused?
-    TunnelType::Doors2, // Unused?
+static constexpr std::array<TunnelType, kLandEdgeDoorFrameCount> kDoorOpeningInwardsToImage = {
+    TunnelType::Doors2, // closed
+    TunnelType::Doors5, // opening
+    TunnelType::Doors5, // opening
+    TunnelType::Doors6, // open
+    TunnelType::Doors5, // closing
+    TunnelType::Doors5, // closing
+    TunnelType::Doors2, // closed
+    TunnelType::Doors2, // unused
 };
 
 static TunnelType GetTunnelDoorsImageStraightFlat(const TrackElement& trackElement, uint8_t direction)
@@ -189,24 +191,26 @@ static TunnelType GetTunnelDoorsImageStraightFlat(const TrackElement& trackEleme
     return TunnelType::Doors2;
 }
 
-static constexpr TunnelType kDoorFlatTo25DegOpeningOutwardsToImage[] = {
-    TunnelType::DoorsFlatTo25Deg2, // Closed
-    TunnelType::DoorsFlatTo25Deg2, // Unused?
-    TunnelType::DoorsFlatTo25Deg3, // Half open
-    TunnelType::DoorsFlatTo25Deg4, // Fully open
-    TunnelType::DoorsFlatTo25Deg2, // Unused?
-    TunnelType::DoorsFlatTo25Deg2, // Unused?
-    TunnelType::DoorsFlatTo25Deg2, // Unused?
+static constexpr std::array<TunnelType, kLandEdgeDoorFrameCount> kDoorFlatTo25DegOpeningOutwardsToImage = {
+    TunnelType::DoorsFlatTo25Deg2, // closed
+    TunnelType::DoorsFlatTo25Deg3, // opening
+    TunnelType::DoorsFlatTo25Deg3, // opening
+    TunnelType::DoorsFlatTo25Deg4, // open
+    TunnelType::DoorsFlatTo25Deg3, // closing
+    TunnelType::DoorsFlatTo25Deg3, // closing
+    TunnelType::DoorsFlatTo25Deg2, // closed
+    TunnelType::DoorsFlatTo25Deg2, // unused
 };
 
-static constexpr TunnelType kDoorFlatTo25DegOpeningInwardsToImage[] = {
-    TunnelType::DoorsFlatTo25Deg2, // Closed
-    TunnelType::DoorsFlatTo25Deg2, // Unused?
-    TunnelType::DoorsFlatTo25Deg5, // Half open
-    TunnelType::DoorsFlatTo25Deg6, // Fully open
-    TunnelType::DoorsFlatTo25Deg2, // Unused?
-    TunnelType::DoorsFlatTo25Deg2, // Unused?
-    TunnelType::DoorsFlatTo25Deg2, // Unused?
+static constexpr std::array<TunnelType, kLandEdgeDoorFrameCount> kDoorFlatTo25DegOpeningInwardsToImage = {
+    TunnelType::DoorsFlatTo25Deg2, // closed
+    TunnelType::DoorsFlatTo25Deg5, // opening
+    TunnelType::DoorsFlatTo25Deg5, // opening
+    TunnelType::DoorsFlatTo25Deg6, // open
+    TunnelType::DoorsFlatTo25Deg5, // closing
+    TunnelType::DoorsFlatTo25Deg5, // closing
+    TunnelType::DoorsFlatTo25Deg2, // closed
+    TunnelType::DoorsFlatTo25Deg2, // unused
 };
 
 /** rct2: 0x00770BEC */

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -1287,13 +1287,6 @@ namespace OpenRCT2::RCT1
 
     enum
     {
-        RCT1_LANDSCAPE_DOOR_CLOSED = 0,
-        RCT1_LANDSCAPE_DOOR_HALF_OPEN = 2,
-        RCT1_LANDSCAPE_DOOR_OPEN = 3,
-    };
-
-    enum
-    {
         RCT1_PATH_SUPPORT_TYPE_TRUSS,
         RCT1_PATH_SUPPORT_TYPE_COATED_WOOD,
         RCT1_PATH_SUPPORT_TYPE_SPACE,

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1472,6 +1472,11 @@ namespace OpenRCT2::RCT1
                             { mapAnimation.x, mapAnimation.y, (mapAnimation.BaseZ / 2) * kCoordsZStep },
                             MapAnimations::TemporaryType::onRidePhoto);
                         break;
+                    case kRCT12MapAnimationTypeLandEdgeDoor:
+                        MapAnimations::CreateTemporary(
+                            { mapAnimation.x, mapAnimation.y, (mapAnimation.BaseZ / 2) * kCoordsZStep },
+                            MapAnimations::TemporaryType::landEdgeDoor);
+                        break;
                 }
             }
         }

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -1166,6 +1166,7 @@ struct RCT12MapAnimation
 static_assert(sizeof(RCT12MapAnimation) == 6);
 
 static constexpr uint8_t kRCT12MapAnimationTypeOnRidePhoto = 6;
+static constexpr uint8_t kRCT12MapAnimationTypeLandEdgeDoor = 9;
 static constexpr uint8_t kRCT12MapAnimationTypeWallDoor = 12;
 
 struct RCT12ResearchItem

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -6371,6 +6371,25 @@ static void AnimateLandscapeDoor(const CoordsXYZ& doorLocation, TrackElement& tr
     }
 }
 
+void Vehicle::UpdateLandscapeDoorA(const int32_t previousTrackHeight) const
+{
+    const auto* currentRide = GetRide();
+    if (currentRide == nullptr || !currentRide->getRideTypeDescriptor().HasFlag(RtdFlag::hasLandscapeDoors))
+    {
+        return;
+    }
+
+    const CoordsXYZ previousTrackLocation = CoordsXYZ(x, y, previousTrackHeight).ToTileStart();
+    if (MapGetTrackElementAtBeforeSurfaceFromRide(previousTrackLocation, ride) != nullptr)
+        return;
+
+    auto* const tileElement = MapGetTrackElementAtBeforeSurfaceFromRide(TrackLocation, ride);
+    if (tileElement != nullptr)
+    {
+        AnimateLandscapeDoor<true>(TrackLocation, *tileElement->AsTrack(), next_vehicle_on_train.IsNull());
+    }
+}
+
 void Vehicle::UpdateLandscapeDoorB(const int32_t previousTrackHeight) const
 {
     const auto* currentRide = GetRide();
@@ -6433,25 +6452,6 @@ void Vehicle::UpdateSceneryDoorBackwards() const
     direction = DirectionReverse(direction);
 
     AnimateSceneryDoor<true>({ wallCoords, static_cast<Direction>(direction) }, TrackLocation, next_vehicle_on_train.IsNull());
-}
-
-void Vehicle::UpdateLandscapeDoorA(const int32_t previousTrackHeight) const
-{
-    const auto* currentRide = GetRide();
-    if (currentRide == nullptr || !currentRide->getRideTypeDescriptor().HasFlag(RtdFlag::hasLandscapeDoors))
-    {
-        return;
-    }
-
-    const CoordsXYZ previousTrackLocation = CoordsXYZ(x, y, previousTrackHeight).ToTileStart();
-    if (MapGetTrackElementAtBeforeSurfaceFromRide(previousTrackLocation, ride) != nullptr)
-        return;
-
-    auto* const tileElement = MapGetTrackElementAtBeforeSurfaceFromRide(TrackLocation, ride);
-    if (tileElement != nullptr)
-    {
-        AnimateLandscapeDoor<true>(TrackLocation, *tileElement->AsTrack(), next_vehicle_on_train.IsNull());
-    }
 }
 
 static void vehicle_update_play_water_splash_sound()

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -6347,25 +6347,27 @@ void Vehicle::UpdateSceneryDoor() const
 }
 
 template<bool isBackwards>
-static void AnimateLandscapeDoor(TrackElement* trackElement, bool isLastVehicle)
+static void AnimateLandscapeDoor(const CoordsXYZ& doorLocation, TrackElement& trackElement, const bool isLastVehicle)
 {
-    auto doorState = isBackwards ? trackElement->GetDoorAState() : trackElement->GetDoorBState();
-    if (!isLastVehicle && doorState == LANDSCAPE_DOOR_CLOSED)
+    const auto doorState = isBackwards ? trackElement.GetDoorAState() : trackElement.GetDoorBState();
+    if (!isLastVehicle && doorState == kLandEdgeDoorFrameClosed)
     {
         if (isBackwards)
-            trackElement->SetDoorAState(LANDSCAPE_DOOR_OPEN);
+            trackElement.SetDoorAState(kLandEdgeDoorFrameOpening);
         else
-            trackElement->SetDoorBState(LANDSCAPE_DOOR_OPEN);
-        // TODO: play door open sound
+            trackElement.SetDoorBState(kLandEdgeDoorFrameOpening);
+
+        MapAnimations::CreateTemporary(doorLocation, MapAnimations::TemporaryType::landEdgeDoor);
     }
 
     if (isLastVehicle)
     {
         if (isBackwards)
-            trackElement->SetDoorAState(LANDSCAPE_DOOR_CLOSED);
+            trackElement.SetDoorAState(kLandEdgeDoorFrameClosing);
         else
-            trackElement->SetDoorBState(LANDSCAPE_DOOR_CLOSED);
-        // TODO: play door close sound
+            trackElement.SetDoorBState(kLandEdgeDoorFrameClosing);
+
+        MapAnimations::CreateTemporary(doorLocation, MapAnimations::TemporaryType::landEdgeDoor);
     }
 }
 
@@ -6377,11 +6379,11 @@ void Vehicle::UpdateLandscapeDoor() const
         return;
     }
 
-    auto coords = CoordsXYZ{ x, y, TrackLocation.z }.ToTileStart();
-    auto* tileElement = MapGetTrackElementAtFromRide(coords, ride);
-    if (tileElement != nullptr && tileElement->GetType() == TileElementType::Track)
+    const auto coords = CoordsXYZ{ x, y, TrackLocation.z }.ToTileStart();
+    auto* const tileElement = MapGetTrackElementBeforeSurfaceAtFromRide(coords, ride);
+    if (tileElement != nullptr)
     {
-        AnimateLandscapeDoor<false>(tileElement->AsTrack(), next_vehicle_on_train.IsNull());
+        AnimateLandscapeDoor<false>(coords, *tileElement->AsTrack(), next_vehicle_on_train.IsNull());
     }
 }
 
@@ -6438,11 +6440,11 @@ void Vehicle::UpdateLandscapeDoorBackwards() const
         return;
     }
 
-    auto coords = CoordsXYZ{ TrackLocation, TrackLocation.z };
-    auto* tileElement = MapGetTrackElementAtFromRide(coords, ride);
-    if (tileElement != nullptr && tileElement->GetType() == TileElementType::Track)
+    const auto coords = CoordsXYZ{ TrackLocation, TrackLocation.z };
+    auto* const tileElement = MapGetTrackElementBeforeSurfaceAtFromRide(coords, ride);
+    if (tileElement != nullptr)
     {
-        AnimateLandscapeDoor<true>(tileElement->AsTrack(), next_vehicle_on_train.IsNull());
+        AnimateLandscapeDoor<true>(coords, *tileElement->AsTrack(), next_vehicle_on_train.IsNull());
     }
 }
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -6371,7 +6371,7 @@ static void AnimateLandscapeDoor(const CoordsXYZ& doorLocation, TrackElement& tr
     }
 }
 
-void Vehicle::UpdateLandscapeDoorA(const int32_t previousTrackHeight) const
+void Vehicle::UpdateLandscapeDoors(const int32_t previousTrackHeight) const
 {
     const auto* currentRide = GetRide();
     if (currentRide == nullptr || !currentRide->getRideTypeDescriptor().HasFlag(RtdFlag::hasLandscapeDoors))
@@ -6380,32 +6380,15 @@ void Vehicle::UpdateLandscapeDoorA(const int32_t previousTrackHeight) const
     }
 
     const CoordsXYZ previousTrackLocation = CoordsXYZ(x, y, previousTrackHeight).ToTileStart();
-    if (MapGetTrackElementAtBeforeSurfaceFromRide(previousTrackLocation, ride) != nullptr)
-        return;
-
-    auto* const tileElement = MapGetTrackElementAtBeforeSurfaceFromRide(TrackLocation, ride);
-    if (tileElement != nullptr)
+    auto* const previousTrackElement = MapGetTrackElementAtBeforeSurfaceFromRide(previousTrackLocation, ride);
+    auto* const currentTrackElement = MapGetTrackElementAtBeforeSurfaceFromRide(TrackLocation, ride);
+    if (previousTrackElement != nullptr && currentTrackElement == nullptr)
     {
-        AnimateLandscapeDoor<true>(TrackLocation, *tileElement->AsTrack(), next_vehicle_on_train.IsNull());
+        AnimateLandscapeDoor<false>(previousTrackLocation, *previousTrackElement->AsTrack(), next_vehicle_on_train.IsNull());
     }
-}
-
-void Vehicle::UpdateLandscapeDoorB(const int32_t previousTrackHeight) const
-{
-    const auto* currentRide = GetRide();
-    if (currentRide == nullptr || !currentRide->getRideTypeDescriptor().HasFlag(RtdFlag::hasLandscapeDoors))
+    else if (previousTrackElement == nullptr && currentTrackElement != nullptr)
     {
-        return;
-    }
-
-    if (MapGetTrackElementAtBeforeSurfaceFromRide(TrackLocation, ride) != nullptr)
-        return;
-
-    const CoordsXYZ previousTrackLocation = CoordsXYZ(x, y, previousTrackHeight).ToTileStart();
-    auto* const tileElement = MapGetTrackElementAtBeforeSurfaceFromRide(previousTrackLocation, ride);
-    if (tileElement != nullptr)
-    {
-        AnimateLandscapeDoor<false>(previousTrackLocation, *tileElement->AsTrack(), next_vehicle_on_train.IsNull());
+        AnimateLandscapeDoor<true>(TrackLocation, *currentTrackElement->AsTrack(), next_vehicle_on_train.IsNull());
     }
 }
 
@@ -7116,8 +7099,7 @@ bool Vehicle::UpdateTrackMotionForwardsGetNewTrack(
     }
     // Change from original: this used to check if the vehicle allowed doors.
     UpdateSceneryDoorBackwards();
-    UpdateLandscapeDoorA(previousTrackHeight);
-    UpdateLandscapeDoorB(previousTrackHeight);
+    UpdateLandscapeDoors(previousTrackHeight);
 
     return true;
 }

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -6371,6 +6371,17 @@ static void AnimateLandscapeDoor(const CoordsXYZ& doorLocation, TrackElement& tr
     }
 }
 
+static const SurfaceElement* GetSurfaceElementAfterElement(const TileElement* tileElement)
+{
+    while (tileElement->GetType() != TileElementType::Surface)
+    {
+        if (tileElement->IsLastForTile())
+            return nullptr;
+        tileElement++;
+    }
+    return tileElement->AsSurface();
+}
+
 void Vehicle::UpdateLandscapeDoors(const int32_t previousTrackHeight) const
 {
     const auto* currentRide = GetRide();
@@ -6384,11 +6395,20 @@ void Vehicle::UpdateLandscapeDoors(const int32_t previousTrackHeight) const
     auto* const currentTrackElement = MapGetTrackElementAtBeforeSurfaceFromRide(TrackLocation, ride);
     if (previousTrackElement != nullptr && currentTrackElement == nullptr)
     {
-        AnimateLandscapeDoor<false>(previousTrackLocation, *previousTrackElement->AsTrack(), next_vehicle_on_train.IsNull());
+        const auto* const surfaceElement = GetSurfaceElementAfterElement(previousTrackElement);
+        if (surfaceElement != nullptr && surfaceElement->GetBaseZ() > previousTrackLocation.z)
+        {
+            AnimateLandscapeDoor<false>(
+                previousTrackLocation, *previousTrackElement->AsTrack(), next_vehicle_on_train.IsNull());
+        }
     }
     else if (previousTrackElement == nullptr && currentTrackElement != nullptr)
     {
-        AnimateLandscapeDoor<true>(TrackLocation, *currentTrackElement->AsTrack(), next_vehicle_on_train.IsNull());
+        const auto* const surfaceElement = GetSurfaceElementAfterElement(currentTrackElement);
+        if (surfaceElement != nullptr && surfaceElement->GetBaseZ() > TrackLocation.z)
+        {
+            AnimateLandscapeDoor<true>(TrackLocation, *currentTrackElement->AsTrack(), next_vehicle_on_train.IsNull());
+        }
     }
 }
 

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -377,8 +377,8 @@ private:
     void UpdateGoKartAttemptSwitchLanes();
     void UpdateSceneryDoor() const;
     void UpdateSceneryDoorBackwards() const;
-    void UpdateLandscapeDoor() const;
-    void UpdateLandscapeDoorBackwards() const;
+    void UpdateLandscapeDoorB(const int32_t previousTrackHeight) const;
+    void UpdateLandscapeDoorA(const int32_t previousTrackHeight) const;
     int32_t CalculateRiderBraking() const;
     uint8_t ChooseBrakeSpeed() const;
     void PopulateBrakeSpeed(const CoordsXYZ& vehicleTrackLocation, TrackElement& brake);

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -377,8 +377,7 @@ private:
     void UpdateGoKartAttemptSwitchLanes();
     void UpdateSceneryDoor() const;
     void UpdateSceneryDoorBackwards() const;
-    void UpdateLandscapeDoorA(const int32_t previousTrackHeight) const;
-    void UpdateLandscapeDoorB(const int32_t previousTrackHeight) const;
+    void UpdateLandscapeDoors(const int32_t previousTrackHeight) const;
     int32_t CalculateRiderBraking() const;
     uint8_t ChooseBrakeSpeed() const;
     void PopulateBrakeSpeed(const CoordsXYZ& vehicleTrackLocation, TrackElement& brake);

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -377,8 +377,8 @@ private:
     void UpdateGoKartAttemptSwitchLanes();
     void UpdateSceneryDoor() const;
     void UpdateSceneryDoorBackwards() const;
-    void UpdateLandscapeDoorB(const int32_t previousTrackHeight) const;
     void UpdateLandscapeDoorA(const int32_t previousTrackHeight) const;
+    void UpdateLandscapeDoorB(const int32_t previousTrackHeight) const;
     int32_t CalculateRiderBraking() const;
     uint8_t ChooseBrakeSpeed() const;
     void PopulateBrakeSpeed(const CoordsXYZ& vehicleTrackLocation, TrackElement& brake);

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2096,6 +2096,29 @@ TileElement* MapGetTrackElementAtFromRide(const CoordsXYZ& trackPos, RideId ride
     return nullptr;
 };
 
+TileElement* MapGetTrackElementAtBeforeSurfaceFromRide(const CoordsXYZ& trackPos, const RideId rideIndex)
+{
+    TileElement* tileElement = MapGetFirstElementAt(trackPos);
+    if (tileElement == nullptr)
+        return nullptr;
+
+    do
+    {
+        if (tileElement->GetType() == TileElementType::Surface)
+        {
+            return nullptr;
+        }
+
+        if (tileElement->GetType() == TileElementType::Track && tileElement->GetBaseZ() == trackPos.z
+            && tileElement->AsTrack()->GetRideIndex() == rideIndex)
+        {
+            return tileElement;
+        }
+    } while (!(tileElement++)->IsLastForTile());
+
+    return nullptr;
+};
+
 /**
  * Gets the track element at x, y, z that is the given track type and sequence.
  * @param x x units, not tiles.

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -247,6 +247,7 @@ TrackElement* MapGetTrackElementAtOfTypeSeq(const CoordsXYZD& location, OpenRCT2
 TileElement* MapGetTrackElementAtOfTypeFromRide(const CoordsXYZ& trackPos, OpenRCT2::TrackElemType trackType, RideId rideIndex);
 TileElement* MapGetTrackElementAtFromRide(const CoordsXYZ& trackPos, RideId rideIndex);
 TileElement* MapGetTrackElementAtWithDirectionFromRide(const CoordsXYZD& trackPos, RideId rideIndex);
+TileElement* MapGetTrackElementAtBeforeSurfaceFromRide(const CoordsXYZ& trackPos, RideId rideIndex);
 
 bool MapIsLocationAtEdge(const CoordsXY& loc);
 

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -416,6 +416,57 @@ static bool UpdateOnRidePhotoAnimation(TrackElement& track, const CoordsXYZ& coo
 }
 
 template<bool invalidate>
+static bool UpdateLandEdgeDoorsAnimation(TrackElement& track, const CoordsXYZ& coords)
+{
+    if (getGameState().currentTicks & 3)
+    {
+        return true;
+    }
+
+    bool isAnimating = false;
+
+    const auto doorAState = track.GetDoorAState();
+    if (doorAState >= kLandEdgeDoorFrameEnd)
+    {
+        track.SetDoorAState(kLandEdgeDoorFrameClosed);
+        if constexpr (invalidate)
+        {
+            ViewportsInvalidate(coords.x, coords.y, coords.z, coords.z + 32, kMaxZoom);
+        }
+    }
+    else if (doorAState != kLandEdgeDoorFrameClosed && doorAState != kLandEdgeDoorFrameOpen)
+    {
+        track.SetDoorAState(doorAState + 1);
+        if constexpr (invalidate)
+        {
+            ViewportsInvalidate(coords.x, coords.y, coords.z, coords.z + 32, kMaxZoom);
+        }
+        isAnimating = true;
+    }
+
+    const auto doorBState = track.GetDoorBState();
+    if (doorBState >= kLandEdgeDoorFrameEnd)
+    {
+        track.SetDoorBState(kLandEdgeDoorFrameClosed);
+        if constexpr (invalidate)
+        {
+            ViewportsInvalidate(coords.x, coords.y, coords.z, coords.z + 32, kMaxZoom);
+        }
+    }
+    else if (doorBState != kLandEdgeDoorFrameClosed && doorBState != kLandEdgeDoorFrameOpen)
+    {
+        track.SetDoorBState(doorBState + 1);
+        if constexpr (invalidate)
+        {
+            ViewportsInvalidate(coords.x, coords.y, coords.z, coords.z + 32, kMaxZoom);
+        }
+        isAnimating = true;
+    }
+
+    return isAnimating;
+}
+
+template<bool invalidate>
 static bool UpdateTemporaryAnimation(const TemporaryMapAnimation& animation)
 {
     const TileCoordsXYZ tileCoords{ animation.location };
@@ -438,6 +489,13 @@ static bool UpdateTemporaryAnimation(const TemporaryMapAnimation& animation)
                     isAnimating |= UpdateOnRidePhotoAnimation<invalidate>(*tileElement->AsTrack(), animation.location);
                 }
                 break;
+            }
+            case MapAnimations::TemporaryType::landEdgeDoor:
+            {
+                if (tileElement->GetType() == TileElementType::Track && tileElement->BaseHeight == tileCoords.z)
+                {
+                    isAnimating |= UpdateLandEdgeDoorsAnimation<invalidate>(*tileElement->AsTrack(), animation.location);
+                }
             }
         }
     } while (!(tileElement++)->IsLastForTile());

--- a/src/openrct2/world/MapAnimation.h
+++ b/src/openrct2/world/MapAnimation.h
@@ -16,6 +16,7 @@ namespace OpenRCT2::MapAnimations
     enum class TemporaryType : uint8_t
     {
         onRidePhoto,
+        landEdgeDoor,
     };
 
     void MarkTileForInvalidation(const TileCoordsXY coords);

--- a/src/openrct2/world/tile_element/TrackElement.h
+++ b/src/openrct2/world/tile_element/TrackElement.h
@@ -41,12 +41,13 @@ enum
     TRACK_ELEMENT_COLOUR_SEAT_ROTATION_MASK = 0b11110000,
 };
 
-enum
-{
-    LANDSCAPE_DOOR_CLOSED = 0,
-    LANDSCAPE_DOOR_HALF_OPEN = 2,
-    LANDSCAPE_DOOR_OPEN = 3,
-};
+constexpr const int32_t kLandEdgeDoorFrameClosed = 0;
+constexpr const int32_t kLandEdgeDoorFrameOpening = 1;
+constexpr const int32_t kLandEdgeDoorFrameOpen = 3;
+constexpr const int32_t kLandEdgeDoorFrameClosing = 4;
+constexpr const int32_t kLandEdgeDoorFrameEnd = 6;
+
+constexpr const int32_t kLandEdgeDoorFrameCount = 8;
 
 #pragma pack(push, 1)
 


### PR DESCRIPTION
This adds animations and sounds to land edge doors.
Closes #23228

https://github.com/user-attachments/assets/4871a511-154b-4445-a85e-d318f1966000

For animating the doors this still works the same as it did in #24498. It now also plays door sounds. The implementation is a bit more complicated to make sure that those sounds only play when they are supposed to.

Like before, ideally this type of animation (temporary, aka these and on ride photos) should be saved in the park file so that they can't get temporarily stuck open when saving and loading the game, but that's not included in this PR. Just as a reminder, this type of animation is separate to updating ones because there is no free space in the track element to store whether it's animating or not.

I wasn't sure where to put `DoorSoundType`, let me know if there's a better place for it.

Here's a quick test park and a RCT1 save. If you load the RCT1 one while paused you can see that the animations continue properly.
[Land Edge Door Test Parks.zip](https://github.com/user-attachments/files/20738834/Land.Edge.Door.Test.Parks.zip)

It looks like there is a few too many tunnel entries for these doors, after this PR they should probably be cleaned up a little bit.