### PR TITLE
Remove duplicate checksums file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -727,7 +727,6 @@ jobs:
           repository: OpenRCT2/OpenRCT2-binaries
           token: ${{ secrets.OPENRCT2_BINARIES_CI_UPLOAD }}
           files: |
-            OpenRCT2-${{ needs.build_variables.outputs.name }}-sha256sums.txt
             OpenRCT2-${{ needs.build_variables.outputs.name }}-*
           body_path: release_notes.txt
           tag_name: ${{ needs.build_variables.outputs.name }}


### PR DESCRIPTION
The filename used in https://github.com/OpenRCT2/OpenRCT2/pull/24877 already matches the main pattern and possibly causes a "soft failure":

```
👩‍🏭 Creating new GitHub release for tag v0.4.25-3-g6f28ef9379...
⬆️ Uploading OpenRCT2-v0.4.25-3-g6f28ef9379-sha256sums.txt...
⬆️ Uploading OpenRCT2-v0.4.25-3-g6f28ef9379-windows-symbols-x64.zip...
⬆️ Uploading OpenRCT2-v0.4.25-3-g6f28ef9379-windows-symbols-win32.zip...
⬆️ Uploading OpenRCT2-v0.4.25-3-g6f28ef9379-windows-symbols-arm64.zip...
⬆️ Uploading OpenRCT2-v0.4.25-3-g6f28ef9379-windows-portable-x64.zip...
⬆️ Uploading OpenRCT2-v0.4.25-3-g6f28ef9379-windows-portable-win32.zip...
⬆️ Uploading OpenRCT2-v0.4.25-3-g6f28ef9379-windows-portable-arm64.zip...
⬆️ Uploading OpenRCT2-v0.4.25-3-g6f28ef9379-windows-installer-x64.exe...
⬆️ Uploading OpenRCT2-v0.4.25-3-g6f28ef9379-windows-installer-win32.exe...
⬆️ Uploading OpenRCT2-v0.4.25-3-g6f28ef9379-windows-installer-arm64.exe...
⬆️ Uploading OpenRCT2-v0.4.25-3-g6f28ef9379-sha256sums.txt...
⬆️ Uploading OpenRCT2-v0.4.25-3-g6f28ef9379-macos-universal.zip...
⬆️ Uploading OpenRCT2-v0.4.25-3-g6f28ef9379-linux-x86_64.AppImage...
⬆️ Uploading OpenRCT2-v0.4.25-3-g6f28ef9379-android-arm.apk...
⬆️ Uploading OpenRCT2-v0.4.25-3-g6f28ef9379-Linux-noble-x86_64.tar.gz...
⬆️ Uploading OpenRCT2-v0.4.25-3-g6f28ef9379-Linux-bookworm-x86_64.tar.gz...
Error: Not Found - https://docs.github.com/rest/releases/assets#update-a-release-asset
✅ Uploaded OpenRCT2-v0.4.25-3-g6f28ef9379-sha256sums.txt
✅ Uploaded OpenRCT2-v0.4.25-3-g6f28ef9379-windows-symbols-win32.zip
✅ Uploaded OpenRCT2-v0.4.25-3-g6f28ef9379-windows-symbols-arm64.zip
✅ Uploaded OpenRCT2-v0.4.25-3-g6f28ef9379-windows-symbols-x64.zip
✅ Uploaded OpenRCT2-v0.4.25-3-g6f28ef9379-windows-portable-arm64.zip
✅ Uploaded OpenRCT2-v0.4.25-3-g6f28ef9379-windows-portable-x64.zip
✅ Uploaded OpenRCT2-v0.4.25-3-g6f28ef9379-Linux-noble-x86_64.tar.gz
✅ Uploaded OpenRCT2-v0.4.25-3-g6f28ef9379-windows-installer-win32.exe
✅ Uploaded OpenRCT2-v0.4.25-3-g6f28ef9379-Linux-bookworm-x86_64.tar.gz
✅ Uploaded OpenRCT2-v0.4.25-3-g6f28ef9379-windows-installer-x64.exe
✅ Uploaded OpenRCT2-v0.4.25-3-g6f28ef9379-windows-installer-arm64.exe
✅ Uploaded OpenRCT2-v0.4.25-3-g6f28ef9379-windows-portable-win32.zip
✅ Uploaded OpenRCT2-v0.4.25-3-g6f28ef9379-macos-universal.zip
✅ Uploaded OpenRCT2-v0.4.25-3-g6f28ef9379-linux-x86_64.AppImage
✅ Uploaded OpenRCT2-v0.4.25-3-g6f28ef9379-android-arm.apk
```

https://github.com/OpenRCT2/OpenRCT2/actions/runs/16705273462/job/47282750562#step:9:16