### PR TITLE
Rename tunnel door types and remove unused entries

### DIFF
--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -168,36 +168,32 @@ struct TunnelDescriptor
     uint8_t imageOffset;
 };
 static constexpr TunnelDescriptor kTunnels[] = {
-    { 2, 2, 0,   15, TunnelType::StandardFlat,        36 },  // TunnelType::StandardFlat
-    { 3, 3, 0,   15, TunnelType::StandardFlat,        40 },  // TunnelType::StandardSlopeStart
-    { 3, 5, -32,  4, TunnelType::StandardFlat,        44 },  // TunnelType::StandardSlopeEnd
-    { 3, 3, 0,   15, TunnelType::InvertedFlat,        48 },  // TunnelType::InvertedFlat
-    { 4, 4, 0,   15, TunnelType::InvertedFlat,        52 },  // TunnelType::InvertedSlopeStart
-    { 4, 7, -48,  4, TunnelType::InvertedFlat,        56 },  // TunnelType::InvertedSlopeEnd
-    { 2, 2, 0,   15, TunnelType::SquareFlat,          60 },  // TunnelType::SquareFlat
-    { 3, 3, 0,   15, TunnelType::SquareFlat,          64 },  // TunnelType::SquareSlopeStart
-    { 3, 5, -32,  4, TunnelType::SquareFlat,          68 },  // TunnelType::SquareSlopeEnd
-    { 3, 3, 0,   15, TunnelType::SquareFlat,          72 },  // TunnelType::InvertedSquare
-    { 2, 3, -16, 15, TunnelType::PathAndMiniGolf,     76 },  // TunnelType::PathAndMiniGolf
-    { 2, 3, -16, 15, TunnelType::Path11,              80 },  // TunnelType::Path11
-    { 2, 3, -16,  4, TunnelType::StandardFlatTo25Deg, 36 },  // TunnelType::StandardFlatTo25Deg
-    { 3, 4, -16,  4, TunnelType::InvertedFlatTo25Deg, 48 },  // TunnelType::InvertedFlatTo25Deg
-    { 2, 3, -16,  4, TunnelType::SquareFlatTo25Deg,   60 },  // TunnelType::SquareFlatTo25Deg
-    { 3, 4, -16,  4, TunnelType::SquareFlatTo25Deg,   72 },  // TunnelType::InvertedSquareFlatTo25Deg
-    { 2, 2, 0,   15, TunnelType::Doors0,              76 },  // TunnelType::Doors0
-    { 2, 2, 0,   15, TunnelType::Doors1,              80 },  // TunnelType::Doors1
-    { 2, 2, 0,   15, TunnelType::Doors2,              84 },  // TunnelType::Doors2
-    { 2, 2, 0,   15, TunnelType::Doors3,              88 },  // TunnelType::Doors3
-    { 2, 2, 0,   15, TunnelType::Doors4,              92 },  // TunnelType::Doors4
-    { 2, 2, 0,   15, TunnelType::Doors5,              96 },  // TunnelType::Doors5
-    { 2, 2, 0,   15, TunnelType::Doors6,              100 }, // TunnelType::Doors6
-    { 2, 3, -16,  4, TunnelType::Doors0,              76 },  // TunnelType::DoorsFlatTo25Deg0
-    { 2, 3, -16,  4, TunnelType::Doors1,              80 },  // TunnelType::DoorsFlatTo25Deg1
-    { 2, 3, -16,  4, TunnelType::Doors2,              84 },  // TunnelType::DoorsFlatTo25Deg2
-    { 2, 3, -16,  4, TunnelType::Doors3,              88 },  // TunnelType::DoorsFlatTo25Deg3
-    { 2, 3, -16,  4, TunnelType::Doors4,              92 },  // TunnelType::DoorsFlatTo25Deg4
-    { 2, 3, -16,  4, TunnelType::Doors5,              96 },  // TunnelType::DoorsFlatTo25Deg5
-    { 2, 3, -16,  4, TunnelType::Doors6,              100 }, // TunnelType::DoorsFlatTo25Deg6
+    { 2, 2, 0,   15, TunnelType::StandardFlat,                    36 }, // TunnelType::StandardFlat
+    { 3, 3, 0,   15, TunnelType::StandardFlat,                    40 }, // TunnelType::StandardSlopeStart
+    { 3, 5, -32,  4, TunnelType::StandardFlat,                    44 }, // TunnelType::StandardSlopeEnd
+    { 3, 3, 0,   15, TunnelType::InvertedFlat,                    48 }, // TunnelType::InvertedFlat
+    { 4, 4, 0,   15, TunnelType::InvertedFlat,                    52 }, // TunnelType::InvertedSlopeStart
+    { 4, 7, -48,  4, TunnelType::InvertedFlat,                    56 }, // TunnelType::InvertedSlopeEnd
+    { 2, 2, 0,   15, TunnelType::SquareFlat,                      60 }, // TunnelType::SquareFlat
+    { 3, 3, 0,   15, TunnelType::SquareFlat,                      64 }, // TunnelType::SquareSlopeStart
+    { 3, 5, -32,  4, TunnelType::SquareFlat,                      68 }, // TunnelType::SquareSlopeEnd
+    { 3, 3, 0,   15, TunnelType::SquareFlat,                      72 }, // TunnelType::InvertedSquare
+    { 2, 3, -16, 15, TunnelType::PathAndMiniGolf,                 76 }, // TunnelType::PathAndMiniGolf
+    { 2, 3, -16, 15, TunnelType::Path11,                          80 }, // TunnelType::Path11
+    { 2, 3, -16,  4, TunnelType::StandardFlatTo25Deg,             36 }, // TunnelType::StandardFlatTo25Deg
+    { 3, 4, -16,  4, TunnelType::InvertedFlatTo25Deg,             48 }, // TunnelType::InvertedFlatTo25Deg
+    { 2, 3, -16,  4, TunnelType::SquareFlatTo25Deg,               60 }, // TunnelType::SquareFlatTo25Deg
+    { 3, 4, -16,  4, TunnelType::SquareFlatTo25Deg,               72 }, // TunnelType::InvertedSquareFlatTo25Deg
+    { 2, 2, 0,   15, TunnelType::doorClosed,                      84 }, // TunnelType::doorClosed
+    { 2, 2, 0,   15, TunnelType::doorOpeningOutward,              88 }, // TunnelType::doorOpeningOutward
+    { 2, 2, 0,   15, TunnelType::doorOpenOutward,                 92 }, // TunnelType::doorOpenOutward
+    { 2, 2, 0,   15, TunnelType::doorOpeningInward,               96 }, // TunnelType::doorOpeningInward
+    { 2, 2, 0,   15, TunnelType::doorOpenInward,                 100 }, // TunnelType::doorOpenInward
+    { 2, 3, -16,  4, TunnelType::doorClosedFlatToDown25,          84 }, // TunnelType::doorClosedFlatToDown25
+    { 2, 3, -16,  4, TunnelType::doorOpeningOutwardFlatToDown25,  88 }, // TunnelType::doorOpeningOutwardFlatToDown25
+    { 2, 3, -16,  4, TunnelType::doorOpenOutwardFlatToDown25,     92 }, // TunnelType::doorOpenOutwardFlatToDown25
+    { 2, 3, -16,  4, TunnelType::doorOpeningInwardFlatToDown25,   96 }, // TunnelType::doorOpeningInwardFlatToDown25
+    { 2, 3, -16,  4, TunnelType::doorOpenInwardFlatToDown25,     100 }, // TunnelType::doorOpenInwardFlatToDown25
 };
 static_assert(std::size(kTunnels) == kTunnelTypeCount);
 

