### PR TITLE
Android: fix crash when device is offline

### DIFF
--- a/src/openrct2-android/app/src/main/java/io/openrct2/HttpAndroid.java
+++ b/src/openrct2-android/app/src/main/java/io/openrct2/HttpAndroid.java
@@ -68,6 +68,7 @@ public class HttpAndroid {
         response.status = Status.Invalid;
         response.error = "Request failed";
         response.body = null;
+        response.headers = new HashMap<>();
         try {
             InputStream inputStream = null;
             try {


### PR DESCRIPTION
When processing response, we unconditionally reference a value in `headers` field, but it is null.

https://github.com/OpenRCT2/OpenRCT2/blob/0f956ef910ca0aee9910c7af5c1b5f1e0327cced/src/openrct2/core/Http.Android.cpp#L110-L113