### PR TITLE
Use ZStandard Compression for PARK and PARKREP Files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,7 +489,7 @@ jobs:
     name: Ubuntu Linux (AppImage, x86_64)
     runs-on: ubuntu-latest
     needs: [check-code-formatting, build_variables]
-    container: openrct2/openrct2-build:14-jammy
+    container: openrct2/openrct2-build:21-jammy
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   clang-tidy-check:
     runs-on: ubuntu-latest
-    container: openrct2/openrct2-build:19-noble
+    container: openrct2/openrct2-build:20-noble
     steps:
     - uses: actions/checkout@v4
     - uses: ZehMatt/clang-tidy-annotations@v1

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.26 (in development)
 ------------------------------------------------------------------------
+- Improved: [#24734] Save files now use Zstd compression for faster saving and smaller files.
 - Improved: [#24893] The ride list now has headers, and can be sorted in both directions.
 - Fix: [#16988] AppImage version does not show changelog.
 

--- a/distribution/readme.txt
+++ b/distribution/readme.txt
@@ -1,4 +1,4 @@
-Last updated:    2024-11-19
+Last updated:    2025-08-04
 ------------------------------------------------------------------------
 
 
@@ -155,6 +155,7 @@ zlib             | zlib licence.
 Google Test      | BSD 3 clause licence.
 Google Benchmark | Apache 2.0 licence.
 sfl              | zlib licence.
+zstd             | BSD 3 clause license.
 
 Licences for sub-libraries used by the above may vary. For more information, visit the libraries' respective official websites.
 

--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -88,7 +88,7 @@
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <AdditionalDependencies>brotlicommon.lib;brotlidec.lib;brotlienc.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Breakpad)'=='true' and ('$(Platform)'=='Win32' or '$(Platform)'=='x64')">libbreakpadd.lib;libbreakpad_clientd.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies>bz2d.lib;discord-rpc.lib;flac.lib;freetyped.lib;libpng16d.lib;ogg.lib;speexdsp.lib;SDL2-staticd.lib;vorbis.lib;vorbisfile.lib;zip.lib;zlibd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bz2d.lib;discord-rpc.lib;flac.lib;freetyped.lib;libpng16d.lib;ogg.lib;speexdsp.lib;SDL2-staticd.lib;vorbis.lib;vorbisfile.lib;zip.lib;zlibd.lib;zstd.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release' or '$(Configuration)'=='ReleaseLTCG'">
@@ -109,7 +109,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>brotlicommon.lib;brotlidec.lib;brotlienc.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Breakpad)'=='true' and ('$(Platform)'=='Win32' or '$(Platform)'=='x64')">libbreakpad.lib;libbreakpad_client.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies>bz2.lib;discord-rpc.lib;flac.lib;freetype.lib;libpng16.lib;ogg.lib;speexdsp.lib;SDL2-static.lib;vorbis.lib;vorbisfile.lib;zip.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bz2.lib;discord-rpc.lib;flac.lib;freetype.lib;libpng16.lib;ogg.lib;speexdsp.lib;SDL2-static.lib;vorbis.lib;vorbisfile.lib;zip.lib;zlib.lib;zstd.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/scripts/build-emscripten
+++ b/scripts/build-emscripten
@@ -7,6 +7,7 @@ START_DIR=$(pwd)
 SPEEXDSP_ROOT=/ext/speexdsp
 ICU_ROOT=/ext/icu/icu4c/source
 LIBZIP_ROOT=/ext/libzip
+ZSTD_ROOT=/ext/zstd
 JSON_DIR=/usr/include/nlohmann/
 
 emcmake cmake ../ \
@@ -25,7 +26,8 @@ emcmake cmake ../ \
 	-DICU_DATA_LIBRARIES=$ICU_ROOT/lib/libicuuc.so \
 	-DICU_DT_LIBRARY_RELEASE="$ICU_ROOT/stubdata/libicudata.so" \
 	-DLIBZIP_LIBRARIES="$LIBZIP_ROOT/build/lib/libzip.a" \
-	-DEMSCRIPTEN_FLAGS="-s USE_SDL=2 -s USE_BZIP2=1 -s USE_LIBPNG=1 -pthread -O3" \
+	-DZSTD_LIBRARIES="$ZSTD_ROOT/build/build/lib/libzstd.a" \
+	-DEMSCRIPTEN_FLAGS="-s USE_SDL=2 -s USE_ZLIB=1 -s USE_BZIP2=1 -s USE_LIBPNG=1 -pthread -O3" \
 	-DEMSCRIPTEN_LDFLAGS="-Wno-pthreads-mem-growth -s SAFE_HEAP=0 -s ALLOW_MEMORY_GROWTH=1 -s MAXIMUM_MEMORY=4GB -s INITIAL_MEMORY=2GB -s STACK_SIZE=8388608 -s MIN_WEBGL_VERSION=2 -s MAX_WEBGL_VERSION=2 -s PTHREAD_POOL_SIZE=120 -pthread -s EXPORTED_RUNTIME_METHODS=ccall,FS,callMain,UTF8ToString,stringToNewUTF8 -lidbfs.js --use-preload-plugins -s MODULARIZE=1 -s 'EXPORT_NAME=\"OPENRCT2_WEB\"'"
 
 emmake ninja

--- a/src/openrct2-android/app/src/main/CMakeLists.txt
+++ b/src/openrct2-android/app/src/main/CMakeLists.txt
@@ -46,6 +46,7 @@ ExternalProject_Add(libs
         ${CMAKE_BINARY_DIR}/libs/lib/${CMAKE_SHARED_LIBRARY_PREFIX}icui18n${CMAKE_SHARED_LIBRARY_SUFFIX}
         ${CMAKE_BINARY_DIR}/libs/lib/${CMAKE_SHARED_LIBRARY_PREFIX}icuuc${CMAKE_SHARED_LIBRARY_SUFFIX}
         ${CMAKE_BINARY_DIR}/libs/lib/${CMAKE_SHARED_LIBRARY_PREFIX}z${CMAKE_SHARED_LIBRARY_SUFFIX}
+        ${CMAKE_BINARY_DIR}/libs/lib/${CMAKE_SHARED_LIBRARY_PREFIX}zstd${CMAKE_SHARED_LIBRARY_SUFFIX}
         ${CMAKE_BINARY_DIR}/libs/lib/${CMAKE_STATIC_LIBRARY_PREFIX}SDL2main${CMAKE_STATIC_LIBRARY_SUFFIX}
 
     LOG_DOWNLOAD 1
@@ -78,6 +79,7 @@ add_custom_command(TARGET libs POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/libs/lib/libspeexdsp.so" ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
     COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/libs/lib/libssl.so" ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
     COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/libs/lib/libz.so" ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/libs/lib/libzstd.so" ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
 )
 
 add_library(freetype SHARED IMPORTED)
@@ -97,6 +99,12 @@ set_target_properties(z PROPERTIES IMPORTED_LOCATION
     ${CMAKE_BINARY_DIR}/libs/lib/${CMAKE_SHARED_LIBRARY_PREFIX}z${CMAKE_SHARED_LIBRARY_SUFFIX}
 )
 add_dependencies(z libs)
+
+add_library(zstd SHARED IMPORTED)
+set_target_properties(zstd PROPERTIES IMPORTED_LOCATION
+    ${CMAKE_BINARY_DIR}/libs/lib/${CMAKE_SHARED_LIBRARY_PREFIX}zstd${CMAKE_SHARED_LIBRARY_SUFFIX}
+)
+add_dependencies(zstd libs)
 
 add_library(SDL2 SHARED IMPORTED)
 set_target_properties(SDL2 PROPERTIES IMPORTED_LOCATION
@@ -250,7 +258,7 @@ file(GLOB_RECURSE OPENRCT2_CLI_SOURCES
     "${ORCT2_ROOT}/src/openrct2-cli/*.hpp")
 
 add_library(openrct2 SHARED ${LIBOPENRCT2_SOURCES})
-target_link_libraries(openrct2 android stdc++ log dl SDL2 png z icu icuuc icudata crypto ssl freetype)
+target_link_libraries(openrct2 android stdc++ log dl SDL2 png z zstd icu icuuc icudata crypto ssl freetype)
 
 add_library(openrct2-ui SHARED ${OPENRCT2_GUI_SOURCES})
 target_link_libraries(openrct2-ui openrct2 android stdc++ GLESv1_CM GLESv2 SDL2main speexdsp brotlicommon brotlidec bz2 freetype ogg vorbis vorbisfile FLAC)

--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -121,12 +121,14 @@ if (EMSCRIPTEN)
 elseif (MSVC)
     find_package(png 1.6 REQUIRED)
     find_package(zlib REQUIRED)
+    find_package(zstd REQUIRED)
 
     find_path(LIBZIP_INCLUDE_DIRS zip.h)
     find_library(LIBZIP_LIBRARIES zip)
 else ()
     PKG_CHECK_MODULES(LIBZIP REQUIRED IMPORTED_TARGET libzip>=1.0)
     PKG_CHECK_MODULES(ZLIB REQUIRED IMPORTED_TARGET zlib)
+    PKG_CHECK_MODULES(ZSTD REQUIRED IMPORTED_TARGET libzstd)
 
     PKG_CHECK_MODULES(PNG IMPORTED_TARGET libpng>=1.6)
     if (NOT PNG_FOUND)
@@ -144,18 +146,21 @@ if (STATIC)
     target_link_libraries(libopenrct2
                                      ${PNG_STATIC_LIBRARIES}
                                      ${ZLIB_STATIC_LIBRARIES}
-                                     ${LIBZIP_STATIC_LIBRARIES})
+                                     ${LIBZIP_STATIC_LIBRARIES}
+                                     ${ZSTD_STATIC_LIBRARIES})
 else ()
     if (NOT MSVC AND NOT EMSCRIPTEN)
         target_link_libraries(libopenrct2
                                      PkgConfig::PNG
                                      PkgConfig::ZLIB
-                                     PkgConfig::LIBZIP)
+                                     PkgConfig::LIBZIP
+                                     PkgConfig::ZSTD)
     else ()
         target_link_libraries(libopenrct2
                                      ${PNG_LIBRARIES}
                                      ${ZLIB_LIBRARIES}
-                                     ${LIBZIP_LIBRARIES})
+                                     ${LIBZIP_LIBRARIES}
+                                     ${ZSTD_LIBRARIES})
     endif ()
 endif ()
 
