### PR TITLE
Fix Compression Issue when Stopping Recording

### DIFF
--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -312,6 +312,7 @@ namespace OpenRCT2
             auto& stream = recSerialiser.GetStream();
 
             MemoryStream compressed;
+            stream.SetPosition(0);
             bool compressStatus = Compression::zlibCompress(
                 stream, static_cast<size_t>(stream.GetLength()), compressed, Compression::ZlibHeaderType::zlib,
                 kReplayCompressionLevel);


### PR DESCRIPTION
This is a quick hotfix for an issue I found in #24701. That PR made the compression function start decompressing at the current position of the input stream (which has some advantages, particularly for the decompress function), but requires resetting the stream position to zero to compress the whole stream. I remembered to make that change for OrcaStream, but forgot it in the ReplayManager. This adds that fix for ReplayManager as well.