### PR TITLE
Fix width of Clear button in Rides window and remove tooltip of

### DIFF
--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -523,8 +523,12 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_LIST].right = width - 26;
             widgets[WIDX_LIST].bottom = height - 15;
 
+            // Get 'Clear' button string width
+            auto clearLabel = LanguageGetString(STR_OBJECT_SEARCH_CLEAR);
+            auto clearLabelWidth = GfxGetStringWidth(clearLabel, FontStyle::Medium) + 12;
+
             widgets[WIDX_SEARCH_CLEAR_BUTTON].right = widgets[WIDX_LIST].right - 1;
-            widgets[WIDX_SEARCH_CLEAR_BUTTON].left = widgets[WIDX_SEARCH_CLEAR_BUTTON].right - 40;
+            widgets[WIDX_SEARCH_CLEAR_BUTTON].left = widgets[WIDX_SEARCH_CLEAR_BUTTON].right - clearLabelWidth;
             widgets[WIDX_SEARCH_TEXT_BOX].right = widgets[WIDX_SEARCH_CLEAR_BUTTON].left - 2;
             widgets[WIDX_SEARCH_TEXT_BOX].string = _searchFilter.data();
 

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -72,7 +72,7 @@ namespace OpenRCT2::Ui::Windows
         makeTab   ({ 34, 17},                                                                STR_LIST_SHOPS_AND_STALLS_TIP                                         ), // tab 2
         makeTab   ({ 65, 17},                                                                STR_LIST_KIOSKS_AND_FACILITIES_TIP                                    ), // tab 3
         makeWidget({  3, 47}, {284,  14}, WidgetType::textBox,      WindowColour::secondary                                                                        ), // search text box
-        makeWidget({284, 47}, { 50,  14}, WidgetType::button,       WindowColour::secondary, STR_OBJECT_SEARCH_CLEAR,            STR_CLEAR_SCENERY_TIP             ), // search clear button
+        makeWidget({284, 47}, { 50,  14}, WidgetType::button,       WindowColour::secondary, STR_OBJECT_SEARCH_CLEAR                                               ), // search clear button
         makeWidget({  3, 62}, {150,  14}, WidgetType::tableHeader,  WindowColour::secondary                                                                        ), // name header
         makeWidget({153, 62}, {147,  14}, WidgetType::tableHeader,  WindowColour::secondary                                                                        ), // other header
         makeWidget({300, 62}, { 14,  14}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH                                                    ), // customise button


### PR DESCRIPTION
1. Change width of Clear button in Rides (`RideList.cpp`) window to be of flexible width, based on width of word in currently set language.
2. Remove tooltip of Clear button

___________

- This PR is concurrent to https://github.com/OpenRCT2/OpenRCT2/pull/25009 and from author's point of view, the dev members are free to choose whatever they find more suited for the game, as certain level of seasonedness is required choose wisely and maintain good bearing of the project :)

___________

**Detail:** 
1. Uses button with variable-width based on text width invented by Mr. AaronVanGeffen for LoadSave window as seen in https://github.com/OpenRCT2/OpenRCT2/commit/5e61768d6187267f4ecb705f99bef77bc2e3098b 

**Why:** 
1. As it was concluded in reason for submitting and discussion under #25009 , the word used for "Clear" varies in width from translation to translation and this makes the text to be cut with "..." in certain languages.
2. In review discussion mentioned above was concluded that tooltips over self-explanatory text buttons are simply overkill + tooltip text is reused from different window and situations, thus is currently somewhat out-of-line and makes quite no sense in given setting

___________

**Image reference:**
current:
<img width="415" height="254" alt="old1" src="https://github.com/user-attachments/assets/50d4a684-9cc1-4b89-8155-645349b25523" />

PR (gif cycling thru various translations)
![new_animate](https://github.com/user-attachments/assets/88fe1d8f-3eb4-430c-9250-a07c80477b4a)
