### PR TITLE
Fix custom RCT1 scenarios potentially being confused with official ones

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,6 +13,7 @@
 - Fix: [#24824] The Air Powered Vertical Coaster top section track piece has vertical tunnels (original bug).
 - Fix: [#24825] The River Rapids flat-to-gentle track piece tunnels are incorrect on the gentle side.
 - Fix: [#24826] The Junior Roller Coaster flat-to-steep track piece tunnels are incorrect.
+- Fix: [#24831] Park names are being overwritten for custom RCT1 scenarios that use competition id slots.
 
 0.4.24 (2025-07-05)
 ------------------------------------------------------------------------

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2424,7 +2424,14 @@ namespace OpenRCT2::RCT1
             if (scNumber != -1)
             {
                 SourceDescriptor desc;
-                if (ScenarioSources::TryGetById(scNumber, &desc) && !desc.textObjectId.empty())
+                // If no entry is found, this is a custom scenario
+                bool isOfficial = ScenarioSources::TryGetById(_s4.ScenarioSlotIndex, &desc);
+
+                // Perform an additional name check if this is detected to be a competition scenario
+                if (isOfficial && desc.category == ScenarioCategory::competitions)
+                    isOfficial = ScenarioSources::TryGetByName(_s4.ScenarioName, &desc);
+
+                if (isOfficial && !desc.textObjectId.empty())
                 {
                     auto& objManager = GetContext()->GetObjectManager();
 


### PR DESCRIPTION
Fixes #24831 by applying the same fix as the one from #24518. ~~Not sure if this does anything for #24830.~~

@ZeeMaji Could you test this?