### PR TITLE
Ride list update on new ride

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -251,6 +251,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * (QuestionableDeer)
 * David Sungaila (sungaila)
 * Garrett Leach (GarrettLeach)
+* Jacob Malone (jacobmalone28)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -20,7 +20,6 @@
 #include <openrct2-ui/input/InputManager.h>
 #include <openrct2-ui/input/MouseInput.h>
 #include <openrct2-ui/input/ShortcutManager.h>
-#include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/GameState.h>
 #include <openrct2/Input.h>
@@ -413,12 +412,7 @@ public:
 
             case INTENT_ACTION_REFRESH_RIDE_LIST:
             {
-                auto window = FindByClass(WindowClass::RideList);
-                if (window != nullptr)
-                {
-                    WindowRideListRefreshList(window);
-                }
-
+                WindowRideListRefreshList();
                 break;
             }
 

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2979,11 +2979,6 @@ namespace OpenRCT2::Ui::Windows
 
             WindowRideConstructionDoEntranceExitCheck();
             WindowRideConstructionUpdateActiveElements();
-            auto rideWindow = GetWindowManager()->FindByClass(WindowClass::RideList);
-            if (rideWindow)
-            {
-                WindowRideListRefreshList(rideWindow);
-            }
         }
 
         auto* windowMgr = Ui::GetWindowManager();

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2979,6 +2979,11 @@ namespace OpenRCT2::Ui::Windows
 
             WindowRideConstructionDoEntranceExitCheck();
             WindowRideConstructionUpdateActiveElements();
+            auto rideWindow = GetWindowManager()->FindByClass(WindowClass::RideList);
+            if (rideWindow)
+            {
+                WindowRideListRefreshList(rideWindow);
+            }
         }
 
         auto* windowMgr = Ui::GetWindowManager();
@@ -4933,12 +4938,6 @@ namespace OpenRCT2::Ui::Windows
         if (!std::get<0>(updated_element))
         {
             return true;
-        }
-
-        auto rideWindow = GetWindowManager()->FindByClass(WindowClass::RideList);
-        if (rideWindow)
-        {
-            WindowRideListRefreshList(rideWindow);
         }
 
         OpenRCT2::TrackElemType trackType = std::get<1>(updated_element);

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -4928,10 +4928,17 @@ namespace OpenRCT2::Ui::Windows
 
         auto intent = Intent(INTENT_ACTION_RIDE_CONSTRUCTION_UPDATE_PIECES);
         ContextBroadcastIntent(&intent);
+
         auto updated_element = WindowRideConstructionUpdateStateGetTrackElement();
         if (!std::get<0>(updated_element))
         {
             return true;
+        }
+
+        auto rideWindow = GetWindowManager()->FindByClass(WindowClass::RideList);
+        if (rideWindow)
+        {
+            WindowRideListRefreshList(rideWindow);
         }
 
         OpenRCT2::TrackElemType trackType = std::get<1>(updated_element);

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -1147,8 +1147,14 @@ namespace OpenRCT2::Ui::Windows
         return window;
     }
 
-    void WindowRideListRefreshList(WindowBase* w)
+    void WindowRideListRefreshList()
     {
-        dynamic_cast<RideListWindow*>(w)->RefreshListWrapper();
+        auto* windowMgr = GetWindowManager();
+        auto w = static_cast<RideListWindow*>(windowMgr->FindByClass(WindowClass::RideList));
+        if (w)
+        {
+            w->RefreshListWrapper();
+        }
+        
     }
 } // namespace OpenRCT2::Ui::Windows

--- a/src/openrct2-ui/windows/Windows.h
+++ b/src/openrct2-ui/windows/Windows.h
@@ -259,7 +259,7 @@ namespace OpenRCT2::Ui::Windows
 
     // RideList
     WindowBase* RideListOpen();
-    void WindowRideListRefreshList(WindowBase* w);
+    void WindowRideListRefreshList();
 
     // SavePrompt
     WindowBase* SavePromptOpen();

