### PR TITLE
Don't Double-Compress Park Chunks in Replay File

### DIFF
--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -261,7 +261,7 @@ namespace OpenRCT2
 
             auto exporter = std::make_unique<ParkFileExporter>();
             exporter->ExportObjectsList = objects;
-            exporter->Export(gameState, replayData->parkData);
+            exporter->Export(gameState, replayData->parkData, Compression::kNoCompressionLevel);
 
             replayData->timeRecorded = std::chrono::seconds(std::time(nullptr)).count();
 
@@ -314,8 +314,7 @@ namespace OpenRCT2
             MemoryStream compressed;
             stream.SetPosition(0);
             bool compressStatus = Compression::zlibCompress(
-                stream, static_cast<size_t>(stream.GetLength()), compressed, Compression::ZlibHeaderType::zlib,
-                kReplayCompressionLevel);
+                stream, stream.GetLength(), compressed, Compression::ZlibHeaderType::zlib, kReplayCompressionLevel);
             if (!compressStatus)
                 throw IOException("Compression Error");
 
@@ -567,8 +566,8 @@ namespace OpenRCT2
 
                 recFile.data.SetPosition(0);
                 decompressStatus = Compression::zlibDecompress(
-                    recFile.data, static_cast<size_t>(recFile.data.GetLength()), decompressed,
-                    static_cast<size_t>(recFile.uncompressedSize), Compression::ZlibHeaderType::zlib);
+                    recFile.data, recFile.data.GetLength(), decompressed, recFile.uncompressedSize,
+                    Compression::ZlibHeaderType::zlib);
 
                 if (!decompressStatus)
                     throw IOException("Decompression Error");

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include "../core/Compression.h"
+
 #include <cstdint>
 #include <string_view>
 #include <vector>
@@ -54,13 +56,17 @@ namespace OpenRCT2
     constexpr uint16_t kExtendedGoKartsVersion = 54;
     constexpr uint16_t kHigherInversionsHolesHelicesStatsVersion = 55;
     constexpr uint16_t kFixedObsoleteFootpathsVersion = 56;
+
+    class ParkFileExporter
+    {
+    public:
+        std::vector<const ObjectRepositoryItem*> ExportObjectsList;
+
+        void Export(
+            OpenRCT2::GameState_t& gameState, std::string_view path,
+            int16_t compressionLevel = Compression::kZlibDefaultCompressionLevel);
+        void Export(
+            OpenRCT2::GameState_t& gameState, OpenRCT2::IStream& stream,
+            int16_t compressionLevel = Compression::kZlibDefaultCompressionLevel);
+    };
 } // namespace OpenRCT2
-
-class ParkFileExporter
-{
-public:
-    std::vector<const ObjectRepositoryItem*> ExportObjectsList;
-
-    void Export(OpenRCT2::GameState_t& gameState, std::string_view path);
-    void Export(OpenRCT2::GameState_t& gameState, OpenRCT2::IStream& stream);
-};


### PR DESCRIPTION
While messing around with the code related to compression, I noticed an oddity around the format of .parkrep files. So for the current version of the .parkrep files, it compresses the entire contents of the file using Zlib max level compression. However, the replay file also contains a copy of the park data, stored using the OrcaStream format where the chunks' data is stored Zlib compressed. This means that the park chunks data ends up double-compressed. This can result in significantly longer total compression and decompression times for minimal impact, and in part because the second compression is done at a higher compression level, will likely result in a larger resulting file.

Luckily, changing this to avoid the double compression is fairly straightforward. The OrcaStream format already has a field to indicate if compression is used (the `CompressionType` value), so we just need a way to request that compression isn't used when using `ParkFileExporter`. For this, I opted to use a "compression level" argument, as it can be used both to specify a Zlib compression level, which could prove useful, and disable compression by using a value of zero (which I previously named `Compression::kNoCompressionLevel`). I also went ahead and moved the `ParkFileExporter` class to the OpenRCT2 namespace, since that seems to be the code style for C++ classes, and it made referencing the `Compression` namespace easier.