### PR TITLE
Fix Junior Roller Coaster flat to steep tunnels

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Fix: [#24775] The scenery and new ride windows do not filter by file name or identifier correctly for non legacy objects.
 - Fix: [#24824] The Air Powered Vertical Coaster top section track piece has vertical tunnels (original bug).
 - Fix: [#24825] The River Rapids flat-to-gentle track piece tunnels are incorrect on the gentle side.
+- Fix: [#24826] The Junior Roller Coaster flat-to-steep track piece tunnels are incorrect.
 
 0.4.24 (2025-07-05)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/coaster/JuniorRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/JuniorRollerCoaster.cpp
@@ -5592,7 +5592,7 @@ static void JuniorRCFlatTo60DegUpPaintSetup(
     switch (direction)
     {
         case 0:
-            PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::SlopeStart);
+            PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::Flat);
             break;
         case 1:
             PaintUtilPushTunnelRight(session, height + 24, kTunnelGroup, TunnelSubType::SlopeEnd);
@@ -5601,7 +5601,7 @@ static void JuniorRCFlatTo60DegUpPaintSetup(
             PaintUtilPushTunnelLeft(session, height + 24, kTunnelGroup, TunnelSubType::SlopeEnd);
             break;
         case 3:
-            PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::SlopeStart);
+            PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::Flat);
             break;
     }
 
@@ -5655,16 +5655,16 @@ static void JuniorRC60DegUpToFlatPaintSetup(
     switch (direction)
     {
         case 0:
-            PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::SlopeStart);
+            PaintUtilPushTunnelLeft(session, height - 8, kTunnelGroup, TunnelSubType::SlopeStart);
             break;
         case 1:
-            PaintUtilPushTunnelRight(session, height + 24, kTunnelGroup, TunnelSubType::SlopeEnd);
+            PaintUtilPushTunnelRight(session, height + 24, kTunnelGroup, TunnelSubType::Flat);
             break;
         case 2:
-            PaintUtilPushTunnelLeft(session, height + 24, kTunnelGroup, TunnelSubType::SlopeEnd);
+            PaintUtilPushTunnelLeft(session, height + 24, kTunnelGroup, TunnelSubType::Flat);
             break;
         case 3:
-            PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::SlopeStart);
+            PaintUtilPushTunnelRight(session, height - 8, kTunnelGroup, TunnelSubType::SlopeStart);
             break;
     }
 


### PR DESCRIPTION
This fixes some of the Junior Roller Coaster flat to steep track piece tunnels. They are different to how they appear in RCT1. This fixes that, they now use the same tunnels as all other track types use for these pieces.

RCT1 - current ORCT2 - this fix
<img width="334" height="291" alt="juniorflattosteeprct1" src="https://github.com/user-attachments/assets/234ae47b-125c-46e8-9412-d00582b35d5c" />
<img width="334" height="291" alt="juniorflattosteepbug" src="https://github.com/user-attachments/assets/4141719b-7ab5-40f2-bcc1-762f2bbf3020" />
<img width="334" height="291" alt="juniorflattosteepfix" src="https://github.com/user-attachments/assets/e7405647-adba-4327-808b-00f1ab4375bd" />

RCT1 save:
[juniorflattosteeptunnels.zip](https://github.com/user-attachments/files/21405434/juniorflattosteeptunnels.zip)
