### PR TITLE
Fix corkscrew rc inline twist inverted supports drawing below track

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -31,6 +31,7 @@
 - Fix: [#24994] The Alpine Coaster and Mine Ride left s-bends have an incorrectly rotated support at certain angles.
 - Fix: [#25001] The Hybrid Coaster small banked sloped right turn and large sloped right turn to orthogonal have some incorrectly rotated supports.
 - Fix: [#25002] The large right turn to diagonal on the Miniature Railway draws incorrectly at certain angles.
+- Fix: [#25005] The Corkscrew Roller Coaster inline twist inverted supports draw below the track.
 
 0.4.25 (2025-08-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/coaster/CorkscrewRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/CorkscrewRollerCoaster.cpp
@@ -9796,7 +9796,7 @@ static void CorkscrewRCTrackLeftTwistDownToUp(
                     direction),
                 0xFFFF, 0);
             MetalASupportsPaintSetupRotated(
-                session, supportType.metal, MetalSupportPlace::centre, direction, 0, height, session.SupportColours);
+                session, supportType.metal, MetalSupportPlace::centre, direction, 0, height + 1, session.SupportColours);
 
             switch (direction)
             {
@@ -9913,7 +9913,7 @@ static void CorkscrewRCTrackRightTwistDownToUp(
                     direction),
                 0xFFFF, 0);
             MetalASupportsPaintSetupRotated(
-                session, supportType.metal, MetalSupportPlace::centre, direction, 0, height, session.SupportColours);
+                session, supportType.metal, MetalSupportPlace::centre, direction, 0, height + 1, session.SupportColours);
 
             switch (direction)
             {
@@ -9964,7 +9964,7 @@ static void CorkscrewRCTrackLeftTwistUpToDown(
                     direction),
                 0xFFFF, 0);
             MetalASupportsPaintSetupRotated(
-                session, supportType.metal, MetalSupportPlace::centre, direction, 0, height, session.SupportColours);
+                session, supportType.metal, MetalSupportPlace::centre, direction, 0, height + 1, session.SupportColours);
 
             if (direction == 0 || direction == 3)
             {
@@ -10081,7 +10081,7 @@ static void CorkscrewRCTrackRightTwistUpToDown(
                     direction),
                 0xFFFF, 0);
             MetalASupportsPaintSetupRotated(
-                session, supportType.metal, MetalSupportPlace::centre, direction, 0, height, session.SupportColours);
+                session, supportType.metal, MetalSupportPlace::centre, direction, 0, height + 1, session.SupportColours);
 
             if (direction == 0 || direction == 3)
             {


### PR DESCRIPTION
Fixes these supports on the corkscrew coaster inline twist. Just adds one to their base height, they are now the same height as the flying coaster equivalent, accounting for differences in track piece height.

<img width="417" height="245" alt="corkscrewinlinetwistssupportsbug" src="https://github.com/user-attachments/assets/fd4af44a-0062-4d96-8d39-9201cf785e75" />
<img width="417" height="245" alt="corkscrewinlinetwistssupportsfix" src="https://github.com/user-attachments/assets/fc45c5c9-8339-458c-a74f-15cdae7d8c3b" />

Tested with [spaceks modern corkscrew trains](https://www.nedesigns.com/topic/34573/spaceks-custom-rides/) and some others.

https://github.com/user-attachments/assets/cef1d965-d2ce-46d7-afdd-59ae330d1ec4

Save:
[corkscrew inline twists.zip](https://github.com/user-attachments/files/21899571/corkscrew.inline.twists.zip)
