### PR TITLE
Add tunnels to dive loop track pieces

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Fix: [#24001] Sloped diagonal metal supports that are offset with a crossbeam draw incorrectly.
 - Fix: [#24173] Allow all game speeds between 1 and 8 if developer mode is on.
 - Fix: [#24745] Potential crash when lighting effects are enabled and loading a save or a new scenario.
+- Fix: [#24835] Dive loop track pieces do not have tunnels.
 - Fix: [#24915] LIM Launched (original bug), Corkscrew and Twister Roller Coaster inline twists have some incorrect tunnels.
 - Fix: [#24953] Crash when opening the Scenario Editor, Track Designer or Track Designs Manager.
 - Fix: [#24958] Android: fix crash when device is offline.

--- a/src/openrct2/paint/track/coaster/CorkscrewRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/CorkscrewRollerCoaster.cpp
@@ -20217,6 +20217,7 @@ static void CorkscrewRCTrackLeftEighthDiveLoopUpToOrthogonal(
                         { -16, -16, height }, { { 0, 6, height + 28 }, { 32, 20, 1 } });
                     MetalASupportsPaintSetup(
                         session, supportType.metal, MetalSupportPlace::topLeftSide, 0, height + 37, session.SupportColours);
+                    PaintUtilPushTunnelRight(session, height + 8, kTunnelGroup, TunnelSubType::Tall);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -20224,6 +20225,7 @@ static void CorkscrewRCTrackLeftEighthDiveLoopUpToOrthogonal(
                         { -16, -16, height }, { { 0, 6, height + 28 }, { 32, 20, 1 } });
                     MetalASupportsPaintSetup(
                         session, supportType.metal, MetalSupportPlace::topRightSide, 0, height + 37, session.SupportColours);
+                    PaintUtilPushTunnelLeft(session, height + 8, kTunnelGroup, TunnelSubType::Tall);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -20394,6 +20396,7 @@ static void CorkscrewRCTrackRightEighthDiveLoopUpToOrthogonal(
                         { -16, -16, height }, { { 6, 0, height + 28 }, { 20, 32, 1 } });
                     MetalASupportsPaintSetup(
                         session, supportType.metal, MetalSupportPlace::topLeftSide, 0, height + 37, session.SupportColours);
+                    PaintUtilPushTunnelRight(session, height + 8, kTunnelGroup, TunnelSubType::Tall);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -20401,6 +20404,7 @@ static void CorkscrewRCTrackRightEighthDiveLoopUpToOrthogonal(
                         { -16, -16, height }, { { 6, 0, height + 28 }, { 20, 32, 1 } });
                     MetalASupportsPaintSetup(
                         session, supportType.metal, MetalSupportPlace::topRightSide, 0, height + 37, session.SupportColours);
+                    PaintUtilPushTunnelLeft(session, height + 8, kTunnelGroup, TunnelSubType::Tall);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/LatticeTriangleTrack.cpp
+++ b/src/openrct2/paint/track/coaster/LatticeTriangleTrack.cpp
@@ -19341,6 +19341,7 @@ static void LatticeTriangleTrackLeftEighthDiveLoopUpToOrthogonal(
                         { -16, -16, height }, { { 0, 6, height + 36 }, { 32, 20, 1 } });
                     MetalASupportsPaintSetup(
                         session, supportType.metal, MetalSupportPlace::topLeftSide, 0, height + 44, session.SupportColours);
+                    PaintUtilPushTunnelRight(session, height + 8, kTunnelGroup, TunnelSubType::Tall);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -19348,6 +19349,7 @@ static void LatticeTriangleTrackLeftEighthDiveLoopUpToOrthogonal(
                         { -16, -16, height }, { { 0, 6, height + 36 }, { 32, 20, 1 } });
                     MetalASupportsPaintSetup(
                         session, supportType.metal, MetalSupportPlace::topRightSide, 0, height + 44, session.SupportColours);
+                    PaintUtilPushTunnelLeft(session, height + 8, kTunnelGroup, TunnelSubType::Tall);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -19518,6 +19520,7 @@ static void LatticeTriangleTrackRightEighthDiveLoopUpToOrthogonal(
                         { -16, -16, height }, { { 6, 0, height + 36 }, { 20, 32, 1 } });
                     MetalASupportsPaintSetup(
                         session, supportType.metal, MetalSupportPlace::topLeftSide, 0, height + 44, session.SupportColours);
+                    PaintUtilPushTunnelRight(session, height + 8, kTunnelGroup, TunnelSubType::Tall);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -19525,6 +19528,7 @@ static void LatticeTriangleTrackRightEighthDiveLoopUpToOrthogonal(
                         { -16, -16, height }, { { 6, 0, height + 36 }, { 20, 32, 1 } });
                     MetalASupportsPaintSetup(
                         session, supportType.metal, MetalSupportPlace::topRightSide, 0, height + 44, session.SupportColours);
+                    PaintUtilPushTunnelLeft(session, height + 8, kTunnelGroup, TunnelSubType::Tall);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/SingleRailRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/SingleRailRollerCoaster.cpp
@@ -19569,6 +19569,7 @@ namespace OpenRCT2::SingleRailRC
                             { -16, -16, height }, { { 0, 6, height + 26 }, { 32, 20, 1 } });
                         MetalASupportsPaintSetup(
                             session, supportType.metal, MetalSupportPlace::topLeftSide, 0, height + 33, session.SupportColours);
+                        PaintUtilPushTunnelRight(session, height + 8, kTunnelGroup, TunnelSubType::Tall);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -19577,6 +19578,7 @@ namespace OpenRCT2::SingleRailRC
                         MetalASupportsPaintSetup(
                             session, supportType.metal, MetalSupportPlace::topRightSide, 0, height + 33,
                             session.SupportColours);
+                        PaintUtilPushTunnelLeft(session, height + 8, kTunnelGroup, TunnelSubType::Tall);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
@@ -19749,6 +19751,7 @@ namespace OpenRCT2::SingleRailRC
                             { -16, -16, height }, { { 6, 0, height + 26 }, { 20, 32, 1 } });
                         MetalASupportsPaintSetup(
                             session, supportType.metal, MetalSupportPlace::topLeftSide, 0, height + 33, session.SupportColours);
+                        PaintUtilPushTunnelRight(session, height + 8, kTunnelGroup, TunnelSubType::Tall);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -19757,6 +19760,7 @@ namespace OpenRCT2::SingleRailRC
                         MetalASupportsPaintSetup(
                             session, supportType.metal, MetalSupportPlace::topRightSide, 0, height + 33,
                             session.SupportColours);
+                        PaintUtilPushTunnelLeft(session, height + 8, kTunnelGroup, TunnelSubType::Tall);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(

--- a/src/openrct2/paint/track/coaster/TwisterRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/TwisterRollerCoaster.cpp
@@ -19836,6 +19836,7 @@ static void TwisterRCTrackLeftEighthDiveLoopUpToOrthogonal(
                         { -16, -16, height }, { { 0, 6, height + 32 }, { 32, 20, 1 } });
                     MetalASupportsPaintSetup(
                         session, supportType.metal, MetalSupportPlace::topLeftSide, 0, height + 41, session.SupportColours);
+                    PaintUtilPushTunnelRight(session, height + 8, kTunnelGroup, TunnelSubType::Tall);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -19843,6 +19844,7 @@ static void TwisterRCTrackLeftEighthDiveLoopUpToOrthogonal(
                         { -16, -16, height }, { { 0, 6, height + 32 }, { 32, 20, 1 } });
                     MetalASupportsPaintSetup(
                         session, supportType.metal, MetalSupportPlace::topRightSide, 0, height + 41, session.SupportColours);
+                    PaintUtilPushTunnelLeft(session, height + 8, kTunnelGroup, TunnelSubType::Tall);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -20013,6 +20015,7 @@ static void TwisterRCTrackRightEighthDiveLoopUpToOrthogonal(
                         { -16, -16, height }, { { 6, 0, height + 32 }, { 20, 32, 1 } });
                     MetalASupportsPaintSetup(
                         session, supportType.metal, MetalSupportPlace::topLeftSide, 0, height + 41, session.SupportColours);
+                    PaintUtilPushTunnelRight(session, height + 8, kTunnelGroup, TunnelSubType::Tall);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -20020,6 +20023,7 @@ static void TwisterRCTrackRightEighthDiveLoopUpToOrthogonal(
                         { -16, -16, height }, { { 6, 0, height + 32 }, { 20, 32, 1 } });
                     MetalASupportsPaintSetup(
                         session, supportType.metal, MetalSupportPlace::topRightSide, 0, height + 41, session.SupportColours);
+                    PaintUtilPushTunnelLeft(session, height + 8, kTunnelGroup, TunnelSubType::Tall);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(


### PR DESCRIPTION
This fixes dive loop track pieces not having any tunnels. This gives them tall tunnels, as all others are unsuitable. They are still within the clearances of the track.

<img width="419" height="437" alt="divelooptunnelsbug" src="https://github.com/user-attachments/assets/2fb3196c-861e-4b0d-9045-f358b9b381c7" />
<img width="419" height="437" alt="divelooptunnelsfix" src="https://github.com/user-attachments/assets/5721d883-42a0-4c00-ae43-345468c91889" />
<img width="609" height="288" alt="divelooptunnels" src="https://github.com/user-attachments/assets/c2bc6239-114c-4620-b335-37d4106d6e8b" />

Save game:
[dive loop tunnels.zip](https://github.com/user-attachments/files/21422322/dive.loop.tunnels.zip)
