### PR TITLE
Only add full initialized windows to the window list

### DIFF
--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -895,34 +895,33 @@ public:
             }
         }
 
-        auto itNew = g_window_list.insert(itDestPos, std::move(wp));
-        auto w = itNew->get();
-
         // Setup window
-        w->classification = cls;
-        w->flags = flags;
+        wp->classification = cls;
+        wp->flags = flags;
 
         // Play sounds and flash the window
         if (!(flags & (WF_STICK_TO_BACK | WF_STICK_TO_FRONT)))
         {
-            w->flags |= WF_WHITE_BORDER_MASK;
+            wp->flags |= WF_WHITE_BORDER_MASK;
             OpenRCT2::Audio::Play(OpenRCT2::Audio::SoundId::WindowOpen, 0, pos.x + (windowSize.width / 2));
         }
 
-        w->windowPos = pos;
-        w->width = windowSize.width;
-        w->height = windowSize.height;
-        w->min_width = windowSize.width;
-        w->max_width = windowSize.width;
-        w->min_height = windowSize.height;
-        w->max_height = windowSize.height;
+        wp->windowPos = pos;
+        wp->width = windowSize.width;
+        wp->height = windowSize.height;
+        wp->min_width = windowSize.width;
+        wp->max_width = windowSize.width;
+        wp->min_height = windowSize.height;
+        wp->max_height = windowSize.height;
 
-        w->focus = std::nullopt;
+        wp->focus = std::nullopt;
 
-        ColourSchemeUpdate(w);
-        w->Invalidate();
-        w->OnOpen();
-        return w;
+        ColourSchemeUpdate(wp.get());
+        wp->Invalidate();
+        wp->OnOpen();
+
+        auto itNew = g_window_list.insert(itDestPos, std::move(wp));
+        return itNew->get();
     }
 
     /**


### PR DESCRIPTION
This removes the possibility of a race condition where a window is added to the window list (`g_window_list`) but `OnOpen` has not been called. Many windows use `OnOpen` to set up required members so if `OnDraw` is called it may use uninitialized members.

This can happen with `ProgressWindow` if the asynchronous path in `Context::Initialize()` is taken when calling `InitialiseRepositories`. This is because the main thread will call `OnDraw` on all windows added to the list even if `OnOpen` has not been called on them. There is a short period of time where windows have been added but are not ready to have `OnDraw` be called. This change simply moves adding to the list to after the window is set up.