### PR TITLE
Fix Miniature Railway large right turn track drawing glitch

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -29,6 +29,7 @@
 - Fix: [#24993] The Mine Train Coaster sloped left medium turn has an incorrectly rotated support at one angle.
 - Fix: [#24994] The Alpine Coaster and Mine Ride left s-bends have an incorrectly rotated support at certain angles.
 - Fix: [#25001] The Hybrid Coaster small banked sloped right turn and large sloped right turn to orthogonal have some incorrectly rotated supports.
+- Fix: [#25002] The large right turn to diagonal on the Miniature Railway draws incorrectly at certain angles.
 
 0.4.25 (2025-08-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/transport/MiniatureRailway.cpp
+++ b/src/openrct2/paint/track/transport/MiniatureRailway.cpp
@@ -311,7 +311,7 @@ static constexpr CoordsXYZ miniature_railway_track_pieces_right_eight_to_diag_bo
     {
         { 32, 32, 2 },
         { 34, 16, 2 },
-        { 16, 16, 2 },
+        { 14, 14, 2 },
         { 32, 34, 0 },
     },
     {
@@ -1655,7 +1655,7 @@ static constexpr CoordsXYZ kFloorPiecesRightEighthToDiagBounds[4][5] = {
     {
         { 32, 32, 2 },
         { 34, 16, 2 },
-        { 16, 16, 2 },
+        { 14, 14, 2 },
         { 16, 16, 0 },
         { 32, 34, 0 },
     },


### PR DESCRIPTION
This fixes this glitch on the mini railway large turn. The bounding box for this tile is different to the mirrored left turn, so this copies it over as the left turn works fine. There's 2 because of how the track and supports work.
This is an example of how the bounding boxes size being [modified depending on the camera angle](https://github.com/OpenRCT2/OpenRCT2/blob/622acf61a66e13bc614ff35b3520241ee9637d1b/src/openrct2/paint/Paint.cpp#L152-L164) causes subtle differences. There is one rotation where this isn't a problem because it happens to make the bounding box small enough to not cause the bug.

<img width="253" height="103" alt="minirailwaylargeteurnbug" src="https://github.com/user-attachments/assets/873840b0-880d-4315-a48c-dd6e40be066b" />
<img width="253" height="103" alt="minirailwaylargeturnfix" src="https://github.com/user-attachments/assets/7c92d151-9ae6-49f5-9e50-da5a40d4c117" />

Save:
[mini railway large turns bug.zip](https://github.com/user-attachments/files/21853726/mini.railway.large.turns.bug.zip)
