### PR TITLE
Improve String 5862

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -2953,7 +2953,7 @@ STR_5858    :Use GPU for displaying instead of CPU. Improves compatibility with 
 STR_5859    :Enables frame tweening for visually{NEWLINE}smoother gameplay. When disabled,{NEWLINE}the game will run at 40 FPS.
 STR_5860    :Toggle original/decompiled track drawing
 STR_5861    :Key verification failure.
-STR_5862    :Block unknown players.
+STR_5862    :Block unknown players
 STR_5863    :Only allow players with known keys to join.
 STR_5864    :This server only allows whitelisted players to connect.
 STR_5865    :Log chat history


### PR DESCRIPTION
Improve `STR_5862` by removing trailing full stop (period at the end)

Why? - Because it is not looking good in user interface, since this is a checkbox text 
(I think we can agree that checkbox text is not supposed to have trailing period :)

Image reference current state:
<img width="316" height="116" alt="old" src="https://github.com/user-attachments/assets/bbae0f93-c535-487f-ab99-e78da9fea27f" />

State proposed by this PR:
<img width="316" height="116" alt="new" src="https://github.com/user-attachments/assets/5fbd85a8-24c3-496c-a06e-85ada4487df9" />
