### PR TITLE
Mac: do not save window_height to config.ini for nonWindow

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -842,11 +842,7 @@ private:
         GfxInvalidateScreen();
 
         // Check if the window has been resized in windowed mode and update the config file accordingly
-        int32_t nonWindowFlags =
-#ifndef __MACOSX__
-            SDL_WINDOW_MAXIMIZED |
-#endif
-            SDL_WINDOW_MINIMIZED | SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP;
+        int32_t nonWindowFlags = SDL_WINDOW_MAXIMIZED | SDL_WINDOW_MINIMIZED | SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP;
 
         if (!(flags & nonWindowFlags))
         {


### PR DESCRIPTION
For issue "MacOS Full screen mouse alignment #21973" https://github.com/OpenRCT2/OpenRCT2/issues/21973 the problem was that going to full screen would save the new window_height to config.ini, misaligning the cursor when the app is relaunched in a window.

The solution is to not save the window_height for all min, max, fullscreen conditions: SDL_WINDOW_MAXIMIZED | SDL_WINDOW_MINIMIZED | SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP not just SDL_WINDOW_MAXIMIZED for macOS.