### PR TITLE
Fix classic wooden small banked turns blocking supports incorrectly

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -22,6 +22,7 @@
 - Fix: [#24958] Android: fix crash when device is offline.
 - Fix: [#24961] Queues with corner connections set with the tile inspector draw incorrect sprites.
 - Fix: [#24972] Fix crash when closing windows would open other windows.
+- Fix: [#24989] Classic Wooden Roller Coaster small banked turns do not block metal supports correctly.
 
 0.4.25 (2025-08-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/coaster/ClassicWoodenRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/ClassicWoodenRollerCoaster.cpp
@@ -1071,11 +1071,9 @@ static void ClassicWoodenRCTrackRightQuarterTurn3Bank(
 
     static constexpr int blockedSegments[4] = {
         kSegmentsAll,
-        0,
-        EnumsToFlags(PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft),
-        EnumsToFlags(
-            PaintSegment::top, PaintSegment::left, PaintSegment::right, PaintSegment::centre, PaintSegment::topLeft,
-            PaintSegment::topRight, PaintSegment::bottomLeft, PaintSegment::bottomRight),
+        kSegmentsAll,
+        EnumsToFlags(PaintSegment::bottom, PaintSegment::centre, PaintSegment::bottomLeft, PaintSegment::bottomRight),
+        kSegmentsAll,
     };
 
     WoodenRCTrackPaintBb<true>(session, &imageIds[direction][trackSequence][0], height);


### PR DESCRIPTION
This fixes the classic wooden coaster small banked turns not blocking supports correctly. This makes them the same as the other wooden coaster types.

<img width="220" height="220" alt="classicwoodensmallbankturnsupportbug" src="https://github.com/user-attachments/assets/d846447e-b317-42ad-b4c2-263bb954058a" />
<img width="212" height="129" alt="classicwoodensmallbankturnssegmentsbug" src="https://github.com/user-attachments/assets/91217ef3-07f8-4f4b-992c-80a73f0378f9" />
<img width="212" height="129" alt="classicwoodensmallbankturnssegments" src="https://github.com/user-attachments/assets/1dda3243-4b0b-415a-a87f-fa504b039161" />
<img width="212" height="129" alt="woodensmallbankturnsegments" src="https://github.com/user-attachments/assets/b806e5c8-b86d-43c2-86f5-bd2fcc2be717" />

Save:
[classicwoodensmallbankturnsupports.zip](https://github.com/user-attachments/files/21821222/classicwoodensmallbankturnsupports.zip)