@@ -235,6 +240,7 @@ endif()
 target_include_directories(libopenrct2 SYSTEM PRIVATE ${LIBZIP_INCLUDE_DIRS})
 target_include_directories(libopenrct2 SYSTEM PRIVATE ${PNG_INCLUDE_DIRS}
                                                           ${ZLIB_INCLUDE_DIRS})
+target_include_directories(libopenrct2 SYSTEM PRIVATE ${ZSTD_INCLUDE_DIRS})
 include_directories(libopenrct2 SYSTEM ${CMAKE_CURRENT_LIST_DIR}/../thirdparty)
 
 # To avoid unnecessary rebuilds set the current branch and

--- a/src/openrct2/command_line/CommandLine.hpp
+++ b/src/openrct2/command_line/CommandLine.hpp
@@ -108,6 +108,7 @@ consteval CommandLineCommand DefineSubCommand(const char* name, const CommandLin
 namespace OpenRCT2::CommandLine
 {
     extern const CommandLineCommand kRootCommands[];
+    extern const CommandLineCommand kConvertCommands[];
     extern const CommandLineCommand kScreenshotCommands[];
     extern const CommandLineCommand kSpriteCommands[];
     extern const CommandLineCommand kSimulateCommands[];
@@ -118,6 +119,5 @@ namespace OpenRCT2::CommandLine
     void PrintHelp(bool allCommands = false);
     exitcode_t HandleCommandDefault();
 
-    exitcode_t HandleCommandConvert(CommandLineArgEnumerator* enumerator);
     exitcode_t HandleCommandUri(CommandLineArgEnumerator* enumerator);
 } // namespace OpenRCT2::CommandLine

--- a/src/openrct2/command_line/ConvertCommand.cpp
+++ b/src/openrct2/command_line/ConvertCommand.cpp
@@ -12,6 +12,8 @@
 #include "../GameState.h"
 #include "../OpenRCT2.h"
 #include "../ParkImporter.h"
+#include "../PlatformEnvironment.h"
+#include "../config/Config.h"
 #include "../core/Console.hpp"
 #include "../core/Path.hpp"
 #include "../object/ObjectManager.h"
@@ -20,14 +22,33 @@
 #include "CommandLine.hpp"
 
 #include <cassert>
+#include <limits>
 #include <memory>
 
 using namespace OpenRCT2;
 
+static int32_t _compressLevel = kParkFileSaveCompressionLevel;
+
+// clang-format off
+static constexpr CommandLineOptionDefinition kConvertOptions[]
+{
+    { CMDLINE_TYPE_INTEGER, &_compressLevel, 'l', "compress-level", "The compression level to use when writing the converted file" },
+    kOptionTableEnd
+};
+
+static exitcode_t HandleCommandConvert(CommandLineArgEnumerator* argEnumerator);
+
+const CommandLineCommand CommandLine::kConvertCommands[]{
+    // Main commands
+    DefineCommand("", "<source> [destination]", kConvertOptions, HandleCommandConvert),
+    kCommandTableEnd
+};
+// clang-format on
+
 static void WriteConvertFromAndToMessage(FileExtension sourceFileType, FileExtension destinationFileType);
 static u8string GetFileTypeFriendlyName(FileExtension fileType);
 
-exitcode_t CommandLine::HandleCommandConvert(CommandLineArgEnumerator* enumerator)
+static exitcode_t HandleCommandConvert(CommandLineArgEnumerator* enumerator)
 {
     exitcode_t result = CommandLine::HandleCommandDefault();
     if (result != EXITCODE_CONTINUE)
@@ -48,10 +69,10 @@ exitcode_t CommandLine::HandleCommandConvert(CommandLineArgEnumerator* enumerato
 
     // Get the destination path
     const utf8* rawDestinationPath;
-    if (!enumerator->TryPopString(&rawDestinationPath))
+    if (!enumerator->TryPopString(&rawDestinationPath) || String::startsWith(rawDestinationPath, "-"))
     {
-        Console::Error::WriteLine("Expected a destination path.");
-        return EXITCODE_FAIL;
+        // if no destination path is provided, convert the park file in-place
+        rawDestinationPath = rawSourcePath;
     }
 
     const auto destinationPath = Path::GetAbsolute(rawDestinationPath);
@@ -75,12 +96,12 @@ exitcode_t CommandLine::HandleCommandConvert(CommandLineArgEnumerator* enumerato
         case FileExtension::PARK:
             if (destinationFileType == FileExtension::PARK)
             {
-                Console::Error::WriteLine("File is already an OpenRCT2 saved game or scenario.");
-                return EXITCODE_FAIL;
+                Console::Error::WriteLine(
+                    "File is already an OpenRCT2 saved game or scenario. Updating file version and recompressing.");
             }
             break;
         default:
-            Console::Error::WriteLine("Only conversion from .SC4, .SV4, .SC6 or .SV6 is supported.");
+            Console::Error::WriteLine("Only conversion from .SC4, .SV4, .SC6, .SV6, or .PARK is supported.");
             return EXITCODE_FAIL;
     }
 
@@ -125,7 +146,7 @@ exitcode_t CommandLine::HandleCommandConvert(CommandLineArgEnumerator* enumerato
         auto* windowMgr = Ui::GetWindowManager();
         windowMgr->CloseByClass(WindowClass::MainWindow);
 
-        exporter->Export(gameState, destinationPath);
+        exporter->Export(gameState, destinationPath, static_cast<int16_t>(_compressLevel));
     }
     catch (const std::exception& ex)
     {

--- a/src/openrct2/command_line/RootCommands.cpp
+++ b/src/openrct2/command_line/RootCommands.cpp
@@ -133,7 +133,6 @@ const CommandLineCommand CommandLine::kRootCommands[]
     DefineCommand("join",     "<hostname>",             kStandardOptions, HandleCommandJoin   ),
 #endif
     DefineCommand("set-rct2", "<path>",                 kStandardOptions, HandleCommandSetRCT2),
-    DefineCommand("convert",  "<source> <destination>", kStandardOptions, CommandLine::HandleCommandConvert),
     DefineCommand("scan-objects", "<path>",             kStandardOptions, HandleCommandScanObjects),
     DefineCommand("handle-uri", "openrct2://.../",      kStandardOptions, CommandLine::HandleCommandUri),
 
@@ -142,6 +141,7 @@ const CommandLineCommand CommandLine::kRootCommands[]
 #endif
 
     // Sub-commands
+    DefineSubCommand("convert",         CommandLine::kConvertCommands          ),
     DefineSubCommand("screenshot",      CommandLine::kScreenshotCommands       ),
     DefineSubCommand("sprite",          CommandLine::kSpriteCommands           ),
     DefineSubCommand("simulate",        CommandLine::kSimulateCommands         ),

--- a/src/openrct2/command_line/SimulateCommands.cpp
+++ b/src/openrct2/command_line/SimulateCommands.cpp
@@ -23,26 +23,36 @@
 
 using namespace OpenRCT2;
 
+// clang-format off
+static constexpr CommandLineOptionDefinition kNoOptions[]
+{
+    kOptionTableEnd
+};
+
 static exitcode_t HandleSimulate(CommandLineArgEnumerator* argEnumerator);
 
-const CommandLineCommand CommandLine::kSimulateCommands[]{ // Main commands
-                                                           DefineCommand("", "<ticks>", nullptr, HandleSimulate),
-                                                           kCommandTableEnd
+const CommandLineCommand CommandLine::kSimulateCommands[]{
+    // Main commands
+    DefineCommand("", "<park file> <ticks>", kNoOptions, HandleSimulate),
+    kCommandTableEnd
 };
+// clang-format on
 
 static exitcode_t HandleSimulate(CommandLineArgEnumerator* argEnumerator)
 {
-    const char** argv = const_cast<const char**>(argEnumerator->GetArguments()) + argEnumerator->GetIndex();
-    int32_t argc = argEnumerator->GetCount() - argEnumerator->GetIndex();
-
-    if (argc < 2)
+    const utf8* inputPath;
+    if (!argEnumerator->TryPopString(&inputPath))
     {
-        Console::Error::WriteLine("Missing arguments <sv6-file> <ticks>.");
+        Console::Error::WriteLine("Expected a save file path");
         return EXITCODE_FAIL;
     }
 
-    const char* inputPath = argv[0];
-    uint32_t ticks = atol(argv[1]);
+    int32_t ticks;
+    if (!argEnumerator->TryPopInteger(&ticks))
+    {
+        Console::Error::WriteLine("Expected a number of ticks to simulate");
+        return EXITCODE_FAIL;
+    }
 
     gOpenRCT2Headless = true;
 
@@ -59,7 +69,7 @@ static exitcode_t HandleSimulate(CommandLineArgEnumerator* argEnumerator)
         }
 
         Console::WriteLine("Running %d ticks...", ticks);
-        for (uint32_t i = 0; i < ticks; i++)
+        for (int32_t i = 0; i < ticks; i++)
         {
             gameStateUpdateLogic();
         }

--- a/src/openrct2/core/Compression.h
+++ b/src/openrct2/core/Compression.h
@@ -17,7 +17,7 @@
 
 namespace OpenRCT2::Compression
 {
-    // zlib doesn't use 0 as a real compression level, so use it to mean no compression
+    // both zlib and zstd don't use 0 as a real compression level, so use it to mean no compression
     constexpr int16_t kNoCompressionLevel = 0;
 
     // Zlib methods, using the DEFLATE compression algorithm
@@ -36,4 +36,22 @@ namespace OpenRCT2::Compression
         int16_t level = kZlibDefaultCompressionLevel);
     bool zlibDecompress(
         IStream& source, uint64_t sourceLength, IStream& dest, uint64_t decompressLength, ZlibHeaderType header);
+
+    // Zstd methods, using the ZStandard compression algorithm
+    constexpr int16_t kZstdDefaultCompressionLevel = 3;
+
+    // Options for optional metadata to attach to a ZStandard frame. Zstd default is length-only,
+    // but callers to zstdCompress should use whatever is not already duplicated by other headers.
+    enum class ZstdMetadata
+    {
+        none = 0,
+        length = 1,
+        checksum = 2,
+        both = 3,
+    };
+
+    bool zstdCompress(
+        IStream& source, uint64_t sourceLength, IStream& dest, ZstdMetadata metadata,
+        int16_t level = kZstdDefaultCompressionLevel);
+    bool zstdDecompress(IStream& source, uint64_t sourceLength, IStream& dest, uint64_t decompressLength);
 } // namespace OpenRCT2::Compression

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -49,7 +49,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kNetworkStreamVersion = 0;
+constexpr uint8_t kNetworkStreamVersion = 1;
 
 const std::string kNetworkStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kNetworkStreamVersion);
 
@@ -2876,7 +2876,7 @@ bool NetworkBase::SaveMap(IStream* stream, const std::vector<const ObjectReposit
         exporter->ExportObjectsList = objects;
 
         auto& gameState = getGameState();
-        exporter->Export(gameState, *stream);
+        exporter->Export(gameState, *stream, kParkFileNetCompressionLevel);
         result = true;
     }
     catch (const std::exception& e)

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -17,6 +17,7 @@
 #include "../OpenRCT2.h"
 #include "../ParkImporter.h"
 #include "../Version.h"
+#include "../config/Config.h"
 #include "../core/Console.hpp"
 #include "../core/Crypt.h"
 #include "../core/DataSerialiser.h"
@@ -2766,7 +2767,7 @@ int32_t ScenarioSave(GameState_t& gameState, u8string_view path, int32_t flags)
         {
             // s6exporter->SaveGame(path);
         }
-        parkFile->Save(gameState, path, Compression::kZlibDefaultCompressionLevel);
+        parkFile->Save(gameState, path, gIsAutosave ? kParkFileAutoCompressionLevel : kParkFileSaveCompressionLevel);
         result = true;
     }
     catch (const std::exception& e)

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -22,16 +22,21 @@ namespace OpenRCT2
     struct GameState_t;
 
     // Current version that is saved.
-    constexpr uint32_t kParkFileCurrentVersion = 56;
+    constexpr uint32_t kParkFileCurrentVersion = 57;
 
     // The minimum version that is forwards compatible with the current version.
-    constexpr uint32_t kParkFileMinVersion = 55;
+    constexpr uint32_t kParkFileMinVersion = 57;
 
     // The minimum version that is backwards compatible with the current version.
     // If this is increased beyond 0, uncomment the checks in ParkFile.cpp and Context.cpp!
     constexpr uint32_t kParkFileMinSupportedVersion = 0x0;
 
     constexpr uint32_t kParkFileMagic = 0x4B524150; // PARK
+
+    // ZStd compression levels to use for various types of saves
+    constexpr int16_t kParkFileSaveCompressionLevel = 7;
+    constexpr int16_t kParkFileAutoCompressionLevel = 4;
+    constexpr int16_t kParkFileNetCompressionLevel = 4;
 
     struct IStream;
 
@@ -62,11 +67,7 @@ namespace OpenRCT2
     public:
         std::vector<const ObjectRepositoryItem*> ExportObjectsList;
 
-        void Export(
-            OpenRCT2::GameState_t& gameState, std::string_view path,
-            int16_t compressionLevel = Compression::kZlibDefaultCompressionLevel);
-        void Export(
-            OpenRCT2::GameState_t& gameState, OpenRCT2::IStream& stream,
-            int16_t compressionLevel = Compression::kZlibDefaultCompressionLevel);
+        void Export(OpenRCT2::GameState_t& gameState, std::string_view path, int16_t compressionLevel);
+        void Export(OpenRCT2::GameState_t& gameState, OpenRCT2::IStream& stream, int16_t compressionLevel);
     };
 } // namespace OpenRCT2

