### PR TITLE
Change [De]Compress Asserts to Exceptions

### DIFF
--- a/src/openrct2/core/Compression.cpp
+++ b/src/openrct2/core/Compression.cpp
@@ -38,7 +38,8 @@ namespace OpenRCT2::Compression
 
     bool zlibCompress(IStream& source, uint64_t sourceLength, IStream& dest, ZlibHeaderType header, int16_t level)
     {
-        Guard::Assert(sourceLength <= source.GetLength() - source.GetPosition());
+        if (sourceLength > source.GetLength() - source.GetPosition())
+            throw IOException("Not Enough Data to Compress");
 
         int ret;
         StreamReadBuffer sourceBuf(source, sourceLength, kZlibChunkSize);
@@ -84,7 +85,8 @@ namespace OpenRCT2::Compression
 
     bool zlibDecompress(IStream& source, uint64_t sourceLength, IStream& dest, uint64_t decompressLength, ZlibHeaderType header)
     {
-        Guard::Assert(sourceLength <= source.GetLength() - source.GetPosition());
+        if (sourceLength > source.GetLength() - source.GetPosition())
+            throw IOException("Not Enough Data to Deompress");
 
         int ret;
         StreamReadBuffer sourceBuf(source, sourceLength, kZlibChunkSize);
@@ -152,7 +154,8 @@ namespace OpenRCT2::Compression
 
     bool zstdCompress(IStream& source, uint64_t sourceLength, IStream& dest, ZstdMetadata metadata, int16_t level)
     {
-        Guard::Assert(sourceLength <= source.GetLength() - source.GetPosition());
+        if (sourceLength > source.GetLength() - source.GetPosition())
+            throw IOException("Not Enough Data to Compress");
 
         size_t ret;
         StreamReadBuffer sourceBuf(source, sourceLength, ZSTD_CStreamInSize());
@@ -223,7 +226,8 @@ namespace OpenRCT2::Compression
 
     bool zstdDecompress(IStream& source, uint64_t sourceLength, IStream& dest, uint64_t decompressLength)
     {
-        Guard::Assert(sourceLength <= source.GetLength() - source.GetPosition());
+        if (sourceLength > source.GetLength() - source.GetPosition())
+            throw IOException("Not Enough Data to Decompress");
 
         size_t ret;
         StreamReadBuffer sourceBuf(source, sourceLength, ZSTD_DStreamInSize());


### PR DESCRIPTION
While investigating #24927, I started thinking about how I chose to handle errors in the [de]compression functions, and realized that it should probably be changed. Right now, it uses an assert to ensure that there's enough data in the source stream to read the requested number of bytes. However, this can cause problems if it's called with user-provided data. For example, the compressed length when loading a save file is read from the file's header, but then it passes the file stream to the decompress function directly, so an accidentally truncated file will trigger the assert. This PR changes the assert into a conditional exception, which prevents this specific case from crashing the game.

This isn't the only way to resolve this issue, so I quickly want to go over why I opted for this method specifically.

Firstly, an alternative option would be to add checks to every caller of the [de]compression functions to have them check that the input stream has enough data. However, I figured this would result in an unnecessary amount of code duplication, and didn't seem like the cleanest solution to me. Checking for this error in the [de]compression functions is reasonable, so having the correct error handling there makes sense. Also, having the functions throw an exception in this case makes sense because it's the behavior we'd expect to happen if there was no check performed in the first place.

Secondly, it's worth noting this is the only case where these functions will throw an exception, since it mainly uses `return false` to indicate a [de]compression error. However, I think this specific error is distinct enough to warrant the different behavior. The `return false` cases are caused by **data** errors, where the compressed data doesn't match the expectations. For example, if the decompressed length doesn't match, that's an error of the compressed data containing the wrong amount of content. In contrast, not having enough data to read is a **contract** error, as it's an expectation of the function that enough data is provided to read the requested number of bytes. I think that, combined with the previously mentioned fact that this matches the behavior of when the check isn't performed, this is a good enough reason to have the difference in behavior.