### PR TITLE
Fix Twister RC inline twists not drawing in tunnels at certain angles

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -32,6 +32,7 @@
 - Fix: [#25001] The Hybrid Coaster small banked sloped right turn and large sloped right turn to orthogonal have some incorrectly rotated supports.
 - Fix: [#25002] The large right turn to diagonal on the Miniature Railway draws incorrectly at certain angles.
 - Fix: [#25005] The Corkscrew Roller Coaster inline twist inverted supports draw below the track.
+- Fix: [#25006] The Twister Roller Coaster inline twists do not draw in tunnels at some angles.
 
 0.4.25 (2025-08-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/coaster/TwisterRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/TwisterRollerCoaster.cpp
@@ -13395,22 +13395,22 @@ static void TwisterRCTrackLeftTwistDownToUp(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27430), { 0, 6, height - 5 },
-                        { { 0, 0, height + 6 }, { 32, 20, 3 } });
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27436), { 0, 6, height - 5 },
-                        { { 0, 0, height + 6 }, { 32, 20, 3 } });
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27429), { 0, 6, height - 5 },
-                        { { 0, 0, height + 6 }, { 32, 20, 3 } });
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27435), { 0, 6, height - 5 },
-                        { { 0, 0, height + 6 }, { 32, 20, 3 } });
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
             }
             MetalASupportsPaintSetup(
@@ -13516,22 +13516,22 @@ static void TwisterRCTrackRightTwistDownToUp(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27442), { 0, 6, height - 5 },
-                        { { 0, 0, height + 6 }, { 32, 20, 3 } });
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27448), { 0, 6, height - 5 },
-                        { { 0, 0, height + 6 }, { 32, 20, 3 } });
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27441), { 0, 6, height - 5 },
-                        { { 0, 0, height + 6 }, { 32, 20, 3 } });
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27447), { 0, 6, height - 5 },
-                        { { 0, 0, height + 6 }, { 32, 20, 3 } });
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
             }
             MetalASupportsPaintSetup(
@@ -13704,22 +13704,22 @@ static void TwisterRCTrackLeftTwistUpToDown(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27429), { 0, 6, height - 5 },
-                        { { 0, 0, height + 6 }, { 32, 20, 3 } });
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27435), { 0, 6, height - 5 },
-                        { { 0, 0, height + 6 }, { 32, 20, 3 } });
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27430), { 0, 6, height - 5 },
-                        { { 0, 0, height + 6 }, { 32, 20, 3 } });
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27436), { 0, 6, height - 5 },
-                        { { 0, 0, height + 6 }, { 32, 20, 3 } });
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
             }
             MetalASupportsPaintSetup(
@@ -13825,22 +13825,22 @@ static void TwisterRCTrackRightTwistUpToDown(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27441), { 0, 6, height - 5 },
-                        { { 0, 0, height + 6 }, { 32, 20, 3 } });
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27447), { 0, 6, height - 5 },
-                        { { 0, 0, height + 6 }, { 32, 20, 3 } });
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27442), { 0, 6, height - 5 },
-                        { { 0, 0, height + 6 }, { 32, 20, 3 } });
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27448), { 0, 6, height - 5 },
-                        { { 0, 0, height + 6 }, { 32, 20, 3 } });
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
             }
             MetalASupportsPaintSetup(


### PR DESCRIPTION
This fixes Twister RC inline twists not drawing in tunnels at certain angles.
It looks like these bounding boxes accidentally had 6 added to the height rather than used as an offset.
`{ { 0, 6, height }, { 32, 20, 3 } }` is the typical straight flat track bounding box, this changes those tiles to that.

<img width="280" height="217" alt="twisterinlinetwisttunnelbug" src="https://github.com/user-attachments/assets/1428b801-cc86-419a-9031-fc0f56c06e61" />
<img width="280" height="217" alt="twisterinlinetwisttunnelfix" src="https://github.com/user-attachments/assets/8a89869c-d25b-419e-a8d4-d81a301fba79" />
<img width="280" height="217" alt="twisterinlinetwistboundboxbug" src="https://github.com/user-attachments/assets/ca055ee1-cb39-4d19-b403-3a2dc7d7e2a9" />
<img width="280" height="217" alt="twisterinlinetwistboundboxfix" src="https://github.com/user-attachments/assets/0ce73f45-dd4c-4914-8778-1f8a9e2f6789" />

Save:
[twister inline twists.zip](https://github.com/user-attachments/files/21907631/twister.inline.twists.zip)