--- a/src/openrct2/paint/tile_element/Paint.Tunnel.h
+++ b/src/openrct2/paint/tile_element/Paint.Tunnel.h
@@ -37,24 +37,19 @@ enum class TunnelType : uint8_t
     InvertedSquareFlatTo25Deg = 15,
 
     // Ghost train doors
-    Doors0 = 16,
-    Doors1 = 17,
-    Doors2 = 18,
-    Doors3 = 19,
-    Doors4 = 20,
-    Doors5 = 21,
-    Doors6 = 22,
-
-    DoorsFlatTo25Deg0 = 23,
-    DoorsFlatTo25Deg1 = 24,
-    DoorsFlatTo25Deg2 = 25,
-    DoorsFlatTo25Deg3 = 26,
-    DoorsFlatTo25Deg4 = 27,
-    DoorsFlatTo25Deg5 = 28,
-    DoorsFlatTo25Deg6 = 29,
+    doorClosed = 16,
+    doorOpeningOutward = 17,
+    doorOpenOutward = 18,
+    doorOpeningInward = 19,
+    doorOpenInward = 20,
+    doorClosedFlatToDown25 = 21,
+    doorOpeningOutwardFlatToDown25 = 22,
+    doorOpenOutwardFlatToDown25 = 23,
+    doorOpeningInwardFlatToDown25 = 24,
+    doorOpenInwardFlatToDown25 = 25,
 };
 constexpr uint8_t kRegularTunnelTypeCount = 16;