--- a/src/openrct2/actions/MazePlaceTrackAction.cpp
+++ b/src/openrct2/actions/MazePlaceTrackAction.cpp
@@ -19,6 +19,8 @@
 #include "../world/Wall.h"
 #include "../world/tile_element/SurfaceElement.h"
 #include "../world/tile_element/TrackElement.h"
+#include "../ui/WindowManager.h"
+#include "../windows/Intent.h"
 
 using namespace OpenRCT2;
 
@@ -201,6 +203,9 @@ GameActions::Result MazePlaceTrackAction::Execute() const
     {
         ride->overallView = startLoc;
     }
+
+    auto* windowMgr = Ui::GetWindowManager();
+    windowMgr->BroadcastIntent(Intent(INTENT_ACTION_REFRESH_RIDE_LIST));
 
     return res;
 }

--- a/src/openrct2/actions/MazeSetTrackAction.cpp
+++ b/src/openrct2/actions/MazeSetTrackAction.cpp
@@ -20,6 +20,8 @@
 #include "../ride/Track.h"
 #include "../ride/TrackData.h"
 #include "../world/ConstructionClearance.h"
+#include "../ui/WindowManager.h"
+#include "../windows/Intent.h"
 #include "../world/Footpath.h"
 #include "../world/Park.h"
 #include "../world/Wall.h"
@@ -335,6 +337,13 @@ GameActions::Result MazeSetTrackAction::Execute() const
         TileElementRemove(tileElement);
         ride->validateStations();
         ride->mazeTiles--;
+    }
+
+    // Refresh the RideList when maze track is placed (non-ghost). This ensures the ride appears after first placement.
+    if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
+    {
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->BroadcastIntent(Intent(INTENT_ACTION_REFRESH_RIDE_LIST));
     }
 
     return res;

--- a/src/openrct2/actions/MazeSetTrackAction.cpp
+++ b/src/openrct2/actions/MazeSetTrackAction.cpp
@@ -25,6 +25,8 @@
 #include "../world/Wall.h"
 #include "../world/tile_element/SurfaceElement.h"
 #include "../world/tile_element/TrackElement.h"
+#include "../ui/WindowManager.h"
+#include "../windows/Intent.h"
 
 using namespace OpenRCT2;
 
@@ -239,6 +241,14 @@ GameActions::Result MazeSetTrackAction::Execute() const
         if (_initialPlacement && !(flags & GAME_COMMAND_FLAG_GHOST))
         {
             ride->overallView = startLoc;
+        }
+
+        // Broadcast a Ride List refresh only on the first actual (non-ghost) placement
+        // to align maze behavior with standard rides.
+        if (_initialPlacement && !(flags & GAME_COMMAND_FLAG_GHOST))
+        {
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->BroadcastIntent(Intent(INTENT_ACTION_REFRESH_RIDE_LIST));
         }
     }
 

--- a/src/openrct2/actions/MazeSetTrackAction.cpp
+++ b/src/openrct2/actions/MazeSetTrackAction.cpp
@@ -20,8 +20,6 @@
 #include "../ride/Track.h"
 #include "../ride/TrackData.h"
 #include "../world/ConstructionClearance.h"
-#include "../ui/WindowManager.h"
-#include "../windows/Intent.h"
 #include "../world/Footpath.h"
 #include "../world/Park.h"
 #include "../world/Wall.h"
@@ -337,13 +335,6 @@ GameActions::Result MazeSetTrackAction::Execute() const
         TileElementRemove(tileElement);
         ride->validateStations();
         ride->mazeTiles--;
-    }
-
-    // Refresh the RideList when maze track is placed (non-ghost). This ensures the ride appears after first placement.
-    if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
-    {
-        auto* windowMgr = Ui::GetWindowManager();
-        windowMgr->BroadcastIntent(Intent(INTENT_ACTION_REFRESH_RIDE_LIST));
     }
 
     return res;

--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -297,6 +297,8 @@ GameActions::Result RideCreateAction::Execute() const
     RideSetVehicleColoursToRandomPreset(*ride, _colour2);
 
     auto* windowMgr = Ui::GetWindowManager();
