### PR TITLE
Android: Resolve hard-crash for network errors

### DIFF
--- a/src/openrct2-android/app/src/main/java/io/openrct2/HttpAndroid.java
+++ b/src/openrct2-android/app/src/main/java/io/openrct2/HttpAndroid.java
@@ -67,6 +67,7 @@ public class HttpAndroid {
         Response response = new Response();
         response.status = Status.Invalid;
         response.error = "Request failed";
+        response.body = null;
         try {
             InputStream inputStream = null;
             try {


### PR DESCRIPTION
It seems the C++ code assumes `body` is always defined, so if the network permission is revoked the game will always hard-crash on startup