### PR TITLE
Improve visual of Rides window

### DIFF
--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -71,8 +71,8 @@ namespace OpenRCT2::Ui::Windows
         makeTab   ({  3, 17},                                                                STR_LIST_RIDES_TIP                                                    ), // tab 1
         makeTab   ({ 34, 17},                                                                STR_LIST_SHOPS_AND_STALLS_TIP                                         ), // tab 2
         makeTab   ({ 65, 17},                                                                STR_LIST_KIOSKS_AND_FACILITIES_TIP                                    ), // tab 3
-        makeWidget({  3, 47}, {284,  14}, WidgetType::textBox,      WindowColour::secondary                                                                        ), // search text box
-        makeWidget({284, 47}, { 50,  14}, WidgetType::button,       WindowColour::secondary, STR_OBJECT_SEARCH_CLEAR,            STR_CLEAR_SCENERY_TIP             ), // search clear button
+        makeWidget({  3, 47}, {264,  14}, WidgetType::textBox,      WindowColour::secondary                                                                        ), // search text box
+        makeWidget({264, 47}, { 70,  14}, WidgetType::button,       WindowColour::secondary, STR_OBJECT_SEARCH_CLEAR,            STR_CLEAR_SCENERY_TIP             ), // search clear button
         makeWidget({  3, 62}, {150,  14}, WidgetType::tableHeader,  WindowColour::secondary                                                                        ), // name header
         makeWidget({153, 62}, {147,  14}, WidgetType::tableHeader,  WindowColour::secondary                                                                        ), // other header
         makeWidget({300, 62}, { 14,  14}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH                                                    ), // customise button
@@ -524,7 +524,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_LIST].bottom = height - 15;
 
             widgets[WIDX_SEARCH_CLEAR_BUTTON].right = widgets[WIDX_LIST].right - 1;
-            widgets[WIDX_SEARCH_CLEAR_BUTTON].left = widgets[WIDX_SEARCH_CLEAR_BUTTON].right - 40;
+            widgets[WIDX_SEARCH_CLEAR_BUTTON].left = widgets[WIDX_SEARCH_CLEAR_BUTTON].right - 70;
             widgets[WIDX_SEARCH_TEXT_BOX].right = widgets[WIDX_SEARCH_CLEAR_BUTTON].left - 2;
             widgets[WIDX_SEARCH_TEXT_BOX].string = _searchFilter.data();
 

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -72,7 +72,7 @@ namespace OpenRCT2::Ui::Windows
         makeTab   ({ 34, 17},                                                                STR_LIST_SHOPS_AND_STALLS_TIP                                         ), // tab 2
         makeTab   ({ 65, 17},                                                                STR_LIST_KIOSKS_AND_FACILITIES_TIP                                    ), // tab 3
         makeWidget({  3, 47}, {264,  14}, WidgetType::textBox,      WindowColour::secondary                                                                        ), // search text box
-        makeWidget({264, 47}, { 70,  14}, WidgetType::button,       WindowColour::secondary, STR_OBJECT_SEARCH_CLEAR,            STR_CLEAR_SCENERY_TIP             ), // search clear button
+        makeWidget({264, 47}, { 70,  14}, WidgetType::button,       WindowColour::secondary, STR_OBJECT_SEARCH_CLEAR                                               ), // search clear button
         makeWidget({  3, 62}, {150,  14}, WidgetType::tableHeader,  WindowColour::secondary                                                                        ), // name header
         makeWidget({153, 62}, {147,  14}, WidgetType::tableHeader,  WindowColour::secondary                                                                        ), // other header
         makeWidget({300, 62}, { 14,  14}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH                                                    ), // customise button


### PR DESCRIPTION
Make "Clear" button in Rides window wider to accommodate text from all Localisations (detail **1**), fix tooltip for Clear button in Rides window (detail **2**) and add tooltip for alike Clear buttons (detail **3**)

___________

**(1) What is changed:** In Rides window (RideList.cpp) make "Clear" button wider, to width of 70, which is used for other Clear buttons in same list clearing context.

**(1) Why is it changed** The button was too narrow (small on x axis) and since it reuses already present and translated string, it breaks translations, and would in matter of time press translators into Sophia's choice (Syphilos choice ??) of bad solutions (shortening the string)

**(2) What is changed:** Fix text of tooltip by introducing new string, since actual tooltip is somewhat a bit out-of-line

**(2) Why is it changed:** This is obliviously confusing

**(3) What is changed:** Add tooltip for other uses of visually same clear button (with same STR)

**(3) Why is it changed:** Since new string for tooltip is introduced, it would be shameful not to use it

____________

**Image reference:** (gayscale current state, colour PR)
<img width="415" height="254" alt="old1" src="https://github.com/user-attachments/assets/6db05417-29a6-4c96-9a5a-21f51e063abb" />
<img width="407" height="252" alt="new1" src="https://github.com/user-attachments/assets/eeb5b67a-d38a-44b9-9cc9-e650532a2f04" />

gifs showing various translations
![old_animate](https://github.com/user-attachments/assets/7afad437-e2d4-411d-8114-ce8d5d593586)
![new_animate](https://github.com/user-attachments/assets/20010073-f6f5-43bf-858f-3ede928b949d)

add tooltip as detailed in (3)
<img width="407" height="252" alt="new1" src="https://github.com/user-attachments/assets/786498ad-fdb3-41dd-81ae-b6f82e5751b7" />
<img width="724" height="253" alt="new2" src="https://github.com/user-attachments/assets/b28d137d-e738-450d-934b-62dc11c1dc07" />
<img width="612" height="112" alt="new3" src="https://github.com/user-attachments/assets/b7951fdd-0c63-45b7-90c8-cd87d95d460c" />


Thank you for reading