### PR TITLE
Refactor how dropdown items are passed

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1344,7 +1344,7 @@ namespace OpenRCT2
                             dropdown_index = DropdownIndexFromPoint(screenCoords, w);
                             dropdownCleanup = dropdown_index == -1
                                 || (dropdown_index < Dropdown::kItemsMaxSize && Dropdown::IsDisabled(dropdown_index))
-                                || gDropdownItems[dropdown_index].IsSeparator();
+                                || gDropdownItems[dropdown_index].isSeparator();
                             w = nullptr; // To be closed right next
                         }
                         else
@@ -1481,7 +1481,7 @@ namespace OpenRCT2
                 return;
             }
 
-            if (gDropdownItems[dropdown_index].IsSeparator())
+            if (gDropdownItems[dropdown_index].isSeparator())
             {
                 return;
             }

--- a/src/openrct2-ui/interface/Dropdown.h
+++ b/src/openrct2-ui/interface/Dropdown.h
@@ -54,8 +54,6 @@ namespace OpenRCT2::Ui::Windows
     void WindowDropdownShowColour(
         WindowBase* w, Widget* widget, ColourWithFlags dropdownColour, colour_t selectedColour,
         bool alwaysHideSpecialColours = false);
-    void WindowDropdownShowColourAvailable(
-        WindowBase* w, Widget* widget, uint8_t dropdownColour, uint8_t selectedColour, uint32_t availableColours);
 
     colour_t ColourDropDownIndexToColour(uint8_t ddidx);
 

--- a/src/openrct2-ui/interface/Dropdown.h
+++ b/src/openrct2-ui/interface/Dropdown.h
@@ -13,6 +13,7 @@
 #include <openrct2-ui/UiStringIds.h>
 #include <openrct2/core/EnumUtils.hpp>
 #include <openrct2/interface/Window.h>
+#include <span>
 
 struct ImageId;
 
@@ -39,9 +40,15 @@ namespace OpenRCT2::Ui::Windows
     void WindowDropdownShowText(
         const ScreenCoordsXY& screenPos, int32_t extray, ColourWithFlags colour, uint8_t flags, size_t num_items,
         size_t prefRowsPerColumn = 0);
+    void WindowDropdownShowText(
+        const ScreenCoordsXY& screenPos, int32_t extray, ColourWithFlags colour, uint8_t flags,
+        std::span<const Dropdown::Item> items, size_t prefRowsPerColumn = 0);
     void WindowDropdownShowTextCustomWidth(
         const ScreenCoordsXY& screenPos, int32_t extray, ColourWithFlags colour, uint8_t custom_height, uint8_t flags,
         size_t num_items, int32_t width, size_t prefRowsPerColumn = 0);
+    void WindowDropdownShowTextCustomWidth(
+        const ScreenCoordsXY& screenPos, int32_t extray, ColourWithFlags colour, uint8_t custom_height, uint8_t flags,
+        std::span<const Dropdown::Item> items, int32_t width, size_t prefRowsPerColumn = 0);
 
     void WindowDropdownShowImage(
         int32_t x, int32_t y, int32_t extray, ColourWithFlags colour, uint8_t flags, int32_t numItems, int32_t itemWidth,

--- a/src/openrct2-ui/interface/Dropdown.h
+++ b/src/openrct2-ui/interface/Dropdown.h
@@ -78,29 +78,30 @@ namespace OpenRCT2::Dropdown
 
     enum class ItemFlag : uint8_t
     {
-        IsDisabled = (1 << 0),
-        IsChecked = (1 << 1),
+        isDisabled = 0,
+        isChecked = 1,
     };
+    using ItemFlags = FlagHolder<uint8_t, ItemFlag>;
 
     struct Item
     {
-        StringId Format;
-        int64_t Args;
-        uint8_t Flags;
+        StringId format{};
+        int64_t args{};
+        ItemFlags flags{};
 
-        constexpr bool IsSeparator() const
+        constexpr bool isSeparator() const
         {
-            return Format == kSeparatorString;
+            return format == kSeparatorString;
         }
 
-        constexpr bool IsDisabled() const
+        constexpr bool isDisabled() const
         {
-            return (Flags & EnumValue(ItemFlag::IsDisabled));
+            return flags.has(ItemFlag::isDisabled);
         }
 
-        constexpr bool IsChecked() const
+        constexpr bool isChecked() const
         {
-            return (Flags & EnumValue(ItemFlag::IsChecked));
+            return flags.has(ItemFlag::isChecked);
         }
     };
 
@@ -134,8 +135,8 @@ namespace OpenRCT2::Dropdown
         for (int i = 0; i < N; ++i)
         {
             const ItemExt& item = items[i];
-            OpenRCT2::Ui::Windows::gDropdownItems[i].Format = item.itemFormat;
-            OpenRCT2::Ui::Windows::gDropdownItems[i].Args = item.stringId;
+            OpenRCT2::Ui::Windows::gDropdownItems[i].format = item.itemFormat;
+            OpenRCT2::Ui::Windows::gDropdownItems[i].args = item.stringId;
         }
     }
 

