### PR TITLE
Test a split between scenario and sandbox mode

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -2939,7 +2939,7 @@ STR_5836    :Select music to use on the main menu.{NEWLINE}Selecting the RCT1 th
 STR_5837    :Create and manage custom UI themes
 STR_5838    :Show a separate button for the finance window in the toolbar
 STR_5839    :Show a separate button for the research and development window in the toolbar
-STR_5840    :Show a separate button for the cheats window in the toolbar
+STR_5840    :Show a separate button for the cheats window in the toolbar.{NEWLINE}Unavailable in scenarios
 STR_5841    :Show a separate button for the recent news window in the toolbar
 STR_5842    :Sort scenarios into tabs by their difficulty (RCT2 behaviour) or their source game (RCT1 behaviour)
 STR_5843    :Enables progressive unlocking of scenarios (RCT1 behaviour)

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -2939,7 +2939,7 @@ STR_5836    :Select music to use on the main menu.{NEWLINE}Selecting the RCT1 th
 STR_5837    :Create and manage custom UI themes
 STR_5838    :Show a separate button for the finance window in the toolbar
 STR_5839    :Show a separate button for the research and development window in the toolbar
-STR_5840    :Show a separate button for the cheats window in the toolbar.{NEWLINE}Unavailable in scenarios
+STR_5840    :Show a separate button for the cheats window in the toolbar.{NEWLINE}Unavailable in original scenarios
 STR_5841    :Show a separate button for the recent news window in the toolbar
 STR_5842    :Sort scenarios into tabs by their difficulty (RCT2 behaviour) or their source game (RCT1 behaviour)
 STR_5843    :Enables progressive unlocking of scenarios (RCT1 behaviour)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Improved: [#22684] The limit of 2000 animated tile elements has been removed.
 - Improved: [#24026] Notification settings have been made into a tab of the Recent Messages window.
 - Change: [#24559] Scenario options are now disabled rather than hidden when disabling money makes them non-applicable.
+- Change: [#24633] Disable cheats in scenarios.
 - Change: [objects#383] Disable all base colours on non-remappable WWTT vehicles, change black to light_blue.
 - Change: [objects#384] Remove erroneously enabled WWTT third remaps.
 - Fix: [#15846] Rightclicking on track piece when there is construction below does not work.

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -40,6 +40,7 @@
 #include <openrct2/interface/Screenshot.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/network/Network.h>
+#include <openrct2/scenario/Scenario.h>
 #include <openrct2/ui/UiContext.h>
 #include <openrct2/ui/WindowManager.h>
 #include <openrct2/windows/Intent.h>
@@ -628,7 +629,7 @@ namespace OpenRCT2::Ui::Windows
             if (!Config::Get().interface.ToolbarShowResearch)
                 widgets[WIDX_RESEARCH].type = WidgetType::empty;
 
-            if (!Config::Get().interface.ToolbarShowCheats)
+            if (!Config::Get().interface.ToolbarShowCheats || getGameState().scenarioHideCheats)
                 widgets[WIDX_CHEATS].type = WidgetType::empty;
 
             if (!Config::Get().interface.ToolbarShowNews)

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -88,6 +88,7 @@ namespace OpenRCT2
         std::string scenarioDetails;
         std::string scenarioCompletedBy;
         std::string scenarioFileName;
+        bool scenarioHideCheats{};
 
         std::vector<Banner> banners;
         Entity_t entities[kMaxEntities]{};

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -90,6 +90,9 @@ void ScenarioBegin(GameState_t& gameState)
         ContextOpenWindowView(WV_PARK_OBJECTIVE);
 
     gScreenAge = 0;
+
+    // Hide cheats button when scenario begins to prevent cheating during scenario play
+    gameState.scenarioHideCheats = true;
 }
 
 void ScenarioReset(GameState_t& gameState)

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -91,8 +91,11 @@ void ScenarioBegin(GameState_t& gameState)
 
     gScreenAge = 0;
 
-    // Hide cheats button when scenario begins to prevent cheating during scenario play
-    gameState.scenarioHideCheats = true;
+    // Hide cheats button only for original scenarios to prevent cheating during scenario play
+    // User-provided scenarios should allow cheats
+    SourceDescriptor sourceDesc;
+    bool isOriginalScenario = ScenarioSources::TryGetByName(gameState.scenarioName, &sourceDesc);
+    gameState.scenarioHideCheats = isOriginalScenario;
 }
 
 void ScenarioReset(GameState_t& gameState)

--- a/src/openrct2/scenes/title/TitleScene.cpp
+++ b/src/openrct2/scenes/title/TitleScene.cpp
@@ -23,6 +23,7 @@
 #include "../../interface/Viewport.h"
 #include "../../network/Network.h"
 #include "../../network/NetworkBase.h"
+#include "../../scenario/Scenario.h"
 #include "../../scenario/ScenarioRepository.h"
 #include "../../ui/UiContext.h"
 #include "../../ui/WindowManager.h"
@@ -101,6 +102,9 @@ void TitleScene::Load()
     gLegacyScene = LegacyScene::titleSequence;
     gScreenAge = 0;
     gCurrentLoadedPath.clear();
+
+    // Reset cheats button visibility when returning to title screen
+    getGameState().scenarioHideCheats = false;
 
 #ifndef DISABLE_NETWORK
     GetContext().GetNetwork().Close();


### PR DESCRIPTION
**Since this has got people concerned:**

**This PR is to test some things out for something behind the scenes. Please note that we’re not taking cheats or sandbox play away.**

This disables cheats when playing a scenario. All possible cheat modes are disabled:
- Cheat window
- Tile inspector
- Object selection
- Inventions list
- Scenario options
- Sandbox mode
- Disabling clearance checks
- Disabling support limits