### PR TITLE
Fix new ride window authors

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#24468] [Plugin] Add awards to plugin API.
 - Feature: [#24702] [Plugin] Add bindings for missing cheats (forcedParkRating, ignoreRidePrice, makeAllDestructible).
 - Fix: [#24598] Cannot load .park files that use official legacy footpaths by accident.
+- Fix: [#24773] The new ride window debug authors does not show the correct authors for non legacy ride objects.
 
 0.4.24 (2025-07-05)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -980,14 +980,12 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Draw object author(s) if debugging tools are active
-            if (Config::Get().general.DebuggingTools)
+            if (Config::Get().general.DebuggingTools && rideObj->GetAuthors().size() > 0)
             {
-                auto repoItem = ObjectRepositoryFindObjectByEntry(&(rideObj->GetObjectEntry()));
-
-                StringId authorStringId = repoItem->Authors.size() > 1 ? STR_AUTHORS_STRING : STR_AUTHOR_STRING;
+                const auto& authors = rideObj->GetAuthors();
 
                 std::string authorsString;
-                for (auto& author : repoItem->Authors)
+                for (auto& author : authors)
                 {
                     if (!authorsString.empty())
                         authorsString.append(", ");
@@ -996,7 +994,7 @@ namespace OpenRCT2::Ui::Windows
                 }
 
                 ft = Formatter();
-                ft.Add<StringId>(authorStringId);
+                ft.Add<StringId>(authors.size() > 1 ? STR_AUTHORS_STRING : STR_AUTHOR_STRING);
                 ft.Add<const char*>(authorsString.c_str());
 
                 DrawTextEllipsised(

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -980,7 +980,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Draw object author(s) if debugging tools are active
-            if (Config::Get().general.DebuggingTools && rideObj->GetAuthors().size() > 0)
+            if (Config::Get().general.DebuggingTools && !rideObj->GetAuthors().empty())
             {
                 const auto& authors = rideObj->GetAuthors();
 


### PR DESCRIPTION
This fixes the new ride window debug authors showing incorrect authors for non legacy ride objects. You need to have debug tools enabled in the options to see this.

Judging by the comments, the function `Object::GetObjectEntry` is deprecated and only returns a legacy object entry, so it's presumably looking up some random object and getting the authors from there. This is one of only a few remaining uses of this function.

<img width="351" height="246" alt="authorbug" src="https://github.com/user-attachments/assets/6575b17e-e002-4ef0-96b6-db4724a48472" />
<img width="351" height="246" alt="authorfix" src="https://github.com/user-attachments/assets/bd9ac1a4-5cb3-4c14-bade-aff9b9773c5a" />
