### PR TITLE
Fix LIM Launched inline twists drawing over land when built underground

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -20,6 +20,7 @@
 - Fix: [#24835] Dive loop track pieces do not have tunnels.
 - Fix: [#24884] Smooth map and add beaches functions use incorrect map size with height map image files.
 - Fix: [#24915] LIM Launched (original bug), Corkscrew and Twister Roller Coaster inline twists have some incorrect tunnels.
+- Fix: [#24916] LIM Launched inline twists can draw over land edges when built underground (original bug).
 - Fix: [#24953] Crash when opening the Scenario Editor, Track Designer or Track Designs Manager.
 - Fix: [#24955] Hybrid Zero G Rolls do not fully block metal supports.
 - Fix: [#24958] Android: fix crash when device is offline.

--- a/src/openrct2/paint/track/coaster/LimLaunchedRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/LimLaunchedRollerCoaster.cpp
@@ -693,34 +693,34 @@ static void LimLaunchedRCTrackLeftTwistDownToUp(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15760), { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 3 } });
+                        { { 0, 6, height - 16 }, { 32, 20, 3 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15784), { 0, 0, height },
-                        { { 0, 6, height + 44 }, { 32, 20, 0 } });
+                        { { 0, 6, height + 12 }, { 32, 20, 0 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15763), { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 3 } });
+                        { { 0, 6, height - 16 }, { 32, 20, 3 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15787), { 0, 0, height },
-                        { { 0, 6, height + 44 }, { 32, 20, 0 } });
+                        { { 0, 6, height + 12 }, { 32, 20, 0 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15766), { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 3 } });
+                        { { 0, 6, height - 16 }, { 32, 20, 3 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15790), { 0, 0, height },
-                        { { 0, 6, height + 44 }, { 32, 20, 0 } });
+                        { { 0, 6, height + 12 }, { 32, 20, 0 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15769), { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 3 } });
+                        { { 0, 6, height - 16 }, { 32, 20, 3 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15793), { 0, 0, height },
-                        { { 0, 6, height + 44 }, { 32, 20, 0 } });
+                        { { 0, 6, height + 12 }, { 32, 20, 0 } });
                     break;
             }
             switch (direction)
@@ -855,34 +855,34 @@ static void LimLaunchedRCTrackRightTwistDownToUp(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15772), { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 3 } });
+                        { { 0, 6, height - 16 }, { 32, 20, 3 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15796), { 0, 0, height },
-                        { { 0, 6, height + 44 }, { 32, 20, 0 } });
+                        { { 0, 6, height + 12 }, { 32, 20, 0 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15775), { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 3 } });
+                        { { 0, 6, height - 16 }, { 32, 20, 3 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15799), { 0, 0, height },
-                        { { 0, 6, height + 44 }, { 32, 20, 0 } });
+                        { { 0, 6, height + 12 }, { 32, 20, 0 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15778), { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 3 } });
+                        { { 0, 6, height - 16 }, { 32, 20, 3 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15802), { 0, 0, height },
-                        { { 0, 6, height + 44 }, { 32, 20, 0 } });
+                        { { 0, 6, height + 12 }, { 32, 20, 0 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15781), { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 3 } });
+                        { { 0, 6, height - 16 }, { 32, 20, 3 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15805), { 0, 0, height },
-                        { { 0, 6, height + 44 }, { 32, 20, 0 } });
+                        { { 0, 6, height + 12 }, { 32, 20, 0 } });
                     break;
             }
             switch (direction)
@@ -920,34 +920,34 @@ static void LimLaunchedRCTrackLeftTwistUpToDown(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15766), { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 3 } });
+                        { { 0, 6, height - 16 }, { 32, 20, 3 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15790), { 0, 0, height },
-                        { { 0, 6, height + 44 }, { 32, 20, 0 } });
+                        { { 0, 6, height + 12 }, { 32, 20, 0 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15769), { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 3 } });
+                        { { 0, 6, height - 16 }, { 32, 20, 3 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15793), { 0, 0, height },
-                        { { 0, 6, height + 44 }, { 32, 20, 0 } });
+                        { { 0, 6, height + 12 }, { 32, 20, 0 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15760), { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 3 } });
+                        { { 0, 6, height - 16 }, { 32, 20, 3 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15784), { 0, 0, height },
-                        { { 0, 6, height + 44 }, { 32, 20, 0 } });
+                        { { 0, 6, height + 12 }, { 32, 20, 0 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15763), { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 3 } });
+                        { { 0, 6, height - 16 }, { 32, 20, 3 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15787), { 0, 0, height },
-                        { { 0, 6, height + 44 }, { 32, 20, 0 } });
+                        { { 0, 6, height + 12 }, { 32, 20, 0 } });
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -1082,34 +1082,34 @@ static void LimLaunchedRCTrackRightTwistUpToDown(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15778), { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 3 } });
+                        { { 0, 6, height - 16 }, { 32, 20, 3 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15802), { 0, 0, height },
-                        { { 0, 6, height + 44 }, { 32, 20, 0 } });
+                        { { 0, 6, height + 12 }, { 32, 20, 0 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15781), { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 3 } });
+                        { { 0, 6, height - 16 }, { 32, 20, 3 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15805), { 0, 0, height },
-                        { { 0, 6, height + 44 }, { 32, 20, 0 } });
+                        { { 0, 6, height + 12 }, { 32, 20, 0 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15772), { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 3 } });
+                        { { 0, 6, height - 16 }, { 32, 20, 3 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15796), { 0, 0, height },
-                        { { 0, 6, height + 44 }, { 32, 20, 0 } });
+                        { { 0, 6, height + 12 }, { 32, 20, 0 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15775), { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 3 } });
+                        { { 0, 6, height - 16 }, { 32, 20, 3 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(15799), { 0, 0, height },
-                        { { 0, 6, height + 44 }, { 32, 20, 0 } });
+                        { { 0, 6, height + 12 }, { 32, 20, 0 } });
                     break;
             }
             if (direction == 0 || direction == 3)


### PR DESCRIPTION
This fixes LIM Launched inline twists drawing over land when built underground. This is an original bug from RCT2.
The bounding boxes were very offset, the front and back sprites weren't even working on this tile because they were both above the train. This makes those tiles the same as the other tiles.
Closes #24916 as the other issues there are now fixed.

<img width="573" height="349" alt="475442440-f7930af2-c295-4efe-bce8-c67d61836dff" src="https://github.com/user-attachments/assets/7ec0e372-0cc9-463d-9bdc-5b74f5909382" />
<img width="573" height="349" alt="liminlinetwiststunnelsfix" src="https://github.com/user-attachments/assets/01462ee9-651a-4da3-b27c-cd1747534948" />

<img width="417" height="260" alt="liminlinetwistsbbsbug" src="https://github.com/user-attachments/assets/1db25390-b989-425c-89e0-83a6c813571b" />
<img width="417" height="260" alt="liminlinetwistsbbsfix" src="https://github.com/user-attachments/assets/23ce175a-53b1-41ef-847c-9dc4aba8e48d" />

https://github.com/user-attachments/assets/8cfb6e77-db97-4787-b6d5-0792311ba209

Saves:
[lim inline twists.zip](https://github.com/user-attachments/files/21925730/lim.inline.twists.zip)
