### PR TITLE
Ignore corners when painting queues and rename some unknowns

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Fix: [#24915] LIM Launched (original bug), Corkscrew and Twister Roller Coaster inline twists have some incorrect tunnels.
 - Fix: [#24953] Crash when opening the Scenario Editor, Track Designer or Track Designs Manager.
 - Fix: [#24958] Android: fix crash when device is offline.
+- Fix: [#24961] Queues with corner connections set with the tile inspector draw incorrect sprites.
 
 0.4.25 (2025-08-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -598,7 +598,7 @@ static void PathPaintFencesAndQueueBanners(
  * @param imageFlags (0x00F3EF70)
  * @param sceneryImageFlags (0x00F3EF74)
  */
-static void Sub6A3F61(
+static void PathPaintFencesAdditionsTunnels(
     PaintSession& session, const PathElement& pathElement, uint16_t connectedEdges, uint16_t height,
     const FootpathPaintInfo& pathPaintInfo, ImageId imageTemplate, ImageId sceneryImageTemplate, bool hasSupports)
 {
@@ -990,7 +990,8 @@ void PathPaintBoxSupport(
         }
     }
 
-    Sub6A3F61(session, pathElement, edgesAndCorners, height, pathPaintInfo, imageTemplate, sceneryImageTemplate, hasSupports);
+    PathPaintFencesAdditionsTunnels(
+        session, pathElement, edgesAndCorners, height, pathPaintInfo, imageTemplate, sceneryImageTemplate, hasSupports);
 
     Direction slopeDirection{};
     if (pathElement.IsSloped())
@@ -1044,7 +1045,7 @@ void PathPaintPoleSupport(
         }
     }
 
-    Sub6A3F61(
+    PathPaintFencesAdditionsTunnels(
         session, pathElement, edgesAndCorners, height, pathPaintInfo, imageTemplate, sceneryImageTemplate,
         hasSupports); // TODO: arguments
 

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -859,7 +859,7 @@ static std::pair<uint8_t, uint8_t> PathPaintGetRotatedEdgesAndCorners(
 
 static ImageIndex PathPaintGetBaseImage(
     const PaintSession& session, const PathElement& pathElement, const FootpathPaintInfo& pathPaintInfo,
-    uint16_t rotatedEdgesAndCorners)
+    const uint8_t rotatedEdgesAndCorners)
 {
     ImageIndex surfaceBaseImageIndex = pathPaintInfo.SurfaceImageId;
     if (pathElement.IsSloped())

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -69,7 +69,7 @@ static constexpr uint8_t kPathEdgesAndCornersToSurfaceImageIndexOffset[] = {
 };
 
 // clang-format off
-static constexpr BoundBoxXY stru_98D804[] = {
+static constexpr BoundBoxXY kPathBoundingBoxes[] = {
     { { 3, 3 }, { 26, 26 } },
     { { 0, 3 }, { 29, 26 } },
     { { 3, 3 }, { 26, 29 } },
@@ -878,8 +878,8 @@ static ImageIndex PathPaintGetBaseImage(
 
 static BoundBoxXYZ PathPaintGetBoundbox(const PaintSession& session, int32_t height, uint8_t edges)
 {
-    CoordsXY boundBoxOffset = stru_98D804[edges].offset;
-    CoordsXY boundBoxSize = stru_98D804[edges].length;
+    CoordsXY boundBoxOffset = kPathBoundingBoxes[edges].offset;
+    CoordsXY boundBoxSize = kPathBoundingBoxes[edges].length;
 
     const bool hasPassedSurface = (session.Flags & PaintSessionFlags::PassedSurface) != 0;
     if (!hasPassedSurface)

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -57,7 +57,7 @@ const uint8_t kPathSlopeToLandSlope[] = {
     kTileSlopeSESideUp,
 };
 
-static constexpr uint8_t Byte98D6E0[] = {
+static constexpr uint8_t kPathEdgesAndCornersToSurfaceImageIndexOffset[] = {
     0, 1, 2, 3, 4, 5, 6,  7,  8, 9,  10, 11, 12, 13, 14, 15, 0, 1, 2, 20, 4, 5, 6, 22, 8, 9, 10, 26, 12, 13, 14, 36,
     0, 1, 2, 3, 4, 5, 21, 23, 8, 9,  10, 11, 12, 13, 33, 37, 0, 1, 2, 3,  4, 5, 6, 24, 8, 9, 10, 11, 12, 13, 14, 38,
     0, 1, 2, 3, 4, 5, 6,  7,  8, 9,  10, 11, 29, 30, 34, 39, 0, 1, 2, 3,  4, 5, 6, 7,  8, 9, 10, 11, 12, 13, 14, 40,
@@ -870,7 +870,7 @@ static ImageIndex PathPaintGetBaseImage(
     }
     else
     {
-        surfaceBaseImageIndex += Byte98D6E0[rotatedEdgesAndCorners];
+        surfaceBaseImageIndex += kPathEdgesAndCornersToSurfaceImageIndexOffset[rotatedEdgesAndCorners];
     }
 
     return surfaceBaseImageIndex;

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -958,9 +958,9 @@ void PathPaintBoxSupport(
     PROFILED_FUNCTION();
 
     auto [edges, corners] = PathPaintGetRotatedEdgesAndCorners(session, pathElement);
-    uint16_t edi = edges | (corners << 4);
+    const uint8_t edgesAndCorners = pathElement.IsQueue() ? edges : edges | (corners << 4);
 
-    auto surfaceBaseImageIndex = PathPaintGetBaseImage(session, pathElement, pathPaintInfo, edi);
+    const auto surfaceBaseImageIndex = PathPaintGetBaseImage(session, pathElement, pathPaintInfo, edgesAndCorners);
     auto boundbox = PathPaintGetBoundbox(session, height, edges);
 
     const bool hasPassedSurface = (session.Flags & PaintSessionFlags::PassedSurface) != 0;
@@ -990,7 +990,7 @@ void PathPaintBoxSupport(
         }
     }
 
-    Sub6A3F61(session, pathElement, edi, height, pathPaintInfo, imageTemplate, sceneryImageTemplate, hasSupports);
+    Sub6A3F61(session, pathElement, edgesAndCorners, height, pathPaintInfo, imageTemplate, sceneryImageTemplate, hasSupports);
 
     Direction slopeDirection{};
     if (pathElement.IsSloped())
@@ -1011,9 +1011,9 @@ void PathPaintPoleSupport(
     PROFILED_FUNCTION();
 
     auto [edges, corners] = PathPaintGetRotatedEdgesAndCorners(session, pathElement);
-    uint16_t edi = edges | (corners << 4);
+    const uint8_t edgesAndCorners = pathElement.IsQueue() ? edges : edges | (corners << 4);
 
-    auto surfaceBaseImageIndex = PathPaintGetBaseImage(session, pathElement, pathPaintInfo, edi);
+    const auto surfaceBaseImageIndex = PathPaintGetBaseImage(session, pathElement, pathPaintInfo, edgesAndCorners);
     auto boundbox = PathPaintGetBoundbox(session, height, edges);
 
     // Below Surface
@@ -1045,7 +1045,7 @@ void PathPaintPoleSupport(
     }
 
     Sub6A3F61(
-        session, pathElement, edi, height, pathPaintInfo, imageTemplate, sceneryImageTemplate,
+        session, pathElement, edgesAndCorners, height, pathPaintInfo, imageTemplate, sceneryImageTemplate,
         hasSupports); // TODO: arguments
 
     MetalSupportPlace supports[] = {


### PR DESCRIPTION
This ignores corner connections when painting queues. It's okay to lookup the sprite with the edges as queues have all 16 sprites, the 3 and 4 edge ones are just blank. The sprite offset is looked up in an array of 256 entries, this changes the index to a uint8_t just to clarify. The value was always under 256 as it originally comes from two 4 bit numbers put together.

You could also prevent queues from ever having corner connections, but that's a larger change and there's a small chance that somebody somewhere has set a corner connection because it does something.

<img width="211" height="190" alt="queuecornersbug" src="https://github.com/user-attachments/assets/76974446-d12f-4366-b26d-953e23d2d6ad" />
<img width="211" height="190" alt="queuecornersfix" src="https://github.com/user-attachments/assets/8144ace1-6382-4f92-9e43-44f1a7796d16" />

Save (the exact sprites you get will probably be different):
[queuecorners.zip](https://github.com/user-attachments/files/21747921/queuecorners.zip)

This also renames a couple of previously unnamed arrays and a function.