### PR TITLE
Fix #19137: Non inverted left corkscrew supports wrong at one angle

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Change: [#24974] Raise the Go-Karts maximum support height to allow 2 large sloped turns to be built on flat ground.
 - Fix: [#16988] AppImage version does not show changelog.
 - Fix: [#18048] Play music from all ride's stations.
+- Fix: [#19137] Non-inverted left corkscrew supports are incorrect at one angle (original bug).
 - Fix: [#23440] Quarter loops do not block metal supports correctly (original bug).
 - Fix: [#24001] Sloped diagonal metal supports that are offset with a crossbeam draw incorrectly.
 - Fix: [#24151] Sprites are cut off by 1 row of pixels when using OpenGL on Intel Macs.

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -1916,31 +1916,16 @@ void TrackPaintUtilRightVerticalLoopSegments(PaintSession& session, Direction di
 
 void TrackPaintUtilLeftCorkscrewUpSupports(PaintSession& session, Direction direction, uint16_t height)
 {
-    // TODO: Figure out which of these looks best, and use one to keep a consistent world
-    if (direction == 2)
-    {
-        PaintUtilSetSegmentSupportHeight(
-            session,
-            PaintUtilRotateSegments(
-                EnumsToFlags(
-                    PaintSegment::top, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::topRight,
-                    PaintSegment::bottomLeft),
-                direction),
-            0xFFFF, 0);
-    }
     MetalASupportsPaintSetupRotated(
         session, MetalSupportType::tubes, MetalSupportPlace::centre, direction, 0, height, session.SupportColours);
-    if (direction != 2)
-    {
-        PaintUtilSetSegmentSupportHeight(
-            session,
-            PaintUtilRotateSegments(
-                EnumsToFlags(
-                    PaintSegment::top, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::topRight,
-                    PaintSegment::bottomLeft),
-                direction),
-            0xFFFF, 0);
-    }
+    PaintUtilSetSegmentSupportHeight(
+        session,
+        PaintUtilRotateSegments(
+            EnumsToFlags(
+                PaintSegment::top, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::topRight,
+                PaintSegment::bottomLeft),
+            direction),
+        0xFFFF, 0);
 }
 
 ImageId GetStationColourScheme(PaintSession& session, const TrackElement& trackElement)


### PR DESCRIPTION
This fixes #19137. Original bug from RCT1. Fixes it for standup, corkscrew, twister and lim coasters.

<img width="90" height="150" alt="corkscrewsupportbugrct1" src="https://github.com/user-attachments/assets/4adfdfa0-aedf-4314-941b-d90a9b800da3" />
<img width="90" height="150" alt="corkscrewsupportbugfix" src="https://github.com/user-attachments/assets/742bee0e-3d3d-4398-b04e-239b665db61a" />

Save:
[leftcorkscrewsupport.zip](https://github.com/user-attachments/files/21821158/leftcorkscrewsupport.zip)
