### PR TITLE
GCC15 fix in ReplayManager.cpp

### DIFF
--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -713,9 +713,9 @@ namespace OpenRCT2
             if (serialiser.IsLoading())
             {
                 command.action = GameActions::Create(static_cast<GameCommand>(actionType));
-                Guard::Assert(command.action != nullptr);
             }
 
+            Guard::Assert(command.action != nullptr);
             command.action->Serialise(serialiser);
 
             return true;


### PR DESCRIPTION
```
In member function ‘bool OpenRCT2::ReplayManager::SerialiseCommand(DataSerialiser&, OpenRCT2::ReplayCommand&)’,
    inlined from ‘bool OpenRCT2::ReplayManager::Serialise(DataSerialiser&, OpenRCT2::ReplayRecordData&)’ at /home/janisozaur/workspace/openrct2/src/openrct2/ReplayManager.cpp:778:37:
/home/janisozaur/workspace/openrct2/src/openrct2/ReplayManager.cpp:719:38: error: potential null pointer dereference [-Werror=null-dereference]
  719 |             command.action->Serialise(serialiser);
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

```
$ gcc --version
gcc (GCC) 15.1.1 20250425
Copyright (C) 2025 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```