### PR TITLE
Fix scenery and new ride window non legacy object filters

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Change: [#24730] Security guards now only walk slowly in crowded areas.
 - Fix: [#24598] Cannot load .park files that use official legacy footpaths by accident.
 - Fix: [#24773] The new ride window debug authors does not show the correct authors for non legacy ride objects.
+- Fix: [#24775] The scenery and new ride windows do not filter by file name or identifier correctly for non legacy objects.
 
 0.4.24 (2025-07-05)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -786,9 +786,7 @@ namespace OpenRCT2::Ui::Windows
 
         bool IsFilterInIdentifier(const RideObject& rideObject)
         {
-            auto objectName = rideObject.GetObjectEntry().GetName();
-
-            return String::contains(objectName, _filter, true);
+            return String::contains(rideObject.GetIdentifier(), _filter, true);
         }
 
         bool IsFilterInFilename(const RideObject& rideObject)

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -793,8 +793,7 @@ namespace OpenRCT2::Ui::Windows
 
         bool IsFilterInFilename(const RideObject& rideObject)
         {
-            auto repoItem = ObjectRepositoryFindObjectByEntry(&(rideObject.GetObjectEntry()));
-
+            const auto* const repoItem = OpenRCT2::GetContext()->GetObjectRepository().FindObject(rideObject.GetIdentifier());
             return String::contains(repoItem->Path, _filter, true);
         }
 

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -1366,7 +1366,7 @@ namespace OpenRCT2::Ui::Windows
 
         bool IsFilterInFilename(const Object& object)
         {
-            auto repoItem = ObjectRepositoryFindObjectByEntry(&(object.GetObjectEntry()));
+            const auto* const repoItem = OpenRCT2::GetContext()->GetObjectRepository().FindObject(object.GetIdentifier());
             return String::contains(repoItem->Path, _filteredSceneryTab.Filter, true);
         }
 


### PR DESCRIPTION
This fixes the scenery and new ride window not filtering non legacy object file names or identifiers correctly.

Both windows looked up the legacy object for the file path, and the new ride window used it for the identifier. Both now use the same code for each.

Here are some test objects:
[filter test objects.zip](https://github.com/user-attachments/files/21219192/filter.test.objects.zip)
There are two of each because the issue does not always happen when there is only one object. The legacy object lookup needs to clash for the bug to show.
You can filter with "filtertest" and "zzzz" for the file names, and "blabla" and "yehyeh" for the ride identifiers.
The rides are in the gentle rides tab.