### PR TITLE
Fix mine train coaster sloped left medium turn support rotation

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -25,6 +25,7 @@
 - Fix: [#24961] Queues with corner connections set with the tile inspector draw incorrect sprites.
 - Fix: [#24972] Fix crash when closing windows would open other windows.
 - Fix: [#24989] Classic Wooden Roller Coaster small banked turns do not block metal supports correctly.
+- Fix: [#24993] The Mine Train Coaster sloped left medium turn has an incorrectly rotated support at one angle.
 
 0.4.25 (2025-08-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/MineTrainCoaster.cpp
@@ -1630,7 +1630,7 @@ static void MineTrainRCTrackLeftQuarterTurn525DegUp(
                         session, direction, session.TrackColours.WithIndex(20264), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 1 } });
                     WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours,
+                        session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours,
                         WoodenSupportTransitionType::up25Deg, 1);
                     break;
                 case 3:


### PR DESCRIPTION
This fixes this support rotation. It only affects this angle for this left turn.

<img width="315" height="393" alt="minetraincoasterupleftturnsupportbug" src="https://github.com/user-attachments/assets/8b482475-c813-4484-9d69-645bb7bc1a1d" />
<img width="315" height="393" alt="minetraincoasterupleftturnsupportfix" src="https://github.com/user-attachments/assets/07edf88a-e01e-4b2c-80aa-8eb31cb3a460" />

Save:
[mine train coaster up left turn support bug.zip](https://github.com/user-attachments/files/21822557/mine.train.coaster.up.left.turn.support.bug.zip)