--- a/src/openrct2-ui/interface/LandTool.cpp
+++ b/src/openrct2-ui/interface/LandTool.cpp
@@ -67,7 +67,7 @@ void LandTool::ShowSurfaceStyleDropdown(WindowBase* w, Widget* widget, ObjectEnt
             if (surfaceObj->Colour != TerrainSurfaceObject::kNoValue)
                 imageId = imageId.WithPrimary(surfaceObj->Colour);
 
-            gDropdownItems[itemIndex].Format = Dropdown::kFormatLandPicker;
+            gDropdownItems[itemIndex].format = Dropdown::kFormatLandPicker;
             Dropdown::SetImage(itemIndex, imageId);
             if (i == currentSurfaceType)
             {
@@ -117,7 +117,7 @@ void LandTool::ShowEdgeStyleDropdown(WindowBase* w, Widget* widget, ObjectEntryI
         // If fallback images are loaded, the RCT1 styles will just look like copies of already existing styles, so hide them.
         if (edgeObj != nullptr && !edgeObj->UsesFallbackImages())
         {
-            gDropdownItems[itemIndex].Format = Dropdown::kFormatLandPicker;
+            gDropdownItems[itemIndex].format = Dropdown::kFormatLandPicker;
             Dropdown::SetImage(itemIndex, ImageId(edgeObj->IconImageId));
             if (i == currentEdgeType)
             {

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -649,12 +649,12 @@ namespace OpenRCT2::Ui::Windows
                     const auto numItems = std::min<size_t>(items.size(), Dropdown::kItemsMaxSize);
                     for (size_t i = 0; i < numItems; i++)
                     {
-                        gDropdownItems[i].Format = STR_OPTIONS_DROPDOWN_ITEM;
+                        gDropdownItems[i].format = STR_OPTIONS_DROPDOWN_ITEM;
                         if (selectedIndex == static_cast<int32_t>(i))
-                            gDropdownItems[i].Format = STR_OPTIONS_DROPDOWN_ITEM_SELECTED;
+                            gDropdownItems[i].format = STR_OPTIONS_DROPDOWN_ITEM_SELECTED;
 
                         auto sz = items[i].c_str();
-                        std::memcpy(&gDropdownItems[i].Args, &sz, sizeof(const char*));
+                        std::memcpy(&gDropdownItems[i].args, &sz, sizeof(const char*));
                     }
                     WindowDropdownShowTextCustomWidth(
                         { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1,

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -167,8 +167,8 @@ namespace OpenRCT2::Ui::Windows
                     auto numItems = std::size(kBannerColouredTextFormats) - 1;
                     for (size_t i = 0; i < numItems; ++i)
                     {
-                        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
-                        gDropdownItems[i].Args = kBannerColouredTextFormats[i + 1];
+                        gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL;
+                        gDropdownItems[i].args = kBannerColouredTextFormats[i + 1];
                     }
 
                     // Switch to the dropdown box widget.

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -994,8 +994,8 @@ static StringId window_cheats_page_titles[] = {
 
                     for (size_t i = 0; i < std::size(_staffSpeedNames); i++)
                     {
-                        gDropdownItems[i].Args = _staffSpeedNames[i];
-                        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+                        gDropdownItems[i].args = _staffSpeedNames[i];
+                        gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL;
                     }
 
                     WindowDropdownShowTextCustomWidth(
@@ -1018,8 +1018,8 @@ static StringId window_cheats_page_titles[] = {
 
                     for (size_t i = 0; i < std::size(WeatherTypes); i++)
                     {
-                        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
-                        gDropdownItems[i].Args = WeatherTypes[i];
+                        gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL;
+                        gDropdownItems[i].args = WeatherTypes[i];
                     }
                     WindowDropdownShowTextCustomWidth(
                         { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -87,11 +87,11 @@ namespace OpenRCT2::Ui::Windows
                     }
                     break;
                 case WIDX_AFFIX_DROPDOWN_BUTTON:
-                    gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[0].Args = STR_PREFIX;
+                    gDropdownItems[0].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[0].args = STR_PREFIX;
 
-                    gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[1].Args = STR_SUFFIX;
+                    gDropdownItems[1].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[1].args = STR_SUFFIX;
 
                     WindowDropdownShowTextCustomWidth(
                         { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1, colours[1], 0,

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -310,6 +310,14 @@ namespace OpenRCT2::Ui::Windows
         }
     };
 
+    static void copyItemsToGlobal(std::span<const Dropdown::Item> items)
+    {
+        for (size_t i = 0; i < items.size(); i++)
+        {
+            gDropdownItems[i] = items[i];
+        }
+    }
+
     /**
      * Shows a text dropdown menu.
      *  rct2: 0x006ECFB9
@@ -338,6 +346,14 @@ namespace OpenRCT2::Ui::Windows
 
         WindowDropdownShowTextCustomWidth(
             screenPos, extray, colour, 0, flags, num_items, max_string_width + 3, prefRowsPerColumn);
+    }
+
+    void WindowDropdownShowText(
+        const ScreenCoordsXY& screenPos, int32_t extray, ColourWithFlags colour, uint8_t flags,
+        std::span<const Dropdown::Item> items, size_t prefRowsPerColumn)
+    {
+        copyItemsToGlobal(items);
+        WindowDropdownShowText(screenPos, extray, colour, flags, items.size(), prefRowsPerColumn);
     }
 
     /**
@@ -371,6 +387,15 @@ namespace OpenRCT2::Ui::Windows
             auto numRowsPerColumn = prefRowsPerColumn > 0 ? static_cast<int32_t>(prefRowsPerColumn) : Dropdown::kItemsMaxSize;
             w->SetTextItems(screenPos, extray, colour, customItemHeight, flags, num_items, width, numRowsPerColumn);
         }
+    }
+
+    void WindowDropdownShowTextCustomWidth(
+        const ScreenCoordsXY& screenPos, int32_t extray, ColourWithFlags colour, uint8_t custom_height, uint8_t flags,
+        std::span<const Dropdown::Item> items, int32_t width, size_t prefRowsPerColumn)
+    {
+        copyItemsToGlobal(items);
+        WindowDropdownShowTextCustomWidth(
+            screenPos, extray, colour, custom_height, flags, items.size(), width, prefRowsPerColumn);
     }
 
     /**

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -61,7 +61,7 @@ namespace OpenRCT2::Ui::Windows
     {
         for (size_t i = 0; i < std::size(gDropdownItems); i++)
         {
-            gDropdownItems[i].Flags = 0;
+            gDropdownItems[i].flags.clearAll();
         }
     }
 
@@ -113,7 +113,7 @@ namespace OpenRCT2::Ui::Windows
                 ScreenCoordsXY screenCoords = windowPos
                     + ScreenCoordsXY{ 2 + (cellCoords.x * ItemWidth), 2 + (cellCoords.y * ItemHeight) };
 
-                if (gDropdownItems[i].IsSeparator())
+                if (gDropdownItems[i].isSeparator())
                 {
                     const auto leftTop = screenCoords + ScreenCoordsXY{ 2, (ItemHeight / 2) - 1 };
                     const auto rightBottom = leftTop + ScreenCoordsXY{ ItemWidth - 4, 0 };
@@ -141,12 +141,12 @@ namespace OpenRCT2::Ui::Windows
                         GfxFilterRect(rt, { screenCoords, rightBottom }, FilterPaletteID::PaletteDarken3);
                     }
 
-                    StringId item = gDropdownItems[i].Format;
+                    StringId item = gDropdownItems[i].format;
                     if (item == Dropdown::kFormatLandPicker || item == Dropdown::kFormatColourPicker)
                     {
                         // Image item
                         auto image = UseImages ? _dropdownItemsImages[i]
-                                               : ImageId(static_cast<uint32_t>(gDropdownItems[i].Args));
+                                               : ImageId(static_cast<uint32_t>(gDropdownItems[i].args));
                         if (item == Dropdown::kFormatColourPicker && highlightedIndex == i)
                             image = image.WithIndexOffset(1);
                         GfxDrawSprite(rt, image, screenCoords);
@@ -166,7 +166,7 @@ namespace OpenRCT2::Ui::Windows
 
                         // Draw item string
                         auto yOffset = GetAdditionalRowPadding();
-                        Formatter ft(reinterpret_cast<uint8_t*>(&gDropdownItems[i].Args));
+                        Formatter ft(reinterpret_cast<uint8_t*>(&gDropdownItems[i].args));
                         DrawTextEllipsised(
                             rt, { screenCoords.x + 2, screenCoords.y + yOffset }, width - 7, item, ft, { colour });
                     }
@@ -331,7 +331,7 @@ namespace OpenRCT2::Ui::Windows
         int32_t max_string_width = 0;
         for (size_t i = 0; i < num_items; i++)
         {
-            FormatStringLegacy(buffer, 256, gDropdownItems[i].Format, static_cast<void*>(&gDropdownItems[i].Args));
+            FormatStringLegacy(buffer, 256, gDropdownItems[i].format, static_cast<void*>(&gDropdownItems[i].args));
             int32_t string_width = GfxGetStringWidth(buffer, FontStyle::Medium);
             max_string_width = std::max(string_width, max_string_width);
         }
@@ -584,7 +584,7 @@ namespace OpenRCT2::Ui::Windows
             auto imageId = (orderedColour == COLOUR_INVISIBLE) ? ImageId(SPR_G2_ICON_PALETTE_INVISIBLE, COLOUR_WHITE)
                                                                : ImageId(SPR_PALETTE_BTN, orderedColour);
 
-            gDropdownItems[i].Format = Dropdown::kFormatColourPicker;
+            gDropdownItems[i].format = Dropdown::kFormatColourPicker;
             Dropdown::SetImage(i, imageId);
         }
 
@@ -619,7 +619,7 @@ bool Dropdown::IsChecked(int32_t index)
     {
         return false;
     }
-    return gDropdownItems[index].IsChecked();
+    return gDropdownItems[index].isChecked();
 }
 
 bool Dropdown::IsDisabled(int32_t index)
@@ -628,7 +628,7 @@ bool Dropdown::IsDisabled(int32_t index)
     {
         return true;
     }
-    return gDropdownItems[index].IsDisabled();
+    return gDropdownItems[index].isDisabled();
 }
 
 void Dropdown::SetChecked(int32_t index, bool value)
@@ -637,10 +637,8 @@ void Dropdown::SetChecked(int32_t index, bool value)
     {
         return;
     }
-    if (value)
-        gDropdownItems[index].Flags |= EnumValue(Dropdown::ItemFlag::IsChecked);
-    else
-        gDropdownItems[index].Flags &= ~EnumValue(Dropdown::ItemFlag::IsChecked);
+
+    gDropdownItems[index].flags.set(Dropdown::ItemFlag::isChecked, value);
 }
 
 void Dropdown::SetDisabled(int32_t index, bool value)
@@ -649,10 +647,8 @@ void Dropdown::SetDisabled(int32_t index, bool value)
     {
         return;
     }
-    if (value)
-        gDropdownItems[index].Flags |= EnumValue(Dropdown::ItemFlag::IsDisabled);
-    else
-        gDropdownItems[index].Flags &= ~EnumValue(Dropdown::ItemFlag::IsDisabled);
+
+    gDropdownItems[index].flags.set(Dropdown::ItemFlag::isDisabled, value);
 }
 
 void Dropdown::SetImage(int32_t index, ImageId image)

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -513,8 +513,8 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_FILTER_DROPDOWN_BTN:
                     for (auto ddIdx = EnumValue(DDIX_FILTER_RCT1); ddIdx <= EnumValue(DDIX_FILTER_CUSTOM); ddIdx++)
                     {
-                        gDropdownItems[ddIdx].Args = kSourceStringIds[ddIdx];
-                        gDropdownItems[ddIdx].Format = STR_TOGGLE_OPTION;
+                        gDropdownItems[ddIdx].args = kSourceStringIds[ddIdx];
+                        gDropdownItems[ddIdx].format = STR_TOGGLE_OPTION;
                     }
 
                     // Track designs manager cannot select multiple, so only show selection filters if not in track designs
@@ -522,12 +522,12 @@ namespace OpenRCT2::Ui::Windows
                     if (!(gLegacyScene == LegacyScene::trackDesignsManager))
                     {
                         numSelectionItems = 3;
-                        gDropdownItems[DDIX_FILTER_SEPARATOR].Format = 0;
-                        gDropdownItems[DDIX_FILTER_SELECTED].Format = STR_TOGGLE_OPTION;
-                        gDropdownItems[DDIX_FILTER_NONSELECTED].Format = STR_TOGGLE_OPTION;
-                        gDropdownItems[DDIX_FILTER_SEPARATOR].Args = kStringIdNone;
-                        gDropdownItems[DDIX_FILTER_SELECTED].Args = STR_SELECTED_ONLY;
-                        gDropdownItems[DDIX_FILTER_NONSELECTED].Args = STR_NON_SELECTED_ONLY;
+                        gDropdownItems[DDIX_FILTER_SEPARATOR].format = 0;
+                        gDropdownItems[DDIX_FILTER_SELECTED].format = STR_TOGGLE_OPTION;
+                        gDropdownItems[DDIX_FILTER_NONSELECTED].format = STR_TOGGLE_OPTION;
+                        gDropdownItems[DDIX_FILTER_SEPARATOR].args = kStringIdNone;
+                        gDropdownItems[DDIX_FILTER_SELECTED].args = STR_SELECTED_ONLY;
+                        gDropdownItems[DDIX_FILTER_NONSELECTED].args = STR_NON_SELECTED_ONLY;
                     }
 
                     auto& ddWidget = widgets[WIDX_FILTER_DROPDOWN];

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -743,8 +743,8 @@ namespace OpenRCT2::Ui::Windows
                     || Park::RidePricesUnlocked();
                 if (objectiveAllowedByMoneyUsage && objectiveAllowedByPaymentSettings)
                 {
-                    gDropdownItems[numItems].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[numItems].Args = ObjectiveDropdownOptionNames[i];
+                    gDropdownItems[numItems].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[numItems].args = ObjectiveDropdownOptionNames[i];
                     numItems++;
                 }
             }
@@ -756,7 +756,7 @@ namespace OpenRCT2::Ui::Windows
             objectiveType = gameState.scenarioObjective.Type;
             for (int32_t j = 0; j < numItems; j++)
             {
-                if (gDropdownItems[j].Args - STR_OBJECTIVE_DROPDOWN_NONE == objectiveType)
+                if (gDropdownItems[j].args - STR_OBJECTIVE_DROPDOWN_NONE == objectiveType)
                 {
                     Dropdown::SetChecked(j, true);
                     break;
@@ -773,8 +773,8 @@ namespace OpenRCT2::Ui::Windows
 
             for (i = EnumValue(ScenarioCategory::beginner); i <= EnumValue(ScenarioCategory::other); i++)
             {
-                gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItems[i].Args = kScenarioCategoryStringIds[i];
+                gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[i].args = kScenarioCategoryStringIds[i];
             }
             WindowDropdownShowTextCustomWidth(
                 { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
@@ -1008,7 +1008,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 case WIDX_OBJECTIVE_DROPDOWN:
                     // TODO: Don't rely on string ID order
-                    newObjectiveType = static_cast<uint8_t>(gDropdownItems[dropdownIndex].Args - STR_OBJECTIVE_DROPDOWN_NONE);
+                    newObjectiveType = static_cast<uint8_t>(gDropdownItems[dropdownIndex].args - STR_OBJECTIVE_DROPDOWN_NONE);
                     if (gameState.scenarioObjective.Type != newObjectiveType)
                         SetObjective(newObjectiveType);
                     break;
@@ -1541,12 +1541,12 @@ namespace OpenRCT2::Ui::Windows
                 {
                     Widget* dropdownWidget = &widgets[widgetIndex - 1];
 
-                    gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[0].Args = STR_FREE_PARK_ENTER;
-                    gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[1].Args = STR_PAY_PARK_ENTER;
-                    gDropdownItems[2].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[2].Args = STR_PAID_ENTRY_PAID_RIDES;
+                    gDropdownItems[0].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[0].args = STR_FREE_PARK_ENTER;
+                    gDropdownItems[1].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[1].args = STR_PAY_PARK_ENTER;
+                    gDropdownItems[2].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[2].args = STR_PAID_ENTRY_PAID_RIDES;
 
                     WindowDropdownShowTextCustomWidth(
                         { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height() - 1,
@@ -1879,15 +1879,15 @@ namespace OpenRCT2::Ui::Windows
                 {
                     auto& dropdownWidget = widgets[widgetIndex - 1];
 
-                    gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[2].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[3].Format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[0].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[1].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[2].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[3].format = STR_DROPDOWN_MENU_LABEL;
 
-                    gDropdownItems[0].Args = STR_GUESTS_PREFER_INTENSITY_NONE;
-                    gDropdownItems[1].Args = STR_GUESTS_PREFER_INTENSITY_BALANCED;
-                    gDropdownItems[2].Args = STR_GUESTS_PREFER_INTENSITY_LESS_INTENSE_RIDES;
-                    gDropdownItems[3].Args = STR_GUESTS_PREFER_INTENSITY_MORE_INTENSE_RIDES;
+                    gDropdownItems[0].args = STR_GUESTS_PREFER_INTENSITY_NONE;
+                    gDropdownItems[1].args = STR_GUESTS_PREFER_INTENSITY_BALANCED;
+                    gDropdownItems[2].args = STR_GUESTS_PREFER_INTENSITY_LESS_INTENSE_RIDES;
+                    gDropdownItems[3].args = STR_GUESTS_PREFER_INTENSITY_MORE_INTENSE_RIDES;
 
                     WindowDropdownShowTextCustomWidth(
                         { windowPos.x + dropdownWidget.left, windowPos.y + dropdownWidget.top }, dropdownWidget.height() - 1,

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -702,7 +702,7 @@ namespace OpenRCT2::Ui::Windows
                     defaultIndex = numPathTypes;
                 }
 
-                gDropdownItems[numPathTypes].Format = kStringIdNone;
+                gDropdownItems[numPathTypes].format = kStringIdNone;
                 gDropdownTooltips[numPathTypes] = pathType->NameStringId;
                 Dropdown::SetImage(numPathTypes, ImageId(pathType->PreviewImageId));
                 _dropdownEntries.push_back({ ObjectType::footpathSurface, i });
@@ -728,7 +728,7 @@ namespace OpenRCT2::Ui::Windows
                     defaultIndex = numPathTypes;
                 }
 
-                gDropdownItems[numPathTypes].Format = kStringIdNone;
+                gDropdownItems[numPathTypes].format = kStringIdNone;
                 gDropdownTooltips[numPathTypes] = pathEntry->string_idx;
                 Dropdown::SetImage(
                     numPathTypes, ImageId(showQueues ? pathEntry->GetQueuePreviewImage() : pathEntry->GetPreviewImage()));
@@ -766,7 +766,7 @@ namespace OpenRCT2::Ui::Windows
                     defaultIndex = numRailingsTypes;
                 }
 
-                gDropdownItems[numRailingsTypes].Format = kStringIdNone;
+                gDropdownItems[numRailingsTypes].format = kStringIdNone;
                 gDropdownTooltips[numRailingsTypes] = railingsEntry->NameStringId;
                 Dropdown::SetImage(numRailingsTypes, ImageId(railingsEntry->PreviewImageId));
                 _dropdownEntries.push_back({ ObjectType::footpathRailings, i });

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -715,8 +715,8 @@ namespace OpenRCT2::Ui::Windows
 
         void ShowLocateDropdown(Widget& widget)
         {
-            gDropdownItems[0].Format = STR_LOCATE_SUBJECT_TIP;
-            gDropdownItems[1].Format = STR_FOLLOW_SUBJECT_TIP;
+            gDropdownItems[0].format = STR_LOCATE_SUBJECT_TIP;
+            gDropdownItems[1].format = STR_FOLLOW_SUBJECT_TIP;
 
             WindowDropdownShowText(
                 { windowPos.x + widget.left, windowPos.y + widget.top }, widget.height() + 1, colours[1], 0, 2);

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -715,11 +715,13 @@ namespace OpenRCT2::Ui::Windows
 
         void ShowLocateDropdown(Widget& widget)
         {
-            gDropdownItems[0].format = STR_LOCATE_SUBJECT_TIP;
-            gDropdownItems[1].format = STR_FOLLOW_SUBJECT_TIP;
+            constexpr std::array<Dropdown::Item, 2> dropdownItems = {
+                Dropdown::Item{ STR_LOCATE_SUBJECT_TIP },
+                Dropdown::Item{ STR_FOLLOW_SUBJECT_TIP },
+            };
 
             WindowDropdownShowText(
-                { windowPos.x + widget.left, windowPos.y + widget.top }, widget.height() + 1, colours[1], 0, 2);
+                { windowPos.x + widget.left, windowPos.y + widget.top }, widget.height() + 1, colours[1], 0, dropdownItems);
             gDropdownDefaultIndex = 0;
         }
 

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -338,8 +338,8 @@ namespace OpenRCT2::Ui::Windows
 
                     for (size_t i = 0; i < _numPages; i++)
                     {
-                        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
-                        uint16_t* args = reinterpret_cast<uint16_t*>(&gDropdownItems[i].Args);
+                        gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL;
+                        uint16_t* args = reinterpret_cast<uint16_t*>(&gDropdownItems[i].args);
                         args[0] = STR_PAGE_X;
                         args[1] = static_cast<uint16_t>(i + 1);
                     }
@@ -348,10 +348,10 @@ namespace OpenRCT2::Ui::Windows
                 }
                 case WIDX_INFO_TYPE_DROPDOWN_BUTTON:
                 {
-                    gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[0].Args = GetViewName(GuestViewType::Actions);
-                    gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[1].Args = GetViewName(GuestViewType::Thoughts);
+                    gDropdownItems[0].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[0].args = GetViewName(GuestViewType::Actions);
+                    gDropdownItems[1].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[1].args = GetViewName(GuestViewType::Thoughts);
 
                     auto* widget = &widgets[widgetIndex - 1];
                     WindowDropdownShowTextCustomWidth(

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -902,20 +902,20 @@ namespace OpenRCT2::Ui::Windows
             if (widgetIndex != WIDX_SORT_CUSTOMISE)
                 return;
 
-            gDropdownItems[0].Format = STR_TOGGLE_OPTION;
-            gDropdownItems[1].Format = STR_TOGGLE_OPTION;
-            gDropdownItems[2].Format = STR_TOGGLE_OPTION;
-            gDropdownItems[3].Format = kStringIdEmpty;
-            gDropdownItems[4].Format = STR_DROPDOWN_BULLET_OPTION;
-            gDropdownItems[5].Format = STR_DROPDOWN_BULLET_OPTION;
-            gDropdownItems[6].Format = STR_DROPDOWN_BULLET_OPTION;
+            gDropdownItems[0].format = STR_TOGGLE_OPTION;
+            gDropdownItems[1].format = STR_TOGGLE_OPTION;
+            gDropdownItems[2].format = STR_TOGGLE_OPTION;
+            gDropdownItems[3].format = kStringIdEmpty;
+            gDropdownItems[4].format = STR_DROPDOWN_BULLET_OPTION;
+            gDropdownItems[5].format = STR_DROPDOWN_BULLET_OPTION;
+            gDropdownItems[6].format = STR_DROPDOWN_BULLET_OPTION;
 
-            gDropdownItems[0].Args = STR_FILEBROWSER_CUSTOMISE_FILENAME;
-            gDropdownItems[1].Args = STR_FILEBROWSER_CUSTOMISE_SIZE;
-            gDropdownItems[2].Args = STR_FILEBROWSER_CUSTOMISE_DATE;
-            gDropdownItems[4].Args = STR_FILEBROWSER_PREVIEW_DISABLED;
-            gDropdownItems[5].Args = STR_FILEBROWSER_PREVIEW_MINIMAP;
-            gDropdownItems[6].Args = STR_FILEBROWSER_PREVIEW_SCREENSHOT;
+            gDropdownItems[0].args = STR_FILEBROWSER_CUSTOMISE_FILENAME;
+            gDropdownItems[1].args = STR_FILEBROWSER_CUSTOMISE_SIZE;
+            gDropdownItems[2].args = STR_FILEBROWSER_CUSTOMISE_DATE;
+            gDropdownItems[4].args = STR_FILEBROWSER_PREVIEW_DISABLED;
+            gDropdownItems[5].args = STR_FILEBROWSER_PREVIEW_MINIMAP;
+            gDropdownItems[6].args = STR_FILEBROWSER_PREVIEW_SCREENSHOT;
 
             Widget* widget = &widgets[WIDX_SORT_CUSTOMISE];
 

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -528,8 +528,8 @@ namespace OpenRCT2::Ui::Windows
 
         for (auto i = 0; i < NetworkGetNumGroups(); i++)
         {
-            gDropdownItems[i].Format = STR_OPTIONS_DROPDOWN_ITEM;
-            gDropdownItems[i].Args = reinterpret_cast<uintptr_t>(NetworkGetGroupName(i));
+            gDropdownItems[i].format = STR_OPTIONS_DROPDOWN_ITEM;
+            gDropdownItems[i].args = reinterpret_cast<uintptr_t>(NetworkGetGroupName(i));
         }
         if (widget == &widgets[WIDX_DEFAULT_GROUP_DROPDOWN])
         {

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -211,8 +211,8 @@ namespace OpenRCT2::Ui::Windows
                             int32_t maxSize = std::min(Dropdown::kItemsMaxSize, static_cast<int32_t>(ShopItems.size()));
                             for (int32_t i = 0; i < maxSize; i++)
                             {
-                                gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
-                                gDropdownItems[i].Args = GetShopItemDescriptor(ShopItems[i]).Naming.Plural;
+                                gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL;
+                                gDropdownItems[i].args = GetShopItemDescriptor(ShopItems[i]).Naming.Plural;
                                 numItems++;
                             }
 
@@ -231,15 +231,15 @@ namespace OpenRCT2::Ui::Windows
                             if (curRide != nullptr)
                             {
                                 // HACK until dropdown items have longer argument buffers
-                                gDropdownItems[numItems].Format = STR_DROPDOWN_MENU_LABEL;
-                                Formatter ft(reinterpret_cast<uint8_t*>(&gDropdownItems[numItems].Args));
+                                gDropdownItems[numItems].format = STR_DROPDOWN_MENU_LABEL;
+                                Formatter ft(reinterpret_cast<uint8_t*>(&gDropdownItems[numItems].args));
                                 if (curRide->customName.empty())
                                 {
                                     curRide->formatNameTo(ft);
                                 }
                                 else
                                 {
-                                    gDropdownItems[numItems].Format = STR_OPTIONS_DROPDOWN_ITEM;
+                                    gDropdownItems[numItems].format = STR_OPTIONS_DROPDOWN_ITEM;
                                     ft.Add<const char*>(curRide->customName.c_str());
                                 }
                                 numItems++;

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -822,9 +822,9 @@ namespace OpenRCT2::Ui::Windows
                     {
                         const Resolution& resolution = resolutions[i];
 
-                        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+                        gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL;
 
-                        uint16_t* args = reinterpret_cast<uint16_t*>(&gDropdownItems[i].Args);
+                        uint16_t* args = reinterpret_cast<uint16_t*>(&gDropdownItems[i].args);
                         args[0] = STR_RESOLUTION_X_BY_Y;
                         args[1] = resolution.Width;
                         args[2] = resolution.Height;
@@ -846,12 +846,12 @@ namespace OpenRCT2::Ui::Windows
 
                 break;
                 case WIDX_FULLSCREEN_DROPDOWN:
-                    gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[2].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[0].Args = STR_OPTIONS_DISPLAY_WINDOWED;
-                    gDropdownItems[1].Args = STR_OPTIONS_DISPLAY_FULLSCREEN;
-                    gDropdownItems[2].Args = STR_OPTIONS_DISPLAY_FULLSCREEN_BORDERLESS;
+                    gDropdownItems[0].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[1].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[2].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[0].args = STR_OPTIONS_DISPLAY_WINDOWED;
+                    gDropdownItems[1].args = STR_OPTIONS_DISPLAY_FULLSCREEN;
+                    gDropdownItems[2].args = STR_OPTIONS_DISPLAY_FULLSCREEN_BORDERLESS;
 
                     ShowDropdown(widget, 3);
 
@@ -862,8 +862,8 @@ namespace OpenRCT2::Ui::Windows
                     const auto numItems = static_cast<int32_t>(std::size(kDrawingEngineStringIds));
                     for (int32_t i = 0; i < numItems; i++)
                     {
-                        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
-                        gDropdownItems[i].Args = kDrawingEngineStringIds[i];
+                        gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL;
+                        gDropdownItems[i].args = kDrawingEngineStringIds[i];
                     }
                     ShowDropdown(widget, numItems);
                     Dropdown::SetChecked(EnumValue(Config::Get().general.DrawingEngine), true);
@@ -886,12 +886,12 @@ namespace OpenRCT2::Ui::Windows
                     break;
                 case WIDX_FRAME_RATE_LIMIT_DROPDOWN:
                 {
-                    gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[2].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[0].Args = STR_FRAME_RATE_LIMIT_DEFAULT;
-                    gDropdownItems[1].Args = STR_FRAME_RATE_LIMIT_VSYNC;
-                    gDropdownItems[2].Args = STR_FRAME_RATE_LIMIT_UNRESTRICTED;
+                    gDropdownItems[0].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[1].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[2].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[0].args = STR_FRAME_RATE_LIMIT_DEFAULT;
+                    gDropdownItems[1].args = STR_FRAME_RATE_LIMIT_VSYNC;
+                    gDropdownItems[2].args = STR_FRAME_RATE_LIMIT_UNRESTRICTED;
 
                     ShowDropdown(widget, 3);
 
@@ -1112,12 +1112,12 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_VIRTUAL_FLOOR_DROPDOWN:
-                    gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[2].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[0].Args = STR_VIRTUAL_FLOOR_STYLE_DISABLED;
-                    gDropdownItems[1].Args = STR_VIRTUAL_FLOOR_STYLE_TRANSPARENT;
-                    gDropdownItems[2].Args = STR_VIRTUAL_FLOOR_STYLE_GLASSY;
+                    gDropdownItems[0].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[1].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[2].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[0].args = STR_VIRTUAL_FLOOR_STYLE_DISABLED;
+                    gDropdownItems[1].args = STR_VIRTUAL_FLOOR_STYLE_TRANSPARENT;
+                    gDropdownItems[2].args = STR_VIRTUAL_FLOOR_STYLE_GLASSY;
 
                     Widget* widget = &widgets[widgetIndex - 1];
                     ShowDropdown(widget, 3);
@@ -1205,10 +1205,10 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_HEIGHT_LABELS_DROPDOWN:
-                    gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[0].Args = STR_HEIGHT_IN_UNITS;
-                    gDropdownItems[1].Args = STR_REAL_VALUES;
+                    gDropdownItems[0].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[1].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[0].args = STR_HEIGHT_IN_UNITS;
+                    gDropdownItems[1].args = STR_REAL_VALUES;
 
                     ShowDropdown(widget, 2);
 
@@ -1224,14 +1224,14 @@ namespace OpenRCT2::Ui::Windows
 
                     for (size_t i = 0; i < numOrdinaryCurrencies; i++)
                     {
-                        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
-                        gDropdownItems[i].Args = CurrencyDescriptors[i].stringId;
+                        gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL;
+                        gDropdownItems[i].args = CurrencyDescriptors[i].stringId;
                     }
 
-                    gDropdownItems[numOrdinaryCurrencies].Format = Dropdown::kSeparatorString;
+                    gDropdownItems[numOrdinaryCurrencies].format = Dropdown::kSeparatorString;
 
-                    gDropdownItems[numOrdinaryCurrencies + 1].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[numOrdinaryCurrencies + 1].Args = CurrencyDescriptors[EnumValue(CurrencyType::Custom)]
+                    gDropdownItems[numOrdinaryCurrencies + 1].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[numOrdinaryCurrencies + 1].args = CurrencyDescriptors[EnumValue(CurrencyType::Custom)]
                                                                          .stringId;
 
                     ShowDropdown(widget, numItems);
@@ -1247,22 +1247,22 @@ namespace OpenRCT2::Ui::Windows
                     break;
                 }
                 case WIDX_DISTANCE_DROPDOWN:
-                    gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[2].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[0].Args = STR_IMPERIAL;
-                    gDropdownItems[1].Args = STR_METRIC;
-                    gDropdownItems[2].Args = STR_SI;
+                    gDropdownItems[0].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[1].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[2].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[0].args = STR_IMPERIAL;
+                    gDropdownItems[1].args = STR_METRIC;
+                    gDropdownItems[2].args = STR_SI;
 
                     ShowDropdown(widget, 3);
 
                     Dropdown::SetChecked(static_cast<int32_t>(Config::Get().general.MeasurementFormat), true);
                     break;
                 case WIDX_TEMPERATURE_DROPDOWN:
-                    gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[0].Args = STR_CELSIUS;
-                    gDropdownItems[1].Args = STR_FAHRENHEIT;
+                    gDropdownItems[0].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[1].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[0].args = STR_CELSIUS;
+                    gDropdownItems[1].args = STR_FAHRENHEIT;
 
                     ShowDropdown(widget, 2);
 
@@ -1271,8 +1271,8 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_LANGUAGE_DROPDOWN:
                     for (size_t i = 1; i < LANGUAGE_COUNT; i++)
                     {
-                        gDropdownItems[i - 1].Format = STR_OPTIONS_DROPDOWN_ITEM;
-                        gDropdownItems[i - 1].Args = reinterpret_cast<uintptr_t>(LanguagesDescriptors[i].native_name);
+                        gDropdownItems[i - 1].format = STR_OPTIONS_DROPDOWN_ITEM;
+                        gDropdownItems[i - 1].args = reinterpret_cast<uintptr_t>(LanguagesDescriptors[i].native_name);
                     }
                     ShowDropdown(widget, LANGUAGE_COUNT - 1);
                     Dropdown::SetChecked(LocalisationService_GetCurrentLanguage() - 1, true);
@@ -1280,8 +1280,8 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_DATE_FORMAT_DROPDOWN:
                     for (size_t i = 0; i < 4; i++)
                     {
-                        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
-                        gDropdownItems[i].Args = DateFormatStringIDs[i];
+                        gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL;
+                        gDropdownItems[i].args = DateFormatStringIDs[i];
                     }
                     ShowDropdown(widget, 4);
                     Dropdown::SetChecked(Config::Get().general.DateFormat, true);
@@ -1464,8 +1464,8 @@ namespace OpenRCT2::Ui::Windows
                     // populate the list with the sound devices
                     for (int32_t i = 0; i < OpenRCT2::Audio::GetDeviceCount(); i++)
                     {
-                        gDropdownItems[i].Format = STR_OPTIONS_DROPDOWN_ITEM;
-                        gDropdownItems[i].Args = reinterpret_cast<uintptr_t>(OpenRCT2::Audio::GetDeviceName(i).c_str());
+                        gDropdownItems[i].format = STR_OPTIONS_DROPDOWN_ITEM;
+                        gDropdownItems[i].args = reinterpret_cast<uintptr_t>(OpenRCT2::Audio::GetDeviceName(i).c_str());
                     }
 
                     ShowDropdown(widget, OpenRCT2::Audio::GetDeviceCount());
@@ -1485,8 +1485,8 @@ namespace OpenRCT2::Ui::Windows
                         if (Config::Get().sound.TitleMusic == theme.Kind)
                             checkedIndex = numItems;
 
-                        gDropdownItems[numItems].Format = STR_DROPDOWN_MENU_LABEL;
-                        gDropdownItems[numItems++].Args = theme.Name;
+                        gDropdownItems[numItems].format = STR_DROPDOWN_MENU_LABEL;
+                        gDropdownItems[numItems++].args = theme.Name;
                     }
                     ShowDropdown(widget, numItems);
                     Dropdown::SetChecked(checkedIndex, true);
@@ -1822,8 +1822,8 @@ namespace OpenRCT2::Ui::Windows
 
                     for (size_t i = 0; i < numItems; i++)
                     {
-                        gDropdownItems[i].Format = STR_OPTIONS_DROPDOWN_ITEM;
-                        gDropdownItems[i].Args = reinterpret_cast<uintptr_t>(ThemeManagerGetAvailableThemeName(i));
+                        gDropdownItems[i].format = STR_OPTIONS_DROPDOWN_ITEM;
+                        gDropdownItems[i].args = reinterpret_cast<uintptr_t>(ThemeManagerGetAvailableThemeName(i));
                     }
 
                     WindowDropdownShowTextCustomWidth(
@@ -1932,14 +1932,14 @@ namespace OpenRCT2::Ui::Windows
                     uint32_t numItems = static_cast<int32_t>(TitleSequenceManager::GetCount());
                     for (size_t i = 0; i < numItems; i++)
                     {
-                        gDropdownItems[i].Format = STR_OPTIONS_DROPDOWN_ITEM;
-                        gDropdownItems[i].Args = reinterpret_cast<uintptr_t>(TitleSequenceManager::GetName(i));
+                        gDropdownItems[i].format = STR_OPTIONS_DROPDOWN_ITEM;
+                        gDropdownItems[i].args = reinterpret_cast<uintptr_t>(TitleSequenceManager::GetName(i));
                     }
 
-                    gDropdownItems[numItems].Format = 0;
+                    gDropdownItems[numItems].format = 0;
                     numItems++;
-                    gDropdownItems[numItems].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[numItems].Args = STR_TITLE_SEQUENCE_RANDOM;
+                    gDropdownItems[numItems].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[numItems].args = STR_TITLE_SEQUENCE_RANDOM;
                     numItems++;
 
                     WindowDropdownShowText(
@@ -1956,10 +1956,10 @@ namespace OpenRCT2::Ui::Windows
                 {
                     uint32_t numItems = 2;
 
-                    gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[0].Args = STR_SCENARIO_PREVIEWS_MINIMAPS;
-                    gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[1].Args = STR_SCENARIO_PREVIEWS_SCREENSHOTS;
+                    gDropdownItems[0].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[0].args = STR_SCENARIO_PREVIEWS_MINIMAPS;
+                    gDropdownItems[1].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[1].args = STR_SCENARIO_PREVIEWS_SCREENSHOTS;
 
                     WindowDropdownShowTextCustomWidth(
                         { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1, colours[1], 0,
@@ -1971,8 +1971,8 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_DEFAULT_INSPECTION_INTERVAL_DROPDOWN:
                     for (size_t i = 0; i < 7; i++)
                     {
-                        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
-                        gDropdownItems[i].Args = kRideInspectionIntervalNames[i];
+                        gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL;
+                        gDropdownItems[i].args = kRideInspectionIntervalNames[i];
                     }
 
                     ShowDropdown(widget, 7);
@@ -2167,8 +2167,8 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_AUTOSAVE_FREQUENCY_DROPDOWN:
                     for (size_t i = AUTOSAVE_EVERY_MINUTE; i <= AUTOSAVE_NEVER; i++)
                     {
-                        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
-                        gDropdownItems[i].Args = AutosaveNames[i];
+                        gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL;
+                        gDropdownItems[i].args = AutosaveNames[i];
                     }
 
                     ShowDropdown(widget, AUTOSAVE_NEVER + 1);

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -444,10 +444,10 @@ namespace OpenRCT2::Ui::Windows
             if (widgetIndex == WIDX_OPEN_OR_CLOSE)
             {
                 auto& widget = widgets[widgetIndex];
-                gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItems[0].Args = STR_CLOSE_PARK;
-                gDropdownItems[1].Args = STR_OPEN_PARK;
+                gDropdownItems[0].format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[1].format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[0].args = STR_CLOSE_PARK;
+                gDropdownItems[1].args = STR_OPEN_PARK;
                 WindowDropdownShowText(
                     { windowPos.x + widget.left, windowPos.y + widget.top }, widget.height() + 1, colours[1], 0, 2);
 

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -559,8 +559,8 @@ namespace OpenRCT2::Ui::Windows
 
             for (i = 0; i < NetworkGetNumGroups(); i++)
             {
-                gDropdownItems[i].Format = STR_OPTIONS_DROPDOWN_ITEM;
-                gDropdownItems[i].Args = reinterpret_cast<uintptr_t>(NetworkGetGroupName(i));
+                gDropdownItems[i].format = STR_OPTIONS_DROPDOWN_ITEM;
+                gDropdownItems[i].args = reinterpret_cast<uintptr_t>(NetworkGetGroupName(i));
             }
 
             Dropdown::SetChecked(NetworkGetGroupIndex(NetworkGetPlayerGroup(player)), true);

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -478,8 +478,8 @@ namespace OpenRCT2::Ui::Windows
 
         for (std::size_t i = 0; i < std::size(kResearchFundingLevelNames); i++)
         {
-            gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
-            gDropdownItems[i].Args = kResearchFundingLevelNames[i];
+            gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL;
+            gDropdownItems[i].args = kResearchFundingLevelNames[i];
         }
         WindowDropdownShowTextCustomWidth(
             { w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1761,16 +1761,16 @@ namespace OpenRCT2::Ui::Windows
                 colours[1], 0, 0, numItems, widget->right - dropdownWidget->left);
 
             // First item
-            gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
-            gDropdownItems[0].Args = STR_OVERALL_VIEW;
+            gDropdownItems[0].format = STR_DROPDOWN_MENU_LABEL;
+            gDropdownItems[0].args = STR_OVERALL_VIEW;
             int32_t currentItem = 1;
 
             // Vehicles
             int32_t name = GetRideComponentName(rtd.NameConvention.vehicle).number;
             for (int32_t i = 0; i < ride->numTrains; i++)
             {
-                gDropdownItems[currentItem].Format = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItems[currentItem].Args = name | (currentItem << 16);
+                gDropdownItems[currentItem].format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[currentItem].args = name | (currentItem << 16);
                 if (TrainMustBeHidden(*ride, i))
                 {
                     Dropdown::SetDisabled(currentItem, true);
@@ -1782,8 +1782,8 @@ namespace OpenRCT2::Ui::Windows
             name = GetRideComponentName(rtd.NameConvention.station).number;
             for (int32_t i = 1; i <= ride->numStations; i++)
             {
-                gDropdownItems[currentItem].Format = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItems[currentItem].Args = name | (i << 16);
+                gDropdownItems[currentItem].format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[currentItem].args = name | (i << 16);
                 currentItem++;
             }
 
@@ -1832,8 +1832,8 @@ namespace OpenRCT2::Ui::Windows
             if (info.Ride->supportsStatus(status))
             {
                 auto index = info.NumItems;
-                gDropdownItems[index].Format = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItems[index].Args = text;
+                gDropdownItems[index].format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[index].args = text;
                 if (info.CurrentStatus == status)
                 {
                     info.CheckedIndex = index;
@@ -1925,8 +1925,8 @@ namespace OpenRCT2::Ui::Windows
 
             for (size_t i = 0; i < _rideDropdownData.size(); i++)
             {
-                gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItems[i].Args = _rideDropdownData[i].LabelId;
+                gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[i].args = _rideDropdownData[i].LabelId;
             }
 
             Widget* dropdownWidget = widget - 1;
@@ -1956,8 +1956,8 @@ namespace OpenRCT2::Ui::Windows
             if (ride == nullptr)
                 return;
 
-            gDropdownItems[0].Format = STR_LOCATE_SUBJECT_TIP;
-            gDropdownItems[1].Format = STR_FOLLOW_SUBJECT_TIP;
+            gDropdownItems[0].format = STR_LOCATE_SUBJECT_TIP;
+            gDropdownItems[1].format = STR_FOLLOW_SUBJECT_TIP;
 
             WindowDropdownShowText(
                 { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1, colours[1], 0, 2);
@@ -2073,8 +2073,8 @@ namespace OpenRCT2::Ui::Windows
 
             for (size_t i = 0; i < numItems; i++)
             {
-                gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItems[i].Args = _vehicleDropdownData[i].LabelId;
+                gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[i].args = _vehicleDropdownData[i].LabelId;
             }
 
             Widget* dropdownWidget = widget - 1;
@@ -2134,10 +2134,10 @@ namespace OpenRCT2::Ui::Windows
 
             for (size_t i = 0; i < _entranceDropdownData.size(); i++)
             {
-                gDropdownItems[i].Args = _entranceDropdownData[i].LabelId;
-                gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[i].args = _entranceDropdownData[i].LabelId;
+                gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL;
                 if (_entranceDropdownData[i].EntranceTypeId == ride->entranceStyle)
-                    gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL_SELECTED;
+                    gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL_SELECTED;
             }
 
             WindowDropdownShowTextCustomWidth(
@@ -2204,7 +2204,7 @@ namespace OpenRCT2::Ui::Windows
                         }
                         if (dropdownIndex < static_cast<int32_t>(std::size(gDropdownItems)))
                         {
-                            switch (gDropdownItems[dropdownIndex].Args)
+                            switch (gDropdownItems[dropdownIndex].args)
                             {
                                 case STR_CLOSE_RIDE:
                                     status = RideStatus::closed;
@@ -3112,8 +3112,8 @@ namespace OpenRCT2::Ui::Windows
             {
                 if (availableModes & (1uLL << i))
                 {
-                    gDropdownItems[numAvailableModes].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[numAvailableModes].Args = kRideModeNames[i];
+                    gDropdownItems[numAvailableModes].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[numAvailableModes].args = kRideModeNames[i];
 
                     if (ride->mode == static_cast<RideMode>(i))
                         checkedIndex = numAvailableModes;
@@ -3141,8 +3141,8 @@ namespace OpenRCT2::Ui::Windows
             auto dropdownWidget = widget - 1;
             for (auto i = 0; i < 5; i++)
             {
-                gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItems[i].Args = VehicleLoadNames[i];
+                gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[i].args = VehicleLoadNames[i];
             }
             WindowDropdownShowTextCustomWidth(
                 { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
@@ -3791,8 +3791,8 @@ namespace OpenRCT2::Ui::Windows
                     dropdownWidget--;
                     for (int32_t i = 0; i < 7; i++)
                     {
-                        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
-                        gDropdownItems[i].Args = kRideInspectionIntervalNames[i];
+                        gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL;
+                        gDropdownItems[i].args = kRideInspectionIntervalNames[i];
                     }
                     WindowDropdownShowTextCustomWidth(
                         { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
@@ -3808,8 +3808,8 @@ namespace OpenRCT2::Ui::Windows
                         if (rideEntry->ride_type[j] != kRideTypeNull)
                             break;
                     }
-                    gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[0].Args = STR_DEBUG_FIX_RIDE;
+                    gDropdownItems[0].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[0].args = STR_DEBUG_FIX_RIDE;
                     for (int32_t i = 0; i < 8; i++)
                     {
                         assert(j < static_cast<int32_t>(std::size(rideEntry->ride_type)));
@@ -3820,8 +3820,8 @@ namespace OpenRCT2::Ui::Windows
                                 if (ride->numTrains != 1)
                                     continue;
                             }
-                            gDropdownItems[numItems].Format = STR_DROPDOWN_MENU_LABEL;
-                            gDropdownItems[numItems].Args = RideBreakdownReasonNames[i];
+                            gDropdownItems[numItems].format = STR_DROPDOWN_MENU_LABEL;
+                            gDropdownItems[numItems].args = RideBreakdownReasonNames[i];
                             numItems++;
                         }
                     }
@@ -3854,8 +3854,8 @@ namespace OpenRCT2::Ui::Windows
                                         Dropdown::SetChecked(numItems, true);
                                         break;
                                     }
-                                    gDropdownItems[numItems].Format = STR_DROPDOWN_MENU_LABEL;
-                                    gDropdownItems[numItems].Args = RideBreakdownReasonNames[i];
+                                    gDropdownItems[numItems].format = STR_DROPDOWN_MENU_LABEL;
+                                    gDropdownItems[numItems].args = RideBreakdownReasonNames[i];
                                     numItems++;
                                 }
                             }
@@ -4325,8 +4325,8 @@ namespace OpenRCT2::Ui::Windows
                 {
                     for (size_t i = 0; i < std::size(ColourSchemeNames); i++)
                     {
-                        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
-                        gDropdownItems[i].Args = ColourSchemeNames[i];
+                        gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL;
+                        gDropdownItems[i].args = ColourSchemeNames[i];
                     }
 
                     WindowDropdownShowTextCustomWidth(
@@ -4352,8 +4352,8 @@ namespace OpenRCT2::Ui::Windows
                 {
                     for (auto i = 0; i < 4; i++)
                     {
-                        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
-                        gDropdownItems[i].Args = MazeOptions[i].text;
+                        gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL;
+                        gDropdownItems[i].args = MazeOptions[i].text;
                     }
 
                     WindowDropdownShowTextCustomWidth(
@@ -4372,16 +4372,16 @@ namespace OpenRCT2::Ui::Windows
                     auto vehicleTypeName = GetRideComponentName(ride->getRideTypeDescriptor().NameConvention.vehicle).singular;
 
                     auto numDropdownItems = 2;
-                    gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[0].Args = STR_ALL_VEHICLES_IN_SAME_COLOURS;
-                    gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[1].Args = (vehicleTypeName << 16) | STR_DIFFERENT_COLOURS_PER;
+                    gDropdownItems[0].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[0].args = STR_ALL_VEHICLES_IN_SAME_COLOURS;
+                    gDropdownItems[1].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[1].args = (vehicleTypeName << 16) | STR_DIFFERENT_COLOURS_PER;
 
                     if (getNumVisibleCars() > 1)
                     {
                         numDropdownItems++;
-                        gDropdownItems[2].Format = STR_DROPDOWN_MENU_LABEL;
-                        gDropdownItems[2].Args = STR_DIFFERENT_COLOURS_PER_VEHICLE;
+                        gDropdownItems[2].format = STR_DROPDOWN_MENU_LABEL;
+                        gDropdownItems[2].args = STR_DIFFERENT_COLOURS_PER_VEHICLE;
                     }
 
                     WindowDropdownShowTextCustomWidth(
@@ -4414,8 +4414,8 @@ namespace OpenRCT2::Ui::Windows
                         }
 
                         int64_t vehicleIndex = dropdownIndex + 1;
-                        gDropdownItems[dropdownIndex].Format = STR_DROPDOWN_MENU_LABEL;
-                        gDropdownItems[dropdownIndex].Args = (vehicleIndex << 32)
+                        gDropdownItems[dropdownIndex].format = STR_DROPDOWN_MENU_LABEL;
+                        gDropdownItems[dropdownIndex].args = (vehicleIndex << 32)
                             | ((GetRideComponentName(ride->getRideTypeDescriptor().NameConvention.vehicle).capitalised) << 16)
                             | stringId;
                         dropdownIndex++;
@@ -5085,8 +5085,8 @@ namespace OpenRCT2::Ui::Windows
             for (size_t i = 0; i < numItems; i++)
             {
                 auto musicObj = objManager.GetLoadedObject<MusicObject>(musicOrder[i]);
-                gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItems[i].Args = musicObj->NameStringId;
+                gDropdownItems[i].format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[i].args = musicObj->NameStringId;
             }
 
             WindowDropdownShowTextCustomWidth(
@@ -5467,8 +5467,8 @@ namespace OpenRCT2::Ui::Windows
             if (ride == nullptr)
                 return;
 
-            gDropdownItems[0].Format = STR_SAVE_TRACK_DESIGN_ITEM;
-            gDropdownItems[1].Format = STR_SAVE_TRACK_DESIGN_WITH_SCENERY_ITEM;
+            gDropdownItems[0].format = STR_SAVE_TRACK_DESIGN_ITEM;
+            gDropdownItems[1].format = STR_SAVE_TRACK_DESIGN_WITH_SCENERY_ITEM;
 
             WindowDropdownShowText(
                 { windowPos.x + widgets[widgetIndex].left, windowPos.y + widgets[widgetIndex].top },

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2591,7 +2591,7 @@ namespace OpenRCT2::Ui::Windows
                 // Separate elements logically
                 if (trackPiece == TrackElemType::None)
                 {
-                    gDropdownItems[i++].Format = kStringIdEmpty;
+                    gDropdownItems[i++].format = kStringIdEmpty;
                     continue;
                 }
 
@@ -2610,7 +2610,7 @@ namespace OpenRCT2::Ui::Windows
                     }
                 }
 
-                gDropdownItems[i].Format = trackPieceStringId;
+                gDropdownItems[i].format = trackPieceStringId;
                 if (_currentlySelectedTrack == trackPiece)
                     defaultIndex = i;
 

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -301,8 +301,8 @@ namespace OpenRCT2::Ui::Windows
             if (widgetIndex == WIDX_OPEN_CLOSE_ALL)
             {
                 const auto& widget = widgets[widgetIndex];
-                gDropdownItems[0].Format = STR_CLOSE_ALL;
-                gDropdownItems[1].Format = STR_OPEN_ALL;
+                gDropdownItems[0].format = STR_CLOSE_ALL;
+                gDropdownItems[1].format = STR_OPEN_ALL;
                 WindowDropdownShowText(
                     { windowPos.x + widget.left, windowPos.y + widget.top }, widget.height(), colours[1], 0, 2);
             }
@@ -331,8 +331,8 @@ namespace OpenRCT2::Ui::Windows
                         selectedIndex = numItems;
                     }
 
-                    gDropdownItems[numItems].Format = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItems[numItems].Args = ride_info_type_string_mapping[type];
+                    gDropdownItems[numItems].format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[numItems].args = ride_info_type_string_mapping[type];
                     numItems++;
                 }
 
@@ -376,7 +376,7 @@ namespace OpenRCT2::Ui::Windows
                     return;
 
                 int32_t informationType = INFORMATION_TYPE_STATUS;
-                uint32_t arg = static_cast<uint32_t>(gDropdownItems[dropdownIndex].Args);
+                uint32_t arg = static_cast<uint32_t>(gDropdownItems[dropdownIndex].args);
                 for (size_t i = 0; i < std::size(ride_info_type_string_mapping); i++)
                 {
                     if (arg == ride_info_type_string_mapping[i])

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -220,20 +220,16 @@ namespace OpenRCT2::Ui::Windows
 
                 const auto& listWidget = widgets[WIDX_LIST];
 
-                gDropdownItems[0].format = STR_JOIN_GAME;
-                if (server.Favourite)
-                {
-                    gDropdownItems[1].format = STR_REMOVE_FROM_FAVOURITES;
-                }
-                else
-                {
-                    gDropdownItems[1].format = STR_ADD_TO_FAVOURITES;
-                }
+                std::array<Dropdown::Item, 2> dropdownItems = {
+                    Dropdown::Item{ STR_JOIN_GAME },
+                    Dropdown::Item{ server.Favourite ? STR_REMOVE_FROM_FAVOURITES : STR_ADD_TO_FAVOURITES },
+                };
+
                 auto dropdownPos = ScreenCoordsXY{
                     windowPos.x + listWidget.left + screenCoords.x + 2 - scrolls[0].contentOffsetX,
                     windowPos.y + listWidget.top + screenCoords.y + 2 - scrolls[0].contentOffsetY
                 };
-                WindowDropdownShowText(dropdownPos, 0, { COLOUR_GREY }, 0, 2);
+                WindowDropdownShowText(dropdownPos, 0, { COLOUR_GREY }, 0, dropdownItems);
             }
         }
 

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -220,14 +220,14 @@ namespace OpenRCT2::Ui::Windows
 
                 const auto& listWidget = widgets[WIDX_LIST];
 
-                gDropdownItems[0].Format = STR_JOIN_GAME;
+                gDropdownItems[0].format = STR_JOIN_GAME;
                 if (server.Favourite)
                 {
-                    gDropdownItems[1].Format = STR_REMOVE_FROM_FAVOURITES;
+                    gDropdownItems[1].format = STR_REMOVE_FROM_FAVOURITES;
                 }
                 else
                 {
-                    gDropdownItems[1].Format = STR_ADD_TO_FAVOURITES;
+                    gDropdownItems[1].format = STR_ADD_TO_FAVOURITES;
                 }
                 auto dropdownPos = ScreenCoordsXY{
                     windowPos.x + listWidget.left + screenCoords.x + 2 - scrolls[0].contentOffsetX,

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -427,8 +427,8 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_PATROL:
                 {
                     // Dropdown names
-                    gDropdownItems[0].Format = STR_SET_PATROL_AREA;
-                    gDropdownItems[1].Format = STR_CLEAR_PATROL_AREA;
+                    gDropdownItems[0].format = STR_SET_PATROL_AREA;
+                    gDropdownItems[1].format = STR_CLEAR_PATROL_AREA;
 
                     auto ddPos = ScreenCoordsXY{ widget->left + windowPos.x, widget->top + windowPos.y };
                     int32_t extraHeight = widget->height() + 1;
@@ -782,8 +782,8 @@ namespace OpenRCT2::Ui::Windows
             {
                 // TODO: rework interface to dropdown arguments so memcpy won't be needed
                 auto* nameStr = _availableCostumes[i].friendlyName.c_str();
-                std::memcpy(&gDropdownItems[i].Args, &nameStr, sizeof(const char*));
-                gDropdownItems[i].Format = STR_OPTIONS_DROPDOWN_ITEM;
+                std::memcpy(&gDropdownItems[i].args, &nameStr, sizeof(const char*));
+                gDropdownItems[i].format = STR_OPTIONS_DROPDOWN_ITEM;
 
                 // Remember what item to check for the end of this event function
                 auto costumeIndex = _availableCostumes[i].index;
@@ -1164,8 +1164,8 @@ namespace OpenRCT2::Ui::Windows
 
         void ShowLocateDropdown(Widget* widget)
         {
-            gDropdownItems[0].Format = STR_LOCATE_SUBJECT_TIP;
-            gDropdownItems[1].Format = STR_FOLLOW_SUBJECT_TIP;
+            gDropdownItems[0].format = STR_LOCATE_SUBJECT_TIP;
+            gDropdownItems[1].format = STR_FOLLOW_SUBJECT_TIP;
 
             WindowDropdownShowText(
                 { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1, colours[1], 0, 2);

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -440,8 +440,8 @@ namespace OpenRCT2::Ui::Windows
                     widget--;
                     for (int32_t i = 0; i < num_items; i++)
                     {
-                        gDropdownItems[i].Format = STR_OPTIONS_DROPDOWN_ITEM;
-                        gDropdownItems[i].Args = reinterpret_cast<uintptr_t>(ThemeManagerGetAvailableThemeName(i));
+                        gDropdownItems[i].format = STR_OPTIONS_DROPDOWN_ITEM;
+                        gDropdownItems[i].args = reinterpret_cast<uintptr_t>(ThemeManagerGetAvailableThemeName(i));
                     }
 
                     WindowDropdownShowTextCustomWidth(

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -894,12 +894,12 @@ static uint64_t PageDisabledWidgets[] = {
                             // Use dropdown instead of dropdown button
                             widget--;
                             // Fill dropdown list
-                            gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
-                            gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
-                            gDropdownItems[2].Format = STR_DROPDOWN_MENU_LABEL;
-                            gDropdownItems[0].Args = STR_TILE_INSPECTOR_WALL_FLAT;
-                            gDropdownItems[1].Args = STR_TILE_INSPECTOR_WALL_SLOPED_LEFT;
-                            gDropdownItems[2].Args = STR_TILE_INSPECTOR_WALL_SLOPED_RIGHT;
+                            gDropdownItems[0].format = STR_DROPDOWN_MENU_LABEL;
+                            gDropdownItems[1].format = STR_DROPDOWN_MENU_LABEL;
+                            gDropdownItems[2].format = STR_DROPDOWN_MENU_LABEL;
+                            gDropdownItems[0].args = STR_TILE_INSPECTOR_WALL_FLAT;
+                            gDropdownItems[1].args = STR_TILE_INSPECTOR_WALL_SLOPED_LEFT;
+                            gDropdownItems[2].args = STR_TILE_INSPECTOR_WALL_SLOPED_RIGHT;
                             WindowDropdownShowTextCustomWidth(
                                 { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1, colours[1], 0,
                                 Dropdown::Flag::StayOpen, 3, widget->width() - 3);

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -175,11 +175,11 @@ namespace OpenRCT2::Ui::Windows
             if (widgetIndex == WIDX_GAME_TOOLS)
             {
                 int32_t i = 0;
-                gDropdownItems[i++].Format = STR_SCENARIO_EDITOR;
-                gDropdownItems[i++].Format = STR_CONVERT_SAVED_GAME_TO_SCENARIO;
-                gDropdownItems[i++].Format = STR_ROLLER_COASTER_DESIGNER;
-                gDropdownItems[i++].Format = STR_TRACK_DESIGNS_MANAGER;
-                gDropdownItems[i++].Format = STR_OPEN_USER_CONTENT_FOLDER;
+                gDropdownItems[i++].format = STR_SCENARIO_EDITOR;
+                gDropdownItems[i++].format = STR_CONVERT_SAVED_GAME_TO_SCENARIO;
+                gDropdownItems[i++].format = STR_ROLLER_COASTER_DESIGNER;
+                gDropdownItems[i++].format = STR_TRACK_DESIGNS_MANAGER;
+                gDropdownItems[i++].format = STR_OPEN_USER_CONTENT_FOLDER;
 
 #ifdef ENABLE_SCRIPTING
                 auto hasCustomItems = false;
@@ -194,12 +194,12 @@ namespace OpenRCT2::Ui::Windows
                             if (!hasCustomItems)
                             {
                                 hasCustomItems = true;
-                                gDropdownItems[i++].Format = kStringIdEmpty;
+                                gDropdownItems[i++].format = kStringIdEmpty;
                             }
 
-                            gDropdownItems[i].Format = STR_STRING;
+                            gDropdownItems[i].format = STR_STRING;
                             auto sz = item.Text.c_str();
-                            std::memcpy(&gDropdownItems[i].Args, &sz, sizeof(const char*));
+                            std::memcpy(&gDropdownItems[i].args, &sz, sizeof(const char*));
                             i++;
                         }
                     }

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1164,25 +1164,25 @@ namespace OpenRCT2::Ui::Windows
     void TopToolbar::InitMapMenu(Widget& widget)
     {
         auto i = 0;
-        gDropdownItems[i++].Format = STR_SHORTCUT_SHOW_MAP;
-        gDropdownItems[i++].Format = STR_EXTRA_VIEWPORT;
+        gDropdownItems[i++].format = STR_SHORTCUT_SHOW_MAP;
+        gDropdownItems[i++].format = STR_EXTRA_VIEWPORT;
         if (gLegacyScene == LegacyScene::scenarioEditor && getGameState().editorStep == EditorStep::LandscapeEditor)
         {
-            gDropdownItems[i++].Format = STR_MAPGEN_MENU_ITEM;
+            gDropdownItems[i++].format = STR_MAPGEN_MENU_ITEM;
         }
 
 #ifdef ENABLE_SCRIPTING
         const auto& customMenuItems = OpenRCT2::Scripting::CustomMenuItems;
         if (!customMenuItems.empty())
         {
-            gDropdownItems[i++].Format = kStringIdEmpty;
+            gDropdownItems[i++].format = kStringIdEmpty;
             for (const auto& item : customMenuItems)
             {
                 if (item.Kind == OpenRCT2::Scripting::CustomToolbarMenuItemKind::Standard)
                 {
-                    gDropdownItems[i].Format = STR_STRING;
+                    gDropdownItems[i].format = STR_STRING;
                     auto sz = item.Text.c_str();
-                    std::memcpy(&gDropdownItems[i].Args, &sz, sizeof(const char*));
+                    std::memcpy(&gDropdownItems[i].args, &sz, sizeof(const char*));
                     i++;
                 }
             }
@@ -1243,22 +1243,22 @@ namespace OpenRCT2::Ui::Windows
     void TopToolbar::InitFastforwardMenu(Widget& widget)
     {
         int32_t num_items = 4;
-        gDropdownItems[0].Format = STR_TOGGLE_OPTION;
-        gDropdownItems[1].Format = STR_TOGGLE_OPTION;
-        gDropdownItems[2].Format = STR_TOGGLE_OPTION;
-        gDropdownItems[3].Format = STR_TOGGLE_OPTION;
+        gDropdownItems[0].format = STR_TOGGLE_OPTION;
+        gDropdownItems[1].format = STR_TOGGLE_OPTION;
+        gDropdownItems[2].format = STR_TOGGLE_OPTION;
+        gDropdownItems[3].format = STR_TOGGLE_OPTION;
         if (Config::Get().general.DebuggingTools)
         {
-            gDropdownItems[4].Format = kStringIdEmpty;
-            gDropdownItems[5].Format = STR_TOGGLE_OPTION;
-            gDropdownItems[5].Args = STR_SPEED_HYPER;
+            gDropdownItems[4].format = kStringIdEmpty;
+            gDropdownItems[5].format = STR_TOGGLE_OPTION;
+            gDropdownItems[5].args = STR_SPEED_HYPER;
             num_items = 6;
         }
 
-        gDropdownItems[0].Args = STR_SPEED_NORMAL;
-        gDropdownItems[1].Args = STR_SPEED_QUICK;
-        gDropdownItems[2].Args = STR_SPEED_FAST;
-        gDropdownItems[3].Args = STR_SPEED_TURBO;
+        gDropdownItems[0].args = STR_SPEED_NORMAL;
+        gDropdownItems[1].args = STR_SPEED_QUICK;
+        gDropdownItems[2].args = STR_SPEED_FAST;
+        gDropdownItems[3].args = STR_SPEED_TURBO;
 
         WindowDropdownShowText(
             { windowPos.x + widget.left, windowPos.y + widget.top }, widget.height() + 1,
@@ -1310,66 +1310,66 @@ namespace OpenRCT2::Ui::Windows
         int32_t numItems = 0;
         if (isInTrackDesignerOrManager())
         {
-            gDropdownItems[numItems++].Format = STR_SCREENSHOT;
-            gDropdownItems[numItems++].Format = STR_GIANT_SCREENSHOT;
-            gDropdownItems[numItems++].Format = kStringIdEmpty;
-            gDropdownItems[numItems++].Format = STR_ABOUT;
-            gDropdownItems[numItems++].Format = STR_FILE_BUG_ON_GITHUB;
+            gDropdownItems[numItems++].format = STR_SCREENSHOT;
+            gDropdownItems[numItems++].format = STR_GIANT_SCREENSHOT;
+            gDropdownItems[numItems++].format = kStringIdEmpty;
+            gDropdownItems[numItems++].format = STR_ABOUT;
+            gDropdownItems[numItems++].format = STR_FILE_BUG_ON_GITHUB;
 
             if (OpenRCT2::GetContext()->HasNewVersionInfo())
-                gDropdownItems[numItems++].Format = STR_UPDATE_AVAILABLE;
+                gDropdownItems[numItems++].format = STR_UPDATE_AVAILABLE;
 
-            gDropdownItems[numItems++].Format = STR_OPTIONS;
-            gDropdownItems[numItems++].Format = kStringIdEmpty;
+            gDropdownItems[numItems++].format = STR_OPTIONS;
+            gDropdownItems[numItems++].format = kStringIdEmpty;
 
             if (gLegacyScene == LegacyScene::trackDesigner)
-                gDropdownItems[numItems++].Format = STR_QUIT_ROLLERCOASTER_DESIGNER;
+                gDropdownItems[numItems++].format = STR_QUIT_ROLLERCOASTER_DESIGNER;
             else
-                gDropdownItems[numItems++].Format = STR_QUIT_TRACK_DESIGNS_MANAGER;
+                gDropdownItems[numItems++].format = STR_QUIT_TRACK_DESIGNS_MANAGER;
 
-            gDropdownItems[numItems++].Format = STR_EXIT_OPENRCT2;
+            gDropdownItems[numItems++].format = STR_EXIT_OPENRCT2;
         }
         else if (gLegacyScene == LegacyScene::scenarioEditor)
         {
-            gDropdownItems[numItems++].Format = STR_LOAD_LANDSCAPE;
-            gDropdownItems[numItems++].Format = kStringIdEmpty;
-            gDropdownItems[numItems++].Format = STR_SAVE_LANDSCAPE;
-            gDropdownItems[numItems++].Format = kStringIdEmpty;
-            gDropdownItems[numItems++].Format = STR_SCREENSHOT;
-            gDropdownItems[numItems++].Format = STR_GIANT_SCREENSHOT;
-            gDropdownItems[numItems++].Format = kStringIdEmpty;
-            gDropdownItems[numItems++].Format = STR_ABOUT;
-            gDropdownItems[numItems++].Format = STR_FILE_BUG_ON_GITHUB;
+            gDropdownItems[numItems++].format = STR_LOAD_LANDSCAPE;
+            gDropdownItems[numItems++].format = kStringIdEmpty;
+            gDropdownItems[numItems++].format = STR_SAVE_LANDSCAPE;
+            gDropdownItems[numItems++].format = kStringIdEmpty;
+            gDropdownItems[numItems++].format = STR_SCREENSHOT;
+            gDropdownItems[numItems++].format = STR_GIANT_SCREENSHOT;
+            gDropdownItems[numItems++].format = kStringIdEmpty;
+            gDropdownItems[numItems++].format = STR_ABOUT;
+            gDropdownItems[numItems++].format = STR_FILE_BUG_ON_GITHUB;
 
             if (OpenRCT2::GetContext()->HasNewVersionInfo())
-                gDropdownItems[numItems++].Format = STR_UPDATE_AVAILABLE;
+                gDropdownItems[numItems++].format = STR_UPDATE_AVAILABLE;
 
-            gDropdownItems[numItems++].Format = STR_OPTIONS;
-            gDropdownItems[numItems++].Format = kStringIdEmpty;
-            gDropdownItems[numItems++].Format = STR_QUIT_SCENARIO_EDITOR;
-            gDropdownItems[numItems++].Format = STR_EXIT_OPENRCT2;
+            gDropdownItems[numItems++].format = STR_OPTIONS;
+            gDropdownItems[numItems++].format = kStringIdEmpty;
+            gDropdownItems[numItems++].format = STR_QUIT_SCENARIO_EDITOR;
+            gDropdownItems[numItems++].format = STR_EXIT_OPENRCT2;
         }
         else
         {
-            gDropdownItems[numItems++].Format = STR_NEW_GAME;
-            gDropdownItems[numItems++].Format = STR_LOAD_GAME;
-            gDropdownItems[numItems++].Format = kStringIdEmpty;
-            gDropdownItems[numItems++].Format = STR_SAVE_GAME;
-            gDropdownItems[numItems++].Format = STR_SAVE_GAME_AS;
-            gDropdownItems[numItems++].Format = kStringIdEmpty;
-            gDropdownItems[numItems++].Format = STR_SCREENSHOT;
-            gDropdownItems[numItems++].Format = STR_GIANT_SCREENSHOT;
-            gDropdownItems[numItems++].Format = kStringIdEmpty;
-            gDropdownItems[numItems++].Format = STR_ABOUT;
-            gDropdownItems[numItems++].Format = STR_FILE_BUG_ON_GITHUB;
+            gDropdownItems[numItems++].format = STR_NEW_GAME;
+            gDropdownItems[numItems++].format = STR_LOAD_GAME;
+            gDropdownItems[numItems++].format = kStringIdEmpty;
+            gDropdownItems[numItems++].format = STR_SAVE_GAME;
+            gDropdownItems[numItems++].format = STR_SAVE_GAME_AS;
+            gDropdownItems[numItems++].format = kStringIdEmpty;
+            gDropdownItems[numItems++].format = STR_SCREENSHOT;
+            gDropdownItems[numItems++].format = STR_GIANT_SCREENSHOT;
+            gDropdownItems[numItems++].format = kStringIdEmpty;
+            gDropdownItems[numItems++].format = STR_ABOUT;
+            gDropdownItems[numItems++].format = STR_FILE_BUG_ON_GITHUB;
 
             if (OpenRCT2::GetContext()->HasNewVersionInfo())
-                gDropdownItems[numItems++].Format = STR_UPDATE_AVAILABLE;
+                gDropdownItems[numItems++].format = STR_UPDATE_AVAILABLE;
 
-            gDropdownItems[numItems++].Format = STR_OPTIONS;
-            gDropdownItems[numItems++].Format = kStringIdEmpty;
-            gDropdownItems[numItems++].Format = STR_QUIT_TO_MENU;
-            gDropdownItems[numItems++].Format = STR_EXIT_OPENRCT2;
+            gDropdownItems[numItems++].format = STR_OPTIONS;
+            gDropdownItems[numItems++].format = kStringIdEmpty;
+            gDropdownItems[numItems++].format = STR_QUIT_TO_MENU;
+            gDropdownItems[numItems++].format = STR_EXIT_OPENRCT2;
         }
 
         WindowDropdownShowText(
@@ -1469,10 +1469,10 @@ namespace OpenRCT2::Ui::Windows
 
     void TopToolbar::InitDebugMenu(Widget& widget)
     {
-        gDropdownItems[DDIDX_CONSOLE].Format = STR_TOGGLE_OPTION;
-        gDropdownItems[DDIDX_CONSOLE].Args = STR_DEBUG_DROPDOWN_CONSOLE;
-        gDropdownItems[DDIDX_DEBUG_PAINT].Format = STR_TOGGLE_OPTION;
-        gDropdownItems[DDIDX_DEBUG_PAINT].Args = STR_DEBUG_DROPDOWN_DEBUG_PAINT;
+        gDropdownItems[DDIDX_CONSOLE].format = STR_TOGGLE_OPTION;
+        gDropdownItems[DDIDX_CONSOLE].args = STR_DEBUG_DROPDOWN_CONSOLE;
+        gDropdownItems[DDIDX_DEBUG_PAINT].format = STR_TOGGLE_OPTION;
+        gDropdownItems[DDIDX_DEBUG_PAINT].args = STR_DEBUG_DROPDOWN_DEBUG_PAINT;
 
         WindowDropdownShowText(
             { windowPos.x + widget.left, windowPos.y + widget.top }, widget.height() + 1,
@@ -1514,8 +1514,8 @@ namespace OpenRCT2::Ui::Windows
 
     void TopToolbar::InitNetworkMenu(Widget& widget)
     {
-        gDropdownItems[DDIDX_MULTIPLAYER].Format = STR_MULTIPLAYER;
-        gDropdownItems[DDIDX_MULTIPLAYER_RECONNECT].Format = STR_MULTIPLAYER_RECONNECT;
+        gDropdownItems[DDIDX_MULTIPLAYER].format = STR_MULTIPLAYER;
+        gDropdownItems[DDIDX_MULTIPLAYER_RECONNECT].format = STR_MULTIPLAYER_RECONNECT;
 
         WindowDropdownShowText(
             { windowPos.x + widget.left, windowPos.y + widget.top }, widget.height() + 1,


### PR DESCRIPTION
Currently, dropdown items are written into a global. This PR starts a move away from this.

At present, it only modifies two dropdowns to avoid having to throw away too much work if changes are requested. I can add more of them in this PR or a follow-up PR if desired.