### PR TITLE
Fix #24617: Prevent hired boat with 0 speed causing division by 0

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -16,6 +16,7 @@
 - Fix: [#24576] It is possible to edit open rides in certain circumstances.
 - Fix: [#24589] Music tab doesn’t fully render in multiplayer.
 - Fix: [#24615] Blank strings in Windows installer.
+- Fix: [#24617] ‘Divide by zero’ error when updating boat hire acceleration.
 
 0.4.23 (2025-06-07)
 ------------------------------------------------------------------------

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -3920,7 +3920,10 @@ void Vehicle::UpdateMotionBoatHire()
             }
             eax -= velocity;
             edx = powered_acceleration * 2;
-            ecx += (eax * edx) / ebx;
+            if (ebx != 0)
+            {
+                ecx += (eax * edx) / ebx;
+            }
         }
         acceleration = ecx;
     }

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -3909,7 +3909,7 @@ void Vehicle::UpdateMotionBoatHire()
         int32_t curMass = mass == 0 ? 1 : mass;
 
         int32_t eax = ((velocity >> 1) + edx) / curMass;
-        int32_t ecx = -eax;
+        int32_t newAcceleration = -eax;
         if (carEntry->flags & CAR_ENTRY_FLAG_POWERED)
         {
             eax = speed << 14;
@@ -3922,10 +3922,10 @@ void Vehicle::UpdateMotionBoatHire()
             edx = powered_acceleration * 2;
             if (ebx != 0)
             {
-                ecx += (eax * edx) / ebx;
+                newAcceleration += (eax * edx) / ebx;
             }
         }
-        acceleration = ecx;
+        acceleration = newAcceleration;
     }
     // eax = _vehicleMotionTrackFlags;
     // ebx = _vehicleStationIndex;


### PR DESCRIPTION
In the failing scenario `Vehicle::speed` was set to 0