### PR TITLE
Print the object image table entry after sprite build command

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Improved: [#24734] Save files now use Zstd compression for faster saving and smaller files.
 - Improved: [#24893] The ride list now has headers, and can be sorted in both directions.
+- Improved: [#24921] The command line sprite build command now prints out the images table entry for the compiled sprite file.
 - Fix: [#16988] AppImage version does not show changelog.
 - Fix: [#24173] Allow all game speeds between 1 and 8 if developer mode is on.
 

--- a/src/openrct2/CommandLineSprite.cpp
+++ b/src/openrct2/CommandLineSprite.cpp
@@ -604,6 +604,14 @@ int32_t CommandLineForSprite(const char** argv, int32_t argc)
         }
 
         fprintf(stdout, "Finished building graphics repository with %u images\n", numSuccessful);
+
+        if (numSuccessful > 0)
+        {
+            printf("Replace the object's images table entries with this:\n");
+            const auto spriteFileName = OpenRCT2::Path::GetFileName(spriteFilePath);
+            fprintf(stdout, "\"$LGX:%s[0..%u]\"\n", spriteFileName.c_str(), numSuccessful - 1);
+        }
+
         return 1;
     }
 


### PR DESCRIPTION
This prints out the images table entry you should use in your object.json to use sprites compiled with the command line `sprite build` command, as suggested by @ZeeMaji.
It mainly helps to clarify that the range is inclusive. We've both been caught out by this.

```
Building: C:\Files\RCT\RCT2 Style Corkscrew Roller Coaster Train\object\images.dat
Finished building graphics repository with 3471 images
Replace the object's images table entries with this:
"$LGX:images.dat[0..3470]"
```