### PR TITLE
Run tests on macos amd64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,8 +365,8 @@ jobs:
             run_tests: true
           - arch: x64
             cache_key: macos-x64
-            build_flags: -DARCH="x86_64"
-            run_tests: false
+            build_flags: -DARCH="x86_64" -DWITH_TESTS=on
+            run_tests: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
We can't run aarch64 tests on amd64, but we can run amd64 on aarch64 using rosetta