### PR TITLE
Fix #24785: Scenery window filter to use filename instead of full path

### DIFF
--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -791,8 +791,7 @@ namespace OpenRCT2::Ui::Windows
 
         bool IsFilterInFilename(const RideObject& rideObject)
         {
-            const auto* const repoItem = OpenRCT2::GetContext()->GetObjectRepository().FindObject(rideObject.GetIdentifier());
-            return String::contains(repoItem->Path, _filter, true);
+            return String::contains(rideObject.GetFileName(), _filter, true);
         }
 
         void SetPressedTab()

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -1366,8 +1366,7 @@ namespace OpenRCT2::Ui::Windows
 
         bool IsFilterInFilename(const Object& object)
         {
-            const auto* const repoItem = OpenRCT2::GetContext()->GetObjectRepository().FindObject(object.GetIdentifier());
-            return String::contains(repoItem->Path, _filteredSceneryTab.Filter, true);
+            return String::contains(object.GetFileName(), _filteredSceneryTab.Filter, true);
         }
 
         void SortTabs()

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -197,6 +197,7 @@ private:
     bool _usesFallbackImages{};
     bool _isCompatibilityObject{};
     ImageIndex _baseImageId{ kImageIndexUndefined };
+    std::string _fileName;
 
 protected:
     StringTable& GetStringTable()
@@ -257,6 +258,15 @@ public:
     void SetDescriptor(const ObjectEntryDescriptor& value)
     {
         _descriptor = value;
+    }
+
+    std::string_view GetFileName() const
+    {
+        return _fileName;
+    }
+    void SetFileName(const std::string_view fileName)
+    {
+        _fileName = fileName;
     }
 
     constexpr bool UsesFallbackImages() const

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -226,7 +226,8 @@ namespace OpenRCT2::ObjectFactory
      * @note jRoot is deliberately left non-const: json_t behaviour changes when const
      */
     static std::unique_ptr<Object> CreateObjectFromJson(
-        IObjectRepository& objectRepository, json_t& jRoot, const IFileDataRetriever* fileRetriever, bool loadImageTable);
+        IObjectRepository& objectRepository, json_t& jRoot, const IFileDataRetriever* fileRetriever, bool loadImageTable,
+        const std::string_view path);
 
     static ObjectSourceGame ParseSourceGame(const std::string_view s)
     {
@@ -277,6 +278,7 @@ namespace OpenRCT2::ObjectFactory
             {
                 result = CreateObject(entry.GetType());
                 result->SetDescriptor(ObjectEntryDescriptor(entry));
+                result->SetFileName(OpenRCT2::Path::GetFileNameWithoutExtension(path));
 
                 utf8 objectName[kDatNameLength + 1] = { 0 };
                 ObjectEntryGetNameFixed(objectName, sizeof(objectName), &entry);
@@ -446,7 +448,7 @@ namespace OpenRCT2::ObjectFactory
             if (jRoot.is_object())
             {
                 auto fileDataRetriever = ZipDataRetriever(path, *archive);
-                return CreateObjectFromJson(objectRepository, jRoot, &fileDataRetriever, loadImages);
+                return CreateObjectFromJson(objectRepository, jRoot, &fileDataRetriever, loadImages, path);
             }
         }
         catch (const std::exception& e)
@@ -465,7 +467,7 @@ namespace OpenRCT2::ObjectFactory
         {
             json_t jRoot = Json::ReadFromFile(path.c_str());
             auto fileDataRetriever = FileSystemDataRetriever(Path::GetDirectory(path));
-            return CreateObjectFromJson(objectRepository, jRoot, &fileDataRetriever, loadImages);
+            return CreateObjectFromJson(objectRepository, jRoot, &fileDataRetriever, loadImages, path);
         }
         catch (const std::runtime_error& err)
         {
@@ -514,7 +516,8 @@ namespace OpenRCT2::ObjectFactory
     }
 
     std::unique_ptr<Object> CreateObjectFromJson(
-        IObjectRepository& objectRepository, json_t& jRoot, const IFileDataRetriever* fileRetriever, bool loadImageTable)
+        IObjectRepository& objectRepository, json_t& jRoot, const IFileDataRetriever* fileRetriever, bool loadImageTable,
+        const std::string_view path)
     {
         if (!jRoot.is_object())
         {
@@ -573,6 +576,7 @@ namespace OpenRCT2::ObjectFactory
             result->SetVersion(version);
             result->SetIdentifier(id);
             result->SetDescriptor(descriptor);
+            result->SetFileName(OpenRCT2::Path::GetFileNameWithoutExtension(path));
             result->MarkAsJsonObject();
             auto readContext = ReadObjectContext(objectRepository, id, loadImageTable, fileRetriever);
             result->ReadJson(&readContext, jRoot);


### PR DESCRIPTION
Fixes #24785

#24775 is causing a crash when looking up some objects in the object repository when searching in the scenery / new ride window.
This changes it so that the object now keeps its own file name, so it's not necessary to look it up in the repo to get it, which is also only the file name and not the full path. I didn't catch before that it's possible to match every object by searching anything that happens to be in the path (this was always the case not a change in #24775).
Apologies for not noticing this bug before.