### PR TITLE
Fix incorrect height and width passed to smoothMap in png map gen

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -18,6 +18,7 @@
 - Fix: [#24173] Allow all game speeds between 1 and 8 if developer mode is on.
 - Fix: [#24745] Potential crash when lighting effects are enabled and loading a save or a new scenario.
 - Fix: [#24835] Dive loop track pieces do not have tunnels.
+- Fix: [#24884] Smooth map and add beaches functions use incorrect map size with height map image files.
 - Fix: [#24915] LIM Launched (original bug), Corkscrew and Twister Roller Coaster inline twists have some incorrect tunnels.
 - Fix: [#24953] Crash when opening the Scenario Editor, Track Designer or Track Designs Manager.
 - Fix: [#24955] Hybrid Zero G Rolls do not fully block metal supports.

--- a/src/openrct2/world/map_generator/MapGen.cpp
+++ b/src/openrct2/world/map_generator/MapGen.cpp
@@ -93,10 +93,10 @@ namespace OpenRCT2::World::MapGenerator
             return;
 
         // Add sandy beaches
-        const auto& mapSize = settings->mapSize;
-        for (auto y = 1; y < mapSize.y - 1; y++)
+        auto& gameState = getGameState();
+        for (auto y = 1; y < gameState.mapSize.y - 1; y++)
         {
-            for (auto x = 1; x < mapSize.x - 1; x++)
+            for (auto x = 1; x < gameState.mapSize.x - 1; x++)
             {
                 auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
 

--- a/src/openrct2/world/map_generator/PngTerrainGenerator.cpp
+++ b/src/openrct2/world/map_generator/PngTerrainGenerator.cpp
@@ -158,7 +158,10 @@ namespace OpenRCT2::World::MapGenerator
         // Get technical map size, +2 for the black tiles around the map
         auto mapWidth = static_cast<int32_t>(dest.width + 2);
         auto mapHeight = static_cast<int32_t>(dest.height + 2);
-        MapInit({ mapHeight, mapWidth });
+
+        // The x and y axis are flipped in the world, so this uses y for x and x for y.
+        TileCoordsXY flippedMapSize{ mapHeight, mapWidth };
+        MapInit(flippedMapSize);
 
         if (settings->smooth_height_map)
         {
@@ -203,7 +206,6 @@ namespace OpenRCT2::World::MapGenerator
         {
             for (auto x = 0; x < dest.width; x++)
             {
-                // The x and y axis are flipped in the world, so this uses y for x and x for y.
                 auto tileCoords = HeightmapCoordToTileCoordsXY(x, y);
                 auto* const surfaceElement = MapGetSurfaceElementAt(tileCoords);
                 if (surfaceElement == nullptr)
@@ -236,7 +238,7 @@ namespace OpenRCT2::World::MapGenerator
         if (settings->smoothTileEdges)
         {
             // Set the tile slopes so that there are no cliffs
-            smoothMap({ mapWidth, mapHeight }, smoothTileWeak);
+            smoothMap(flippedMapSize, smoothTileWeak);
         }
     }
 } // namespace OpenRCT2::World::MapGenerator


### PR DESCRIPTION
See https://github.com/OpenRCT2/OpenRCT2/pull/24782#discussion_r2250208224

`mapWidth` and `mapHeight` should be flipped here like in the `MapInit` call above:

<img width="2320" height="1240" alt="Image" src="https://github.com/user-attachments/assets/1613d2e5-f03a-4a86-bb19-d7137ad5b4bb" />
<img width="2320" height="1240" alt="Image" src="https://github.com/user-attachments/assets/00d3ae4d-9792-402f-a48a-61f99a495c42" />
