### PR TITLE
Fix track deletion confirmation prompt not being aligned vertically 

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Feature: [#24702] [Plugin] Add bindings for missing cheats (forcedParkRating, ignoreRidePrice, makeAllDestructible).
 - Change: [#24730] Security guards now only walk slowly in crowded areas.
 - Fix: [#24598] Cannot load .park files that use official legacy footpaths by accident.
+- Fix: [#24611] The confirmation prompt for track file deletion is not vertically aligned.
 - Fix: [#24711] The map smoothing function only partially works for custom height map image files.
 - Fix: [#24773] The new ride window debug authors does not show the correct authors for non legacy ride objects.
 - Fix: [#24775] The scenery and new ride windows do not filter by file name or identifier correctly for non legacy objects.

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -230,11 +230,17 @@ namespace OpenRCT2::Ui::Windows
     {
         DrawWidgets(rt);
 
+        const auto titleBarBottom = widgets[WIDX_TITLE].bottom;
+        const auto buttonTop = widgets[WIDX_PROMPT_DELETE].top;
+        const auto fontHeight = FontGetLineHeight(FontStyle::Medium);
+
+        const auto maxMessageHeight = buttonTop - titleBarBottom;
+        const auto messageTop = titleBarBottom + (maxMessageHeight - fontHeight) / 2;
+
         auto ft = Formatter();
         ft.Add<const utf8*>(_trackDesignFileReference->name.c_str());
         DrawTextWrapped(
-            rt, windowPos + ScreenCoordsXY{ (kWindowSizeDeletePrompt.width / 2), ((kWindowSizeDeletePrompt.height / 2) - 9) },
-            (kWindowSizeDeletePrompt.width - 4), STR_ARE_YOU_SURE_YOU_WANT_TO_PERMANENTLY_DELETE_TRACK, ft,
-            { TextAlignment::CENTRE });
+            rt, windowPos + ScreenCoordsXY{ width / 2, messageTop }, (width - 4),
+            STR_ARE_YOU_SURE_YOU_WANT_TO_PERMANENTLY_DELETE_TRACK, ft, { TextAlignment::CENTRE });
     }
 } // namespace OpenRCT2::Ui::Windows


### PR DESCRIPTION
Fix for issue #24611; the text in the track delete confirmation prompt is now aligned properly when Enlarged UI setting is enabled.

However, I am not fully satisfied as the text is still not exactly centered, it still is mostly fixed towards to the top. I have played around using different values in the ScreenCoordsXY parameter used for DrawTextWrapped() which is influencing the offset of the text, but even when I put value 1 or nothing, the text is still not perfectly aligned in the middle. Is this even achievable? Or is this fix good enough?

<img width="1300" height="668" alt="enlarged_ui_fix_not_centre" src="https://github.com/user-attachments/assets/511d4499-7551-47ba-a3be-d0b909c751e5" />


I have tested this on Windows 11 but the issue was reported for Ubuntu 24.04. I will test it tomorrow on Ubuntu as well, just need to update my machine as it is currently running 22.