### PR TITLE
Fix incorrectly rotated support on alpine and mine ride left s bend

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -27,6 +27,7 @@
 - Fix: [#24986] LIM Launched Roller Coaster inline twists block metal supports on the wrong side (original bug).
 - Fix: [#24989] Classic Wooden Roller Coaster small banked turns do not block metal supports correctly.
 - Fix: [#24993] The Mine Train Coaster sloped left medium turn has an incorrectly rotated support at one angle.
+- Fix: [#24994] The Alpine Coaster and Mine Ride left s-bends have an incorrectly rotated support at certain angles.
 
 0.4.25 (2025-08-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -2072,7 +2072,8 @@ void DrawSBendLeftSupports(
                     session.SupportColours);
             break;
         case 3:
-            MetalASupportsPaintSetup(session, supportType, MetalSupportPlace::centre, specialA, height, session.SupportColours);
+            MetalASupportsPaintSetupRotated(
+                session, supportType, MetalSupportPlace::centre, direction, specialA, height, session.SupportColours);
             break;
     }
 }


### PR DESCRIPTION
This fixes these supports being rotated incorrectly at certain angles. The call to paint the support is supposed to be rotated, like the others in these functions.

<img width="456" height="252" alt="sbendsupportbugs" src="https://github.com/user-attachments/assets/2d23c8a7-ee03-4552-afd7-abc8dc18d9db" />
<img width="456" height="252" alt="sbendsupportfix" src="https://github.com/user-attachments/assets/dffaa062-a797-4852-9c91-bd473902ae0c" />

Save:
[alpine mine s bend support bug.zip](https://github.com/user-attachments/files/21823178/alpine.mine.s.bend.support.bug.zip)
