### PR TITLE
Fix Air Powered Vertical Coaster top section tunnels

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#24711] The map smoothing function only partially works for custom height map image files.
 - Fix: [#24773] The new ride window debug authors does not show the correct authors for non legacy ride objects.
 - Fix: [#24775] The scenery and new ride windows do not filter by file name or identifier correctly for non legacy objects.
+- Fix: [#24824] The Air Powered Vertical Coaster top section track piece has vertical tunnels (original bug).
 
 0.4.24 (2025-07-05)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/coaster/AirPoweredVerticalCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/AirPoweredVerticalCoaster.cpp
@@ -903,7 +903,6 @@ static void AirPoweredVerticalRCTrackVerticalTop(
                 PaintAddImageAsParentRotated(
                     session, direction, imageIdT, { 0, 0, height }, { { 33, 6, height }, { 2, 20, 1 } });
             }
-            PaintUtilSetVerticalTunnel(session, height + 80);
             break;
         case 2:
             imageIdT = session.TrackColours.WithIndex(imageIds[direction][3]);
@@ -917,7 +916,6 @@ static void AirPoweredVerticalRCTrackVerticalTop(
                 PaintAddImageAsParentRotated(
                     session, direction, imageIdT, { 0, 0, height }, { { 0, 6, height }, { 2, 20, 15 } });
             }
-            PaintUtilSetVerticalTunnel(session, height + 80);
             break;
         case 3:
             imageIdS = session.SupportColours.WithIndex(imageIds[direction][4]);


### PR DESCRIPTION
This fixes the Air Powered Vertical Coaster top section track piece having vertical tunnels when it should have none. This is an original bug from RCT1, possibly copied accidentally from the vertical track piece when it was originally made.

<img width="300" height="220" alt="airpoweredtoptunnelbug" src="https://github.com/user-attachments/assets/0055ae75-2e4d-43d7-bb4c-2c2f16d9a8dc" /> <img width="300" height="220" alt="airpoweredtoptunnelfix" src="https://github.com/user-attachments/assets/b8b4a770-77e8-42e9-bc48-40885372b25d" />

RCT1 save:
[airpoweredtoptunnelsbug.zip](https://github.com/user-attachments/files/21403130/airpoweredtoptunnelsbug.zip)
