### PR TITLE
Use static keystore for signing Android builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,6 +613,11 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.18
         with:
           key: android
+      - name: Setup keystore
+        run: |
+          echo "${{ secrets.OPENRCT2_KEYSTORE_CONTENTS }}" | base64 -d > keystore.jks
+          echo "OPENRCT2_KEYSTORE_FILE=${{ github.workspace }}/keystore.jks" >> $GITHUB_ENV
+          echo "OPENRCT2_KEYSTORE_PASSWORD=${{ secrets.OPENRCT2_KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
       - name: Install GCC problem matcher
         uses: ammaraskar/gcc-problem-matcher@master
       - name: Build OpenRCT2

--- a/scripts/create-android-keystore
+++ b/scripts/create-android-keystore
@@ -1,0 +1,48 @@
+#!/bin/bash
+# OpenRCT2 Android Keystore Creation Script
+# This script creates a sample keystore for signing Android APKs
+
+set -e
+
+# Configuration - modify these values as needed
+KEYSTORE_FILE="openrct2-release-key.keystore"
+KEY_ALIAS="openrct2"
+KEY_ALGORITHM="RSA"
+KEY_SIZE="2048"
+VALIDITY_DAYS="10950"  # 30 years
+
+# Certificate details
+CERT_DNAME="CN=OpenRCT2 Team, OU=Development, O=OpenRCT2 Team"
+
+if [ -z "$KEYSTORE_PASSWORD" ]; then
+    echo "Error: KEYSTORE_PASSWORD environment variable must be set"
+    echo "Usage: KEYSTORE_PASSWORD='your_secure_password' $0"
+    exit 1
+fi
+
+echo "Creating OpenRCT2 release keystore..."
+echo "File: $KEYSTORE_FILE"
+echo "Alias: $KEY_ALIAS"
+echo "Algorithm: $KEY_ALGORITHM $KEY_SIZE"
+echo "Validity: $VALIDITY_DAYS days"
+echo "DN: $CERT_DNAME"
+
+# Create the keystore
+keytool -genkeypair \
+    -keystore "$KEYSTORE_FILE" \
+    -alias "$KEY_ALIAS" \
+    -keyalg "$KEY_ALGORITHM" \
+    -keysize "$KEY_SIZE" \
+    -validity "$VALIDITY_DAYS" \
+    -dname "$CERT_DNAME" \
+    -storetype PKCS12 \
+    -storepass "$KEYSTORE_PASSWORD" \
+    -keypass "$KEYSTORE_PASSWORD" \
+    -noprompt
+
+echo "Keystore created successfully: $KEYSTORE_FILE"
+
+# Verify the keystore
+echo ""
+echo "Keystore information:"
+keytool -list -v -keystore "$KEYSTORE_FILE" -storepass "$KEYSTORE_PASSWORD"

--- a/src/openrct2-android/app/build.gradle
+++ b/src/openrct2-android/app/build.gradle
@@ -34,7 +34,12 @@ android {
     }
     buildTypes {
         release {
-            signingConfig signingConfigs.release
+            if (System.getenv('OPENRCT2_KEYSTORE_FILE') && System.getenv('OPENRCT2_KEYSTORE_PASSWORD')) {
+                signingConfig signingConfigs.release
+            } else {
+                // Fallback to ephemeral debug signing when keystore is not available
+                signingConfig signingConfigs.debug
+            }
         }
     }
 

--- a/src/openrct2-android/app/build.gradle
+++ b/src/openrct2-android/app/build.gradle
@@ -4,6 +4,18 @@ android {
     compileSdk 36
     ndkVersion "27.3.13750724" // Latest r27d (LTS), to be synced with CI container image
     namespace "io.openrct2"
+
+    signingConfigs {
+        release {
+            if (System.getenv('OPENRCT2_KEYSTORE_FILE') && System.getenv('OPENRCT2_KEYSTORE_PASSWORD')) {
+                storeFile file(System.getenv('OPENRCT2_KEYSTORE_FILE'))
+                storePassword System.getenv('OPENRCT2_KEYSTORE_PASSWORD')
+                keyAlias "openrct2"
+                keyPassword System.getenv('OPENRCT2_KEYSTORE_PASSWORD')  // Same as keystore password in PKCS12
+            }
+        }
+    }
+
     defaultConfig {
         applicationId 'io.openrct2'
         minSdkVersion 24
@@ -22,7 +34,7 @@ android {
     }
     buildTypes {
         release {
-            signingConfig signingConfigs.debug
+            signingConfig signingConfigs.release
         }
     }
 


### PR DESCRIPTION
Fixes #22861

GitHub Actions CI uses ephemeral debug keystore resulting in APKs being signed differently each time. This results in user not having trust in where the builds come from and Android rejecting the update due to mismatched keys.

This commit introduces a script to (re)create a keystore to be used for signing APKs in GitHub Actions, sets environment variables for CI job with generated key and modifies gradle project to consume those variables.

I have generated the keystore with aforementioned script and set secrects in the main repository with both the keystore password and keystore contents.

With this change, using an APK built in GitHub Actions you should see:
```
$ apksigner verify --print-certs /home/janisozaur/Downloads/OpenRCT2-v0.4.24-95-g92602ed602-Android/OpenRCT2-v0.4.24-95-g92602ed602-android-arm.apk 
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::loadLibrary has been called by org.conscrypt.NativeLibraryUtil in an unnamed module (file:/opt/android-sdk/build-tools/35.0.0/lib/apksigner.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled

Signer #1 certificate DN: CN=OpenRCT2 Team, OU=Development, O=OpenRCT2 Team
Signer #1 certificate SHA-256 digest: f22b57042c6d4114b40ce559216ac049cdae9b34b830f7b0f018bca090ef99a9
Signer #1 certificate SHA-1 digest: d6881bc89098179b2d769d8550042380261938bb
Signer #1 certificate MD5 digest: 79e09614695687d34b51ac1dfd4c8841
```

Instead of:
```
$ apksigner verify --print-certs /home/janisozaur/Downloads/OpenRCT2-v0.4.24-99-g53bd53d83e-Android/OpenRCT2-v0.4.24-99-g53bd53d83e-android-arm.apk
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::loadLibrary has been called by org.conscrypt.NativeLibraryUtil in an unnamed module (file:/opt/android-sdk/build-tools/35.0.0/lib/apksigner.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled

Signer #1 certificate DN: C=US, O=Android, CN=Android Debug
Signer #1 certificate SHA-256 digest: 7912e83c87a2a2fbfc7d76fe1e3b48af240cee4a0d4187bebc2cbeced1531892
Signer #1 certificate SHA-1 digest: 58d86cf1aa3d8b107b9502c19d092ce467868057
Signer #1 certificate MD5 digest: 7c311a396569a94911ebad9e5100a05a
```