-constexpr uint8_t kTunnelTypeCount = 30;
+constexpr uint8_t kTunnelTypeCount = 26;
 
 enum class TunnelGroup : uint8_t
 {

--- a/src/openrct2/paint/track/gentle/GhostTrain.cpp
+++ b/src/openrct2/paint/track/gentle/GhostTrain.cpp
@@ -153,25 +153,13 @@ static constexpr uint32_t kGhostTrainTrackPiecesBrakes[4] = {
 };
 
 static constexpr std::array<TunnelType, kLandEdgeDoorFrameCount> kDoorOpeningOutwardsToImage = {
-    TunnelType::Doors2, // closed
-    TunnelType::Doors3, // opening
-    TunnelType::Doors3, // opening
-    TunnelType::Doors4, // open
-    TunnelType::Doors3, // closing
-    TunnelType::Doors3, // closing
-    TunnelType::Doors2, // closed
-    TunnelType::Doors2, // unused
+    TunnelType::doorClosed,         TunnelType::doorOpeningOutward, TunnelType::doorOpeningOutward, TunnelType::doorOpenOutward,
+    TunnelType::doorOpeningOutward, TunnelType::doorOpeningOutward, TunnelType::doorClosed,         TunnelType::doorClosed,
 };
 
 static constexpr std::array<TunnelType, kLandEdgeDoorFrameCount> kDoorOpeningInwardsToImage = {
-    TunnelType::Doors2, // closed
-    TunnelType::Doors5, // opening
-    TunnelType::Doors5, // opening
-    TunnelType::Doors6, // open
-    TunnelType::Doors5, // closing
-    TunnelType::Doors5, // closing
-    TunnelType::Doors2, // closed
-    TunnelType::Doors2, // unused
+    TunnelType::doorClosed,        TunnelType::doorOpeningInward, TunnelType::doorOpeningInward, TunnelType::doorOpenInward,
+    TunnelType::doorOpeningInward, TunnelType::doorOpeningInward, TunnelType::doorClosed,        TunnelType::doorClosed,
 };
 
 static TunnelType GetTunnelDoorsImageStraightFlat(const TrackElement& trackElement, uint8_t direction)
@@ -187,29 +175,21 @@ static TunnelType GetTunnelDoorsImageStraightFlat(const TrackElement& trackEleme
         case 3:
             return kDoorOpeningInwardsToImage[trackElement.GetDoorAState()];
     }
-    return TunnelType::Doors2;
+    return TunnelType::doorClosed;
 }
 
 static constexpr std::array<TunnelType, kLandEdgeDoorFrameCount> kDoorFlatTo25DegOpeningOutwardsToImage = {
-    TunnelType::DoorsFlatTo25Deg2, // closed
-    TunnelType::DoorsFlatTo25Deg3, // opening
-    TunnelType::DoorsFlatTo25Deg3, // opening
-    TunnelType::DoorsFlatTo25Deg4, // open
-    TunnelType::DoorsFlatTo25Deg3, // closing
-    TunnelType::DoorsFlatTo25Deg3, // closing
-    TunnelType::DoorsFlatTo25Deg2, // closed
-    TunnelType::DoorsFlatTo25Deg2, // unused
+    TunnelType::doorClosedFlatToDown25,         TunnelType::doorOpeningOutwardFlatToDown25,
+    TunnelType::doorOpeningOutwardFlatToDown25, TunnelType::doorOpenOutwardFlatToDown25,
+    TunnelType::doorOpeningOutwardFlatToDown25, TunnelType::doorOpeningOutwardFlatToDown25,
+    TunnelType::doorClosedFlatToDown25,         TunnelType::doorClosedFlatToDown25,
 };
 
 static constexpr std::array<TunnelType, kLandEdgeDoorFrameCount> kDoorFlatTo25DegOpeningInwardsToImage = {
-    TunnelType::DoorsFlatTo25Deg2, // closed
-    TunnelType::DoorsFlatTo25Deg5, // opening
-    TunnelType::DoorsFlatTo25Deg5, // opening
-    TunnelType::DoorsFlatTo25Deg6, // open
-    TunnelType::DoorsFlatTo25Deg5, // closing
-    TunnelType::DoorsFlatTo25Deg5, // closing
-    TunnelType::DoorsFlatTo25Deg2, // closed
-    TunnelType::DoorsFlatTo25Deg2, // unused
+    TunnelType::doorClosedFlatToDown25,        TunnelType::doorOpeningInwardFlatToDown25,
+    TunnelType::doorOpeningInwardFlatToDown25, TunnelType::doorOpenInwardFlatToDown25,
+    TunnelType::doorOpeningInwardFlatToDown25, TunnelType::doorOpeningInwardFlatToDown25,
+    TunnelType::doorClosedFlatToDown25,        TunnelType::doorClosedFlatToDown25,
 };
 
 /** rct2: 0x00770BEC */


### PR DESCRIPTION
Just a quick cleanup of the door tunnel types. This renames them to make them clear what they actually are. Doors0 and Doors1 are removed as they were unused and didn't refer to a door sprite.