### PR TITLE
Fix #24151: Sprites are cut off by 1 row of pixels when using OpenGL on Intel Macs

### DIFF
--- a/data/shaders/drawrect.frag
+++ b/data/shaders/drawrect.frag
@@ -13,7 +13,7 @@ uniform usampler2D      uPaletteTex;
 uniform sampler2D       uPeelingTex;
 uniform bool            uPeeling;
 
-layout(origin_upper_left, pixel_center_integer) in vec4 gl_FragCoord;
+in vec4 gl_FragCoord;
 
 flat in int             fFlags;
 flat in uint            fColour;
@@ -26,6 +26,7 @@ in vec3                 fPeelPos;
 flat in float           fZoom;
 flat in int             fTexColourAtlas;
 flat in int             fTexMaskAtlas;
+flat in int             fScreenHeight;
 // clang-format on
 
 out uint oColour;
@@ -41,7 +42,8 @@ void main()
         }
     }
 
-    vec2 position = (gl_FragCoord.xy - fPosition) * fZoom;
+    vec2 fragCoord = vec2(floor(gl_FragCoord.x), fScreenHeight - floor(gl_FragCoord.y) - 1);
+    vec2 position = (fragCoord - fPosition) * fZoom;
 
     uint texel;
     if ((fFlags & FLAG_NO_TEXTURE) == 0)

--- a/data/shaders/drawrect.vert
+++ b/data/shaders/drawrect.vert
@@ -31,6 +31,7 @@ flat out vec3  fPalettes;
 flat out float fZoom;
 flat out int   fTexColourAtlas;
 flat out int   fTexMaskAtlas;
+flat out int   fScreenHeight;
 // clang-format on
 
 void main()
@@ -56,6 +57,8 @@ void main()
     fFlags = vFlags;
     fColour = vColour;
     fPalettes = vec3(vPalettes);
+
+    fScreenHeight = uScreenSize.y;
 
     // Transform texture coordinates to viewport coordinates
     pos = pos * 2.0 - 1.0;

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Fix: [#16988] AppImage version does not show changelog.
 - Fix: [#18048] Play music from all ride's stations.
 - Fix: [#24001] Sloped diagonal metal supports that are offset with a crossbeam draw incorrectly.
+- Fix: [#24151] Sprites are cut off by 1 row of pixels when using OpenGL on Intel Macs.
 - Fix: [#24173] Allow all game speeds between 1 and 8 if developer mode is on.
 - Fix: [#24745] Potential crash when lighting effects are enabled and loading a save or a new scenario.
 - Fix: [#24835] Dive loop track pieces do not have tunnels.


### PR DESCRIPTION
This fixes #24151.

The shaders use `gl_FragCoord` with the `origin_upper_left` layout, this must be off by one for these intel mac drivers which is causing the sprites to get cut off. The screen height is already passed in to the vertex shader so it's an easy change. I've also removed the other layout specifier just in case as it is not really necessary, you can get the same thing by just flooring it manually.

I've tested and compared it with the previous version at all the zoom levels and it's working for me, but it would be great if this can be tested on as much different hardware as possible.