--- a/src/openrct2/platform/Crash.cpp
+++ b/src/openrct2/platform/Crash.cpp
@@ -139,6 +139,8 @@ static bool OnCrash(
         FileStream source(dumpFilePath, FileMode::open);
         FileStream dest(dumpFilePathGZIP, FileMode::write);
 
+        // We could switch this to zstdCompress() if supported by backtrace.io. If you switch it,
+        // use the extension .zst and ZstdMetadataType::both to use the appropriate metadata.
         if (Compression::zlibCompress(source, source.GetLength(), dest, Compression::ZlibHeaderType::gzip))
         {
             // TODO: enable upload of gzip-compressed dumps once supported on
@@ -183,7 +185,7 @@ static bool OnCrash(
         exporter->ExportObjectsList = objManager.GetPackableObjects();
 
         auto& gameState = getGameState();
-        exporter->Export(gameState, saveFilePathUTF8.c_str());
+        exporter->Export(gameState, saveFilePathUTF8.c_str(), kParkFileSaveCompressionLevel);
         savedGameDumped = true;
     }
     catch (const std::exception& e)

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -120,7 +120,7 @@ static bool ExportSave(MemoryStream& stream, std::unique_ptr<IContext>& context)
     exporter->ExportObjectsList = objManager.GetPackableObjects();
 
     auto& gameState = getGameState();
-    exporter->Export(gameState, stream);
+    exporter->Export(gameState, stream, OpenRCT2::kParkFileSaveCompressionLevel);
 
     return true;
 }


### PR DESCRIPTION
When it comes to comparing compression algorithms, there are largely two important metrics: compression (and decompression) speed, and compression ratio. Compared to Zlib, which is the current compression library used by OpenRCT2, most algorithms only improve on it in one of these factors, such as LZ4 being faster with a worse compression ratio, or LZMA having a better compression ratio at a slower speed. However, the relatively new compression algorithm [ZStandard](https://github.com/facebook/zstd) (Zstd, not to be confused with Zlib) developed by Facebook is generally both faster than Zlib and produces smaller results at the same time. Both Zlib and Zstd have multiple compression levels to tune the priority between speed and compression ratio, but Zstd generally has a compression level that is strictly better than any given Zlib level.

![Graph comparing Zstd and Zlib compression levels, showing Zstd compression being both faster and smaller than Zstd compression.](https://github.com/facebook/zstd/blob/dev/doc/images/CSpeed2.png?raw=true)
(Provided by the Zstd project's [Github page](https://github.com/facebook/zstd?tab=readme-ov-file#benchmarks))

I had been thinking about experimenting with adding Zstd to OpenRCT2 for a while, knowing that both compression speed and ratio would have a significant impact on networking, as improving both of these would decrease the time it takes for the client to receive the park data, and therefore how much catching up it has to do. While investigating it, I saw that the PARK format has a field for the type of compression used, which makes it simple to just add a new value there to indicate Zstd compression. Similarly, I noticed that Zlib was being used for the replay files, so I decided to switch that one over as well.

One question then is what compression level to use with Zstd. The default level is 3, but the standard levels range from 1 to 19. (The levels do go lower with the negative "fast" levels, as well as the higher "ultra" levels 20-22. However, the negative levels aren't very useful for this, and the ultra levels are not recommended by Facebook due to their increased memory usage.) Since the best level to use for people may vary by machine, I decided to add config options to config.ini for each of the cases that a save file is generated (so separate options for auto saves, manual saves, saves for network transfers, and replay file saves). I didn't add options to the UI to adjust these, as these would only be power-user options, and the majority of users shouldn't ever adjust these. The question, then, is what default levels should these configs use.

To test how the different compression levels perform, it helps to have a representative sample of the data being compressed. With that in mind, I downloaded a ton of .park save files off of RCTgo, collecting 477 files that should be fairly representative. I then extracted and decompressed the chunks section of these files to use for benchmarking. I then ran the benchmarking tool built into the `zstd` command-line tool on all the files with all 19 levels, averaged the result across the files, and analyzed the result. This is the graph I got from the results of this testing (x axis is in MB/s, and y axis is compressed size / uncompressed size):

![Graph showing how Zstd performs at different compression levels with OpenRCT2 park file data](https://github.com/user-attachments/assets/10a9464e-954e-4850-ad9f-7b3d7f4f0b98)

With this information, I chose some different default compression levels for the different save cases. I then tested these specific levels against Zlib using another tool that supported both compression types (lzbench) to get the relative performance of making the switch from Zlib to Zstd.

* For Network and Automatic Saves, a good balance of speed and size is needed. For networking, smaller sizes means less time spent transferring data, but only if you're not spending more time compressing than you save in transferring time. As for auto-saves, decreasing the file size is useful for reducing the storage space used and reducing the time spent writing, but the longer spent compressing means the game can stutter for longer during the save. (Even if the auto-save compression and write is performed on a separate thread, it can still impact performance due to things like scheduling and reduced CPU clock rates.) The default compression level of 3 is a good choice for a balance between speed and compression ratio. However, the testing showed that level 4 is **very** similar performance-wise to level 3 for this test data, so I opted to go with level 4 instead for the slight size improvement. Compared to Zlib default level compression (which this replaces), Zstd level 4 compresses 12.8 times faster, and produces 12.5% smaller results.
* For manual saves, getting a smaller file is more important than speed. Since manual saves are triggered directly by the user, it's reasonable for the game to take longer compressing the data. Additionally, manual saves are generally intended to be kept for longer than auto-saves, so the resulting file size is more important for them. However, it's not worth it to dramatically slow down the compression speed for minimal size improvements, so a reasonable compromise is needed here. For this case, I chose a default compression level of 7, since the compression ratio levels off a lot after that level. Compared to Zlib default level compression, Zstd level 7 compresses 4.5 times faster, and produces 20.5% smaller results.
* For replay files, this gets a bit more complicated. I don't have access to a good representative sample of these files. However, with the change made in #24728, the largest portion of these files will be the chunks from the park data, so the sample data used here should hopefully be reasonably representative. Since this currently uses max-level Zlib compression, I assume this is a case where higher compression ratios is more important than speed. An obvious choice would be Zstd level 19 compression (or higher if we're ok with "ultra" levels), but based on the results of the testing, I instead went with level 18. This is because the results showed a bit of a falling off in the ratio going up from 18, and level 18 is already a significant upgrade. Compared to Zlib max level compression, Zstd level 18 compresses 1.7 times faster, and produces 28.0% smaller results.

The decompression speeds of both Zstd and Zlib don't change significantly with compression level, but in all three tested cases, Zstd decompresses about 3.5 to 3.9 times faster than Zlib, which is also useful.

There is certainly room here for more testing or fine tuning these compression levels based on feedback, so feel free to let me know if you want me to adjust these values or perform more tests. I can also remove the INI file options for these levels if you'd rather these levels simply be hard-coded into the game.

Since using a new compression algorithm breaks compatibility with older builds, I bumped the version numbers for the PARK files, the PARKREP files, and the networking version. Notably, the use of a variable for the compression type in the PARK files means I *could* have avoided bumping that version number. However, prior to #24701, OpenRCT2 didn't properly handle invalid compression types in the PARK header, so bumping the version number prevents builds from before that change from misinterpreting the PARK file. If a new compression type is added in the future, or `kParkFileMinVersion` gets bumped before this is merged, then the PARK file version does not need to be bumped again.

I did keep support for loading Gzip-compressed PARK and PARKREP files using Zlib for backwards compatibility. I don't see any reason that we would consider dropping this in the future, as we will still depend on Zlib to support loading things like PNG and ZIP files. This also still continues to use Gzip compression for crash logs. That *can* be switched over to using Zstd compression (with the file extension .zst), but before doing so, we should check if it's supported not only with things like backtrace.io, but also with common decompressing tools, especially those people might be using on Windows and macOS. For now, I'm keeping the crash log compression as Gzip compression.

Lastly, I went ahead and updated the `convert` command-line command to allow for updating PARK files with the new compression to make it easier to test this change. I also added a new argument `--compress-level` (or `-l`) that lets you specify a compression level to use. This could be useful to, for example, re-compress park files with a higher compression level before releasing a new title sequence.