### PR TITLE
Remove Memory Copy in FileIndex::LoadOrBuild

### DIFF
--- a/src/openrct2/core/FileIndex.hpp
+++ b/src/openrct2/core/FileIndex.hpp
@@ -106,10 +106,10 @@ public:
         std::vector<TItem> items;
         auto scanResult = Scan();
         auto readIndexResult = ReadIndexFile(language, scanResult.Stats);
-        if (std::get<0>(readIndexResult))
+        if (readIndexResult.first)
         {
             // Index was loaded
-            items = std::get<1>(readIndexResult);
+            items = std::move(readIndexResult.second);
         }
         else
         {


### PR DESCRIPTION
I tried building OpenRCT2 from source on my Arch Linux laptop, and got a warning-as-error:

```
FAILED: CMakeFiles/libopenrct2.dir/src/openrct2/object/ObjectRepository.cpp.o
/usr/bin/c++ -DDOCDIR=\"/usr/local/share/doc/openrct2\" -DENABLE_SCRIPTING -D_FILE_OFFSET_BITS=64 -I/home/lrflew/Documents/OpenRCT2/src/openrct2/../thirdparty/duktape -I/home/lrflew/Documents/OpenRCT2/libopenrct2 -isystem /usr/include/freetype2 -isystem /usr/include/libpng16 -isystem /usr/include/harfbuzz -isystem /usr/include/glib-2.0 -isystem /usr/lib/glib-2.0/include -isystem /usr/include/sysprof-6 -isystem /home/lrflew/Documents/OpenRCT2/src/openrct2/../thirdparty -fstrict-overflow -fstrict-aliasing -Werror -Wundef -Wmissing-declarations -Winit-self -Wall -Wextra -Wshadow -Wno-unknown-pragmas -Wno-missing-braces -Wno-comment -Wnonnull -Wno-unused-parameter -Wno-attributes -DDEBUG=0 -fno-char8_t -Wno-deprecated-declarations -O2 -g -DNDEBUG -std=gnu++20 -fPIC -Wsuggest-override -Wduplicated-cond -Wnon-virtual-dtor -Wduplicated-branches -Wrestrict -Wmissing-field-initializers -Wlogical-op -Wold-style-cast -Wunused-const-variable=1 -Wno-clobbered -Wredundant-decls -Wnull-dereference -Wignored-qualifiers -Wstrict-overflow=1 -pthread -MD -MT CMakeFiles/libopenrct2.dir/src/openrct2/object/ObjectRepository.cpp.o -MF CMakeFiles/libopenrct2.dir/src/openrct2/object/ObjectRepository.cpp.o.d -o CMakeFiles/libopenrct2.dir/src/openrct2/object/ObjectRepository.cpp.o -c /home/lrflew/Documents/OpenRCT2/src/openrct2/object/ObjectRepository.cpp
In file included from /home/lrflew/Documents/OpenRCT2/src/openrct2/object/ObjectRepository.cpp:10:
In member function ‘ObjectRepositoryItem& ObjectRepositoryItem::operator=(const ObjectRepositoryItem&)’,
    inlined from ‘constexpr void std::__assign_one(_OutIter&, _InIter&) [with bool _IsMove = false; _OutIter = ObjectRepositoryItem*; _InIter = const ObjectRepositoryItem*]’ at /usr/include/c++/15.1.1/bits/stl_algobase.h:407:9,
    inlined from ‘constexpr _OutIter std::__copy_move_a2(_InIter, _Sent, _OutIter) [with bool _IsMove = false; _InIter = const ObjectRepositoryItem*; _Sent = const ObjectRepositoryItem*; _OutIter = ObjectRepositoryItem*]’ at /usr/include/c++/15.1.1/bits/stl_algobase.h:462:28,
    inlined from ‘constexpr _OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = false; _II = const ObjectRepositoryItem*; _OI = ObjectRepositoryItem*]’ at /usr/include/c++/15.1.1/bits/stl_algobase.h:492:42,
    inlined from ‘constexpr _OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = __gnu_cxx::__normal_iterator<const ObjectRepositoryItem*, vector<ObjectRepositoryItem, allocator<ObjectRepositoryItem> > >; _OI = __gnu_cxx::__normal_iterator<ObjectRepositoryItem*, vector<ObjectRepositoryItem, allocator<ObjectRepositoryItem> > >]’ at /usr/include/c++/15.1.1/bits/stl_algobase.h:500:31,
    inlined from ‘constexpr _OI std::copy(_II, _II, _OI) [with _II = __gnu_cxx::__normal_iterator<const ObjectRepositoryItem*, vector<ObjectRepositoryItem, allocator<ObjectRepositoryItem> > >; _OI = __gnu_cxx::__normal_iterator<ObjectRepositoryItem*, vector<ObjectRepositoryItem, allocator<ObjectRepositoryItem> > >]’ at /usr/include/c++/15.1.1/bits/stl_algobase.h:642:7,
    inlined from ‘constexpr std::vector<_Tp, _Alloc>& std::vector<_Tp, _Alloc>::operator=(const std::vector<_Tp, _Alloc>&) [with _Tp = ObjectRepositoryItem; _Alloc = std::allocator<ObjectRepositoryItem>]’ at /usr/include/c++/15.1.1/bits/vector.tcc:250:21,
    inlined from ‘std::vector<T> FileIndex<TItem>::LoadOrBuild(int32_t) const [with TItem = ObjectRepositoryItem]’ at /home/lrflew/Documents/OpenRCT2/src/openrct2/object/../core/FileIndex.hpp:112:19,
    inlined from ‘virtual void ObjectRepository::LoadOrConstruct(int32_t)’ at /home/lrflew/Documents/OpenRCT2/src/openrct2/object/ObjectRepository.cpp:206:53:
/home/lrflew/Documents/OpenRCT2/src/openrct2/object/ObjectRepository.h:39:8: error: potential null pointer dereference [-Werror=null-dereference]
   39 | struct ObjectRepositoryItem
      |        ^~~~~~~~~~~~~~~~~~~~
/home/lrflew/Documents/OpenRCT2/src/openrct2/object/ObjectRepository.h:39:8: error: potential null pointer dereference [-Werror=null-dereference]
/home/lrflew/Documents/OpenRCT2/src/openrct2/object/ObjectRepository.h:39:8: error: potential null pointer dereference [-Werror=null-dereference]
cc1plus: all warnings being treated as errors
```

I'm pretty sure this is a GCC / libstdc++ bug (specifically, I think it's [this bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108860)), not an issue with OpenRCT2 itself. However, while investigating it, I found a vector copy in `FileIndex::LoadOrBuild` that could instead be a move. Making this change not only fixes the build for me, but also removes an unnecessary vector copy.