### PR TITLE
Fix #24509: Use std::sort instead of std::stable_sort

### DIFF
--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -2235,7 +2235,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Sort the rides alphabetically
-            std::stable_sort(_rideableRides.begin(), _rideableRides.end(), [](const RideId& a, const RideId& b) {
+            std::sort(_rideableRides.begin(), _rideableRides.end(), [](const RideId& a, const RideId& b) {
                 return String::compare(GetRideString(a), GetRideString(b), false) < 0;
             });
 


### PR DESCRIPTION
Should resolve #24509, hopefully, also even if it doesn't we should still use std::sort as the stable_sort does quite some heavy lifting, in this case it is not important to how it sorts equal things.