### PR TITLE
Fix #24777: Random checkbox ticked now cycles between possible colours in preview

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Fix: [#24761] The reliability bar in the ride window visually does not go below 10%.
 - Fix: [#24773] The new ride window debug authors does not show the correct authors for non legacy ride objects.
 - Fix: [#24775] The scenery and new ride windows do not filter by file name or identifier correctly for non legacy objects.
+- Fix: [#24777] The stall item preview cycles between all possible colours when random checkbox is ticked.
 - Fix: [#24794] The load/save browser does not resize cleanly when toggling the preview sidebar.
 - Fix: [#24824] The Air Powered Vertical Coaster top section track piece has vertical tunnels (original bug).
 - Fix: [#24825] The River Rapids flat-to-gentle track piece tunnels are incorrect on the gentle side.

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4873,16 +4873,7 @@ namespace OpenRCT2::Ui::Windows
                                                                               : rideEntry->shop_item[1];
                 if (ride->hasLifecycleFlag(RIDE_LIFECYCLE_RANDOM_SHOP_COLOURS))
                 {
-                    colour_t spriteColour = COLOUR_BLACK;
-                    // Limit update rate of preview to avoid making people dizzy.
-                    if ((getGameState().currentTicks % 64) == 0)
-                    {
-                        spriteColour++;
-                        if (spriteColour >= kColourNumNormal)
-                        {
-                            spriteColour = COLOUR_BLACK;
-                        }
-                    }
+                    colour_t spriteColour = (getGameState().currentTicks / 32) % COLOUR_COUNT;
 
                     GfxDrawSprite(rt, ImageId(GetShopItemDescriptor(shopItem).Image, spriteColour), screenCoords);
                 }


### PR DESCRIPTION
Fix addressing #24777 

I want some feedback on this fix, I noticed this bug a week or so ago and reported it, I then asked on the Discord how it should behave. I got a response saying it should cycle between possible colours. 

My solution was to use the currentTick value, as you can see it worked in quite a different way before but something must have changed to break it because I don't see how it did work. The sprite colour is always set to black and then... incremented? Doesn't make sense to me.

This solution works pretty well, except for one problem, when the game is paused the colour is also paused. But perhaps this isn't an issue? Either way it make me question myself, is this the right way to fix this? Maybe there should just be an instance variable to hold the preview colour so I can cycle through the colours that way. Any feedback would be much appreciated. 

This is what it looks like at the moment, colour shifts every 32 ticks, which I understand to be half a second.

![random_colour_animation](https://github.com/user-attachments/assets/9161d9c1-ed67-4c85-91f7-d0c8c20c0c08)
