### PR TITLE
Add option to draw bounding boxes to command line screenshot command

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.26 (in development)
 ------------------------------------------------------------------------
+- Feature: [#24949] Add an option to the command line screenshot function to draw debug bounding boxes.
 - Improved: [#24734] Save files now use Zstd compression for faster saving and smaller files.
 - Improved: [#24893] The ride list now has headers, and can be sorted in both directions.
 - Improved: [#24921] The command line sprite build command now prints out the images table entry for the compiled sprite file.

--- a/src/openrct2/command_line/ScreenshotCommands.cpp
+++ b/src/openrct2/command_line/ScreenshotCommands.cpp
@@ -17,16 +17,17 @@ static ScreenshotOptions _options;
 // clang-format off
 static constexpr CommandLineOptionDefinition kScreenshotOptionsDef[]
 {
-    { CMDLINE_TYPE_INTEGER, &_options.weather,       kNAC, "weather",       "weather to be used (0 = default, 1 = sunny, ..., 6 = thunder)." },
-    { CMDLINE_TYPE_SWITCH,  &_options.hide_guests,   kNAC, "no-peeps",      "hide peeps" },
-    { CMDLINE_TYPE_SWITCH,  &_options.hide_sprites,  kNAC, "no-sprites",    "hide all sprites (e.g. balloons, vehicles, guests)" },
-    { CMDLINE_TYPE_SWITCH,  &_options.clear_grass,   kNAC, "clear-grass",   "set all grass to be clear of weeds" },
-    { CMDLINE_TYPE_SWITCH,  &_options.mowed_grass,   kNAC, "mowed-grass",   "set all grass to be mowed" },
-    { CMDLINE_TYPE_SWITCH,  &_options.water_plants,  kNAC, "water-plants",  "water plants for the screenshot" },
-    { CMDLINE_TYPE_SWITCH,  &_options.fix_vandalism, kNAC, "fix-vandalism", "fix vandalism for the screenshot" },
-    { CMDLINE_TYPE_SWITCH,  &_options.remove_litter, kNAC, "remove-litter", "remove litter for the screenshot" },
-    { CMDLINE_TYPE_SWITCH,  &_options.tidy_up_park,  kNAC, "tidy-up-park",  "clear grass, water plants, fix vandalism and remove litter" },
-    { CMDLINE_TYPE_SWITCH,  &_options.transparent,   kNAC, "transparent",   "make the background transparent" },
+    { CMDLINE_TYPE_INTEGER, &_options.weather,             kNAC, "weather",             "weather to be used (0 = default, 1 = sunny, ..., 6 = thunder)." },
+    { CMDLINE_TYPE_SWITCH,  &_options.hide_guests,         kNAC, "no-peeps",            "hide peeps" },
+    { CMDLINE_TYPE_SWITCH,  &_options.hide_sprites,        kNAC, "no-sprites",          "hide all sprites (e.g. balloons, vehicles, guests)" },
+    { CMDLINE_TYPE_SWITCH,  &_options.clear_grass,         kNAC, "clear-grass",         "set all grass to be clear of weeds" },
+    { CMDLINE_TYPE_SWITCH,  &_options.mowed_grass,         kNAC, "mowed-grass",         "set all grass to be mowed" },
+    { CMDLINE_TYPE_SWITCH,  &_options.water_plants,        kNAC, "water-plants",        "water plants for the screenshot" },
+    { CMDLINE_TYPE_SWITCH,  &_options.fix_vandalism,       kNAC, "fix-vandalism",       "fix vandalism for the screenshot" },
+    { CMDLINE_TYPE_SWITCH,  &_options.remove_litter,       kNAC, "remove-litter",       "remove litter for the screenshot" },
+    { CMDLINE_TYPE_SWITCH,  &_options.tidy_up_park,        kNAC, "tidy-up-park",        "clear grass, water plants, fix vandalism and remove litter" },
+    { CMDLINE_TYPE_SWITCH,  &_options.transparent,         kNAC, "transparent",         "make the background transparent" },
+    { CMDLINE_TYPE_SWITCH,  &_options.draw_bounding_boxes, kNAC, "draw-bounding-boxes", "draw bounding boxes" },
     kOptionTableEnd
 };
 

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -422,6 +422,11 @@ static void ApplyOptions(const ScreenshotOptions* options, Viewport& viewport)
     {
         viewport.flags |= VIEWPORT_FLAG_TRANSPARENT_BACKGROUND;
     }
+
+    if (options->draw_bounding_boxes)
+    {
+        gPaintBoundingBoxes = true;
+    }
 }
 
 int32_t CommandLineForScreenshot(const char** argv, int32_t argc, ScreenshotOptions* options)

--- a/src/openrct2/interface/Screenshot.h
+++ b/src/openrct2/interface/Screenshot.h
@@ -33,6 +33,7 @@ struct ScreenshotOptions
     bool remove_litter = false;
     bool tidy_up_park = false;
     bool transparent = false;
+    bool draw_bounding_boxes = false;
 };
 
 struct CaptureView


### PR DESCRIPTION
This would be useful for automated diffing of screenshots.