### PR TITLE
Fix River Rapids flat to gentle track piece tunnels

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Fix: [#24773] The new ride window debug authors does not show the correct authors for non legacy ride objects.
 - Fix: [#24775] The scenery and new ride windows do not filter by file name or identifier correctly for non legacy objects.
 - Fix: [#24824] The Air Powered Vertical Coaster top section track piece has vertical tunnels (original bug).
+- Fix: [#24825] The River Rapids flat-to-gentle track piece tunnels are incorrect on the gentle side.
 
 0.4.24 (2025-07-05)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/water/RiverRapids.cpp
+++ b/src/openrct2/paint/track/water/RiverRapids.cpp
@@ -348,7 +348,8 @@ static void PaintRiverRapidsTrack25DegToFlatB(
     DrawSupportForSequenceA<TrackElemType::FlatToUp25>(
         session, supportType.wooden, 0, direction, height, session.SupportColours);
 
-    PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
+    const auto tunnelType = direction == 0 || direction == 3 ? TunnelSubType::Flat : TunnelSubType::SlopeEnd;
+    PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, tunnelType);
 
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 48);


### PR DESCRIPTION
This fixes the tunnels on the gentle side of the flat to gentle track piece of the River Rapids. They are different from how they are in RCT1 and 2, and this fixes them, it is also the tunnels that all other track types use for this track piece.

Here are some pictures from RCT1 - Current ORCT2 - this fix
<img width="272" height="223" alt="riverrapidstunnelrct1" src="https://github.com/user-attachments/assets/43117c2b-d392-401b-9058-e972fa28d268" />
<img width="272" height="223" alt="riverrapidstunnelbug" src="https://github.com/user-attachments/assets/e5a92486-b5a1-4699-8ad6-6dfbaf440867" />
<img width="272" height="223" alt="riverrapidstunnelfix" src="https://github.com/user-attachments/assets/bf92924c-1cbc-42b3-ae43-ca1d0da30a67" />

RCT1 save and ORCT2 save:
[riverrapidsflattogentletunnel.zip](https://github.com/user-attachments/files/21403750/riverrapidsflattogentletunnel.zip)