+    // Mark the ride list as needing refresh; the actual refresh occurs when the first non-ghost piece is placed.
+    ride->windowInvalidateFlags |= RIDE_INVALIDATE_RIDE_LIST;
     windowMgr->InvalidateByClass(WindowClass::RideList);
 
     res.Expenditure = ExpenditureType::RideConstruction;

--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -298,8 +298,6 @@ GameActions::Result RideCreateAction::Execute() const
 
     auto* windowMgr = Ui::GetWindowManager();
     windowMgr->InvalidateByClass(WindowClass::RideList);
-    // Ensure RideList window updates after placing a ride
-    windowMgr->BroadcastIntent(Intent(INTENT_ACTION_REFRESH_RIDE_LIST));
 
     res.Expenditure = ExpenditureType::RideConstruction;
     res.SetData(RideId{ rideIndex });

--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -298,6 +298,8 @@ GameActions::Result RideCreateAction::Execute() const
 
     auto* windowMgr = Ui::GetWindowManager();
     windowMgr->InvalidateByClass(WindowClass::RideList);
+    // Ensure RideList window updates after placing a ride
+    windowMgr->BroadcastIntent(Intent(INTENT_ACTION_REFRESH_RIDE_LIST));
 
     res.Expenditure = ExpenditureType::RideConstruction;
     res.SetData(RideId{ rideIndex });

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -14,10 +14,13 @@
 #include "../core/Money.hpp"
 #include "../core/Numerics.hpp"
 #include "../management/Finance.h"
+#include "../ride/Ride.h"
 #include "../ride/RideData.h"
 #include "../ride/Track.h"
 #include "../ride/TrackData.h"
 #include "../ride/TrackDesign.h"
+#include "../ui/WindowManager.h"
+#include "../windows/Intent.h"
 #include "../world/ConstructionClearance.h"
 #include "../world/Footpath.h"
 #include "../world/MapAnimation.h"
@@ -743,6 +746,13 @@ GameActions::Result TrackPlaceAction::Execute() const
     price >>= 16;
     res.Cost = costs + supportCosts + price;
     res.SetData(std::move(resultData));
+
+    // On any non-ghost placement, refresh the RideList so new rides appear immediately.
+    if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
+    {
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->BroadcastIntent(Intent(INTENT_ACTION_REFRESH_RIDE_LIST));
+    }
 
     return res;
 }

--- a/src/openrct2/actions/TrackRemoveAction.cpp
+++ b/src/openrct2/actions/TrackRemoveAction.cpp
@@ -20,6 +20,9 @@
 #include "../world/tile_element/SurfaceElement.h"
 #include "../world/tile_element/TrackElement.h"
 #include "RideSetSettingAction.h"
+#include "../ride/Ride.h"
+#include "../ui/WindowManager.h"
+#include "../windows/Intent.h"
 
 using namespace OpenRCT2;
 using namespace OpenRCT2::TrackMetaData;
@@ -496,6 +499,18 @@ GameActions::Result TrackRemoveAction::Execute() const
                 break;
             default:
                 break;
+        }
+    }
+
+    // If removing non-ghost track resulted in no remaining track for this ride,
+    // invalidate and refresh the Ride List so it disappears immediately.
+    if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
+    {
+        if (!RideHasAnyTrackElements(*ride))
+        {
+            ride->windowInvalidateFlags |= RIDE_INVALIDATE_RIDE_LIST;
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->BroadcastIntent(Intent(INTENT_ACTION_REFRESH_RIDE_LIST));
         }
     }
 


### PR DESCRIPTION
Now, when the ride list is open, and a track is placed, the ride list updates the ride list and the ride count. Also updates upon removing all the track pieces of a given ride.

Testing:
Create Ride:
- [x] Coaster Track Placed
- [x] Maze Placed
- [x] Flat ride Placed 
Remove Ride:
- [x] Coaster Track Removed
- [x] Flat ride right clicked to remove
- [x] Maze removed (caveat in that I found a new bug to be worked on haha)  