### PR TITLE
Add explicit <cstdlib> include to Range.hpp

### DIFF
--- a/src/openrct2/core/Range.hpp
+++ b/src/openrct2/core/Range.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <cmath>
+#include <cstdlib>
 #include <type_traits>
 
 template<typename T>


### PR DESCRIPTION
LLVM libc++ 21 shuffled around some includes internally, causing cstddef to no longer be transitively included here. Explicitly include it for size_t.