### PR TITLE
Smooth map based on inferred PNG image size, not leftover setting

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Feature: [#24702] [Plugin] Add bindings for missing cheats (forcedParkRating, ignoreRidePrice, makeAllDestructible).
 - Change: [#24730] Security guards now only walk slowly in crowded areas.
 - Fix: [#24598] Cannot load .park files that use official legacy footpaths by accident.
+- Fix: [#24711] The map soothing function only partially works for custom height map image files.
 - Fix: [#24773] The new ride window debug authors does not show the correct authors for non legacy ride objects.
 - Fix: [#24775] The scenery and new ride windows do not filter by file name or identifier correctly for non legacy objects.
 

--- a/src/openrct2/world/map_generator/PngTerrainGenerator.cpp
+++ b/src/openrct2/world/map_generator/PngTerrainGenerator.cpp
@@ -156,9 +156,9 @@ namespace OpenRCT2::World::MapGenerator
         HeightMap dest = _heightMapData;
 
         // Get technical map size, +2 for the black tiles around the map
-        auto maxWidth = static_cast<int32_t>(dest.width + 2);
-        auto maxHeight = static_cast<int32_t>(dest.height + 2);
-        MapInit({ maxHeight, maxWidth });
+        auto mapWidth = static_cast<int32_t>(dest.width + 2);
+        auto mapHeight = static_cast<int32_t>(dest.height + 2);
+        MapInit({ mapHeight, mapWidth });
 
         if (settings->smooth_height_map)
         {
@@ -236,7 +236,7 @@ namespace OpenRCT2::World::MapGenerator
         if (settings->smoothTileEdges)
         {
             // Set the tile slopes so that there are no cliffs
-            smoothMap(settings->mapSize, smoothTileWeak);
+            smoothMap({ mapWidth, mapHeight }, smoothTileWeak);
         }
     }
 } // namespace OpenRCT2::World::MapGenerator


### PR DESCRIPTION
When applying tile smoothing in the map generator, a generalised loop is used to iterate over the entire map (#24280). To this end, the map size property from the generator settings struct is used. However, for PNG images, the map size is not set by the user, but _inferred_ from the selected PNG image. This leads to only part of the map being iterated over.

Fixes #24711, #24729