### PR TITLE
Revert "Close #1787: Replace blood-curdling scream with regular roller coaster screams"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,9 +82,9 @@ set(OPENMSX_VERSION "1.6")
 set(OPENMSX_URL  "https://github.com/OpenRCT2/OpenMusic/releases/download/v${OPENMSX_VERSION}/openmusic.zip")
 set(OPENMSX_SHA1 "ba170fa6d777b309c15420f4b6eb3fa25082a9d1")
 
-set(REPLAYS_VERSION "0.0.88")
+set(REPLAYS_VERSION "0.0.87")
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
-set(REPLAYS_SHA1 "0FA51560A46599FE77B59E068C6BCA3ABA5FC380")
+set(REPLAYS_SHA1 "6061B53DE346BD853BB997E635AC7374B1A7D2F0")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,7 +6,6 @@
 - Improved: [#23228] Landscape edge doors now animate opening and closing and play a sound.
 - Improved: [#24026] Notification settings have been made into a tab of the Recent Messages window.
 - Improved: [#24569] Add nine additional translations to the Windows installer.
-- Change: [#1787, #17718] Replaced blood-curdling scream with regular roller coaster screams.
 - Change: [#24559] Scenario options are now disabled rather than hidden when disabling money makes them non-applicable.
 - Change: [objects#383] Disable all base colours on non-remappable WWTT vehicles, change black to light_blue.
 - Change: [objects#384] Remove erroneously enabled WWTT third remaps.

--- a/openrct2.deps.targets
+++ b/openrct2.deps.targets
@@ -224,8 +224,8 @@
     <OpenSFXSha1>b1b1f1b241d2cbff63a1889c4dc5a09bdf769bfb</OpenSFXSha1>
     <OpenMSXUrl>https://github.com/OpenRCT2/OpenMusic/releases/download/v1.6/openmusic.zip</OpenMSXUrl>
     <OpenMSXSha1>ba170fa6d777b309c15420f4b6eb3fa25082a9d1</OpenMSXSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.88/replays.zip</ReplaysUrl>
-    <ReplaysSha1>0FA51560A46599FE77B59E068C6BCA3ABA5FC380</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.87/replays.zip</ReplaysUrl>
+    <ReplaysSha1>6061B53DE346BD853BB997E635AC7374B1A7D2F0</ReplaysSha1>
   </PropertyGroup>
   
   <!-- Unified Dependency Target -->

--- a/src/openrct2/audio/Audio.h
+++ b/src/openrct2/audio/Audio.h
@@ -121,7 +121,7 @@ namespace OpenRCT2::Audio
         LiftWildMouse,
         LiftBM,
         TrackFrictionBM,
-        Scream8, // Blood-curdling, Haunted House-like scream
+        Scream8,
         Tram,
         DoorOpen,
         DoorClose,

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -94,18 +94,17 @@ uint8_t _vehicleF64E2C;
 Vehicle* _vehicleFrontVehicle;
 CoordsXYZ _vehicleCurPosition;
 
-static constexpr OpenRCT2::Audio::SoundId _screamSetNonCoaster[] = {
+static constexpr OpenRCT2::Audio::SoundId _screamSet0[] = {
+    OpenRCT2::Audio::SoundId::Scream8,
     OpenRCT2::Audio::SoundId::Scream1,
 };
-static constexpr OpenRCT2::Audio::SoundId _screamSetWooden[] = {
+static constexpr OpenRCT2::Audio::SoundId _screamSet1Wooden[] = {
     OpenRCT2::Audio::SoundId::Scream3, OpenRCT2::Audio::SoundId::Scream1, OpenRCT2::Audio::SoundId::Scream5,
     OpenRCT2::Audio::SoundId::Scream6, OpenRCT2::Audio::SoundId::Scream7, OpenRCT2::Audio::SoundId::Scream2,
     OpenRCT2::Audio::SoundId::Scream4,
 };
-static constexpr OpenRCT2::Audio::SoundId _screamSetSteel[] = {
-    OpenRCT2::Audio::SoundId::Scream4,
+static constexpr OpenRCT2::Audio::SoundId _screamSet2[] = {
     OpenRCT2::Audio::SoundId::Scream1,
-    OpenRCT2::Audio::SoundId::Scream2,
     OpenRCT2::Audio::SoundId::Scream6,
 };
 
@@ -5035,14 +5034,14 @@ OpenRCT2::Audio::SoundId Vehicle::ProduceScreamSound(const int32_t totalNumPeeps
         {
             switch (carEntry.sound_range)
             {
-                case SOUND_RANGE_SCREAMS_NON_COASTER:
-                    scream_sound_id = _screamSetNonCoaster[r % std::size(_screamSetNonCoaster)];
+                case SOUND_RANGE_SCREAMS_0:
+                    scream_sound_id = _screamSet0[r % std::size(_screamSet0)];
                     break;
-                case SOUND_RANGE_SCREAMS_WOODEN_COASTERS:
-                    scream_sound_id = _screamSetWooden[r % std::size(_screamSetWooden)];
+                case SOUND_RANGE_SCREAMS_1_WOODEN_COASTERS:
+                    scream_sound_id = _screamSet1Wooden[r % std::size(_screamSet1Wooden)];
                     break;
-                case SOUND_RANGE_SCREAMS_STEEL:
-                    scream_sound_id = _screamSetSteel[r % std::size(_screamSetSteel)];
+                case SOUND_RANGE_SCREAMS_2:
+                    scream_sound_id = _screamSet2[r % std::size(_screamSet2)];
                     break;
                 default:
                     scream_sound_id = OpenRCT2::Audio::SoundId::NoScream;

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -537,9 +537,9 @@ enum
 
 enum
 {
-    SOUND_RANGE_SCREAMS_NON_COASTER = 0, // Used by rides where the screams should not include rolling sounds.
-    SOUND_RANGE_SCREAMS_WOODEN_COASTERS = 1,
-    SOUND_RANGE_SCREAMS_STEEL = 2,
+    SOUND_RANGE_SCREAMS_0 = 0,
+    SOUND_RANGE_SCREAMS_1_WOODEN_COASTERS = 1,
+    SOUND_RANGE_SCREAMS_2 = 2,
     SOUND_RANGE_WHISTLE = 3,
     SOUND_RANGE_BELL = 4,
     SOUND_RANGE_NONE = 255


### PR DESCRIPTION
This reverts commit f176b27076fe7374e592f3fd53d97ae1b8235257.

Here is some context:

There are two relevant sets of screams here, set #0 and #2. Both used to contain 2 screams, the blood-curdling being one of them.

#17718 changed set 0 to remove the blood-curdling screams and changed set 2 to remove the blood-curdling scream, but also add 3 additional screams with friction noise in them. For set 2, this is fine as it’s used by steel roller coasters.

Now, set #0 was left with a single scream, but this seemed fine as it would only affect water rides and the roto drop. Or so I thought, [Claude’s comment](
https://github.com/OpenRCT2/OpenRCT2/pull/17718#issuecomment-3032997963) made me aware that a lot of steel roller coaster trains, like all the B&M’s, also use set #0.

Now, while I’m a bit miffed nobody mentioned anything for 3 years, the point of the PR _was_ to improve the scream sounds, and I’m not going to keep it in this state out of spite. It needs more work. I do think we’ll need to update the B&M objects, but we may also need to consider reverting set #0 to how it was and only keep the changes to set #2.

Those are not things we can easily do before the release, so I’m backing out the change for now.