### PR TITLE
Fix crash when loading null peep animation

### DIFF
--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -2779,6 +2779,11 @@ void Peep::Paint(PaintSession& session, int32_t imageDirection) const
     auto& objManager = GetContext()->GetObjectManager();
     auto* animObj = objManager.GetLoadedObject<PeepAnimationsObject>(AnimationObjectIndex);
 
+    if (animObj == nullptr)
+    {
+        return;
+    }
+
     uint32_t baseImageId = animObj->GetPeepAnimation(AnimationGroup, actionAnimationGroup).base_image;
 
     // Offset frame onto the base image, using rotation except for the 'picked up' state


### PR DESCRIPTION
This happens when RCT1AALL title sequence is used and scenario editor is started from title sequence screen

cc @AaronVanGeffen @ZeeMaji 