### PR TITLE
24606 - Raise misc entity limit 2x

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Improved: [#24893] The ride list now has headers, and can be sorted in both directions.
 - Improved: [#24921] The command line sprite build command now prints out the images table entry for the compiled sprite file.
 - Improved: [#24953] Opening the Scenario Editor, Track Designer or Track Designs Manager now display the progress bar.
+- Change: [#24606] Increase Misc Entity limit from 1600 to 3200.
 - Fix: [#16988] AppImage version does not show changelog.
 - Fix: [#24173] Allow all game speeds between 1 and 8 if developer mode is on.
 - Fix: [#24745] Potential crash when lighting effects are enabled and loading a save or a new scenario.

--- a/src/openrct2/entity/EntityRegistry.cpp
+++ b/src/openrct2/entity/EntityRegistry.cpp
@@ -270,7 +270,7 @@ static void EntityReset(EntityBase& entity)
     entity.Type = EntityType::Null;
 }
 
-static constexpr uint16_t kMaxMiscEntities = 1600;
+static constexpr uint16_t kMaxMiscEntities = 16000;
 
 static void AddToEntityList(EntityBase& entity)
 {

--- a/src/openrct2/entity/EntityRegistry.cpp
+++ b/src/openrct2/entity/EntityRegistry.cpp
@@ -270,7 +270,7 @@ static void EntityReset(EntityBase& entity)
     entity.Type = EntityType::Null;
 }
 
-static constexpr uint16_t kMaxMiscEntities = 16000;
+static constexpr uint16_t kMaxMiscEntities = 3200;
 
 static void AddToEntityList(EntityBase& entity)
 {

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -49,7 +49,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kNetworkStreamVersion = 1;
+constexpr uint8_t kNetworkStreamVersion = 2;
 
 const std::string kNetworkStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kNetworkStreamVersion);
 


### PR DESCRIPTION
I would like to raise the misc entity limit. 
I doubt anyone will agree with outright raising it 10x like this, but who knows. (Edit: Matt suggested 2x)
I started a discussion earlier with a more complex solution, but no-one replied. 

Misc entities would rarely get this high naturally, I suspect. However, with plugins it's very easy to run into this 1600 limit, hence I'd like it raised, possibly only for plugin use, keeping normal spawning the same. 