### PR TITLE
Change staff animation while waiting for level crossing, avoid animation triggers that may cause peeps to be run over

### DIFF
--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -531,7 +531,7 @@ void Guest::GivePassingGuestPizza(Guest& passingPeep)
     int32_t otherPeepOppositeDirection = passingPeep.Orientation >> 3;
     if (peepDirection == otherPeepOppositeDirection)
     {
-        if (passingPeep.IsActionInterruptable() && !IsOnLevelCrossing())
+        if (passingPeep.IsActionInterruptable() && !passingPeep.IsOnLevelCrossing())
         {
             passingPeep.Action = PeepActionType::Wave2;
             passingPeep.AnimationFrameNum = 0;
@@ -546,7 +546,7 @@ void Guest::MakePassingGuestSick(Guest& passingPeep)
     if (passingPeep.State != PeepState::Walking)
         return;
 
-    if (passingPeep.IsActionInterruptable() && !IsOnLevelCrossing())
+    if (passingPeep.IsActionInterruptable() && !passingPeep.IsOnLevelCrossing())
     {
         passingPeep.Action = PeepActionType::ThrowUp;
         passingPeep.AnimationFrameNum = 0;

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -531,7 +531,7 @@ void Guest::GivePassingGuestPizza(Guest& passingPeep)
     int32_t otherPeepOppositeDirection = passingPeep.Orientation >> 3;
     if (peepDirection == otherPeepOppositeDirection)
     {
-        if (passingPeep.IsActionInterruptable())
+        if (passingPeep.IsActionInterruptable() && !IsOnLevelCrossing())
         {
             passingPeep.Action = PeepActionType::Wave2;
             passingPeep.AnimationFrameNum = 0;
@@ -546,7 +546,7 @@ void Guest::MakePassingGuestSick(Guest& passingPeep)
     if (passingPeep.State != PeepState::Walking)
         return;
 
-    if (passingPeep.IsActionInterruptable())
+    if (passingPeep.IsActionInterruptable() && !IsOnLevelCrossing())
     {
         passingPeep.Action = PeepActionType::ThrowUp;
         passingPeep.AnimationFrameNum = 0;
@@ -594,7 +594,7 @@ void Guest::UpdateEasterEggInteractions()
     {
         if ((ScenarioRand() & 0xFFFF) <= 1456)
         {
-            if (IsActionInterruptable())
+            if (IsActionInterruptable() && !IsOnLevelCrossing())
             {
                 Action = PeepActionType::Joy;
                 AnimationFrameNum = 0;
@@ -795,11 +795,11 @@ void Guest::UpdateMotivesIdle()
         Toilet--;
     }
 
-    if (State == PeepState::Walking && NauseaTarget >= 128 && !IsOnLevelCrossing())
+    if (State == PeepState::Walking && NauseaTarget >= 128)
     {
         if ((ScenarioRand() & 0xFF) <= static_cast<uint8_t>((Nausea - 128) / 2))
         {
-            if (IsActionInterruptable())
+            if (IsActionInterruptable() && !IsOnLevelCrossing())
             {
                 Action = PeepActionType::ThrowUp;
                 AnimationFrameNum = 0;
@@ -7080,7 +7080,7 @@ void Guest::InsertNewThought(PeepThoughtType thought_type, RideId rideId)
 void Guest::InsertNewThought(PeepThoughtType thoughtType, uint16_t thoughtArguments)
 {
     PeepActionType newAction = PeepThoughtToActionMap[EnumValue(thoughtType)].action;
-    if (newAction != PeepActionType::Walking && IsActionInterruptable())
+    if (newAction != PeepActionType::Walking && IsActionInterruptable() && !IsOnLevelCrossing())
     {
         Action = newAction;
         AnimationFrameNum = 0;

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -795,7 +795,7 @@ void Guest::UpdateMotivesIdle()
         Toilet--;
     }
 
-    if (State == PeepState::Walking && NauseaTarget >= 128)
+    if (State == PeepState::Walking && NauseaTarget >= 128 && !IsOnLevelCrossing())
     {
         if ((ScenarioRand() & 0xFF) <= static_cast<uint8_t>((Nausea - 128) / 2))
         {
@@ -5492,7 +5492,7 @@ void Guest::UpdateWalking()
 
     if (PeepFlags & PEEP_FLAGS_LITTER)
     {
-        if (!GetNextIsSurface())
+        if (!GetNextIsSurface() && !IsOnLevelCrossing())
         {
             if ((0xFFFF & ScenarioRand()) <= 4096)
             {
@@ -5514,7 +5514,8 @@ void Guest::UpdateWalking()
     }
     else if (HasEmptyContainer())
     {
-        if ((!GetNextIsSurface()) && (static_cast<uint32_t>(Id.ToUnderlying() & 0x1FF) == (currentTicks & 0x1FF))
+        if (!GetNextIsSurface() && !IsOnLevelCrossing()
+            && (static_cast<uint32_t>(Id.ToUnderlying() & 0x1FF) == (currentTicks & 0x1FF))
             && ((0xFFFF & ScenarioRand()) <= 4096))
         {
             int32_t container = Numerics::bitScanForward(GetEmptyContainerFlags());

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -5696,44 +5696,6 @@ void Guest::UpdateWalking()
     }
 }
 
-void Guest::UpdateWaitingAtCrossing()
-{
-    if (!IsActionInterruptable())
-    {
-        UpdateAction();
-        Invalidate();
-        if (!IsActionWalking())
-            return;
-    }
-
-    Action = PeepActionType::Idle;
-    NextAnimationType = PeepAnimationType::WatchRide;
-    SwitchNextAnimationType();
-
-    if (HasFoodOrDrink())
-    {
-        if ((ScenarioRand() & 0xFFFF) <= 1310)
-        {
-            Action = PeepActionType::EatFood;
-            AnimationFrameNum = 0;
-            AnimationImageIdOffset = 0;
-        }
-
-        UpdateCurrentAnimationType();
-
-        return;
-    }
-
-    if ((ScenarioRand() & 0xFFFF) <= 64)
-    {
-        Action = PeepActionType::Wave2;
-        AnimationFrameNum = 0;
-        AnimationImageIdOffset = 0;
-    }
-
-    UpdateCurrentAnimationType();
-}
-
 /**
  *
  *  rct2: 0x69185D

--- a/src/openrct2/entity/Guest.h
+++ b/src/openrct2/entity/Guest.h
@@ -376,7 +376,6 @@ private:
     void UpdateRide();
     void UpdateOnRide() {}; // TODO
     void UpdateWalking();
-    void UpdateWaitingAtCrossing();
     void UpdateQueuing();
     void UpdateSitting();
     void UpdateEnteringPark();

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -1290,7 +1290,8 @@ void PeepApplause()
         GuestReleaseBalloon(peep, peep->z + 9);
 
         // Clap
-        if ((peep->State == PeepState::Walking || peep->State == PeepState::Queuing) && peep->IsActionInterruptable())
+        if ((peep->State == PeepState::Walking || peep->State == PeepState::Queuing) && peep->IsActionInterruptable()
+            && !peep->IsOnLevelCrossing())
         {
             peep->Action = PeepActionType::Clap;
             peep->AnimationFrameNum = 0;

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -257,6 +257,43 @@ void PeepUpdateAllBoundingBoxes()
     }
 }
 
+void Peep::UpdateWaitingAtCrossing()
+{
+    if (!IsActionInterruptable())
+    {
+        UpdateAction();
+        Invalidate();
+        if (!IsActionWalking())
+            return;
+    }
+
+    Action = PeepActionType::Idle;
+    NextAnimationType = PeepAnimationType::WatchRide;
+    SwitchNextAnimationType();
+
+    auto* guest = As<Guest>();
+    if (guest != nullptr)
+    {
+        if (guest->HasFoodOrDrink())
+        {
+            if ((ScenarioRand() & 0xFFFF) <= 1310)
+            {
+                Action = PeepActionType::EatFood;
+                AnimationFrameNum = 0;
+                AnimationImageIdOffset = 0;
+            }
+        }
+        else if ((ScenarioRand() & 0xFFFF) <= 64)
+        {
+            Action = PeepActionType::Wave2;
+            AnimationFrameNum = 0;
+            AnimationImageIdOffset = 0;
+        }
+    }
+
+    UpdateCurrentAnimationType();
+}
+
 /*
  * rct2: 0x68F3AE
  * Set peep state to falling if path below has gone missing, return true if current path is valid, false if peep starts falling.

--- a/src/openrct2/entity/Peep.h
+++ b/src/openrct2/entity/Peep.h
@@ -366,6 +366,7 @@ public: // Peep
     void Remove();
     void UpdateCurrentAnimationType();
     void UpdateSpriteBoundingBox();
+    void UpdateWaitingAtCrossing();
     void SwitchToSpecialSprite(uint8_t special_sprite_id);
     void StateReset();
     [[nodiscard]] uint8_t GetNextDirection() const;

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -1822,7 +1822,10 @@ void Staff::UpdatePatrolling()
         return;
 
     if (ShouldWaitForLevelCrossing() && !IsMechanicHeadingToFixRideBlockingPath())
+    {
+        UpdateWaitingAtCrossing();
         return;
+    }
 
     const auto [pathingResult, _] = PerformNextAction();
     if (!(pathingResult & PATHING_DESTINATION_REACHED))

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -921,7 +921,7 @@ void Staff::EntertainerUpdateNearbyPeeps() const
  */
 bool Staff::DoEntertainerPathFinding()
 {
-    if (((ScenarioRand() & 0xFFFF) <= 0x4000) && IsActionInterruptable())
+    if (((ScenarioRand() & 0xFFFF) <= 0x4000) && IsActionInterruptable() && !IsOnLevelCrossing())
     {
         Action = (ScenarioRand() & 1) ? PeepActionType::Wave2 : PeepActionType::Joy;
         AnimationFrameNum = 0;

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -49,7 +49,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kNetworkStreamVersion = 0;
+constexpr uint8_t kNetworkStreamVersion = 1;
 
 const std::string kNetworkStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kNetworkStreamVersion);
 

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -175,7 +175,8 @@ static std::optional<UpdateType> UpdateSmallSceneryAnimation(
                 auto quad = EntityTileList<Peep>(CoordsXY{ loc.x, loc.y } - CoordsDirectionDelta[direction]);
                 for (auto peep : quad)
                 {
-                    if (peep->State != PeepState::Walking || peep->z != baseZ || peep->Action < PeepActionType::Idle)
+                    if (peep->State != PeepState::Walking || peep->z != baseZ || peep->Action < PeepActionType::Idle
+                        || peep->IsOnLevelCrossing())
                         continue;
                     peep->Action = PeepActionType::CheckTime;
                     peep->AnimationFrameNum = 0;


### PR DESCRIPTION
This implements the following changes (https://github.com/OpenRCT2/OpenRCT2/discussions/24863):

- [x] Staff use their standing animation while waiting for the train to pass
- [x] Entertainers do not perform at crossings
- [x] Guests do not throw up or litter at crossings (also affects the Felicity Anderson and Lisa Stirling Easter egg names)
- [x] Guests do not clap at crossings (they do still let go of their balloons)
- [x] Guests do not check the time at crossings (triggered by the garden clock scenery item)
- [x] Guests do not use special animations triggered by thoughts at crossings (encompasses `CheckTime` (_"I've been queueing for ages"_), `ShakeHead` (_"I can't afford X"_ and _"I'm running out of money"_), `Wave` (scratching head, _"I'm lost," "I can't find X"_ and _"wow, a new ride being built"_), `Joy` (_"X was great"_), `Disgust` (_"this path is disgusting"_), `EmptyPockets` (_"I have no money left"_) and `Wow` (_"X is too intense for me"_))
- [x] Guests with the Katie Smith Easter egg name (jumps in joy frequently) do not do it at crossings
- [x] Guests with the Joanne Barton Easter egg name (gives other guests pizza and also causes them to wave depending on their relative orientation) will not cause other guests to wave if they are at a crossing

Also I'm sorry for the bad commit history!! Will try to be more careful next time!