### PR TITLE
Fix hybrid large slope right to orth and small bank slope right supports

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -28,6 +28,7 @@
 - Fix: [#24989] Classic Wooden Roller Coaster small banked turns do not block metal supports correctly.
 - Fix: [#24993] The Mine Train Coaster sloped left medium turn has an incorrectly rotated support at one angle.
 - Fix: [#24994] The Alpine Coaster and Mine Ride left s-bends have an incorrectly rotated support at certain angles.
+- Fix: [#25001] The Hybrid Coaster small banked sloped right turn and large sloped right turn to orthogonal have some incorrectly rotated supports.
 
 0.4.25 (2025-08-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/coaster/HybridCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/HybridCoaster.cpp
@@ -7257,8 +7257,8 @@ namespace OpenRCT2::HybridRC
                         break;
                 }
                 WoodenASupportsPaintSetupRotated(
-                    session, supportType.wooden, WoodenSupportSubType::neSw, DirectionNext(direction), height,
-                    session.SupportColours, WoodenSupportTransitionType::up25Deg);
+                    session, supportType.wooden, WoodenSupportSubType::neSw, direction, height, session.SupportColours,
+                    WoodenSupportTransitionType::up25Deg);
                 if (direction == 0 || direction == 3)
                 {
                     PaintUtilPushTunnelRotated(session, direction, height - 8, kTunnelGroup, TunnelSubType::SlopeStart);
@@ -12631,7 +12631,7 @@ namespace OpenRCT2::HybridRC
                         break;
                 }
                 WoodenASupportsPaintSetupRotated(
-                    session, supportType.wooden, WoodenSupportSubType::nwSe, DirectionNext(direction), height,
+                    session, supportType.wooden, WoodenSupportSubType::neSw, DirectionNext(direction), height,
                     session.SupportColours, WoodenSupportTransitionType::up25Deg);
                 if (direction == 0 || direction == 1)
                 {


### PR DESCRIPTION
This fixes these supports rotations on the hybrid coaster. As far as I know, they're the only ones affected.

<img width="728" height="733" alt="hybrid support rotations bug" src="https://github.com/user-attachments/assets/1be66454-ee5a-4952-b555-8af387be6b40" />
<img width="728" height="733" alt="hybrid support rotations fix" src="https://github.com/user-attachments/assets/c439a40e-5185-40af-9826-7a9fd58b1692" />

Save:
[hybrid coaster support rotations.zip](https://github.com/user-attachments/files/21850137/hybrid.coaster.support.rotations.zip)
