### PR TITLE
Fix #24589: Ride's music tab doesn't redraw in multiplayer

### DIFF
--- a/src/openrct2/actions/RideSetSettingAction.cpp
+++ b/src/openrct2/actions/RideSetSettingAction.cpp
@@ -215,6 +215,9 @@ GameActions::Result RideSetSettingAction::Execute() const
             {
                 ride->lifecycleFlags |= RIDE_LIFECYCLE_MUSIC;
             }
+            // Set invalidation flag to trigger window redraw
+            // https://github.com/OpenRCT2/OpenRCT2/issues/24589
+            ride->windowInvalidateFlags |= RIDE_INVALIDATE_RIDE_MUSIC;
             break;
         case RideSetSetting::MusicType:
             if (_value != ride->music)


### PR DESCRIPTION
Trigger an invalidation of the window when actually executing the command.