### PR TITLE
Store paint stable sort option in park, default to true for new parks

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#24468] [Plugin] Add awards to plugin API.
 - Feature: [#24702] [Plugin] Add bindings for missing cheats (forcedParkRating, ignoreRidePrice, makeAllDestructible).
 - Feature: [#24794] The load/save browser can now optionally show mini map previews instead of screenshots.
+- Feature: [#24870] Use stable sorting for paint by default, store it in a park.
 - Improved: [#24812] Taiwan Park has been added to the Extras tab if it is present.
 - Improved: [OpenSFX#12] Add Brake Fix, Buy and Dinghy Slide running sounds.
 - Change: [#24730] Security guards now only walk slowly in crowded areas.

--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -10,6 +10,7 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
+#include <openrct2/GameState.h>
 #include <openrct2/core/Guard.hpp>
 #include <openrct2/localisation/Language.h>
 #include <openrct2/localisation/LocalisationService.h>
@@ -94,7 +95,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
 
                 case WIDX_TOGGLE_STABLE_PAINT_SORT:
-                    gPaintStableSort = !gPaintStableSort;
+                    getGameState().useStablePaintSort = !getGameState().useStablePaintSort;
                     GfxInvalidateScreen();
                     break;
             }
@@ -142,7 +143,7 @@ namespace OpenRCT2::Ui::Windows
             widgetSetCheckboxValue(*this, WIDX_TOGGLE_SHOW_SEGMENT_HEIGHTS, gShowSupportSegmentHeights);
             widgetSetCheckboxValue(*this, WIDX_TOGGLE_SHOW_BOUND_BOXES, gPaintBoundingBoxes);
             widgetSetCheckboxValue(*this, WIDX_TOGGLE_SHOW_DIRTY_VISUALS, gShowDirtyVisuals);
-            widgetSetCheckboxValue(*this, WIDX_TOGGLE_STABLE_PAINT_SORT, gPaintStableSort);
+            widgetSetCheckboxValue(*this, WIDX_TOGGLE_STABLE_PAINT_SORT, getGameState().useStablePaintSort);
         }
 
         void OnDraw(RenderTarget& rt) override

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -111,6 +111,7 @@ namespace OpenRCT2::Editor
         gameState.editorStep = EditorStep::ObjectSelection;
         gameState.park.Flags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
         gameState.scenarioCategory = ScenarioCategory::other;
+        gameState.useStablePaintSort = true; // Default to stable paint sort for new scenarios
         ViewportInitAll();
         WindowBase* mainWindow = OpenEditorWindows();
         mainWindow->SetViewportLocation(TileCoordsXYZ{ 75, 75, 14 }.ToCoordsXYZ());
@@ -154,6 +155,7 @@ namespace OpenRCT2::Editor
         gLegacyScene = LegacyScene::scenarioEditor;
         gameState.editorStep = EditorStep::OptionsSelection;
         gameState.scenarioCategory = ScenarioCategory::other;
+        gameState.useStablePaintSort = true; // Default to stable paint sort for converted scenarios
         ViewportInitAll();
         OpenEditorWindows();
         FinaliseMainView();

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -147,6 +147,9 @@ namespace OpenRCT2
          */
         uint32_t suggestedGuestMaximum;
 
+        /** Whether to use stable paint sort (true) or legacy paint sort (false) */
+        bool useStablePaintSort;
+
         CheatsState cheats;
     };
 

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -10,6 +10,7 @@
 #include "Paint.h"
 
 #include "../Context.h"
+#include "../GameState.h"
 #include "../config/Config.h"
 #include "../core/Guard.hpp"
 #include "../core/Money.hpp"
@@ -57,7 +58,6 @@ static constexpr uint8_t BoundBoxDebugColours[] = {
 bool gShowDirtyVisuals;
 bool gPaintBoundingBoxes;
 bool gPaintBlockedTiles;
-bool gPaintStableSort;
 
 static void PaintPSImageWithBoundingBoxes(PaintSession& session, PaintStruct* ps, ImageId imageId, int32_t x, int32_t y);
 static ImageId PaintPSColourifyImage(const PaintStruct* ps, ImageId imageId, uint32_t viewFlags);
@@ -676,7 +676,8 @@ constexpr std::array _paintArrangeFuncsStable = {
 void PaintSessionArrange(PaintSessionCore& session)
 {
     PROFILED_FUNCTION();
-    if (gPaintStableSort)
+    auto& gameState = getGameState();
+    if (gameState.useStablePaintSort)
     {
         return _paintArrangeFuncsStable[session.CurrentRotation](session);
     }

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -256,7 +256,6 @@ extern bool gShowDirtyVisuals;
 extern bool gPaintBoundingBoxes;
 extern bool gPaintBlockedTiles;
 extern bool gPaintWidePathsAsGhost;
-extern bool gPaintStableSort;
 
 PaintStruct* PaintAddImageAsParent(
     PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -168,6 +168,13 @@ namespace OpenRCT2
             ReadWriteCheatsChunk(gameState, os);
             ReadWriteRestrictedObjectsChunk(gameState, os);
             ReadWritePluginStorageChunk(gameState, os);
+
+            if (os.GetHeader().TargetVersion < 57)
+            {
+                // For older park files, preserve existing behaviour (legacy sort)
+                gameState.useStablePaintSort = false;
+            }
+
             if (os.GetHeader().TargetVersion < 0x4)
             {
                 UpdateTrackElementsRideType();
@@ -662,6 +669,11 @@ namespace OpenRCT2
                 if (os.GetHeader().TargetVersion >= 14)
                 {
                     cs.ReadWrite(gIsAutosave);
+                }
+
+                if (os.GetHeader().TargetVersion >= 57)
+                {
+                    cs.ReadWrite(gameState.useStablePaintSort);
                 }
             });
             if (!found)

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -22,7 +22,7 @@ namespace OpenRCT2
     struct GameState_t;
 
     // Current version that is saved.
-    constexpr uint32_t kParkFileCurrentVersion = 56;
+    constexpr uint32_t kParkFileCurrentVersion = 57;
 
     // The minimum version that is forwards compatible with the current version.
     constexpr uint32_t kParkFileMinVersion = 55;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -223,6 +223,9 @@ namespace OpenRCT2::RCT1
             CheatsReset();
             ClearRestrictedScenery();
             RestrictAllMiscScenery();
+
+            // Default to stable paint sort for RCT1 imports
+            gameState.useStablePaintSort = true;
         }
 
         bool PopulateIndexEntry(ScenarioIndexEntry* dst) override

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -626,6 +626,9 @@ namespace OpenRCT2::RCT2
 
             CheatsReset();
             ClearRestrictedScenery();
+
+            // Default to stable paint sort for RCT2 imports
+            gameState.useStablePaintSort = true;
         }
 
         void AddDefaultEntries()


### PR DESCRIPTION
PR #23229 introduced a stable sorting algorithm for painting, but it could negatively affect old parks and was only ever presented as a runtime option in debug options.

This makes stable sort option get stored in the park file. Old parks default to legacy version, but new ones should use stable sorting.

The paint debug window got updated to modify the park's value and users can elect to use paint stable sorting on their old parks (or downgrade to legacy algorithm for new park if they choose so).