### PR TITLE
Fix lim, corkscrew and twister coasters inline twist tunnels

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Improved: [#24921] The command line sprite build command now prints out the images table entry for the compiled sprite file.
 - Fix: [#16988] AppImage version does not show changelog.
 - Fix: [#24173] Allow all game speeds between 1 and 8 if developer mode is on.
+- Fix: [#24915] LIM Launched (original bug), Corkscrew and Twister Roller Coaster inline twists have some incorrect tunnels.
 
 0.4.25 (2025-08-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/coaster/CorkscrewRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/CorkscrewRollerCoaster.cpp
@@ -9801,10 +9801,10 @@ static void CorkscrewRCTrackLeftTwistDownToUp(
             switch (direction)
             {
                 case 1:
-                    PaintUtilPushTunnelRight(session, height - 26, kTunnelGroup, TunnelSubType::Flat);
+                    PaintUtilPushTunnelRight(session, height - 32, kTunnelGroup, TunnelSubType::Tall);
                     break;
                 case 2:
-                    PaintUtilPushTunnelLeft(session, height - 26, kTunnelGroup, TunnelSubType::Flat);
+                    PaintUtilPushTunnelLeft(session, height - 32, kTunnelGroup, TunnelSubType::Tall);
                     break;
             }
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -9918,10 +9918,10 @@ static void CorkscrewRCTrackRightTwistDownToUp(
             switch (direction)
             {
                 case 1:
-                    PaintUtilPushTunnelRight(session, height - 26, kTunnelGroup, TunnelSubType::Flat);
+                    PaintUtilPushTunnelRight(session, height - 32, kTunnelGroup, TunnelSubType::Tall);
                     break;
                 case 2:
-                    PaintUtilPushTunnelLeft(session, height - 26, kTunnelGroup, TunnelSubType::Flat);
+                    PaintUtilPushTunnelLeft(session, height - 32, kTunnelGroup, TunnelSubType::Tall);
                     break;
             }
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -9968,7 +9968,7 @@ static void CorkscrewRCTrackLeftTwistUpToDown(
 
             if (direction == 0 || direction == 3)
             {
-                PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
+                PaintUtilPushTunnelRotated(session, direction, height - 32, kTunnelGroup, TunnelSubType::Tall);
             }
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
             break;
@@ -10027,10 +10027,10 @@ static void CorkscrewRCTrackLeftTwistUpToDown(
             switch (direction)
             {
                 case 1:
-                    PaintUtilPushTunnelRight(session, height - 26, kTunnelGroup, TunnelSubType::Flat);
+                    PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::Flat);
                     break;
                 case 2:
-                    PaintUtilPushTunnelLeft(session, height - 26, kTunnelGroup, TunnelSubType::Flat);
+                    PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::Flat);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -10085,7 +10085,7 @@ static void CorkscrewRCTrackRightTwistUpToDown(
 
             if (direction == 0 || direction == 3)
             {
-                PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
+                PaintUtilPushTunnelRotated(session, direction, height - 32, kTunnelGroup, TunnelSubType::Tall);
             }
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
             break;
@@ -10144,10 +10144,10 @@ static void CorkscrewRCTrackRightTwistUpToDown(
             switch (direction)
             {
                 case 1:
-                    PaintUtilPushTunnelRight(session, height - 26, kTunnelGroup, TunnelSubType::Flat);
+                    PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::Flat);
                     break;
                 case 2:
-                    PaintUtilPushTunnelLeft(session, height - 26, kTunnelGroup, TunnelSubType::Flat);
+                    PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::Flat);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(

--- a/src/openrct2/paint/track/coaster/LimLaunchedRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/LimLaunchedRollerCoaster.cpp
@@ -888,10 +888,10 @@ static void LimLaunchedRCTrackRightTwistDownToUp(
             switch (direction)
             {
                 case 1:
-                    PaintUtilPushTunnelRight(session, height + 32, kTunnelGroup, TunnelSubType::Tall);
+                    PaintUtilPushTunnelRight(session, height - 32, kTunnelGroup, TunnelSubType::Tall);
                     break;
                 case 2:
-                    PaintUtilPushTunnelLeft(session, height + 32, kTunnelGroup, TunnelSubType::Tall);
+                    PaintUtilPushTunnelLeft(session, height - 32, kTunnelGroup, TunnelSubType::Tall);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -1114,7 +1114,7 @@ static void LimLaunchedRCTrackRightTwistUpToDown(
             }
             if (direction == 0 || direction == 3)
             {
-                PaintUtilPushTunnelRotated(session, direction, height + 32, kTunnelGroup, TunnelSubType::Tall);
+                PaintUtilPushTunnelRotated(session, direction, height - 32, kTunnelGroup, TunnelSubType::Tall);
             }
             PaintUtilSetSegmentSupportHeight(
                 session,

--- a/src/openrct2/paint/track/coaster/TwisterRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/TwisterRollerCoaster.cpp
@@ -13502,10 +13502,10 @@ static void TwisterRCTrackLeftTwistDownToUp(
             switch (direction)
             {
                 case 1:
-                    PaintUtilPushTunnelRight(session, height - 32, kTunnelGroup, TunnelSubType::Flat);
+                    PaintUtilPushTunnelRight(session, height - 32, kTunnelGroup, TunnelSubType::Tall);
                     break;
                 case 2:
-                    PaintUtilPushTunnelLeft(session, height - 32, kTunnelGroup, TunnelSubType::Flat);
+                    PaintUtilPushTunnelLeft(session, height - 32, kTunnelGroup, TunnelSubType::Tall);
                     break;
             }
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -13623,10 +13623,10 @@ static void TwisterRCTrackRightTwistDownToUp(
             switch (direction)
             {
                 case 1:
-                    PaintUtilPushTunnelRight(session, height - 16, kTunnelGroup, TunnelSubType::Flat);
+                    PaintUtilPushTunnelRight(session, height - 32, kTunnelGroup, TunnelSubType::Tall);
                     break;
                 case 2:
-                    PaintUtilPushTunnelLeft(session, height - 16, kTunnelGroup, TunnelSubType::Flat);
+                    PaintUtilPushTunnelLeft(session, height - 32, kTunnelGroup, TunnelSubType::Tall);
                     break;
             }
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -13673,7 +13673,7 @@ static void TwisterRCTrackLeftTwistUpToDown(
 
             if (direction == 0 || direction == 3)
             {
-                PaintUtilPushTunnelRotated(session, direction, height - 24, kTunnelGroup, TunnelSubType::Flat);
+                PaintUtilPushTunnelRotated(session, direction, height - 32, kTunnelGroup, TunnelSubType::Tall);
             }
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
             break;
@@ -13794,7 +13794,7 @@ static void TwisterRCTrackRightTwistUpToDown(
 
             if (direction == 0 || direction == 3)
             {
-                PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
+                PaintUtilPushTunnelRotated(session, direction, height - 32, kTunnelGroup, TunnelSubType::Tall);
             }
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
             break;
@@ -13857,10 +13857,10 @@ static void TwisterRCTrackRightTwistUpToDown(
             switch (direction)
             {
                 case 1:
-                    PaintUtilPushTunnelRight(session, height - 16, kTunnelGroup, TunnelSubType::Flat);
+                    PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::Flat);
                     break;
                 case 2:
-                    PaintUtilPushTunnelLeft(session, height - 16, kTunnelGroup, TunnelSubType::Flat);
+                    PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::Flat);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(


### PR DESCRIPTION
This fixes the tunnels on the LIM Launched, Corkscrew and Twister coaster inline twists. This changes all the tunnels to the same tall tunnels, based on the original (correct) tunnels from the LIM launched twist from RCT2. 

The LIM launched was the only one to have this piece in RCT2, some of those tunnels were missing (they're actually offset high above and would appear if the land was higher):
<img width="573" height="349" alt="inlinetwisttunnelslimrct2" src="https://github.com/user-attachments/assets/28ae3bdc-e939-4428-9348-ca5984662448" />
This PR:
<img width="573" height="349" alt="inlinetwisttunnelslimfix" src="https://github.com/user-attachments/assets/f7930af2-c295-4efe-bce8-c67d61836dff" />
It's pretty clear here that the bounding boxes for the LIM inline twist are totally broken too. Issue here #24916.

The tunnels for the corkscrew and twister pieces are all over the place:
<img width="582" height="338" alt="inlinetwisttunnelsbug" src="https://github.com/user-attachments/assets/0a2e5988-370f-4cf3-82ed-ba14f234c637" />
<img width="573" height="337" alt="inlinetwisttunnelsbug2" src="https://github.com/user-attachments/assets/828fe962-d13f-4af9-9c06-f116d8580ea0" />
<img width="578" height="351" alt="inlinetwisttunnelsbug3" src="https://github.com/user-attachments/assets/b9f02eed-5a8f-4b3d-9feb-247e29088aa0" />
<img width="582" height="338" alt="inlinetwisttunnelsbug4" src="https://github.com/user-attachments/assets/9d4bc746-ab7c-42c7-9ee1-40a1ba24ae70" />

This PR:
<img width="582" height="338" alt="inlinetwisttunnelsfix" src="https://github.com/user-attachments/assets/f36fb448-7b6b-4440-81f8-a60415c8ff14" />
<img width="573" height="337" alt="inlinetwisttunnelsfix2" src="https://github.com/user-attachments/assets/ca7ed1f0-ee9b-436a-a455-7f8a0ac84f89" />
<img width="582" height="338" alt="inlinetwisttunnelsfix3" src="https://github.com/user-attachments/assets/e2ecba22-2401-4a06-9a1e-a7cbc9f9f345" />

Here's the save games from these pictures:
[inline twist tunnels.zip](https://github.com/user-attachments/files/21659941/inline.twist.tunnels.zip)

One thing I wanted to mention quickly is that any possible tunnel for these pieces are well out of their clearances, because this track piece was only ever meant to be used for inverted coasters. (The equivalent flying coaster pieces have different clearances to account for this). The LIM launched piece was obviously really lazily implemented and this track piece should probably not be used for any more non inverted coasters. Issue here: #22660
It's possible to build this without cheats in which case a tunnel won't appear:
<img width="447" height="382" alt="inlinetwistclearances" src="https://github.com/user-attachments/assets/8de516ee-ff97-429a-9318-d1737f5cd643" />
