### PR TITLE
Fix a crash when closing windows would open other windows

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Fix: [#24955] Hybrid Zero G Rolls do not fully block metal supports.
 - Fix: [#24958] Android: fix crash when device is offline.
 - Fix: [#24961] Queues with corner connections set with the tile inspector draw incorrect sprites.
+- Fix: [#24972] Fix crash when closing windows would open other windows.
 
 0.4.25 (2025-08-03)
 ------------------------------------------------------------------------


### PR DESCRIPTION
This could happen when trying to open a ride, which does not have entrance or exit, from the ride list window. The `OnClose` handler would want to open a window for placing said elements causing invalidation of the window list.

https://github.com/OpenRCT2/OpenRCT2/blob/20ac77904b0586c66af5a764035c8141ba3e9081/src/openrct2-ui/windows/RideConstruction.cpp#L324